### PR TITLE
Add 'trackfollowcircle' to settings

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             base.InitialiseDefaults();
             SetDefault(OsuRulesetSetting.SnakingInSliders, true);
             SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
+            SetDefault(OsuRulesetSetting.TrackFollowCircle, true);
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
             SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
         }
@@ -30,6 +31,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
     {
         SnakingInSliders,
         SnakingOutSliders,
+        TrackFollowCircle,
         ShowCursorTrail,
         PlayfieldBorderStyle,
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
@@ -44,10 +45,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager config)
         {
+            ReadFromConfig(config);
             PositionBindable.BindValueChanged(_ => updatePosition());
             pathVersion.BindValueChanged(_ => updatePosition());
+        }
+
+         private void ReadFromConfig(OsuRulesetConfigManager config)
+        {
+           TrackFollowCircle = config.Get<bool>(OsuRulesetSetting.TrackFollowCircle);
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Rulesets.Osu.UI
                     LabelText = "Snaking out sliders",
                     Current = config.GetBindable<bool>(OsuRulesetSetting.SnakingOutSliders)
                 },
+                 new SettingsCheckbox
+                {
+                    LabelText = "Track follow circle",
+                    Current = config.GetBindable<bool>(OsuRulesetSetting.TrackFollowCircle)
+                },
                 new SettingsCheckbox
                 {
                     LabelText = "Cursor trail",


### PR DESCRIPTION
Adds the ability to enable and disable the TrackFollowCircle feature in the ruleset settings.
![Shotcut_00_00_25_217](https://user-images.githubusercontent.com/115698367/196151801-a59575ba-5d1e-4a84-92dd-31d1bffabc99.png)
![on](https://user-images.githubusercontent.com/115698367/196150114-01ad4bc4-3298-49ff-96d7-357477b917a8.gif)
![Shotcut_00_00_15_850](https://user-images.githubusercontent.com/115698367/196151830-2244c7ca-44f8-44be-a7f5-e96dac12db2b.png)
![off](https://user-images.githubusercontent.com/115698367/196150412-bccf2115-8c50-47fe-a0e6-f088986d1e37.gif)
