### PR TITLE
Fix player potentially getting stuck on completion with storyboard enabled

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected new OutroPlayer Player => (OutroPlayer)base.Player;
 
+        private double currentBeatmapDuration;
         private double currentStoryboardDuration;
 
         private bool showResults = true;
@@ -45,7 +46,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("enable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, true));
             AddStep("set dim level to 0", () => LocalConfig.SetValue<double>(OsuSetting.DimLevel, 0));
             AddStep("reset fail conditions", () => currentFailConditions = (_, _) => false);
-            AddStep("set storyboard duration to 2s", () => currentStoryboardDuration = 2000);
+            AddStep("set beatmap duration to 0s", () => currentBeatmapDuration = 0);
+            AddStep("set storyboard duration to 8s", () => currentStoryboardDuration = 8000);
             AddStep("set ShowResults = true", () => showResults = true);
         }
 
@@ -151,6 +153,24 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("player exited", () => Stack.CurrentScreen == null);
         }
 
+        [Test]
+        public void TestPerformExitAfterOutro()
+        {
+            CreateTest(() =>
+            {
+                AddStep("set beatmap duration to 4s", () => currentBeatmapDuration = 4000);
+                AddStep("set storyboard duration to 1s", () => currentStoryboardDuration = 1000);
+            });
+
+            AddUntilStep("storyboard ends", () => Player.GameplayClockContainer.CurrentTime >= currentStoryboardDuration);
+            AddStep("exit via pause", () => Player.ExitViaPause());
+            AddAssert("player paused", () => !Player.IsResuming);
+
+            AddStep("resume player", () => Player.Resume());
+            AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
+            AddUntilStep("wait for score shown", () => Player.IsScoreShown);
+        }
+
         protected override bool AllowFail => true;
 
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
@@ -160,7 +180,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {
             var beatmap = new Beatmap();
-            beatmap.HitObjects.Add(new HitCircle());
+            beatmap.HitObjects.Add(new HitCircle { StartTime = currentBeatmapDuration });
             return beatmap;
         }
 
@@ -189,7 +209,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             private event Func<HealthProcessor, JudgementResult, bool> failConditions;
 
             public OutroPlayer(Func<HealthProcessor, JudgementResult, bool> failConditions, bool showResults = true)
-                : base(false, showResults)
+                : base(showResults: showResults)
             {
                 this.failConditions = failConditions;
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -566,9 +566,6 @@ namespace osu.Game.Screens.Play
         /// </param>
         protected void PerformExit(bool showDialogFirst)
         {
-            // if an exit has been requested, cancel any pending completion (the user has shown intention to exit).
-            resultsDisplayDelegate?.Cancel();
-
             // there is a chance that an exit request occurs after the transition to results has already started.
             // even in such a case, the user has shown intent, so forcefully return to this screen (to proceed with the upwards exit process).
             if (!this.IsCurrentScreen())
@@ -602,6 +599,9 @@ namespace osu.Game.Screens.Play
                     return;
                 }
             }
+
+            // if an exit has been requested, cancel any pending completion (the user has shown intention to exit).
+            resultsDisplayDelegate?.Cancel();
 
             // The actual exit is performed if
             // - the pause / fail dialog was not requested

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -780,19 +780,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <remarks>
         /// A final display will only occur once all work is completed in <see cref="PrepareScoreForResultsAsync"/>. This means that even after calling this method, the results screen will never be shown until <see cref="JudgementProcessor.HasCompleted">ScoreProcessor.HasCompleted</see> becomes <see langword="true"/>.
-        ///
-        /// Calling this method multiple times will have no effect.
         /// </remarks>
         /// <param name="withDelay">Whether a minimum delay (<see cref="RESULTS_DISPLAY_DELAY"/>) should be added before the screen is displayed.</param>
         private void progressToResults(bool withDelay)
         {
-            if (resultsDisplayDelegate != null)
-                // Note that if progressToResults is called one withDelay=true and then withDelay=false, this no-delay timing will not be
-                // accounted for. shouldn't be a huge concern (a user pressing the skip button after a results progression has already been queued
-                // may take x00 more milliseconds than expected in the very rare edge case).
-                //
-                // If required we can handle this more correctly by rescheduling here.
-                return;
+            resultsDisplayDelegate?.Cancel();
 
             double delay = withDelay ? RESULTS_DISPLAY_DELAY : 0;
 


### PR DESCRIPTION
- Closes #20548 

Once the last storyboard event ends, `progressToResults(false)` is called, but will wait for player to complete. If a player pauses after that point, then the delegate will get cancelled *without* being set to null. Causing the second `progressToResults` call on player completion to get ignored and making player end up stuck indefinitely.

While I've fixed this by moving the cancellation to happen once an actual exit is performed, I've also replaced the early guard in `progressToResults` with a reschedule to ensure no such soft-lock could happen (that would also fix the transition having no delay if storyboard finishes before gameplay).