### PR TITLE
Avoid crashing when a system audio device provides a `null` name

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioDevicesSettings.cs
@@ -59,7 +59,11 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
             // the dropdown. BASS does not give us a simple mechanism to select
             // specific audio devices in such a case anyways. Such
             // functionality would require involved OS-specific code.
-            dropdown.Items = deviceItems.Distinct().ToList();
+            dropdown.Items = deviceItems
+                             // Dropdown doesn't like null items. Somehow we are seeing some arrive here (see https://github.com/ppy/osu/issues/21271)
+                             .Where(i => i != null)
+                             .Distinct()
+                             .ToList();
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Going to be hard to track down what exactly is going on here, but I think this would be enough to at least stop the game from crashing. Since only one user has hit this in several years it will probably suffice (until the user wants to actually select that audio device).

Closes #21271.