### PR TITLE
Fix hit error bar icon orientation

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -123,13 +123,15 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 RelativeSizeAxes = Axes.Y,
                                 Width = judgement_line_width,
                             },
-                            labelEarly = new UprightAspectMaintainingContainer {
+                            labelEarly = new UprightAspectMaintainingContainer
+                            {
                                 AutoSizeAxes = Axes.Both,
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.Centre,
                                 Y = -10,
                             },
-                            labelLate = new UprightAspectMaintainingContainer {
+                            labelLate = new UprightAspectMaintainingContainer
+                            {
                                 AutoSizeAxes = Axes.Both,
                                 Anchor = Anchor.BottomCentre,
                                 Origin = Anchor.Centre,

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
@@ -273,45 +274,74 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                     break;
 
                 case LabelStyles.Icons:
-                    labelEarly = new SpriteIcon
+                    labelEarly = new UprightAspectMaintainingContainer
                     {
-                        Y = -10,
-                        Size = new Vector2(icon_size),
-                        Icon = FontAwesome.Solid.ShippingFast,
+                        AutoSizeAxes = Axes.Both,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.Centre,
+                        Y = -10,
+                        Children = new Drawable[]
+                        {
+                            new SpriteIcon
+                            {
+                                Size = new Vector2(icon_size),
+                                Icon = FontAwesome.Solid.ShippingFast,
+                            }
+                        }
                     };
 
-                    labelLate = new SpriteIcon
+                    labelLate = new UprightAspectMaintainingContainer
                     {
-                        Y = 10,
-                        Size = new Vector2(icon_size),
-                        Icon = FontAwesome.Solid.Bicycle,
+                        AutoSizeAxes = Axes.Both,
                         Anchor = Anchor.BottomCentre,
                         Origin = Anchor.Centre,
+                        Y = 10,
+                        Children = new Drawable[]
+                        {
+                            new SpriteIcon
+                            {
+                                Y = 10,
+                                Size = new Vector2(icon_size),
+                                Icon = FontAwesome.Solid.Bicycle,
+                            }
+                        }
                     };
 
                     break;
 
                 case LabelStyles.Text:
-                    labelEarly = new OsuSpriteText
+                    labelEarly = new UprightAspectMaintainingContainer
                     {
-                        Y = -10,
-                        Text = "Early",
-                        Font = OsuFont.Default.With(size: 10),
-                        Height = 12,
+                        AutoSizeAxes = Axes.Both,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.Centre,
+                        Y = -10,
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = "Early",
+                                Font = OsuFont.Default.With(size: 10),
+                                Height = 12,
+                            }
+                        }
                     };
 
-                    labelLate = new OsuSpriteText
+                    labelLate = new UprightAspectMaintainingContainer
                     {
-                        Y = 10,
-                        Text = "Late",
-                        Font = OsuFont.Default.With(size: 10),
-                        Height = 12,
+                        AutoSizeAxes = Axes.Both,
                         Anchor = Anchor.BottomCentre,
                         Origin = Anchor.Centre,
+                        Y = 10,
+                        Children = new Drawable[]
+                        {
+                            new OsuSpriteText
+                            {
+                                Text = "Late",
+                                Font = OsuFont.Default.With(size: 10),
+                                Height = 12,
+                            }
+                        }
                     };
 
                     break;
@@ -330,33 +360,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             {
                 colourBars.Add(labelLate);
                 labelLate.FadeInFromZero(500);
-            }
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // undo any layout rotation to display icons in the correct orientation
-            bool xFlipped = Scale.X < 0;
-            bool yFlipped = Scale.Y < 0;
-            bool horizontal = Rotation == 90 || Rotation == -90;
-
-            bool flipX = (xFlipped && yFlipped) || (xFlipped && !horizontal) || (yFlipped && horizontal);
-            bool flipY = (xFlipped && yFlipped) || (xFlipped && horizontal) || (yFlipped && !horizontal);
-
-            Vector2 flipScale = new Vector2(flipX ? -1 : 1, flipY ? -1 : 1);
-
-            if (labelEarly != null)
-            {
-                labelEarly.Rotation = -Rotation;
-                labelEarly.Scale = flipScale;
-            }
-
-            if (labelLate != null)
-            {
-                labelLate.Rotation = -Rotation;
-                labelLate.Scale = flipScale;
             }
         }
 

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         public Bindable<LabelStyles> LabelStyle { get; } = new Bindable<LabelStyles>(LabelStyles.Icons);
 
         private SpriteIcon arrow;
-        private Drawable labelEarly;
-        private Drawable labelLate;
+        private UprightAspectMaintainingContainer labelEarly;
+        private UprightAspectMaintainingContainer labelLate;
 
         private Container colourBarsEarly;
         private Container colourBarsLate;
@@ -122,6 +122,18 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                                 Origin = Anchor.TopCentre,
                                 RelativeSizeAxes = Axes.Y,
                                 Width = judgement_line_width,
+                            },
+                            labelEarly = new UprightAspectMaintainingContainer {
+                                AutoSizeAxes = Axes.Both,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.Centre,
+                                Y = -10,
+                            },
+                            labelLate = new UprightAspectMaintainingContainer {
+                                AutoSizeAxes = Axes.Both,
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.Centre,
+                                Y = 10,
                             },
                         }
                     },
