### PR TITLE
Fix argon hit circle outer gradient getting smaller each state application

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         // This is to give it a bomb-like effect, with the border "triggering" its animation when getting close.
                         using (BeginDelayedSequence(flash_in_duration / 12))
                         {
-                            outerGradient.ResizeTo(outerGradient.Size * shrink_size, resize_duration, Easing.OutElasticHalf);
+                            outerGradient.ResizeTo(OUTER_GRADIENT_SIZE * shrink_size, resize_duration, Easing.OutElasticHalf);
                             outerGradient
                                 .FadeColour(Color4.White, 80)
                                 .Then()


### PR DESCRIPTION
Fixes an issue I noticed while reviewing https://github.com/ppy/osu/pull/20736

Can be tested using:

```diff
diff --git a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
index d624164013..4747c9c19b 100644
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -11,6 +11,7 @@
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
@@ -194,6 +195,8 @@ protected override void LoadComplete()
 
             // Apply transforms
             updateState(State.Value, true);
+
+            Scheduler.AddDelayed(() => AccentColour.Value = AccentColour.Value.Lighten(0.001f), 1, true);
         }
 
         /// <summary>

```

Before:


https://user-images.githubusercontent.com/191335/199203910-9544ce77-bcbd-4c95-a8df-30a4548808fb.mp4


After:

https://user-images.githubusercontent.com/191335/199204192-372ea008-1bca-4503-a5ac-e4107c17f77f.mp4

