### PR TITLE
Remove fade easing from legacy hit circles to match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -134,10 +134,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        CircleSprite.FadeOut(legacy_fade_duration, Easing.Out);
+                        CircleSprite.FadeOut(legacy_fade_duration);
                         CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
-                        OverlaySprite.FadeOut(legacy_fade_duration, Easing.Out);
+                        OverlaySprite.FadeOut(legacy_fade_duration);
                         OverlaySprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 
                         if (hasNumber)
@@ -146,11 +146,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
                             if (legacyVersion >= 2.0m)
                                 // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
-                                hitCircleText.FadeOut(legacy_fade_duration / 4, Easing.Out);
+                                hitCircleText.FadeOut(legacy_fade_duration / 4);
                             else
                             {
                                 // old skins scale and fade it normally along other pieces.
-                                hitCircleText.FadeOut(legacy_fade_duration, Easing.Out);
+                                hitCircleText.FadeOut(legacy_fade_duration);
                                 hitCircleText.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
                             }
                         }


### PR DESCRIPTION
- First part of https://github.com/ppy/osu/issues/20806 

I'm keeping this in parts since some may require further discussion while others should be mergeable.

Simplest of all. Stable code for reference:
```csharp
                //Fade out the actual hit circle
                Transformation circleScaleOut = new Transformation(TransformationType.Scale, 1.0F, 1.4F, armTime, (int)(armTime + (HitObjectManager.FadeOut)), EasingTypes.Out) { TagNumeric = ARMED };

                SpriteHitCircle1.Transformations.Add(circleScaleOut);
                SpriteHitCircle1.Transformations.Add(new Transformation(TransformationType.Fade, 1, 0, armTime, armTime + HitObjectManager.FadeOut) { TagNumeric = ARMED });

                SpriteHitCircle2.Transformations.Add(circleScaleOut.Clone());
                SpriteHitCircle2.Transformations.Add(new Transformation(TransformationType.Fade, 1, 0, armTime, armTime + HitObjectManager.FadeOut) { TagNumeric = ARMED });

                SpriteApproachCircle.Transformations.Add(new Transformation(TransformationType.Fade, SpriteApproachCircle.Alpha, 0, armTime, armTime) { TagNumeric = ARMED });

                if (SkinManager.UseNewLayout)
                {
                    SpriteHitCircleText.Transformations.Add(new Transformation(TransformationType.Fade, 1, 0, armTime, armTime + 60) { TagNumeric = ARMED });
                }
                else
                {
                    SpriteHitCircleText.Transformations.Add(new Transformation(TransformationType.Scale, 1.0F * TEXT_SIZE, 1.4F * TEXT_SIZE, armTime, (int)(armTime + (HitObjectManager.FadeOut)), EasingTypes.Out) { TagNumeric = ARMED });
                    SpriteHitCircleText.Transformations.Add(new Transformation(TransformationType.Fade, SpriteHitCircleText.Alpha, 0, armTime, armTime + HitObjectManager.FadeOut) { TagNumeric = ARMED });
                }
```

https://user-images.githubusercontent.com/22781491/196539550-080bc0ce-703c-4875-832a-2b95e8acd992.mp4