### PR TITLE
Triangles background improvements

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesBackground.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesBackground.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics.Backgrounds;
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Game.Tests.Visual.Background
+{
+    public class TestSceneTrianglesBackground : OsuTestScene
+    {
+        private readonly Triangles triangles;
+
+        public TestSceneTrianglesBackground()
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Black
+                },
+                triangles = new Triangles
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    ColourLight = Color4.White,
+                    ColourDark = Color4.Gray
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AddSliderStep("Triangle scale", 0f, 10f, 1f, s => triangles.TriangleScale = s);
+        }
+    }
+}

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -177,7 +177,9 @@ namespace osu.Game.Graphics.Backgrounds
 
             AimCount = (int)Math.Min(max_triangles, DrawWidth * DrawHeight * 0.002f / (TriangleScale * TriangleScale) * SpawnRatio);
 
-            for (int i = 0; i < AimCount - parts.Count; i++)
+            int currentCount = parts.Count;
+
+            for (int i = 0; i < AimCount - currentCount; i++)
                 parts.Add(createTriangle(randomY));
         }
 

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Graphics.Backgrounds
         private const float base_velocity = 50;
 
         /// <summary>
+        /// sqrt(3) / 2
+        /// </summary>
+        private const float equilateral_triangle_ratio = 0.866f;
+
+        /// <summary>
         /// How many screen-space pixels are smoothed over.
         /// Same behavior as Sprite's EdgeSmoothness.
         /// </summary>
@@ -149,7 +154,7 @@ namespace osu.Game.Graphics.Backgrounds
 
                 parts[i] = newParticle;
 
-                float bottomPos = parts[i].Position.Y + triangle_size * parts[i].Scale * 0.866f / DrawHeight;
+                float bottomPos = parts[i].Position.Y + triangle_size * parts[i].Scale * equilateral_triangle_ratio / DrawHeight;
                 if (bottomPos < 0)
                     parts.RemoveAt(i);
             }
@@ -201,7 +206,7 @@ namespace osu.Game.Graphics.Backgrounds
             if (randomY)
             {
                 // since triangles are drawn from the top - allow them to be positioned a bit above the screen
-                float maxOffset = triangle_size * scale * 0.866f / DrawHeight;
+                float maxOffset = triangle_size * scale * equilateral_triangle_ratio / DrawHeight;
                 y = Interpolation.ValueAt(nextRandom(), -maxOffset, 1f, 0f, 1f);
             }
 
@@ -290,7 +295,7 @@ namespace osu.Game.Graphics.Backgrounds
 
                 foreach (TriangleParticle particle in parts)
                 {
-                    var offset = triangle_size * new Vector2(particle.Scale * 0.5f, particle.Scale * 0.866f);
+                    var offset = triangle_size * new Vector2(particle.Scale * 0.5f, particle.Scale * equilateral_triangle_ratio);
 
                     var triangle = new Triangle(
                         Vector2Extensions.Transform(particle.Position * size, DrawInfo.Matrix),

--- a/osu.Game/Graphics/Backgrounds/Triangles.cs
+++ b/osu.Game/Graphics/Backgrounds/Triangles.cs
@@ -187,11 +187,25 @@ namespace osu.Game.Graphics.Backgrounds
         {
             TriangleParticle particle = CreateTriangle();
 
-            particle.Position = new Vector2(nextRandom(), randomY ? nextRandom() : 1);
+            particle.Position = getRandomPosition(randomY, particle.Scale);
             particle.ColourShade = nextRandom();
             particle.Colour = CreateTriangleShade(particle.ColourShade);
 
             return particle;
+        }
+
+        private Vector2 getRandomPosition(bool randomY, float scale)
+        {
+            float y = 1;
+
+            if (randomY)
+            {
+                // since triangles are drawn from the top - allow them to be positioned a bit above the screen
+                float maxOffset = triangle_size * scale * 0.866f / DrawHeight;
+                y = Interpolation.ValueAt(nextRandom(), -maxOffset, 1f, 0f, 1f);
+            }
+
+            return new Vector2(nextRandom(), y);
         }
 
         /// <summary>


### PR DESCRIPTION
* **Fixed changing triangle scale may cause big problems**
Previously changing the scale was not causing `AimCount` to recompute, which could cause big problems when changing the scale of already drawn triangles. Example: set scale to something small, so there are thousands of triangles being drawn, then increase the scale. Now we have thousands of big triangles rendered, which causes massive performance drop.
* **Fixed incorrect number of added triangles**
This is was caused by a small overlook which caused half of needed triangles being drawn on first frame which leaded to other half to be added on the second one and looked as a bias in random function.
* **Improved triangles distribution on initial draw**

Each fix is it's own commit, should be pretty straightforward to review.