### PR TITLE
Fix control points not being cloned when running beatmap conversion

### DIFF
--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Beatmaps
             // Shallow clone isn't enough to ensure we don't mutate beatmap info unexpectedly.
             // Can potentially be removed after `Beatmap.Difficulty` doesn't save back to `Beatmap.BeatmapInfo`.
             original.BeatmapInfo = original.BeatmapInfo.Clone();
+            original.ControlPointInfo = original.ControlPointInfo.DeepClone();
 
             return ConvertBeatmap(original, cancellationToken);
         }


### PR DESCRIPTION
Closes #20994.

I haven't considered how this affects performance of difficulty calculation or otherwise. Seems like a sane initial fix which we can iterate on going forward.

I've tested using the scenario in the linked issue.

I'm not going to add test coverage because [BeatmapConversionTest](https://github.com/ppy/osu/blob/master/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs) should correctly cover this scenario once we are serialising control points as well.