### PR TITLE
Fix parsing of `Language` when using system default language

### DIFF
--- a/osu.Game/Extensions/LanguageExtensions.cs
+++ b/osu.Game/Extensions/LanguageExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Globalization;
+using osu.Framework.Configuration;
+using osu.Framework.Localisation;
 using osu.Game.Localisation;
 
 namespace osu.Game.Extensions
@@ -29,5 +31,28 @@ namespace osu.Game.Extensions
         /// <returns>Whether the parsing succeeded.</returns>
         public static bool TryParseCultureCode(string cultureCode, out Language language)
             => Enum.TryParse(cultureCode.Replace("-", "_"), out language);
+
+        /// <summary>
+        /// Parses the <see cref="Language"/> that is specified in <paramref name="frameworkLocale"/>,
+        /// or if that is not valid, the language of the current <see cref="ResourceManagerLocalisationStore"/> as exposed by <paramref name="localisationParameters"/>.
+        /// </summary>
+        /// <param name="frameworkLocale">The current <see cref="FrameworkSetting.Locale"/>.</param>
+        /// <param name="localisationParameters">The current <see cref="LocalisationParameters"/> of the <see cref="LocalisationManager"/>.</param>
+        /// <returns>The parsed language.</returns>
+        public static Language GetLanguageFor(string frameworkLocale, LocalisationParameters localisationParameters)
+        {
+            // the usual case when the user has changed the language
+            if (TryParseCultureCode(frameworkLocale, out var language))
+                return language;
+
+            if (localisationParameters.Store != null)
+            {
+                // startup case, locale not explicitly set, or the set language was removed in an update
+                if (TryParseCultureCode(localisationParameters.Store.EffectiveCulture.Name, out language))
+                    return language;
+            }
+
+            return Language.en;
+        }
     }
 }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
@@ -63,11 +63,12 @@ namespace osu.Game.Overlays.FirstRunSetup
         private class LanguageSelectionFlow : FillFlowContainer
         {
             private Bindable<string> frameworkLocale = null!;
+            private IBindable<LocalisationParameters> localisationParameters = null!;
 
             private ScheduledDelegate? updateSelectedDelegate;
 
             [BackgroundDependencyLoader]
-            private void load(FrameworkConfigManager frameworkConfig)
+            private void load(FrameworkConfigManager frameworkConfig, LocalisationManager localisation)
             {
                 Direction = FillDirection.Full;
                 Spacing = new Vector2(5);
@@ -80,10 +81,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                                          });
 
                 frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
-                frameworkLocale.BindValueChanged(locale =>
+
+                localisationParameters = localisation.CurrentParameters.GetBoundCopy();
+                localisationParameters.BindValueChanged(p =>
                 {
-                    if (!LanguageExtensions.TryParseCultureCode(locale.NewValue, out var language))
-                        language = Language.en;
+                    var language = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, p.NewValue);
 
                     // Changing language may cause a short period of blocking the UI thread while the new glyphs are loaded.
                     // Scheduling ensures the button animation plays smoothly after any blocking operation completes.

--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -16,15 +14,17 @@ namespace osu.Game.Overlays.Settings.Sections.General
 {
     public class LanguageSettings : SettingsSubsection
     {
-        private SettingsDropdown<Language> languageSelection;
-        private Bindable<string> frameworkLocale;
+        private SettingsDropdown<Language> languageSelection = null!;
+        private Bindable<string> frameworkLocale = null!;
+        private IBindable<LocalisationParameters> localisationParameters = null!;
 
         protected override LocalisableString Header => GeneralSettingsStrings.LanguageHeader;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager frameworkConfig, OsuConfigManager config)
+        private void load(FrameworkConfigManager frameworkConfig, OsuConfigManager config, LocalisationManager localisation)
         {
             frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
+            localisationParameters = localisation.CurrentParameters.GetBoundCopy();
 
             Children = new Drawable[]
             {
@@ -44,12 +44,8 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 },
             };
 
-            frameworkLocale.BindValueChanged(locale =>
-            {
-                if (!LanguageExtensions.TryParseCultureCode(locale.NewValue, out var language))
-                    language = Language.en;
-                languageSelection.Current.Value = language;
-            }, true);
+            localisationParameters.BindValueChanged(p
+                => languageSelection.Current.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, p.NewValue), true);
 
             languageSelection.Current.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
         }


### PR DESCRIPTION
Fixes the language settings dropdown and the first run overlay displaying the wrong language when using the system default language. (Issue since https://github.com/ppy/osu-framework/pull/5505).

The buggy behaviour:

![image](https://user-images.githubusercontent.com/16479013/201214291-12249ace-702d-4688-8f9e-c5981d6e7b62.png)

