### PR TITLE
Fix time snap of sliders not matching when SV is not 1.0x

### DIFF
--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -125,6 +125,9 @@ namespace osu.Game.Tests.Editing
             assertSnapDistance(base_distance * slider_velocity, referenceObject, true);
             assertSnappedDistance(base_distance * slider_velocity + 10, base_distance * slider_velocity, referenceObject);
             assertSnappedDuration(base_distance * slider_velocity + 10, 1000, referenceObject);
+
+            assertDistanceToDuration(base_distance * slider_velocity, 1000, referenceObject);
+            assertDurationToDistance(1000, base_distance * slider_velocity, referenceObject);
         }
 
         [Test]

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -102,6 +103,28 @@ namespace osu.Game.Tests.Editing
             AddStep($"set divisor = {divisor}", () => BeatDivisor.Value = divisor);
 
             assertSnapDistance(100f / divisor, null, true);
+        }
+
+        /// <summary>
+        /// The basic distance-duration functions should always include slider velocity of the reference object.
+        /// </summary>
+        [Test]
+        public void TestConversionsWithSliderVelocity()
+        {
+            const float base_distance = 100;
+            const float slider_velocity = 1.2f;
+
+            var referenceObject = new HitObject
+            {
+                DifficultyControlPoint = new DifficultyControlPoint
+                {
+                    SliderVelocity = slider_velocity
+                }
+            };
+
+            assertSnapDistance(base_distance * slider_velocity, referenceObject, true);
+            assertSnappedDistance(base_distance * slider_velocity + 10, base_distance * slider_velocity, referenceObject);
+            assertSnappedDuration(base_distance * slider_velocity + 10, 1000, referenceObject);
         }
 
         [Test]
@@ -210,20 +233,20 @@ namespace osu.Game.Tests.Editing
             assertSnappedDistance(400, 400);
         }
 
-        private void assertSnapDistance(float expectedDistance, HitObject? refereneObject, bool includeSliderVelocity)
-            => AddAssert($"distance is {expectedDistance}", () => composer.GetBeatSnapDistanceAt(refereneObject ?? new HitObject(), includeSliderVelocity), () => Is.EqualTo(expectedDistance));
+        private void assertSnapDistance(float expectedDistance, HitObject? referenceObject, bool includeSliderVelocity)
+            => AddAssert($"distance is {expectedDistance}", () => composer.GetBeatSnapDistanceAt(referenceObject ?? new HitObject(), includeSliderVelocity), () => Is.EqualTo(expectedDistance).Within(Precision.FLOAT_EPSILON));
 
-        private void assertDurationToDistance(double duration, float expectedDistance)
-            => AddAssert($"duration = {duration} -> distance = {expectedDistance}", () => composer.DurationToDistance(new HitObject(), duration) == expectedDistance);
+        private void assertDurationToDistance(double duration, float expectedDistance, HitObject? referenceObject = null)
+            => AddAssert($"duration = {duration} -> distance = {expectedDistance}", () => composer.DurationToDistance(referenceObject ?? new HitObject(), duration), () => Is.EqualTo(expectedDistance).Within(Precision.FLOAT_EPSILON));
 
-        private void assertDistanceToDuration(float distance, double expectedDuration)
-            => AddAssert($"distance = {distance} -> duration = {expectedDuration}", () => composer.DistanceToDuration(new HitObject(), distance) == expectedDuration);
+        private void assertDistanceToDuration(float distance, double expectedDuration, HitObject? referenceObject = null)
+            => AddAssert($"distance = {distance} -> duration = {expectedDuration}", () => composer.DistanceToDuration(referenceObject ?? new HitObject(), distance), () => Is.EqualTo(expectedDuration).Within(Precision.FLOAT_EPSILON));
 
-        private void assertSnappedDuration(float distance, double expectedDuration)
-            => AddAssert($"distance = {distance} -> duration = {expectedDuration} (snapped)", () => composer.FindSnappedDuration(new HitObject(), distance) == expectedDuration);
+        private void assertSnappedDuration(float distance, double expectedDuration, HitObject? referenceObject = null)
+            => AddAssert($"distance = {distance} -> duration = {expectedDuration} (snapped)", () => composer.FindSnappedDuration(referenceObject ?? new HitObject(), distance), () => Is.EqualTo(expectedDuration).Within(Precision.FLOAT_EPSILON));
 
-        private void assertSnappedDistance(float distance, float expectedDistance)
-            => AddAssert($"distance = {distance} -> distance = {expectedDistance} (snapped)", () => composer.FindSnappedDistance(new HitObject(), distance) == expectedDistance);
+        private void assertSnappedDistance(float distance, float expectedDistance, HitObject? referenceObject = null)
+            => AddAssert($"distance = {distance} -> distance = {expectedDistance} (snapped)", () => composer.FindSnappedDistance(referenceObject ?? new HitObject(), distance), () => Is.EqualTo(expectedDistance).Within(Precision.FLOAT_EPSILON));
 
         private class TestHitObjectComposer : OsuHitObjectComposer
         {

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Editing
         {
             AddStep($"set slider multiplier = {multiplier}", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = multiplier);
 
-            assertSnapDistance(100 * multiplier);
+            assertSnapDistance(100 * multiplier, null, true);
         }
 
         [TestCase(1)]
@@ -79,7 +79,20 @@ namespace osu.Game.Tests.Editing
                 {
                     SliderVelocity = multiplier
                 }
-            });
+            }, false);
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        public void TestSpeedMultiplierDoesChangeDistanceSnap(float multiplier)
+        {
+            assertSnapDistance(100 * multiplier, new HitObject
+            {
+                DifficultyControlPoint = new DifficultyControlPoint
+                {
+                    SliderVelocity = multiplier
+                }
+            }, true);
         }
 
         [TestCase(1)]
