### PR TITLE
Fix large transform retention when adjusting accent colour of hitobject during pause

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -121,11 +121,15 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 innerGradient.Colour = ColourInfo.GradientVertical(colour.NewValue.Darken(0.5f), colour.NewValue.Darken(0.6f));
                 flash.Colour = colour.NewValue;
 
-                updateStateTransforms(drawableObject, drawableObject.State.Value);
+                // Accent colour may be changed many times during a paused gameplay state.
+                // Schedule the change to avoid transforms piling up.
+                Scheduler.AddOnce(updateStateTransforms);
             }, true);
 
             drawableObject.ApplyCustomUpdateState += updateStateTransforms;
         }
+
+        private void updateStateTransforms() => updateStateTransforms(drawableObject, drawableObject.State.Value);
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {


### PR DESCRIPTION
Fixes an issue I noticed while reviewing #20736.

![Parallels Desktop 2022-11-01 at 10 13 25](https://user-images.githubusercontent.com/191335/199210946-0fca03ba-4861-4a8b-b754-22511d44aa1d.png)
