### PR TITLE
Fix `SkinnableSprite` lookups broken in lazer-first skins

### DIFF
--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -82,21 +82,14 @@ namespace osu.Game.Skinning
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
+            // Temporary until default skin has a valid hit lighting.
+            if ((lookup as SkinnableSprite.SpriteComponentLookup)?.LookupName == @"lighting") return Drawable.Empty();
+
             if (base.GetDrawableComponent(lookup) is Drawable c)
                 return c;
 
             switch (lookup)
             {
-                case SkinnableSprite.SpriteComponentLookup spriteLookup:
-                    switch (spriteLookup.LookupName)
-                    {
-                        // Temporary until default skin has a valid hit lighting.
-                        case @"lighting":
-                            return Drawable.Empty();
-                    }
-
-                    break;
-
                 case GlobalSkinComponentLookup globalLookup:
                     switch (globalLookup.Lookup)
                     {

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -396,9 +396,6 @@ namespace osu.Game.Skinning
                     }
 
                     return null;
-
-                case SkinnableSprite.SpriteComponentLookup sprite:
-                    return this.GetAnimation(sprite.LookupName, false, false);
             }
 
             return null;

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -158,6 +158,10 @@ namespace osu.Game.Skinning
         {
             switch (lookup)
             {
+                // This fallback is important for user skins which use SkinnableSprites.
+                case SkinnableSprite.SpriteComponentLookup sprite:
+                    return this.GetAnimation(sprite.LookupName, false, false);
+
                 case GlobalSkinComponentLookup target:
                     if (!DrawableComponentInfo.TryGetValue(target.Lookup, out var skinnableInfo))
                         return null;

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -60,21 +60,14 @@ namespace osu.Game.Skinning
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
+            // Temporary until default skin has a valid hit lighting.
+            if ((lookup as SkinnableSprite.SpriteComponentLookup)?.LookupName == @"lighting") return Drawable.Empty();
+
             if (base.GetDrawableComponent(lookup) is Drawable c)
                 return c;
 
             switch (lookup)
             {
-                case SkinnableSprite.SpriteComponentLookup spriteLookup:
-                    switch (spriteLookup.LookupName)
-                    {
-                        // Temporary until default skin has a valid hit lighting.
-                        case @"lighting":
-                            return Drawable.Empty();
-                    }
-
-                    break;
-
                 case GlobalSkinComponentLookup target:
                     switch (target.Lookup)
                     {


### PR DESCRIPTION
Regressed with removal of local `GetTexture` calls in https://github.com/ppy/osu/commit/e19ba65f9186afab21aec536a636d7d152636dde.

Can be tested by dragging a png/jpeg into the skin editor with argon or triangles active.

I tried to find a good place to add a test but there's really nowhere good. Can make a new test scene if required, but it will be involved (needs to check fallbacks to one or more default skins correctly query the user skin resources).