### PR TITLE
Fix `FallbackSampleStore.GetAsync` fallback logic

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
+++ b/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
@@ -115,7 +115,11 @@ namespace osu.Game.Rulesets.UI
 
             public Sample Get(string name) => primary.Get(name) ?? fallback.Get(name);
 
-            public Task<Sample> GetAsync(string name, CancellationToken cancellationToken = default) => primary.GetAsync(name, cancellationToken) ?? fallback.GetAsync(name, cancellationToken);
+            public async Task<Sample> GetAsync(string name, CancellationToken cancellationToken = default)
+            {
+                return await primary.GetAsync(name, cancellationToken).ConfigureAwait(false)
+                       ?? await fallback.GetAsync(name, cancellationToken).ConfigureAwait(false);
+            }
 
             public Stream GetStream(string name) => primary.GetStream(name) ?? fallback.GetStream(name);
 


### PR DESCRIPTION
Noticed while looking into https://github.com/ppy/osu-framework/pull/5514.

Previously, `GetAsync` would never use the fallback store, even if the primary returned a `null` value.

On a quick check, `GetAsync` doesn't seem to be used for samples, only `Get`.