### PR TITLE
Fix slider ticks appearing before sliders are done snaking in with Freeze Frame

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Rulesets.Osu.Mods
                 {
                     switch (nested)
                     {
+                        //Freezing the SliderTicks doesnt play well with snaking sliders
+                        case SliderTick:
                         //SliderRepeat wont layer correctly if preempt is changed.
                         case SliderRepeat:
                             break;


### PR DESCRIPTION
Closes: https://github.com/ppy/osu/issues/21075