### PR TITLE
Stop requesting messages as part of initial chat presence

### DIFF
--- a/osu.Game/Online/API/Requests/GetUpdatesRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUpdatesRequest.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Online.API.Requests
             var req = base.CreateWebRequest();
             if (channel != null) req.AddParameter(@"channel", channel.Id.ToString());
             req.AddParameter(@"since", since.ToString());
+            req.AddParameter(@"includes[]", "presence");
 
             return req;
         }

--- a/osu.Game/Online/API/Requests/GetUpdatesResponse.cs
+++ b/osu.Game/Online/API/Requests/GetUpdatesResponse.cs
@@ -16,5 +16,7 @@ namespace osu.Game.Online.API.Requests
 
         [JsonProperty]
         public List<Message> Messages;
+
+        // TODO: Handle Silences here (will need to add to includes[] in the request).
     }
 }

--- a/osu.Game/Online/Notifications/NotificationsClient.cs
+++ b/osu.Game/Online/Notifications/NotificationsClient.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Online.Notifications
 
         public override Task ConnectAsync(CancellationToken cancellationToken)
         {
-            API.Queue(CreateFetchMessagesRequest(0));
+            API.Queue(CreateInitialFetchRequest(0));
             return Task.CompletedTask;
         }
 
-        protected APIRequest CreateFetchMessagesRequest(long? lastMessageId = null)
+        protected APIRequest CreateInitialFetchRequest(long? lastMessageId = null)
         {
             var fetchReq = new GetUpdatesRequest(lastMessageId ?? this.lastMessageId);
 

--- a/osu.Game/Online/Notifications/NotificationsClient.cs
+++ b/osu.Game/Online/Notifications/NotificationsClient.cs
@@ -67,8 +67,11 @@ namespace osu.Game.Online.Notifications
 
         protected void HandleChannelParted(Channel channel) => ChannelParted?.Invoke(channel);
 
-        protected void HandleMessages(List<Message> messages)
+        protected void HandleMessages(List<Message>? messages)
         {
+            if (messages == null)
+                return;
+
             NewMessages?.Invoke(messages);
             lastMessageId = Math.Max(lastMessageId, messages.LastOrDefault()?.Id ?? 0);
         }

--- a/osu.Game/Tests/PollingNotificationsClient.cs
+++ b/osu.Game/Tests/PollingNotificationsClient.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    await API.PerformAsync(CreateFetchMessagesRequest());
+                    await API.PerformAsync(CreateInitialFetchRequest());
                     await Task.Delay(1000, cancellationToken);
                 }
             }, cancellationToken);


### PR DESCRIPTION
This is not required since the switch to websockets. The osu-web API call will be removed soon as it is too expensive to maintain.

This fixes my game timing out on initial `GetUpdatesRequest`s (client-side enforced 10 seconds is too short).