### PR TITLE
Reduce size of spinner blueprint to better represent gameplay size

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
@@ -5,11 +5,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Skinning.Default;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/Components/SpinnerPiece.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components
 {
     public class SpinnerPiece : BlueprintPiece<Spinner>
     {
-        private readonly CircularContainer circle;
-        private readonly RingPiece ring;
+        private readonly Circle circle;
+        private readonly Circle ring;
 
         public SpinnerPiece()
         {
@@ -25,18 +25,21 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners.Components
 
             RelativeSizeAxes = Axes.Both;
             FillMode = FillMode.Fit;
-            Size = new Vector2(1.3f);
+            Size = new Vector2(1);
 
             InternalChildren = new Drawable[]
             {
-                circle = new CircularContainer
+                circle = new Circle
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Masking = true,
                     Alpha = 0.5f,
-                    Child = new Box { RelativeSizeAxes = Axes.Both }
                 },
-                ring = new RingPiece()
+                ring = new Circle
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(OsuHitObject.OBJECT_RADIUS),
+                },
             };
         }
 


### PR DESCRIPTION
Noticed that when selecting all objects, the spinners were hiding most of the visibility of other objects due to being much larger than they should be.

| before | after |
| -- | -- |
|![osu Game Rulesets Osu Tests 2022-10-27 at 07 17 02](https://user-images.githubusercontent.com/191335/198216559-c35fc3ac-4c93-4320-aabe-f6a4865101bd.png)|![osu Game Rulesets Osu Tests 2022-10-27 at 07 15 53](https://user-images.githubusercontent.com/191335/198216322-aadd8c03-da2a-4645-9d71-112f05a17aa1.png)|
|![osu Game Rulesets Osu Tests 2022-10-27 at 07 17 13](https://user-images.githubusercontent.com/191335/198216581-a27a96ce-6fec-4f55-8498-0b252ec5e709.png)|![osu Game Rulesets Osu Tests 2022-10-27 at 07 16 13](https://user-images.githubusercontent.com/191335/198216382-11b335b0-f7fa-4f3f-b196-af6290f03d82.png)|