### PR TITLE
Hide scroll speed control from effects section on rulesets which don't support it

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -3,14 +3,15 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
-using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Timing;
 using osu.Game.Screens.Edit.Timing.RowAttributes;
@@ -21,10 +22,6 @@ namespace osu.Game.Tests.Visual.Editing
     [TestFixture]
     public class TestSceneTimingScreen : EditorClockTestScene
     {
-        [Cached(typeof(EditorBeatmap))]
-        [Cached(typeof(IBeatSnapProvider))]
-        private readonly EditorBeatmap editorBeatmap;
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
@@ -32,21 +29,27 @@ namespace osu.Game.Tests.Visual.Editing
 
         protected override bool ScrollUsingMouseWheel => false;
 
-        public TestSceneTimingScreen()
-        {
-            editorBeatmap = new EditorBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            Beatmap.Value = CreateWorkingBeatmap(editorBeatmap.PlayableBeatmap);
+            Beatmap.Value = CreateWorkingBeatmap(Ruleset.Value);
             Beatmap.Disabled = true;
 
-            Child = timingScreen = new TimingScreen
+            var editorBeatmap = new EditorBeatmap(Beatmap.Value.GetPlayableBeatmap(Ruleset.Value));
+
+            Child = new DependencyProvidingContainer
             {
-                State = { Value = Visibility.Visible },
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies = new (Type, object)[]
+                {
+                    (typeof(EditorBeatmap), editorBeatmap),
+                    (typeof(IBeatSnapProvider), editorBeatmap)
+                },
+                Child = timingScreen = new TimingScreen
+                {
+                    State = { Value = Visibility.Visible },
+                },
             };
         }
 

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
     /// A type of <see cref="DrawableRuleset{TObject}"/> that supports a <see cref="ScrollingPlayfield"/>.
     /// <see cref="HitObject"/>s inside this <see cref="DrawableRuleset{TObject}"/> will scroll within the playfield.
     /// </summary>
-    public abstract class DrawableScrollingRuleset<TObject> : DrawableRuleset<TObject>, IKeyBindingHandler<GlobalAction>
+    public abstract class DrawableScrollingRuleset<TObject> : DrawableRuleset<TObject>, IDrawableScrollingRuleset, IKeyBindingHandler<GlobalAction>
         where TObject : HitObject
     {
         /// <summary>
@@ -65,6 +65,8 @@ namespace osu.Game.Rulesets.UI.Scrolling
         };
 
         protected virtual ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Sequential;
+
+        ScrollVisualisationMethod IDrawableScrollingRuleset.VisualisationMethod => VisualisationMethod;
 
         /// <summary>
         /// Whether the player can change <see cref="TimeRange"/>.

--- a/osu.Game/Rulesets/UI/Scrolling/IDrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/IDrawableScrollingRuleset.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.UI.Scrolling

--- a/osu.Game/Rulesets/UI/Scrolling/IDrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/IDrawableScrollingRuleset.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using osu.Game.Configuration;
+
+namespace osu.Game.Rulesets.UI.Scrolling
+{
+    /// <summary>
+    /// An interface for scrolling-based <see cref="DrawableRuleset{TObject}"/>s.
+    /// </summary>
+    public interface IDrawableScrollingRuleset
+    {
+        ScrollVisualisationMethod VisualisationMethod { get; }
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Screens.Edit.Timing
 {
@@ -40,6 +41,12 @@ namespace osu.Game.Screens.Edit.Timing
             kiai.Current.BindValueChanged(_ => saveChanges());
             omitBarLine.Current.BindValueChanged(_ => saveChanges());
             scrollSpeedSlider.Current.BindValueChanged(_ => saveChanges());
+
+            // adjusting scroll speed on osu/catch rulesets results in undefined behaviour during legacy beatmap decoding, and generally shouldn't be shown.
+            // todo: there should be proper way to identify such rulesets, but this should do for now.
+            var ruleset = Beatmap.BeatmapInfo.Ruleset;
+            if (ruleset.OnlineID == 0 || ruleset.OnlineID == 2)
+                scrollSpeedSlider.Hide();
 
             void saveChanges()
             {

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.UserInterfaceV2;
-using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Screens.Edit.Timing
 {

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -7,7 +7,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Screens.Edit.Timing
 {
@@ -41,10 +43,8 @@ namespace osu.Game.Screens.Edit.Timing
             omitBarLine.Current.BindValueChanged(_ => saveChanges());
             scrollSpeedSlider.Current.BindValueChanged(_ => saveChanges());
 
-            // adjusting scroll speed on osu/catch rulesets results in undefined behaviour during legacy beatmap decoding, and generally shouldn't be shown.
-            // todo: there should be proper way to identify such rulesets, but this should do for now.
-            var ruleset = Beatmap.BeatmapInfo.Ruleset;
-            if (ruleset.OnlineID == 0 || ruleset.OnlineID == 2)
+            var drawableRuleset = Beatmap.BeatmapInfo.Ruleset.CreateInstance().CreateDrawableRulesetWith(Beatmap.PlayableBeatmap);
+            if (drawableRuleset is not IDrawableScrollingRuleset scrollingRuleset || scrollingRuleset.VisualisationMethod == ScrollVisualisationMethod.Constant)
                 scrollSpeedSlider.Hide();
 
             void saveChanges()


### PR DESCRIPTION
- Closes #21139 

Scroll speed is also no-op on catch rulesets, as they use the "constant" scrolling algorithm, which ignores this value.