### PR TITLE
Hide spinner ticks / bonus from results screen when not applicable to score

### DIFF
--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -296,6 +296,13 @@ namespace osu.Game.Scoring
                         break;
                     }
 
+                    case HitResult.LargeBonus:
+                    case HitResult.SmallBonus:
+                        if (MaximumStatistics.TryGetValue(r.result, out int count) && count > 0)
+                            yield return new HitResultDisplayStatistic(r.result, value, null, r.displayName);
+
+                        break;
+
                     case HitResult.SmallTickMiss:
                     case HitResult.LargeTickMiss:
                         break;


### PR DESCRIPTION
Addresses concerns in https://github.com/ppy/osu/discussions/21309.

Need confirmation that using `MaximumStatistics` here is okay. In the scenarios I've tested it seems to be.