### PR TITLE
Fix some issues with storyboard variables

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -130,14 +130,20 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        protected KeyValuePair<string, string> SplitKeyVal(string line, char separator = ':')
+        protected KeyValuePair<string, string> SplitKeyVal(string line, char separator = ':', bool shouldTrim = true)
         {
             string[] split = line.Split(separator, 2);
 
+            if (shouldTrim)
+            {
+                for (int i = 0; i < split.Length; i++)
+                    split[i] = split[i].Trim();
+            }
+
             return new KeyValuePair<string, string>
             (
-                split[0].Trim(),
-                split.Length > 1 ? split[1].Trim() : string.Empty
+                split[0],
+                split.Length > 1 ? split[1] : string.Empty
             );
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Beatmaps.Formats
 
         private void handleEvents(string line)
         {
+            decodeVariables(ref line);
+
             int depth = 0;
 
             foreach (char c in line)
@@ -90,8 +92,6 @@ namespace osu.Game.Beatmaps.Formats
             }
 
             line = line.Substring(depth);
-
-            decodeVariables(ref line);
 
             string[] split = line.Split(',');
 

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -349,7 +349,7 @@ namespace osu.Game.Beatmaps.Formats
 
         private void handleVariables(string line)
         {
-            var pair = SplitKeyVal(line, '=');
+            var pair = SplitKeyVal(line, '=', false);
             variables[pair.Key] = pair.Value;
         }
 


### PR DESCRIPTION
No tests because this is mostly stupid and should not be done.

Fixes variable parsing portion of https://github.com/ppy/osu/issues/21159 (https://osu.ppy.sh/beatmapsets/774573#osu/1627968) which has variables like `$ ` (yes, that is a single space as the "variable name") and `$　` (you guessed it, that's a full-width space as the "variable name").

![iTerm2 2022-11-08 at 04 31 38](https://user-images.githubusercontent.com/191335/200475549-85d41fbe-0993-434e-a12d-256e3d68a834.png)


Note that the linked beatmap will still not work correctly due to another issue I'm working through (filename missing `.png` suffix doesn't work) but with a temporary fix for that I can confirm the storyboard now plays back correctly.