### PR TITLE
Add momentary shortcuts to toggle grid/distance snap

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -26,7 +26,6 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -94,29 +94,36 @@ namespace osu.Game.Rulesets.Catch.Edit
             if (e.Repeat)
                 return false;
 
-            if (handleToggleViaKey(e.Key))
-                return true;
-
+            handleToggleViaKey(e);
             return base.OnKeyDown(e);
         }
 
         protected override void OnKeyUp(KeyUpEvent e)
         {
-            handleToggleViaKey(e.Key);
+            handleToggleViaKey(e);
             base.OnKeyUp(e);
         }
 
-        private bool handleToggleViaKey(Key key)
-        {
-            switch (key)
-            {
-                case Key.AltLeft:
-                case Key.AltRight:
-                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                    return true;
-            }
+        private TernaryState? distanceSnapBeforeMomentary;
 
-            return false;
+        private void handleToggleViaKey(KeyboardEvent key)
+        {
+            if (key.AltPressed)
+            {
+                if (distanceSnapBeforeMomentary == null)
+                {
+                    distanceSnapBeforeMomentary = distanceSnapToggle.Value;
+                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                }
+            }
+            else
+            {
+                if (distanceSnapBeforeMomentary != null)
+                {
+                    distanceSnapToggle.Value = distanceSnapBeforeMomentary.Value;
+                    distanceSnapBeforeMomentary = null;
+                }
+            }
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -103,25 +103,16 @@ namespace osu.Game.Rulesets.Catch.Edit
             base.OnKeyUp(e);
         }
 
-        private TernaryState? distanceSnapBeforeMomentary;
+        private bool distanceSnapMomentary;
 
         private void handleToggleViaKey(KeyboardEvent key)
         {
-            if (key.AltPressed)
+            bool altPressed = key.AltPressed;
+
+            if (altPressed != distanceSnapMomentary)
             {
-                if (distanceSnapBeforeMomentary == null)
-                {
-                    distanceSnapBeforeMomentary = distanceSnapToggle.Value;
-                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                }
-            }
-            else
-            {
-                if (distanceSnapBeforeMomentary != null)
-                {
-                    distanceSnapToggle.Value = distanceSnapBeforeMomentary.Value;
-                    distanceSnapBeforeMomentary = null;
-                }
+                distanceSnapMomentary = altPressed;
+                distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
             }
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -10,7 +10,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
@@ -23,7 +22,6 @@ using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -34,8 +32,6 @@ namespace osu.Game.Rulesets.Catch.Edit
         private const float distance_snap_radius = 50;
 
         private CatchDistanceSnapGrid distanceSnapGrid;
-
-        private readonly Bindable<TernaryState> distanceSnapToggle = new Bindable<TernaryState>();
 
         private InputManager inputManager;
 
@@ -88,34 +84,6 @@ namespace osu.Game.Rulesets.Catch.Edit
             updateDistanceSnapGrid();
         }
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.Repeat)
-                return false;
-
-            handleToggleViaKey(e);
-            return base.OnKeyDown(e);
-        }
-
-        protected override void OnKeyUp(KeyUpEvent e)
-        {
-            handleToggleViaKey(e);
-            base.OnKeyUp(e);
-        }
-
-        private bool distanceSnapMomentary;
-
-        private void handleToggleViaKey(KeyboardEvent key)
-        {
-            bool altPressed = key.AltPressed;
-
-            if (altPressed != distanceSnapMomentary)
-            {
-                distanceSnapMomentary = altPressed;
-                distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-            }
-        }
-
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             switch (e.Action)
@@ -147,11 +115,6 @@ namespace osu.Game.Rulesets.Catch.Edit
             new JuiceStreamCompositionTool(),
             new BananaShowerCompositionTool()
         };
-
-        protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]
-        {
-            new TernaryButton(distanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler })
-        });
 
         public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
