### PR TITLE
Fix incorrect handling of storyboard events with `end_time` before `start_time`

### DIFF
--- a/osu.Game/Storyboards/CommandTimeline.cs
+++ b/osu.Game/Storyboards/CommandTimeline.cs
@@ -28,8 +28,7 @@ namespace osu.Game.Storyboards
         {
             if (endTime < startTime)
             {
-                (startTime, endTime) = (endTime, startTime);
-                (startValue, endValue) = (endValue, startValue);
+                endTime = startTime;
             }
 
             commands.Add(new TypedCommand { Easing = easing, StartTime = startTime, EndTime = endTime, StartValue = startValue, EndValue = endValue });


### PR DESCRIPTION
Closes #20632 again.