### PR TITLE
Add support for 'disabled' sample variation to HoverClickSounds

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -51,7 +51,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1021.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1103.0" />
     <PackageReference Include="ppy.osu.Framework.Android" Version="2022.1101.0" />
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLabelledSliderBar.cs
@@ -38,6 +38,14 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("revert back", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.ResizeWidthTo(1, 200, Easing.OutQuint)));
         }
 
+        [Test]
+        public void TestDisable()
+        {
+            createSliderBar();
+            AddStep("set disabled", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.Current.Disabled = true));
+            AddStep("unset disabled", () => this.ChildrenOfType<LabelledSliderBar<double>>().ForEach(l => l.Current.Disabled = false));
+        }
+
         private void createSliderBar()
         {
             AddStep("create component", () =>

--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override Container<Drawable> Content => content;
 
-        protected virtual HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet);
+        protected virtual HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { BindTarget = Enabled } };
 
         public OsuClickableContainer(HoverSampleSet sampleSet = HoverSampleSet.Default)
         {

--- a/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Graphics.UserInterface
         private const int transition_length = 80;
 
         private TextContainer text;
+        private HoverClickSounds hoverClickSounds;
 
         public DrawableOsuMenuItem(MenuItem item)
             : base(item)
@@ -36,7 +37,7 @@ namespace osu.Game.Graphics.UserInterface
             BackgroundColour = Color4.Transparent;
             BackgroundColourHover = Color4Extensions.FromHex(@"172023");
 
-            AddInternal(new HoverClickSounds());
+            AddInternal(hoverClickSounds = new HoverClickSounds());
 
             updateTextColour();
 
@@ -76,6 +77,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private void updateState()
         {
+            hoverClickSounds.Enabled.Value = !Item.Action.Disabled;
             Alpha = Item.Action.Disabled ? 0.2f : 1;
 
             if (IsHovered && !Item.Action.Disabled)

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -21,9 +21,11 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public class HoverClickSounds : HoverSounds
     {
+        public Bindable<bool> Enabled = new Bindable<bool>(true);
+
         private Sample sampleClick;
         private Sample sampleClickDisabled;
-        public Bindable<bool> Enabled = new Bindable<bool>(true);
+
         private readonly MouseButton[] buttons;
 
         /// <summary>

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
@@ -21,6 +22,8 @@ namespace osu.Game.Graphics.UserInterface
     public class HoverClickSounds : HoverSounds
     {
         private Sample sampleClick;
+        private Sample sampleClickDisabled;
+        public Bindable<bool> Enabled = new Bindable<bool>(true);
         private readonly MouseButton[] buttons;
 
         /// <summary>
@@ -41,8 +44,13 @@ namespace osu.Game.Graphics.UserInterface
         {
             if (buttons.Contains(e.Button) && Contains(e.ScreenSpaceMousePosition))
             {
-                sampleClick.Frequency.Value = 0.99 + RNG.NextDouble(0.02);
-                sampleClick.Play();
+                var channel = Enabled.Value ? sampleClick?.GetChannel() : sampleClickDisabled?.GetChannel();
+
+                if (channel != null)
+                {
+                    channel.Frequency.Value = 0.99 + RNG.NextDouble(0.02);
+                    channel.Play();
+                }
             }
 
             return base.OnClick(e);
@@ -53,6 +61,9 @@ namespace osu.Game.Graphics.UserInterface
         {
             sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select")
                           ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
+
+            sampleClickDisabled = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select-disabled")
+                                  ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select-disabled");
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/LoadingButton.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingButton.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Graphics.UserInterface
         private readonly LoadingSpinner loading;
 
         protected LoadingButton()
+            : base(HoverSampleSet.Button)
         {
             Add(loading = new LoadingSpinner
             {

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Graphics.UserInterface
             });
 
             if (hoverSounds.HasValue)
-                AddInternal(new HoverClickSounds(hoverSounds.Value));
+                AddInternal(new HoverClickSounds(hoverSounds.Value) { Enabled = { BindTarget = Enabled } });
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/OsuSliderBar.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public bool PlaySamplesOnAdjust { get; set; } = true;
 
+        private readonly HoverClickSounds hoverClickSounds;
+
         /// <summary>
         /// Whether to format the tooltip as a percentage or the actual value.
         /// </summary>
@@ -127,7 +129,7 @@ namespace osu.Game.Graphics.UserInterface
                         Current = { Value = true }
                     },
                 },
-                new HoverClickSounds()
+                hoverClickSounds = new HoverClickSounds()
             };
 
             Current.DisabledChanged += disabled => { Alpha = disabled ? 0.3f : 1; };
@@ -152,6 +154,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
             CurrentNumber.BindValueChanged(current => TooltipText = getTooltipText(current.NewValue), true);
+            Current.DisabledChanged += disabled => hoverClickSounds.Enabled.Value = !disabled;
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet);
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { BindTarget = Enabled } };
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Overlays/Comments/CancellableCommentEditor.cs
+++ b/osu.Game/Overlays/Comments/CancellableCommentEditor.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Overlays.Comments
@@ -38,6 +39,7 @@ namespace osu.Game.Overlays.Comments
             private readonly Box background;
 
             public CancelButton()
+                : base(HoverSampleSet.Button)
             {
                 AutoSizeAxes = Axes.Both;
                 Child = new CircularContainer

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Overlays.Toolbar
             base.OnHoverLost(e);
         }
 
-        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { Value = true } };
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet);
 
         private void cycleDisplayMode()
         {

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -13,6 +13,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
 
@@ -122,6 +123,8 @@ namespace osu.Game.Overlays.Toolbar
 
             base.OnHoverLost(e);
         }
+
+        protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds(sampleSet) { Enabled = { Value = true } };
 
         private void cycleDisplayMode()
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.17.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.1101.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1021.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1103.0" />
     <PackageReference Include="Sentry" Version="3.22.0" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -61,7 +61,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1021.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1103.0" />
     <PackageReference Include="ppy.osu.Framework.iOS" Version="2022.1101.0" />
   </ItemGroup>
   <!-- See https://github.com/dotnet/runtime/issues/35988 (can be removed after Xamarin uses net6.0) -->


### PR DESCRIPTION
Not sure if calling the field `Enabled` will be misleading? Also not sure if I missed anything else that's disable-able? 

- [x] depends on ppy/osu-resources#224