### PR TITLE
Hide approach circles immediate on successful hit

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -204,12 +204,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             // todo: temporary / arbitrary, used for lifetime optimisation.
             this.Delay(800).FadeOut();
 
-            // in the case of an early state change, the fade should be expedited to the current point in time.
-            if (HitStateUpdateTime < HitObject.StartTime)
-                ApproachCircle.FadeOut(50);
-
             switch (state)
             {
+                default:
+                    ApproachCircle.FadeOut();
+                    break;
+
                 case ArmedState.Idle:
                     HitArea.HitAction = null;
                     break;


### PR DESCRIPTION
Something was bugging me about argon while testing with actual gameplay recently. Something about the animation made it feel like I wasn't in control. Turns out it was the fact that the approach circle stays visible for 50ms after a hit. This is less noticeable on classic/triangles skins, but an especially uneasy feeling on argon where the hitcircle is scaled inwards at the same time.

Note that as it's only a 50ms fade, this is much more noticeable at >60hz and may not show in the videos below very well.

This matches osu-stable behaviour.

Before:

https://user-images.githubusercontent.com/191335/193983207-a5324880-8944-42ad-aecf-f8205289342f.mp4

After:

https://user-images.githubusercontent.com/191335/193983121-42864603-0fbc-41b6-90ef-cc1fa6f74a13.mp4