@@ -224,7 +187,7 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         private void updateDistanceSnapGrid()
         {
-            if (distanceSnapToggle.Value != TernaryState.True)
+            if (DistanceSnapToggle.Value != TernaryState.True)
             {
                 distanceSnapGrid.Hide();
                 return;

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -26,6 +26,7 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {
@@ -86,6 +87,36 @@ namespace osu.Game.Rulesets.Catch.Edit
             base.Update();
 
             updateDistanceSnapGrid();
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat)
+                return false;
+
+            if (handleToggleViaKey(e.Key))
+                return true;
+
+            return base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            handleToggleViaKey(e.Key);
+            base.OnKeyUp(e);
+        }
+
+        private bool handleToggleViaKey(Key key)
+        {
+            switch (key)
+            {
+                case Key.AltLeft:
+                case Key.AltRight:
+                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                    return true;
+            }
+
+            return false;
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -44,6 +44,28 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             rectangularGridActive(false);
         }
 
+        [Test]
+        public void TestDistanceSnapMomentaryToggle()
+        {
+            AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
+
+            AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("hold alt", () => InputManager.PressKey(Key.AltLeft));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
+            AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+        }
+
+        [Test]
+        public void TestGridSnapMomentaryToggle()
+        {
+            rectangularGridActive(false);
+            AddStep("hold shift", () => InputManager.PressKey(Key.ShiftLeft));
+            rectangularGridActive(true);
+            AddStep("release shift", () => InputManager.ReleaseKey(Key.ShiftLeft));
+            rectangularGridActive(false);
+        }
+
         private void rectangularGridActive(bool active)
         {
             AddStep("choose placement tool", () => InputManager.Key(Key.Number2));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -79,8 +79,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 AddAssert("placement blueprint at (0, 0)", () => Precision.AlmostEquals(Editor.ChildrenOfType<HitCirclePlacementBlueprint>().Single().HitObject.Position, new Vector2(0, 0)));
             else
                 AddAssert("placement blueprint at (1, 1)", () => Precision.AlmostEquals(Editor.ChildrenOfType<HitCirclePlacementBlueprint>().Single().HitObject.Position, new Vector2(1, 1)));
-
-            AddStep("choose selection tool", () => InputManager.Key(Key.Number1));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -236,8 +236,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (e.Repeat)
                 return false;
 
-            if (handleToggleViaKey(e.Key))
-                return true;
+            handleToggleViaKey(e.Key);
 
             return base.OnKeyDown(e);
         }
@@ -248,22 +247,20 @@ namespace osu.Game.Rulesets.Osu.Edit
             base.OnKeyUp(e);
         }
 
-        private bool handleToggleViaKey(Key key)
+        private void handleToggleViaKey(Key key)
         {
             switch (key)
             {
                 case Key.ShiftLeft:
                 case Key.ShiftRight:
                     rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                    return true;
+                    break;
 
                 case Key.AltLeft:
                 case Key.AltRight:
                     distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                    return true;
+                    break;
             }
-
-            return false;
         }
 
         private DistanceSnapGrid createDistanceSnapGrid(IEnumerable<HitObject> selectedHitObjects)

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -46,12 +46,10 @@ namespace osu.Game.Rulesets.Osu.Edit
             new SpinnerCompositionTool()
         };
 
-        private readonly Bindable<TernaryState> distanceSnapToggle = new Bindable<TernaryState>();
         private readonly Bindable<TernaryState> rectangularGridSnapToggle = new Bindable<TernaryState>();
 
         protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]
         {
-            new TernaryButton(distanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler }),
             new TernaryButton(rectangularGridSnapToggle, "Grid Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Th })
         });
 
@@ -82,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             placementObject = EditorBeatmap.PlacementObject.GetBoundCopy();
             placementObject.ValueChanged += _ => updateDistanceSnapGrid();
-            distanceSnapToggle.ValueChanged += _ => updateDistanceSnapGrid();
+            DistanceSnapToggle.ValueChanged += _ => updateDistanceSnapGrid();
 
             // we may be entering the screen with a selection already active
             updateDistanceSnapGrid();
