### PR TITLE
Fix invalid taiko flashlight size calculation

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
@@ -1,8 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Tests.Mods
 {
@@ -16,5 +20,37 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
 
         [Test]
         public void TestComboBasedSize([Values] bool comboBasedSize) => CreateModTest(new ModTestData { Mod = new TaikoModFlashlight { ComboBasedSize = { Value = comboBasedSize } }, PassCondition = () => true });
+
+        [Test]
+        public void TestFlashlightAlwaysHasNonZeroSize()
+        {
+            bool failed = false;
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new TestTaikoModFlashlight { ComboBasedSize = { Value = true } },
+                Autoplay = false,
+                PassCondition = () =>
+                {
+                    failed |= this.ChildrenOfType<TestTaikoModFlashlight.TestTaikoFlashlight>().SingleOrDefault()?.FlashlightSize.Y == 0;
+                    return !failed;
+                }
+            });
+        }
+
+        private class TestTaikoModFlashlight : TaikoModFlashlight
+        {
+            protected override Flashlight CreateFlashlight() => new TestTaikoFlashlight(this, Playfield);
+
+            public class TestTaikoFlashlight : TaikoFlashlight
+            {
+                public TestTaikoFlashlight(TaikoModFlashlight modFlashlight, TaikoPlayfield taikoPlayfield)
+                    : base(modFlashlight, taikoPlayfield)
+                {
+                }
+
+                public new Vector2 FlashlightSize => base.FlashlightSize;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -27,17 +27,17 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         public override float DefaultFlashlightSize => 200;
 
-        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, playfield);
+        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, Playfield);
 
-        private TaikoPlayfield playfield = null!;
+        protected TaikoPlayfield Playfield { get; private set; } = null!;
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
-            playfield = (TaikoPlayfield)drawableRuleset.Playfield;
+            Playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             base.ApplyToDrawableRuleset(drawableRuleset);
         }
 
-        private class TaikoFlashlight : Flashlight
+        public class TaikoFlashlight : Flashlight
         {
             private readonly LayoutValue flashlightProperties = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo);
             private readonly TaikoPlayfield taikoPlayfield;

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
-                    FlashlightSize = adjustSize(Combo.Value);
+                    FlashlightSize = adjustSize(GetSize());
 
                     flashlightProperties.Validate();
                 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -47,21 +47,28 @@ namespace osu.Game.Rulesets.Taiko.Mods
             {
                 this.taikoPlayfield = taikoPlayfield;
 
-                FlashlightSize = adjustSize(GetSize());
+                FlashlightSize = adjustSizeForPlayfieldAspectRatio(GetSize());
                 FlashlightSmoothness = 1.4f;
 
                 AddLayout(flashlightProperties);
             }
 
-            private Vector2 adjustSize(float size)
+            /// <summary>
+            /// Returns the aspect ratio-adjusted size of the flashlight.
+            /// This ensures that the size of the flashlight remains independent of taiko-specific aspect ratio adjustments.
+            /// </summary>
+            /// <param name="size">
+            /// The size of the flashlight.
+            /// The value provided here should always come from <see cref="ModFlashlight{T}.Flashlight.GetSize"/>.
+            /// </param>
+            private Vector2 adjustSizeForPlayfieldAspectRatio(float size)
             {
-                // Preserve flashlight size through the playfield's aspect adjustment.
                 return new Vector2(0, size * taikoPlayfield.DrawHeight / TaikoPlayfield.DEFAULT_HEIGHT);
             }
 
             protected override void UpdateFlashlightSize(float size)
             {
-                this.TransformTo(nameof(FlashlightSize), adjustSize(size), FLASHLIGHT_FADE_DURATION);
+                this.TransformTo(nameof(FlashlightSize), adjustSizeForPlayfieldAspectRatio(size), FLASHLIGHT_FADE_DURATION);
             }
 
             protected override string FragmentShader => "CircularFlashlight";
@@ -75,7 +82,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
-                    FlashlightSize = adjustSize(GetSize());
+                    FlashlightSize = adjustSizeForPlayfieldAspectRatio(GetSize());
 
                     flashlightProperties.Validate();
                 }


### PR DESCRIPTION
Closes #20905.

This regressed in https://github.com/ppy/osu/pull/20714. In that pull, one usage of `getSizeFor(0)` was replaced by `adjustSize(GetSize())`, but another usage of `getSizeFor(Combo.Value)` was replaced by `adjustSize(Combo.Value)`, which is not correct, since `adjustSize()` is expecting to receive a combo-based size, rather than a combo value directly. Note that `GetSize()` internally reads the current combo.

I've added some test coverage, but it's rather wonky because I had to expose awkward things in awkward ways. Also attempted to make this a bit more legible, but the code is still pretty ~~bad~~ convoluted due to how flashlight is structured, and I'm not really looking to be making huge refactors right now.