### PR TITLE
Fix editor selection behaviour regressions due to new path visualiser optimisation

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
@@ -1,0 +1,117 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    [TestFixture]
+    public class TestSceneOsuComposerSelection : TestSceneOsuEditor
+    {
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Test]
+        public void TestContextMenuShownCorrectlyForSelectedSlider()
+        {
+            var slider = new Slider
+            {
+                StartTime = 0,
+                Position = new Vector2(100, 100),
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(),
+                        new PathControlPoint(new Vector2(100))
+                    }
+                }
+            };
+            AddStep("add slider", () => EditorBeatmap.Add(slider));
+
+            moveMouseToObject(() => slider);
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddUntilStep("slider selected", () => EditorBeatmap.SelectedHitObjects.Single() == slider);
+
+            AddStep("move mouse to centre", () => InputManager.MoveMouseTo(blueprintContainer.ChildrenOfType<SliderBodyPiece>().Single().ScreenSpaceDrawQuad.Centre));
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
+        }
+
+        [Test]
+        public void TestSelectionIncludingSliderPreservedOnClick()
+        {
+            var firstSlider = new Slider
+            {
+                StartTime = 0,
+                Position = new Vector2(0, 0),
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(),
+                        new PathControlPoint(new Vector2(100))
+                    }
+                }
+            };
+            var secondSlider = new Slider
+            {
+                StartTime = 1000,
+                Position = new Vector2(100, 100),
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(),
+                        new PathControlPoint(new Vector2(100, -100))
+                    }
+                }
+            };
+            var hitCircle = new HitCircle
+            {
+                StartTime = 200,
+                Position = new Vector2(300, 0)
+            };
+
+            AddStep("add objects", () => EditorBeatmap.AddRange(new HitObject[] { firstSlider, secondSlider, hitCircle }));
+            AddStep("select last 2 objects", () => EditorBeatmap.SelectedHitObjects.AddRange(new HitObject[] { secondSlider, hitCircle }));
+
+            moveMouseToObject(() => secondSlider);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddAssert("selection preserved", () => EditorBeatmap.SelectedHitObjects.Count == 2);
+        }
+
+        private ComposeBlueprintContainer blueprintContainer
+            => Editor.ChildrenOfType<ComposeBlueprintContainer>().First();
+
+        private ContextMenuContainer contextMenuContainer
+            => Editor.ChildrenOfType<ContextMenuContainer>().First();
+
+        private void moveMouseToObject(Func<HitObject> targetFunc)
+        {
+            AddStep("move mouse to object", () =>
+            {
+                var pos = blueprintContainer.SelectionBlueprints
+                                            .First(s => s.Item == targetFunc())
+                                            .ChildrenOfType<HitCirclePiece>()
+                                            .First().ScreenSpaceDrawQuad.Centre;
+
+                InputManager.MoveMouseTo(pos);
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -119,10 +119,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             updateVisualDefinition();
 
-            // In the case more than a single object is selected, block hover from arriving at sliders behind this one.
-            // Without doing this, the path visualisers of potentially hundreds of sliders will render, which is not only
-            // visually noisy but also functionally useless.
-            return !hasSingleObjectSelected;
+            return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
@@ -148,7 +145,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void updateVisualDefinition()
         {
             // To reduce overhead of drawing these blueprints, only add extra detail when hovered or when only this slider is selected.
-            if (IsSelected && (hasSingleObjectSelected || IsHovered))
+            if (IsSelected && selectedObjects.Count == 1)
             {
                 if (ControlPointVisualiser == null)
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateVisualDefinition()
         {
-            // To reduce overhead of drawing these blueprints, only add extra detail when hovered or when only this slider is selected.
+            // To reduce overhead of drawing these blueprints, only add extra detail when only this slider is selected.
             if (IsSelected && selectedObjects.Count < 2)
             {
                 if (ControlPointVisualiser == null)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -105,8 +105,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             return true;
         }
 
-        private bool hasSingleObjectSelected => selectedObjects.Count == 1;
-
         protected override void Update()
         {
             base.Update();
@@ -145,7 +143,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private void updateVisualDefinition()
         {
             // To reduce overhead of drawing these blueprints, only add extra detail when hovered or when only this slider is selected.
-            if (IsSelected && selectedObjects.Count == 1)
+            if (IsSelected && selectedObjects.Count < 2)
             {
                 if (ControlPointVisualiser == null)
                 {


### PR DESCRIPTION
- Closes #21114.
- Closes #21113.

I've just removed the hover display part to keep things simple. I don't think it was that useful.