### PR TITLE
Eagerly dispose of triangles intro textures to avoid holding for full length of game session

### DIFF
--- a/osu.Game/Screens/Menu/IntroTriangles.cs
+++ b/osu.Game/Screens/Menu/IntroTriangles.cs
@@ -224,8 +224,8 @@ namespace osu.Game.Screens.Menu
                     {
                         rulesetsScale.ScaleTo(0.8f, 1000);
                         rulesets.FadeIn().ScaleTo(1).TransformSpacingTo(new Vector2(200, 0));
-                        welcomeText.FadeOut();
-                        triangles.FadeOut();
+                        welcomeText.FadeOut().Expire();
+                        triangles.FadeOut().Expire();
                     }
 
                     using (BeginDelayedSequence(rulesets_2))
@@ -307,7 +307,7 @@ namespace osu.Game.Screens.Menu
                 }
 
                 [BackgroundDependencyLoader]
-                private void load(TextureStore textures)
+                private void load(LargeTextureStore textures)
                 {
                     InternalChildren = new Drawable[]
                     {


### PR DESCRIPTION
`IntroTriangles` itself should be disposed and handle this (via `Expire` in `OnSuspending`) but it turns out there's a chance that won't happen. This give the game more chance to clean up early.

Also I think the case of texture retrieval from `TextureStore.Get` where it bypassing atlasing is broken. I've switched to `LargeTextureStore` here as it makes more sense for this usage, but I'll double-check the framework side implementation as a separate effort.