### PR TITLE
Fix legacy fallbacks not working correctly for beatmap skins

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -13,6 +13,10 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 {
     public class CatchLegacySkinTransformer : LegacySkinTransformer
     {
+        public override bool IsProvidingLegacyResources => base.IsProvidingLegacyResources || hasPear;
+
+        private bool hasPear => GetTexture("fruit-pear") != null;
+
         /// <summary>
         /// For simplicity, let's use legacy combo font texture existence as a way to identify legacy skins from default.
         /// </summary>
@@ -49,7 +53,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                 switch (catchSkinComponent.Component)
                 {
                     case CatchSkinComponents.Fruit:
-                        if (GetTexture("fruit-pear") != null)
+                        if (hasPear)
                             return new LegacyFruitPiece();
 
                         return null;

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 {
     public class ManiaLegacySkinTransformer : LegacySkinTransformer
     {
+        public override bool IsProvidingLegacyResources => base.IsProvidingLegacyResources || hasKeyTexture.Value;
+
         /// <summary>
         /// Mapping of <see cref="HitResult"/> to their corresponding
         /// <see cref="LegacyManiaSkinConfigurationLookups"/> value.

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -13,6 +13,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {
     public class OsuLegacySkinTransformer : LegacySkinTransformer
     {
+        public override bool IsProvidingLegacyResources => base.IsProvidingLegacyResources || hasHitCircle.Value;
+
         private readonly Lazy<bool> hasHitCircle;
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -14,7 +14,12 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public class TaikoLegacySkinTransformer : LegacySkinTransformer
     {
+        public override bool IsProvidingLegacyResources => base.IsProvidingLegacyResources || hasHitCircle || hasBarLeft;
+
         private readonly Lazy<bool> hasExplosion;
+
+        private bool hasHitCircle => GetTexture("taikohitcircle") != null;
+        private bool hasBarLeft => GetTexture("taiko-bar-left") != null;
 
         public TaikoLegacySkinTransformer(ISkin skin)
             : base(skin)
@@ -42,14 +47,14 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         return null;
 
                     case TaikoSkinComponents.InputDrum:
-                        if (GetTexture("taiko-bar-left") != null)
+                        if (hasBarLeft)
                             return new LegacyInputDrum();
 
                         return null;
 
                     case TaikoSkinComponents.CentreHit:
                     case TaikoSkinComponents.RimHit:
-                        if (GetTexture("taikohitcircle") != null)
+                        if (hasHitCircle)
                             return new LegacyHit(taikoComponent.Component);
 
                         return null;

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -67,9 +67,12 @@ namespace osu.Game.Skinning
             return sampleInfo is StoryboardSampleInfo || beatmapHitsounds.Value;
         }
 
+        private readonly ISkin skin;
+
         public BeatmapSkinProvidingContainer(ISkin skin)
             : base(skin)
         {
+            this.skin = skin;
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -84,11 +87,21 @@ namespace osu.Game.Skinning
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(SkinManager skins)
         {
             beatmapSkins.BindValueChanged(_ => TriggerSourceChanged());
             beatmapColours.BindValueChanged(_ => TriggerSourceChanged());
             beatmapHitsounds.BindValueChanged(_ => TriggerSourceChanged());
+
+            // If the beatmap skin looks to have skinnable resources, add the default classic skin as a fallback opportunity.
+            if (skin is LegacySkinTransformer legacySkin && legacySkin.IsProvidingLegacyResources)
+            {
+                SetSources(new[]
+                {
+                    skin,
+                    skins.DefaultClassicSkin
+                });
+            }
         }
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -389,18 +389,17 @@ namespace osu.Game.Skinning
 
                         if (particle != null)
                             return new LegacyJudgementPieceNew(resultComponent.Component, createDrawable, particle);
-                        else
-                            return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
+
+                        return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }
 
                     return null;
 
                 case SkinnableSprite.SpriteComponent sprite:
                     return this.GetAnimation(sprite.LookupName, false, false);
-
-                default:
-                    throw new UnsupportedSkinComponentException(component);
             }
+
+            return null;
         }
 
         private Texture? getParticleTexture(HitResult result)

--- a/osu.Game/Skinning/LegacySkinTransformer.cs
+++ b/osu.Game/Skinning/LegacySkinTransformer.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Skinning
     /// </summary>
     public abstract class LegacySkinTransformer : SkinTransformer
     {
+        /// <summary>
+        /// Whether the skin being transformed is able to provide legacy resources for the ruleset.
+        /// </summary>
+        public virtual bool IsProvidingLegacyResources => this.HasFont(LegacyFont.Combo);
+
         protected LegacySkinTransformer(ISkin skin)
             : base(skin)
         {

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Skinning
             Ruleset = ruleset;
             Beatmap = beatmap;
 
-            InternalChild = new BeatmapSkinProvidingContainer(beatmapSkin is LegacySkin ? GetRulesetTransformedSkin(beatmapSkin) : beatmapSkin)
+            InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin))
             {
                 Child = Content = new Container
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/20710.

Not much to say here. If the code doesn't seem like a good direction I have a local implementation in `LegacyBeatmapSkin` as an alternative (https://github.com/ppy/osu/compare/master...peppy:osu:fix-beatmap-skin-fallbacks-local?expand=1).

I also attempted to implement this in `SkinProvidingContainer` and remove the fallback logic in `SkinManager.AllSource` but it's a pain in the ass to make work and I've spent too long on this already 😅.