### PR TITLE
Fix entering gameplay while network connection is in a bad state taking too long

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -419,7 +419,7 @@ namespace osu.Game.Online.API
             failureCount++;
             log.Add($@"API failure count is now {failureCount}");
 
-            if (failureCount >= 3 && State.Value == APIState.Online)
+            if (failureCount >= 3)
             {
                 state.Value = APIState.Failing;
                 flushQueue();

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Play
             api.Queue(req);
 
             // Generally a timeout would not happen here as APIAccess will timeout first.
-            if (!tcs.Task.Wait(60000))
+            if (!tcs.Task.Wait(30000))
                 req.TriggerFailure(new InvalidOperationException("Token retrieval timed out (request never run)"));
 
             return true;


### PR DESCRIPTION
Addresses concerns in https://github.com/ppy/osu/discussions/21241.

Can be tested using this patch:

```diff
diff --git a/osu.Game/Online/DevelopmentEndpointConfiguration.cs b/osu.Game/Online/DevelopmentEndpointConfiguration.cs
index 3171d15fc2..6966a35c5b 100644
--- a/osu.Game/Online/DevelopmentEndpointConfiguration.cs
+++ b/osu.Game/Online/DevelopmentEndpointConfiguration.cs
@@ -9,7 +9,7 @@ public class DevelopmentEndpointConfiguration : EndpointConfiguration
     {
         public DevelopmentEndpointConfiguration()
         {
-            WebsiteRootUrl = APIEndpointUrl = @"https://dev.ppy.sh";
+            WebsiteRootUrl = APIEndpointUrl = @"https://wang";
             APIClientSecret = @"3LP2mhUrV89xxzD1YKNndXHEhWWCRLPNKioZ9ymT";
             APIClientID = "5";
             SpectatorEndpointUrl = $"{APIEndpointUrl}/spectator";

```