### PR TITLE
Use hit object time for timeline drag selection instead of relying on blueprint

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -29,16 +29,18 @@ namespace osu.Game.Tests.Visual.Editing
         private TimelineBlueprintContainer blueprintContainer
             => Editor.ChildrenOfType<TimelineBlueprintContainer>().First();
 
+        private Vector2 getPosition(HitObject hitObject) =>
+            blueprintContainer.SelectionBlueprints.First(s => s.Item == hitObject).ScreenSpaceDrawQuad.Centre;
+
+        private Vector2 getMiddlePosition(HitObject hitObject1, HitObject hitObject2) =>
+            (getPosition(hitObject1) + getPosition(hitObject2)) / 2;
+
         private void moveMouseToObject(Func<HitObject> targetFunc)
         {
             AddStep("move mouse to object", () =>
             {
-                var pos = blueprintContainer.SelectionBlueprints
-                                            .First(s => s.Item == targetFunc())
-                                            .ChildrenOfType<TimelineHitObjectBlueprint>()
-                                            .First().ScreenSpaceDrawQuad.Centre;
-
-                InputManager.MoveMouseTo(pos);
+                var hitObject = targetFunc();
+                InputManager.MoveMouseTo(getPosition(hitObject));
             });
         }
 
@@ -260,6 +262,55 @@ namespace osu.Game.Tests.Visual.Editing
             assertSelectionIs(addedObjects.Skip(1));
 
             AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
+        }
+
+        [Test]
+        public void TestBasicDragSelection()
+        {
+            var addedObjects = new[]
+            {
+                new HitCircle { StartTime = 0 },
+                new HitCircle { StartTime = 500, Position = new Vector2(100) },
+                new HitCircle { StartTime = 1000, Position = new Vector2(200) },
+                new HitCircle { StartTime = 1500, Position = new Vector2(300) },
+            };
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(getMiddlePosition(addedObjects[0], addedObjects[1])));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("drag to select", () => InputManager.MoveMouseTo(getMiddlePosition(addedObjects[2], addedObjects[3])));
+            assertSelectionIs(new[] { addedObjects[1], addedObjects[2] });
+
+            AddStep("drag to deselect", () => InputManager.MoveMouseTo(getMiddlePosition(addedObjects[1], addedObjects[2])));
+            assertSelectionIs(new[] { addedObjects[1] });
+
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+            assertSelectionIs(new[] { addedObjects[1] });
+        }
+
+        [Test]
+        public void TestFastDragSelection()
+        {
+            var addedObjects = new[]
+            {
+                new HitCircle { StartTime = 0 },
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 20000, Position = new Vector2(100) },
+                new HitCircle { StartTime = 31000, Position = new Vector2(200) },
+                new HitCircle { StartTime = 60000, Position = new Vector2(300) },
+            };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(getMiddlePosition(addedObjects[0], addedObjects[1])));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("start drag", () => InputManager.MoveMouseTo(getPosition(addedObjects[1])));
+
+            AddStep("jump editor clock", () => EditorClock.Seek(30000));
+            AddStep("jump editor clock", () => EditorClock.Seek(60000));
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+            assertSelectionIs(addedObjects.Skip(1));
         }
 
         private void assertSelectionIs(IEnumerable<HitObject> hitObjects)

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -311,6 +311,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("jump editor clock", () => EditorClock.Seek(60000));
             AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
             assertSelectionIs(addedObjects.Skip(1));
+            AddAssert("all blueprints are present", () => blueprintContainer.SelectionBlueprints.Count == EditorBeatmap.SelectedHitObjects.Count);
         }
 
         private void assertSelectionIs(IEnumerable<HitObject> hitObjects)

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -58,13 +58,19 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 {
                     case NotifyCollectionChangedAction.Add:
                         foreach (object o in args.NewItems)
-                            SelectionBlueprints.FirstOrDefault(b => b.Item == o)?.Select();
+                        {
+                            if (blueprintMap.TryGetValue((T)o, out var blueprint))
+                                blueprint.Select();
+                        }
 
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
                         foreach (object o in args.OldItems)
-                            SelectionBlueprints.FirstOrDefault(b => b.Item == o)?.Deselect();
+                        {
+                            if (blueprintMap.TryGetValue((T)o, out var blueprint))
+                                blueprint.Deselect();
+                        }
 
                         break;
                 }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
 
             SelectionHandler = CreateSelectionHandler();
-            SelectionHandler.DeselectAll = deselectAll;
+            SelectionHandler.DeselectAll = DeselectAll;
             SelectionHandler.SelectedItems.BindTo(SelectedItems);
 
             AddRangeInternal(new[]
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (endClickSelection(e) || ClickedBlueprint != null)
                 return true;
 
-            deselectAll();
+            DeselectAll();
             return true;
         }
 
