### PR TITLE
Add ability to set custom menu background in `SkinEditor`

### DIFF
--- a/osu.Game/Configuration/BackgroundSource.cs
+++ b/osu.Game/Configuration/BackgroundSource.cs
@@ -18,5 +18,8 @@ namespace osu.Game.Configuration
 
         [LocalisableDescription(typeof(UserInterfaceStrings), nameof(UserInterfaceStrings.BeatmapWithStoryboard))]
         BeatmapWithStoryboard,
+
+        [LocalisableDescription(typeof(CommonStrings), nameof(CommonStrings.Default))]
+        Default,
     }
 }

--- a/osu.Game/Localisation/ToastStrings.cs
+++ b/osu.Game/Localisation/ToastStrings.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Localisation
         public static LocalisableString SkinSaved => new TranslatableString(getKey(@"skin_saved"), @"Skin saved");
 
         /// <summary>
+        /// "Menu Background changed"
+        /// </summary>
+        public static LocalisableString MenuBackgroundChanged => new TranslatableString(getKey(@"menu_background_changed"), @"Menu Background changed");
+
+        /// <summary>
         /// "URL copied"
         /// </summary>
         public static LocalisableString UrlCopied => new TranslatableString(getKey(@"url_copied"), @"URL copied");

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -157,7 +157,11 @@ namespace osu.Game.Screens.Backgrounds
             // seasonal background loading gets highest priority.
             Background newBackground = seasonalBackgroundLoader.LoadNextBackground();
 
+#if DEBUG
+            if (newBackground == null)
+#else
             if (newBackground == null && user.Value?.IsSupporter == true)
+#endif
             {
                 switch (source.Value)
                 {
@@ -165,14 +169,14 @@ namespace osu.Game.Screens.Backgrounds
                     case BackgroundSource.BeatmapWithStoryboard:
                     {
                         if (source.Value == BackgroundSource.BeatmapWithStoryboard && AllowStoryboardBackground)
-                            newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, getBackgroundTextureName());
-                        newBackground ??= new BeatmapBackground(beatmap.Value, getBackgroundTextureName());
+                            newBackground = new BeatmapBackgroundWithStoryboard(beatmap.Value, GetBackgroundFallbackTextureName());
+                        newBackground ??= new BeatmapBackground(beatmap.Value, GetBackgroundFallbackTextureName());
 
                         break;
                     }
 
                     case BackgroundSource.Skin:
-                        newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
+                        newBackground = new SkinBackground(skin.Value, GetBackgroundFallbackTextureName());
                         break;
                 }
             }
@@ -182,13 +186,13 @@ namespace osu.Game.Screens.Backgrounds
             if (newBackground?.Equals(background) == true)
                 return background;
 
-            newBackground ??= new Background(getBackgroundTextureName());
+            newBackground ??= new Background(GetBackgroundFallbackTextureName());
             newBackground.Depth = currentDisplay;
 
             return newBackground;
         }
 
-        private string getBackgroundTextureName()
+        public string GetBackgroundFallbackTextureName()
         {
             switch (introSequence.Value)
             {

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -110,6 +110,18 @@ namespace osu.Game.Screens.Backgrounds
                 return false;
 
             return queueNext(nextBackground);
+        }
+
+        /// <summary>
+        /// Request loading a specific background.
+        /// </summary>
+        /// <param name="background">The background to load.</param>
+        /// <returns>Whether a new background was queued for load. May return false if the current background is still valid.</returns>
+        public virtual bool Next(Background background)
+        {
+            background.Depth = currentDisplay;
+
+            return queueNext(background);
         }
 
         private bool queueNext(Background nextBackground)

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -129,19 +129,7 @@ namespace osu.Game.Screens.Backgrounds
                     }
 
                     case BackgroundSource.Skin:
-                        switch (skin.Value)
-                        {
-                            case TrianglesSkin:
-                            case ArgonSkin:
-                            case DefaultLegacySkin:
-                                // default skins should use the default background rotation, which won't be the case if a SkinBackground is created for them.
-                                break;
-
-                            default:
-                                newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
-                                break;
-                        }
-
+                        newBackground = new SkinBackground(skin.Value, getBackgroundTextureName());
                         break;
                 }
             }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -157,11 +157,7 @@ namespace osu.Game.Screens.Backgrounds
             // seasonal background loading gets highest priority.
             Background newBackground = seasonalBackgroundLoader.LoadNextBackground();
 
-#if DEBUG
-            if (newBackground == null)
-#else
             if (newBackground == null && user.Value?.IsSupporter == true)
