### PR TITLE
Add a toggle to hide "Great" judgements in the osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
         protected override void InitialiseDefaults()
         {
             base.InitialiseDefaults();
+            SetDefault(OsuRulesetSetting.HideGreatJudgements, false);
             SetDefault(OsuRulesetSetting.SnakingInSliders, true);
             SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
@@ -28,6 +29,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
 
     public enum OsuRulesetSetting
     {
+        HideGreatJudgements,
         SnakingInSliders,
         SnakingOutSliders,
         ShowCursorTrail,

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly Container judgementAboveHitObjectLayer;
 
+        [Resolved]
+        private OsuRulesetConfigManager rulesetConfig { get; set; }
+
         public OsuPlayfield()
         {
             Anchor = Anchor.Centre;
@@ -166,7 +169,11 @@ namespace osu.Game.Rulesets.Osu.UI
             // Hitobjects that block future hits should miss previous hitobjects if they're hit out-of-order.
             hitPolicy.HandleHit(judgedObject);
 
-            if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
+            bool hideGreats = rulesetConfig.Get<bool>(OsuRulesetSetting.HideGreatJudgements);
+
+            bool showJudgement = !hideGreats || result.Type != HitResult.Great;
+
+            if (!judgedObject.DisplayResult || !DisplayJudgements.Value || !showJudgement)
                 return;
 
             DrawableOsuJudgement explosion = poolDictionary[result.Type].Get(doj => doj.Apply(result, judgedObject));

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -30,6 +30,11 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 new SettingsCheckbox
                 {
+                    LabelText = "Hide \"Great\" judgements",
+                    Current = config.GetBindable<bool>(OsuRulesetSetting.HideGreatJudgements)
+                },
+                new SettingsCheckbox
+                {
                     LabelText = "Snaking in sliders",
                     Current = config.GetBindable<bool>(OsuRulesetSetting.SnakingInSliders)
                 },


### PR DESCRIPTION
This is what the vast majority of user skins does, so this setting might be useful to improve the "playability" of the default skins.

<h1>The setting:</h1>

![image](https://user-images.githubusercontent.com/43830312/194962141-003ea530-054e-4f0f-8461-67dff7f9d590.png)
<h1>On:</h1>

![image](https://user-images.githubusercontent.com/43830312/194961907-5a012cc8-33e2-4f25-acb7-fdff3b97cb29.png)
<h1>Off:</h1>

![image](https://user-images.githubusercontent.com/43830312/194962218-5e89f682-5216-4f1c-bff8-8c3f75d29f8e.png)
