### PR TITLE
Add support for storyboards with incorrect path specifications (`\\` instead of `\`)

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -147,7 +147,11 @@ namespace osu.Game.Beatmaps.Formats
             );
         }
 
-        protected string CleanFilename(string path) => path.Trim('"').ToStandardisedPath();
+        protected string CleanFilename(string path) => path
+                                                       // User error which is supported by stable (https://github.com/ppy/osu/issues/21204)
+                                                       .Replace(@"\\", @"\")
+                                                       .Trim('"')
+                                                       .ToStandardisedPath();
 
         public enum Section
         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21204.

Tested with provided beatmap.