-#endif
             {
                 switch (source.Value)
                 {

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -388,8 +388,8 @@ namespace osu.Game.Skinning.Editor
             {
                 (screen as MainMenu)?.ApplyToBackground(b =>
                 {
-                    if (b is BackgroundScreenDefault targetScreen)
-                        AddInternal(previewBackground = new MenuBackgroundPreview(targetScreen, previewTexture));
+                    if (b is BackgroundScreenDefault target)
+                        AddInternal(previewBackground = new MenuBackgroundPreview(target, previewTexture));
                 });
             });
         }
@@ -398,7 +398,7 @@ namespace osu.Game.Skinning.Editor
         {
             currentSkin.Value.SkinInfo.PerformWrite(skinInfo =>
             {
-                foreach (var file in skinInfo.Files.Where(f => f.Filename.StartsWith("menu-background.")))
+                foreach (var file in skinInfo.Files.Where(f => f.Filename.StartsWith("menu-background.", StringComparison.Ordinal)))
                     skins.DeleteFile(skinInfo, file);
             });
             realm.Run(r => r.Refresh());
@@ -410,8 +410,8 @@ namespace osu.Game.Skinning.Editor
             {
                 (screen as MainMenu)?.ApplyToBackground(b =>
                 {
-                    if (b is BackgroundScreenDefault targetScreen)
-                        AddInternal(previewBackground = new MenuBackgroundPreview(targetScreen));
+                    if (b is BackgroundScreenDefault target)
+                        AddInternal(previewBackground = new MenuBackgroundPreview(target));
                 });
             });
         }

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -405,6 +405,15 @@ namespace osu.Game.Skinning.Editor
 
             if (previewBackground != null)
                 Remove(previewBackground, true);
+
+            game?.PerformFromScreen(screen =>
+            {
+                (screen as MainMenu)?.ApplyToBackground(b =>
+                {
+                    if (b is BackgroundScreenDefault targetScreen)
+                        AddInternal(previewBackground = new MenuBackgroundPreview(targetScreen));
+                });
+            });
         }
 
         public void Save()
@@ -526,6 +535,12 @@ namespace osu.Game.Skinning.Editor
 
             private bool isDisposed;
 
+            public MenuBackgroundPreview(BackgroundScreenDefault targetScreen)
+            {
+                screen = targetScreen;
+                preview = new PreviewBackground(screen.GetBackgroundFallbackTextureName());
+            }
+
             public MenuBackgroundPreview(BackgroundScreenDefault targetScreen, Texture texture)
             {
                 screen = targetScreen;
@@ -556,6 +571,11 @@ namespace osu.Game.Skinning.Editor
             {
                 private readonly Texture texture;
 
+                public PreviewBackground(string textureName)
+                    : base(textureName)
+                {
+                }
+
                 public PreviewBackground(Texture texture)
                 {
                     this.texture = texture;
@@ -565,7 +585,8 @@ namespace osu.Game.Skinning.Editor
                 {
                     base.LoadComplete();
 
-                    Sprite.Texture = texture;
+                    if (texture != null)
+                        Sprite.Texture = texture;
                 }
             }
         }

--- a/osu.Game/Skinning/Editor/SkinEditorMenuBackgroundChooser.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorMenuBackgroundChooser.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Skinning.Editor
 
         private readonly SkinEditor skinEditor;
 
-        private Bindable<FileInfo?> menuBackground;
+        private readonly Bindable<FileInfo?> menuBackground;
 
         private MenuBackgroundChooserPopover? popover;
 
@@ -41,11 +41,6 @@ namespace osu.Game.Skinning.Editor
 
             menuBackground = new Bindable<FileInfo?>();
             menuBackground.BindValueChanged(onFileSelected);
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
         }
 
         private void onFileSelected(ValueChangedEvent<FileInfo?> file)

