### PR TITLE
Fix osu!mania key / stage lighting / explosions not working well with rewind

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Platform;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -68,7 +69,7 @@ namespace osu.Game.Rulesets.Mania.UI
         private ISkinSource skin { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(GameHost host)
         {
             skin.SourceChanged += onSourceChanged;
             onSourceChanged();
@@ -82,7 +83,10 @@ namespace osu.Game.Rulesets.Mania.UI
 
             Drawable background = new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.ColumnBackground), _ => new DefaultColumnBackground())
             {
-                RelativeSizeAxes = Axes.Both
+                RelativeSizeAxes = Axes.Both,
+                // This is pretty dodgy (and will cause weirdness when pausing gameplay) but is better than completely broken rewind.
+                Clock = host.UpdateThread.Clock,
+                ProcessCustomClock = false,
             };
 
             InternalChildren = new[]
@@ -94,7 +98,10 @@ namespace osu.Game.Rulesets.Mania.UI
                 HitObjectArea,
                 new SkinnableDrawable(new ManiaSkinComponent(ManiaSkinComponents.KeyArea), _ => new DefaultKeyArea())
                 {
-                    RelativeSizeAxes = Axes.Both
+                    RelativeSizeAxes = Axes.Both,
+                    // This is pretty dodgy (and will cause weirdness when pausing gameplay) but is better than completely broken rewind.
+                    Clock = host.UpdateThread.Clock,
+                    ProcessCustomClock = false,
                 },
                 background,
                 TopLevelContainer,

--- a/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/UI/PoolableHitExplosion.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             base.PrepareForUse();
 
+            LifetimeStart = Time.Current;
+
             (skinnableExplosion?.Drawable as IHitExplosion)?.Animate(Result);
 
             this.Delay(DURATION).Then().Expire();


### PR DESCRIPTION
As per inline comments, a bit temporary but this is the easiest way to fix an absolutely game-breaking level display issue with osu!mania rewinding.

I'm still figuring a good path forward for elements like this (see discussion on discord for various ideas) but would prefer to fix this for now and then figure a good long-term solution.

Closes https://github.com/ppy/osu/issues/9117

- [x] Depends on https://github.com/ppy/osu/pull/20592 (conflict avoidance)
