### PR TITLE
Fix `DrawableHitObject.AccentColour` not being updated if object entry is not attached

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -266,6 +266,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
                     updateState(ArmedState.Miss, true);
                 else
                     updateState(ArmedState.Idle, true);
+
+                // Combo colour may have been applied via a bindable flow while no object entry was attached.
+                // Update here to ensure we're in a good state.
+                UpdateComboColour();
             }
         }
 


### PR DESCRIPTION
As noticed in #20736. Can be tested on that pull request by seeking forward a good distance into a higher difficulty osu! beatmap, pausing and adjusting brightness. Future objects will have the incorrect adjustment when they are retrieved from the pool due to the early abort:

https://github.com/ppy/osu/blob/f014acfc8d54c453a50b0f9b22862f6c29204761/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L512