### PR TITLE
Match in-game search to the exact map.

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -18,7 +18,7 @@
     </None>
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Humanizer" Version="2.14.1" />


### PR DESCRIPTION
Instead of selecting a random map after searching, select the map whose name matches exactly with the search made.
