### PR TITLE
Add "argon" key area for osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -26,6 +26,7 @@ using osu.Game.Rulesets.Mania.Edit.Setup;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mania.Replays;
 using osu.Game.Rulesets.Mania.Scoring;
+using osu.Game.Rulesets.Mania.Skinning.Argon;
 using osu.Game.Rulesets.Mania.Skinning.Legacy;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
@@ -68,6 +69,9 @@ namespace osu.Game.Rulesets.Mania
             {
                 case LegacySkin:
                     return new ManiaLegacySkinTransformer(skin, beatmap);
+
+                case ArgonSkin:
+                    return new ManiaArgonSkinTransformer(skin);
             }
 
             return null;

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Mania.Skinning.Default;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Argon
+{
+    public class ArgonHitTarget : CompositeDrawable
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            Height = DefaultNotePiece.NOTE_HEIGHT;
+
+            InternalChildren = new[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.3f,
+                    Blending = BlendingParameters.Additive,
+                    Colour = Color4.White
+                },
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
@@ -2,18 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Mania.Skinning.Default;
+using osu.Game.Rulesets.UI.Scrolling;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Argon
 {
     public class ArgonHitTarget : CompositeDrawable
     {
+        private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(IScrollingInfo scrollingInfo)
         {
             RelativeSizeAxes = Axes.X;
             Height = DefaultNotePiece.NOTE_HEIGHT;
@@ -28,6 +32,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     Colour = Color4.White
                 },
             };
+
+            direction.BindTo(scrollingInfo.Direction);
+            direction.BindValueChanged(onDirectionChanged, true);
+        }
+
+        private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
+        {
+            Anchor = Origin = direction.NewValue == ScrollingDirection.Up ? Anchor.TopLeft : Anchor.BottomLeft;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
@@ -25,6 +26,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private Container directionContainer = null!;
         private Container keyIcon = null!;
         private Drawable background = null!;
+
+        private Circle hitTargetLine = null!;
 
         [Resolved]
         private Column column { get; set; } = null!;
@@ -61,6 +64,15 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                         Origin = Anchor.TopCentre,
                         Children = new[]
                         {
+                            hitTargetLine = new Circle()
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.Centre,
+                                Colour = OsuColour.Gray(196 / 255f),
+                                Height = 4,
+                                Masking = true,
+                            },
                             new Circle
                             {
                                 Y = icon_vertical_offset,
@@ -149,13 +161,18 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                 foreach (var circle in keyIcon.Children.OfType<CompositeDrawable>())
                 {
-                    circle.ScaleTo(0.9f, 50, Easing.OutQuint);
+                    if (circle != hitTargetLine)
+                        circle.ScaleTo(0.9f, 50, Easing.OutQuint);
 
                     circle.FadeColour(Color4.White, 50, Easing.OutQuint);
+
+                    // TODO: VERY TMPOERAOIRY.
+                    float f = circle == hitTargetLine ? 0.2f : (circle is Circle ? 0.05f : 0.2f);
+
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
-                        Colour = Color4.White.Opacity(circle is Circle ? 0.05f : 0.2f),
+                        Colour = Color4.White.Opacity(f),
                         Radius = 40,
                     }, 50, Easing.OutQuint);
                 }
@@ -175,7 +192,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     circle.ScaleTo(1f, 200, Easing.OutQuint);
 
                     // TODO: temp lol
-                    if (circle is Circle)
+                    if (circle == hitTargetLine)
+                    {
+                        circle.FadeColour(OsuColour.Gray(196 / 255f), 800, Easing.OutQuint);
+                    }
+                    else if (circle is Circle)
                         circle.FadeColour(column.AccentColour, 800, Easing.OutQuint);
 
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
@@ -1,11 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
@@ -20,13 +20,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 {
     public class ArgonKeyArea : CompositeDrawable, IKeyBindingHandler<ManiaAction>
     {
-        private const float key_icon_size = 10;
-
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
 
         private Container directionContainer = null!;
-        private Container<Circle> keyIcon = null!;
-        private Drawable gradient = null!;
+        private Container keyIcon = null!;
+        private Drawable background = null!;
 
         [Resolved]
         private Column column { get; set; } = null!;
@@ -40,8 +38,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private void load(IScrollingInfo scrollingInfo)
         {
             const float icon_circle_size = 8;
-            const float icon_spacing = 8;
-            const float icon_vertical_offset = 20;
+            const float icon_spacing = 7;
+            const float icon_vertical_offset = -30;
 
             InternalChild = directionContainer = new Container
             {
@@ -49,13 +47,13 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 Height = Stage.HIT_TARGET_POSITION,
                 Children = new[]
                 {
-                    gradient = new Box
+                    background = new Box
                     {
                         Name = "Key gradient",
                         RelativeSizeAxes = Axes.Both,
-                        Alpha = 0.5f
+                        Colour = column.AccentColour.Darken(0.6f),
                     },
-                    keyIcon = new Container<Circle>
+                    keyIcon = new Container
                     {
                         Name = "Icons",
                         RelativeSizeAxes = Axes.Both,
@@ -67,8 +65,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                             {
                                 Y = icon_vertical_offset,
                                 Size = new Vector2(icon_circle_size),
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.Centre,
                                 Blending = BlendingParameters.Additive,
                                 Colour = column.AccentColour,
                                 Masking = true,
@@ -78,8 +76,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                                 X = -icon_spacing,
                                 Y = icon_vertical_offset + icon_spacing * 1.2f,
                                 Size = new Vector2(icon_circle_size),
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.Centre,
                                 Blending = BlendingParameters.Additive,
                                 Colour = column.AccentColour,
                                 Masking = true,
@@ -89,11 +87,30 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                                 X = icon_spacing,
                                 Y = icon_vertical_offset + icon_spacing * 1.2f,
                                 Size = new Vector2(icon_circle_size),
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.Centre,
                                 Blending = BlendingParameters.Additive,
                                 Colour = column.AccentColour,
                                 Masking = true,
+                            },
+                            new CircularContainer
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.Centre,
+                                Y = -icon_vertical_offset,
+                                Size = new Vector2(22, 14),
+                                Masking = true,
+                                BorderThickness = 4,
+                                BorderColour = Color4.White,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0,
+                                        AlwaysPresent = true,
+                                    },
+                                },
                             }
                         }
                     },
@@ -112,14 +129,12 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     directionContainer.Scale = new Vector2(1, -1);
                     directionContainer.Anchor = Anchor.TopLeft;
                     directionContainer.Origin = Anchor.BottomLeft;
-                    gradient.Colour = ColourInfo.GradientVertical(Color4.Black, Color4.Black.Opacity(0));
                     break;
 
                 case ScrollingDirection.Down:
                     directionContainer.Scale = new Vector2(1, 1);
                     directionContainer.Anchor = Anchor.BottomLeft;
                     directionContainer.Origin = Anchor.BottomLeft;
-                    gradient.Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Color4.Black);
                     break;
             }
         }
