### PR TITLE
Fix beatmap cards still potentially showing twice in listing

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -198,13 +198,13 @@ namespace osu.Game.Tests.Visual.Online
                 beatmapSet = CreateAPIBeatmapSet(Ruleset.Value);
                 beatmapSet.Title = "last beatmap of first page";
 
-                fetchFor(getManyBeatmaps(49).Append(beatmapSet).ToArray(), true);
+                fetchFor(getManyBeatmaps(49).Append(new APIBeatmapSet { Title = "last beatmap of first page", OnlineID = beatmapSet.OnlineID }).ToArray(), true);
             });
             AddUntilStep("wait for loaded", () => this.ChildrenOfType<BeatmapCard>().Count() == 50);
 
-            AddStep("set next page", () => setSearchResponse(getManyBeatmaps(49).Prepend(beatmapSet).ToArray(), false));
+            AddStep("set next page", () => setSearchResponse(getManyBeatmaps(49).Prepend(new APIBeatmapSet { Title = "this shouldn't show up", OnlineID = beatmapSet.OnlineID }).ToArray(), false));
             AddStep("scroll to end", () => overlay.ChildrenOfType<OverlayScrollContainer>().Single().ScrollToEnd());
-            AddUntilStep("wait for loaded", () => this.ChildrenOfType<BeatmapCard>().Count() == 99);
+            AddUntilStep("wait for loaded", () => this.ChildrenOfType<BeatmapCard>().Count() >= 99);
 
             AddAssert("beatmap not duplicated", () => overlay.ChildrenOfType<BeatmapCard>().Count(c => c.BeatmapSet.Equals(beatmapSet)) == 1);
         }

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -14,7 +14,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
-    public abstract class BeatmapCard : OsuClickableContainer, IEquatable<BeatmapCard>
+    public abstract class BeatmapCard : OsuClickableContainer
     {
         public const float TRANSITION_DURATION = 400;
         public const float CORNER_RADIUS = 10;
@@ -96,16 +96,5 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     throw new ArgumentOutOfRangeException(nameof(size), size, @"Unsupported card size");
             }
         }
-
-        public bool Equals(BeatmapCard? other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (ReferenceEquals(this, other)) return true;
-
-            return BeatmapSet.Equals(other.BeatmapSet);
-        }
-
-        public override bool Equals(object obj) => obj is BeatmapCard other && Equals(other);
-        public override int GetHashCode() => BeatmapSet.GetHashCode();
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmapSet.cs
@@ -149,5 +149,8 @@ namespace osu.Game.Online.API.Requests.Responses
         #endregion
 
         public bool Equals(IBeatmapSetInfo? other) => other is APIBeatmapSet b && this.MatchesOnlineID(b);
+
+        // ReSharper disable once NonReadonlyMemberInGetHashCode
+        public override int GetHashCode() => OnlineID.GetHashCode();
     }
 }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Overlays
                 // new results may contain beatmaps from a previous page,
                 // this is dodgy but matches web behaviour for now.
                 // see: https://github.com/ppy/osu-web/issues/9270
-                newCards = newCards.Except(foundContent);
+                newCards = newCards.Except(foundContent, BeatmapCardEqualityComparer.Default);
 
                 panelLoadTask = LoadComponentsAsync(newCards, loaded =>
                 {
@@ -393,6 +393,22 @@ namespace osu.Game.Overlays
 
             if (shouldShowMore)
                 filterControl.FetchNextPage();
+        }
+
+        private class BeatmapCardEqualityComparer : IEqualityComparer<BeatmapCard>
+        {
+            public static BeatmapCardEqualityComparer Default { get; } = new BeatmapCardEqualityComparer();
+
+            public bool Equals(BeatmapCard x, BeatmapCard y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+
+                return x.BeatmapSet.Equals(y.BeatmapSet);
+            }
+
+            public int GetHashCode(BeatmapCard obj) => obj.BeatmapSet.GetHashCode();
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -180,6 +180,8 @@ namespace osu.Game.Overlays
                 // new results may contain beatmaps from a previous page,
                 // this is dodgy but matches web behaviour for now.
                 // see: https://github.com/ppy/osu-web/issues/9270
+                // todo: replace custom equality compraer with ExceptBy in net6.0
+                // newCards = newCards.ExceptBy(foundContent.Select(c => c.BeatmapSet.OnlineID), c => c.BeatmapSet.OnlineID);
                 newCards = newCards.Except(foundContent, BeatmapCardEqualityComparer.Default);
 
                 panelLoadTask = LoadComponentsAsync(newCards, loaded =>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/20170

Turns out `APIBeatmapSet.GetHashCode` doesn't work and would be different per instance. Have only implemented it for `APIBeatmapSet`, but can apply for every API model available if that's preferred (slightly hesitant about doing it all here).

Can confirm this works correctly now, with a breakpoint being set on the LINQ explicit operation and checking whether the bug has been it in the web response then ensuring no duplication occurred in the listing.