### PR TITLE
Adjust transition effect for main menu backgrounds

### DIFF
--- a/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
+++ b/osu.Game/Graphics/Backgrounds/SeasonalBackgroundLoader.cs
@@ -111,8 +111,6 @@ namespace osu.Game.Graphics.Backgrounds
         private void load(LargeTextureStore textures)
         {
             Sprite.Texture = textures.Get(url) ?? textures.Get(fallback_texture_name);
-            // ensure we're not loading in without a transition.
-            this.FadeInFromZero(200, Easing.InOutSine);
         }
 
         public override bool Equals(Background other)

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Screens.Backgrounds
 
         private void displayNext(Background newBackground)
         {
-            background?.FadeOut(800, Easing.InOutSine);
+            background?.FadeOut(800, Easing.OutQuint);
             background?.Expire();
 
             AddInternal(background = newBackground);

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Backgrounds
             nextTask = Scheduler.AddDelayed(() =>
             {
                 LoadComponentAsync(nextBackground, displayNext, cancellationTokenSource.Token);
-            }, 100);
+            }, 500);
 
             return true;
         }


### PR DESCRIPTION
### Increase delay for changing background on returning to main menu

It was happening too quickly after returning to the main menu from song select. Delaying a bit more helps reduce the amount of things happening on screen at once.

I also experimented with turning off the forced cycling on returning to the main menu, but am not committing this as it has adverse side effects (basically, calling `Next()` there ensures the delay is actually waited for. if it's not called and a beatmap changes at song select, it will be scheduled for "500ms in the future" but at the point of returning to main menu it becomes immediate).

### Remove unnecessary fade in `SeasonalBackground`

This looks to have been added to account for loading the image data, but in manual testing with `Thread.Sleep` it doesn't seem required. Leaving this in place causes a visual dim to black during transition between two seasonal backgrounds.