### PR TITLE
Remove smoke point maximum

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
             private Vector2 drawSize;
             private Texture? texture;
             private int rotationSeed;
-            private int firstVisibleIndex;
+            private int firstVisiblePointIndex;
 
             // anim calculation vars (color, scale, direction)
             private double initialFadeOutDurationTrunc;
@@ -221,12 +221,12 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 reFadeInTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTimeAfterSmokeEnded * (1 - 1 / re_fade_in_speed);
                 finalFadeOutTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTimeAfterSmokeEnded * (1 - 1 / final_fade_out_speed);
 
-                double firstVisibleTime = Math.Min(SmokeEndTime, CurrentTime) - initialFadeOutDurationTrunc;
-                firstVisibleIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = firstVisibleTime }, new SmokePoint.LowerBoundComparer());
-                int futureIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = CurrentTime }, new SmokePoint.UpperBoundComparer());
+                double firstVisiblePointTime = Math.Min(SmokeEndTime, CurrentTime) - initialFadeOutDurationTrunc;
+                firstVisiblePointIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = firstVisiblePointTime }, new SmokePoint.LowerBoundComparer());
+                int futurePointIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = CurrentTime }, new SmokePoint.UpperBoundComparer());
 
                 points.Clear();
-                points.AddRange(Source.SmokePoints.Skip(firstVisibleIndex).Take(futureIndex - firstVisibleIndex));
+                points.AddRange(Source.SmokePoints.Skip(firstVisiblePointIndex).Take(futurePointIndex - firstVisiblePointIndex));
             }
 
             public sealed override void Draw(IRenderer renderer)
@@ -256,7 +256,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 texture.Bind();
 
                 for (int i = 0; i < points.Count; i++)
-                    drawPointQuad(points[i], textureRect, i + firstVisibleIndex);
+                    drawPointQuad(points[i], textureRect, i + firstVisiblePointIndex);
 
                 shader.Unbind();
                 renderer.PopLocalMatrix();
@@ -272,7 +272,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 double timeDoingFinalFadeOut = finalFadeOutTime - point.Time / final_fade_out_speed;
 
