### PR TITLE
Add osu! hit object dim

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
-using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Osu.Scoring;
 using osuTK;
 using osuTK.Graphics;
 
@@ -70,14 +70,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            double missWindow = HitObject.HitWindows.WindowFor(HitResult.Miss);
-
             // Of note, no one noticed this was missing for years, but it definitely feels like it should still exist.
             // For now this is applied across all skins, and matches stable.
             // For simplicity, dim colour is applied to the DrawableHitObject itself.
             // We may need to make a nested container setup if this even causes a usage conflict (ie. with a mod).
             this.FadeColour(new Color4(195, 195, 195, 255));
-            using (BeginDelayedSequence(InitialLifetimeOffset - missWindow))
+            using (BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
                 this.FadeColour(Color4.White, 100);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -11,7 +11,9 @@ using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -62,6 +64,21 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             PositionBindable.UnbindFrom(HitObject.PositionBindable);
             StackHeightBindable.UnbindFrom(HitObject.StackHeightBindable);
             ScaleBindable.UnbindFrom(HitObject.ScaleBindable);
+        }
+
+        protected override void UpdateInitialTransforms()
+        {
+            base.UpdateInitialTransforms();
+
+            double missWindow = HitObject.HitWindows.WindowFor(HitResult.Miss);
+
+            // Of note, no one noticed this was missing for years, but it definitely feels like it should still exist.
+            // For now this is applied across all skins, and matches stable.
+            // For simplicity, dim colour is applied to the DrawableHitObject itself.
+            // We may need to make a nested container setup if this even causes a usage conflict (ie. with a mod).
+            this.FadeColour(new Color4(195, 195, 195, 255));
+            using (BeginDelayedSequence(InitialLifetimeOffset - missWindow))
+                this.FadeColour(Color4.White, 100);
         }
 
         protected sealed override double InitialLifetimeOffset => HitObject.TimePreempt;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -70,13 +70,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            // Of note, no one noticed this was missing for years, but it definitely feels like it should still exist.
-            // For now this is applied across all skins, and matches stable.
-            // For simplicity, dim colour is applied to the DrawableHitObject itself.
-            // We may need to make a nested container setup if this even causes a usage conflict (ie. with a mod).
-            this.FadeColour(new Color4(195, 195, 195, 255));
-            using (BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
-                this.FadeColour(Color4.White, 100);
+            // Dim should only be applied at a top level, as it will be implicitly applied to nested objects.
+            if (ParentHitObject == null)
+            {
+                // Of note, no one noticed this was missing for years, but it definitely feels like it should still exist.
+                // For now this is applied across all skins, and matches stable.
+                // For simplicity, dim colour is applied to the DrawableHitObject itself.
+                // We may need to make a nested container setup if this even causes a usage conflict (ie. with a mod).
+                this.FadeColour(new Color4(195, 195, 195, 255));
+                using (BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
+                    this.FadeColour(Color4.White, 100);
+            }
         }
 
         protected sealed override double InitialLifetimeOffset => HitObject.TimePreempt;

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHitWindows.cs
@@ -1,20 +1,23 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
     public class OsuHitWindows : HitWindows
     {
+        /// <summary>
+        /// osu! ruleset has a fixed miss window regardless of difficulty settings.
+        /// </summary>
+        public const double MISS_WINDOW = 400;
+
         private static readonly DifficultyRange[] osu_ranges =
         {
             new DifficultyRange(HitResult.Great, 80, 50, 20),
             new DifficultyRange(HitResult.Ok, 140, 100, 60),
             new DifficultyRange(HitResult.Meh, 200, 150, 100),
-            new DifficultyRange(HitResult.Miss, 400, 400, 400),
+            new DifficultyRange(HitResult.Miss, MISS_WINDOW, MISS_WINDOW, MISS_WINDOW),
         };
 
         public override bool IsHitResultAllowed(HitResult result)


### PR DESCRIPTION
Stable would dim objects when they can't be hit (ie. the "miss" window is not active yet). This was never implemented in lazer, and causes quite large visual differences.

No one has mentioned this yet, but it will definitely be one of those missing pieces which makes lazer feel different to stable.

Before:

https://user-images.githubusercontent.com/191335/193773449-dd6196a3-8917-4265-a522-7cba2f27f9fb.mp4

After:

https://user-images.githubusercontent.com/191335/193772521-0de6bb75-b037-4417-96c2-2747c313a6fd.mp4


