### PR TITLE
Rework BarGraph to use Quads

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -32,6 +33,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("values from 1-10", () => graph.Values = Enumerable.Range(1, 10).Select(i => (float)i));
             AddStep("values from 1-100", () => graph.Values = Enumerable.Range(1, 100).Select(i => (float)i));
             AddStep("reversed values from 1-10", () => graph.Values = Enumerable.Range(1, 10).Reverse().Select(i => (float)i));
+            AddStep("empty values", () => graph.Values = Array.Empty<float>());
             AddStep("Bottom to top", () => graph.Direction = BarDirection.BottomToTop);
             AddStep("Top to bottom", () => graph.Direction = BarDirection.TopToBottom);
             AddStep("Left to right", () => graph.Direction = BarDirection.LeftToRight);

--- a/osu.Game/Graphics/UserInterface/Bar.cs
+++ b/osu.Game/Graphics/UserInterface/Bar.cs
@@ -109,15 +109,11 @@ namespace osu.Game.Graphics.UserInterface
         }
     }
 
-    [Flags]
     public enum BarDirection
     {
-        LeftToRight = 1,
-        RightToLeft = 1 << 1,
-        TopToBottom = 1 << 2,
-        BottomToTop = 1 << 3,
-
-        Vertical = TopToBottom | BottomToTop,
-        Horizontal = LeftToRight | RightToLeft,
+        LeftToRight,
+        RightToLeft,
+        TopToBottom,
+        BottomToTop
     }
 }

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Graphics.UserInterface
                 if (size != 0)
                     size = 1.0f / size;
 
