### PR TITLE
Adjust leaderboard score panels sizing based on accuracy/combo width

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.928.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2022.1005.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -137,12 +137,13 @@ namespace osu.Desktop
         {
             base.SetHost(host);
 
-            var iconStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(GetType(), "lazer.ico");
-
             var desktopWindow = (SDL2DesktopWindow)host.Window;
 
+            var iconStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(GetType(), "lazer.ico");
+            if (iconStream != null)
+                desktopWindow.SetIconFromStream(iconStream);
+
             desktopWindow.CursorState |= CursorState.Hidden;
-            desktopWindow.SetIconFromStream(iconStream);
             desktopWindow.Title = Name;
             desktopWindow.DragDrop += f => fileDrop(new[] { f });
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSoloGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSoloGameplayLeaderboard.cs
@@ -66,7 +66,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddSliderStep("score", 0, 1000000, 500000, v => scoreProcessor.TotalScore.Value = v);
             AddSliderStep("accuracy", 0f, 1f, 0.5f, v => scoreProcessor.Accuracy.Value = v);
-            AddSliderStep("combo", 0, 1000, 0, v => scoreProcessor.HighestCombo.Value = v);
+            AddSliderStep("combo", 0, 10000, 0, v => scoreProcessor.HighestCombo.Value = v);
+            AddStep("toggle expanded", () => leaderboard.Expanded.Value = !leaderboard.Expanded.Value);
         }
 
         [Test]

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -335,8 +335,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private float? scoreComponentsTargetWidth;
 
-        // Schedule required to get correct DrawWidth from text after updates.
-        private void updateDetailsWidth() => SchedulerAfterChildren.AddOnce(() =>
+        private void updateDetailsWidth()
         {
             const float score_components_min_width = 88f;
 
@@ -349,7 +348,7 @@ namespace osu.Game.Screens.Play.HUD
 
             scoreComponentsTargetWidth = newWidth;
             scoreComponents.ResizeWidthTo(newWidth, panel_transition_duration, Easing.OutQuint);
-        });
+        }
 
         private void updateState()
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.15.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.928.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.1005.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
     <PackageReference Include="Sentry" Version="3.20.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.928.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.1005.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2022.831.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->
@@ -82,7 +82,7 @@
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="ppy.osu.Framework" Version="2022.928.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2022.1005.0" />
     <PackageReference Include="SharpCompress" Version="0.32.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/20536.

I didn't want to make this a hugely nested `GridContainer` inside `GridContainer` to automate this, so just a bit of manual logic instead. Should work out simpler in the long run.

https://user-images.githubusercontent.com/191335/193541766-339455e4-47a4-47d7-9ec3-029b076fa0be.mp4

