### PR TITLE
Reduce unnecessary texture overhead incurred by beatmap listing

### DIFF
--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -287,7 +287,7 @@ namespace osu.Game.Overlays
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(LargeTextureStore textures)
             {
                 AddInternal(new FillFlowContainer
                 {
@@ -332,7 +332,7 @@ namespace osu.Game.Overlays
             }
 
             [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
+            private void load(LargeTextureStore textures)
             {
                 AddInternal(new FillFlowContainer
                 {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -147,8 +147,7 @@ namespace osu.Game.Overlays
 
             if (searchResult.Type == BeatmapListingFilterControl.SearchResultType.SupporterOnlyFilters)
             {
-                var supporterOnly = new SupporterRequiredDrawable();
-                supporterOnly.UpdateText(searchResult.SupporterOnlyFiltersUsed);
+                var supporterOnly = new SupporterRequiredDrawable(searchResult.SupporterOnlyFiltersUsed);
                 replaceResultsAreaContent(supporterOnly);
                 return;
             }
@@ -297,11 +296,15 @@ namespace osu.Game.Overlays
         {
             private LinkFlowContainer supporterRequiredText;
 
-            public SupporterRequiredDrawable()
+            private readonly List<LocalisableString> filtersUsed;
+
+            public SupporterRequiredDrawable(List<LocalisableString> filtersUsed)
             {
                 RelativeSizeAxes = Axes.X;
                 Height = 225;
                 Alpha = 0;
+
+                this.filtersUsed = filtersUsed;
             }
 
             [BackgroundDependencyLoader]
@@ -333,14 +336,9 @@ namespace osu.Game.Overlays
                         },
                     }
                 });
-            }
-
-            public void UpdateText(List<LocalisableString> filters)
-            {
-                supporterRequiredText.Clear();
 
                 supporterRequiredText.AddText(
-                    BeatmapsStrings.ListingSearchSupporterFilterQuoteDefault(string.Join(" and ", filters), "").ToString(),
+                    BeatmapsStrings.ListingSearchSupporterFilterQuoteDefault(string.Join(" and ", filtersUsed), "").ToString(),
                     t =>
                     {
                         t.Font = OsuFont.GetFont(size: 16);


### PR DESCRIPTION
The two placeholder textures were loaded at startup, even though there's a chance they would never be used.

This simplifies the content update flow and also fixes the issue.