### PR TITLE
Add ability to clone objects in the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -156,6 +156,20 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestClone()
+        {
+            var addedObject = new HitCircle { StartTime = 1000 };
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+            AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+
+            AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
+            AddStep("clone", () => Editor.Duplicate());
+            AddAssert("is two objects", () => EditorBeatmap.HitObjects.Count == 2);
+            AddStep("clone", () => Editor.Duplicate());
+            AddAssert("is three objects", () => EditorBeatmap.HitObjects.Count == 3);
+        }
+
+        [Test]
         public void TestCutNothing()
         {
             AddStep("cut hitobject", () => Editor.Cut());
@@ -174,6 +188,23 @@ namespace osu.Game.Tests.Visual.Editing
         {
             AddStep("paste hitobject", () => Editor.Paste());
             AddAssert("are no objects", () => EditorBeatmap.HitObjects.Count == 0);
+        }
+
+        [Test]
+        public void TestCloneNothing()
+        {
+            // Add arbitrary object and copy to clipboard.
+            // This is tested to ensure that clone doesn't incorrectly read from the clipboard when no selection is made.
+            var addedObject = new HitCircle { StartTime = 1000 };
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+            AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+            AddStep("copy hitobject", () => Editor.Copy());
+
+            AddStep("deselect all objects", () => EditorBeatmap.SelectedHitObjects.Clear());
+
+            AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
+            AddStep("clone", () => Editor.Duplicate());
+            AddAssert("still one object", () => EditorBeatmap.HitObjects.Count == 1);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -163,9 +163,9 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
 
             AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
-            AddStep("clone", () => Editor.Duplicate());
+            AddStep("clone", () => Editor.Clone());
             AddAssert("is two objects", () => EditorBeatmap.HitObjects.Count == 2);
-            AddStep("clone", () => Editor.Duplicate());
+            AddStep("clone", () => Editor.Clone());
             AddAssert("is three objects", () => EditorBeatmap.HitObjects.Count == 3);
         }
 
@@ -203,7 +203,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("deselect all objects", () => EditorBeatmap.SelectedHitObjects.Clear());
 
             AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
-            AddStep("clone", () => Editor.Duplicate());
+            AddStep("clone", () => Editor.Clone());
             AddAssert("still one object", () => EditorBeatmap.HitObjects.Count == 1);
         }
     }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -90,6 +90,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.EditorTimingMode),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.EditorSetupMode),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, GlobalAction.EditorVerifyMode),
+            new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.EditorDuplicateSelection),
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
@@ -346,5 +347,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleProfile))]
         ToggleProfile,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDuplicateSelection))]
+        EditorDuplicateSelection
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -31,14 +31,17 @@ namespace osu.Game.Input.Bindings
             parentInputManager = GetContainingInputManager();
         }
 
-        // IMPORTANT: Do not change the order of key bindings in this list.
-        // It is used to decide the order of precedence (see note in DatabasedKeyBindingContainer).
+        // IMPORTANT: Take care when changing order of the items in the enumerable.
+        // It is used to decide the order of precedence, with the earlier items having higher precedence.
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
-                                                                       .Concat(OverlayKeyBindings)
                                                                        .Concat(EditorKeyBindings)
                                                                        .Concat(InGameKeyBindings)
                                                                        .Concat(SongSelectKeyBindings)
-                                                                       .Concat(AudioControlKeyBindings);
+                                                                       .Concat(AudioControlKeyBindings)
+                                                                       // Overlay bindings may conflict with more local cases like the editor so they are checked last.
+                                                                       // It has generally been agreed on that local screens like the editor should have priority,
+                                                                       // based on such usages potentially requiring a lot more key bindings that may be "shared" with global ones.
+                                                                       .Concat(OverlayKeyBindings);
 
         public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.EditorTimingMode),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.EditorSetupMode),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, GlobalAction.EditorVerifyMode),
-            new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.EditorDuplicateSelection),
+            new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.EditorCloneSelection),
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
@@ -348,7 +348,7 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleProfile))]
         ToggleProfile,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorDuplicateSelection))]
-        EditorDuplicateSelection
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCloneSelection))]
+        EditorCloneSelection
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -185,6 +185,11 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorTapForBPM => new TranslatableString(getKey(@"editor_tap_for_bpm"), @"Tap for BPM");
 
         /// <summary>
