### PR TITLE
Show distance snap at current point in time (and add ability to set as usable value)

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -81,6 +81,12 @@ namespace osu.Game.Rulesets.Catch.Edit
             inputManager = GetContainingInputManager();
         }
 
+        protected override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
+        {
+            // TODO: catch lol
+            return 1;
+        }
+
         protected override void Update()
         {
             base.Update();

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -79,8 +80,15 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         protected override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
         {
-            // TODO: catch lol
-            return 1;
+            // osu!catch's distance snap implementation is limited, in that a custom spacing cannot be specified.
+            // Therefore this functionality is not currently used.
+            //
+            // The implementation below is probably correct but should be checked if/when exposed via controls.
+
+            float expectedDistance = DurationToDistance(before, after.StartTime - before.GetEndTime());
+            float actualDistance = Math.Abs(((CatchHitObject)before).EffectiveX - ((CatchHitObject)after).EffectiveX);
+
+            return actualDistance / expectedDistance;
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -112,6 +112,14 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private RectangularPositionSnapGrid rectangularPositionSnapGrid;
 
+        protected override double ReadCurrentDistanceSnap(HitObject before, HitObject after)
+        {
+            float expectedDistance = DurationToDistance(before, after.StartTime - before.GetEndTime());
+            float actualDistance = Vector2.Distance(((OsuHitObject)before).EndPosition, ((OsuHitObject)after).Position);
+
+            return actualDistance / expectedDistance;
+        }
+
         protected override void Update()
         {
             base.Update();

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -17,7 +17,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
@@ -48,9 +47,7 @@ namespace osu.Game.Rulesets.Edit
         protected ExpandingToolboxContainer RightSideToolboxContainer { get; private set; }
 
         private ExpandableSlider<double, SizeSlider<double>> distanceSpacingSlider;
-        private ExpandableButton readCurrentButton;
-
-        private OsuSpriteText currentDistanceSpacingDisplay;
+        private ExpandableButton currentDistanceSpacingButton;
 
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
@@ -88,12 +85,8 @@ namespace osu.Game.Rulesets.Edit
                                     Current = { BindTarget = DistanceSpacingMultiplier },
                                     KeyboardStep = adjust_step,
                                 },
-                                currentDistanceSpacingDisplay = new OsuSpriteText
+                                currentDistanceSpacingButton = new ExpandableButton
                                 {
-                                },
-                                readCurrentButton = new ExpandableButton
-                                {
-                                    Text = "Use current",
                                     Action = () =>
                                     {
                                         (HitObject before, HitObject after)? objects = getObjectsOnEitherSideOfCurrentTime();
@@ -140,14 +133,17 @@ namespace osu.Game.Rulesets.Edit
             if (objects != null)
             {
                 double currentSnap = ReadCurrentDistanceSnap(objects.Value.before, objects.Value.after);
-                readCurrentButton.Enabled.Value = Precision.AlmostEquals(currentSnap, DistanceSpacingMultiplier.Value, DistanceSpacingMultiplier.Precision);
 
-                currentDistanceSpacingDisplay.Text = $"Current {currentSnap:N1}x";
+                currentDistanceSpacingButton.Enabled.Value = currentDistanceSpacingButton.Expanded.Value
+                                                             && !Precision.AlmostEquals(currentSnap, DistanceSpacingMultiplier.Value, DistanceSpacingMultiplier.Precision / 2);
+                currentDistanceSpacingButton.ContractedLabelText = $"(current {currentSnap:N2}x)";
+                currentDistanceSpacingButton.ExpandedLabelText = $"Use current ({currentSnap:N2}x)";
             }
             else
             {
-                readCurrentButton.Enabled.Value = false;
-                currentDistanceSpacingDisplay.Text = "Current: -";
+                currentDistanceSpacingButton.Enabled.Value = false;
+                currentDistanceSpacingButton.ContractedLabelText = "Current N/A";
+                currentDistanceSpacingButton.ExpandedLabelText = "Use current (N/A)";
             }
         }
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -94,6 +94,7 @@ namespace osu.Game.Rulesets.Edit
                                         Debug.Assert(objects != null);
 
                                         DistanceSpacingMultiplier.Value = ReadCurrentDistanceSnap(objects.Value.before, objects.Value.after);
+                                        // TODO: This should probably also force distance spacing grid on.
                                     },
                                     RelativeSizeAxes = Axes.X,
                                 }
@@ -130,20 +131,22 @@ namespace osu.Game.Rulesets.Edit
 
             (HitObject before, HitObject after)? objects = getObjectsOnEitherSideOfCurrentTime();
 
-            if (objects != null)
-            {
-                double currentSnap = ReadCurrentDistanceSnap(objects.Value.before, objects.Value.after);
+            double currentSnap = objects == null
+                ? 0
+                : ReadCurrentDistanceSnap(objects.Value.before, objects.Value.after);
 
+            if (currentSnap > DistanceSpacingMultiplier.MinValue)
+            {
                 currentDistanceSpacingButton.Enabled.Value = currentDistanceSpacingButton.Expanded.Value
                                                              && !Precision.AlmostEquals(currentSnap, DistanceSpacingMultiplier.Value, DistanceSpacingMultiplier.Precision / 2);
-                currentDistanceSpacingButton.ContractedLabelText = $"(current {currentSnap:N2}x)";
+                currentDistanceSpacingButton.ContractedLabelText = $"current {currentSnap:N2}x";
                 currentDistanceSpacingButton.ExpandedLabelText = $"Use current ({currentSnap:N2}x)";
             }
             else
             {
                 currentDistanceSpacingButton.Enabled.Value = false;
-                currentDistanceSpacingButton.ContractedLabelText = "Current N/A";
-                currentDistanceSpacingButton.ExpandedLabelText = "Use current (N/A)";
+                currentDistanceSpacingButton.ContractedLabelText = string.Empty;
+                currentDistanceSpacingButton.ExpandedLabelText = "Use current (unavailable)";
             }
         }
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Edit
 
         private (HitObject before, HitObject after)? getObjectsOnEitherSideOfCurrentTime()
         {
-            HitObject lastBefore = Playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.HitObject.GetEndTime() <= EditorClock.CurrentTime)?.HitObject;
+            HitObject lastBefore = Playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.HitObject.StartTime <= EditorClock.CurrentTime)?.HitObject;
 
             if (lastBefore == null)
                 return null;

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -89,8 +89,9 @@ namespace osu.Game.Rulesets.Edit
                             {
                                 distanceSpacingSlider = new ExpandableSlider<double, SizeSlider<double>>
                                 {
-                                    Current = { BindTarget = DistanceSpacingMultiplier },
                                     KeyboardStep = adjust_step,
+                                    // Manual binding in LoadComplete to handle one-way event flow.
+                                    Current = DistanceSpacingMultiplier.GetUnboundCopy(),
                                 },
                                 currentDistanceSpacingButton = new ExpandableButton
                                 {
@@ -101,6 +102,7 @@ namespace osu.Game.Rulesets.Edit
                                         Debug.Assert(objects != null);
 
                                         DistanceSpacingMultiplier.Value = ReadCurrentDistanceSnap(objects.Value.before, objects.Value.after);
+                                        DistanceSnapToggle.Value = TernaryState.True;
                                     },
                                     RelativeSizeAxes = Axes.X,
                                 }