--- a/osu.Game/Skinning/Editor/SkinEditorMenuBackgroundChooser.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorMenuBackgroundChooser.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
+
+namespace osu.Game.Skinning.Editor
+{
+    public class SkinEditorMenuBackgroundChooser : Container, ICanAcceptFiles, IHasPopover
+    {
+        private readonly string[] handledExtensions = { ".jpg", ".jpeg", ".png" };
+
+        private readonly SkinEditor skinEditor;
+
+        private Bindable<FileInfo?> menuBackground;
+
+        private MenuBackgroundChooserPopover? popover;
+
+        public bool PopoverVisible => popover?.State.Value == Visibility.Visible;
+
+        [Resolved(canBeNull: true)]
+        private OsuGame? game { get; set; }
+
+        public SkinEditorMenuBackgroundChooser(SkinEditor skinEditor)
+        {
+            this.skinEditor = skinEditor;
+
+            menuBackground = new Bindable<FileInfo?>();
+            menuBackground.BindValueChanged(onFileSelected);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+        }
+
+        private void onFileSelected(ValueChangedEvent<FileInfo?> file)
+        {
+            if (file.NewValue == null)
+                return;
+
+            this.HidePopover();
+            skinEditor.SetMenuBackground(file.NewValue);
+        }
+
+        public Task Import(params string[] paths)
+        {
+            Schedule(() =>
+            {
+                HoverClickSounds sounds = new HoverClickSounds();
+                AddInternal(sounds);
+                sounds.TriggerClick();
+                sounds.Expire();
+                menuBackground.Value = new FileInfo(paths.First());
+            });
+
+            return Task.CompletedTask;
+        }
+
+        public Task Import(params ImportTask[] tasks) => throw new NotImplementedException();
+
+        public IEnumerable<string> HandledExtensions => handledExtensions;
+
+        public Popover GetPopover()
+        {
+            popover = new MenuBackgroundChooserPopover(handledExtensions, menuBackground);
+            popover.State.BindValueChanged(state =>
+            {
+                switch (state.NewValue)
+                {
+                    case Visibility.Visible:
+                        game?.RegisterImportHandler(this);
+                        break;
+
+                    case Visibility.Hidden:
+                        game?.UnregisterImportHandler(this);
+                        break;
+                }
+            });
+
+            return popover;
+        }
+
+        private class MenuBackgroundChooserPopover : OsuPopover
+        {
+            public MenuBackgroundChooserPopover(string[] handledExtensions, Bindable<FileInfo?> currentFile)
+            {
+                Child = new Container
+                {
+                    Size = new Vector2(600, 400),
+                    Child = new OsuFileSelector(currentFile.Value?.DirectoryName, handledExtensions)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        CurrentFile = { BindTarget = currentFile },
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Skinning.Editor
             }
 
             [BackgroundDependencyLoader(true)]
-            private void load([CanBeNull] OverlayColourProvider overlayColourProvider, OsuColour colours)
+            private void load(OverlayColourProvider? overlayColourProvider, OsuColour colours)
             {
                 BackgroundColour = overlayColourProvider?.Background3 ?? colours.Blue3;
                 Content.CornerRadius = 5;

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -36,13 +34,13 @@ namespace osu.Game.Skinning.Editor
         private const float padding = 10;
 
         [Resolved(canBeNull: true)]
-        private IPerformFromScreenRunner performer { get; set; }
+        private IPerformFromScreenRunner? performer { get; set; }
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; }
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
-        private Bindable<IReadOnlyList<Mod>> mods { get; set; }
+        private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         public SkinEditorSceneLibrary()
         {
@@ -83,6 +81,13 @@ namespace osu.Game.Skinning.Editor
                                 },
                                 new SceneButton
                                 {
+                                    Text = "Main Menu",
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Action = () => performer?.PerformFromScreen(screen => { })
+                                },
+                                new SceneButton
+                                {
                                     Text = "Song Select",
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -106,7 +111,7 @@ namespace osu.Game.Skinning.Editor
 
                                         var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
 
-                                        if (!ModUtils.CheckCompatibleSet(mods.Value.Append(replayGeneratingMod), out var invalid))
+                                        if (!ModUtils.CheckCompatibleSet(replayGeneratingMod == null ? mods.Value : mods.Value.Append(replayGeneratingMod), out var invalid))
                                             mods.Value = mods.Value.Except(invalid).ToArray();
 
                                         if (replayGeneratingMod != null)

--- a/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Skinning/Editor/SkinEditorSceneLibrary.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -189,6 +189,11 @@ namespace osu.Game.Skinning
             skinImporter.Save(skin);
         }
 
+        public void Reload()
+        {
+            CurrentSkin.Value = CurrentSkinInfo.Value.PerformRead(GetSkin);
+        }
+
         /// <summary>
         /// Perform a lookup query on available <see cref="SkinInfo"/>s.
         /// </summary>


### PR DESCRIPTION
This change proposes to allow osu!supporters to set custom menu backgrounds even for argon skins and triangle skins.

https://user-images.githubusercontent.com/20679825/198125457-36fe3a59-1a62-4958-9d90-5c605f9e63bf.mp4

