### PR TITLE
Fix mania hold note head disappears

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteHead.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             // the hold note head should never change its visual state on its own due to the "freezing" mechanic
             // (when hit, it remains visible in place at the judgement line; when dropped, it will scroll past the line).
             // it will be hidden along with its parenting hold note when required.
+
+            // Set `LifetimeEnd` explicitly to a non-`double.MaxValue` because otherwise this DHO is automatically expired.
+            LifetimeEnd = double.PositiveInfinity;
         }
 
         public override bool OnPressed(KeyBindingPressEvent<ManiaAction> e) => false; // Handled by the hold note


### PR DESCRIPTION
Regressed by #20570 (<https://github.com/ppy/osu/pull/20570#issuecomment-1269741388>) (cause: <https://github.com/ppy/osu/pull/20570/files#diff-c6b2eaa417fa18db1503562b54b23f49e93f03d65bf2265c2a03d1a823be9f99L37-L38>).
I used `Infinity` instead of previous arbitrary 30 seconds because that is broken for a very long note.