@@ -128,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             if (snapType.HasFlagFast(SnapType.Grids))
             {
-                if (distanceSnapToggle.Value == TernaryState.True && distanceSnapGrid != null)
+                if (DistanceSnapToggle.Value == TernaryState.True && distanceSnapGrid != null)
                 {
                     (Vector2 pos, double time) = distanceSnapGrid.GetSnappedPosition(distanceSnapGrid.ToLocalSpace(screenSpacePosition));
 
@@ -197,7 +195,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             distanceSnapGridCache.Invalidate();
             distanceSnapGrid = null;
 
-            if (distanceSnapToggle.Value != TernaryState.True)
+            if (DistanceSnapToggle.Value != TernaryState.True)
                 return;
 
             switch (BlueprintContainer.CurrentTool)
@@ -242,24 +240,15 @@ namespace osu.Game.Rulesets.Osu.Edit
         protected override bool AdjustDistanceSpacing(GlobalAction action, float amount)
         {
             // To allow better visualisation, ensure that the spacing grid is visible before adjusting.
-            distanceSnapToggle.Value = TernaryState.True;
+            DistanceSnapToggle.Value = TernaryState.True;
 
             return base.AdjustDistanceSpacing(action, amount);
         }
 
-        private bool distanceSnapMomentary;
         private bool gridSnapMomentary;
 
         private void handleToggleViaKey(KeyboardEvent key)
         {
-            bool altPressed = key.AltPressed;
-
-            if (altPressed != distanceSnapMomentary)
-            {
-                distanceSnapMomentary = altPressed;
-                distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-            }
-
             bool shiftPressed = key.ShiftPressed;
 
             if (shiftPressed != gridSnapMomentary)

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             if (key.ShiftPressed)
             {
-                if (gridSnapBeforeMomentary == null)
+                if (distanceSnapBeforeMomentary == null && gridSnapBeforeMomentary == null)
                 {
                     gridSnapBeforeMomentary = rectangularGridSnapToggle.Value;
                     rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
@@ -278,7 +278,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             if (key.AltPressed)
             {
-                if (distanceSnapBeforeMomentary == null)
+                if (gridSnapBeforeMomentary == null && distanceSnapBeforeMomentary == null)
                 {
                     distanceSnapBeforeMomentary = distanceSnapToggle.Value;
                     distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -247,43 +247,25 @@ namespace osu.Game.Rulesets.Osu.Edit
             return base.AdjustDistanceSpacing(action, amount);
         }
 
-        private TernaryState? gridSnapBeforeMomentary;
-        private TernaryState? distanceSnapBeforeMomentary;
+        private bool distanceSnapMomentary;
+        private bool gridSnapMomentary;
 
         private void handleToggleViaKey(KeyboardEvent key)
         {
-            if (key.ShiftPressed)
+            bool altPressed = key.AltPressed;
+
+            if (altPressed != distanceSnapMomentary)
             {
-                if (distanceSnapBeforeMomentary == null && gridSnapBeforeMomentary == null)
-                {
-                    gridSnapBeforeMomentary = rectangularGridSnapToggle.Value;
-                    rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                }
-            }
-            else
-            {
-                if (gridSnapBeforeMomentary != null)
-                {
-                    rectangularGridSnapToggle.Value = gridSnapBeforeMomentary.Value;
-                    gridSnapBeforeMomentary = null;
-                }
+                distanceSnapMomentary = altPressed;
+                distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
             }
 
-            if (key.AltPressed)
+            bool shiftPressed = key.ShiftPressed;
+
+            if (shiftPressed != gridSnapMomentary)
             {
-                if (gridSnapBeforeMomentary == null && distanceSnapBeforeMomentary == null)
-                {
-                    distanceSnapBeforeMomentary = distanceSnapToggle.Value;
-                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                }
-            }
-            else
-            {
-                if (distanceSnapBeforeMomentary != null)
-                {
-                    distanceSnapToggle.Value = distanceSnapBeforeMomentary.Value;
-                    distanceSnapBeforeMomentary = null;
-                }
+                gridSnapMomentary = shiftPressed;
+                rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -13,6 +13,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
@@ -24,6 +25,7 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -227,6 +229,41 @@ namespace osu.Game.Rulesets.Osu.Edit
                 distanceSnapGridContainer.Add(distanceSnapGrid);
                 distanceSnapGridCache.Validate();
             }
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat)
+                return false;
+
+            if (handleToggleViaKey(e.Key))
+                return true;
+
+            return base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            handleToggleViaKey(e.Key);
+            base.OnKeyUp(e);
+        }
+
+        private bool handleToggleViaKey(Key key)
+        {
+            switch (key)
+            {
+                case Key.ShiftLeft:
+                case Key.ShiftRight:
+                    rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                    return true;
+
+                case Key.AltLeft:
+                case Key.AltRight:
+                    distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                    return true;
+            }
+
+            return false;
         }
 
         private DistanceSnapGrid createDistanceSnapGrid(IEnumerable<HitObject> selectedHitObjects)

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
@@ -25,7 +26,6 @@ using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -236,30 +236,61 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (e.Repeat)
                 return false;
 
-            handleToggleViaKey(e.Key);
-
+            handleToggleViaKey(e);
             return base.OnKeyDown(e);
         }
 
         protected override void OnKeyUp(KeyUpEvent e)
         {
-            handleToggleViaKey(e.Key);
+            handleToggleViaKey(e);
             base.OnKeyUp(e);
         }
 
-        private void handleToggleViaKey(Key key)
+        protected override bool AdjustDistanceSpacing(GlobalAction action, float amount)
         {
-            switch (key)
-            {
-                case Key.ShiftLeft:
-                case Key.ShiftRight:
-                    rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                    break;
+            // To allow better visualisation, ensure that the spacing grid is visible before adjusting.
+            distanceSnapToggle.Value = TernaryState.True;
 
-                case Key.AltLeft:
-                case Key.AltRight:
+            return base.AdjustDistanceSpacing(action, amount);
+        }
+
+        private TernaryState? gridSnapBeforeMomentary;
+        private TernaryState? distanceSnapBeforeMomentary;
+
+        private void handleToggleViaKey(KeyboardEvent key)
+        {
+            if (key.ShiftPressed)
+            {
+                if (gridSnapBeforeMomentary == null)
+                {
+                    gridSnapBeforeMomentary = rectangularGridSnapToggle.Value;
+                    rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                }
+            }
+            else
+            {
+                if (gridSnapBeforeMomentary != null)
+                {
+                    rectangularGridSnapToggle.Value = gridSnapBeforeMomentary.Value;
+                    gridSnapBeforeMomentary = null;
+                }
+            }
+
+            if (key.AltPressed)
+            {
+                if (distanceSnapBeforeMomentary == null)
+                {
+                    distanceSnapBeforeMomentary = distanceSnapToggle.Value;
                     distanceSnapToggle.Value = distanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
-                    break;
+                }
+            }
+            else
+            {
+                if (distanceSnapBeforeMomentary != null)
+                {
+                    distanceSnapToggle.Value = distanceSnapBeforeMomentary.Value;
+                    distanceSnapBeforeMomentary = null;
+                }
             }
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
@@ -161,10 +161,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("hold alt", () => InputManager.PressKey(Key.LAlt));
 
             AddStep("scroll mouse 5 steps", () => InputManager.ScrollVerticalBy(5));
-            AddAssert("distance spacing increased by 0.5", () => editorBeatmap.BeatmapInfo.DistanceSpacing == originalSpacing + 0.5);
 
             AddStep("release alt", () => InputManager.ReleaseKey(Key.LAlt));
             AddStep("release ctrl", () => InputManager.ReleaseKey(Key.LControl));
+
+            AddAssert("distance spacing increased by 0.5", () => editorBeatmap.BeatmapInfo.DistanceSpacing == originalSpacing + 0.5);
         }
 
         public class EditorBeatmapContainer : Container

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -10,6 +12,7 @@ using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -20,6 +23,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
 using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -47,6 +51,10 @@ namespace osu.Game.Rulesets.Edit
 
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
+
+        protected readonly Bindable<TernaryState> DistanceSnapToggle = new Bindable<TernaryState>();
+
+        private bool distanceSnapMomentary;
 
         protected DistancedHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -102,6 +110,37 @@ namespace osu.Game.Rulesets.Edit
 
                     EditorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
                 }, true);
+            }
+        }
+
+        protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]
+        {
+            new TernaryButton(DistanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = FontAwesome.Solid.Ruler })
+        });
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat)
+                return false;
+
+            handleToggleViaKey(e);
+            return base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            handleToggleViaKey(e);
+            base.OnKeyUp(e);
+        }
+
+        private void handleToggleViaKey(KeyboardEvent key)
+        {
+            bool altPressed = key.AltPressed;
+
+            if (altPressed != distanceSnapMomentary)
+            {
+                distanceSnapMomentary = altPressed;
+                DistanceSnapToggle.Value = DistanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
             }
         }
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Edit
             {
                 case GlobalAction.EditorIncreaseDistanceSpacing:
                 case GlobalAction.EditorDecreaseDistanceSpacing:
-                    return adjustDistanceSpacing(e.Action, adjust_step);
+                    return AdjustDistanceSpacing(e.Action, adjust_step);
             }
 
             return false;
@@ -127,13 +127,13 @@ namespace osu.Game.Rulesets.Edit
             {
                 case GlobalAction.EditorIncreaseDistanceSpacing:
                 case GlobalAction.EditorDecreaseDistanceSpacing:
-                    return adjustDistanceSpacing(e.Action, e.ScrollAmount * adjust_step);
+                    return AdjustDistanceSpacing(e.Action, e.ScrollAmount * adjust_step);
             }
 
             return false;
         }
 
-        private bool adjustDistanceSpacing(GlobalAction action, float amount)
+        protected virtual bool AdjustDistanceSpacing(GlobalAction action, float amount)
         {
             if (DistanceSpacingMultiplier.Disabled)
                 return false;


### PR DESCRIPTION
Matching osu!stable. I use these quite a lot while mapping and I'm sure others do as well.

Hold `Shift` = invert grid snap
Hold `Alt` = invert distance snap

- [x] Depends on #20914