@@ -234,7 +234,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     if (!SelectionHandler.SelectedBlueprints.Any())
                         return false;
 
-                    deselectAll();
+                    DeselectAll();
                     return true;
             }
 
@@ -399,18 +399,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
-        /// Selects all <see cref="SelectionBlueprint{T}"/>s.
+        /// Select all currently-present items.
         /// </summary>
-        protected virtual void SelectAll()
-        {
-            // Scheduled to allow the change in lifetime to take place.
-            Schedule(() => SelectionBlueprints.ToList().ForEach(m => m.Select()));
-        }
+        protected abstract void SelectAll();
 
         /// <summary>
-        /// Deselects all selected <see cref="SelectionBlueprint{T}"/>s.
+        /// Deselect all selected items.
         /// </summary>
-        private void deselectAll() => SelectionHandler.SelectedBlueprints.ToList().ForEach(m => m.Deselect());
+        protected void DeselectAll() => SelectedItems.Clear();
 
         protected virtual void OnBlueprintSelected(SelectionBlueprint<T> blueprint)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -13,11 +12,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osuTK;
 using osuTK.Input;
@@ -79,7 +76,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             AddRangeInternal(new[]
             {
-                DragBox = CreateDragBox(selectBlueprintsFromDragRectangle),
+                DragBox = CreateDragBox(),
                 SelectionHandler,
                 SelectionBlueprints = CreateSelectionBlueprintContainer(),
                 SelectionHandler.CreateProxy(),
@@ -101,7 +98,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [CanBeNull]
         protected virtual SelectionBlueprint<T> CreateBlueprintFor(T item) => null;
 
-        protected virtual DragBox CreateDragBox(Action<RectangleF> performSelect) => new DragBox(performSelect);
+        protected virtual DragBox CreateDragBox() => new DragBox();
 
         /// <summary>
         /// Whether this component is in a state where items outside a drag selection should be deselected. If false, selection will only be added to.
@@ -183,13 +180,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return true;
             }
 
-            if (DragBox.HandleDrag(e))
-            {
-                DragBox.Show();
-                return true;
-            }
-
-            return false;
+            DragBox.HandleDrag(e);
+            DragBox.Show();
+            return true;
         }
 
         protected override void OnDrag(DragEvent e)
@@ -198,7 +191,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return;
 
             if (DragBox.State == Visibility.Visible)
+            {
                 DragBox.HandleDrag(e);
+                UpdateSelectionFromDragBox();
+            }
 
             moveCurrentSelection(e);
         }
@@ -214,8 +210,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 changeHandler?.EndChange();
             }
 
-            if (DragBox.State == Visibility.Visible)
-                DragBox.Hide();
+            DragBox.Hide();
         }
 
         /// <summary>
@@ -380,28 +375,20 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
-        /// Select all masks in a given rectangle selection area.
+        /// Select all blueprints in a selection area specified by <see cref="DragBox"/>.
         /// </summary>
