### PR TITLE
Add Fake Feedback Mods

### DIFF
--- a/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Objects/Drawables/DrawableEmptyFreeformHitObject.cs
+++ b/Templates/Rulesets/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Objects/Drawables/DrawableEmptyFreeformHitObject.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -22,11 +24,11 @@ namespace osu.Game.Rulesets.EmptyFreeform.Objects.Drawables
             // todo: add visuals.
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (timeOffset >= 0)
                 // todo: implement judgement logic
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                onAction?.Invoke(r => r.Type = HitResult.Perfect);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/Templates/Rulesets/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -47,10 +49,10 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
             new HitSampleInfo(HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK)
         };
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (timeOffset >= 0)
-                ApplyResult(r => r.Type = IsHovered ? HitResult.Perfect : HitResult.Miss);
+                onAction?.Invoke(r => r.Type = IsHovered ? HitResult.Perfect : HitResult.Miss);
         }
 
         protected override double InitialLifetimeOffset => time_preempt;

--- a/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Objects/Drawables/DrawableEmptyScrollingHitObject.cs
+++ b/Templates/Rulesets/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Objects/Drawables/DrawableEmptyScrollingHitObject.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -20,11 +22,11 @@ namespace osu.Game.Rulesets.EmptyScrolling.Objects.Drawables
             // todo: add visuals.
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (timeOffset >= 0)
                 // todo: implement judgement logic
-                ApplyResult(r => r.Type = HitResult.Perfect);
+                onAction?.Invoke(r => r.Type = HitResult.Perfect);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/Templates/Rulesets/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -9,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Pippidon.UI;
 using osu.Game.Rulesets.Scoring;
@@ -47,10 +49,10 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
             new HitSampleInfo(HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK)
         };
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (timeOffset >= 0)
-                ApplyResult(r => r.Type = currentLane.Value == HitObject.Lane ? HitResult.Perfect : HitResult.Miss);
+                onAction?.Invoke(r => r.Type = currentLane.Value == HitObject.Lane ? HitResult.Perfect : HitResult.Miss);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableCatchHitObject.cs
@@ -57,12 +57,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         protected override JudgementResult CreateResult(Judgement judgement) => new CatchJudgementResult(HitObject, judgement);
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (CheckPosition == null) return;
 
             if (timeOffset >= 0 && Result != null)
-                ApplyResult(r => r.Type = CheckPosition.Invoke(HitObject) ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = CheckPosition.Invoke(HitObject) ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -238,7 +239,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (Tail.AllJudged)
             {
@@ -248,7 +249,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                         tick.MissForcefully();
                 }
 
-                ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
                 endHold();
             }
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -3,9 +3,11 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
@@ -42,7 +44,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected override double MaximumJudgementOffset => base.MaximumJudgementOffset * release_window_lenience;
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             Debug.Assert(HitObject.HitWindows != null);
 
@@ -52,7 +54,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
 
                 return;
             }
@@ -61,7 +63,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (result == HitResult.None)
                 return;
 
