### PR TITLE
Fix phantom beatmap sets appearing on carousel after delete/update

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -116,6 +117,15 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 checkSelectionIsCentered();
             }
+        }
+
+        [Test]
+        public void TestDeletion()
+        {
+            loadBeatmaps(count: 5, randomDifficulties: true);
+
+            AddStep("remove first set", () => carousel.RemoveBeatmapSet(carousel.Items.Select(item => item.Item).OfType<CarouselBeatmapSet>().First().BeatmapSet));
+            AddUntilStep("4 beatmap sets visible", () => this.ChildrenOfType<DrawableCarouselBeatmapSet>().Count(set => set.Alpha > 0) == 4);
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -770,7 +770,7 @@ namespace osu.Game.Screens.Select
             {
                 updateItem(item);
 
-                if (!item.Item.Filtered.Value)
+                if (item.Item.Visible)
                 {
                     bool isSelected = item.Item.State.Value == CarouselItemState.Selected;
 


### PR DESCRIPTION
Closes #21272.

Regressed in c40c70509e1909fab2488120c9e867cb76f66827.

As it turns out, `item.Item.Filtered.Value` is not the only condition that should be checked to determine if a carousel item should be hidden or not - `item.Item.State.Value != CarouselItemState.Collapsed` should also be true. This was even available as the `item.Item.Visible` convenience property, which is used in this PR.

Failing to check `item.Item.State.Value` led to setting non-zero alpha on collapsed carousel items, leading to phantom beatmap sets appearing, as the alpha was set in the entire carousel's `Update()` method, thus firing every frame.