### PR TITLE
Downgrade AutoMapper to fix Android startup crash

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     </None>
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Humanizer" Version="2.14.1" />


### PR DESCRIPTION
Upstream issue about this:
- https://github.com/AutoMapper/AutoMapper/issues/4113

This is already in the `realease` branch: https://github.com/ppy/osu/commit/fac386eb43eaa33482c007db86e96aa20dc3d363.
