### PR TITLE
Dialog popup interface

### DIFF
--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddAssert("dialog displayed", () => dialogOverlay.CurrentDialog is DeleteCollectionDialog);
             AddStep("click confirmation", () =>
             {
-                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogButton>().First());
+                InputManager.MoveMouseTo((dialogOverlay.CurrentDialog as Drawable).ChildrenOfType<PopupDialogButton>().First());
                 InputManager.PressButton(MouseButton.Left);
             });
 
@@ -230,7 +230,7 @@ namespace osu.Game.Tests.Visual.Collections
             AddAssert("dialog displayed", () => dialogOverlay.CurrentDialog is DeleteCollectionDialog);
             AddStep("click cancellation", () =>
             {
-                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogButton>().Last());
+                InputManager.MoveMouseTo((dialogOverlay.CurrentDialog as Drawable).ChildrenOfType<PopupDialogButton>().Last());
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("exit without save", () => Editor.Exit());
             AddStep("hold to confirm", () =>
             {
-                var confirmButton = DialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogDangerousButton>().First();
+                var confirmButton = (DialogOverlay.CurrentDialog as Drawable).ChildrenOfType<PopupDialogDangerousButton>().First();
 
                 InputManager.MoveMouseTo(confirmButton);
                 InputManager.PressButton(MouseButton.Left);
@@ -194,7 +194,7 @@ namespace osu.Game.Tests.Visual.Editing
             if (sameRuleset)
             {
                 AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog is CreateNewDifficultyDialog);
-                AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog.PerformOkAction());
+                AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog?.PerformOkAction());
             }
 
             AddUntilStep("wait for created", () =>
@@ -222,7 +222,8 @@ namespace osu.Game.Tests.Visual.Editing
                 return beatmap != null
                        && beatmap.DifficultyName == secondDifficultyName
                        && set != null
-                       && set.PerformRead(s => s.Beatmaps.Count == 2 && s.Beatmaps.Any(b => b.DifficultyName == secondDifficultyName) && s.Beatmaps.All(b => s.Status == BeatmapOnlineStatus.LocallyModified));
+                       && set.PerformRead(s =>
+                           s.Beatmaps.Count == 2 && s.Beatmaps.Any(b => b.DifficultyName == secondDifficultyName) && s.Beatmaps.All(b => s.Status == BeatmapOnlineStatus.LocallyModified));
             });
         }
 
@@ -280,7 +281,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("create new difficulty", () => Editor.CreateNewDifficulty(new OsuRuleset().RulesetInfo));
 
             AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog is CreateNewDifficultyDialog);
-            AddStep("confirm creation as a copy", () => DialogOverlay.CurrentDialog.Buttons.ElementAt(1).TriggerClick());
+            AddStep("confirm creation as a copy", () => DialogOverlay.CurrentDialog?.Buttons.ElementAt(1).TriggerClick());
 
             AddUntilStep("wait for created", () =>
             {
@@ -341,7 +342,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("try to create new difficulty", () => Editor.CreateNewDifficulty(new OsuRuleset().RulesetInfo));
             AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog is CreateNewDifficultyDialog);
-            AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog.PerformOkAction());
+            AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog?.PerformOkAction());
 
             AddUntilStep("wait for created", () =>
             {
@@ -376,7 +377,7 @@ namespace osu.Game.Tests.Visual.Editing
             if (sameRuleset)
             {
                 AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog is CreateNewDifficultyDialog);
-                AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog.PerformOkAction());
+                AddStep("confirm creation with no objects", () => DialogOverlay.CurrentDialog?.PerformOkAction());
             }
 
             AddUntilStep("wait for created", () =>

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("dialog displayed", () => dialogOverlay.CurrentDialog is UpdateLocalConfirmationDialog);
             AddStep("click confirmation", () =>
             {
-                InputManager.MoveMouseTo(dialogOverlay.CurrentDialog.ChildrenOfType<PopupDialogButton>().First());
+                InputManager.MoveMouseTo((dialogOverlay.CurrentDialog as Drawable).ChildrenOfType<PopupDialogButton>().First());
                 InputManager.PressButton(MouseButton.Left);
             });
 

--- a/osu.Game/Overlays/Dialog/IPopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/IPopupDialog.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Overlays.Dialog
+{
+    public interface IPopupDialog : IDrawable
+    {
+        IEnumerable<PopupDialogButton> Buttons { get; }
+        Bindable<Visibility> State { get; }
+
+        /// <summary>
+        /// Programmatically clicks the first <see cref="PopupDialogOkButton"/>.
+        /// </summary>
+        public void PerformOkAction() => PerformAction<PopupDialogOkButton>();
+
+        /// <summary>
+        /// Programmatically clicks the first button of the provided type.
+        /// </summary>
+        public void PerformAction<T>() where T : PopupDialogButton;
+    }
+}

--- a/osu.Game/Overlays/Dialog/IPopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/IPopupDialog.cs
@@ -10,7 +10,8 @@ namespace osu.Game.Overlays.Dialog
 {
     public interface IPopupDialog : IDrawable
     {
-        IEnumerable<PopupDialogButton> Buttons { get; }
+        IEnumerable<ClickableContainer> Buttons { get; }
+
         Bindable<Visibility> State { get; }
 
         /// <summary>
@@ -21,6 +22,6 @@ namespace osu.Game.Overlays.Dialog
         /// <summary>
         /// Programmatically clicks the first button of the provided type.
         /// </summary>
-        public void PerformAction<T>() where T : PopupDialogButton;
+        public void PerformAction<T>() where T : ClickableContainer;
     }
 }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,7 +22,7 @@ using osuTK.Input;
 
 namespace osu.Game.Overlays.Dialog
 {
-    public abstract class PopupDialog : VisibilityContainer
+    public abstract class PopupDialog : VisibilityContainer, IPopupDialog
     {
         public const float ENTER_DURATION = 500;
         public const float EXIT_DURATION = 200;
@@ -101,6 +102,8 @@ namespace osu.Game.Overlays.Dialog
                 }
             }
         }
