### PR TITLE
Add ability to remove the current item in multiplayer

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerQueueList.cs
@@ -97,14 +97,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        public void TestCurrentItemDoesNotHaveDeleteButton()
+        public void TestSingleItemDoesNotHaveDeleteButton()
+        {
+            AddStep("set all players queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
+            AddUntilStep("wait for queue mode change", () => MultiplayerClient.ClientAPIRoom?.QueueMode.Value == QueueMode.AllPlayers);
+
+            assertDeleteButtonVisibility(0, false);
+        }
+
+        [Test]
+        public void TestCurrentItemHasDeleteButtonIfNotSingle()
         {
             AddStep("set all players queue mode", () => MultiplayerClient.ChangeSettings(new MultiplayerRoomSettings { QueueMode = QueueMode.AllPlayers }).WaitSafely());
             AddUntilStep("wait for queue mode change", () => MultiplayerClient.ClientAPIRoom?.QueueMode.Value == QueueMode.AllPlayers);
 
             addPlaylistItem(() => API.LocalUser.Value.OnlineID);
 
-            assertDeleteButtonVisibility(0, false);
+            assertDeleteButtonVisibility(0, true);
             assertDeleteButtonVisibility(1, true);
 
             AddStep("finish current item", () => MultiplayerClient.FinishCurrentItem().WaitSafely());

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/Playlist/MultiplayerQueueList.cs
@@ -78,9 +78,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match.Playlist
                     return;
 
                 bool isItemOwner = Item.OwnerID == api.LocalUser.Value.OnlineID || multiplayerClient.IsHost;
+                bool isValidItem = isItemOwner && !Item.Expired;
 
-                AllowDeletion = isItemOwner && !Item.Expired && Item.ID != multiplayerClient.Room.Settings.PlaylistItemId;
-                AllowEditing = isItemOwner && !Item.Expired;
+                AllowDeletion = isValidItem
+                                && (Item.ID != multiplayerClient.Room.Settings.PlaylistItemId // This is an optimisation for the following check.
+                                    || multiplayerClient.Room.Playlist.Count(i => !i.Expired) > 1);
+
+                AllowEditing = isValidItem;
             }
 
             protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/18828

|         | Old Server           | New Server  |
| ------------- |:-------------:| :-----:|
| Old Client      | :green_circle:  | :green_circle: |
| New Client      | :orange_circle: (error will trigger on attempting removal)  | :green_circle: |

- Requires osu-server-spectator release with https://github.com/ppy/osu-server-spectator/pull/149