### PR TITLE
Add url clicking support to profile badges

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -52,8 +52,15 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     AwardedAt = DateTimeOffset.FromUnixTimeSeconds(1505741569),
                     Description = "Outstanding help by being a voluntary test subject.",
-                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor.jpg"
-                }
+                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor.jpg",
+                    Url = "https://osu.ppy.sh/wiki/en/People/Community_Contributors",
+                },
+                new Badge
+                {
+                    AwardedAt = DateTimeOffset.FromUnixTimeSeconds(1505741569),
+                    Description = "Badge without a url.",
+                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor.jpg",
+                },
             },
             Title = "osu!volunteer",
             Colour = "ff0000",

--- a/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
@@ -1,22 +1,20 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
+using osu.Game.Online;
 using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
     [LongRunningLoad]
-    public class DrawableBadge : CompositeDrawable, IHasTooltip
+    public class DrawableBadge : OsuClickableContainer
     {
         public static readonly Vector2 DRAWABLE_BADGE_SIZE = new Vector2(86, 40);
 
@@ -29,22 +27,25 @@ namespace osu.Game.Overlays.Profile.Header.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures)
+        private void load(LargeTextureStore textures, ILinkHandler? linkHandler)
         {
-            InternalChild = new Sprite
+            Child = new Sprite
             {
                 FillMode = FillMode.Fit,
                 RelativeSizeAxes = Axes.Both,
                 Texture = textures.Get(badge.ImageUrl),
             };
+
+            if (!string.IsNullOrEmpty(badge.Url))
+                Action = () => linkHandler?.HandleLink(badge.Url);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            InternalChild.FadeInFromZero(200);
+            this.FadeInFromZero(200);
         }
 
-        public LocalisableString TooltipText => badge.Description;
+        public override LocalisableString TooltipText => badge.Description;
     }
 }

--- a/osu.Game/Users/Badge.cs
+++ b/osu.Game/Users/Badge.cs
@@ -18,5 +18,8 @@ namespace osu.Game.Users
 
         [JsonProperty("image_url")]
         public string ImageUrl;
+
+        [JsonProperty("url")]
+        public string Url;
     }
 }


### PR DESCRIPTION
When testing manually, the link doesn't actually work (because no `OsuGame`), but one badge is `Enabled` and the other is not, therefore making different sounds thanks to https://github.com/ppy/osu/pull/21097.