### PR TITLE
Add test scene as environment to test changes to score algorithms

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoring.cs
@@ -54,30 +54,38 @@ namespace osu.Game.Tests.Gameplay
                     new GridContainer
                     {
                         RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
+                        {
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(GridSizeMode.AutoSize),
+                        },
                         Content = new[]
                         {
                             new Drawable[]
                             {
                                 graphs = new GraphContainer
                                 {
-                                    RelativeSizeAxes = Axes.X,
-                                    Height = 200,
+                                    RelativeSizeAxes = Axes.Both,
                                 },
                             },
                             new Drawable[]
                             {
                                 legend = new FillFlowContainer
                                 {
+                                    Padding = new MarginPadding(20),
                                     Direction = FillDirection.Vertical,
                                     RelativeSizeAxes = Axes.X,
-                                    Height = 200,
+                                    AutoSizeAxes = Axes.Y,
                                 },
                             },
                             new Drawable[]
                             {
                                 new FillFlowContainer
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    Padding = new MarginPadding(20),
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
                                     Direction = FillDirection.Full,
                                     Children = new Drawable[]
                                     {
@@ -230,13 +238,26 @@ namespace osu.Game.Tests.Gameplay
             {
                 if (i % 100 == 0)
                 {
-                    verticalGridLines.Add(new Box
+                    verticalGridLines.AddRange(new Drawable[]
                     {
-                        Colour = OsuColour.Gray(0.2f),
-                        Width = 1,
-                        RelativeSizeAxes = Axes.Y,
-                        RelativePositionAxes = Axes.X,
-                        X = (float)i / MaxCombo.Value,
+                        new Box
+                        {
+                            Colour = OsuColour.Gray(0.2f),
+                            Width = 1,
+                            RelativeSizeAxes = Axes.Y,
+                            RelativePositionAxes = Axes.X,
+                            X = (float)i / MaxCombo.Value,
+                        },
+                        new OsuSpriteText
+                        {
+                            RelativePositionAxes = Axes.X,
+                            X = (float)i / MaxCombo.Value,
+                            Anchor = Anchor.BottomLeft,
+                            Origin = Anchor.BottomLeft,
+                            Text = $"{i:#,0}",
+                            Rotation = -30,
+                            Y = -20,
+                        }
                     });
                 }
             }

--- a/osu.Game.Tests/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoring.cs
@@ -180,6 +180,7 @@ namespace osu.Game.Tests.Gameplay
         private readonly Box hoverLine;
 
         private readonly Container missLines;
+        private readonly Container verticalGridLines;
 
         public GraphContainer()
         {
@@ -191,6 +192,10 @@ namespace osu.Game.Tests.Gameplay
                     new Box
                     {
                         Colour = OsuColour.Gray(0.1f),
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    verticalGridLines = new Container
+                    {
                         RelativeSizeAxes = Axes.Both,
                     },
                     Content,
@@ -208,9 +213,33 @@ namespace osu.Game.Tests.Gameplay
                 }
             };
 
-            MissLocations.BindCollectionChanged((_, _) => updateMissLocations(), true);
+            MissLocations.BindCollectionChanged((_, _) => updateMissLocations());
 
-            MaxCombo.BindValueChanged(_ => updateMissLocations());
+            MaxCombo.BindValueChanged(_ =>
+            {
+                updateMissLocations();
+                updateVerticalGridLines();
+            }, true);
+        }
+
+        private void updateVerticalGridLines()
+        {
+            verticalGridLines.Clear();
+
+            for (int i = 0; i < MaxCombo.Value; i++)
+            {
+                if (i % 100 == 0)
+                {
+                    verticalGridLines.Add(new Box
+                    {
+                        Colour = OsuColour.Gray(0.2f),
+                        Width = 1,
+                        RelativeSizeAxes = Axes.Y,
+                        RelativePositionAxes = Axes.X,
+                        X = (float)i / MaxCombo.Value,
+                    });
+                }
+            }
         }
 
         private void updateMissLocations()

--- a/osu.Game.Tests/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoring.cs
@@ -1,0 +1,138 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Threading;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Tests.Visual;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Gameplay
+{
+    public class TestSceneScoring : OsuTestScene
+    {
+        private Container graphs = null!;
+        private SettingsSlider<int> sliderMaxCombo = null!;
+
+        [Test]
+        public void TestBasic()
+        {
+            AddStep("setup tests", () =>
+            {
+                Children = new Drawable[]
+                {
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Content = new[]
+                        {
+                            new Drawable[]
+                            {
+                                graphs = new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    Height = 200,
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new FillFlowContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Direction = FillDirection.Full,
+                                    Children = new Drawable[]
+                                    {
+                                        sliderMaxCombo = new SettingsSlider<int>
+                                        {
+                                            Width = 0.5f,
+                                            Current = new BindableInt(1024)
+                                            {
+                                                MinValue = 96,
+                                                MaxValue = 8192,
+                                            },
+                                            LabelText = "max combo",
+                                        }
+                                    }
+                                },
+                            },
+                        }
+                    }
+                };
+
+                sliderMaxCombo.Current.BindValueChanged(_ => rerun());
+
+                rerun();
+            });
+        }
+
+        private ScheduledDelegate? debouncedRun;
+
+        private void rerun()
+        {
+            graphs.Clear();
+
+            debouncedRun?.Cancel();
+            debouncedRun = Scheduler.AddDelayed(() =>
+            {
+                runForProcessor("lazer-classic", new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Classic } });
+                runForProcessor("lazer-standardised", new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Standardised } });
+            }, 200);
+        }
+
+        private void runForProcessor(string name, ScoreProcessor processor)
+        {
+            int maxCombo = sliderMaxCombo.Current.Value;
+
+            var beatmap = new OsuBeatmap();
+
+            for (int i = 0; i < maxCombo; i++)
+            {
+                beatmap.HitObjects.Add(new HitCircle());
+            }
+
+            processor.ApplyBeatmap(beatmap);
+
+            int[] missLocations = { 200, 500, 800 };
+
+            List<float> results = new List<float>();
+
+            for (int i = 0; i < maxCombo; i++)
+            {
+                if (missLocations.Contains(i))
+                {
+                    processor.ApplyResult(new OsuJudgementResult(new HitCircle(), new OsuJudgement())
+                    {
+                        Type = HitResult.Miss
+                    });
+                }
+                else
+                {
+                    processor.ApplyResult(new OsuJudgementResult(new HitCircle(), new OsuJudgement())
+                    {
+                        Type = HitResult.Great
+                    });
+                }
+
+                results.Add((float)processor.TotalScore.Value);
+            }
+
+            graphs.Add(new LineGraph
+            {
+                RelativeSizeAxes = Axes.Both,
+                LineColour = Color4.Red,
+                Values = results
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
@@ -85,6 +86,13 @@ namespace osu.Game.Tests.Visual.Gameplay
                                                 MaxValue = 8192,
                                             },
                                             LabelText = "max combo",
+                                        },
+                                        new OsuTextFlowContainer
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Width = 0.5f,
+                                            AutoSizeAxes = Axes.Y,
+                                            Text = "Left click to add miss"
                                         }
                                     }
                                 },