-                float maxLength = MaxValue ?? value.Max();
+                float maxLength = MaxValue ?? (newCount == 0 ? 0 : value.Max());
 
                 foreach (var bar in value.Select((length, index) => new { Value = length, Index = index }))
                 {

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -51,13 +51,18 @@ namespace osu.Game.Graphics.UserInterface
         {
             set
             {
+                if (!value.Any())
+                {
+                    bars.Clear();
+                    Invalidate(Invalidation.DrawNode);
+                    return;
+                }
+
                 int newCount = value.Count();
 
-                float size = newCount;
-                if (size != 0)
-                    size = 1.0f / size;
+                float size = 1.0f / newCount;
 
-                float maxLength = MaxValue ?? (newCount == 0 ? 0 : value.Max());
+                float maxLength = MaxValue ?? value.Max();
 
                 foreach (var bar in value.Select((length, index) => new { Value = length, Index = index }))
                 {

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private readonly List<BarStruct> bars = new List<BarStruct>();
+        private readonly List<BarInfo> bars = new List<BarInfo>();
 
         /// <summary>
         /// A list of floats that defines the length of each <see cref="Bar"/>
@@ -70,20 +70,20 @@ namespace osu.Game.Graphics.UserInterface
 
                     if (bar.Index < bars.Count)
                     {
-                        BarStruct b = bars[bar.Index];
+                        BarInfo b = bars[bar.Index];
 
-                        b.OldValue = b.Value;
-                        b.Value = length;
-                        b.ShortSide = size;
+                        b.InitialLength = b.FinalLength;
+                        b.FinalLength = length;
+                        b.Breadth = size;
 
                         bars[bar.Index] = b;
                     }
                     else
                     {
-                        bars.Add(new BarStruct
+                        bars.Add(new BarInfo
                         {
-                            Value = length,
-                            ShortSide = size
+                            FinalLength = length,
+                            Breadth = size
                         });
                     }
                 }
@@ -122,8 +122,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 for (int i = 0; i < bars.Count; i++)
                 {
-                    BarStruct bar = bars[i];
-                    bar.IntermediateValue = Interpolation.ValueAt(currentTime, bar.OldValue, bar.Value, animationStartTime, animationStartTime + resize_duration, easing);
+                    BarInfo bar = bars[i];
+                    bar.InstantaneousLength = Interpolation.ValueAt(currentTime, bar.InitialLength, bar.FinalLength, animationStartTime, animationStartTime + resize_duration, easing);
                     bars[i] = bar;
                 }
 
@@ -133,8 +133,8 @@ namespace osu.Game.Graphics.UserInterface
             {
                 for (int i = 0; i < bars.Count; i++)
                 {
-                    BarStruct bar = bars[i];
-                    bar.IntermediateValue = bar.Value;
+                    BarInfo bar = bars[i];
+                    bar.InstantaneousLength = bar.FinalLength;
                     bars[i] = bar;
                 }
 
@@ -160,7 +160,7 @@ namespace osu.Game.Graphics.UserInterface
             private Vector2 drawSize;
             private BarDirection direction;
 
-            private readonly List<BarStruct> bars = new List<BarStruct>();
+            private readonly List<BarInfo> bars = new List<BarInfo>();
 
             public override void ApplyState()
             {
@@ -188,8 +188,8 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     var bar = bars[i];
 
-                    float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? bar.IntermediateValue : bar.ShortSide);
-                    float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? bar.IntermediateValue : bar.ShortSide);
+                    float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? bar.InstantaneousLength : bar.Breadth);
+                    float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? bar.InstantaneousLength : bar.Breadth);
 
                     Vector2 topLeft;
 
@@ -231,12 +231,12 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private struct BarStruct
+        private struct BarInfo
         {
-            public float OldValue { get; set; }
-            public float Value { get; set; }
-            public float IntermediateValue { get; set; }
-            public float ShortSide { get; set; }
+            public float InitialLength { get; set; }
+            public float FinalLength { get; set; }
+            public float InstantaneousLength { get; set; }
+            public float Breadth { get; set; }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -5,15 +5,23 @@
 
 using osuTK;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Utils;
+using System;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public class BarGraph : FillFlowContainer<Bar>
+    public class BarGraph : Drawable
     {
+        private const int resize_duration = 250;
+        private const Easing easing = Easing.InOutCubic;
+
         /// <summary>
         /// Manually sets the max value, if null <see cref="Enumerable.Max(IEnumerable{float})"/> is instead used
         /// </summary>
@@ -21,21 +29,20 @@ namespace osu.Game.Graphics.UserInterface
 
         private BarDirection direction = BarDirection.BottomToTop;
 
-        public new BarDirection Direction
+        public BarDirection Direction
         {
             get => direction;
             set
             {
-                direction = value;
-                base.Direction = direction.HasFlagFast(BarDirection.Horizontal) ? FillDirection.Vertical : FillDirection.Horizontal;
+                if (direction == value)
+                    return;
 
-                foreach (var bar in Children)
-                {
-                    bar.Size = direction.HasFlagFast(BarDirection.Horizontal) ? new Vector2(1, 1.0f / Children.Count) : new Vector2(1.0f / Children.Count, 1);
-                    bar.Direction = direction;
-                }
+                direction = value;
+                Invalidate(Invalidation.DrawNode);
             }
         }
+
+        private IEnumerable<BarDescriptor> bars;
 
         /// <summary>
         /// A list of floats that defines the length of each <see cref="Bar"/>
@@ -44,38 +51,188 @@ namespace osu.Game.Graphics.UserInterface
         {
             set
             {
-                List<Bar> bars = Children.ToList();
+                List<BarDescriptor> newBars = bars?.ToList() ?? new List<BarDescriptor>();
 
-                foreach (var bar in value.Select((length, index) => new { Value = length, Bar = bars.Count > index ? bars[index] : null }))
+                int newCount = value.Count();
+
+                float size = newCount;
+                if (size != 0)
+                    size = 1.0f / size;
+
+                foreach (var bar in value.Select((length, index) => new { Value = length, Bar = newBars.Count > index ? newBars[index] : null }))
                 {
                     float length = MaxValue ?? value.Max();
                     if (length != 0)
-                        length = bar.Value / length;
-
-                    float size = value.Count();
-                    if (size != 0)
-                        size = 1.0f / size;
+                        length = Math.Max(0f, bar.Value / length);
 
                     if (bar.Bar != null)
                     {
-                        bar.Bar.Length = length;
-                        bar.Bar.Size = direction.HasFlagFast(BarDirection.Horizontal) ? new Vector2(1, size) : new Vector2(size, 1);
+                        bar.Bar.OldValue = bar.Bar.Value;
+
+                        bar.Bar.Value = length;
+                        bar.Bar.ShortSide = size;
                     }
                     else
                     {
-                        Add(new Bar
+                        newBars.Add(new BarDescriptor
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = direction.HasFlagFast(BarDirection.Horizontal) ? new Vector2(1, size) : new Vector2(size, 1),
-                            Length = length,
-                            Direction = Direction,
+                            Value = length,
+                            ShortSide = size
                         });
                     }
                 }
 
-                //I'm using ToList() here because Where() returns an Enumerable which can change it's elements afterwards
-                RemoveRange(Children.Where((_, index) => index >= value.Count()).ToList(), true);
+                if (newBars.Count > newCount)
+                    newBars.RemoveRange(newCount, newBars.Count - newCount);
+
+                bars = newBars;
+
+                animationStartTime = Clock.CurrentTime;
+                animationComplete = false;
             }
+        }
+
+        private double animationStartTime;
+        private bool animationComplete;
+
+        private IShader shader = null!;
+        private Texture texture = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(IRenderer renderer, ShaderManager shaders)
+        {
+            texture = renderer.WhitePixel;
+            shader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (noBars)
+                return;
+
+            double currentTime = Clock.CurrentTime;
+
+            if (currentTime < animationStartTime + resize_duration)
+            {
+                foreach (var bar in bars)
+                    bar.IntermediateValue = Interpolation.ValueAt(currentTime, bar.OldValue, bar.Value, animationStartTime, animationStartTime + resize_duration, easing);
+
+                Invalidate(Invalidation.DrawNode);
+                return;
+            }
+            else if (!animationComplete)
+            {
+                foreach (var bar in bars)
+                    bar.IntermediateValue = bar.Value;
+
+                Invalidate(Invalidation.DrawNode);
+
+                animationComplete = true;
+                return;
+            }
+        }
+
+        private bool noBars => bars?.Any() != true;
+
+        protected override DrawNode CreateDrawNode() => new BarGraphDrawNode(this);
+
+        private class BarGraphDrawNode : DrawNode
+        {
+            public new BarGraph Source => (BarGraph)base.Source;
+
+            public BarGraphDrawNode(BarGraph source)
+                : base(source)
+            {
+            }
+
+            private IShader shader = null!;
+            private Texture texture = null!;
+            private Vector2 drawSize;
+            private BarDirection direction;
+
+            private readonly List<BarDescriptor> bars = new List<BarDescriptor>();
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                shader = Source.shader;
+                texture = Source.texture;
+                drawSize = Source.DrawSize;
+                direction = Source.direction;
+
+                bars.Clear();
+
+                if (Source.noBars)
+                    return;
+
+                bars.AddRange(Source.bars);
+            }
+
+            public override void Draw(IRenderer renderer)
+            {
+                base.Draw(renderer);
+
+                if (!bars.Any())
+                    return;
+
+                shader.Bind();
+
+                for (int i = 0; i < bars.Count; i++)
+                {
+                    var bar = bars[i];
+
+                    float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? bar.IntermediateValue : bar.ShortSide);
+                    float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? bar.IntermediateValue : bar.ShortSide);
+
+                    Vector2 topLeft;
+
+                    switch (direction)
+                    {
+                        default:
+                        case BarDirection.LeftToRight:
+                            topLeft = new Vector2(0, i * barHeight);
+                            break;
+
+                        case BarDirection.RightToLeft:
+                            topLeft = new Vector2(drawSize.X - barWidth, i * barHeight);
+                            break;
+
+                        case BarDirection.TopToBottom:
+                            topLeft = new Vector2(i * barWidth, 0);
+                            break;
+
+                        case BarDirection.BottomToTop:
+                            topLeft = new Vector2(i * barWidth, drawSize.Y - barHeight);
+                            break;
+                    }
+
+                    Vector2 topRight = topLeft + new Vector2(barWidth, 0);
+                    Vector2 bottomLeft = topLeft + new Vector2(0, barHeight);
+                    Vector2 bottomRight = bottomLeft + new Vector2(barWidth, 0);
+
+                    var drawQuad = new Quad(
+                        Vector2Extensions.Transform(topLeft, DrawInfo.Matrix),
+                        Vector2Extensions.Transform(topRight, DrawInfo.Matrix),
+                        Vector2Extensions.Transform(bottomLeft, DrawInfo.Matrix),
+                        Vector2Extensions.Transform(bottomRight, DrawInfo.Matrix)
+                    );
+
+                    renderer.DrawQuad(texture, drawQuad, DrawColourInfo.Colour);
+                }
+
+                shader.Unbind();
+            }
+        }
+
+        private class BarDescriptor
+        {
+            public float OldValue { get; set; }
+            public float Value { get; set; }
+            public float IntermediateValue { get; set; }
+            public float ShortSide { get; set; }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -120,7 +120,6 @@ namespace osu.Game.Graphics.UserInterface
                     bar.IntermediateValue = Interpolation.ValueAt(currentTime, bar.OldValue, bar.Value, animationStartTime, animationStartTime + resize_duration, easing);
 
                 Invalidate(Invalidation.DrawNode);
-                return;
             }
             else if (!animationComplete)
             {
@@ -130,7 +129,6 @@ namespace osu.Game.Graphics.UserInterface
                 Invalidate(Invalidation.DrawNode);
 
                 animationComplete = true;
-                return;
             }
         }
 

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterface
 
             if (currentTime < animationStartTime + resize_duration)
             {
-                for (int i = 0; i < bars.Count(); i++)
+                for (int i = 0; i < bars.Count; i++)
                 {
                     BarStruct bar = bars[i];
                     bar.IntermediateValue = Interpolation.ValueAt(currentTime, bar.OldValue, bar.Value, animationStartTime, animationStartTime + resize_duration, easing);
@@ -126,7 +126,7 @@ namespace osu.Game.Graphics.UserInterface
             }
             else if (!animationComplete)
             {
-                for (int i = 0; i < bars.Count(); i++)
+                for (int i = 0; i < bars.Count; i++)
                 {
                     BarStruct bar = bars[i];
                     bar.IntermediateValue = bar.Value;

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -203,9 +203,9 @@ namespace osu.Game.Graphics.UserInterface
 
         private struct BarsInfo
         {
-            private readonly List<float> initialLengths;
-            private readonly List<float> finalLengths;
-            private readonly List<float> instantaneousLengths;
+            private List<float> initialLengths;
+            private List<float> finalLengths;
+            private List<float> instantaneousLengths;
 
             public bool Any => initialLengths.Any();
 

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         private readonly List<BarInfo> bars = new List<BarInfo>();
+        private float barBreadth;
 
         /// <summary>
         /// A list of floats that defines the length of each <see cref="Bar"/>
@@ -60,7 +61,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 int newCount = value.Count();
 
-                float size = 1.0f / newCount;
+                barBreadth = 1.0f / newCount;
 
                 float maxLength = MaxValue ?? value.Max();
 
@@ -74,18 +75,12 @@ namespace osu.Game.Graphics.UserInterface
 
                         b.InitialLength = b.FinalLength;
                         b.FinalLength = length;
-                        b.Breadth = size;
 
                         bars[bar.Index] = b;
+                        continue;
                     }
-                    else
-                    {
-                        bars.Add(new BarInfo
-                        {
-                            FinalLength = length,
-                            Breadth = size
-                        });
-                    }
+
+                    bars.Add(new BarInfo { FinalLength = length });
                 }
 
                 if (bars.Count > newCount)
@@ -159,6 +154,7 @@ namespace osu.Game.Graphics.UserInterface
             private Texture texture = null!;
             private Vector2 drawSize;
             private BarDirection direction;
+            private float barBreadth;
 
             private readonly List<BarInfo> bars = new List<BarInfo>();
 
@@ -170,6 +166,7 @@ namespace osu.Game.Graphics.UserInterface
                 texture = Source.texture;
                 drawSize = Source.DrawSize;
                 direction = Source.direction;
+                barBreadth = Source.barBreadth;
 
                 bars.Clear();
                 bars.AddRange(Source.bars);
@@ -188,8 +185,8 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     var bar = bars[i];
 
-                    float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? bar.InstantaneousLength : bar.Breadth);
-                    float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? bar.InstantaneousLength : bar.Breadth);
+                    float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? bar.InstantaneousLength : barBreadth);
+                    float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? bar.InstantaneousLength : barBreadth);
 
                     Vector2 topLeft;
 
