### PR TITLE
Reduce precision of accuracy when submitting scores

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Online.API.Requests.Responses
         {
             Rank = score.Rank,
             TotalScore = (int)score.TotalScore,
-            Accuracy = score.Accuracy,
+            Accuracy = Math.Round(score.Accuracy, 4, MidpointRounding.ToEven),
             PP = score.PP,
             MaxCombo = score.MaxCombo,
             RulesetID = score.RulesetID,


### PR DESCRIPTION
I'm not sure if there's a better place to do this. Optionally it could be enforced using a computed property on `SoloScoreInfo` but maybe a bit ugly?

I intend on applying this at score submission and in the import command for now.

```json
{
  "ruleset_id": 0,
  "passed": false,
  "total_score": 23247,
  "accuracy": 0.1111,
  "max_combo": 2,
  "rank": "F",
  "statistics": {
    "miss": 10,
    "ok": 1,
    "great": 1
  },
  "maximum_statistics": {
    "great": 75,
    "small_tick_hit": 6,
    "large_tick_hit": 3,
    "small_bonus": 2,
    "large_bonus": 9,
    "ignore_hit": 6
  }
}
```
