### PR TITLE
Fix velocity test failing with no audio device

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/TimelinePart.cs
@@ -57,15 +57,13 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
         private void updateRelativeChildSize()
         {
-            // the track may not be loaded completely (only has a length once it is).
-            if (!beatmap.Value.Track.IsLoaded)
-            {
-                content.RelativeChildSize = Vector2.One;
-                Schedule(updateRelativeChildSize);
-                return;
-            }
+            // If the track is not loaded, assign a default sane length otherwise relative positioning becomes meaningless.
+            double trackLength = beatmap.Value.Track.IsLoaded ? beatmap.Value.Track.Length : 60000;
+            content.RelativeChildSize = new Vector2((float)Math.Max(1, trackLength), 1);
 
-            content.RelativeChildSize = new Vector2((float)Math.Max(1, beatmap.Value.Track.Length), 1);
+            // The track may not be loaded completely (only has a length once it is).
+            if (!beatmap.Value.Track.IsLoaded)
+                Schedule(updateRelativeChildSize);
         }
 
         protected virtual void LoadBeatmap(EditorBeatmap beatmap)

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Edit
 
         private readonly Bindable<Track> track = new Bindable<Track>();
 
-        public double TrackLength => track.Value?.Length ?? 60000;
+        public double TrackLength => track.Value?.IsLoaded == true ? track.Value.Length : 60000;
 
         public ControlPointInfo ControlPointInfo => Beatmap.ControlPointInfo;
 


### PR DESCRIPTION
TeamCity builds have been failing 100% of the time for a while now with:

```
TearDown : System.InvalidOperationException : Sequence contains no elements
--TearDown
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at osu.Game.Rulesets.Osu.Tests.Editor.TestSceneSliderVelocityAdjust.get_difficultyPointPiece() in /opt/buildagent/work/ecd860037212ac52/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs:line 37
   at osu.Game.Rulesets.Osu.Tests.Editor.TestSceneSliderVelocityAdjust.<>c__DisplayClass15_0.<TestVelocityChangeSavesCorrectly>b__13() in /opt/buildagent/work/ecd860037212ac52/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs:line 73
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in /opt/buildagent/work/ecd860037212ac52/osu.Game/Tests/Visual/OsuTestScene.cs:line 523
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
```

This is happening because the runners can't get an audio device, and the failure can be reproed with a local framework by returning `false` in `AudioManager.InitBass()`.

This PR is a minimum viable effort to get TC builds back online, and not an extensive auditing of similar usages across the rest of the codebase.