### PR TITLE
Avoid serialising some more properties of `SoloScoreInfo` unless present

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -114,6 +114,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("has_replay")]
         public bool HasReplay { get; set; }
 
+        // These properties are calculated or not relevant to any external usage.
         public bool ShouldSerializeID() => false;
         public bool ShouldSerializeUser() => false;
         public bool ShouldSerializeBeatmap() => false;
@@ -121,6 +122,18 @@ namespace osu.Game.Online.API.Requests.Responses
         public bool ShouldSerializePP() => false;
         public bool ShouldSerializeOnlineID() => false;
         public bool ShouldSerializeHasReplay() => false;
+
+        // These fields only need to be serialised if they hold values.
+        // Generally this is required because this model may be used by server-side components, but
+        // we don't want to bother sending these fields in score submission requests, for instance.
+        public bool ShouldSerializeEndedAt() => EndedAt != default;
+        public bool ShouldSerializeStartedAt() => StartedAt != default;
+        public bool ShouldSerializeLegacyScoreId() => LegacyScoreId != null;
+        public bool ShouldSerializeLegacyTotalScore() => LegacyTotalScore != null;
+        public bool ShouldSerializeMods() => Mods.Length > 0;
+        public bool ShouldSerializeUserID() => UserID > 0;
+        public bool ShouldSerializeBeatmapID() => BeatmapID > 0;
+        public bool ShouldSerializeBuildID() => BuildID != null;
 
         #endregion
 


### PR DESCRIPTION
During score submission, this results in the following change.

Before:

```json
{
  "beatmap_id": 0,
  "ruleset_id": 0,
  "build_id": null,
  "passed": false,
  "total_score": 19273,
  "accuracy": 0.027777777777777776,
  "user_id": 0,
  "max_combo": 2,
  "rank": "F",
  "started_at": null,
  "ended_at": "0001-01-01T00:00:00+00:00",
  "mods": [],
  "statistics": {
    "miss": 10,
    "meh": 2
  },
  "maximum_statistics": {
    "great": 75,
    "small_tick_hit": 6,
    "large_tick_hit": 3,
    "small_bonus": 2,
    "large_bonus": 9,
    "ignore_hit": 6
  },
  "legacy_total_score": null,
  "legacy_score_id": null
}
```

After:
```json
{
  "ruleset_id": 0,
  "passed": false,
  "total_score": 19935,
  "accuracy": 0.038461538461538464,
  "max_combo": 2,
  "rank": "F",
  "statistics": {
    "miss": 11,
    "meh": 1,
    "ok": 1
  },
  "maximum_statistics": {
    "great": 75,
    "small_tick_hit": 6,
    "large_tick_hit": 3,
    "small_bonus": 2,
    "large_bonus": 9,
    "ignore_hit": 6
  }
}
```