+
+        Bindable<Visibility> IPopupDialog.State => State;
 
         protected PopupDialog()
         {

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -103,6 +103,8 @@ namespace osu.Game.Overlays.Dialog
             }
         }
 
+        IEnumerable<ClickableContainer> IPopupDialog.Buttons => Buttons;
+
         Bindable<Visibility> IPopupDialog.State => State;
 
         protected PopupDialog()
@@ -229,7 +231,7 @@ namespace osu.Game.Overlays.Dialog
         /// <summary>
         /// Programmatically clicks the first button of the provided type.
         /// </summary>
-        public void PerformAction<T>() where T : PopupDialogButton => Buttons.OfType<T>().First().TriggerClick();
+        public void PerformAction<T>() where T : ClickableContainer => Buttons.OfType<T>().First().TriggerClick();
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Overlays.Dialog;
@@ -23,9 +21,9 @@ namespace osu.Game.Overlays
         protected override string PopInSampleName => "UI/dialog-pop-in";
         protected override string PopOutSampleName => "UI/dialog-pop-out";
 
-        private AudioFilter lowPassFilter;
+        private AudioFilter lowPassFilter = null!;
 
-        public PopupDialog CurrentDialog { get; private set; }
+        public IPopupDialog? CurrentDialog { get; private set; }
 
         public DialogOverlay()
         {
@@ -47,7 +45,7 @@ namespace osu.Game.Overlays
             AddInternal(lowPassFilter = new AudioFilter(audio.TrackMixer));
         }
 
-        public void Push(PopupDialog dialog)
+        public void Push(IPopupDialog dialog)
         {
             if (dialog == CurrentDialog || dialog.State.Value == Visibility.Hidden) return;
 
@@ -68,7 +66,7 @@ namespace osu.Game.Overlays
                     return;
                 }
 
-                dialogContainer.Add(dialog);
+                dialogContainer.Add((Drawable)dialog);
                 Show();
 
                 dialog.State.BindValueChanged(state =>
@@ -76,7 +74,7 @@ namespace osu.Game.Overlays
                     if (state.NewValue != Visibility.Hidden) return;
 
                     // Trigger the demise of the dialog as soon as it hides.
-                    dialog.Delay(PopupDialog.EXIT_DURATION).Expire();
+                    ((Drawable)dialog).Delay(PopupDialog.EXIT_DURATION).Expire();
 
                     dismiss();
                 });
@@ -123,7 +121,7 @@ namespace osu.Game.Overlays
                 case GlobalAction.Select:
                     var clickableButton =
                         CurrentDialog?.Buttons.OfType<PopupDialogOkButton>().FirstOrDefault() ??
-                        CurrentDialog?.Buttons.First();
+                        CurrentDialog?.Buttons.FirstOrDefault();
 
                     clickableButton?.TriggerClick();
                     return true;

--- a/osu.Game/Overlays/IDialogOverlay.cs
+++ b/osu.Game/Overlays/IDialogOverlay.cs
@@ -20,11 +20,11 @@ namespace osu.Game.Overlays
         /// If the dialog instance provided is already displayed, it will be a noop.
         /// </remarks>
         /// <param name="dialog">The dialog to be presented.</param>
-        void Push(PopupDialog dialog);
+        void Push(IPopupDialog dialog);
 
         /// <summary>
         /// The currently displayed dialog, if any.
         /// </summary>
-        PopupDialog? CurrentDialog { get; }
+        IPopupDialog? CurrentDialog { get; }
     }
 }

--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -35,7 +35,7 @@ namespace osu.Game
 
         private readonly ScheduledDelegate task;
 
-        private PopupDialog lastEncounteredDialog;
+        private IPopupDialog lastEncounteredDialog;
         private IScreen lastEncounteredDialogScreen;
 
         /// <summary>


### PR DESCRIPTION
Adds interface for popups to allow displaying custom drawables via `DialogOverlay`.

`ClickableContainer` was chosen as base button type to allow exposing both `OsuButton`s and `DialogButton`s.
