### PR TITLE
Added PreferOriginalMetadataLanguage to FirstRunSetup

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
@@ -18,6 +18,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
 using osuTK;
 
 namespace osu.Game.Overlays.FirstRunSetup
@@ -26,7 +27,7 @@ namespace osu.Game.Overlays.FirstRunSetup
     public class ScreenWelcome : FirstRunSetupScreen
     {
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(FrameworkConfigManager frameworkConfig)
         {
             Content.Children = new Drawable[]
             {
@@ -51,6 +52,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                             },
                         },
                     }
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = GeneralSettingsStrings.PreferOriginalMetadataLanguage,
+                    Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowUnicode)
                 },
                 new LanguageSelectionFlow
                 {


### PR DESCRIPTION
closes #18617

![afbeelding](https://user-images.githubusercontent.com/75315940/202929382-01dbd97a-feae-48b5-8183-813a91bee16f.png)

Not 100% sure about the design of this but placing the setting below is a lot worse as you can't see it without scrolling. So i think this is the best solution. 