-        /// <param name="rect">The rectangle to perform a selection on in screen-space coordinates.</param>
-        private void selectBlueprintsFromDragRectangle(RectangleF rect)
+        protected virtual void UpdateSelectionFromDragBox()
         {
+            var quad = DragBox.Box.ScreenSpaceDrawQuad;
+
             foreach (var blueprint in SelectionBlueprints)
             {
-                // only run when utmost necessary to avoid unnecessary rect computations.
-                bool isValidForSelection() => blueprint.IsAlive && blueprint.IsPresent && rect.Contains(blueprint.ScreenSpaceSelectionPoint);
+                if (blueprint.IsSelected && !AllowDeselectionDuringDrag)
+                    continue;
 
-                switch (blueprint.State)
-                {
-                    case SelectionState.NotSelected:
-                        if (isValidForSelection())
-                            blueprint.Select();
-                        break;
-
-                    case SelectionState.Selected:
-                        if (AllowDeselectionDuringDrag && !isValidForSelection())
-                            blueprint.Deselect();
-                        break;
-                }
+                bool shouldBeSelected = blueprint.IsAlive && blueprint.IsPresent && quad.Contains(blueprint.ScreenSpaceSelectionPoint);
+                if (blueprint.IsSelected != shouldBeSelected)
+                    blueprint.ToggleSelection();
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -83,6 +83,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
+        protected override bool AllowDeselectionDuringDrag => !EditorClock.IsRunning;
+
         protected override void TransferBlueprintFor(HitObject hitObject, DrawableHitObject drawableObject)
         {
             base.TransferBlueprintFor(hitObject, drawableObject);

--- a/osu.Game/Screens/Edit/Compose/Components/DragBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DragBox.cs
@@ -8,7 +8,6 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
@@ -21,18 +20,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// </summary>
     public class DragBox : CompositeDrawable, IStateful<Visibility>
     {
-        protected readonly Action<RectangleF> PerformSelection;
-
-        protected Drawable Box;
+        public Drawable Box { get; private set; }
 
         /// <summary>
         /// Creates a new <see cref="DragBox"/>.
         /// </summary>
-        /// <param name="performSelection">A delegate that performs drag selection.</param>
-        public DragBox(Action<RectangleF> performSelection)
+        public DragBox()
         {
-            PerformSelection = performSelection;
-
             RelativeSizeAxes = Axes.Both;
             AlwaysPresent = true;
             Alpha = 0;
@@ -46,30 +40,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected virtual Drawable CreateBox() => new BoxWithBorders();
 
-        private RectangleF? dragRectangle;
-
         /// <summary>
         /// Handle a forwarded mouse event.
         /// </summary>
         /// <param name="e">The mouse event.</param>
-        /// <returns>Whether the event should be handled and blocking.</returns>
-        public virtual bool HandleDrag(MouseButtonEvent e)
+        public virtual void HandleDrag(MouseButtonEvent e)
         {
-            var dragPosition = e.ScreenSpaceMousePosition;
-            var dragStartPosition = e.ScreenSpaceMouseDownPosition;
-
-            var dragQuad = new Quad(dragStartPosition.X, dragStartPosition.Y, dragPosition.X - dragStartPosition.X, dragPosition.Y - dragStartPosition.Y);
-
-            // We use AABBFloat instead of RectangleF since it handles negative sizes for us
-            var rec = dragQuad.AABBFloat;
-            dragRectangle = rec;
-
-            var topLeft = ToLocalSpace(rec.TopLeft);
-            var bottomRight = ToLocalSpace(rec.BottomRight);
-
-            Box.Position = topLeft;
-            Box.Size = bottomRight - topLeft;
-            return true;
+            Box.Position = Vector2.ComponentMin(e.MouseDownPosition, e.MousePosition);
+            Box.Size = Vector2.ComponentMax(e.MouseDownPosition, e.MousePosition) - Box.Position;
         }
 
         private Visibility state;
@@ -87,19 +65,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            if (dragRectangle != null)
-                PerformSelection?.Invoke(dragRectangle.Value);
-        }
-
-        public override void Hide()
-        {
-            State = Visibility.Hidden;
-            dragRectangle = null;
-        }
+        public override void Hide() => State = Visibility.Hidden;
 
         public override void Show() => State = Visibility.Visible;
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -66,8 +66,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override IEnumerable<SelectionBlueprint<HitObject>> SortForMovement(IReadOnlyList<SelectionBlueprint<HitObject>> blueprints)
             => blueprints.OrderBy(b => b.Item.StartTime);
 
-        protected override bool AllowDeselectionDuringDrag => !EditorClock.IsRunning;
-
         protected override bool ApplySnapResult(SelectionBlueprint<HitObject>[] blueprints, SnapResult result)
         {
             if (!base.ApplySnapResult(blueprints, result))

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -131,8 +131,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override void SelectAll()
         {
             Composer.Playfield.KeepAllAlive();
-            SelectedItems.Clear();
-            SelectedItems.AddRange(Beatmap.HitObjects);
+            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).ToArray());
         }
 
         protected override void OnBlueprintSelected(SelectionBlueprint<HitObject> blueprint)

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -131,8 +131,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override void SelectAll()
         {
             Composer.Playfield.KeepAllAlive();
-
-            base.SelectAll();
+            SelectedItems.Clear();
+            SelectedItems.AddRange(Beatmap.HitObjects);
         }
 
         protected override void OnBlueprintSelected(SelectionBlueprint<HitObject> blueprint)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -305,7 +305,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected void DeleteSelected()
         {
-            DeleteItems(selectedBlueprints.Select(b => b.Item));
+            DeleteItems(SelectedItems.ToArray());
         }
 
         #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -304,10 +304,20 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         public double VisibleRange => editorClock.TrackLength / Zoom;
 
-        public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All) =>
-            new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(getTimeFromPosition(Content.ToLocalSpace(screenSpacePosition))));
+        public double TimeAtPosition(float x)
+        {
+            return x / Content.DrawWidth * editorClock.TrackLength;
+        }
 
-        private double getTimeFromPosition(Vector2 localPosition) =>
-            (localPosition.X / Content.DrawWidth) * editorClock.TrackLength;
+        public float PositionAtTime(double time)
+        {
+            return (float)(time / editorClock.TrackLength * Content.DrawWidth);
+        }
+
+        public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
+        {
+            double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);
+            return new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(time));
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -185,7 +185,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             SelectedItems.RemoveAll(hitObject => !shouldBeSelected(hitObject));
             SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected));
 