@@ -128,7 +143,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         {
             if (e.Action == column.Action.Value)
             {
-                foreach (var circle in keyIcon.Children)
+                foreach (var circle in keyIcon.Children.OfType<CompositeDrawable>())
                 {
                     circle.ScaleTo(1.1f, 50, Easing.OutQuint);
 
@@ -136,8 +151,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
-                        Colour = Color4.White.Opacity(0.05f),
-                        Radius = 10,
+                        Colour = Color4.White.Opacity(circle is Circle ? 0.05f : 0.2f),
+                        Radius = 40,
                     }, 50, Easing.OutQuint);
                 }
             }
@@ -149,16 +164,19 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         {
             if (e.Action == column.Action.Value)
             {
-                foreach (var circle in keyIcon.Children)
+                foreach (var circle in keyIcon.Children.OfType<CompositeDrawable>())
                 {
                     circle.ScaleTo(1f, 125, Easing.OutQuint);
 
-                    circle.FadeColour(column.AccentColour, 200, Easing.OutQuint);
+                    // TODO: temp lol
+                    if (circle is Circle)
+                        circle.FadeColour(column.AccentColour, 200, Easing.OutQuint);
+
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
                         Colour = Color4.White.Opacity(0),
-                        Radius = 10,
+                        Radius = 30,
                     }, 200, Easing.OutQuint);
                 }
             }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