-            ApplyResult(r =>
+            onAction?.Invoke(r =>
             {
                 // If the head wasn't hit or the hold note was broken, cap the max score to Meh.
                 if (result > HitResult.Meh && (!HoldNote.Head.IsHit || HoldNote.HoldBrokenTime != null))

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTick.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Judgements;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
@@ -94,7 +95,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             holdStartTime = null;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (Time.Current < HitObject.StartTime)
                 return;
@@ -102,9 +103,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             double? startTime = holdStartTime?.Invoke();
 
             if (startTime == null || startTime > HitObject.StartTime)
-                ApplyResult(r => r.Type = r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
             else
-                ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -11,6 +12,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
@@ -82,14 +84,14 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             headPiece.Anchor = headPiece.Origin = e.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             Debug.Assert(HitObject.HitWindows != null);
 
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 
@@ -97,7 +99,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             if (result == HitResult.None)
                 return;
 
-            ApplyResult(r => r.Type = result);
+            onAction?.Invoke(r => r.Type = result);
         }
 
         public virtual bool OnPressed(KeyBindingPressEvent<ManiaAction> e)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -3,11 +3,13 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -119,15 +121,15 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             public void TriggerJudgement() => Schedule(() => UpdateResult(true));
 
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
             {
                 if (auto && !userTriggered && timeOffset > hitOffset && CheckHittable?.Invoke(this, Time.Current) != false)
                 {
                     // force success
-                    ApplyResult(r => r.Type = HitResult.Great);
+                    onAction?.Invoke(r => r.Type = HitResult.Great);
                 }
                 else
-                    base.CheckForResult(userTriggered, timeOffset);
+                    base.CheckForResult(userTriggered, timeOffset, ApplyResult);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAlternate.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -14,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Acronym => @"AL";
         public override LocalisableString Description => @"Don't use the same key twice in a row!";
         public override IconUsage? Icon => FontAwesome.Solid.Keyboard;
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModSingleTap) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModRelax), typeof(ModRelaxDisplay), typeof(OsuModSingleTap) }).ToArray();
 
         protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction != action;
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Automation;
         public override LocalisableString Description => @"Automatic cursor movement - just follow the rhythm.";
         public override double ScoreMultiplier => 0.1;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModSpunOut), typeof(ModRelax), typeof(ModFailCondition), typeof(ModNoFail), typeof(ModAutoplay), typeof(OsuModMagnetised), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModSpunOut), typeof(ModRelax), typeof(ModRelaxDisplay), typeof(ModFailCondition), typeof(ModNoFail), typeof(ModAutoplay), typeof(OsuModMagnetised), typeof(OsuModRepel) };
 
         public bool PerformFail() => false;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
         public override double ScoreMultiplier => 0.5;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(OsuModRelax), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModRepel) };
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]
         public BindableFloat AttractionStrength { get; } = new BindableFloat(0.5f)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "No need to chase the circles – your cursor is a magnet!";
         public override double ScoreMultiplier => 0.5;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => new[] { typeof(OsuModAutopilot), typeof(OsuModWiggle), typeof(OsuModTransform), typeof(ModAutoplay), typeof(ModRelax), typeof(ModRelaxDisplay), typeof(OsuModRepel) };
 
         [SettingSource("Attraction strength", "How strong the pull is.", 0)]
         public BindableFloat AttractionStrength { get; } = new BindableFloat(0.5f)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSingleTap.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override string Name => @"Single Tap";
         public override string Acronym => @"SG";
         public override LocalisableString Description => @"You must only use one key!";
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAlternate) }).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModRelax), typeof(ModRelaxDisplay), typeof(OsuModAlternate) }).ToArray();
 
         protected override bool CheckValidNewAction(OsuAction action) => LastAcceptedAction == null || LastAcceptedAction == action;
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -74,6 +74,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                                 UpdateResult(true);
                                 return true;
                             },
+                            UnscoredHit = () =>
+                            {
+                                if (AllResultsDisplayed)
+                                    return false;
+
+                                UpdateUnscoredResult(true);
+                                return true;
+                            },
                         },
                         shakeContainer = new ShakeContainer
                         {
@@ -232,6 +240,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             public override bool HandlePositionalInput => true;
 
             public Func<bool> Hit;
+            public Func<bool> UnscoredHit;
 
             public OsuAction? HitAction;
 
@@ -253,6 +262,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     case OsuAction.LeftButton:
                     case OsuAction.RightButton:
                         if (IsHovered && (Hit?.Invoke() ?? false))
+                        {
+                            HitAction = e.Action;
+                            return true;
+                        }
+
+                        break;
+
+                    case OsuAction.UnscoredLeftButton:
+                    case OsuAction.UnscoredRightButton:
+                        if (IsHovered && (UnscoredHit?.Invoke() ?? false))
                         {
                             HitAction = e.Action;
                             return true;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -136,14 +136,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public override void Shake() => shakeContainer.Shake();
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             Debug.Assert(HitObject.HitWindows != null);
 
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
 
                 return;
             }
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 return;
             }
 
