### PR TITLE
Avoid unnecessarily refreshing `SliderBodyPiece`'s path

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
@@ -40,16 +40,23 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             body.BorderColour = colours.Yellow;
         }
 
+        private int? lastVersion;
+
         public override void UpdateFrom(Slider hitObject)
         {
             base.UpdateFrom(hitObject);
 
             body.PathRadius = hitObject.Scale * OsuHitObject.OBJECT_RADIUS;
 
-            var vertices = new List<Vector2>();
-            hitObject.Path.GetPathToProgress(vertices, 0, 1);
+            if (lastVersion != hitObject.Path.Version.Value)
+            {
+                lastVersion = hitObject.Path.Version.Value;
 
-            body.SetVertices(vertices);
+                var vertices = new List<Vector2>();
+                hitObject.Path.GetPathToProgress(vertices, 0, 1);
+
+                body.SetVertices(vertices);
+            }
 
             Size = body.Size;
             OriginPosition = body.PathOffset;


### PR DESCRIPTION
This reduces the draw thread overhead when many sliders are selected in the editor. I'm making this a very local optimisation for now because I want to avoid changing all the `UpdateFrom` flow (profiling that alone shows that it has quite low overhead relative to other issues).

Before (on https://github.com/ppy/osu/pull/20965): Update 44fps, Draw 22fps
After: Update 44fps, Draw 38fps