### PR TITLE
Fix multiple notifications arriving for imports in edge cases

### DIFF
--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Overlays.Notifications
                 return;
 
             // Thread-safe barrier, as this may be called by a web request and also scheduled to the update thread at the same time.
-            if (Interlocked.Increment(ref completionSent) == 0)
+            if (Interlocked.Exchange(ref completionSent, 1) == 0)
                 return;
 
             CompletionTarget.Invoke(CreateCompletionNotification());

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.Notifications
             }
         }
 
-        private bool completionSent;
+        private int completionSent;
 
         /// <summary>
         /// Attempt to post a completion notification.
@@ -162,11 +162,11 @@ namespace osu.Game.Overlays.Notifications
             if (CompletionTarget == null)
                 return;
 
-            if (completionSent)
+            // Thread-safe barrier, as this may be called by a web request and also scheduled to the update thread at the same time.
+            if (Interlocked.Increment(ref completionSent) == 0)
                 return;
 
             CompletionTarget.Invoke(CreateCompletionNotification());
-            completionSent = true;
 
             Close(false);
         }

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Overlays.Notifications
                 return;
 
             // Thread-safe barrier, as this may be called by a web request and also scheduled to the update thread at the same time.
-            if (Interlocked.Exchange(ref completionSent, 1) == 0)
+            if (Interlocked.Exchange(ref completionSent, 1) == 1)
                 return;
 
             CompletionTarget.Invoke(CreateCompletionNotification());


### PR DESCRIPTION
I've noticed this a few times, and caught it once earlier today (in log form). This has got to be the reason for it.

```
[database] 2022-11-02 03:48:45 [verbose]: [8fa77] Import successfully completed!
[runtime] 2022-11-02 03:48:45 [verbose]: ⚠️ Imported Unlike Pluto - Everything Black (feat. Mike Taylor) (CoolGuyRift)! Click to view.
[runtime] 2022-11-02 03:48:45 [verbose]: ⚠️ Imported Unlike Pluto - Everything Black (feat. Mike Taylor) (CoolGuyRift)! Click to view.
```

Probably closes https://github.com/ppy/osu/issues/20875.