### PR TITLE
Enable slider ball tint on "classic" skin

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Skinning.Legacy;
 using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -68,10 +69,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddStep("create slider", () =>
             {
-                var tintingSkin = skinManager.GetSkin(DefaultLegacySkin.CreateInfo());
-                tintingSkin.Configuration.ConfigDictionary["AllowSliderBallTint"] = "1";
-
-                var provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(tintingSkin, Beatmap.Value.Beatmap);
+                var skin = skinManager.GetSkin(DefaultLegacySkin.CreateInfo());
+                var provider = Ruleset.Value.CreateInstance().CreateSkinTransformer(skin, Beatmap.Value.Beatmap);
 
                 Child = new SkinProvidingContainer(provider)
                 {
@@ -92,10 +91,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             AddStep("set accent white", () => dho.AccentColour.Value = Color4.White);
-            AddAssert("ball is white", () => dho.ChildrenOfType<DrawableSliderBall>().Single().AccentColour == Color4.White);
+            AddAssert("ball is white", () => dho.ChildrenOfType<LegacySliderBall>().Single().BallColour == Color4.White);
 
             AddStep("set accent red", () => dho.AccentColour.Value = Color4.Red);
-            AddAssert("ball is red", () => dho.ChildrenOfType<DrawableSliderBall>().Single().AccentColour == Color4.Red);
+            AddAssert("ball is red", () => dho.ChildrenOfType<LegacySliderBall>().Single().BallColour == Color4.Red);
         }
 
         private Slider prepareObject(Slider slider)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -14,12 +14,10 @@ using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -106,7 +104,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 foreach (var drawableHitObject in NestedHitObjects)
                     drawableHitObject.AccentColour.Value = colour.NewValue;
-                updateBallTint();
             }, true);
 
             Tracking.BindValueChanged(updateSlidingSample);
@@ -255,22 +252,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.OnKilled();
             SliderBody?.RecyclePath();
-        }
-
-        protected override void ApplySkin(ISkinSource skin, bool allowFallback)
-        {
-            base.ApplySkin(skin, allowFallback);
-
-            updateBallTint();
-        }
-
-        private void updateBallTint()
-        {
-            if (CurrentSkin == null)
-                return;
-
-            bool allowBallTint = CurrentSkin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.AllowSliderBallTint)?.Value ?? false;
-            Ball.AccentColour = allowBallTint ? AccentColour.Value : Color4.White;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderBall.cs
@@ -11,27 +11,19 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
-    public class DrawableSliderBall : CircularContainer, ISliderProgress, IRequireHighFrequencyMousePosition, IHasAccentColour
+    public class DrawableSliderBall : CircularContainer, ISliderProgress, IRequireHighFrequencyMousePosition
     {
         public const float FOLLOW_AREA = 2.4f;
 
         public Func<OsuAction?> GetInitialHitAction;
-
-        public Color4 AccentColour
-        {
-            get => ball.Colour;
-            set => ball.Colour = value;
-        }
 
         private Drawable followCircleReceptor;
         private DrawableSlider drawableSlider;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -20,6 +21,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         [Resolved(canBeNull: true)]
         private DrawableHitObject? parentObject { get; set; }
+
+        public Color4 BallColour => animationContent.Colour;
 
         private Sprite layerNd = null!;
         private Sprite layerSpec = null!;
@@ -61,6 +64,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             };
         }
 
+        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -69,6 +74,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             {
                 parentObject.ApplyCustomUpdateState += updateStateTransforms;
                 updateStateTransforms(parentObject, parentObject.State.Value);
+
+                if (skin.GetConfig<SkinConfiguration.LegacySetting, bool>(SkinConfiguration.LegacySetting.AllowSliderBallTint)?.Value == true)
+                {
+                    accentColour.BindTo(parentObject.AccentColour);
+                    accentColour.BindValueChanged(a => animationContent.Colour = a.NewValue, true);
+                }
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -9,7 +9,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
     {
         SliderBorderSize,
         SliderPathRadius,
-        AllowSliderBallTint,
         CursorCentre,
         CursorExpand,
         CursorRotate,

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Skinning
                 new Color4(242, 24, 57, 255)
             };
 
+            Configuration.ConfigDictionary[nameof(SkinConfiguration.LegacySetting.AllowSliderBallTint)] = @"true";
+
             Configuration.LegacyVersion = 2.7m;
         }
     }

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Skinning
             HitCirclePrefix,
             HitCircleOverlap,
             AnimationFramerate,
-            LayeredHitSounds
+            LayeredHitSounds,
+            AllowSliderBallTint,
         }
 
         public static List<Color4> DefaultComboColours { get; } = new List<Color4>


### PR DESCRIPTION
- Closes #6176 

Also fixes tint not applying correctly. On master, the tint is applied on `LegacySliderBall` while the `SliderBall` colour specification is still applied in the underlying `sliderb` sprite. Unlike stable, which overwrites the colour applied to the `sliderb` sprite with the combo colour.