+        /// "Duplicate selection"
+        /// </summary>
+        public static LocalisableString EditorDuplicateSelection => new TranslatableString(getKey(@"editor_duplicate_selection"), @"Duplicate selection");
+
+        /// <summary>
         /// "Cycle grid display mode"
         /// </summary>
         public static LocalisableString EditorCycleGridDisplayMode => new TranslatableString(getKey(@"editor_cycle_grid_display_mode"), @"Cycle grid display mode");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -185,9 +185,9 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorTapForBPM => new TranslatableString(getKey(@"editor_tap_for_bpm"), @"Tap for BPM");
 
         /// <summary>
-        /// "Duplicate selection"
+        /// "Clone selection"
         /// </summary>
-        public static LocalisableString EditorDuplicateSelection => new TranslatableString(getKey(@"editor_duplicate_selection"), @"Duplicate selection");
+        public static LocalisableString EditorCloneSelection => new TranslatableString(getKey(@"editor_clone_selection"), @"Clone selection");
 
         /// <summary>
         /// "Cycle grid display mode"

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -777,6 +777,10 @@ namespace osu.Game.Screens.Edit
 
         protected void Duplicate()
         {
+            // Avoid attempting to clone if copying is not available (as it may result in pasting something unexpected).
+            if (!canCopy.Value)
+                return;
+
             // This is an initial implementation just to get an idea of how people used this function.
             // There are a couple of differences from osu!stable's implementation which will require more work to match:
             // - The "clipboard" is not populated during the duplication process.

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -304,7 +304,7 @@ namespace osu.Game.Screens.Edit
                                             cutMenuItem = new EditorMenuItem("Cut", MenuItemType.Standard, Cut),
                                             copyMenuItem = new EditorMenuItem("Copy", MenuItemType.Standard, Copy),
                                             pasteMenuItem = new EditorMenuItem("Paste", MenuItemType.Standard, Paste),
-                                            duplicateMenuItem = new EditorMenuItem("Clone", MenuItemType.Standard, Clone),
+                                            cloneMenuItem = new EditorMenuItem("Clone", MenuItemType.Standard, Clone),
                                         }
                                     },
                                     new MenuItem("View")
@@ -746,7 +746,7 @@ namespace osu.Game.Screens.Edit
 
         private EditorMenuItem cutMenuItem;
         private EditorMenuItem copyMenuItem;
-        private EditorMenuItem duplicateMenuItem;
+        private EditorMenuItem cloneMenuItem;
         private EditorMenuItem pasteMenuItem;
 
         private readonly BindableWithCurrent<bool> canCut = new BindableWithCurrent<bool>();
@@ -759,7 +759,7 @@ namespace osu.Game.Screens.Edit
             canCopy.Current.BindValueChanged(copy =>
             {
                 copyMenuItem.Action.Disabled = !copy.NewValue;
-                duplicateMenuItem.Action.Disabled = !copy.NewValue;
+                cloneMenuItem.Action.Disabled = !copy.NewValue;
             }, true);
             canPaste.Current.BindValueChanged(paste => pasteMenuItem.Action.Disabled = !paste.NewValue, true);
         }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -304,7 +304,7 @@ namespace osu.Game.Screens.Edit
                                             cutMenuItem = new EditorMenuItem("Cut", MenuItemType.Standard, Cut),
                                             copyMenuItem = new EditorMenuItem("Copy", MenuItemType.Standard, Copy),
                                             pasteMenuItem = new EditorMenuItem("Paste", MenuItemType.Standard, Paste),
-                                            duplicateMenuItem = new EditorMenuItem("Duplicate", MenuItemType.Standard, Duplicate),
+                                            duplicateMenuItem = new EditorMenuItem("Clone", MenuItemType.Standard, Clone),
                                         }
                                     },
                                     new MenuItem("View")
@@ -576,8 +576,8 @@ namespace osu.Game.Screens.Edit
                     this.Exit();
                     return true;
 
-                case GlobalAction.EditorDuplicateSelection:
-                    Duplicate();
+                case GlobalAction.EditorCloneSelection:
+                    Clone();
                     return true;
 
                 case GlobalAction.EditorComposeMode:
@@ -775,7 +775,7 @@ namespace osu.Game.Screens.Edit
 
         protected void Copy() => currentScreen?.Copy();
 
