### PR TITLE
Add support for nonsquare smoke textures

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -52,11 +52,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
         protected Texture? Texture { get; set; }
 
-        private float radius => Texture?.DisplayWidth * 0.165f ?? 3;
+        private float height => Texture?.DisplayHeight * 0.165f ?? 3;
+
+        private float width => Texture?.DisplayWidth * 0.165f ?? 3;
 
         protected readonly List<SmokePoint> SmokePoints = new List<SmokePoint>();
 
-        private float pointInterval => radius * 7f / 8;
+        private float pointInterval => width * 7f / 8;
 
         private double smokeStartTime { get; set; } = double.MinValue;
 
@@ -179,7 +181,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             private readonly List<SmokePoint> points = new List<SmokePoint>();
             private IVertexBatch<TexturedVertex2D>? quadBatch;
-            private float radius;
+            private float width;
+            private float height;
             private Vector2 drawSize;
             private Texture? texture;
             private int rotationSeed;
@@ -202,7 +205,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
             {
                 base.ApplyState();
 
-                radius = Source.radius;
+                width = Source.width;
+                height = Source.height;
                 drawSize = Source.DrawSize;
                 texture = Source.Texture;
 
@@ -334,11 +338,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
                 var dir = PointDirection(point, index);
                 var ortho = dir.PerpendicularLeft;
+                dir *= scale * width;
+                ortho *= scale * height;
 
-                var localTopLeft = point.Position + (radius * scale * (-ortho - dir));
-                var localTopRight = point.Position + (radius * scale * (-ortho + dir));
-                var localBotLeft = point.Position + (radius * scale * (ortho - dir));
-                var localBotRight = point.Position + (radius * scale * (ortho + dir));
+                var localTopLeft = point.Position - ortho - dir;
+                var localTopRight = point.Position - ortho + dir;
+                var localBotLeft = point.Position + ortho - dir;
+                var localBotRight = point.Position + ortho + dir;
 
                 quadBatch.Add(new TexturedVertex2D
                 {


### PR DESCRIPTION
Closes #21331

Pretty straightforward, just use separate height/width instead of a single radius. Stable implementation (#20372) uses width for interval calculation (kinda weird, would've expected the diagonal), so I did the same here.
