### PR TITLE
Realign white line on argon hold note ends to match hit target

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 },
                 new Container
                 {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                     RelativeSizeAxes = Axes.Both,
                     Height = 0.82f,
                     Masking = true,
@@ -54,6 +56,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = ArgonNotePiece.CORNER_RADIUS * 2,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                 },
             };
         }


### PR DESCRIPTION
| before | after |
| -- | -- |
|![osu! 2022-11-21 at 09 32 22](https://user-images.githubusercontent.com/191335/203015411-b3c3baa2-f31f-496b-ace4-3c38af6e3355.png)|![osu! 2022-11-21 at 09 28 54](https://user-images.githubusercontent.com/191335/203015286-7beaddb7-bcb9-4f8f-a42a-c63ee24504bf.png)|

The "shadow" colour still clashes a bit with the hold note body, but let's fix one thing at a time.

Closes #20979.