### PR TITLE
Fix Realm package downgrade issue in mobile projects

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -56,6 +56,6 @@
   </ItemGroup>
   <ItemGroup Label="Transitive Dependencies">
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->
-    <PackageReference Include="Realm" Version="10.17.0" />
+    <PackageReference Include="Realm" Version="10.18.0" />
   </ItemGroup>
 </Project>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -87,6 +87,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2022.429.0" ExcludeAssets="all" />
-    <PackageReference Include="Realm" Version="10.17.0" />
+    <PackageReference Include="Realm" Version="10.18.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In #21115 Realm was bumped from 10.17.0 to 10.18.0 in the `osu.Game` project, but the same bump was not applied to the `osu.{Android,iOS}.props` files. This leads to android builds [failing on master](https://github.com/ppy/osu/actions/runs/3392429278/jobs/5638623005) due to a package downgrade error. (I'm not sure why iOS is apparently fine with this state of things.)

Android has been lightly tested to work. Can't check iOS ~~because too poor~~.