### PR TITLE
Attempt to fix deadlock in `TestSceneOnlinePlayBeatmapAvailabilityTracker`

### DIFF
--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -78,7 +77,7 @@ namespace osu.Game.Tests.Online
                 }
             };
 
-            beatmaps.AllowImport = new TaskCompletionSource<bool>();
+            beatmaps.AllowImport.Reset();
 
             testBeatmapFile = TestResources.GetQuickTestBeatmapForImport();
 
@@ -132,7 +131,7 @@ namespace osu.Game.Tests.Online
             AddStep("finish download", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet))!.TriggerSuccess(testBeatmapFile));
             addAvailabilityCheckStep("state importing", BeatmapAvailability.Importing);
 
-            AddStep("allow importing", () => beatmaps.AllowImport.SetResult(true));
+            AddStep("allow importing", () => beatmaps.AllowImport.Set());
             AddUntilStep("wait for import", () => beatmaps.CurrentImport != null);
             AddUntilStep("ensure beatmap available", () => beatmaps.IsAvailableLocally(testBeatmapSet));
             addAvailabilityCheckStep("state is locally available", BeatmapAvailability.LocallyAvailable);
@@ -141,7 +140,7 @@ namespace osu.Game.Tests.Online
         [Test]
         public void TestTrackerRespectsSoftDeleting()
         {
-            AddStep("allow importing", () => beatmaps.AllowImport.SetResult(true));
+            AddStep("allow importing", () => beatmaps.AllowImport.Set());
             AddStep("import beatmap", () => beatmaps.Import(testBeatmapFile).WaitSafely());
             addAvailabilityCheckStep("state locally available", BeatmapAvailability.LocallyAvailable);
 
@@ -155,7 +154,7 @@ namespace osu.Game.Tests.Online
         [Test]
         public void TestTrackerRespectsChecksum()
         {
-            AddStep("allow importing", () => beatmaps.AllowImport.SetResult(true));
+            AddStep("allow importing", () => beatmaps.AllowImport.Set());
             AddStep("import beatmap", () => beatmaps.Import(testBeatmapFile).WaitSafely());
             addAvailabilityCheckStep("initially locally available", BeatmapAvailability.LocallyAvailable);
 
@@ -202,7 +201,7 @@ namespace osu.Game.Tests.Online
 
         private class TestBeatmapManager : BeatmapManager
         {
-            public TaskCompletionSource<bool> AllowImport = new TaskCompletionSource<bool>();
+            public readonly ManualResetEventSlim AllowImport = new ManualResetEventSlim();
 
             public Live<BeatmapSetInfo> CurrentImport { get; private set; }
 
@@ -229,7 +228,9 @@ namespace osu.Game.Tests.Online
 
                 public override Live<BeatmapSetInfo> ImportModel(BeatmapSetInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default)
                 {
-                    testBeatmapManager.AllowImport.Task.WaitSafely();
+                    if (!testBeatmapManager.AllowImport.Wait(TimeSpan.FromSeconds(10), cancellationToken))
+                        throw new TimeoutException("Timeout waiting for import to be allowed.");
+
                     return (testBeatmapManager.CurrentImport = base.ImportModel(item, archive, batchImport, cancellationToken));
                 }
             }


### PR DESCRIPTION
[stack trace](https://github.com/ppy/osu/files/9703128/message.txt)

Refer to threads 10 & 27 in particular. I'm not sure how this one occurs - it shouldn't be possible since `SetResult(true)` is called in the step leading up to the call to `WaitSafely()`, but I don't trust the TCS usage in any case.

I've added a safeguard so the test will fail if it comes up again.