### PR TITLE
Vertically stacked osu!catch touch input

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Rulesets.Catch.UI
         private void load(CatchInputManager catchInputManager, OsuColour colours)
         {
             const float width = 0.15f;
+            // Ratio between normal move area height and total input height
+            const float normal_area_height_ratio = 0.45f;
 
             keyBindingContainer = catchInputManager.KeyBindingContainer;
 
@@ -54,18 +56,18 @@ namespace osu.Game.Rulesets.Catch.UI
                             Width = width,
                             Children = new Drawable[]
                             {
-                                leftDashBox = new InputArea(TouchCatchAction.DashLeft, trackedActionSources)
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Width = 0.5f,
-                                },
                                 leftBox = new InputArea(TouchCatchAction.MoveLeft, trackedActionSources)
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Width = 0.5f,
+                                    Height = normal_area_height_ratio,
                                     Colour = colours.Gray9,
-                                    Anchor = Anchor.TopRight,
-                                    Origin = Anchor.TopRight,
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
+                                },
+                                leftDashBox = new InputArea(TouchCatchAction.DashLeft, trackedActionSources)
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Height = 1 - normal_area_height_ratio,
                                 },
                             }
                         },
@@ -80,15 +82,15 @@ namespace osu.Game.Rulesets.Catch.UI
                                 rightBox = new InputArea(TouchCatchAction.MoveRight, trackedActionSources)
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Width = 0.5f,
+                                    Height = normal_area_height_ratio,
                                     Colour = colours.Gray9,
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.BottomRight,
                                 },
                                 rightDashBox = new InputArea(TouchCatchAction.DashRight, trackedActionSources)
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Width = 0.5f,
-                                    Anchor = Anchor.TopRight,
-                                    Origin = Anchor.TopRight,
+                                    Height = 1 - normal_area_height_ratio,
                                 },
                             }
                         },


### PR DESCRIPTION
A simple PR to make the default touch input for osu!catch vertically stacking dash on normal instead of a vertical split like the current implementation. It also split the area by a constant ratio (currently 60% dash on top of 40% normal) instead of equal split, because it's more comfortable to hold the device that way.

Should be good for now, before we get actual touch handlers with customization.

Screenshot:
![image](https://user-images.githubusercontent.com/32929093/201516894-cd954e65-0e5d-46ab-bc7a-49c27c6ce5a4.png)