@@ -173,6 +175,14 @@ namespace osu.Game.Rulesets.Edit
 
                     EditorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
                 }, true);
+
+                // Manual binding to handle enabling distance spacing when the slider is interacted with.
+                distanceSpacingSlider.Current.BindValueChanged(spacing =>
+                {
+                    DistanceSpacingMultiplier.Value = spacing.NewValue;
+                    DistanceSnapToggle.Value = TernaryState.True;
+                });
+                DistanceSpacingMultiplier.BindValueChanged(spacing => distanceSpacingSlider.Current.Value = spacing.NewValue);
             }
         }
 
@@ -245,6 +255,7 @@ namespace osu.Game.Rulesets.Edit
             else if (action == GlobalAction.EditorDecreaseDistanceSpacing)
                 DistanceSpacingMultiplier.Value -= amount;
 
+            DistanceSnapToggle.Value = TernaryState.True;
             return true;
         }
 

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Edit
         private LocalisableString contractedLabelText;
 
         /// <summary>
-        /// The label text to display when this slider is in a contracted state.
+        /// The label text to display when this button is in a contracted state.
         /// </summary>
         public LocalisableString ContractedLabelText
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Edit
         private LocalisableString expandedLabelText;
 
         /// <summary>
-        /// The label text to display when this slider is in an expanded state.
+        /// The label text to display when this button is in an expanded state.
         /// </summary>
         public LocalisableString ExpandedLabelText
         {

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Edit
                     SpriteText.Anchor = Anchor.CentreLeft;
                     SpriteText.Origin = Anchor.CentreLeft;
                     SpriteText.Font = OsuFont.GetFont(weight: FontWeight.Regular);
-                    base.Height = SpriteText.DrawHeight;
+                    base.Height = actualHeight / 2;
                     Background.Hide();
                 }
             }, true);

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -3,6 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 
@@ -10,6 +13,54 @@ namespace osu.Game.Rulesets.Edit
 {
     internal class ExpandableButton : RoundedButton, IExpandable
     {
+        private float actualHeight;
+
+        public override float Height
+        {
+            get => base.Height;
+            set => base.Height = actualHeight = value;
+        }
+
+        private LocalisableString contractedLabelText;
+
+        /// <summary>
+        /// The label text to display when this slider is in a contracted state.
+        /// </summary>
+        public LocalisableString ContractedLabelText
+        {
+            get => contractedLabelText;
+            set
+            {
+                if (value == contractedLabelText)
+                    return;
+
+                contractedLabelText = value;
+
+                if (!Expanded.Value)
+                    Text = value;
+            }
+        }
+
+        private LocalisableString expandedLabelText;
+
+        /// <summary>
+        /// The label text to display when this slider is in an expanded state.
+        /// </summary>
+        public LocalisableString ExpandedLabelText
+        {
+            get => expandedLabelText;
+            set
+            {
+                if (value == expandedLabelText)
+                    return;
+
+                expandedLabelText = value;
+
+                if (Expanded.Value)
+                    Text = value;
+            }
+        }
+
         public BindableBool Expanded { get; } = new BindableBool();
 
         [Resolved(canBeNull: true)]
@@ -26,10 +77,24 @@ namespace osu.Game.Rulesets.Edit
 
             Expanded.BindValueChanged(expanded =>
             {
+                Text = expanded.NewValue ? expandedLabelText : contractedLabelText;
+
                 if (expanded.NewValue)
-                    Show();
+                {
+                    SpriteText.Anchor = Anchor.Centre;
+                    SpriteText.Origin = Anchor.Centre;
+                    SpriteText.Font = OsuFont.GetFont(weight: FontWeight.Bold);
+                    base.Height = actualHeight;
+                    Background.Show();
+                }
                 else
-                    Hide();
+                {
+                    SpriteText.Anchor = Anchor.CentreLeft;
+                    SpriteText.Origin = Anchor.CentreLeft;
+                    SpriteText.Font = OsuFont.GetFont(weight: FontWeight.Regular);
+                    base.Height = SpriteText.DrawHeight;
+                    Background.Hide();
+                }
             }, true);
         }
     }

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Rulesets.Edit
+{
+    internal class ExpandableButton : RoundedButton, IExpandable
+    {
+        public BindableBool Expanded { get; } = new BindableBool();
+
+        [Resolved(canBeNull: true)]
+        private IExpandingContainer? expandingContainer { get; set; }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            expandingContainer?.Expanded.BindValueChanged(containerExpanded =>
+            {
+                Expanded.Value = containerExpanded.NewValue;
+            }, true);
+
+            Expanded.BindValueChanged(expanded =>
+            {
+                if (expanded.NewValue)
+                    Show();
+                else
+                    Hide();
+            }, true);
+        }
+    }
+}


### PR DESCRIPTION
RFC, working with what I have for the UI.

osu!stable shows "prev" and "next" values (based on selection), but this time i've tried showing the current instead.

- [x] Depends on #20850
- [x] Depends on #20828