### PR TITLE
Fix "perform from screen" invoking action on non-loaded screens

### DIFF
--- a/osu.Game/PerformFromMenuRunner.cs
+++ b/osu.Game/PerformFromMenuRunner.cs
@@ -89,6 +89,10 @@ namespace osu.Game
             // check if we are already at a valid target screen.
             if (validScreens.Any(t => t.IsAssignableFrom(type)))
             {
+                if (!((Drawable)current).IsLoaded)
+                    // wait until screen is loaded before invoking action.
+                    return true;
+
                 finalAction(current);
                 Cancel();
                 return true;


### PR DESCRIPTION
- Addresses test failure in https://github.com/ppy/osu/actions/runs/3496799455/jobs/5855136468#step:5:358

Can be reproduced with a simple delay in `MainMenu` BDL, i.e.:
```diff
diff --git a/osu.Game/Screens/Menu/MainMenu.cs b/osu.Game/Screens/Menu/MainMenu.cs
index 0071ada05a..7b833a3f37 100644
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -97,6 +98,8 @@ private void load(BeatmapListingOverlay beatmapListing, SettingsOverlay settings
                 });
             }
 
+            Thread.Sleep(5000);
+
             AddRangeInternal(new[]
             {
                 buttonsContainer = new ParallaxContainer
```