-            bool shouldBeSelected(HitObject hitObject) => minTime <= hitObject.StartTime && hitObject.StartTime <= maxTime;
+            bool shouldBeSelected(HitObject hitObject)
+            {
+                double midTime = (hitObject.StartTime + hitObject.GetEndTime()) / 2;
+                return minTime <= midTime && midTime <= maxTime;
+            }
         }
 
         private void handleScrollViaDrag(DragEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -184,7 +183,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             double maxTime = dragBox.MaxTime;
 
             SelectedItems.RemoveAll(hitObject => !shouldBeSelected(hitObject));
-            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).Where(hitObject => shouldBeSelected(hitObject)));
+            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected));
 
             bool shouldBeSelected(HitObject hitObject) => minTime <= hitObject.StartTime && hitObject.StartTime <= maxTime;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -182,21 +182,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             var dragBox = (TimelineDragBox)DragBox;
             double minTime = dragBox.MinTime;
             double maxTime = dragBox.MaxTime;
-            Console.WriteLine($"{minTime}, {maxTime}");
 
-            // TODO: performance
-            foreach (var hitObject in Beatmap.HitObjects)
-            {
-                bool shouldBeSelected = minTime <= hitObject.StartTime && hitObject.StartTime <= maxTime;
-                bool isSelected = SelectedItems.Contains(hitObject);
-                if (isSelected != shouldBeSelected)
-                {
-                    if (!isSelected)
-                        SelectedItems.Add(hitObject);
-                    else
-                        SelectedItems.Remove(hitObject);
-                }
-            }
+            SelectedItems.RemoveAll(hitObject => !shouldBeSelected(hitObject));
+            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).Where(hitObject => shouldBeSelected(hitObject)));
+
+            bool shouldBeSelected(HitObject hitObject) => minTime <= hitObject.StartTime && hitObject.StartTime <= maxTime;
         }
 
         private void handleScrollViaDrag(DragEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -183,7 +183,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             double maxTime = dragBox.MaxTime;
 
             SelectedItems.RemoveAll(hitObject => !shouldBeSelected(hitObject));
-            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected));
+
+            foreach (var hitObject in Beatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected))
+            {
+                Composer.Playfield.SetKeepAlive(hitObject, true);
+                SelectedItems.Add(hitObject);
+            }
 
             bool shouldBeSelected(HitObject hitObject)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -175,7 +175,29 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             };
         }
 
-        protected override DragBox CreateDragBox() => new TimelineDragBox();
+        protected sealed override DragBox CreateDragBox() => new TimelineDragBox();
+
+        protected override void UpdateSelectionFromDragBox()
+        {
+            var dragBox = (TimelineDragBox)DragBox;
+            double minTime = dragBox.MinTime;
+            double maxTime = dragBox.MaxTime;
+            Console.WriteLine($"{minTime}, {maxTime}");
+
+            // TODO: performance
+            foreach (var hitObject in Beatmap.HitObjects)
+            {
+                bool shouldBeSelected = minTime <= hitObject.StartTime && hitObject.StartTime <= maxTime;
+                bool isSelected = SelectedItems.Contains(hitObject);
+                if (isSelected != shouldBeSelected)
+                {
+                    if (!isSelected)
+                        SelectedItems.Add(hitObject);
+                    else
+                        SelectedItems.Remove(hitObject);
+                }
+            }
+        }
 
         private void handleScrollViaDrag(DragEvent e)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -13,7 +13,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
@@ -65,7 +64,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            DragBox.Alpha = 0;
 
             placement = Beatmap.PlacementObject.GetBoundCopy();
             placement.ValueChanged += placementChanged;
@@ -92,6 +90,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         protected override Container<SelectionBlueprint<HitObject>> CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            if (!base.ReceivePositionalInputAt(e.ScreenSpaceMouseDownPosition))
+                return false;
+
+            return base.OnDragStart(e);
+        }
 
         protected override void OnDrag(DragEvent e)
         {
@@ -169,7 +175,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             };
         }
 
-        protected override DragBox CreateDragBox(Action<RectangleF> performSelect) => new TimelineDragBox(performSelect);
+        protected override DragBox CreateDragBox() => new TimelineDragBox();
 
         private void handleScrollViaDrag(DragEvent e)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
