### PR TITLE
Improve messaging when ruleset load fails

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Rulesets
             }
             catch (Exception e)
             {
-                LogFailedLoad(assembly.FullName, e);
+                LogFailedLoad(assembly.GetName().Name.Split('.').Last(), e);
             }
         }
 
@@ -168,14 +168,14 @@ namespace osu.Game.Rulesets
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        protected void Dispose(bool disposing)
         {
             AppDomain.CurrentDomain.AssemblyResolve -= resolveRulesetDependencyAssembly;
         }
 
         protected void LogFailedLoad(string name, Exception exception)
         {
-            Logger.Log($"Could not load ruleset {name}. Please check for an update from the developer.", level: LogLevel.Error);
+            Logger.Log($"Could not load ruleset \"{name}\". Please check for an update from the developer.", level: LogLevel.Error);
             Logger.Log($"Ruleset load failed: {exception}");
         }
 


### PR DESCRIPTION
This used to show the full assembly name, including version and `PublicKey`. I know this is confusing as a friend of mine saw it and could not process what they were supposed to do due to the noise the full assembly name added.

![osu! 2022-11-01 at 04 57 14](https://user-images.githubusercontent.com/191335/199162182-42b560cb-cdc7-4e88-bfa8-2cf2c956b9af.png)
