### PR TITLE
Fix incorrect rounding of tablet aspect ratio values

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -212,17 +212,17 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.Update();
 
-            if (tablet.Value?.Size is Vector2 size)
-            {
-                float maxDimension = size.LengthFast;
+            if (!(tablet.Value?.Size is Vector2 size))
+                return;
 
-                float fitX = maxDimension / (DrawWidth - Padding.Left - Padding.Right);
-                float fitY = maxDimension / DrawHeight;
+            float maxDimension = size.LengthFast;
 
-                float adjust = MathF.Max(fitX, fitY);
+            float fitX = maxDimension / (DrawWidth - Padding.Left - Padding.Right);
+            float fitY = maxDimension / DrawHeight;
 
-                tabletContainer.Scale = new Vector2(1 / adjust);
-            }
+            float adjust = MathF.Max(fitX, fitY);
+
+            tabletContainer.Scale = new Vector2(1 / adjust);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -125,11 +125,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 usableAreaContainer.ResizeTo(val.NewValue, 100, Easing.OutQuint);
 
-                int x = (int)val.NewValue.X;
-                int y = (int)val.NewValue.Y;
+                int x = (int)Math.Round(val.NewValue.X);
+                int y = (int)Math.Round(val.NewValue.Y);
                 int commonDivider = greatestCommonDivider(x, y);
 
-                usableAreaText.Text = $"{(float)x / commonDivider}:{(float)y / commonDivider}";
+                usableAreaText.Text = $"{x / commonDivider}:{y / commonDivider}";
                 checkBounds();
             }, true);
 
@@ -212,17 +212,17 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.Update();
 
-            if (!(tablet.Value?.Size is Vector2 size))
-                return;
+            if (tablet.Value?.Size is Vector2 size)
+            {
+                float maxDimension = size.LengthFast;
 
-            float maxDimension = size.LengthFast;
+                float fitX = maxDimension / (DrawWidth - Padding.Left - Padding.Right);
+                float fitY = maxDimension / DrawHeight;
 
-            float fitX = maxDimension / (DrawWidth - Padding.Left - Padding.Right);
-            float fitY = maxDimension / DrawHeight;
+                float adjust = MathF.Max(fitX, fitY);
 
-            float adjust = MathF.Max(fitX, fitY);
-
-            tabletContainer.Scale = new Vector2(1 / adjust);
+                tabletContainer.Scale = new Vector2(1 / adjust);
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -342,8 +342,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private float currentAspectRatio => sizeX.Value / sizeY.Value;
 
-        private static float getHeight(float width, float aspectRatio) => MathF.Round(width / aspectRatio);
+        private static float getHeight(float width, float aspectRatio) => width / aspectRatio;
 
-        private static float getWidth(float height, float aspectRatio) => MathF.Round(height * aspectRatio);
+        private static float getWidth(float height, float aspectRatio) => height * aspectRatio;
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -342,8 +342,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private float currentAspectRatio => sizeX.Value / sizeY.Value;
 
-        private static float getHeight(float width, float aspectRatio) => (float)Math.Round(width / aspectRatio);
+        private static float getHeight(float width, float aspectRatio) => MathF.Round(width / aspectRatio);
 
-        private static float getWidth(float height, float aspectRatio) => (float)Math.Round(height * aspectRatio);
+        private static float getWidth(float height, float aspectRatio) => MathF.Round(height * aspectRatio);
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -325,7 +325,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             aspectLock.Value = false;
 
-            int proposedHeight = getHeight(sizeX.Value, aspectRatio);
+            float proposedHeight = getHeight(sizeX.Value, aspectRatio);
 
             if (proposedHeight < sizeY.MaxValue)
                 sizeY.Value = proposedHeight;
@@ -342,8 +342,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private float currentAspectRatio => sizeX.Value / sizeY.Value;
 
-        private static int getHeight(float width, float aspectRatio) => (int)Math.Round(width / aspectRatio);
+        private static float getHeight(float width, float aspectRatio) => (float)Math.Round(width / aspectRatio);
 
-        private static int getWidth(float height, float aspectRatio) => (int)Math.Round(height * aspectRatio);
+        private static float getWidth(float height, float aspectRatio) => (float)Math.Round(height * aspectRatio);
     }
 }


### PR DESCRIPTION
The values of the aspect ratio on the tablet area preview are sometimes incorrectly rounded down.
For example: My area here is set to 80x45, but due to `sizeX`, `sizeY` and their `SettingsSlider`'s being floats the values are incorrectly rounded down.
![image](https://user-images.githubusercontent.com/26160742/201390374-bc593b46-af35-4498-b749-fb1682682bcb.png)
I also changed the functions from my previous PR to return floats, since I don't see the point in converting them to integers when `sizeX` and `sizeY` are floats.