### PR TITLE
Apply distance snap time component even when nearby object snap kicks in

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 // In the case of snapping to nearby objects, a time value is not provided.
                 // This matches the stable editor (which also uses current time), but with the introduction of time-snapping distance snap
-                // this could result in unexpected behaviour when distance snapping is turned on an a user attempts to place an object that is
+                // this could result in unexpected behaviour when distance snapping is turned on and a user attempts to place an object that is
                 // BOTH on a valid distance snap ring, and also at the same position as a previous object.
                 //
                 // We want to ensure that in this particular case, the time-snapping component of distance snap is still applied.


### PR DESCRIPTION
This is a bit of a hard one to explain, but I'm hopeful that the inline comment does a good job.

Visually, this is the behaviour that is changed by this PR (pay attention to the position of the placement in the timeline):

Before:

https://user-images.githubusercontent.com/191335/197944319-fd33ba60-8b5d-4172-be5c-4911dc4002a5.mp4

After:

https://user-images.githubusercontent.com/191335/197944222-69a09d83-35a6-48e7-99fa-3a7f57aeb42a.mp4

Closes #20940 (probably)