### PR TITLE
Fix slider ball facing incorrect direction during rewinding in editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
@@ -186,17 +186,22 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private Vector2? lastPosition;
 
+        private bool rewinding;
+
         public void UpdateProgress(double completionProgress)
         {
             Position = drawableSlider.HitObject.CurvePositionAt(completionProgress);
 
             var diff = lastPosition.HasValue ? lastPosition.Value - Position : Position - drawableSlider.HitObject.CurvePositionAt(completionProgress + 0.01f);
 
+            if (Clock.ElapsedFrameTime != 0)
+                rewinding = Clock.ElapsedFrameTime < 0;
+
             // Ensure the value is substantially high enough to allow for Atan2 to get a valid angle.
             if (diff.LengthFast < 0.01f)
                 return;
 
-            ball.Rotation = -90 + (float)(-Math.Atan2(diff.X, diff.Y) * 180 / Math.PI);
+            ball.Rotation = -90 + (float)(-Math.Atan2(diff.X, diff.Y) * 180 / Math.PI) + (rewinding ? 180 : 0);
             lastPosition = Position;
         }
     }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/20648.

The same thing actually happened during gameplay, but was less obvious due to rewinding running at crazy fast speeds.