@@ -261,18 +269,20 @@ namespace osu.Game.Tests.Visual.Gameplay
                     {
                         RelativeSizeAxes = Axes.Both,
                     },
-                    Content,
                     hoverLine = new Box
                     {
                         Colour = Color4.Yellow,
                         RelativeSizeAxes = Axes.Y,
+                        Origin = Anchor.TopCentre,
                         Alpha = 0,
                         Width = 1,
                     },
                     missLines = new Container
                     {
+                        Alpha = 0.6f,
                         RelativeSizeAxes = Axes.Both,
                     },
+                    Content,
                 }
             };
 
@@ -298,6 +308,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                         new Box
                         {
                             Colour = OsuColour.Gray(0.2f),
+                            Origin = Anchor.TopCentre,
                             Width = 1,
                             RelativeSizeAxes = Axes.Y,
                             RelativePositionAxes = Axes.X,
@@ -327,6 +338,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 missLines.Add(new Box
                 {
                     Colour = Color4.Red,
+                    Origin = Anchor.TopCentre,
                     Width = 1,
                     RelativeSizeAxes = Axes.Y,
                     RelativePositionAxes = Axes.X,

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -167,14 +167,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void runScoreV2()
         {
-            int currentCombo = 0;
-            double comboPortion = 0;
-
             int maxCombo = sliderMaxCombo.Current.Value;
 
+            int currentCombo = 0;
+            double comboPortion = 0;
             double currentBaseScore = 0;
             double maxBaseScore = 0;
-
             int currentHits = 0;
 
             for (int i = 0; i < maxCombo; i++)
@@ -182,9 +180,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             double comboPortionMax = comboPortion;
 
+            currentCombo = 0;
             comboPortion = 0;
-            maxBaseScore = 0;
             currentBaseScore = 0;
+            maxBaseScore = 0;
             currentHits = 0;
 
             void applyHitV2(int baseScore)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                                 legend = new FillFlowContainer
                                 {
                                     Padding = new MarginPadding(20),
-                                    Direction = FillDirection.Vertical,
+                                    Direction = FillDirection.Full,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                 },
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             graphs.Clear();
             legend.Clear();
 
-            runForProcessor("lazer-standardised", Color4.Cyan, new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Standardised } });
+            runForProcessor("lazer-standardised", Color4.YellowGreen, new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Standardised } });
             runForProcessor("lazer-classic", Color4.MediumPurple, new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Classic } });
 
             int totalScore = 0;
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             const int base_score = 300;
 
