### PR TITLE
Add setting to force hide `JudgementBody` for Great Judgements

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -175,6 +175,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorWaveformOpacity, 0.25f);
 
             SetDefault(OsuSetting.LastProcessedMetadataId, -1);
+            SetDefault(OsuSetting.ForceHideGreatJudgement, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -370,6 +371,7 @@ namespace osu.Game.Configuration
         DiscordRichPresence,
         AutomaticallyDownloadWhenSpectating,
         ShowOnlineExplicitContent,
-        LastProcessedMetadataId
+        LastProcessedMetadataId,
+        ForceHideGreatJudgement,
     }
 }

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -105,6 +105,11 @@ namespace osu.Game.Localisation
         public static LocalisableString HitLighting => new TranslatableString(getKey(@"hit_lighting"), @"Hit lighting");
 
         /// <summary>
+        /// "Force hide Great hit judgements"
+        /// </summary>
+        public static LocalisableString ForceHideGreatJudgement => new TranslatableString(getKey(@"force_hide_great_hit_judgement"), @"Force hide Great hit judgements");
+
+        /// <summary>
         /// "Screenshots"
         /// </summary>
         public static LocalisableString Screenshots => new TranslatableString(getKey(@"screenshots"), @"Screenshots");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = GraphicsSettingsStrings.HitLighting,
                     Current = config.GetBindable<bool>(OsuSetting.HitLighting)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = GraphicsSettingsStrings.ForceHideGreatJudgement,
+                    Current = config.GetBindable<bool>(OsuSetting.ForceHideGreatJudgement)
+                },
             };
         }
     }

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
@@ -112,8 +113,17 @@ namespace osu.Game.Rulesets.Judgements
             runAnimation();
         }
 
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
         private void runAnimation()
         {
+            // hide the judgement body if the user has disabled them.
+            if ((Result.Type == HitResult.Great) && config.Get<bool>(OsuSetting.ForceHideGreatJudgement)) {
+                JudgementBody.Scale = new Vector2(0);
+                return;
+            }
+
             // is a no-op if the drawables are already in a correct state.
             prepareDrawables();
 


### PR DESCRIPTION
Closes #2106.

This PR adds option to force hide `JudgementBody` for Judgements with the `Type` of `HitResults.Great`. It's toggleable from settings under Gameplay/General.

<img width="396" alt="Screen Shot 2022-10-24 at 8 56 42 PM" src="https://user-images.githubusercontent.com/16894959/197593564-f287cdbf-6b44-4515-9774-aa25442316a5.png">

https://user-images.githubusercontent.com/16894959/197595134-f0e44496-6c78-432d-9256-3844cfb26333.mp4


