### PR TITLE
Remove some small code repetition on Flashlight mod classes

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
@@ -45,7 +44,6 @@ namespace osu.Game.Rulesets.Catch.Mods
             {
                 this.playfield = playfield;
 
-                FlashlightSize = new Vector2(0, GetSize());
                 FlashlightSmoothness = 1.4f;
             }
 
@@ -66,10 +64,7 @@ namespace osu.Game.Rulesets.Catch.Mods
                 FlashlightPosition = playfield.CatcherArea.ToSpaceOfOtherDrawable(playfield.Catcher.DrawPosition, this);
             }
 
-            protected override void UpdateFlashlightSize(float size)
-            {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
-            }
+            protected override Vector2 AdjustSize(float size) => new Vector2(0, size);
 
             protected override string FragmentShader => "CircularFlashlight";
         }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFlashlight.cs
@@ -36,8 +36,6 @@ namespace osu.Game.Rulesets.Mania.Mods
             public ManiaFlashlight(ManiaModFlashlight modFlashlight)
                 : base(modFlashlight)
             {
-                FlashlightSize = new Vector2(DrawWidth, GetSize());
-
                 AddLayout(flashlightProperties);
             }
 
@@ -47,17 +45,14 @@ namespace osu.Game.Rulesets.Mania.Mods
 
                 if (!flashlightProperties.IsValid)
                 {
-                    FlashlightSize = new Vector2(DrawWidth, FlashlightSize.Y);
+                    FlashlightSize = AdjustSize(FlashlightSize.Y);
 
                     FlashlightPosition = DrawPosition + DrawSize / 2;
                     flashlightProperties.Validate();
                 }
             }
 
-            protected override void UpdateFlashlightSize(float size)
-            {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(DrawWidth, size), FLASHLIGHT_FADE_DURATION);
-            }
+            protected override Vector2 AdjustSize(float size) => new Vector2(DrawWidth, size);
 
             protected override string FragmentShader => "RectangularFlashlight";
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 followDelay = modFlashlight.FollowDelay.Value;
 
-                FlashlightSize = new Vector2(0, GetSize());
                 FlashlightSmoothness = 1.4f;
             }
 
@@ -83,10 +82,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 return base.OnMouseMove(e);
             }
 
-            protected override void UpdateFlashlightSize(float size)
-            {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
-            }
+            protected override Vector2 AdjustSize(float size) => new Vector2(0, size);
 
             protected override string FragmentShader => "CircularFlashlight";
         }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -47,22 +47,14 @@ namespace osu.Game.Rulesets.Taiko.Mods
             {
                 this.taikoPlayfield = taikoPlayfield;
 
-                FlashlightSize = adjustSize(GetSize());
                 FlashlightSmoothness = 1.4f;
 
                 AddLayout(flashlightProperties);
             }
 
-            private Vector2 adjustSize(float size)
-            {
-                // Preserve flashlight size through the playfield's aspect adjustment.
-                return new Vector2(0, size * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
-            }
+            private float preserveFlashlightAspectRatio(float size) => size * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT;
 
-            protected override void UpdateFlashlightSize(float size)
-            {
-                this.TransformTo(nameof(FlashlightSize), adjustSize(size), FLASHLIGHT_FADE_DURATION);
-            }
+            protected override Vector2 AdjustSize(float size) => new Vector2(0, preserveFlashlightAspectRatio(size));
 
             protected override string FragmentShader => "CircularFlashlight";
 
@@ -75,7 +67,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
-                    FlashlightSize = adjustSize(Combo.Value);
+                    FlashlightSize = AdjustSize(Combo.Value);
 
                     flashlightProperties.Validate();
                 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -52,14 +52,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 AddLayout(flashlightProperties);
             }
 
-            /// <summary>
-            /// Returns the aspect ratio-adjusted size of the flashlight.
-            /// This ensures that the size of the flashlight remains independent of taiko-specific aspect ratio adjustments.
-            /// </summary>
-            /// <param name="size">
-            /// The size of the flashlight.
-            /// The value provided here should always come from <see cref="ModFlashlight{T}.Flashlight.GetSize"/>.
-            /// </param>
             protected override Vector2 AdjustSize(float size) => new Vector2(0, size * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -118,10 +118,22 @@ namespace osu.Game.Rulesets.Mods
 
             private readonly IBindable<bool> isBreakTime = new BindableBool();
 
+            /// <summary>
+            /// Defines the flashlight area's vector, according to a given flashlight size.
+            /// </summary>
+            /// <param name="size">The flashlight size to adjust the area to.</param>
+            /// <returns>The flashlight area's vector.</returns>
+            protected abstract Vector2 AdjustSize(float size);
+
+            private Vector2 adjustCurrentSize() => AdjustSize(GetSize());
+
+            private void updateFlashlightSize() => this.TransformTo(nameof(FlashlightSize), adjustCurrentSize(), 800);
+
             protected override void LoadComplete()
             {
                 base.LoadComplete();
 
+                // Defining the Flashlight area before doing any transforms.
                 FlashlightSize = adjustCurrentSize();
 
                 Combo.ValueChanged += _ => updateFlashlightSize();
@@ -132,12 +144,6 @@ namespace osu.Game.Rulesets.Mods
                     isBreakTime.BindValueChanged(_ => updateFlashlightSize(), true);
                 }
             }
