### PR TITLE
Fix smoke shaking when gameplay is paused

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 if (points.Count == 0)
                     return;
 
-                rotationIndex = rotationSeed;
+                rotationIndex = 0;
 
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(max_point_count / 10, 10);
                 texture ??= renderer.WhitePixel;
@@ -314,11 +314,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 return new Vector2(MathF.Sin(angle), -MathF.Cos(angle));
             }
 
-            private float nextRotation()
-            {
-                rotationIndex++;
-                return max_rotation * (StatelessRNG.NextSingle(rotationIndex) * 2 - 1);
-            }
+            private float nextRotation() => max_rotation * (StatelessRNG.NextSingle(rotationSeed, rotationIndex++) * 2 - 1);
 
             private void drawPointQuad(SmokePoint point, RectangleF textureRect)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -216,8 +216,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 SmokeEndTime = Source.smokeEndTime;
                 CurrentTime = Source.Clock.CurrentTime;
 
-                rotationRNG = new Random(Source.rotationSeed);
-
                 initialFadeOutDurationTrunc = Math.Min(initial_fade_out_duration, SmokeEndTime - SmokeStartTime);
                 firstVisiblePointTime = SmokeEndTime - initialFadeOutDurationTrunc;
 
@@ -232,6 +230,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 if (points.Count == 0)
                     return;
+
+                rotationRNG = new Random(Source.rotationSeed);
 
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(max_point_count / 10, 10);
                 texture ??= renderer.WhitePixel;

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -185,6 +186,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
             private float radius;
             private Vector2 drawSize;
             private Texture? texture;
+            private int rotationSeed;
+            private int rotationIndex;
 
             // anim calculation vars (color, scale, direction)
             private double initialFadeOutDurationTrunc;
@@ -193,8 +196,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
             private double initialFadeOutTime;
             private double reFadeInTime;
             private double finalFadeOutTime;
-
-            private Random rotationRNG = new Random();
 
             public SmokeDrawNode(ITexturedShaderDrawable source)
                 : base(source)
@@ -216,6 +217,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 SmokeEndTime = Source.smokeEndTime;
                 CurrentTime = Source.Clock.CurrentTime;
 
+                rotationSeed = Source.rotationSeed;
+
                 initialFadeOutDurationTrunc = Math.Min(initial_fade_out_duration, SmokeEndTime - SmokeStartTime);
                 firstVisiblePointTime = SmokeEndTime - initialFadeOutDurationTrunc;
 
@@ -231,7 +234,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 if (points.Count == 0)
                     return;
 
-                rotationRNG = new Random(Source.rotationSeed);
+                rotationIndex = rotationSeed;
 
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(max_point_count / 10, 10);
                 texture ??= renderer.WhitePixel;
@@ -311,7 +314,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 return new Vector2(MathF.Sin(angle), -MathF.Cos(angle));
             }
 
-            private float nextRotation() => max_rotation * ((float)rotationRNG.NextDouble() * 2 - 1);
+            private float nextRotation()
+            {
+                rotationIndex++;
+                return max_rotation * (StatelessRNG.NextSingle(rotationIndex) * 2 - 1);
+            }
 
             private void drawPointQuad(SmokePoint point, RectangleF textureRect)
             {


### PR DESCRIPTION
Fixes #20705

Smoke rotation is calculated through a seeded RNG, but the RNG is only reset when the `DrawNode` is invalidated (and the `DrawNode` isn't invalidated while paused). Resetting the RNG each draw fixes the issue.