-                if (timeDoingFinalFadeOut > 0 && point.Time > firstVisiblePointTimeAfterSmokeEnded)
+                if (timeDoingFinalFadeOut > 0 && point.Time >= firstVisiblePointTimeAfterSmokeEnded)
                 {
                     float fraction = Math.Clamp((float)(timeDoingFinalFadeOut / final_fade_out_duration), 0, 1);
                     fraction = MathF.Pow(fraction, 5);

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -238,9 +238,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(200, 4);
 
-                if (points.Count > quadBatch.Size * 4 && quadBatch.Size != 10922)
+                if (points.Count > quadBatch.Size && quadBatch.Size != IRenderer.MAX_QUADS)
                 {
-                    int batchSize = Math.Min((int)(quadBatch.Size * 1.5f), 10922);
+                    int batchSize = Math.Min(quadBatch.Size * 2, IRenderer.MAX_QUADS);
                     quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(batchSize, 4);
                 }
 

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -237,11 +237,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     return;
 
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(200, 4);
+
                 if (points.Count > quadBatch.Size * 4 && quadBatch.Size != 10922)
                 {
                     int batchSize = Math.Min((int)(quadBatch.Size * 1.5f), 10922);
                     quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(batchSize, 4);
                 }
+
                 texture ??= renderer.WhitePixel;
                 RectangleF textureRect = texture.GetTextureRect();
 
@@ -269,6 +271,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 var color = Color4.White;
 
                 double timeDoingFinalFadeOut = finalFadeOutTime - point.Time / final_fade_out_speed;
+
                 if (timeDoingFinalFadeOut > 0 && point.Time > firstVisiblePointTimeAfterSmokeEnded)
                 {
                     float fraction = Math.Clamp((float)(timeDoingFinalFadeOut / final_fade_out_duration), 0, 1);
@@ -278,6 +281,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 else
                 {
                     double timeDoingInitialFadeOut = initialFadeOutTime - point.Time;
+
                     if (timeDoingInitialFadeOut > 0)
                     {
                         float fraction = Math.Clamp((float)(timeDoingInitialFadeOut / initial_fade_out_duration), 0, 1);
@@ -287,6 +291,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     if (point.Time > firstVisiblePointTimeAfterSmokeEnded)
                     {
                         double timeDoingReFadeIn = reFadeInTime - point.Time / re_fade_in_speed;
+
                         if (timeDoingReFadeIn > 0)
                         {
                             float fraction = Math.Clamp((float)(timeDoingReFadeIn / re_fade_in_duration), 0, 1);

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -22,8 +23,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
 {
     public abstract class SmokeSegment : Drawable, ITexturedShaderDrawable
     {
-        private const int max_point_count = 18_000;
-
         // fade anim values
         private const double initial_fade_out_duration = 4000;
 
@@ -85,12 +84,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
             totalDistance = pointInterval;
         }
 
-        private Vector2 nextPointDirection()
-        {
-            float angle = RNG.NextSingle(0, 2 * MathF.PI);
-            return new Vector2(MathF.Sin(angle), -MathF.Cos(angle));
-        }
-
         public void AddPosition(Vector2 position, double time)
         {
             lastPosition ??= position;
@@ -107,33 +100,27 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 Vector2 pointPos = (pointInterval - (totalDistance - delta)) * increment + (Vector2)lastPosition;
                 increment *= pointInterval;
 
-                if (SmokePoints.Count > 0 && SmokePoints[^1].Time > time)
-                {
-                    int index = ~SmokePoints.BinarySearch(new SmokePoint { Time = time }, new SmokePoint.UpperBoundComparer());
-                    SmokePoints.RemoveRange(index, SmokePoints.Count - index);
-                }
-
                 totalDistance %= pointInterval;
 
-                for (int i = 0; i < count; i++)
+                if (SmokePoints.Count == 0 || SmokePoints[^1].Time <= time)
                 {
-                    SmokePoints.Add(new SmokePoint
+                    for (int i = 0; i < count; i++)
                     {
-                        Position = pointPos,
-                        Time = time,
-                        Direction = nextPointDirection(),
-                    });
+                        SmokePoints.Add(new SmokePoint
+                        {
+                            Position = pointPos,
+                            Time = time,
+                            Angle = RNG.NextSingle(0, 2 * MathF.PI),
+                        });
 
-                    pointPos += increment;
+                        pointPos += increment;
+                    }
                 }
 
                 Invalidate(Invalidation.DrawNode);
             }
 
             lastPosition = position;
-
-            if (SmokePoints.Count >= max_point_count)
-                FinishDrawing(time);
         }
 
         public void FinishDrawing(double time)
@@ -157,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         {
             public Vector2 Position;
             public double Time;
-            public Vector2 Direction;
+            public float Angle;
 
             public struct UpperBoundComparer : IComparer<SmokePoint>
             {
@@ -169,6 +156,17 @@ namespace osu.Game.Rulesets.Osu.Skinning
                     // value will be the index's complement.
 
                     return x.Time > target.Time ? 1 : -1;
+                }
+            }
+
+            public struct LowerBoundComparer : IComparer<SmokePoint>
+            {
+                public int Compare(SmokePoint x, SmokePoint target)
+                {
+                    // Similar logic as UpperBoundComparer, except returned index will always be
+                    // the first element larger or equal
+
+                    return x.Time < target.Time ? -1 : 1;
                 }
             }
         }
@@ -187,11 +185,11 @@ namespace osu.Game.Rulesets.Osu.Skinning
             private Vector2 drawSize;
             private Texture? texture;
             private int rotationSeed;
-            private int rotationIndex;
+            private int firstVisibleIndex;
 
             // anim calculation vars (color, scale, direction)
             private double initialFadeOutDurationTrunc;
-            private double firstVisiblePointTime;
+            private double firstVisiblePointTimeAfterSmokeEnded;
 
             private double initialFadeOutTime;
             private double reFadeInTime;
@@ -206,9 +204,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
             {
                 base.ApplyState();
 
-                points.Clear();
-                points.AddRange(Source.SmokePoints);
-
                 radius = Source.radius;
                 drawSize = Source.DrawSize;
                 texture = Source.Texture;
@@ -220,11 +215,18 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 rotationSeed = Source.rotationSeed;
 
                 initialFadeOutDurationTrunc = Math.Min(initial_fade_out_duration, SmokeEndTime - SmokeStartTime);
-                firstVisiblePointTime = SmokeEndTime - initialFadeOutDurationTrunc;
+                firstVisiblePointTimeAfterSmokeEnded = SmokeEndTime - initialFadeOutDurationTrunc;
 
-                initialFadeOutTime = CurrentTime;
-                reFadeInTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTime * (1 - 1 / re_fade_in_speed);
-                finalFadeOutTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTime * (1 - 1 / final_fade_out_speed);
+                initialFadeOutTime = Math.Min(CurrentTime, SmokeEndTime);
+                reFadeInTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTimeAfterSmokeEnded * (1 - 1 / re_fade_in_speed);
+                finalFadeOutTime = CurrentTime - initialFadeOutDurationTrunc - firstVisiblePointTimeAfterSmokeEnded * (1 - 1 / final_fade_out_speed);
+
+                double firstVisibleTime = Math.Min(SmokeEndTime, CurrentTime) - initialFadeOutDurationTrunc;
+                firstVisibleIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = firstVisibleTime }, new SmokePoint.LowerBoundComparer());
+                int futureIndex = ~Source.SmokePoints.BinarySearch(new SmokePoint { Time = CurrentTime }, new SmokePoint.UpperBoundComparer());
+
+                points.Clear();
+                points.AddRange(Source.SmokePoints.Skip(firstVisibleIndex).Take(futureIndex - firstVisibleIndex));
             }
 
             public sealed override void Draw(IRenderer renderer)
@@ -234,9 +236,12 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 if (points.Count == 0)
                     return;
 
-                rotationIndex = 0;
-
-                quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(max_point_count / 10, 10);
+                quadBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(200, 4);
+                if (points.Count > quadBatch.Size * 4 && quadBatch.Size != 10922)
+                {
+                    int batchSize = Math.Min((int)(quadBatch.Size * 1.5f), 10922);
+                    quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(batchSize, 4);
+                }
                 texture ??= renderer.WhitePixel;
                 RectangleF textureRect = texture.GetTextureRect();
 
@@ -248,8 +253,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 shader.Bind();
                 texture.Bind();
 
-                foreach (var point in points)
-                    drawPointQuad(point, textureRect);
+                for (int i = 0; i < points.Count; i++)
+                    drawPointQuad(points[i], textureRect, i + firstVisibleIndex);
 
                 shader.Unbind();
                 renderer.PopLocalMatrix();
@@ -263,30 +268,31 @@ namespace osu.Game.Rulesets.Osu.Skinning
             {
                 var color = Color4.White;
 
-                double timeDoingInitialFadeOut = Math.Min(initialFadeOutTime, SmokeEndTime) - point.Time;
-
-                if (timeDoingInitialFadeOut > 0)
+                double timeDoingFinalFadeOut = finalFadeOutTime - point.Time / final_fade_out_speed;
+                if (timeDoingFinalFadeOut > 0 && point.Time > firstVisiblePointTimeAfterSmokeEnded)
                 {
-                    float fraction = Math.Clamp((float)(timeDoingInitialFadeOut / initial_fade_out_duration), 0, 1);
-                    color.A = (1 - fraction) * initial_alpha;
+                    float fraction = Math.Clamp((float)(timeDoingFinalFadeOut / final_fade_out_duration), 0, 1);
+                    fraction = MathF.Pow(fraction, 5);
+                    color.A = (1 - fraction) * re_fade_in_alpha;
                 }
-
-                if (color.A > 0)
+                else
                 {
-                    double timeDoingReFadeIn = reFadeInTime - point.Time / re_fade_in_speed;
-                    double timeDoingFinalFadeOut = finalFadeOutTime - point.Time / final_fade_out_speed;
-
-                    if (timeDoingFinalFadeOut > 0)
+                    double timeDoingInitialFadeOut = initialFadeOutTime - point.Time;
+                    if (timeDoingInitialFadeOut > 0)
                     {
-                        float fraction = Math.Clamp((float)(timeDoingFinalFadeOut / final_fade_out_duration), 0, 1);
-                        fraction = MathF.Pow(fraction, 5);
-                        color.A = (1 - fraction) * re_fade_in_alpha;
+                        float fraction = Math.Clamp((float)(timeDoingInitialFadeOut / initial_fade_out_duration), 0, 1);
+                        color.A = (1 - fraction) * initial_alpha;
                     }
-                    else if (timeDoingReFadeIn > 0)
+
+                    if (point.Time > firstVisiblePointTimeAfterSmokeEnded)
                     {
-                        float fraction = Math.Clamp((float)(timeDoingReFadeIn / re_fade_in_duration), 0, 1);
-                        fraction = 1 - MathF.Pow(1 - fraction, 5);
-                        color.A = fraction * (re_fade_in_alpha - color.A) + color.A;
+                        double timeDoingReFadeIn = reFadeInTime - point.Time / re_fade_in_speed;
+                        if (timeDoingReFadeIn > 0)
+                        {
+                            float fraction = Math.Clamp((float)(timeDoingReFadeIn / re_fade_in_duration), 0, 1);
+                            fraction = 1 - MathF.Pow(1 - fraction, 5);
+                            color.A = fraction * (re_fade_in_alpha - color.A) + color.A;
+                        }
                     }
                 }
 
@@ -301,32 +307,32 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 return fraction * (final_scale - initial_scale) + initial_scale;
             }
 
-            protected virtual Vector2 PointDirection(SmokePoint point)
+            protected virtual Vector2 PointDirection(SmokePoint point, int index)
             {
-                float initialAngle = MathF.Atan2(point.Direction.Y, point.Direction.X);
-                float finalAngle = initialAngle + nextRotation();
-
                 double timeDoingRotation = CurrentTime - point.Time;
                 float fraction = Math.Clamp((float)(timeDoingRotation / rotation_duration), 0, 1);
                 fraction = 1 - MathF.Pow(1 - fraction, 5);
-                float angle = fraction * (finalAngle - initialAngle) + initialAngle;
+                float angle = fraction * getRotation(index) + point.Angle;
 
                 return new Vector2(MathF.Sin(angle), -MathF.Cos(angle));
             }
 
-            private float nextRotation() => max_rotation * (StatelessRNG.NextSingle(rotationSeed, rotationIndex++) * 2 - 1);
+            private float getRotation(int index) => max_rotation * (StatelessRNG.NextSingle(rotationSeed, index) * 2 - 1);
 
-            private void drawPointQuad(SmokePoint point, RectangleF textureRect)
+            private void drawPointQuad(SmokePoint point, RectangleF textureRect, int index)
             {
                 Debug.Assert(quadBatch != null);
 
                 var colour = PointColour(point);
-                float scale = PointScale(point);
-                var dir = PointDirection(point);
-                var ortho = dir.PerpendicularLeft;
-
-                if (colour.A == 0 || scale == 0)
+                if (colour.A == 0)
                     return;
+
+                float scale = PointScale(point);
+                if (scale == 0)
+                    return;
+
+                var dir = PointDirection(point, index);
+                var ortho = dir.PerpendicularLeft;
 
                 var localTopLeft = point.Position + (radius * scale * (-ortho - dir));
                 var localTopRight = point.Position + (radius * scale * (-ortho + dir));


### PR DESCRIPTION
Closes #20805.

As pointed out, stable smoke is uncapped, so lazer's should be too. This requires some behavior to be rewritten/optimized. It's still not super performant, but it does perform better than stable on my machine (using the same replay where I had max sensitivity and just shook my mouse wildly in circles for a solid minute and a half). Very not rigorous benchmarking though.

Major changes:
1. Keep track of the whole smoke segment, even future points (if rewinding), and then only copy the relevant part of the smoke segment to the `SmokeDrawNode`
2. Make quad batch expand dynamically

Minor optimizations:
1. Early return from `SmokeDrawNode.drawPointQuad` to avoid scale/rotation calculations
2. Reorder `SmokeDrawNode.PointColour` to only calculate initial fade out when necessary (the diff/comparison gets very scuffed)
3. Change `SmokePoint` to hold an angle instead of a direction, which avoids an atan2 in `SmokeDrawNode.PointDirection`
