### PR TITLE
Fix bar hit error meter labels not clearing when setting to none

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -279,6 +279,8 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             switch (style)
             {
                 case LabelStyles.None:
+                    labelEarly.Clear();
+                    labelLate.Clear();
                     break;
 
                 case LabelStyles.Icons:


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/20780.

| Before | After |
| --- | --- |
| ![osu!_kWV2ofnlRE](https://user-images.githubusercontent.com/35318437/198520250-072e938d-f12b-4f1b-9055-3dcb126c52eb.gif) | ![osu!_r127nRhh5d](https://user-images.githubusercontent.com/35318437/198520095-672cf751-6bf3-4c8c-b38e-7d17cc4dd7db.gif) |