### PR TITLE
Adjust slider fade out transition to match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -341,7 +341,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     break;
             }
 
-            this.FadeOut(fade_out_time, Easing.OutQuint).Expire();
+            this.FadeOut(fade_out_time).Expire();
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SliderBody?.ReceivePositionalInputAt(screenSpacePos) ?? base.ReceivePositionalInputAt(screenSpacePos);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -331,7 +331,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateHitStateTransforms(state);
 
-            const float fade_out_time = 450;
+            const float fade_out_time = 240;
 
             switch (state)
             {


### PR DESCRIPTION
- Second part of https://github.com/ppy/osu/issues/20806

Slightly tricky. Sliders fade out by a transform applied in the main `DrawableSlider` component itself rather than based on the skin-specific piece. The stable transition isn't all that different from the lazer one, so I adjusted the general transform rather than moving it to be skin-specific. 

Stable code for reference:
```csharp
                sliderBody.Transformations.Clear();
                sliderBody.Transformations.Add(new Transformation(TransformationType.Fade, 0, 1, StartTime - hitObjectManager.PreEmpt, StartTime - hitObjectManager.PreEmpt + HitObjectManager.FadeIn));
                sliderBody.Transformations.Add(hidden ?
                    new Transformation(TransformationType.Fade, 1, 0, StartTime - hitObjectManager.PreEmpt + HitObjectManager.FadeIn, EndTime, EasingTypes.Out) :
                    new Transformation(TransformationType.Fade, 1, 0, EndTime, EndTime + HitObjectManager.FadeOut));

```

https://user-images.githubusercontent.com/22781491/196542433-209ffd2d-c388-4d02-8d7d-b37b12338232.mp4

(will note that the videos are *slightly* out of sync because timing is hard with the tools I have available, but can try to make it in-sync if necessary)