@@ -236,7 +233,6 @@ namespace osu.Game.Graphics.UserInterface
             public float InitialLength { get; set; }
             public float FinalLength { get; set; }
             public float InstantaneousLength { get; set; }
-            public float Breadth { get; set; }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private readonly BarsInfo bars = new BarsInfo(0);
+        private BarsInfo bars = new BarsInfo(0);
 
         private float barBreadth;
 
@@ -201,11 +201,11 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private struct BarsInfo
+        private readonly struct BarsInfo
         {
-            private List<float> initialLengths;
-            private List<float> finalLengths;
-            private List<float> instantaneousLengths;
+            private readonly List<float> initialLengths;
+            private readonly List<float> finalLengths;
+            private readonly List<float> instantaneousLengths;
 
             public bool Any => initialLengths.Any();
 

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 float maxLength = MaxValue ?? value.Max();
 
-                foreach (var bar in value.Select((length, index) => new { Value = length, Index = index }))
+                foreach (var bar in value.Select((length, index) => (Value: length, Index: index)))
                 {
                     float length = maxLength == 0 ? 0 : Math.Max(0f, bar.Value / maxLength);
 


### PR DESCRIPTION
`BarDirection` enum has been adjusted since `Vertical` and `Horizontal` flags weren't working as expected in my case for some reason. Felt safe to adjust since it was a single usage of these flags.

Old
![old](https://user-images.githubusercontent.com/22874522/202807093-b730d8c3-b891-4318-abe5-b38077f5b07b.png)
New
![new](https://user-images.githubusercontent.com/22874522/202807176-4afdc250-e38f-4778-bc80-26b8adf7d707.png)

Gained ~30 fps in song-select with gtx960