-            ApplyResult(r =>
+            onAction?.Invoke(r =>
             {
                 var circleResult = (OsuHitCircleJudgementResult)r;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -75,6 +75,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public virtual void Shake() { }
 
         /// <summary>
+        /// Causes this <see cref="DrawableOsuHitObject"/> to display a miss, disregarding all conditions in implementations of <see cref="DrawableHitObject.CheckForResult"/>.
+        /// </summary>
+        public void DisplayMissForcefully() => ApplyUnscoredResult(r => r.Type = r.Judgement.MinResult);
+
+        /// <summary>
         /// Causes this <see cref="DrawableOsuHitObject"/> to get missed, disregarding all conditions in implementations of <see cref="DrawableHitObject.CheckForResult"/>.
         /// </summary>
         public void MissForcefully() => ApplyResult(r => r.Type = r.Judgement.MinResult);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Skinning;
@@ -273,7 +274,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Ball.AccentColour = allowBallTint ? AccentColour.Value : Color4.White;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (userTriggered || Time.Current < HitObject.EndTime)
                 return;
@@ -282,12 +283,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             // But the slider needs to still be judged with a reasonable hit/miss result for visual purposes (hit/miss transforms, etc).
             if (HitObject.OnlyJudgeNestedObjects)
             {
-                ApplyResult(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
                 return;
             }
 
             // Otherwise, if this slider also needs to be judged, apply judgement proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
-            ApplyResult(r =>
+            onAction?.Invoke(r =>
             {
                 int totalTicks = NestedHitObjects.Count;
                 int hitTicks = NestedHitObjects.Count(h => h.IsHit);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
@@ -181,6 +181,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (headCircleHit && (!timeToAcceptAnyKeyAfter.HasValue || Time.Current <= timeToAcceptAnyKeyAfter.Value))
                 return action == GetInitialHitAction();
 
+            // Cannot use Unscored OsuActions
             return action == OsuAction.LeftButton || action == OsuAction.RightButton;
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
@@ -79,10 +80,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Position = HitObject.Position - DrawableSlider.Position;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (HitObject.StartTime <= Time.Current)
-                ApplyResult(r => r.Type = DrawableSlider.Tracking.Value ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = DrawableSlider.Tracking.Value ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -3,11 +3,13 @@
 
 #nullable disable
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Skinning.Default;
@@ -118,10 +120,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (!userTriggered && timeOffset >= 0)
-                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void OnApply()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -73,10 +75,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Position = HitObject.Position - DrawableSlider.HitObject.Position;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (timeOffset >= 0)
-                ApplyResult(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = Tracking ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
         protected override void UpdateInitialTransforms()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override JudgementResult CreateResult(Judgement judgement) => new OsuSpinnerJudgementResult(HitObject, judgement);
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (Time.Current < HitObject.StartTime) return;
 
@@ -238,7 +238,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             foreach (var tick in ticks.Where(t => !t.Result.HasResult))
                 tick.TriggerResult(false);
 
-            ApplyResult(r =>
+            onAction?.Invoke(r =>
             {
                 if (Progress >= 1)
                     r.Type = HitResult.Great;

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -80,6 +80,12 @@ namespace osu.Game.Rulesets.Osu
         LeftButton,
 
         [Description("Right button")]
-        RightButton
+        RightButton,
+
+        [Description("Unscored Left button")]
+        UnscoredLeftButton,
+
+        [Description("Unscored Right button")]
+        UnscoredRightButton
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -163,7 +163,8 @@ namespace osu.Game.Rulesets.Osu
                         new MultiMod(new OsuModDoubleTime(), new OsuModNightcore()),
                         new OsuModHidden(),
                         new MultiMod(new OsuModFlashlight(), new OsuModBlinds()),
-                        new OsuModStrictTracking()
+                        new OsuModStrictTracking(),
+                        new OsuModRelaxDisplay()
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Osu/UI/AnyOrderHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/AnyOrderHitPolicy.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public bool IsHittable(DrawableHitObject hitObject, double time) => true;
 
-        public void HandleHit(DrawableHitObject hitObject)
+        public void HandleHit(DrawableHitObject hitObject, JudgementResult result)
         {
         }
     }

--- a/osu.Game.Rulesets.Osu/UI/IHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/IHitPolicy.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
@@ -28,6 +29,7 @@ namespace osu.Game.Rulesets.Osu.UI
         /// Handles a <see cref="HitObject"/> being hit.
         /// </summary>
         /// <param name="hitObject">The <see cref="HitObject"/> that was hit.</param>
-        void HandleHit(DrawableHitObject hitObject);
+        /// <param name="result">The <see cref="JudgementResult"/> of the HitObject's hit.</param>
+        void HandleHit(DrawableHitObject hitObject, JudgementResult result);
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/ObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/ObjectOrderedHitPolicy.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -24,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public bool IsHittable(DrawableHitObject hitObject, double time) => enumerateHitObjectsUpTo(hitObject.HitObject.StartTime).All(obj => obj.AllJudged);
 
-        public void HandleHit(DrawableHitObject hitObject)
+        public void HandleHit(DrawableHitObject hitObject, JudgementResult result)
         {
         }
 

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -163,9 +163,9 @@ namespace osu.Game.Rulesets.Osu.UI
         private void onNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {
             // Hitobjects that block future hits should miss previous hitobjects if they're hit out-of-order.
-            hitPolicy.HandleHit(judgedObject);
+            hitPolicy.HandleHit(judgedObject, result);
 
-            if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
+            if (!judgedObject.DisplayResult || !result.Display || !DisplayJudgements.Value)
                 return;
 
             DrawableOsuJudgement explosion = poolDictionary[result.Type].Get(doj => doj.Apply(result, judgedObject));

--- a/osu.Game.Rulesets.Osu/UI/StartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/StartTimeOrderedHitPolicy.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -45,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.UI
             return blockingObject.Judged || time >= blockingObject.HitObject.StartTime;
         }
 
-        public void HandleHit(DrawableHitObject hitObject)
+        public void HandleHit(DrawableHitObject hitObject, JudgementResult result)
         {
             // Hitobjects which themselves don't block future hitobjects don't cause misses (e.g. slider ticks, spinners).
             if (!hitObjectCanBlockFutureHits(hitObject))
@@ -57,11 +58,16 @@ namespace osu.Game.Rulesets.Osu.UI
             // Miss all hitobjects prior to the hit one.
             foreach (var obj in enumerateHitObjectsUpTo(hitObject.HitObject.StartTime))
             {
-                if (obj.Judged)
+                if ((result.Score && obj.Judged) || (result.Display && obj.ResultDisplayed))
                     continue;
 
                 if (hitObjectCanBlockFutureHits(obj))
-                    ((DrawableOsuHitObject)obj).MissForcefully();
+                {
+                    if (result.Score)
+                        ((DrawableOsuHitObject)obj).MissForcefully();
+                    else
+                        ((DrawableOsuHitObject)obj).DisplayMissForcefully();
+                }
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             updateColour(100);
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (userTriggered)
                 return;
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (timeOffset < 0)
                 return;
 
-            ApplyResult(r => r.Type = r.Judgement.MaxResult);
+            onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
@@ -187,12 +187,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             {
             }
 
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
             {
                 if (!ParentHitObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override void OnKilled()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -7,6 +7,7 @@ using System;
 using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -40,19 +41,19 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override double MaximumJudgementOffset => HitObject.HitWindow;
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (!userTriggered)
             {
                 if (timeOffset > HitObject.HitWindow)
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 
             if (Math.Abs(timeOffset) > HitObject.HitWindow)
                 return;
 
-            ApplyResult(r => r.Type = r.Judgement.MaxResult);
+            onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
         }
 
         public override void OnKilled()
@@ -95,12 +96,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             {
             }
 
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
             {
                 if (!ParentHitObject.Judged)
                     return;
 
-                ApplyResult(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = ParentHitObject.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
 
             public override void OnKilled()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -12,6 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -127,14 +128,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return samples;
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             Debug.Assert(HitObject.HitWindows != null);
 
             if (!userTriggered)
             {
                 if (!HitObject.HitWindows.CanBeHit(timeOffset))
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
                 return;
             }
 
@@ -143,9 +144,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 return;
 
             if (!validActionPressed)
-                ApplyResult(r => r.Type = r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
             else
-                ApplyResult(r => r.Type = result);
+                onAction?.Invoke(r => r.Type = result);
         }
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
@@ -243,29 +244,29 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             {
             }
 
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
             {
                 if (!ParentHitObject.Result.HasResult)
                 {
-                    base.CheckForResult(userTriggered, timeOffset);
+                    base.CheckForResult(userTriggered, timeOffset, onAction);
                     return;
                 }
 
                 if (!ParentHitObject.Result.IsHit)
                 {
-                    ApplyResult(r => r.Type = r.Judgement.MinResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
                     return;
                 }
 
                 if (!userTriggered)
                 {
                     if (timeOffset - ParentHitObject.Result.TimeOffset > second_hit_window)
-                        ApplyResult(r => r.Type = r.Judgement.MinResult);
+                        onAction?.Invoke(r => r.Type = r.Judgement.MinResult);
                     return;
                 }
 
                 if (Math.Abs(timeOffset - ParentHitObject.Result.TimeOffset) <= second_hit_window)
-                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
             }
 
             public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
@@ -171,7 +172,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
             if (userTriggered)
             {
@@ -202,7 +203,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 expandingRing.ScaleTo(1f + Math.Min(target_ring_scale - 1f, (target_ring_scale - 1f) * completion * 1.3f), 260, Easing.OutQuint);
 
                 if (numHits == HitObject.RequiredHits)
-                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
             }
             else
             {
@@ -223,7 +224,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                         tick.TriggerResult(false);
                 }
 
-                ApplyResult(r => r.Type = numHits == HitObject.RequiredHits ? r.Judgement.MaxResult : r.Judgement.MinResult);
+                onAction?.Invoke(r => r.Type = numHits == HitObject.RequiredHits ? r.Judgement.MaxResult : r.Judgement.MinResult);
             }
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -3,9 +3,11 @@
 
 #nullable disable
 
+using System;
 using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 
@@ -33,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : r.Judgement.MinResult);
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
+        protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePoolingRuleset.cs
@@ -311,10 +311,10 @@ namespace osu.Game.Tests.Visual.Gameplay
                 Position = new Vector2(RNG.Next(-200, 200), RNG.Next(-200, 200));
             }
 
-            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            protected override void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
             {
                 if (timeOffset > HitObject.Duration)
-                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                    onAction?.Invoke(r => r.Type = r.Judgement.MaxResult);
             }
 
             protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -33,6 +33,16 @@ namespace osu.Game.Rulesets.Judgements
         public readonly Judgement Judgement;
 
         /// <summary>
+        /// Whether this <see cref="JudgementResult"/> should be displayed.
+        /// </summary>
+        public bool Display { get; set; } = true;
+
+        /// <summary>
+        /// Whether this <see cref="JudgementResult"/> should be scored.
+        /// </summary>
+        public bool Score { get; set; } = true;
+
+        /// <summary>
         /// The offset from a perfect hit at which this <see cref="JudgementResult"/> occurred.
         /// Populated when this <see cref="JudgementResult"/> is applied via <see cref="DrawableHitObject.ApplyResult"/>.
         /// </summary>

--- a/osu.Game/Rulesets/Mods/ModRelax.cs
+++ b/osu.Game/Rulesets/Mods/ModRelax.cs
@@ -16,4 +16,14 @@ namespace osu.Game.Rulesets.Mods
         public override double ScoreMultiplier => 0.1;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModNoFail), typeof(ModFailCondition) };
     }
+
+    public abstract class ModRelaxDisplay : Mod
+    {
+        public override string Name => "Relax Display";
+        public override string Acronym => "RD";
+        public override IconUsage? Icon => OsuIcon.ModRelax;
+        public override ModType Type => ModType.DifficultyIncrease;
+        public override double ScoreMultiplier => 1;
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay) };
+    }
 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -710,7 +710,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// <param name="userTriggered">Whether the user triggered this check.</param>
         /// <param name="timeOffset">The offset from the end time of the <see cref="HitObject"/> at which this check occurred.
         /// A <paramref name="timeOffset"/> &gt; 0 implies that this check occurred after the end time of the <see cref="HitObject"/>. </param>
-        protected virtual void CheckForResult(bool userTriggered, double timeOffset)
+        /// <param name="onAction">The callback that updates the result and notifies responders as necessary.</param>
+        protected virtual void CheckForResult(bool userTriggered, double timeOffset, Action<Action<JudgementResult>> onAction)
         {
         }
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -19,6 +19,12 @@ namespace osu.Game.Rulesets.Objects
         public readonly HitObject HitObject;
 
         /// <summary>
+        /// The result that <see cref="HitObject"/> displayed.
+        /// This is set by the accompanying <see cref="DrawableHitObject"/>, and reused when required for rewinding.
+        /// </summary>
+        internal JudgementResult? DisplayedResult;
+
+        /// <summary>
         /// The result that <see cref="HitObject"/> was judged with.
         /// This is set by the accompanying <see cref="DrawableHitObject"/>, and reused when required for rewinding.
         /// </summary>

--- a/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
@@ -66,12 +66,16 @@ namespace osu.Game.Rulesets.Scoring
                 throw new ArgumentException(@$"A {nameof(HitResult.LegacyComboIncrease)} hit result cannot be applied.");
 #pragma warning restore CS0618
 
-            JudgedHits++;
-            lastAppliedResult = result;
+            if (result.Score)
+            {
+                JudgedHits++;
+                lastAppliedResult = result;
 
-            ApplyResultInternal(result);
+                ApplyResultInternal(result);
+            }
 
-            NewJudgement?.Invoke(result);
+            if (result.Display)
+                NewJudgement?.Invoke(result);
         }
 
         /// <summary>
@@ -80,11 +84,15 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="result">The judgement scoring result.</param>
         public void RevertResult(JudgementResult result)
         {
-            JudgedHits--;
+            if (result.Score)
+            {
+                JudgedHits--;
 
-            RevertResultInternal(result);
+                RevertResultInternal(result);
+            }
 
-            JudgementReverted?.Invoke(result);
+            if (result.Display)
+                JudgementReverted?.Invoke(result);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR adds two mods, Relax Display and Autoplay Display, which make it appear as though either's related mod is on while actually scoring the user's inputs normally controlled by the mod behind the scenes.

Relax Display demo:
https://youtu.be/n8chuWw8h9I
. . . ignore the trackball gameplay lol
(fail prevention is disabled now, unlike in that video)

In addition to these being difficulty enhancers, they can assist in improving gameplay by helping one train themselves to respond to the beatmap instead of the beatmap and then the game's feedback to correct their actions. Somewhat displaying this, I believed I did not need any offset after switching to Pipewire, but playing with Relax Display enabled showed me that I actually tap ~5ms early. I must usually adjust using the hitsound feedback.

I am opening this draft now for discussion and to get initial feedback, as this is my first PR to the repository.

There are currently two commits, it will probably be much easier to look at the second instead of the overall diff. I tried to avoid refactoring but some were unavoidable.

**TODO:**
- [ ] Implement Autoplay Display (possibly in a follow-up PR, this is already a mess to look at)
- [ ] Come up with better names (and icons if too different)
- [ ] Make sliders accept `Unscored` `OsuInput`s
- [ ] Attempt to prevent combobreak sound when caused by tapping (or user cursor in Autoplay Display)
- [ ] Add tests