### PR TITLE
Fix failing gameplay bindings test

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Tests.Visual.Navigation
             PushAndConfirm(() => new PlaySongSelect());
 
             AddUntilStep("wait for selection", () => !Game.Beatmap.IsDefault);
+            AddUntilStep("wait for carousel load", () => songSelect.BeatmapSetsLoaded);
 
             AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
 
@@ -91,6 +92,8 @@ namespace osu.Game.Tests.Visual.Navigation
                                                                   .All<RealmKeyBinding>()
                                                                   .AsEnumerable()
                                                                   .First(k => k.RulesetName == "osu" && k.ActionInt == 0);
+
+        private Screens.Select.SongSelect songSelect => Game.ScreenStack.CurrentScreen as Screens.Select.SongSelect;
 
         private Player player => Game.ScreenStack.CurrentScreen as Player;
 


### PR DESCRIPTION
Fixes tests that are consistently failing on `master`, but only on Windows and only on github CI (could not repro locally or on teamcity). As seen here: https://github.com/ppy/osu/actions/runs/3448933658/jobs/5756410135#step:5:38

The clue for the fix was [this helpful log statement](https://github.com/ppy/osu/actions/runs/3448933658/jobs/5756410135#step:5:251). I briefly looked at why this started happening but couldn't see anything obvious and decided that I didn't care enough to waste time on it as it could have been anything at all related to screen timing.

"Tested" on CI to have stopped failing based on a [sample size of 1 run](https://github.com/bdach/osu/actions/runs/3449673927/jobs/5757767045).