### PR TITLE
Fix beatmap card expanded content not blocking clicks from behind

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/ExpandedContentScrollContainer.cs
@@ -59,6 +59,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             return base.OnScroll(e);
         }
 
+        protected override bool OnClick(ClickEvent e) => true;
+
         private class ExpandedContentScrollbar : OsuScrollbar
         {
             public ExpandedContentScrollbar(Direction scrollDir)


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![osu!_maRvnWv3mx](https://user-images.githubusercontent.com/35318437/201532540-217ebc78-6324-485f-90d7-aa7e2e40d3ef.gif) | ![osu!_4BEUfgUywy](https://user-images.githubusercontent.com/35318437/201532449-2c6ed1b0-bdca-4e9f-9851-67b0c6c9744d.gif) |