### PR TITLE
Fix timeline potentially scrolling at extents while not dragging

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -436,8 +436,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 base.OnDragEnd(e);
 
-                OnDragHandled?.Invoke(null);
+                dragOperation?.Cancel();
+                dragOperation = null;
+
                 changeHandler?.EndChange();
+                OnDragHandled?.Invoke(null);
             }
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21260

When ending drag at the same frame a drag is performed, there's a chance for the scheduled delegate to execute after `OnDragEnd`, thus making the timeline stuck in scrolling mode.