### PR TITLE
Improve automatic cursor hiding logic and limit to gameplay screen

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneCursors.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneCursors.cs
@@ -178,6 +178,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestKeyboardLocalCursor([Values] bool clickToShow)
         {
+            AddStep("Enable cursor hiding", () => globalCursorDisplay.MenuCursor.HideCursorOnNonMouseInput = true);
             AddStep("Move to purple area", () => InputManager.MoveMouseTo(cursorBoxes[3].ScreenSpaceDrawQuad.Centre + new Vector2(10, 0)));
             AddAssert("Check purple cursor visible", () => checkVisible(cursorBoxes[3].Cursor));
             AddAssert("Check global cursor alpha is 1", () => globalCursorDisplay.MenuCursor.Alpha == 1);
@@ -201,6 +202,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestKeyboardUserCursor([Values] bool clickToShow)
         {
+            AddStep("Enable cursor hiding", () => globalCursorDisplay.MenuCursor.HideCursorOnNonMouseInput = true);
             AddStep("Move to green area", () => InputManager.MoveMouseTo(cursorBoxes[0]));
             AddAssert("Check green cursor visible", () => checkVisible(cursorBoxes[0].Cursor));
             AddAssert("Check global cursor alpha is 0", () => !checkVisible(globalCursorDisplay.MenuCursor) && globalCursorDisplay.MenuCursor.ActiveCursor.Alpha == 0);

--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -23,6 +23,21 @@ namespace osu.Game.Graphics.Cursor
         private readonly IBindable<bool> screenshotCursorVisibility = new Bindable<bool>(true);
         public override bool IsPresent => screenshotCursorVisibility.Value && base.IsPresent;
 
+        private bool hideCursorOnNonMouseInput;
+
+        public bool HideCursorOnNonMouseInput
+        {
+            get => hideCursorOnNonMouseInput;
+            set
+            {
+                if (hideCursorOnNonMouseInput == value)
+                    return;
+
+                hideCursorOnNonMouseInput = value;
+                updateState();
+            }
+        }
+
         protected override Drawable CreateCursor() => activeCursor = new Cursor();
 
         private Cursor activeCursor = null!;
@@ -75,7 +90,7 @@ namespace osu.Game.Graphics.Cursor
 
         private void updateState()
         {
-            bool combinedVisibility = State.Value == Visibility.Visible && lastInputWasMouse.Value && !isIdle.Value;
+            bool combinedVisibility = State.Value == Visibility.Visible && (lastInputWasMouse.Value || !hideCursorOnNonMouseInput) && !isIdle.Value;
 
             if (visible == combinedVisibility)
                 return;

--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -277,14 +277,19 @@ namespace osu.Game.Graphics.Cursor
             {
                 switch (e)
                 {
-                    case MouseEvent:
+                    case MouseDownEvent:
+                    case MouseMoveEvent:
                         lastInputWasMouseSource.Value = true;
                         return false;
 
-                    default:
+                    case KeyDownEvent keyDown when !keyDown.Repeat:
+                    case JoystickPressEvent:
+                    case MidiDownEvent:
                         lastInputWasMouseSource.Value = false;
                         return false;
                 }
+
+                return false;
             }
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1333,6 +1333,8 @@ namespace osu.Game
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
                 API.Activity.BindTo(newOsuScreen.Activity);
 
+                GlobalCursorDisplay.MenuCursor.HideCursorOnNonMouseInput = newOsuScreen.HideMenuCursorOnNonMouseInput;
+
                 if (newOsuScreen.HideOverlaysOnEnter)
                     CloseAllOverlays();
                 else

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Screens
         bool HideOverlaysOnEnter { get; }
 
         /// <summary>
+        /// Whether the menu cursor should be hidden when non-mouse input is received.
+        /// </summary>
+        bool HideMenuCursorOnNonMouseInput { get; }
+
+        /// <summary>
         /// Whether overlays should be able to be opened when this screen is current.
         /// </summary>
         IBindable<OverlayActivation> OverlayActivationMode { get; }

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -40,10 +40,9 @@ namespace osu.Game.Screens
 
         public virtual bool AllowExternalScreenChange => false;
 
-        /// <summary>
-        /// Whether all overlays should be hidden when this screen is entered or resumed.
-        /// </summary>
         public virtual bool HideOverlaysOnEnter => false;
+
+        public virtual bool HideMenuCursorOnNonMouseInput => false;
 
         /// <summary>
         /// The initial overlay activation mode to use when this screen is entered for the first time.

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -66,6 +66,8 @@ namespace osu.Game.Screens.Play
 
         public override bool HideOverlaysOnEnter => true;
 
+        public override bool HideMenuCursorOnNonMouseInput => true;
+
         protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;
 
         // We are managing our own adjustments (see OnEntering/OnExiting).


### PR DESCRIPTION
The current name of the property feels mouthful, maybe `HideMenuCursorAutomatically` is a better name, but not sure if it delivers the concept correctly.

In addition, the logic has been improved to only hide cursor on new non-repeat press events, to reduce the chances of the cursor flickering in cases like holding key while moving mouse.