### PR TITLE
Adjust spinner fade transitions to match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// </summary>
         public readonly IBindable<double> SpinsPerMinute = new BindableDouble();
 
-        private const double fade_out_duration = 160;
+        private const double fade_out_duration = 240;
 
         public DrawableSpinner()
             : this(null)

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
@@ -107,8 +107,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
                         this.FadeOut();
 
-                    using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2))
-                        this.FadeInFromZero(spinner.TimeFadeIn / 2);
+                    using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn))
+                        this.FadeInFromZero(spinner.TimeFadeIn);
 
                     using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
                     {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySpinner.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     spin = new Sprite
                     {
+                        Alpha = 0,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.Centre,
                         Texture = source.GetTexture("spinner-spin"),
@@ -82,7 +83,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     },
                     bonusCounter = new LegacySpriteText(LegacyFont.Score)
                     {
-                        Alpha = 0f,
+                        Alpha = 0,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.Centre,
                         Scale = new Vector2(SPRITE_SCALE),
@@ -178,6 +179,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         spmBackground.MoveToOffset(new Vector2(0, -spm_hide_offset), d.HitObject.TimeFadeIn, Easing.Out);
                         spmCounter.MoveToOffset(new Vector2(0, -spm_hide_offset), d.HitObject.TimeFadeIn, Easing.Out);
                     }
+
+                    using (BeginAbsoluteSequence(d.HitObject.StartTime - d.HitObject.TimeFadeIn / 2))
+                        spin.FadeInFromZero(d.HitObject.TimeFadeIn / 2);
 
                     using (BeginAbsoluteSequence(d.HitObject.StartTime))
                         ApproachCircle?.ScaleTo(SPRITE_SCALE * 0.1f, d.HitObject.Duration);


### PR DESCRIPTION
- Third and final part of #20806

Also tricky. Spinner fade-in transform is applied to the whole `LegacySpinner` component, which is a problem for the "spin" sprite now since it's supposed to appear a bit later than the spinner body. That makes the "spin" sprite fade "longer" in lazer than in stable, but I'm not sure that's really an issue so kept it as-is for simplicity.

Like https://github.com/ppy/osu/pull/20816, spinner fade-out transform is also applied to the main `DrawableSpinner` component instead of being skin-specific, so the adjustment will affect non-legacy skins as well, but don't think it's worth the effort to make it skin-specific (if feasible in the first place).

Stable code for reference:
```csharp
                SpriteCircleTop = new pSprite(TextureManager.Load(@"spinner-top"), Fields.TopLeft, Origins.Centre, Clocks.Audio, posTopLeftCentre, SpriteManager.drawOrderFwdLowPrio(StartTime + 1), false, initialColour);
                SpriteCollection.Add(SpriteCircleTop);

                spriteCircleBottom = new pSprite(TextureManager.Load(@"spinner-bottom"), Fields.TopLeft, Origins.Centre, Clocks.Audio, posTopLeftCentre, SpriteManager.drawOrderFwdLowPrio(StartTime), false, initialColour);
                SpriteCollection.Add(spriteCircleBottom);

                spriteMiddleTop = new pSprite(TextureManager.Load(@"spinner-middle"), Fields.TopLeft, Origins.Centre, Clocks.Audio, posTopLeftCentre, SpriteManager.drawOrderFwdLowPrio(StartTime + 3), false, Color.TransparentWhite);
                SpriteCollection.Add(spriteMiddleTop);

                spriteMiddleBottom = new pSprite(TextureManager.Load(@"spinner-middle2"), Fields.TopLeft, Origins.Centre, Clocks.Audio, posTopLeftCentre, SpriteManager.drawOrderFwdLowPrio(StartTime + 2), false, Color.TransparentWhite);
                SpriteCollection.Add(spriteMiddleBottom);

                ...

                foreach (pSprite p in SpriteCollection)
                {
                    if (p.TagNumeric == -5) continue;

                    p.Transformations.Clear();
                    p.Transformations.Add(FadeInTransformation);
                    p.Transformations.Add(new Transformation(TransformationType.Fade, 1, 0, EndTime, EndTime + HitObjectManager.FadeOut));
                }
```

https://user-images.githubusercontent.com/22781491/196544595-ebfb12eb-c158-46d2-ad49-7bed3101bdab.mp4

(videos also *slightly* out of sync here as well, can try to make it in-sync if necessary)