### PR TITLE
Fix flaky update beatmap set test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
@@ -150,6 +151,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         public void TestUpdateLocalBeatmap()
         {
             DialogOverlay dialogOverlay = null!;
+            UpdateBeatmapSetButton? updateButton = null;
 
             AddStep("create carousel with dialog overlay", () =>
             {
@@ -176,7 +178,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 carousel.UpdateBeatmapSet(testBeatmapSetInfo);
             });
 
-            AddStep("click button", () => getUpdateButton()?.TriggerClick());
+            AddUntilStep("wait for update button", () => (updateButton = getUpdateButton()) != null);
+            AddStep("click button", () => updateButton.AsNonNull().TriggerClick());
 
             AddAssert("dialog displayed", () => dialogOverlay.CurrentDialog is UpdateLocalConfirmationDialog);
             AddStep("click confirmation", () =>


### PR DESCRIPTION
As seen [here](https://github.com/ppy/osu/actions/runs/3238669903/jobs/5307140428) and [here](https://github.com/ppy/osu/actions/runs/3244735173/jobs/5321299673)

It is generally not possible to click a button that's not yet there, and it turns out that when the test in question is ran headless, it may not necessarily be there immediately.