### PR TITLE
Fix taiko major barlines no longer rendering correctly

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -60,8 +60,9 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// </remarks>
         private BarLinePlayfield barLinePlayfield;
 
-        private Container playfieldContent;
-        private Container playfieldOverlay;
+        private Container barLineContent;
+        private Container hitObjectContent;
+        private Container overlayContent;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -121,22 +122,20 @@ namespace osu.Game.Rulesets.Taiko.UI
                                 }
                             }
                         },
-                        new Container
+                        barLineContent = new Container
+                        {
+                            Name = "Bar line content",
+                            RelativeSizeAxes = Axes.Both,
+                            Child = barLinePlayfield = new BarLinePlayfield(),
+                        },
+                        hitObjectContent = new Container
                         {
                             Name = "Masked hit objects content",
                             RelativeSizeAxes = Axes.Both,
                             Masking = true,
-                            Child = playfieldContent = new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Children = new Drawable[]
-                                {
-                                    barLinePlayfield = new BarLinePlayfield(),
-                                    HitObjectContainer,
-                                }
-                            }
+                            Child = HitObjectContainer,
                         },
-                        playfieldOverlay = new Container
+                        overlayContent = new Container
                         {
                             Name = "Elements after hit objects",
                             RelativeSizeAxes = Axes.Both,
@@ -215,8 +214,9 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Padding is required to be updated for elements which are based on "absolute" X sized elements.
             // This is basically allowing for correct alignment as relative pieces move around them.
             rightArea.Padding = new MarginPadding { Left = inputDrum.Width };
-            playfieldContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
-            playfieldOverlay.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
+            barLineContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
+            hitObjectContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
+            overlayContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
 
             mascot.Scale = new Vector2(DrawHeight / DEFAULT_HEIGHT);
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21149

Feels pretty awkward to have three conatiners all being padded by the same value, but that's done because the middle container applies a masking outside of the padding area, so it's not possible to group all of them under one container, otherwise masking would apply inside the padding area instead and break hit objects display.