### PR TITLE
Barline generator improvements

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public class TestSceneBarLineGeneration : OsuTestScene
+    {
+        [Test]
+        public void TestCloseBarLineGeneration()
+        {
+            const double start_time = 1000;
+
+            var beatmap = new Beatmap<TaikoHitObject>
+            {
+                HitObjects =
+                {
+                    new Hit
+                    {
+                        Type = HitType.Centre,
+                        StartTime = start_time
+                    }
+                },
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Ruleset = new TaikoRuleset().RulesetInfo
+                },
+            };
+
+            beatmap.ControlPointInfo.Add(start_time, new TimingControlPoint());
+            beatmap.ControlPointInfo.Add(start_time + 1, new TimingControlPoint());
+
+            var barlines = new BarLineGenerator<BarLine>(beatmap).BarLines;
+
+            AddAssert("first barline generated", () => barlines.Any(b => b.StartTime == start_time));
+            AddAssert("second barline generated", () => barlines.Any(b => b.StartTime == start_time + 1));
+        }
+
+        [Test]
+        public void TestOmitBarLineEffectPoint()
+        {
+            const double start_time = 1000;
+            const double beat_length = 500;
+
+            const int time_signature_numerator = 4;
+
+            var beatmap = new Beatmap<TaikoHitObject>
+            {
+                HitObjects =
+                {
+                    new Hit
+                    {
+                        Type = HitType.Centre,
+                        StartTime = start_time
+                    }
+                },
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Ruleset = new TaikoRuleset().RulesetInfo
+                },
+            };
+
+            beatmap.ControlPointInfo.Add(start_time, new TimingControlPoint 
+            {
+                BeatLength = beat_length,
+                TimeSignature = new TimeSignature(time_signature_numerator)
+            });
+
+            beatmap.ControlPointInfo.Add(start_time, new EffectControlPoint { OmitFirstBarLine = true });
+
+            var barlines = new BarLineGenerator<BarLine>(beatmap).BarLines;
+
+            AddAssert("first barline ommited", () => !barlines.Any(b => b.StartTime == start_time));
+            AddAssert("second barline generated", () => barlines.Any(b => b.StartTime == start_time + (beat_length * time_signature_numerator)));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 },
             };
 
