### PR TITLE
Fix language settings dropdown not updating when changing language in first run setup

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -44,9 +44,12 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 },
             };
 
-            if (!LanguageExtensions.TryParseCultureCode(frameworkLocale.Value, out var locale))
-                locale = Language.en;
-            languageSelection.Current.Value = locale;
+            frameworkLocale.BindValueChanged(locale =>
+            {
+                if (!LanguageExtensions.TryParseCultureCode(locale.NewValue, out var language))
+                    language = Language.en;
+                languageSelection.Current.Value = language;
+            }, true);
 
             languageSelection.Current.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
         }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![osu!_Upl7N6Yjcr](https://user-images.githubusercontent.com/35318437/194466923-993144c4-5ce1-48e1-9354-a6409ff97212.gif) | ![osu!_htLqHa06ar](https://user-images.githubusercontent.com/35318437/194466597-6a44dc5d-55dd-4db5-a111-3c4f53b18a11.gif) |