### PR TITLE
Remove shadow effect from icon buttons

### DIFF
--- a/osu.Game/Graphics/UserInterface/IconButton.cs
+++ b/osu.Game/Graphics/UserInterface/IconButton.cs
@@ -6,6 +6,7 @@
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 
@@ -64,6 +65,10 @@ namespace osu.Game.Graphics.UserInterface
         public IconButton()
         {
             Size = new Vector2(DEFAULT_BUTTON_SIZE);
+
+            // base implementation applies a shadow effect, but that looks ugly on an icon button
+            // since the "shadow" would appear as a darkened background box for the button instead.
+            Content.EdgeEffect = new EdgeEffectParameters();
 
             Add(icon = new SpriteIcon
             {


### PR DESCRIPTION
Shadow effect on non-rectangular drawables appear as a background box instead, making it look kind of ugly. More noticeable on changelogs overlay.

| Before | After |
|--------|-------|
| ![CleanShot 2022-10-22 at 03 44 37@2x](https://user-images.githubusercontent.com/22781491/197309169-9fa111ec-f8c2-4ff5-a131-3331b5cf19e8.png) |  ![](https://user-images.githubusercontent.com/22781491/197309210-ff1f0de3-d9c7-47b1-84ba-c80db81d661f.png) |
| ![CleanShot 2022-10-22 at 03 45 17@2x](https://user-images.githubusercontent.com/22781491/197309225-0105609a-e480-496d-846b-564ea9a9995f.png) |  ![CleanShot 2022-10-22 at 03 51 17@2x](https://user-images.githubusercontent.com/22781491/197309230-172b7e45-ac43-409e-ba8e-3ec02223e851.png) |