### PR TITLE
Preserve collections when saving a beatmap

### DIFF
--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
@@ -104,15 +104,17 @@ namespace osu.Game.Tests.Beatmaps
         {
             var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID).Detach());
 
-            var map = beatmaps.GetWorkingBeatmap(beatmap);
+            var working = beatmaps.GetWorkingBeatmap(beatmap);
 
-            Assert.That(map.BeatmapInfo.BeatmapSet?.Files, Has.Count.GreaterThan(0));
+            Assert.That(working.BeatmapInfo.BeatmapSet?.Files, Has.Count.GreaterThan(0));
 
-            string initialHash = map.BeatmapInfo.MD5Hash;
+            string initialHash = working.BeatmapInfo.MD5Hash;
 
-            var preserveCollection = new BeatmapCollection("test save preserves collection");
+            var preserveCollection = new BeatmapCollection("test contained");
             preserveCollection.BeatmapMD5Hashes.Add(initialHash);
-            var noNewCollection = new BeatmapCollection("test save does not introduce new collection");
+
+            var noNewCollection = new BeatmapCollection("test not contained");
+
             Realm.Write(r =>
             {
                 r.Add(preserveCollection);
@@ -122,9 +124,9 @@ namespace osu.Game.Tests.Beatmaps
             Assert.That(preserveCollection.BeatmapMD5Hashes, Does.Contain(initialHash));
             Assert.That(noNewCollection.BeatmapMD5Hashes, Does.Not.Contain(initialHash));
 
-            beatmaps.Save(map.BeatmapInfo, map.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
+            beatmaps.Save(working.BeatmapInfo, working.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
 
-            string finalHash = map.BeatmapInfo.MD5Hash;
+            string finalHash = working.BeatmapInfo.MD5Hash;
 
             Assert.That(finalHash, Is.Not.SameAs(initialHash));
 

--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Beatmaps
 
             Assert.That(preserveCollection.BeatmapMD5Hashes, Does.Contain(initialHash));
             Assert.That(noNewCollection.BeatmapMD5Hashes, Does.Not.Contain(initialHash));
-            
+
             beatmaps.Save(map.BeatmapInfo, map.GetPlayableBeatmap(new OsuRuleset().RulesetInfo));
 
             string finalHash = map.BeatmapInfo.MD5Hash;

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -141,12 +141,9 @@ namespace osu.Game.Beatmaps
             // Handle collections using permissive difficulty name to track difficulties.
             foreach (var originalBeatmap in original.Beatmaps)
             {
-                var updatedBeatmap = updated.Beatmaps.FirstOrDefault(b => b.DifficultyName == originalBeatmap.DifficultyName);
-
-                if (updatedBeatmap == null)
-                    continue;
-
-                updatedBeatmap.TransferCollectionsFrom(realm, originalBeatmap.MD5Hash);
+                updated.Beatmaps
+                       .FirstOrDefault(b => b.DifficultyName == originalBeatmap.DifficultyName)?
+                       .TransferCollectionReferences(realm, originalBeatmap.MD5Hash);
             }
         }
 

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -146,13 +146,7 @@ namespace osu.Game.Beatmaps
                 if (updatedBeatmap == null)
                     continue;
 
-                var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(originalBeatmap.MD5Hash));
-
-                foreach (var c in collections)
-                {
-                    c.BeatmapMD5Hashes.Remove(originalBeatmap.MD5Hash);
-                    c.BeatmapMD5Hashes.Add(updatedBeatmap.MD5Hash);
-                }
+                updatedBeatmap.transferCollectionsFrom(realm, originalBeatmap.MD5Hash);
             }
         }
 

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Beatmaps
                 if (updatedBeatmap == null)
                     continue;
 
-                updatedBeatmap.transferCollectionsFrom(realm, originalBeatmap.MD5Hash);
+                updatedBeatmap.TransferCollectionsFrom(realm, originalBeatmap.MD5Hash);
             }
         }
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
@@ -211,6 +212,17 @@ namespace osu.Game.Beatmaps
             string? fileHashY = y.BeatmapSet.GetFile(getFilename(y.Metadata))?.File.Hash;
 
             return fileHashX == fileHashY;