-            runForAlgorithm("ScoreV1 (classic)", Color4.Beige, () =>
+            runForAlgorithm("ScoreV1 (classic)", Color4.Purple, () =>
             {
                 const float score_multiplier = 1;
 
@@ -129,7 +129,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             }, () =>
             {
                 currentCombo = 0;
-            }, () => totalScore);
+            }, () =>
+            {
+                // Arbitrary value chosen towards the upper range.
+                const double score_multiplier = 4;
+
+                return (int)(totalScore * score_multiplier);
+            });
 
             double comboPortion = 0;
 
@@ -211,7 +217,17 @@ namespace osu.Game.Tests.Visual.Gameplay
             legend.Add(new OsuSpriteText
             {
                 Colour = colour,
+                RelativeSizeAxes = Axes.X,
+                Width = 0.5f,
                 Text = $"{FontAwesome.Solid.Circle.Icon} {name}"
+            });
+
+            legend.Add(new OsuSpriteText
+            {
+                Colour = colour,
+                RelativeSizeAxes = Axes.X,
+                Width = 0.5f,
+                Text = $"final score {getTotalScore():#,0}"
             });
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -20,10 +20,9 @@ using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Tests.Visual;
 using osuTK.Graphics;
 
-namespace osu.Game.Tests.Gameplay
+namespace osu.Game.Tests.Visual.Gameplay
 {
     public class TestSceneScoring : OsuTestScene
     {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             void applyHitV2(int baseScore)
             {
-                maxBaseScore += baseScore;
+                maxBaseScore += base_great;
                 currentBaseScore += baseScore;
                 comboPortion += baseScore * (1 + ++currentCombo / 10.0);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneScoring.cs
@@ -31,18 +31,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private FillFlowContainer legend = null!;
 
-        private static readonly Color4[] line_colours =
-        {
-            Color4Extensions.FromHex("588c7e"),
-            Color4Extensions.FromHex("b2a367"),
-            Color4Extensions.FromHex("c98f65"),
-            Color4Extensions.FromHex("bc5151"),
-            Color4Extensions.FromHex("5c8bd6"),
-            Color4Extensions.FromHex("7f6ab7"),
-            Color4Extensions.FromHex("a368ad"),
-            Color4Extensions.FromHex("aa6880"),
-        };
-
         [Test]
         public void TestBasic()
         {
@@ -120,13 +108,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             graphs.Clear();
             legend.Clear();
 
-            runForProcessor("lazer-classic", new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Classic } });
-            runForProcessor("lazer-standardised", new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Standardised } });
+            runForProcessor("lazer-standardised", Color4.Cyan, new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Standardised } });
+            runForProcessor("lazer-classic", Color4.Orange, new ScoreProcessor(new OsuRuleset()) { Mode = { Value = ScoringMode.Classic } });
 
             int totalScore = 0;
             int currentCombo = 0;
 
-            runForAlgorithm("stable-v1", () =>
+            runForAlgorithm("stable-v1", Color4.Beige, () =>
             {
                 const int base_score = 300;
                 const float score_multiplier = 1;
@@ -144,7 +132,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             }, () => totalScore);
         }
 
-        private void runForProcessor(string name, ScoreProcessor processor)
+        private void runForProcessor(string name, Color4 colour, ScoreProcessor processor)
         {
             int maxCombo = sliderMaxCombo.Current.Value;
 
@@ -154,17 +142,15 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             processor.ApplyBeatmap(beatmap);
 
-            runForAlgorithm(name,
+            runForAlgorithm(name, colour,
                 () => processor.ApplyResult(new OsuJudgementResult(new HitCircle(), new OsuJudgement()) { Type = HitResult.Great }),
                 () => processor.ApplyResult(new OsuJudgementResult(new HitCircle(), new OsuJudgement()) { Type = HitResult.Miss }),
                 () => (int)processor.TotalScore.Value);
         }
 
-        private void runForAlgorithm(string name, Action applyHit, Action applyMiss, Func<int> getTotalScore)
+        private void runForAlgorithm(string name, Color4 colour, Action applyHit, Action applyMiss, Func<int> getTotalScore)
         {
             int maxCombo = sliderMaxCombo.Current.Value;
-
-            Color4 colour = line_colours[Math.Abs(name.GetHashCode()) % line_colours.Length];
 
             List<float> results = new List<float>();
 


### PR DESCRIPTION
Triggered by https://github.com/ppy/osu/discussions/20717 and other similar discussions, I've made a test scene to allow comparing different scoring algorithms, including those from stable which have not been available for comparison until now in lazer.

https://user-images.githubusercontent.com/191335/196401226-356f36af-3ed8-46c6-8364-f96a9f106b8a.mp4

