### PR TITLE
Apply pooling support to hit error metres

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -163,10 +163,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for bars to disappear", () => !this.ChildrenOfType<BarHitErrorMeter.JudgementLine>().Any());
             AddUntilStep("ensure max circles not exceeded", () =>
-            {
-                return this.ChildrenOfType<ColourHitErrorMeter>()
-                           .All(m => m.ChildrenOfType<ColourHitErrorMeter.HitErrorShape>().Count() <= max_displayed_judgements);
-            });
+                this.ChildrenOfType<ColourHitErrorMeter>().First().ChildrenOfType<ColourHitErrorMeter.HitErrorShape>().Count(), () => Is.LessThanOrEqualTo(max_displayed_judgements));
 
             AddStep("show displays", () =>
             {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
         private double floatingAverage;
 
-        private readonly DrawablePool<JudgementLine> judgementLinePool = new DrawablePool<JudgementLine>(50, 100);
+        private readonly DrawablePool<JudgementLine> judgementLinePool = new DrawablePool<JudgementLine>(50);
 
         private SpriteIcon arrow = null!;
         private UprightAspectMaintainingContainer labelEarly = null!;

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -27,8 +25,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
     [Cached]
     public class BarHitErrorMeter : HitErrorMeter
     {
-        private const int judgement_line_width = 14;
-
         [SettingSource("Judgement line thickness", "How thick the individual lines should be.")]
         public BindableNumber<float> JudgementLineThickness { get; } = new BindableNumber<float>(4)
         {
@@ -46,30 +42,33 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         [SettingSource("Label style", "How to show early/late extremities")]
         public Bindable<LabelStyles> LabelStyle { get; } = new Bindable<LabelStyles>(LabelStyles.Icons);
 
-        private readonly DrawablePool<JudgementLine> judgementLinePool = new DrawablePool<JudgementLine>(50, 100);
+        private const int judgement_line_width = 14;
 
-        private SpriteIcon arrow;
-        private UprightAspectMaintainingContainer labelEarly;
-        private UprightAspectMaintainingContainer labelLate;
+        private const int max_concurrent_judgements = 50;
 
-        private Container colourBarsEarly;
-        private Container colourBarsLate;
-
-        private Container judgementsContainer;
+        private const int centre_marker_size = 8;
 
         private double maxHitWindow;
 
         private double floatingAverage;
-        private Container colourBars;
-        private Container arrowContainer;
 
-        private (HitResult result, double length)[] hitWindows;
+        private readonly DrawablePool<JudgementLine> judgementLinePool = new DrawablePool<JudgementLine>(50, 100);
 
-        private const int max_concurrent_judgements = 50;
+        private SpriteIcon arrow = null!;
+        private UprightAspectMaintainingContainer labelEarly = null!;
+        private UprightAspectMaintainingContainer labelLate = null!;
 
-        private Drawable[] centreMarkerDrawables;
+        private Container colourBarsEarly = null!;
+        private Container colourBarsLate = null!;
 
-        private const int centre_marker_size = 8;
+        private Container judgementsContainer = null!;
+
+        private Container colourBars = null!;
+        private Container arrowContainer = null!;
+
+        private (HitResult result, double length)[] hitWindows = null!;
+
+        private Drawable[]? centreMarkerDrawables;
 
         public BarHitErrorMeter()
         {
@@ -427,6 +426,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         {
             public readonly BindableNumber<float> JudgementLineThickness = new BindableFloat();
 
+            [Resolved]
+            private BarHitErrorMeter barHitErrorMeter { get; set; } = null!;
+
             public JudgementLine()
             {
                 RelativeSizeAxes = Axes.X;
@@ -442,9 +444,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                     RelativeSizeAxes = Axes.Both,
                 };
             }
-
-            [Resolved]
-            private BarHitErrorMeter barHitErrorMeter { get; set; }
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -169,7 +169,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
                 IsRemoved = false;
 
-                this.FadeIn();
+                this.FadeIn()
+                    // On pool re-use, start flow animation from (0,0).
+                    .MoveTo(Vector2.Zero);
 
                 content.FadeInFromZero(animation_duration, Easing.OutQuint)
                        .MoveToY(-DrawSize.Y)

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -3,9 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
@@ -15,6 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 {
+    [Cached]
     public class ColourHitErrorMeter : HitErrorMeter
     {
         private const int animation_duration = 200;
@@ -82,7 +85,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             {
                 base.LoadComplete();
 
-                JudgementCount.BindValueChanged(count =>
+                JudgementCount.BindValueChanged(_ =>
                 {
                     removeExtraJudgements();
                     updateMetrics();
@@ -91,11 +94,14 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 JudgementSpacing.BindValueChanged(_ => updateMetrics(), true);
             }
 
+            private readonly DrawablePool<HitErrorShape> judgementLinePool = new DrawablePool<HitErrorShape>(50);
+
             public void Push(Color4 colour)
             {
-                Add(new HitErrorShape(colour, drawable_judgement_size)
+                judgementLinePool.Get(shape =>
                 {
-                    Shape = { BindTarget = JudgementShape },
+                    shape.Colour = colour;
+                    Add(shape);
                 });
 
                 removeExtraJudgements();
@@ -116,32 +122,32 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             }
         }
 
-        public class HitErrorShape : Container
+        public class HitErrorShape : PoolableDrawable
         {
             public bool IsRemoved { get; private set; }
 
             public readonly Bindable<ShapeStyle> Shape = new Bindable<ShapeStyle>();
 
-            private readonly Color4 colour;
+            [Resolved]
+            private ColourHitErrorMeter hitErrorMeter { get; set; } = null!;
 
             private Container content = null!;
 
-            public HitErrorShape(Color4 colour, int size)
+            public HitErrorShape()
             {
-                this.colour = colour;
-                Size = new Vector2(size);
+                Size = new Vector2(drawable_judgement_size);
             }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
 
-                Child = content = new Container
+                InternalChild = content = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colour
                 };
 
+                Shape.BindTo(hitErrorMeter.JudgementShape);
                 Shape.BindValueChanged(shape =>
                 {
                     switch (shape.NewValue)
@@ -155,17 +161,27 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                             break;
                     }
                 }, true);
+            }
 
-                content.FadeInFromZero(animation_duration, Easing.OutQuint);
-                content.MoveToY(-DrawSize.Y);
-                content.MoveToY(0, animation_duration, Easing.OutQuint);
+            protected override void PrepareForUse()
+            {
+                base.PrepareForUse();
+
+                IsRemoved = false;
+
+                this.FadeIn();
+
+                content.FadeInFromZero(animation_duration, Easing.OutQuint)
+                       .MoveToY(-DrawSize.Y)
+                       .MoveToY(0, animation_duration, Easing.OutQuint);
             }
 
             public void Remove()
             {
                 IsRemoved = true;
 
-                this.FadeOut(animation_duration, Easing.OutQuint).Expire();
+                this.FadeOut(animation_duration, Easing.OutQuint)
+                    .Expire();
             }
         }
 

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -102,9 +102,9 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 {
                     shape.Colour = colour;
                     Add(shape);
-                });
 
-                removeExtraJudgements();
+                    removeExtraJudgements();
+                });
             }
 
             private void removeExtraJudgements()
@@ -167,15 +167,18 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             {
                 base.PrepareForUse();
 
-                IsRemoved = false;
-
-                this.FadeIn()
+                this.FadeInFromZero(animation_duration, Easing.OutQuint)
                     // On pool re-use, start flow animation from (0,0).
                     .MoveTo(Vector2.Zero);
 
-                content.FadeInFromZero(animation_duration, Easing.OutQuint)
-                       .MoveToY(-DrawSize.Y)
+                content.MoveToY(-DrawSize.Y)
                        .MoveToY(0, animation_duration, Easing.OutQuint);
+            }
+
+            protected override void FreeAfterUse()
+            {
+                base.FreeAfterUse();
+                IsRemoved = false;
             }
 
             public void Remove()


### PR DESCRIPTION
Fixes one of the remaining large sources of drawable allocation churn during gameplay.