### PR TITLE
Only draw path visualiser when hovered or single slider is selected

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             if (editorBeatmap != null)
                 selectedObjects.BindTo(editorBeatmap.SelectedHitObjects);
-            selectedObjects.BindCollectionChanged((_, _) => updateVisualDefinition());
+            selectedObjects.BindCollectionChanged((_, _) => updateVisualDefinition(), true);
         }
 
         public override bool HandleQuickDeletion()

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return true;
         }
 
-        private bool hasSingleObjectSelected => editorBeatmap == null || selectedObjects.Count == 1;
+        private bool hasSingleObjectSelected => selectedObjects.Count == 1;
 
         protected override void Update()
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -104,6 +104,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return true;
         }
 
+        private bool hasSingleObjectSelected => editorBeatmap.SelectedHitObjects.Count == 1;
+
         protected override void Update()
         {
             base.Update();
@@ -115,7 +117,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         protected override bool OnHover(HoverEvent e)
         {
             updateVisualDefinition();
-            return base.OnHover(e);
+
+            // In the case more than a single object is selected, block hover from arriving at sliders behind this one.
+            // Without doing this, the path visualisers of potentially hundreds of sliders will render, which is not only
+            // visually noisy but also functionally useless.
+            return !hasSingleObjectSelected;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
@@ -140,8 +146,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateVisualDefinition()
         {
-            bool hasSingleObjectSelected = editorBeatmap.SelectedHitObjects.Count == 1;
-
             // To reduce overhead of drawing these blueprints, only add extra detail when hovered or when only this slider is selected.
             if (IsSelected && (hasSingleObjectSelected || IsHovered))
             {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private readonly BindableList<PathControlPoint> controlPoints = new BindableList<PathControlPoint>();
         private readonly IBindable<int> pathVersion = new Bindable<int>();
-        private BindableList<HitObject> selectedObjects;
+        private readonly BindableList<HitObject> selectedObjects = new BindableList<HitObject>();
 
         public SliderSelectionBlueprint(Slider slider)
             : base(slider)
@@ -88,7 +88,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             BodyPiece.UpdateFrom(HitObject);
 
-            selectedObjects = editorBeatmap.SelectedHitObjects.GetBoundCopy();
+            if (editorBeatmap != null)
+                selectedObjects.BindTo(editorBeatmap.SelectedHitObjects);
             selectedObjects.BindCollectionChanged((_, _) => updateVisualDefinition());
         }
 
@@ -104,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return true;
         }
 
-        private bool hasSingleObjectSelected => editorBeatmap == null || editorBeatmap.SelectedHitObjects.Count == 1;
+        private bool hasSingleObjectSelected => editorBeatmap == null || selectedObjects.Count == 1;
 
         protected override void Update()
         {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return true;
         }
 
-        private bool hasSingleObjectSelected => editorBeatmap.SelectedHitObjects.Count == 1;
+        private bool hasSingleObjectSelected => editorBeatmap == null || editorBeatmap.SelectedHitObjects.Count == 1;
 
         protected override void Update()
         {


### PR DESCRIPTION
This matches stable editor behaviour.

Now, slider path visualisations will only be shown when
- A single slider is selected
- A slider in a multi-selection is hovered


https://user-images.githubusercontent.com/191335/198202800-e8fbcb2f-8069-4299-aed9-61ec5dd2a9f7.mp4

This improves performance when selecting all objects by around 25% (on Disco Prince, update 44 / draw 22, up from update 33 / draw 18). Nothing too big but it's a starting point.