### PR TITLE
Fix some editor display metrics up to feel better

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -124,16 +124,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         },
                         new Drawable[]
                         {
-                            new TextFlowContainer(s => s.Font = s.Font.With(size: 14))
-                            {
-                                Padding = new MarginPadding { Horizontal = 15 },
-                                Text = "beat snap",
-                                RelativeSizeAxes = Axes.X,
-                                TextAnchor = Anchor.TopCentre
-                            },
-                        },
-                        new Drawable[]
-                        {
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
@@ -172,6 +162,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                     }
                                 }
                             }
+                        },
+                        new Drawable[]
+                        {
+                            new TextFlowContainer(s => s.Font = s.Font.With(size: 14))
+                            {
+                                Padding = new MarginPadding { Horizontal = 15, Vertical = 8 },
+                                Text = "beat snap",
+                                RelativeSizeAxes = Axes.X,
+                                TextAnchor = Anchor.TopCentre,
+                            },
                         },
                     },
                     RowDimensions = new[]

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -78,16 +78,16 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                                 LabelText = "Waveform",
                                                 Current = { Value = true },
                                             },
-                                            controlPointsCheckbox = new OsuCheckbox
-                                            {
-                                                LabelText = "Control Points",
-                                                Current = { Value = true },
-                                            },
                                             ticksCheckbox = new OsuCheckbox
                                             {
                                                 LabelText = "Ticks",
                                                 Current = { Value = true },
-                                            }
+                                            },
+                                            controlPointsCheckbox = new OsuCheckbox
+                                            {
+                                                LabelText = "BPM",
+                                                Current = { Value = true },
+                                            },
                                         }
                                     }
                                 }

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Screens.Edit
                             Name = "Main content",
                             RelativeSizeAxes = Axes.Both,
                             Depth = float.MaxValue,
+                            Padding = new MarginPadding(10),
                             Child = spinner = new LoadingSpinner(true)
                             {
                                 State = { Value = Visibility.Visible },


### PR DESCRIPTION
Just some quick things:

- Fixes beat snap divisor (and checkboxes) getting cut off when BPM details are hidden
- Adds padding around playfield to match stable

| before | after|
| --- | --- |
|![osu! 2022-10-13 at 07 08 02](https://user-images.githubusercontent.com/191335/195526190-0ed2d210-baff-413d-8012-b6b72b134f61.png)|![osu! 2022-10-13 at 07 06 24](https://user-images.githubusercontent.com/191335/195525840-d1f425ae-305e-4013-8203-8acd7d544f05.png)|

(ignore the toolbox changes, that's separated into a separate PR)