### PR TITLE
Fix potential crash when score submission token retrival fails

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -92,6 +92,11 @@ namespace osu.Game.Screens.Play
 
             void handleTokenFailure(Exception exception)
             {
+                // This method may be invoked multiple times due to the Task.Wait call above.
+                // We only really care about the first error.
+                if (!tcs.TrySetResult(false))
+                    return;
+
                 if (HandleTokenRetrievalFailure(exception))
                 {
                     if (string.IsNullOrEmpty(exception.Message))
@@ -111,8 +116,6 @@ namespace osu.Game.Screens.Play
                     // In the future, this should be visible to the user in some way.
                     Logger.Log($"Score submission token retrieval failed ({exception.Message})");
                 }
-
-                tcs.SetResult(false);
             }
         }
 

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Screens.Play
 
             req.Success += r =>
             {
+                Logger.Log($"Score submission token retrieved ({r.ID})");
                 token = r.ID;
                 tcs.SetResult(true);
             };
@@ -103,6 +104,12 @@ namespace osu.Game.Screens.Play
                         ValidForResume = false;
                         this.Exit();
                     });
+                }
+                else
+                {
+                    // Gameplay is allowed to continue, but we still should keep track of the error.
+                    // In the future, this should be visible to the user in some way.
+                    Logger.Log($"Score submission token retrieval failed ({exception.Message})");
                 }
 
                 tcs.SetResult(false);


### PR DESCRIPTION
Closes #20561.

Slightly different reason to what I originally thought. Explained inline.