-
-            private Vector2 adjustCurrentSize() => AdjustSize(GetSize());
-
-            private void updateFlashlightSize() => this.TransformTo(nameof(FlashlightSize), adjustCurrentSize(), 800);
-
-            protected abstract Vector2 AdjustSize(float size);
 
             protected abstract string FragmentShader { get; }
 

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -48,7 +48,6 @@ namespace osu.Game.Rulesets.Mods
     public abstract class ModFlashlight<T> : ModFlashlight, IApplicableToDrawableRuleset<T>, IApplicableToScoreProcessor
         where T : HitObject
     {
-        public const double FLASHLIGHT_FADE_DURATION = 800;
         protected readonly BindableInt Combo = new BindableInt();
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
@@ -123,16 +122,22 @@ namespace osu.Game.Rulesets.Mods
             {
                 base.LoadComplete();
 
-                Combo.ValueChanged += _ => UpdateFlashlightSize(GetSize());
+                FlashlightSize = adjustCurrentSize();
+
+                Combo.ValueChanged += _ => updateFlashlightSize();
 
                 if (player != null)
                 {
                     isBreakTime.BindTo(player.IsBreakTime);
-                    isBreakTime.BindValueChanged(_ => UpdateFlashlightSize(GetSize()), true);
+                    isBreakTime.BindValueChanged(_ => updateFlashlightSize(), true);
                 }
             }
 
-            protected abstract void UpdateFlashlightSize(float size);
+            private Vector2 adjustCurrentSize() => AdjustSize(GetSize());
+
+            private void updateFlashlightSize() => this.TransformTo(nameof(FlashlightSize), adjustCurrentSize(), 800);
+
+            protected abstract Vector2 AdjustSize(float size);
 
             protected abstract string FragmentShader { get; }
 

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -119,12 +119,10 @@ namespace osu.Game.Rulesets.Mods
             private readonly IBindable<bool> isBreakTime = new BindableBool();
 
             /// <summary>
-            /// Creates a vector that is used to adjust the area that the flashlight should be displayed.
-            /// e.g on osu!mania the flashlight should be displayed on the whole playfield and the height should be scaled with the given size.
-            /// so the resulting vector should be Vector2(DrawWidth, size).
+            /// Returns the aspect ratio-adjusted size of the flashlight.
+            /// This ensures that the size of the flashlight remains independent of ruleset-specific aspect ratio adjustments.
             /// </summary>
-            /// <param name="size">The given flashlight size to scale the flashlight area to.</param>
-            /// <returns>A vector that defines the flashlight's area size.</returns>
+            /// <param name="size">The size of the flashlight.</param>
             protected abstract Vector2 AdjustSize(float size);
 
             private Vector2 adjustCurrentSize() => AdjustSize(GetSize());

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -119,10 +119,12 @@ namespace osu.Game.Rulesets.Mods
             private readonly IBindable<bool> isBreakTime = new BindableBool();
 
             /// <summary>
-            /// Defines the flashlight area's vector, according to a given flashlight size.
+            /// Creates a vector that is used to adjust the area that the flashlight should be displayed.
+            /// e.g on osu!mania the flashlight should be displayed on the whole playfield and the height should be scaled with the given size.
+            /// so the resulting vector should be Vector2(DrawWidth, size).
             /// </summary>
-            /// <param name="size">The flashlight size to adjust the area to.</param>
-            /// <returns>The flashlight area's vector.</returns>
+            /// <param name="size">The given flashlight size to scale the flashlight area to.</param>
+            /// <returns>A vector that defines the flashlight's area size.</returns>
             protected abstract Vector2 AdjustSize(float size);
 
             private Vector2 adjustCurrentSize() => AdjustSize(GetSize());


### PR DESCRIPTION
Since every Flashlight class `UpdateFlashlightSize` method was doing something similar to:
```cs
protected override void UpdateFlashlightSize(float size)
{
    this.TransformTo(nameof(FlashlightSize), AdjustedSize, FLASHLIGHT_FADE_DURATION);
}
```
I figured out it would be better to have a method that adjusts the flashlight's adjusted size according to the ruleset requirements rather than a `UpdateFlashlightSize` method.
This also fixes multiple code repetitions on `ModFlashlight` derivated class, because the FlashlightSize had to be normalized on the constructor according to each ruleset. Which now are done on the base class on the `OnLoadComplete` method
```cs
FlashlightSize = adjustCurrentSize();
```
this can be seem on this pull request diff on all the constructors.
