### PR TITLE
Implement taiko hitobject kiai flashing

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             InternalChildren = new[]
             {
-                CircleSprite = new KiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
+                CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = OverlaySprite = new KiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
+                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRoll.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             TimeRange = { Value = 5000 },
         };
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void DrumrollTest()
         {
             AddStep("Drum roll", () => SetContents(_ =>
             {

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRollKiai.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableDrumRollKiai.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    [TestFixture]
+    public class TestSceneDrawableDrumRollKiai : TestSceneDrawableDrumRoll
+    {
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            var controlPointInfo = new ControlPointInfo();
+
+            controlPointInfo.Add(0, new TimingControlPoint { BeatLength = 500 });
+            controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
+
+            Beatmap.Value = CreateWorkingBeatmap(new Beatmap
+            {
+                ControlPointInfo = controlPointInfo
+            });
+
+            // track needs to be playing for BeatSyncedContainer to work.
+            Beatmap.Value.Track.Start();
+        });
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -16,8 +15,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
     [TestFixture]
     public class TestSceneDrawableHit : TaikoSkinnableTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        [Test]
+        public void TestHits()
         {
             AddStep("Centre hit", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime())
             {

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHitKiai.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHitKiai.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    [TestFixture]
+    public class TestSceneDrawableHitKiai : TestSceneDrawableHit
+    {
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            var controlPointInfo = new ControlPointInfo();
+
+            controlPointInfo.Add(0, new TimingControlPoint { BeatLength = 500 });
+            controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
+
+            Beatmap.Value = CreateWorkingBeatmap(new Beatmap
+            {
+                ControlPointInfo = controlPointInfo
+            });
+
+            // track needs to be playing for BeatSyncedContainer to work.
+            Beatmap.Value.Track.Start();
+        });
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             FlashBox
                 // Make sure the hit indicator usage of FlashBox doesn't get faded out prematurely by a kiai flash
                 .DelayUntilTransformsFinished()
-                .FadeTo(flash_opacity, 0, Easing.OutQuint)
+                .FadeTo(flash_opacity)
                 .Then()
                 .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -31,6 +32,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
         public const float SYMBOL_BORDER = 8;
 
         private const double pre_beat_transition_time = 80;
+
+        private const float flash_opacity = 0.3f;
 
         private Color4 accentColour;
 
@@ -156,6 +159,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
         {
             if (!effectPoint.KiaiMode)
                 return;
+
+            FlashBox
+                // Make sure the hit indicator usage of FlashBox doesn't get faded out prematurely by a kiai flash
+                .DelayUntilTransformsFinished()
+                .FadeTo(flash_opacity, 0, Easing.OutQuint)
+                .Then()
+                .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
 
             if (beatIndex % timingPoint.TimeSignature.Numerator != 0)
                 return;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
@@ -170,7 +169,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
                 FlashBox
                     .FadeTo(flash_opacity)
                     .Then()
-                    .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
+                    .FadeOut(timingPoint.BeatLength * 0.75, Easing.OutSine);
             }
 
             if (beatIndex % timingPoint.TimeSignature.Numerator != 0)

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -14,6 +15,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
 using osuTK.Graphics;
 
@@ -155,17 +157,21 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             };
         }
 
+        [Resolved]
+        private DrawableHitObject drawableHitObject { get; set; }
+
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             if (!effectPoint.KiaiMode)
                 return;
 
-            FlashBox
-                // Make sure the hit indicator usage of FlashBox doesn't get faded out prematurely by a kiai flash
-                .DelayUntilTransformsFinished()
-                .FadeTo(flash_opacity)
-                .Then()
-                .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
+            if (drawableHitObject.State.Value == ArmedState.Idle)
+            {
+                FlashBox
+                    .FadeTo(flash_opacity)
+                    .Then()
+                    .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
+            }
 
             if (beatIndex % timingPoint.TimeSignature.Numerator != 0)
                 return;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             }
 
             // backgroundLayer is guaranteed to exist due to the pre-check in TaikoLegacySkinTransformer.
-            AddInternal(backgroundLayer = getDrawableFor("circle"));
+            AddInternal(backgroundLayer = new LegacyKiaiFlashingDrawable(() => getDrawableFor("circle")));
 
             var foregroundLayer = getDrawableFor("circleoverlay");
             if (foregroundLayer != null)

--- a/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
+++ b/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Skinning
     {
         private readonly Drawable flashingDrawable;
 
-        private const float flash_opacity = 0.3f;
+        private const float flash_opacity = 0.55f;
 
         public LegacyKiaiFlashingDrawable(Func<Drawable?> creationFunc)
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Skinning
             flashingDrawable
                 .FadeTo(flash_opacity)
                 .Then()
-                .FadeOut(timingPoint.BeatLength * 0.75f);
+                .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);
         }
     }
 }

--- a/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
+++ b/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
@@ -7,15 +7,15 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 
-namespace osu.Game.Rulesets.Osu.Skinning.Legacy
+namespace osu.Game.Skinning
 {
-    internal class KiaiFlashingDrawable : BeatSyncedContainer
+    public class LegacyKiaiFlashingDrawable : BeatSyncedContainer
     {
         private readonly Drawable flashingDrawable;
 
         private const float flash_opacity = 0.3f;
 
-        public KiaiFlashingDrawable(Func<Drawable?> creationFunc)
+        public LegacyKiaiFlashingDrawable(Func<Drawable?> creationFunc)
         {
             AutoSizeAxes = Axes.Both;
 


### PR DESCRIPTION
A lot of this code is ~~copied~~ heavily inspired on the kiai flashing implementation for the osu! standard gamemode. It's possible that the intensity and fade values still need to be adjusted since I don't have access to the original values used in stable.

https://user-images.githubusercontent.com/56885706/196560488-047932c2-57e4-49c1-b0a6-afd18dbd0f03.mp4