+        }
+
+        public void transferCollectionsFrom(Realm realm, string oldMd5Hash)
+        {
+            var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(oldMd5Hash));
+
+            foreach (var c in collections)
+            {
+                c.BeatmapMD5Hashes.Remove(oldMd5Hash);
+                c.BeatmapMD5Hashes.Add(MD5Hash);
+            }
         }
 
         IBeatmapMetadataInfo IBeatmapInfo.Metadata => Metadata;

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -214,7 +214,7 @@ namespace osu.Game.Beatmaps
             return fileHashX == fileHashY;
         }
 
-        public void transferCollectionsFrom(Realm realm, string oldMd5Hash)
+        public void TransferCollectionsFrom(Realm realm, string oldMd5Hash)
         {
             var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(oldMd5Hash));
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -214,13 +214,19 @@ namespace osu.Game.Beatmaps
             return fileHashX == fileHashY;
         }
 
-        public void TransferCollectionsFrom(Realm realm, string oldMd5Hash)
+        /// <summary>
+        /// When updating a beatmap, its hashes will change. Collections currently track beatmaps by hash, so they need to be updated.
+        /// This method will handle updating
+        /// </summary>
+        /// <param name="realm">A realm instance in an active write transaction.</param>
+        /// <param name="previousMD5Hash">The previous MD5 hash of the beatmap before update.</param>
+        public void TransferCollectionReferences(Realm realm, string previousMD5Hash)
         {
-            var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(oldMd5Hash));
+            var collections = realm.All<BeatmapCollection>().AsEnumerable().Where(c => c.BeatmapMD5Hashes.Contains(previousMD5Hash));
 
             foreach (var c in collections)
             {
-                c.BeatmapMD5Hashes.Remove(oldMd5Hash);
+                c.BeatmapMD5Hashes.Remove(previousMD5Hash);
                 c.BeatmapMD5Hashes.Add(MD5Hash);
             }
         }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -330,11 +330,7 @@ namespace osu.Game.Beatmaps
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
 
-                    foreach (var collection in r.All<BeatmapCollection>())
-                    {
-                        if (collection.BeatmapMD5Hashes.Remove(oldMd5Hash))
-                            collection.BeatmapMD5Hashes.Add(beatmapInfo.MD5Hash);
-                    }
+                    beatmapInfo.transferCollectionsFrom(r, oldMd5Hash);
 
                     ProcessBeatmap?.Invoke((liveBeatmapSet, false));
                 });

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -17,7 +17,6 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
-using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO.Archives;

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -330,7 +330,7 @@ namespace osu.Game.Beatmaps
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
 
-                    beatmapInfo.TransferCollectionsFrom(r, oldMd5Hash);
+                    beatmapInfo.TransferCollectionReferences(r, oldMd5Hash);
 
                     ProcessBeatmap?.Invoke((liveBeatmapSet, false));
                 });

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -17,6 +17,7 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Collections;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO.Archives;
@@ -311,6 +312,8 @@ namespace osu.Game.Beatmaps
                 if (existingFileInfo != null)
                     DeleteFile(setInfo, existingFileInfo);
 
+                string? oldMd5Hash = beatmapInfo.MD5Hash;
+
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
 
@@ -326,6 +329,12 @@ namespace osu.Game.Beatmaps
                     var liveBeatmapSet = r.Find<BeatmapSetInfo>(setInfo.ID);
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
+
+                    foreach (var collection in r.All<BeatmapCollection>())
+                    {
+                        if (collection.BeatmapMD5Hashes.Remove(oldMd5Hash))
+                            collection.BeatmapMD5Hashes.Add(beatmapInfo.MD5Hash);
+                    }
 
                     ProcessBeatmap?.Invoke((liveBeatmapSet, false));
                 });

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -312,7 +312,7 @@ namespace osu.Game.Beatmaps
                 if (existingFileInfo != null)
                     DeleteFile(setInfo, existingFileInfo);
 
-                string? oldMd5Hash = beatmapInfo.MD5Hash;
+                string oldMd5Hash = beatmapInfo.MD5Hash;
 
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -330,7 +330,7 @@ namespace osu.Game.Beatmaps
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
 
-                    beatmapInfo.transferCollectionsFrom(r, oldMd5Hash);
+                    beatmapInfo.TransferCollectionsFrom(r, oldMd5Hash);
 
                     ProcessBeatmap?.Invoke((liveBeatmapSet, false));
                 });


### PR DESCRIPTION
If you have a beatmap in collections and edit it, it loses those collections on save. This makes it update all the collections to use the map's new md5 hash after saving so you don't have to re-add them all manually.