### PR TITLE
Fix broken rank graph test

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
@@ -65,6 +65,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
+                    IsRanked = true,
                     GlobalRank = 123456,
                     PP = 12345,
                 };
@@ -84,6 +85,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
+                    IsRanked = true,
                     GlobalRank = 89000,
                     PP = 12345,
                     RankHistory = new APIRankHistory
@@ -110,6 +112,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
+                    IsRanked = true,
                     GlobalRank = 89000,
                     PP = 12345,
                     RankHistory = new APIRankHistory
@@ -133,6 +136,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
+                    IsRanked = true,
                     GlobalRank = 12000,
                     PP = 12345,
                     RankHistory = new APIRankHistory
@@ -161,6 +165,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 graph.Statistics.Value = new UserStatistics
                 {
+                    IsRanked = true,
                     GlobalRank = 12000,
                     PP = 12345,
                     RankHistory = new APIRankHistory

--- a/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankGraph.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -8,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Profile.Header.Components;
@@ -50,11 +52,15 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void TestNullUser() =>
+        public void TestNullUser()
+        {
             AddStep("null user", () => graph.Statistics.Value = null);
+            AddAssert("line graph hidden", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 0));
+        }
 
         [Test]
-        public void TestRankOnly() =>
+        public void TestRankOnly()
+        {
             AddStep("rank only", () =>
             {
                 graph.Statistics.Value = new UserStatistics
@@ -63,6 +69,8 @@ namespace osu.Game.Tests.Visual.Online
                     PP = 12345,
                 };
             });
+            AddAssert("line graph hidden", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 0));
+        }
 
         [Test]
         public void TestWithRankHistory()
@@ -84,6 +92,7 @@ namespace osu.Game.Tests.Visual.Online
                     }
                 };
             });
+            AddAssert("line graph shown", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 1));
         }
 
         [Test]
@@ -109,6 +118,7 @@ namespace osu.Game.Tests.Visual.Online
                     }
                 };
             });
+            AddAssert("line graph shown", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 1));
         }
 
         [Test]
@@ -131,6 +141,7 @@ namespace osu.Game.Tests.Visual.Online
                     }
                 };
             });
+            AddAssert("line graph shown", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 1));
         }
 
         [Test]
@@ -158,6 +169,7 @@ namespace osu.Game.Tests.Visual.Online
                     }
                 };
             });
+            AddAssert("line graph shown", () => this.ChildrenOfType<LineGraph>().All(graph => graph.Alpha == 1));
         }
     }
 }


### PR DESCRIPTION
Noticed in passing. Test broke with #16158.

Reading commit-by-commit may be easier on the eyes. In sequence:

* 735cac3104f4ba43eaa9fbdb0d909f506dfe58ae: Rewrote test in more modern style and split each step to separate test case for later use
* 1777a6013619b021c078224ff02c86aad21014ea: Added assertions about alpha of the rank graph to prevent this sort of breakage from happening again (fingers crossed)
* 41039340cfcaf81dee840f56812a1f0f6974fa96: Finally, set `IsRanked = true` where necessary to fix the test in line with logic change in #16158