@@ -1,0 +1,167 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Argon
+{
+    public class ArgonKeyArea : CompositeDrawable, IKeyBindingHandler<ManiaAction>
+    {
+        private const float key_icon_size = 10;
+
+        private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
+
+        private Container directionContainer = null!;
+        private Container<Circle> keyIcon = null!;
+        private Drawable gradient = null!;
+
+        [Resolved]
+        private Column column { get; set; } = null!;
+
+        public ArgonKeyArea()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IScrollingInfo scrollingInfo)
+        {
+            const float icon_circle_size = 8;
+            const float icon_spacing = 8;
+            const float icon_vertical_offset = 20;
+
+            InternalChild = directionContainer = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = Stage.HIT_TARGET_POSITION,
+                Children = new[]
+                {
+                    gradient = new Box
+                    {
+                        Name = "Key gradient",
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.5f
+                    },
+                    keyIcon = new Container<Circle>
+                    {
+                        Name = "Icons",
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Children = new[]
+                        {
+                            new Circle
+                            {
+                                Y = icon_vertical_offset,
+                                Size = new Vector2(icon_circle_size),
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Blending = BlendingParameters.Additive,
+                                Colour = column.AccentColour,
+                                Masking = true,
+                            },
+                            new Circle
+                            {
+                                X = -icon_spacing,
+                                Y = icon_vertical_offset + icon_spacing * 1.2f,
+                                Size = new Vector2(icon_circle_size),
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Blending = BlendingParameters.Additive,
+                                Colour = column.AccentColour,
+                                Masking = true,
+                            },
+                            new Circle
+                            {
+                                X = icon_spacing,
+                                Y = icon_vertical_offset + icon_spacing * 1.2f,
+                                Size = new Vector2(icon_circle_size),
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Blending = BlendingParameters.Additive,
+                                Colour = column.AccentColour,
+                                Masking = true,
+                            }
+                        }
+                    },
+                }
+            };
+
+            direction.BindTo(scrollingInfo.Direction);
+            direction.BindValueChanged(onDirectionChanged, true);
+        }
+
+        private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
+        {
+            switch (direction.NewValue)
+            {
+                case ScrollingDirection.Up:
+                    directionContainer.Scale = new Vector2(1, -1);
+                    directionContainer.Anchor = Anchor.TopLeft;
+                    directionContainer.Origin = Anchor.BottomLeft;
+                    gradient.Colour = ColourInfo.GradientVertical(Color4.Black, Color4.Black.Opacity(0));
+                    break;
+
+                case ScrollingDirection.Down:
+                    directionContainer.Scale = new Vector2(1, 1);
+                    directionContainer.Anchor = Anchor.BottomLeft;
+                    directionContainer.Origin = Anchor.BottomLeft;
+                    gradient.Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Color4.Black);
+                    break;
+            }
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<ManiaAction> e)
+        {
+            if (e.Action == column.Action.Value)
+            {
+                foreach (var circle in keyIcon.Children)
+                {
+                    circle.ScaleTo(1.1f, 50, Easing.OutQuint);
+
+                    circle.FadeColour(Color4.White, 50, Easing.OutQuint);
+                    circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Colour = Color4.White.Opacity(0.05f),
+                        Radius = 10,
+                    }, 50, Easing.OutQuint);
+                }
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<ManiaAction> e)
+        {
+            if (e.Action == column.Action.Value)
+            {
+                foreach (var circle in keyIcon.Children)
+                {
+                    circle.ScaleTo(1f, 125, Easing.OutQuint);
+
+                    circle.FadeColour(column.AccentColour, 200, Easing.OutQuint);
+                    circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Colour = Color4.White.Opacity(0),
+                        Radius = 10,
+                    }, 200, Easing.OutQuint);
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonKeyArea.cs
@@ -143,9 +143,13 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         {
             if (e.Action == column.Action.Value)
             {
+                background
+                    .FadeColour(column.AccentColour.Lighten(0.3f), 50, Easing.OutQuint).Then()
+                    .FadeColour(column.AccentColour, 100, Easing.OutQuint);
+
                 foreach (var circle in keyIcon.Children.OfType<CompositeDrawable>())
                 {
-                    circle.ScaleTo(1.1f, 50, Easing.OutQuint);
+                    circle.ScaleTo(0.9f, 50, Easing.OutQuint);
 
                     circle.FadeColour(Color4.White, 50, Easing.OutQuint);
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
@@ -164,20 +168,22 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         {
             if (e.Action == column.Action.Value)
             {
+                background.FadeColour(column.AccentColour.Darken(0.6f), 800, Easing.OutQuint);
+
                 foreach (var circle in keyIcon.Children.OfType<CompositeDrawable>())
                 {
-                    circle.ScaleTo(1f, 125, Easing.OutQuint);
+                    circle.ScaleTo(1f, 200, Easing.OutQuint);
 
                     // TODO: temp lol
                     if (circle is Circle)
-                        circle.FadeColour(column.AccentColour, 200, Easing.OutQuint);
+                        circle.FadeColour(column.AccentColour, 800, Easing.OutQuint);
 
                     circle.TransformTo(nameof(EdgeEffect), new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
                         Colour = Color4.White.Opacity(0),
                         Radius = 30,
-                    }, 200, Easing.OutQuint);
+                    }, 800, Easing.OutQuint);
                 }
             }
         }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Argon
+{
+    public class ManiaArgonSkinTransformer : SkinTransformer
+    {
+        public ManiaArgonSkinTransformer(ISkin skin)
+            : base(skin)
+        {
+        }
+
+        public override Drawable? GetDrawableComponent(ISkinComponent component)
+        {
+            switch (component)
+            {
+                case ManiaSkinComponent maniaComponent:
+                    switch (maniaComponent.Component)
+                    {
+                        case ManiaSkinComponents.KeyArea:
+                            return new ArgonKeyArea();
+
+                        // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
+                    }
+
+                    break;
+            }
+
+            return base.GetDrawableComponent(component);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             switch (component)
             {
                 case ManiaSkinComponent maniaComponent:
+                    // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
                     switch (maniaComponent.Component)
                     {
                         case ManiaSkinComponents.HitTarget:
@@ -25,8 +26,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                         case ManiaSkinComponents.KeyArea:
                             return new ArgonKeyArea();
-
-                        // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
                     }
 
                     break;

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -20,6 +20,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 case ManiaSkinComponent maniaComponent:
                     switch (maniaComponent.Component)
                     {
+                        case ManiaSkinComponents.HitTarget:
+                            return new ArgonHitTarget();
+
                         case ManiaSkinComponents.KeyArea:
                             return new ArgonKeyArea();
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     return new ArgonJudgementPiece(resultComponent.Component);
 
                 case OsuSkinComponent osuComponent:
+                    // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
                     switch (osuComponent.Component)
                     {
                         case OsuSkinComponents.HitCircle:
@@ -56,8 +57,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         case OsuSkinComponents.CursorTrail:
                             return new ArgonCursorTrail();
-
-                        // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
                     }
 
                     break;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         case OsuSkinComponents.CursorTrail:
                             return new ArgonCursorTrail();
+
+                        // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.
                     }
 
                     break;


### PR DESCRIPTION
This lays the groundwork for the new design to be added in osu!mania.

Further tweaks will come to this visually. I originally intended to get more done before PRing, but there are some refactors that I need to perform before I can proceed with the rest of the skin. I want to get this merged to ease forward development.


https://user-images.githubusercontent.com/191335/193756514-290acce9-8bcb-437a-9247-0bd7e142737b.mp4

Of note

- The colours are the old default skins. Changing those is not simple. It will look better with better colours.
- There's an issue with the lighting being at an incorrect depth, causing it to be occluded at one side of each column by the next column. Will need to look at proxying this to a high level as a separate effort.
- I took a lot of liberty on the design. Not getting any feedback on issues I raised in a week so just moving forward with what I can figure out myself.