@@ -88,7 +101,7 @@ namespace osu.Game.Tests.Editing
         {
             AddStep($"set divisor = {divisor}", () => BeatDivisor.Value = divisor);
 
-            assertSnapDistance(100f / divisor);
+            assertSnapDistance(100f / divisor, null, true);
         }
 
         [Test]
@@ -197,8 +210,8 @@ namespace osu.Game.Tests.Editing
             assertSnappedDistance(400, 400);
         }
 
-        private void assertSnapDistance(float expectedDistance, HitObject? hitObject = null)
-            => AddAssert($"distance is {expectedDistance}", () => composer.GetBeatSnapDistanceAt(hitObject ?? new HitObject()), () => Is.EqualTo(expectedDistance));
+        private void assertSnapDistance(float expectedDistance, HitObject? refereneObject, bool includeSliderVelocity)
+            => AddAssert($"distance is {expectedDistance}", () => composer.GetBeatSnapDistanceAt(refereneObject ?? new HitObject(), includeSliderVelocity), () => Is.EqualTo(expectedDistance));
 
         private void assertDurationToDistance(double duration, float expectedDistance)
             => AddAssert($"duration = {duration} -> distance = {expectedDistance}", () => composer.DurationToDistance(new HitObject(), duration) == expectedDistance);

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             IBindable<double> IDistanceSnapProvider.DistanceSpacingMultiplier => DistanceSpacingMultiplier;
 
-            public float GetBeatSnapDistanceAt(HitObject referenceObject) => beat_snap_distance;
+            public float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true) => beat_snap_distance;
 
             public float DurationToDistance(HitObject referenceObject, double duration) => (float)duration;
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -259,9 +259,9 @@ namespace osu.Game.Rulesets.Edit
             return true;
         }
 
-        public virtual float GetBeatSnapDistanceAt(HitObject referenceObject)
+        public virtual float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true)
         {
-            return (float)(100 * EditorBeatmap.Difficulty.SliderMultiplier * 1 / BeatSnapProvider.BeatDivisor);
+            return (float)(100 * (useReferenceSliderVelocity ? referenceObject.DifficultyControlPoint.SliderVelocity : 1) * EditorBeatmap.Difficulty.SliderMultiplier * 1 / BeatSnapProvider.BeatDivisor);
         }
 
         public virtual float DurationToDistance(HitObject referenceObject, double duration)
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Edit
         public virtual double DistanceToDuration(HitObject referenceObject, float distance)
         {
             double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceObject.StartTime);
-            return distance / GetBeatSnapDistanceAt(referenceObject) * beatLength;
+            return distance / GetBeatSnapDistanceAt(referenceObject) * beatLength * referenceObject.DifficultyControlPoint.SliderVelocity;
         }
 
         public virtual double FindSnappedDuration(HitObject referenceObject, float distance)

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Rulesets.Edit
         public virtual double DistanceToDuration(HitObject referenceObject, float distance)
         {
             double beatLength = BeatSnapProvider.GetBeatLengthAtTime(referenceObject.StartTime);
-            return distance / GetBeatSnapDistanceAt(referenceObject) * beatLength * referenceObject.DifficultyControlPoint.SliderVelocity;
+            return distance / GetBeatSnapDistanceAt(referenceObject) * beatLength;
         }
 
         public virtual double FindSnappedDuration(HitObject referenceObject, float distance)

--- a/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
@@ -27,8 +27,9 @@ namespace osu.Game.Rulesets.Edit
         /// Retrieves the distance between two points within a timing point that are one beat length apart.
         /// </summary>
         /// <param name="referenceObject">An object to be used as a reference point for this operation.</param>
+        /// <param name="useReferenceSliderVelocity">Whether the <paramref name="referenceObject"/>'s slider velocity should be factored into the returned distance.</param>
         /// <returns>The distance between two points residing in the timing point that are one beat length apart.</returns>
-        float GetBeatSnapDistanceAt(HitObject referenceObject);
+        float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true);
 
         /// <summary>
         /// Converts a duration to a distance without applying any snapping.

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private void updateSpacing()
         {
             float distanceSpacingMultiplier = (float)DistanceSpacingMultiplier.Value;
-            float beatSnapDistance = SnapProvider.GetBeatSnapDistanceAt(ReferenceObject);
+            float beatSnapDistance = SnapProvider.GetBeatSnapDistanceAt(ReferenceObject, false);
 
             DistanceBetweenTicks = beatSnapDistance * distanceSpacingMultiplier;
 


### PR DESCRIPTION
Closes #21047

This regressed with https://github.com/ppy/osu/pull/20850 because the function was used in other places which expect it to factor slider velocity into the equation.

Rather than reverting, I've added a new argument, as based on the method naming alone it was hard to discern whether SV should actually be considered.

The reason for the change in #20850 was to avoid the SV coming in from a reference object which may not have a correct SV in the first place. In such cases, passing `false` to the function will give the expected behaviour.

---

Note that I'm still not decided on whether this should be re-integrated into the distance snap grid, which is why I added this back only the the required paths.