@@ -6,7 +6,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
@@ -24,24 +23,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private Timeline timeline { get; set; }
 
-        public TimelineDragBox(Action<RectangleF> performSelect)
-            : base(performSelect)
-        {
-        }
-
         protected override Drawable CreateBox() => new Box
         {
             RelativeSizeAxes = Axes.Y,
             Alpha = 0.3f
         };
 
-        public override bool HandleDrag(MouseButtonEvent e)
+        public override void HandleDrag(MouseButtonEvent e)
         {
-            // The dragbox should only be active if the mouseDownPosition.Y is within this drawable's bounds.
-            float localY = ToLocalSpace(e.ScreenSpaceMouseDownPosition).Y;
-            if (DrawRectangle.Top > localY || DrawRectangle.Bottom < localY)
-                return false;
-
             selectionStart ??= e.MouseDownPosition.X / timeline.CurrentZoom;
 
             // only calculate end when a transition is not in progress to avoid bouncing.
@@ -49,7 +38,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 selectionEnd = e.MousePosition.X / timeline.CurrentZoom;
 
             updateDragBoxPosition();
-            return true;
         }
 
         private void updateDragBoxPosition()
@@ -68,8 +56,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             // we don't care about where the hitobjects are vertically. in cases like stacking display, they may be outside the box without this adjustment.
             boxScreenRect.Y -= boxScreenRect.Height;
             boxScreenRect.Height *= 2;
-
-            PerformSelection?.Invoke(boxScreenRect);
         }
 
         public override void Hide()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineDragBox.cs
@@ -8,19 +8,16 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Utils;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public class TimelineDragBox : DragBox
     {
-        public double MinTime => Math.Min(startTime.Value, endTime);
+        public double MinTime { get; private set; }
 
-        public double MaxTime => Math.Max(startTime.Value, endTime);
+        public double MaxTime { get; private set; }
 
         private double? startTime;
-
-        private double endTime;
 
         [Resolved]
         private Timeline timeline { get; set; }
@@ -34,7 +31,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public override void HandleDrag(MouseButtonEvent e)
         {
             startTime ??= timeline.TimeAtPosition(e.MouseDownPosition.X);
-            endTime = timeline.TimeAtPosition(e.MousePosition.X);
+            double endTime = timeline.TimeAtPosition(e.MousePosition.X);
+
+            MinTime = Math.Min(startTime.Value, endTime);
+            MaxTime = Math.Max(startTime.Value, endTime);
 
             Box.X = timeline.PositionAtTime(MinTime);
             Box.Width = timeline.PositionAtTime(MaxTime) - Box.X;

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -352,6 +352,8 @@ namespace osu.Game.Screens.Edit
             var updates = batchPendingUpdates.ToArray();
             batchPendingUpdates.Clear();
 
+            foreach (var h in deletes) SelectedHitObjects.Remove(h);
+
             foreach (var h in deletes) HitObjectRemoved?.Invoke(h);
             foreach (var h in inserts) HitObjectAdded?.Invoke(h);
             foreach (var h in updates) HitObjectUpdated?.Invoke(h);

--- a/osu.Game/Skinning/Editor/SkinBlueprintContainer.cs
+++ b/osu.Game/Skinning/Editor/SkinBlueprintContainer.cs
@@ -119,8 +119,7 @@ namespace osu.Game.Skinning.Editor
 
         protected override void SelectAll()
         {
-            SelectedItems.Clear();
-            SelectedItems.AddRange(targetComponents.SelectMany(list => list));
+            SelectedItems.AddRange(targetComponents.SelectMany(list => list).Except(SelectedItems).ToArray());
         }
 
         /// <summary>

--- a/osu.Game/Skinning/Editor/SkinBlueprintContainer.cs
+++ b/osu.Game/Skinning/Editor/SkinBlueprintContainer.cs
@@ -117,6 +117,12 @@ namespace osu.Game.Skinning.Editor
             return false;
         }
 
+        protected override void SelectAll()
+        {
+            SelectedItems.Clear();
+            SelectedItems.AddRange(targetComponents.SelectMany(list => list));
+        }
+
         /// <summary>
         /// Move the current selection spatially by the specified delta, in screen coordinates (ie. the same coordinates as the blueprints).
         /// </summary>


### PR DESCRIPTION
- Fix #16410
- FIx #20279

`AllowDeselectionDuringDrag` behavior (not deselecting while clock is running) is removed for timeline.
Note that selecting a large number of hit objects is still very slow (#17712?), because all DHOs must be added and also `AddBlueprintFor` has quadratic behaviors.
