### PR TITLE
Compute lifetime start from entry for scrolling hit objects

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -54,10 +54,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             }
         }
 
-        protected override void UpdateInitialTransforms()
-        {
-        }
-
         protected override void UpdateStartTimeStateTransforms() => this.FadeOut(150);
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -30,14 +30,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public bool UpdateResult() => base.UpdateResult(true);
 
-        protected override void UpdateInitialTransforms()
-        {
-            base.UpdateInitialTransforms();
-
-            // This hitobject should never expire, so this is just a safe maximum.
-            LifetimeEnd = LifetimeStart + 30000;
-        }
-
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
             // suppress the base call explicitly.

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -23,10 +23,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected readonly IBindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
 
-        // Leaving the default (10s) makes hitobjects not appear, as this offset is used for the initial state transforms.
-        // Calculated as DrawableManiaRuleset.MAX_TIME_RANGE + some additional allowance for velocity < 1.
-        protected override double InitialLifetimeOffset => 30000;
-
         [Resolved(canBeNull: true)]
         private ManiaPlayfield playfield { get; set; }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScrollingHitObjects.cs
@@ -340,8 +340,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             protected override RectangleF GetConservativeBoundingBox(HitObjectLifetimeEntry entry)
             {
-                var hitObject = (TestHitObject)entry.HitObject;
-                return new RectangleF().Inflate(hitObject.Size / 2);
+                if (entry.HitObject is TestHitObject testObject)
+                    return new RectangleF().Inflate(testObject.Size / 2);
+
+                return base.GetConservativeBoundingBox(entry);
             }
         }
     }

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -251,8 +251,9 @@ namespace osu.Game.Rulesets.UI.Scrolling
             {
                 updateLayoutRecursive(obj);
 
-                // Nested hitobjects don't need to scroll, but they do need accurate positions
+                // Nested hitobjects don't need to scroll, but they do need accurate positions and start lifetime
                 updatePosition(obj, hitObject.HitObject.StartTime);
+                setComputedLifetimeStart(obj.Entry);
             }
         }
 

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.UI.Scrolling
         /// </summary>
         public virtual Vector2 ScreenSpacePositionAtTime(double time) => HitObjectContainer.ScreenSpacePositionAtTime(time);
 
-        protected sealed override HitObjectContainer CreateHitObjectContainer() => new ScrollingHitObjectContainer();
+        protected sealed override HitObjectContainer CreateHitObjectContainer() => CreateScrollingHitObjectContainer();
+
+        protected virtual ScrollingHitObjectContainer CreateScrollingHitObjectContainer() => new ScrollingHitObjectContainer();
     }
 }


### PR DESCRIPTION
Fix #16440