### PR TITLE
Store and display variant names for osu!mania beatmaps

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -333,7 +333,15 @@ namespace osu.Game.Rulesets.Mania
             return Array.Empty<KeyBinding>();
         }
 
-        public override LocalisableString GetVariantName(int variant)
+        public override string GetVariantName(IBeatmap beatmap)
+        {
+            if (beatmap is ManiaBeatmap maniaBeatmap)
+                return GetVariantName(maniaBeatmap.OriginalTotalColumns);
+
+            return base.GetVariantName(beatmap);
+        }
+
+        public override string GetVariantName(int variant)
         {
             switch (getPlayfieldType(variant))
             {

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Beatmaps
 
         public string DifficultyName { get; set; } = string.Empty;
 
+        public string VariantName { get; set; } = string.Empty;
+
         public RulesetInfo Ruleset { get; set; } = null!;
 
         public BeatmapDifficulty Difficulty { get; set; } = null!;

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -46,7 +46,8 @@ namespace osu.Game.Beatmaps
         public void Queue(Live<BeatmapSetInfo> beatmapSet, bool preferOnlineFetch = false)
         {
             Logger.Log($"Queueing change for local beatmap {beatmapSet}");
-            Task.Factory.StartNew(() => beatmapSet.PerformRead(b => Process(b, preferOnlineFetch)), default, TaskCreationOptions.HideScheduler | TaskCreationOptions.RunContinuationsAsynchronously, updateScheduler);
+            Task.Factory.StartNew(() => beatmapSet.PerformRead(b => Process(b, preferOnlineFetch)), default, TaskCreationOptions.HideScheduler | TaskCreationOptions.RunContinuationsAsynchronously,
+                updateScheduler);
         }
 
         /// <summary>
@@ -75,6 +76,8 @@ namespace osu.Game.Beatmaps
                 beatmap.StarRating = calculator.Calculate().StarRating;
                 beatmap.Length = calculateLength(working.Beatmap);
                 beatmap.BPM = 60000 / working.Beatmap.GetMostCommonBeatLength();
+
+                beatmap.VariantName = ruleset.GetVariantName(working.GetPlayableBeatmap(ruleset.RulesetInfo));
             }
 
             // And invalidate again afterwards as re-fetching the most up-to-date database metadata will be required.

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -71,8 +71,9 @@ namespace osu.Game.Database
         /// 24   2022-08-22    Added MaximumStatistics to ScoreInfo.
         /// 25   2022-09-18    Remove skins to add with new naming.
         /// 26   2023-02-05    Added BeatmapHash to ScoreInfo.
+        /// 27   2023-04-03    Add VariantName to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 26;
+        private const int schema_version = 27;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -305,11 +305,18 @@ namespace osu.Game.Rulesets
         public virtual IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => Array.Empty<KeyBinding>();
 
         /// <summary>
-        /// Gets the name for a key binding variant. This is used for display in the settings overlay.
+        /// Gets the name for a key variant. This is used for display in the settings overlay.
         /// </summary>
         /// <param name="variant">The variant.</param>
         /// <returns>A descriptive name of the variant.</returns>
-        public virtual LocalisableString GetVariantName(int variant) => string.Empty;
+        public virtual string GetVariantName(int variant) => string.Empty;
+
+        /// <summary>
+        /// Gets the name of the key variant for a beatmap.
+        /// </summary>
+        /// <param name="beatmap">The beatmap.</param>
+        /// <returns>A descriptive name of the variant.</returns>
+        public virtual string GetVariantName(IBeatmap beatmap) => string.Empty;
 
         /// <summary>
         /// For rulesets which support legacy (osu-stable) replay conversion, this method will create an empty replay frame

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Select.Carousel
                                     {
                                         new OsuSpriteText
                                         {
-                                            Text = beatmapInfo.DifficultyName,
+                                            Text = beatmapInfo.DifficultyName + (!string.IsNullOrEmpty(beatmapInfo.VariantName) ? $" ({beatmapInfo.VariantName})" : string.Empty),
                                             Font = OsuFont.GetFont(size: 20),
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft


### PR DESCRIPTION
RFC

![osu! 2022-10-13 at 03 06 53](https://user-images.githubusercontent.com/191335/195490409-c65f51c3-3fc8-4a06-82f2-c5f17a62402b.png)


No automatic reprocessing yet, interested in thoughts on how this should be applied. Do we just re-run the full flow for all beatmaps?

Also unfortunately a breaking ruleset API change, due to removing the incorrectly specified `LocalisableString` (which cannot be written to realm).

An alternative solution to this is to process this at runtime, but I don't know how well that will scale. A valid argument is we are doing the same for star difficulty display on beatmap panels, but I dunno. Could it be added into `StarDifficulty`? Do we want it stored in the way done in this PR for other usages?

https://github.com/ppy/osu/issues/5668 etc.