### PR TITLE
Fix slider heads getting misplaced after flipping in editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
@@ -377,7 +377,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private void addJudgementAssert(OsuHitObject hitObject, HitResult result)
         {
             AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judgement is {result}",
-                () => judgementResults.Single(r => r.HitObject == hitObject).Type == result);
+                () => judgementResults.Single(r => r.HitObject == hitObject).Type, () => Is.EqualTo(result));
         }
 
         private void addJudgementAssert(string name, Func<OsuHitObject> hitObject, HitResult result)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -102,8 +102,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             Size = HitArea.DrawSize;
 
-            PositionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
-            StackHeightBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);
+            PositionBindable.BindValueChanged(_ => UpdatePosition());
+            StackHeightBindable.BindValueChanged(_ => UpdatePosition());
             ScaleBindable.BindValueChanged(scale => scaleContainer.Scale = new Vector2(scale.NewValue));
         }
 
@@ -132,6 +132,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 base.LifetimeEnd = value;
                 ApproachCircle.LifetimeEnd = value;
             }
+        }
+
+        protected virtual void UpdatePosition()
+        {
+            Position = HitObject.StackedPosition;
         }
 
         public override void Shake() => shakeContainer.Shake();

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
@@ -43,18 +42,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            PositionBindable.BindValueChanged(_ => updatePosition());
-            pathVersion.BindValueChanged(_ => updatePosition());
-        }
-
         protected override void OnFree()
         {
             base.OnFree();
 
             pathVersion.UnbindFrom(DrawableSlider.PathVersion);
+        }
+
+        protected override void UpdatePosition()
+        {
+            // Slider head is always drawn at (0,0).
         }
 
         protected override void OnApply()
@@ -99,12 +96,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.Shake();
             DrawableSlider.Shake();
-        }
-
-        private void updatePosition()
-        {
-            if (Slider != null)
-                Position = HitObject.Position - Slider.Position;
         }
     }
 }


### PR DESCRIPTION
Slider heads are guaranteed to always be drawn at (0,0). This fixes weird behaviour in the editor, but also simplifies things in the process.  Win-win.

Closes #20644.