### PR TITLE
Allow arbitrary height catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfieldAdjustmentContainer.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    public class CatchEditorPlayfieldAdjustmentContainer : PlayfieldAdjustmentContainer
+    {
+        protected override Container<Drawable> Content => content;
+        private readonly Container content;
+
+        public CatchEditorPlayfieldAdjustmentContainer()
+        {
+            Anchor = Anchor.TopCentre;
+            Origin = Anchor.TopCentre;
+            Size = new Vector2(0.8f, 0.9f);
+
+            InternalChild = new ScalingContainer
+            {
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                Child = content = new Container { RelativeSizeAxes = Axes.Both },
+            };
+        }
+
+        private class ScalingContainer : Container
+        {
+            public ScalingContainer()
+            {
+                RelativeSizeAxes = Axes.Y;
+                Width = CatchPlayfield.WIDTH;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                Scale = new Vector2(Math.Min(Parent.ChildSize.X / CatchPlayfield.WIDTH, Parent.ChildSize.Y / CatchPlayfield.HEIGHT));
+                Height = 1 / Scale.Y;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -51,7 +51,10 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             LayerBelowRuleset.Add(new PlayfieldBorder
             {
-                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.X,
+                Height = CatchPlayfield.HEIGHT,
                 PlayfieldBorderStyle = { Value = PlayfieldBorderStyle.Corners }
             });
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -12,8 +12,10 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
+using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Edit;
@@ -36,6 +38,12 @@ namespace osu.Game.Rulesets.Catch.Edit
         private readonly Bindable<TernaryState> distanceSnapToggle = new Bindable<TernaryState>();
 
         private InputManager inputManager;
+
+        private readonly BindableDouble timeRangeMultiplier = new BindableDouble(1)
+        {
+            MinValue = 1,
+            MaxValue = 10,
+        };
 
         public CatchHitObjectComposer(CatchRuleset ruleset)
             : base(ruleset)
@@ -80,8 +88,27 @@ namespace osu.Game.Rulesets.Catch.Edit
             updateDistanceSnapGrid();
         }
 
+        public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.IncreaseScrollSpeed:
+                    this.TransformBindableTo(timeRangeMultiplier, timeRangeMultiplier.Value - 1, 200, Easing.OutQuint);
+                    break;
+
+                case GlobalAction.DecreaseScrollSpeed:
+                    this.TransformBindableTo(timeRangeMultiplier, timeRangeMultiplier.Value + 1, 200, Easing.OutQuint);
+                    break;
+            }
+
+            return base.OnPressed(e);
+        }
+
         protected override DrawableRuleset<CatchHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null) =>
-            new DrawableCatchEditorRuleset(ruleset, beatmap, mods);
+            new DrawableCatchEditorRuleset(ruleset, beatmap, mods)
+            {
+                TimeRangeMultiplier = { BindTarget = timeRangeMultiplier, }
+            };
 
         protected override IReadOnlyList<HitObjectCompositionTool> CompositionTools => new HitObjectCompositionTool[]
         {

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -92,6 +92,9 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
             switch (e.Action)
             {
+                // Note that right now these are hard to use as the default key bindings conflict with existing editor key bindings.
+                // In the future we will want to expose this via UI and potentially change the key bindings to be editor-specific.
+                // May be worth considering standardising "zoom" behaviour with what the timeline uses (ie. alt-wheel) but that may cause new conflicts.
                 case GlobalAction.IncreaseScrollSpeed:
                     this.TransformBindableTo(timeRangeMultiplier, timeRangeMultiplier.Value - 1, 200, Easing.OutQuint);
                     break;

--- a/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
+++ b/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
@@ -18,6 +18,16 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            double gamePlayTimeRange = GetTimeRange(Beatmap.Difficulty.ApproachRate);
+            TimeRange.Value = gamePlayTimeRange * (Playfield.DrawHeight / CatchPlayfield.HEIGHT);
+        }
+
         protected override Playfield CreatePlayfield() => new CatchEditorPlayfield(Beatmap.Difficulty);
+
+        public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new CatchEditorPlayfieldAdjustmentContainer();
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
+++ b/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
@@ -13,6 +14,8 @@ namespace osu.Game.Rulesets.Catch.Edit
 {
     public class DrawableCatchEditorRuleset : DrawableCatchRuleset
     {
+        public readonly BindableDouble TimeRangeMultiplier = new BindableDouble(1);
+
         public DrawableCatchEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
             : base(ruleset, beatmap, mods)
         {
@@ -23,7 +26,8 @@ namespace osu.Game.Rulesets.Catch.Edit
             base.Update();
 
             double gamePlayTimeRange = GetTimeRange(Beatmap.Difficulty.ApproachRate);
-            TimeRange.Value = gamePlayTimeRange * (Playfield.DrawHeight / CatchPlayfield.HEIGHT);
+            float playfieldStretch = Playfield.DrawHeight / CatchPlayfield.HEIGHT;
+            TimeRange.Value = gamePlayTimeRange * TimeRangeMultiplier.Value * playfieldStretch;
         }
 
         protected override Playfield CreatePlayfield() => new CatchEditorPlayfield(Beatmap.Difficulty);

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -24,6 +24,12 @@ namespace osu.Game.Rulesets.Catch.UI
         public const float WIDTH = 512;
 
         /// <summary>
+        /// The height of the playfield.
+        /// This doesn't include the catcher area.
+        /// </summary>
+        public const float HEIGHT = 384;
+
+        /// <summary>
         /// The center position of the playfield.
         /// </summary>
         public const float CENTER_X = WIDTH / 2;

--- a/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/UI/DrawableCatchRuleset.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Catch.UI
             : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Down;
-            TimeRange.Value = IBeatmapDifficultyInfo.DifficultyRange(beatmap.Difficulty.ApproachRate, 1800, 1200, 450);
+            TimeRange.Value = GetTimeRange(beatmap.Difficulty.ApproachRate);
         }
 
         [BackgroundDependencyLoader]
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             KeyBindingInputManager.Add(new CatchTouchInputMapper());
         }
+
+        protected double GetTimeRange(float approachRate) => IBeatmapDifficultyInfo.DifficultyRange(approachRate, 1800, 1200, 450);
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new CatchFramedReplayInputHandler(replay);
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             switch (e.Action)
             {
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Edit
             return false;
         }
 
-        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        public virtual void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
         }
 


### PR DESCRIPTION
With a tall window size, one can see more fruits at once.

Also [allow changing scrolling speed in catch editor](https://github.com/ppy/osu/commit/9247ff3e0a0e66248ca489b99eb3115cd8bd7da9).
Scroll speed is not saved (this is todo: probably should be like other editor settings?) and doesn't affect gameplay. It is purely a feature for a better visualization.
It is currently bind to scroll speed increase/decrease and default F3/F4 crashes with editor shortcuts so it has to be changed.