### PR TITLE
Clean up taiko classes in preparation for new skin implementation

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
@@ -30,23 +30,24 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                 Origin = Anchor.Centre,
             }));
 
-            AddStep("Rim hit", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime())
+            AddStep("Rim hit", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(rim: true))
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             }));
 
-            AddStep("Rim hit (strong)", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(true))
+            AddStep("Rim hit (strong)", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(true, true))
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             }));
         }
 
-        private Hit createHitAtCurrentTime(bool strong = false)
+        private Hit createHitAtCurrentTime(bool strong = false, bool rim = false)
         {
             var hit = new Hit
             {
+                Type = rim ? HitType.Rim : HitType.Centre,
                 IsStrong = strong,
                 StartTime = Time.Current + 3000,
             };

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 {
@@ -49,11 +50,19 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                     // the hit needs to be added to hierarchy in order for nested objects to be created correctly.
                     // setting zero alpha is supposed to prevent the test from looking broken.
                     hit.With(h => h.Alpha = 0),
-                    new HitExplosion(hit.Type)
+
+                    new AspectContainer
                     {
+                        RelativeSizeAxes = Axes.X,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                    }.With(explosion => explosion.Apply(hit))
+                        Child =
+                            new HitExplosion(hit.Type)
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            }.With(explosion => explosion.Apply(hit))
+                    }
                 }
             };
         }

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CentreHitCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CentreHitCirclePiece.cs
@@ -41,12 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
 
                 Children = new[]
                 {
-                    new CircularContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        Children = new[] { new Box { RelativeSizeAxes = Axes.Both } }
-                    }
+                    new Circle { RelativeSizeAxes = Axes.Both }
                 };
             }
         }

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultHitExplosion.cs
@@ -1,4 +1,3 @@
-#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultHitExplosion.cs
@@ -1,9 +1,7 @@
+#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -12,19 +10,19 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Taiko.UI
+namespace osu.Game.Rulesets.Taiko.Skinning.Default
 {
     internal class DefaultHitExplosion : CircularContainer, IAnimatableHitExplosion
     {
         private readonly HitResult result;
 
-        [CanBeNull]
-        private Box body;
+        private Box? body;
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         public DefaultHitExplosion(HitResult result)
         {
@@ -58,7 +56,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             updateColour();
         }
 
-        private void updateColour([CanBeNull] DrawableHitObject judgedObject = null)
+        private void updateColour(DrawableHitObject? judgedObject = null)
         {
             if (body == null)
                 return;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultInputDrum.cs
@@ -1,0 +1,181 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Screens.Ranking;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.Skinning.Default
+{
+    public class DefaultInputDrum : AspectContainer
+    {
+        public DefaultInputDrum()
+        {
+            RelativeSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            const float middle_split = 0.025f;
+
+            InternalChild = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Scale = new Vector2(0.9f),
+                Children = new[]
+                {
+                    new TaikoHalfDrum(false)
+                    {
+                        Name = "Left Half",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.CentreRight,
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.X,
+                        X = -middle_split / 2,
+                        RimAction = TaikoAction.LeftRim,
+                        CentreAction = TaikoAction.LeftCentre
+                    },
+                    new TaikoHalfDrum(true)
+                    {
+                        Name = "Right Half",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.CentreLeft,
+                        RelativeSizeAxes = Axes.Both,
+                        RelativePositionAxes = Axes.X,
+                        X = middle_split / 2,
+                        RimAction = TaikoAction.RightRim,
+                        CentreAction = TaikoAction.RightCentre
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// A half-drum. Contains one centre and one rim hit.
+        /// </summary>
+        private class TaikoHalfDrum : Container, IKeyBindingHandler<TaikoAction>
+        {
+            /// <summary>
+            /// The key to be used for the rim of the half-drum.
+            /// </summary>
+            public TaikoAction RimAction;
+
+            /// <summary>
+            /// The key to be used for the centre of the half-drum.
+            /// </summary>
+            public TaikoAction CentreAction;
+
+            private readonly Sprite rim;
+            private readonly Sprite rimHit;
+            private readonly Sprite centre;
+            private readonly Sprite centreHit;
+
+            public TaikoHalfDrum(bool flipped)
+            {
+                Masking = true;
+
+                Children = new Drawable[]
+                {
+                    rim = new Sprite
+                    {
+                        Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    rimHit = new Sprite
+                    {
+                        Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0,
+                        Blending = BlendingParameters.Additive,
+                    },
+                    centre = new Sprite
+                    {
+                        Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.7f)
+                    },
+                    centreHit = new Sprite
+                    {
+                        Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.7f),
+                        Alpha = 0,
+                        Blending = BlendingParameters.Additive
+                    }
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures, OsuColour colours)
+            {
+                rim.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-outer");
+                rimHit.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-outer-hit");
+                centre.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-inner");
+                centreHit.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-inner-hit");
+
+                rimHit.Colour = colours.Blue;
+                centreHit.Colour = colours.Pink;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
+            {
+                Drawable target = null;
+                Drawable back = null;
+
+                if (e.Action == CentreAction)
+                {
+                    target = centreHit;
+                    back = centre;
+                }
+                else if (e.Action == RimAction)
+                {
+                    target = rimHit;
+                    back = rim;
+                }
+
+                if (target != null)
+                {
+                    const float scale_amount = 0.05f;
+                    const float alpha_amount = 0.5f;
+
+                    const float down_time = 40;
+                    const float up_time = 1000;
+
+                    back.ScaleTo(target.Scale.X - scale_amount, down_time, Easing.OutQuint)
+                        .Then()
+                        .ScaleTo(1, up_time, Easing.OutQuint);
+
+                    target.Animate(
+                        t => t.ScaleTo(target.Scale.X - scale_amount, down_time, Easing.OutQuint),
+                        t => t.FadeTo(Math.Min(target.Alpha + alpha_amount, 1), down_time, Easing.OutQuint)
+                    ).Then(
+                        t => t.ScaleTo(1, up_time, Easing.OutQuint),
+                        t => t.FadeOut(up_time, Easing.OutQuint)
+                    );
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -11,8 +8,9 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Taiko.Objects;
+using osuTK;
 
-namespace osu.Game.Rulesets.Taiko.UI
+namespace osu.Game.Rulesets.Taiko.Skinning.Default
 {
     public class DefaultKiaiHitExplosion : CircularContainer
     {

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/ElongatedCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/ElongatedCirclePiece.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/RimHitCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/RimHitCirclePiece.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/SwellSymbolPiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/SwellSymbolPiece.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/TickPiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/TickPiece.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyBarLine.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyBarLine.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
@@ -19,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public class LegacyCirclePiece : CompositeDrawable, IHasAccentColour
     {
-        private Drawable backgroundLayer;
+        private Drawable backgroundLayer = null!;
 
         // required for editor blueprints (not sure why these circle pieces are zero size).
         public override Quad ScreenSpaceDrawQuad => backgroundLayer.ScreenSpaceDrawQuad;
@@ -32,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin, DrawableHitObject drawableHitObject)
         {
-            Drawable getDrawableFor(string lookup)
+            Drawable? getDrawableFor(string lookup)
             {
                 const string normal_hit = "taikohit";
                 const string big_hit = "taikobig";

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyDrumRoll.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -28,11 +26,11 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             }
         }
 
-        private LegacyCirclePiece headCircle;
+        private LegacyCirclePiece headCircle = null!;
 
-        private Sprite body;
+        private Sprite body = null!;
 
-        private Sprite tailCircle;
+        private Sprite tailCircle = null!;
 
         public LegacyDrumRoll()
         {

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHit.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHit.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Game.Skinning;
 using osuTK.Graphics;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHitExplosion.cs
@@ -1,4 +1,3 @@
-#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyHitExplosion.cs
@@ -1,9 +1,7 @@
+#nullable enable
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
@@ -17,8 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     {
         private readonly Drawable sprite;
 
-        [CanBeNull]
-        private readonly Drawable strongSprite;
+        private readonly Drawable? strongSprite;
 
         /// <summary>
         /// Creates a new legacy hit explosion.
@@ -29,7 +26,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         /// </remarks>
         /// <param name="sprite">The normal legacy explosion sprite.</param>
         /// <param name="strongSprite">The strong legacy explosion sprite.</param>
-        public LegacyHitExplosion(Drawable sprite, [CanBeNull] Drawable strongSprite = null)
+        public LegacyHitExplosion(Drawable sprite, Drawable? strongSprite = null)
         {
             this.sprite = sprite;
             this.strongSprite = strongSprite;

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyInputDrum.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -20,9 +18,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     /// </summary>
     internal class LegacyInputDrum : Container
     {
-        private Container content;
-        private LegacyHalfDrum left;
-        private LegacyHalfDrum right;
+        private Container content = null!;
+        private LegacyHalfDrum left = null!;
+        private LegacyHalfDrum right = null!;
 
         public LegacyInputDrum()
         {
@@ -142,7 +140,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
             public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
             {
-                Drawable target = null;
+                Drawable? target = null;
 
                 if (e.Action == CentreAction)
                 {

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyTaikoScroller.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyTaikoScroller.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -27,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayState gameplayState)
+        private void load(GameplayState? gameplayState)
         {
             if (gameplayState != null)
                 ((IBindable<JudgementResult>)LastResult).BindTo(gameplayState.LastJudgementResult);
@@ -91,8 +89,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
         private class ScrollerSprite : CompositeDrawable
         {
-            private Sprite passingSprite;
-            private Sprite failingSprite;
+            private Sprite passingSprite = null!;
+            private Sprite failingSprite = null!;
 
             private bool passing = true;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -15,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public class TaikoLegacyHitTarget : CompositeDrawable
     {
-        private Container content;
+        private Container content = null!;
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyPlayfieldBackgroundRight.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyPlayfieldBackgroundRight.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
@@ -16,7 +14,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public class TaikoLegacyPlayfieldBackgroundRight : BeatSyncedContainer
     {
-        private Sprite kiai;
+        private Sprite kiai = null!;
 
         private bool kiaiDisplayed;
 

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponent.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Taiko
 {
     public enum TaikoSkinComponents

--- a/osu.Game.Rulesets.Taiko/UI/BarLinePlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/BarLinePlayfield.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoJudgement.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoMascot.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -24,7 +22,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         public readonly Bindable<JudgementResult> LastResult;
 
         private readonly Dictionary<TaikoMascotAnimationState, TaikoMascotAnimation> animations;
-        private TaikoMascotAnimation currentAnimation;
+
+        private TaikoMascotAnimation? currentAnimation;
 
         private bool lastObjectHit = true;
         private bool kiaiMode;
@@ -40,7 +39,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayState gameplayState)
+        private void load(GameplayState? gameplayState)
         {
             InternalChildren = new[]
             {

--- a/osu.Game.Rulesets.Taiko/UI/DrumRollHitContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumRollHitContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.UI.Scrolling;
 

--- a/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Taiko.Objects;

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -1,10 +1,8 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿#nullable enable
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using JetBrains.Annotations;
 using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -30,10 +28,9 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private double? secondHitTime;
 
-        [CanBeNull]
-        public DrawableHitObject JudgedObject;
+        public DrawableHitObject? JudgedObject;
 
-        private SkinnableDrawable skinnable;
+        private SkinnableDrawable skinnable = null!;
 
         /// <summary>
         /// This constructor only exists to meet the <c>new()</c> type constraint of <see cref="DrawablePool{T}"/>.
@@ -63,7 +60,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             skinnable.OnSkinChanged += runAnimation;
         }
 
-        public void Apply([CanBeNull] DrawableHitObject drawableHitObject)
+        public void Apply(DrawableHitObject? drawableHitObject)
         {
             JudgedObject = drawableHitObject;
             secondHitTime = null;

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.UI

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosionPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosionPool.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Scoring;
 

--- a/osu.Game.Rulesets.Taiko/UI/IAnimatableHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/IAnimatableHitExplosion.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.UI

--- a/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
@@ -3,18 +3,11 @@
 
 #nullable disable
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
-using osu.Game.Graphics;
-using osu.Game.Screens.Ranking;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
-using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -23,8 +16,6 @@ namespace osu.Game.Rulesets.Taiko.UI
     /// </summary>
     internal class InputDrum : Container
     {
-        private const float middle_split = 0.025f;
-
         public InputDrum()
         {
             AutoSizeAxes = Axes.X;
@@ -42,167 +33,6 @@ namespace osu.Game.Rulesets.Taiko.UI
                     AutoSizeAxes = Axes.X,
                 },
             };
-        }
-
-        private class DefaultInputDrum : AspectContainer
-        {
-            public DefaultInputDrum()
-            {
-                RelativeSizeAxes = Axes.Y;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                InternalChild = new Container
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Scale = new Vector2(0.9f),
-                    Children = new[]
-                    {
-                        new TaikoHalfDrum(false)
-                        {
-                            Name = "Left Half",
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.CentreRight,
-                            RelativeSizeAxes = Axes.Both,
-                            RelativePositionAxes = Axes.X,
-                            X = -middle_split / 2,
-                            RimAction = TaikoAction.LeftRim,
-                            CentreAction = TaikoAction.LeftCentre
-                        },
-                        new TaikoHalfDrum(true)
-                        {
-                            Name = "Right Half",
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.CentreLeft,
-                            RelativeSizeAxes = Axes.Both,
-                            RelativePositionAxes = Axes.X,
-                            X = middle_split / 2,
-                            RimAction = TaikoAction.RightRim,
-                            CentreAction = TaikoAction.RightCentre
-                        }
-                    }
-                };
-            }
-
-            /// <summary>
-            /// A half-drum. Contains one centre and one rim hit.
-            /// </summary>
-            private class TaikoHalfDrum : Container, IKeyBindingHandler<TaikoAction>
-            {
-                /// <summary>
-                /// The key to be used for the rim of the half-drum.
-                /// </summary>
-                public TaikoAction RimAction;
-
-                /// <summary>
-                /// The key to be used for the centre of the half-drum.
-                /// </summary>
-                public TaikoAction CentreAction;
-
-                private readonly Sprite rim;
-                private readonly Sprite rimHit;
-                private readonly Sprite centre;
-                private readonly Sprite centreHit;
-
-                public TaikoHalfDrum(bool flipped)
-                {
-                    Masking = true;
-
-                    Children = new Drawable[]
-                    {
-                        rim = new Sprite
-                        {
-                            Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both
-                        },
-                        rimHit = new Sprite
-                        {
-                            Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both,
-                            Alpha = 0,
-                            Blending = BlendingParameters.Additive,
-                        },
-                        centre = new Sprite
-                        {
-                            Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.7f)
-                        },
-                        centreHit = new Sprite
-                        {
-                            Anchor = flipped ? Anchor.CentreLeft : Anchor.CentreRight,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.7f),
-                            Alpha = 0,
-                            Blending = BlendingParameters.Additive
-                        }
-                    };
-                }
-
-                [BackgroundDependencyLoader]
-                private void load(TextureStore textures, OsuColour colours)
-                {
-                    rim.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-outer");
-                    rimHit.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-outer-hit");
-                    centre.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-inner");
-                    centreHit.Texture = textures.Get(@"Gameplay/taiko/taiko-drum-inner-hit");
-
-                    rimHit.Colour = colours.Blue;
-                    centreHit.Colour = colours.Pink;
-                }
-
-                public bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
-                {
-                    Drawable target = null;
-                    Drawable back = null;
-
-                    if (e.Action == CentreAction)
-                    {
-                        target = centreHit;
-                        back = centre;
-                    }
-                    else if (e.Action == RimAction)
-                    {
-                        target = rimHit;
-                        back = rim;
-                    }
-
-                    if (target != null)
-                    {
-                        const float scale_amount = 0.05f;
-                        const float alpha_amount = 0.5f;
-
-                        const float down_time = 40;
-                        const float up_time = 1000;
-
-                        back.ScaleTo(target.Scale.X - scale_amount, down_time, Easing.OutQuint)
-                            .Then()
-                            .ScaleTo(1, up_time, Easing.OutQuint);
-
-                        target.Animate(
-                            t => t.ScaleTo(target.Scale.X - scale_amount, down_time, Easing.OutQuint),
-                            t => t.FadeTo(Math.Min(target.Alpha + alpha_amount, 1), down_time, Easing.OutQuint)
-                        ).Then(
-                            t => t.ScaleTo(1, up_time, Easing.OutQuint),
-                            t => t.FadeOut(up_time, Easing.OutQuint)
-                        );
-                    }
-
-                    return false;
-                }
-
-                public void OnReleased(KeyBindingReleaseEvent<TaikoAction> e)
-                {
-                }
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
 

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -23,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private readonly HitType hitType;
 
-        private SkinnableDrawable skinnable;
+        private SkinnableDrawable skinnable = null!;
 
         public override double LifetimeStart => skinnable.Drawable.LifetimeStart;
 

--- a/osu.Game.Rulesets.Taiko/UI/PlayfieldBackgroundLeft.cs
+++ b/osu.Game.Rulesets.Taiko/UI/PlayfieldBackgroundLeft.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Taiko/UI/PlayfieldBackgroundRight.cs
+++ b/osu.Game.Rulesets.Taiko/UI/PlayfieldBackgroundRight.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Taiko/UI/TaikoHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoHitTarget.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             [BackgroundDependencyLoader]
             private void load(ISkinSource source)
             {
-                ISkin skin = source.FindProvider(s => getAnimationFrame(s, state, 0) != null);
+                ISkin? skin = source.FindProvider(s => getAnimationFrame(s, state, 0) != null);
 
                 if (skin == null) return;
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimation.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
@@ -120,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             [BackgroundDependencyLoader]
             private void load(ISkinSource source)
             {
-                ISkin skin = source.FindProvider(s => getAnimationFrame(s, TaikoMascotAnimationState.Clear, 0) != null);
+                ISkin? skin = source.FindProvider(s => getAnimationFrame(s, TaikoMascotAnimationState.Clear, 0) != null);
 
                 if (skin == null) return;
 
@@ -137,7 +135,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             }
         }
 
-        private static Texture getAnimationFrame(ISkin skin, TaikoMascotAnimationState state, int frameIndex)
+        private static Texture? getAnimationFrame(ISkin skin, TaikoMascotAnimationState state, int frameIndex)
         {
             var texture = skin.GetTexture($"pippidon{state.ToString().ToLowerInvariant()}{frameIndex}");
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimationState.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoMascotAnimationState.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Taiko.UI
 {
     public enum TaikoMascotAnimationState

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game.Rulesets.Taiko/UI/TaikoReplayRecorder.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoReplayRecorder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Taiko.Replays;


### PR DESCRIPTION
Fixes some broken tests, applies NRT (as I will be reusing some of these classes as templates for the new implementation) and moves incorrectly namespaced default implementations to the correct folder.