@@ -262,86 +274,39 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         {
             const float icon_size = 14;
 
-            labelEarly?.Expire();
-            labelEarly = null;
-
-            labelLate?.Expire();
-            labelLate = null;
-
             switch (style)
             {
                 case LabelStyles.None:
                     break;
 
                 case LabelStyles.Icons:
-                    labelEarly = new UprightAspectMaintainingContainer
+                    labelEarly.Child = new SpriteIcon
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.Centre,
-                        Y = -10,
-                        Children = new Drawable[]
-                        {
-                            new SpriteIcon
-                            {
-                                Size = new Vector2(icon_size),
-                                Icon = FontAwesome.Solid.ShippingFast,
-                            }
-                        }
+                        Size = new Vector2(icon_size),
+                        Icon = FontAwesome.Solid.ShippingFast,
                     };
 
-                    labelLate = new UprightAspectMaintainingContainer
+                    labelLate.Child = new SpriteIcon
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.Centre,
-                        Y = 10,
-                        Children = new Drawable[]
-                        {
-                            new SpriteIcon
-                            {
-                                Y = 10,
-                                Size = new Vector2(icon_size),
-                                Icon = FontAwesome.Solid.Bicycle,
-                            }
-                        }
+                        Size = new Vector2(icon_size),
+                        Icon = FontAwesome.Solid.Bicycle,
                     };
 
                     break;
 
                 case LabelStyles.Text:
-                    labelEarly = new UprightAspectMaintainingContainer
+                    labelEarly.Child = new OsuSpriteText
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.Centre,
-                        Y = -10,
-                        Children = new Drawable[]
-                        {
-                            new OsuSpriteText
-                            {
-                                Text = "Early",
-                                Font = OsuFont.Default.With(size: 10),
-                                Height = 12,
-                            }
-                        }
+                        Text = "Early",
+                        Font = OsuFont.Default.With(size: 10),
+                        Height = 12,
                     };
 
-                    labelLate = new UprightAspectMaintainingContainer
+                    labelLate.Child = new OsuSpriteText
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.Centre,
-                        Y = 10,
-                        Children = new Drawable[]
-                        {
-                            new OsuSpriteText
-                            {
-                                Text = "Late",
-                                Font = OsuFont.Default.With(size: 10),
-                                Height = 12,
-                            }
-                        }
+                        Text = "Late",
+                        Font = OsuFont.Default.With(size: 10),
+                        Height = 12,
                     };
 
                     break;
@@ -350,17 +315,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                     throw new ArgumentOutOfRangeException(nameof(style), style, null);
             }
 
-            if (labelEarly != null)
-            {
-                colourBars.Add(labelEarly);
-                labelEarly.FadeInFromZero(500);
-            }
-
-            if (labelLate != null)
-            {
-                colourBars.Add(labelLate);
-                labelLate.FadeInFromZero(500);
-            }
+            labelEarly.FadeInFromZero(500);
+            labelLate.FadeInFromZero(500);
         }
 
         private void createColourBars((HitResult result, double length)[] windows)

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -338,8 +338,26 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             base.Update();
 
             // undo any layout rotation to display icons in the correct orientation
-            if (labelEarly != null) labelEarly.Rotation = -Rotation;
-            if (labelLate != null) labelLate.Rotation = -Rotation;
+            bool xFlipped = Scale.X < 0;
+            bool yFlipped = Scale.Y < 0;
+            bool horizontal = Rotation == 90 || Rotation == -90;
+
+            bool flipX = (xFlipped && yFlipped) || (xFlipped && !horizontal) || (yFlipped && horizontal);
+            bool flipY = (xFlipped && yFlipped) || (xFlipped && horizontal) || (yFlipped && !horizontal);
+
+            Vector2 flipScale = new Vector2(flipX ? -1 : 1, flipY ? -1 : 1);
+
+            if (labelEarly != null)
+            {
+                labelEarly.Rotation = -Rotation;
+                labelEarly.Scale = flipScale;
+            }
+
+            if (labelLate != null)
+            {
+                labelLate.Rotation = -Rotation;
+                labelLate.Scale = flipScale;
+            }
         }
 
         private void createColourBars((HitResult result, double length)[] windows)


### PR DESCRIPTION
Icons now keep their original orientation when the hit error bar is flipped, instead of breaking.

I probably have every possible flip/rotation here,

Before PR:
![image](https://user-images.githubusercontent.com/83010835/196028794-c2e1e83b-bdee-490a-8f4f-8a7ef8efbcc0.png)

After PR:
![image](https://user-images.githubusercontent.com/83010835/196028841-e65040f7-b718-495d-b13e-1bf2b0f9ffd1.png)

Notes:
After running formatting and style analysis (fairly sure thats what `InspectCode.sh` is supposed to do) nearly every file was modified, so I just copied out the formatted version of my change, reverted, and re-applied the change.

Not sure if the new object allocation per `Update()` is bad, didn't check if it runs per frame. Maybe all of this should go into the `set` blocks for `Rotation` and `Scale`.