### PR TITLE
Fixed slider stream convert float precision edge case

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -148,6 +148,37 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
         }
 
+        [Test]
+        public void TestFloatEdgeCaseConversion()
+        {
+            Slider slider = null;
+
+            AddStep("select first slider", () =>
+            {
+                slider = (Slider)EditorBeatmap.HitObjects.First(h => h is Slider);
+                EditorClock.Seek(slider.StartTime);
+                EditorBeatmap.SelectedHitObjects.Add(slider);
+            });
+
+            AddStep("change to these specific circumstances", () =>
+            {
+                EditorBeatmap.Difficulty.SliderMultiplier = 1;
+                var timingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(slider.StartTime);
+                timingPoint.BeatLength = 352.941176470588;
+                slider.Path.ControlPoints[^1].Position = new Vector2(-110, 16);
+                slider.Path.ExpectedDistance.Value = 100;
+            });
+
+            convertToStream();
+
+            AddAssert("stream created", () => streamCreatedFor(slider,
+                (time: 0, pathPosition: 0),
+                (time: 0.25, pathPosition: 0.25),
+                (time: 0.5, pathPosition: 0.5),
+                (time: 0.75, pathPosition: 0.75),
+                (time: 1, pathPosition: 1)));
+        }
+
         private bool streamCreatedFor(Slider slider, params (double time, double pathPosition)[] expectedCircles)
         {
             if (EditorBeatmap.HitObjects.Contains(slider))

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -342,7 +342,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 double positionWithRepeats = (time - HitObject.StartTime) / HitObject.Duration * HitObject.SpanCount();
                 double pathPosition = positionWithRepeats - (int)positionWithRepeats;
                 // every second span is in the reverse direction - need to reverse the path position.
-                if (Precision.AlmostBigger(positionWithRepeats % 2, 1))
+                if (positionWithRepeats % 2 >= 1)
                     pathPosition = 1 - pathPosition;
 
                 Vector2 position = HitObject.Position + HitObject.Path.PositionAt(pathPosition);


### PR DESCRIPTION
Under the right circumstances a slider to stream convert would put the last circle at the start of the slider, creating an incorrect stream.

https://user-images.githubusercontent.com/17460441/194728790-21d2c2e4-1551-4c12-b6b0-d18af25c67a0.mp4

This is because the truncation of `pathPosition` has no leniency but the check after that does have leniency, so if `positionWithRepeats` is something close to but slightly less than 1 then `pathPosition` would not get set to 0 and then the if-statement body would set `pathPosition` to almost 0.

https://github.com/ppy/osu/blob/a1f96ad5f8a2853892b43c7b58c94cb0756b6ea2/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs#L343-L346

I fixed this and added a test