### PR TITLE
Improve UI scaling on iOS devices

### DIFF
--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -37,7 +38,7 @@ namespace osu.Game.Graphics.Containers
 
         private Bindable<ScalingMode> scalingMode;
 
-        private readonly Container content;
+        private readonly DrawSizePreservingFillContainer content;
         protected override Container<Drawable> Content => content;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
@@ -143,6 +144,10 @@ namespace osu.Game.Graphics.Containers
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            // for mobile platforms, enforcing 2x scale globally fits well rather than using 1024x768 as target size.
+            if (RuntimeInfo.IsMobile)
+                content.TargetDrawSize = targetMode == ScalingMode.Everything ? DrawSize / 2f : DrawSize;
 
             updateSize();
             sizableContainer.FinishTransforms();

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -147,10 +146,6 @@ namespace osu.Game.Graphics.Containers
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            // for mobile platforms, enforcing 2x scale globally fits well rather than using 1024x768 as target size.
-            if (RuntimeInfo.IsMobile)
-                content.TargetDrawSize = targetMode == ScalingMode.Everything ? DrawSize / 2f : DrawSize;
 
             updateSize();
             sizableContainer.FinishTransforms();

--- a/osu.Game/Graphics/Containers/ScalingContainer.cs
+++ b/osu.Game/Graphics/Containers/ScalingContainer.cs
@@ -116,6 +116,9 @@ namespace osu.Game.Graphics.Containers
             }
         }
 
+        [Resolved]
+        private OsuGameBase game { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, ISafeArea safeArea)
         {
@@ -151,6 +154,12 @@ namespace osu.Game.Graphics.Containers
 
             updateSize();
             sizableContainer.FinishTransforms();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            content.TargetDrawSize = game.TargetDrawSize;
         }
 
         private bool requiresBackgroundVisible => (scalingMode.Value == ScalingMode.Everything || scalingMode.Value == ScalingMode.ExcludeOverlays) && (sizeX.Value != 1 || sizeY.Value != 1);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -58,6 +58,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Utils;
+using osuTK;
 using File = System.IO.File;
 using RuntimeInfo = osu.Framework.RuntimeInfo;
 
@@ -528,7 +529,12 @@ namespace osu.Game
 
         protected virtual BatteryInfo CreateBatteryInfo() => null;
 
-        protected virtual Container CreateScalingContainer() => new DrawSizePreservingFillContainer();
+        /// <summary>
+        /// The size at which all game elements would be laid out at, then scaled to the window resolution using the scaling container specified in <see cref="CreateScalingContainer"/>.
+        /// </summary>
+        protected internal virtual Vector2 TargetDrawSize => new Vector2(1024, 768);
+
+        protected virtual Container CreateScalingContainer() => new DrawSizePreservingFillContainer { TargetDrawSize = TargetDrawSize };
 
         protected override Storage CreateStorage(GameHost host, Storage defaultStorage) => new OsuStorage(host, defaultStorage);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -204,6 +204,8 @@ namespace osu.Game
 
         protected SafeAreaContainer SafeAreaContainer { get; private set; }
 
+        protected Container MainScalingContainer { get; private set; }
+
         /// <summary>
         /// For now, this is used as a source specifically for beat synced components.
         /// Going forward, it could potentially be used as the single source-of-truth for beatmap timing.
@@ -373,7 +375,7 @@ namespace osu.Game
             {
                 SafeAreaOverrideEdges = SafeAreaOverrideEdges,
                 RelativeSizeAxes = Axes.Both,
-                Child = CreateScalingContainer().WithChildren(new Drawable[]
+                Child = MainScalingContainer = CreateScalingContainer().WithChildren(new Drawable[]
                 {
                     (GlobalCursorDisplay = new GlobalCursorDisplay
                     {

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -13,6 +13,7 @@ using osu.Game;
 using osu.Game.Overlays.Settings;
 using osu.Game.Updater;
 using osu.Game.Utils;
+using osuTK;
 
 namespace osu.iOS
 {
@@ -20,14 +21,19 @@ namespace osu.iOS
     {
         public override Version AssemblyVersion => new Version(NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString());
 
-        protected override UpdateManager CreateUpdateManager() => new SimpleUpdateManager();
-
-        protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();
+        /// <summary>
+        /// For iOS devices, doubling the scale of all game elements fits well rather than using 1024x768 as target size (regardless of the device's DPI scale).
+        /// </summary>
+        protected override Vector2 TargetDrawSize => MainScalingContainer.DrawSize / 2f;
 
         protected override Edges SafeAreaOverrideEdges =>
             // iOS shows a home indicator at the bottom, and adds a safe area to account for this.
             // Because we have the home indicator (mostly) hidden we don't really care about drawing in this region.
             Edges.Bottom;
+
+        protected override UpdateManager CreateUpdateManager() => new SimpleUpdateManager();
+
+        protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();
 
         public override SettingsSubsection CreateSettingsSubsectionFor(InputHandler handler)
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/7012

Been playing around with this on my iPhone 12 and iOS simulators, and applying a general 2x scale makes the game looks pretty fitting on all iOS devices according to the simulator.

Before:
![CleanShot 2022-12-24 at 00 01 51](https://user-images.githubusercontent.com/22781491/209409543-2c6a5755-943c-4003-891a-33c48b95bc54.png)

After:
![CleanShot 2022-12-23 at 23 52 04](https://user-images.githubusercontent.com/22781491/209409550-bc62b1d0-1dce-40d5-8b79-25c8f618c51b.png)