-            beatmap.ControlPointInfo.Add(start_time, new TimingControlPoint 
+            beatmap.ControlPointInfo.Add(start_time, new TimingControlPoint
             {
                 BeatLength = beat_length,
                 TimeSignature = new TimeSignature(time_signature_numerator)
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             var barlines = new BarLineGenerator<BarLine>(beatmap).BarLines;
 
-            AddAssert("first barline ommited", () => !barlines.Any(b => b.StartTime == start_time));
+            AddAssert("first barline ommited", () => barlines.All(b => b.StartTime != start_time));
             AddAssert("second barline generated", () => barlines.Any(b => b.StartTime == start_time + (beat_length * time_signature_numerator)));
         }
     }

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Objects
                 int currentBeat = 0;
 
                 // Stop on the beat before the next timing point, or if there is no next timing point stop slightly past the last object
-                double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time - currentTimingPoint.BeatLength : lastHitTime + currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
+                double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time : lastHitTime + currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
                 double barLength = currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Objects
             for (int i = 0; i < timingPoints.Count; i++)
             {
                 TimingControlPoint currentTimingPoint = timingPoints[i];
-                EffectControlPoint? currentEffectPoint = beatmap.ControlPointInfo.EffectPointAt(currentTimingPoint.Time);
+                EffectControlPoint currentEffectPoint = beatmap.ControlPointInfo.EffectPointAt(currentTimingPoint.Time);
                 int currentBeat = 0;
 
                 // Stop on the next timing point, or if there is no next timing point stop slightly past the last object
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Objects
                 double startTime = currentTimingPoint.Time;
                 double barLength = currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
-                if (currentEffectPoint != null && currentEffectPoint.OmitFirstBarLine)
+                if (currentEffectPoint.OmitFirstBarLine)
                 {
                     startTime += barLength;
                 }

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Objects
                     startTime += barLength;
                 }
 
-                for (double t = startTime; Precision.DefinitelyBigger(endTime, t); t += barLength, currentBeat++)
+                for (double t = startTime; Precision.AlmostBigger(endTime, t); t += barLength, currentBeat++)
                 {
                     double roundedTime = Math.Round(t, MidpointRounding.AwayFromZero);
 

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +31,7 @@ namespace osu.Game.Rulesets.Objects
             double lastHitTime = 1 + lastObject.GetEndTime();
 
             var timingPoints = beatmap.ControlPointInfo.TimingPoints;
+            var effectPoints = beatmap.ControlPointInfo.EffectPoints;
 
             if (timingPoints.Count == 0)
                 return;
@@ -40,14 +39,22 @@ namespace osu.Game.Rulesets.Objects
             for (int i = 0; i < timingPoints.Count; i++)
             {
                 TimingControlPoint currentTimingPoint = timingPoints[i];
+                EffectControlPoint? currentEffectPoint = effectPoints.FirstOrDefault(p => p.Time == currentTimingPoint.Time);
                 int currentBeat = 0;
 
                 // Stop on the beat before the next timing point, or if there is no next timing point stop slightly past the last object
                 double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time : lastHitTime + currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
+                double startTime = currentTimingPoint.Time;
+
                 double barLength = currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
-                for (double t = currentTimingPoint.Time; Precision.DefinitelyBigger(endTime, t); t += barLength, currentBeat++)
+                if (currentEffectPoint != null && currentEffectPoint.OmitFirstBarLine)
+                {
+                    startTime += barLength;
+                }
+
+                for (double t = startTime; Precision.DefinitelyBigger(endTime, t); t += barLength, currentBeat++)
                 {
                     double roundedTime = Math.Round(t, MidpointRounding.AwayFromZero);
 

--- a/osu.Game/Rulesets/Objects/BarLineGenerator.cs
+++ b/osu.Game/Rulesets/Objects/BarLineGenerator.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Objects
             double lastHitTime = 1 + lastObject.GetEndTime();
 
             var timingPoints = beatmap.ControlPointInfo.TimingPoints;
-            var effectPoints = beatmap.ControlPointInfo.EffectPoints;
 
             if (timingPoints.Count == 0)
                 return;
@@ -39,14 +38,13 @@ namespace osu.Game.Rulesets.Objects
             for (int i = 0; i < timingPoints.Count; i++)
             {
                 TimingControlPoint currentTimingPoint = timingPoints[i];
-                EffectControlPoint? currentEffectPoint = effectPoints.FirstOrDefault(p => p.Time == currentTimingPoint.Time);
+                EffectControlPoint? currentEffectPoint = beatmap.ControlPointInfo.EffectPointAt(currentTimingPoint.Time);
                 int currentBeat = 0;
 
-                // Stop on the beat before the next timing point, or if there is no next timing point stop slightly past the last object
+                // Stop on the next timing point, or if there is no next timing point stop slightly past the last object
                 double endTime = i < timingPoints.Count - 1 ? timingPoints[i + 1].Time : lastHitTime + currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
                 double startTime = currentTimingPoint.Time;
-
                 double barLength = currentTimingPoint.BeatLength * currentTimingPoint.TimeSignature.Numerator;
 
                 if (currentEffectPoint != null && currentEffectPoint.OmitFirstBarLine)


### PR DESCRIPTION
This PR contains 2 changes to the barline generator, in addition to tests for both.
1) Remove the `beatLength` "padding", allowing barlines to always be generated on timing points (heavily used in osu!taiko "gimmick"/"Aspire" maps, and stable behaviour)
2) Make the generator respect the `OmitFirstBarLine` effect point, this has been used in stable to avoid cases of unwanted barlines now generated by 1)