### PR TITLE
Populate beatmap ruleset in `SoloScoreInfo.ToScoreInfo()`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -154,10 +154,8 @@ namespace osu.Game.Online.API.Requests.Responses
 
             var mods = Mods.Select(apiMod => apiMod.ToMod(rulesetInstance)).ToArray();
 
-            var scoreInfo = ToScoreInfo(mods);
-
+            var scoreInfo = ToScoreInfo(mods, beatmap);
             scoreInfo.Ruleset = ruleset;
-            if (beatmap != null) scoreInfo.BeatmapInfo = beatmap;
 
             return scoreInfo;
         }
@@ -166,25 +164,47 @@ namespace osu.Game.Online.API.Requests.Responses
         /// Create a <see cref="ScoreInfo"/> from an API score instance.
         /// </summary>
         /// <param name="mods">The mod instances, resolved from a ruleset.</param>
-        /// <returns></returns>
-        public ScoreInfo ToScoreInfo(Mod[] mods) => new ScoreInfo
+        /// <param name="beatmap">The object to populate the scores' beatmap with.
+        ///<list type="bullet">
+        /// <item>If this is a <see cref="BeatmapInfo"/> type, then the score will be fully populated with the given object.</item>
+        /// <item>Otherwise, if this is an <see cref="IBeatmapInfo"/> type (e.g. <see cref="APIBeatmap"/>), then only the beatmap ruleset will be populated.</item>
+        /// <item>Otherwise, if this is <c>null</c>, then the beatmap ruleset will not be populated.</item>
+        /// <item>The online beatmap ID is populated in all cases.</item>
+        /// </list>
+        /// </param>
+        /// <returns>The populated <see cref="ScoreInfo"/>.</returns>
+        public ScoreInfo ToScoreInfo(Mod[] mods, IBeatmapInfo? beatmap = null)
         {
-            OnlineID = OnlineID,
-            User = User ?? new APIUser { Id = UserID },
-            BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
-            Ruleset = new RulesetInfo { OnlineID = RulesetID },
-            Passed = Passed,
-            TotalScore = TotalScore,
-            Accuracy = Accuracy,
-            MaxCombo = MaxCombo,
-            Rank = Rank,
-            Statistics = Statistics,
-            MaximumStatistics = MaximumStatistics,
-            Date = EndedAt,
-            Hash = HasReplay ? "online" : string.Empty, // TODO: temporary?
-            Mods = mods,
-            PP = PP,
-        };
+            var score = new ScoreInfo
+            {
+                OnlineID = OnlineID,
+                User = User ?? new APIUser { Id = UserID },
+                BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
+                Ruleset = new RulesetInfo { OnlineID = RulesetID },
+                Passed = Passed,
+                TotalScore = TotalScore,
+                Accuracy = Accuracy,
+                MaxCombo = MaxCombo,
+                Rank = Rank,
+                Statistics = Statistics,
+                MaximumStatistics = MaximumStatistics,
+                Date = EndedAt,
+                Hash = HasReplay ? "online" : string.Empty, // TODO: temporary?
+                Mods = mods,
+                PP = PP,
+            };
+
+            if (beatmap is BeatmapInfo realmBeatmap)
+                score.BeatmapInfo = realmBeatmap;
+            else if (beatmap != null)
+            {
+                score.BeatmapInfo.Ruleset.OnlineID = beatmap.Ruleset.OnlineID;
+                score.BeatmapInfo.Ruleset.Name = beatmap.Ruleset.Name;
+                score.BeatmapInfo.Ruleset.ShortName = beatmap.Ruleset.ShortName;
+            }
+
+            return score;
+        }
 
         /// <summary>
         /// Creates a <see cref="SoloScoreInfo"/> from a local score for score submission.


### PR DESCRIPTION
If we're to do "is converted beatmap" checks as per https://github.com/ppy/osu/pull/20558, which I don't think is necessarily a bad idea, then the beatmaps' ruleset needs to be populated in the conversion from `SoloScoreInfo` to `ScoreInfo`.

This will also require an osu-queue-score-statistics change to pass in the APIBeatmap, that I'll do as a followup if this PR is accepted/when a new nuget package is released.

I've done the bare minimum here by populating just the ruleset, but there are other members in `IBeatmapInfo` that aren't passed across like BPM, Length, etc... Unfortunately, as far as I know, we don't have a function to convert `IBeatmapInfo`/`APIBeatmapInfo` to `BeatmapInfo`, so populating all members will require substantial effort. Please give me your opinions on this.