### PR TITLE
Fix potential exception in `SubmittingPlayer` token retrieval on request timeout

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -86,16 +86,13 @@ namespace osu.Game.Screens.Play
 
             // Generally a timeout would not happen here as APIAccess will timeout first.
             if (!tcs.Task.Wait(60000))
-                handleTokenFailure(new InvalidOperationException("Token retrieval timed out (request never run)"));
+                req.TriggerFailure(new InvalidOperationException("Token retrieval timed out (request never run)"));
 
             return true;
 
             void handleTokenFailure(Exception exception)
             {
-                // This method may be invoked multiple times due to the Task.Wait call above.
-                // We only really care about the first error.
-                if (!tcs.TrySetResult(false))
-                    return;
+                tcs.SetResult(false);
 
                 if (HandleTokenRetrievalFailure(exception))
                 {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/20762

Detailed explained in https://github.com/ppy/osu/issues/20762#issuecomment-1279790120 / https://github.com/ppy/osu/issues/20762#issuecomment-1280113924. We might want to consider a way for `APIAccess` to automatically disregard any API request initiated from components that have been disposed/finalised, but for now we'll have to explicitly cancel them ourselves beforehand.

Manually tested by the following patch, with a breakpoint attached to process the request after exiting gameplay:
```diff
diff --git a/osu.Game/Online/API/APIAccess.cs b/osu.Game/Online/API/APIAccess.cs
index a0c8e0d555..9ff34af3c5 100644
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -20,6 +20,7 @@
 using osu.Game.Configuration;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
 using osu.Game.Users;
 
 namespace osu.Game.Online.API
@@ -164,6 +165,9 @@ private void processQueuedRequests()
                 {
                     if (queue.Count == 0) return;
 
+                    if (queue.Peek() is APIRequest<APIScoreToken>)
+                        continue;
+
                     req = queue.Dequeue();
                 }
 
```