### PR TITLE
A Taikomania mod...!

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -26,17 +29,17 @@ namespace osu.Game.Rulesets.Taiko.Mods
             MinValue = 10f,
             MaxValue = 40f,
         };
-        
+
         [SettingSource("Dons on top?", "Or on the bottom?", 1)]
         public BindableBool CentreOnTop { get; } = new BindableBool(true);
 
-        private Vector2 CentreShift;
-        private Vector2 RimShift;
+        private Vector2 centreShift;
+        private Vector2 rimShift;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
-            CentreShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? -1 : 1));
-            RimShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? 1 : -1));
+            centreShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? -1 : 1));
+            rimShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? 1 : -1));
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
@@ -50,10 +53,11 @@ namespace osu.Game.Rulesets.Taiko.Mods
                         switch (((DrawableHit)o).HitObject.Type)
                         {
                             case HitType.Centre:
-                                drawable.MoveToOffset(CentreShift);
+                                drawable.MoveToOffset(centreShift);
                                 break;
+
                             case HitType.Rim:
-                                drawable.MoveToOffset(RimShift);
+                                drawable.MoveToOffset(rimShift);
                                 break;
                         }
                     }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
@@ -1,5 +1,8 @@
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -8,16 +11,33 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModTaikomania : Mod, IApplicableToDrawableHitObject
+    public class TaikoModTaikomania : Mod, IApplicableToDrawableHitObject, IApplicableToBeatmap
     {
         public override string Name => "Taikomania";
         public override string Acronym => "TM";
-        public override LocalisableString Description => @"Color confused? Moves dons and kats apart.";
+        public override LocalisableString Description => @"Colour confused? Split dons and kats apart vertically.";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 0.5;
 
-        private Vector2 CentreShift = new Vector2(0, -40);
-        private Vector2 RimShift = new Vector2(0, 40);
+        [SettingSource("Split amount", "How far notes are split apart", 0)]
+        public BindableFloat SplitAmount { get; } = new BindableFloat(40f)
+        {
+            Precision = 1f,
+            MinValue = 10f,
+            MaxValue = 40f,
+        };
+        
+        [SettingSource("Dons on top?", "Or on the bottom?", 1)]
+        public BindableBool CentreOnTop { get; } = new BindableBool(true);
+
+        private Vector2 CentreShift;
+        private Vector2 RimShift;
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            CentreShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? -1 : 1));
+            RimShift = new Vector2(0, SplitAmount.Value * (CentreOnTop.Value ? 1 : -1));
+        }
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModTaikomania.cs
@@ -1,0 +1,44 @@
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class TaikoModTaikomania : Mod, IApplicableToDrawableHitObject
+    {
+        public override string Name => "Taikomania";
+        public override string Acronym => "TM";
+        public override LocalisableString Description => @"Color confused? Moves dons and kats apart.";
+        public override ModType Type => ModType.Fun;
+        public override double ScoreMultiplier => 0.5;
+
+        private Vector2 CentreShift = new Vector2(0, -40);
+        private Vector2 RimShift = new Vector2(0, 40);
+
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            if (drawable is DrawableHit)
+            {
+                drawable.ApplyCustomUpdateState += (o, state) =>
+                {
+                    if (o is DrawableHit)
+                    {
+                        switch (((DrawableHit)o).HitObject.Type)
+                        {
+                            case HitType.Centre:
+                                drawable.MoveToOffset(CentreShift);
+                                break;
+                            case HitType.Rim:
+                                drawable.MoveToOffset(RimShift);
+                                break;
+                        }
+                    }
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -163,7 +163,8 @@ namespace osu.Game.Rulesets.Taiko
                     {
                         new MultiMod(new ModWindUp(), new ModWindDown()),
                         new TaikoModMuted(),
-                        new ModAdaptiveSpeed()
+                        new ModAdaptiveSpeed(),
+                        new TaikoModTaikomania()
                     };
 
                 default:


### PR DESCRIPTION
*Ok, hear me out - I know Taikomania skins are *extremely* controversial (and patched/bannable in stable), but if Taikomania usage shows up on your score with a mod & a hefty score penalty, it's not cheating right? 😉*

This PR adds a Taiko mod that vertically separates dons and kats depending on their color. Options are available to select whether dons or kats are on top and the amount of separation. It is in the Fun section and has a 0.5x multiplier. Swells and drumrolls don't get moved.

Yes, this mod is a huge reading crutch, I think 0.5x might be too generous, even. But it might be fun!

The implementation is roughly modeled after things like `OsuModTransform` (at least, that's where I found out about this `ApplyCustomUpdateState` function, which seemed to be the thing I needed to make transforms that actually apply to taiko objects). It's a bit rough and ready, this is my first time making a mod.

Here are some things I'm not sure about the best way to fix:

* The receptor is, of course, wrong.
* Strong hits are clipped by the playfield. If there's a way to make them not clip, or I could make them smaller, or just reduce the separation amount, idk. What do yall think.
* Scrubbing backwards in a replay will show a few objects without the custom transform, and objects don't keep their custom transform after being hit (they teleport to the drum before doing the regular animation).
* (Checking `is DrawableHit` twice is ugly, but without the outer check you needlessly add custom update states to swells and drumrolls, and without the inner check the game crashes when encountering a strong hit.)

![osu_2022-11-03_11-18-02](https://user-images.githubusercontent.com/2068021/199761098-6bc734c8-9d4b-44e8-b1ab-2d3fc6d9b4e6.jpg)

---

One of my friends who did not intend to play osu!taiko competitively, but just enjoyed the game and music casually, mentioned being bummed about the stable taikomania skin patch when that happened a while back. Since Lazer seems to be more open to features for casual play, there's been talk of [skins that add Don and Kat markers](https://github.com/ppy/osu/discussions/13249), and osu!standard even has a magnet mod now; i figured it's not too outlandish to take another look at taikomania.