### PR TITLE
Move "keybindings" keyword to correct section

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/BindingSettings.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Localisation;
@@ -12,6 +14,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     public class BindingSettings : SettingsSubsection
     {
         protected override LocalisableString Header => BindingSettingsStrings.ShortcutAndGameplayBindings;
+
+        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { "keybindings" });
 
         public BindingSettings(KeyBindingPanel keyConfig)
         {

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -21,8 +19,6 @@ namespace osu.Game.Overlays.Settings.Sections
         private readonly KeyBindingPanel keyConfig;
 
         public override LocalisableString Header => InputSettingsStrings.InputSectionHeader;
-
-        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { "keybindings" });
 
         public override Drawable CreateIcon() => new SpriteIcon
         {


### PR DESCRIPTION
Without this, things like tablet settings would show when searching for bindings, even though these settings have nothing to do with key bindings.