-        protected void Duplicate()
+        protected void Clone()
         {
             // Avoid attempting to clone if copying is not available (as it may result in pasting something unexpected).
             if (!canCopy.Value)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -304,6 +304,7 @@ namespace osu.Game.Screens.Edit
                                             cutMenuItem = new EditorMenuItem("Cut", MenuItemType.Standard, Cut),
                                             copyMenuItem = new EditorMenuItem("Copy", MenuItemType.Standard, Copy),
                                             pasteMenuItem = new EditorMenuItem("Paste", MenuItemType.Standard, Paste),
+                                            duplicateMenuItem = new EditorMenuItem("Duplicate", MenuItemType.Standard, Duplicate),
                                         }
                                     },
                                     new MenuItem("View")
@@ -575,6 +576,10 @@ namespace osu.Game.Screens.Edit
                     this.Exit();
                     return true;
 
+                case GlobalAction.EditorDuplicateSelection:
+                    Duplicate();
+                    return true;
+
                 case GlobalAction.EditorComposeMode:
                     Mode.Value = EditorScreenMode.Compose;
                     return true;
@@ -741,6 +746,7 @@ namespace osu.Game.Screens.Edit
 
         private EditorMenuItem cutMenuItem;
         private EditorMenuItem copyMenuItem;
+        private EditorMenuItem duplicateMenuItem;
         private EditorMenuItem pasteMenuItem;
 
         private readonly BindableWithCurrent<bool> canCut = new BindableWithCurrent<bool>();
@@ -750,7 +756,11 @@ namespace osu.Game.Screens.Edit
         private void setUpClipboardActionAvailability()
         {
             canCut.Current.BindValueChanged(cut => cutMenuItem.Action.Disabled = !cut.NewValue, true);
-            canCopy.Current.BindValueChanged(copy => copyMenuItem.Action.Disabled = !copy.NewValue, true);
+            canCopy.Current.BindValueChanged(copy =>
+            {
+                copyMenuItem.Action.Disabled = !copy.NewValue;
+                duplicateMenuItem.Action.Disabled = !copy.NewValue;
+            }, true);
             canPaste.Current.BindValueChanged(paste => pasteMenuItem.Action.Disabled = !paste.NewValue, true);
         }
 
@@ -764,6 +774,17 @@ namespace osu.Game.Screens.Edit
         protected void Cut() => currentScreen?.Cut();
 
         protected void Copy() => currentScreen?.Copy();
+
+        protected void Duplicate()
+        {
+            // This is an initial implementation just to get an idea of how people used this function.
+            // There are a couple of differences from osu!stable's implementation which will require more work to match:
+            // - The "clipboard" is not populated during the duplication process.
+            // - The duplicated hitobjects are inserted after the original pattern (add one beat_length and then quantize using beat snap).
+            // - The duplicated hitobjects are selected (but this is also applied for all paste operations so should be changed there).
+            Copy();
+            Paste();
+        }
 
         protected void Paste() => currentScreen?.Paste();
 

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Visual
 
             public new void Paste() => base.Paste();
 
-            public new void Duplicate() => base.Duplicate();
+            public new void Clone() => base.Clone();
 
             public new void SwitchToDifficulty(BeatmapInfo beatmapInfo) => base.SwitchToDifficulty(beatmapInfo);
 

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -110,6 +110,8 @@ namespace osu.Game.Tests.Visual
 
             public new void Paste() => base.Paste();
 
+            public new void Duplicate() => base.Duplicate();
+
             public new void SwitchToDifficulty(BeatmapInfo beatmapInfo) => base.SwitchToDifficulty(beatmapInfo);
 
             public new void CreateNewDifficulty(RulesetInfo rulesetInfo) => base.CreateNewDifficulty(rulesetInfo);


### PR DESCRIPTION
A bit of a low-effort implementation, but I'd like to push this out and see what kind of feedback mappers have. The implementation in stable is a bit nuanced, and may be preferred in some cases and potentially not in others. I think stable's behaviour is probably better when the current time is equal to the start time of the pattern being copied, but if the current time point is already in the future, it should work as per this PR's implementation?

One more thing: I'm not sure whether we should call this "clone" or "duplicate" when exposing to the user. I went with "duplicate" to avoid method clashes with `object.Clone` but I think "clone" may be more standard a term to users?

To make this work, I have reordered how bindings are handled at a game-wide level. Now, top level overlay bindings are giving less precedence than all local usages. I think this makes more sense (discussed with @smoogipoo and he tends to agree).

Closes https://github.com/ppy/osu/issues/20860.