### PR TITLE
Fix some argon circle layers not getting correct colour updates in editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -173,11 +173,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                                 .FadeOut(flash_in_duration);
                         }
 
-                        // The flash layer starts white to give the wanted brightness, but is almost immediately
-                        // recoloured to the accent colour. This would more correctly be done with two layers (one for the initial flash)
-                        // but works well enough with the colour fade.
                         flash.FadeTo(1, flash_in_duration, Easing.OutQuint);
-                        flash.FlashColour(accentColour.Value, fade_out_time, Easing.OutQuint);
 
                         this.FadeOut(fade_out_time, Easing.OutQuad);
                         break;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -116,6 +116,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 // Without removing transforms first, when it is rewound it may apply an old colour.
                 outerGradient.ClearTransforms(targetMember: nameof(Colour));
                 outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
+
                 outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
                 innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
                 flash.Colour = colour.NewValue;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -114,9 +114,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             {
                 // A colour transform is applied.
                 // Without removing transforms first, when it is rewound it may apply an old colour.
-                outerGradient.ClearTransforms();
+                outerGradient.ClearTransforms(targetMember: nameof(Colour));
                 outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
-
                 outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
                 innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
                 flash.Colour = colour.NewValue;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -108,18 +108,23 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         {
             base.LoadComplete();
 
-            accentColour.BindValueChanged(colour =>
-            {
-                outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
-                outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
-                innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
-                flash.Colour = colour.NewValue;
-            }, true);
-
             indexInCurrentCombo.BindValueChanged(index => number.Text = (index.NewValue + 1).ToString(), true);
 
+            accentColour.BindValueChanged(colour =>
+            {
+                // A colour transform is applied.
+                // Without removing transforms first, when it is rewound it may apply an old colour.
+                outerGradient.ClearTransforms();
+                outerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.1f));
+
+                outerFill.Colour = innerFill.Colour = colour.NewValue.Darken(4);
+                innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
+                flash.Colour = colour.NewValue;
+
+                updateStateTransforms(drawableObject, drawableObject.State.Value);
+            }, true);
+
             drawableObject.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableObject, drawableObject.State.Value);
         }
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)


### PR DESCRIPTION
Kinda ugly, not sure how to handle better. The important change is running `ClearTransforms()` and reapplying the state change when accent colour changes.

Closes #20807.