### PR TITLE
Pressing left control while rotating selection box snaps it to nearest fifths

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -187,5 +187,31 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("top-right rotation handle shown", () =>
                 this.ChildrenOfType<SelectionBoxRotationHandle>().Single(r => r.Anchor == Anchor.TopRight).Alpha == 1);
         }
+
+        [Test]
+        public void TestRotationSnapping()
+        {
+            SelectionBoxRotationHandle rotationHandle = null;
+
+            AddStep("retrieve rotation handle", () => rotationHandle = this.ChildrenOfType<SelectionBoxRotationHandle>().First());
+
+            AddStep("hover over rotation handle", () => InputManager.MoveMouseTo(rotationHandle));
+
+            AddStep("press left mouse button", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(rotationHandle, new Vector2(21, 112)));
+
+            AddAssert("rotation is not divisible by 5", () => selectionArea.Rotation % 5 != 0);
+
+            AddStep("press left control", () => InputManager.PressKey(Key.ControlLeft));
+
+            AddStep("move mouse", () => InputManager.MoveMouseTo(rotationHandle));
+
+            AddAssert("rotation is divisible by 5", () => selectionArea.Rotation % 5 == 0);
+
+            AddStep("release left mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("release left control", () => InputManager.ReleaseKey(Key.ControlLeft));
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private readonly Bindable<float?> cumulativeRotation = new Bindable<float?>();
 
-        private bool isSnapping = false;
+        private bool isSnapping;
 
         [Resolved]
         private SelectionBox selectionBox { get; set; }
@@ -118,7 +118,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void OnKeyUp(KeyUpEvent e)
         {
-            isSnapping = !(e.Key == Key.ControlLeft);
+            if (e.Key == Key.ControlLeft)
+                isSnapping = false;
 
             base.OnKeyUp(e);
         }


### PR DESCRIPTION
**When left control is not pressed**
![Screenshot from 2022-11-22 10-35-36](https://user-images.githubusercontent.com/54083498/203207472-6af98c2d-7035-4da9-ab1e-6c7767625124.png)

**When left control is pressed**
![Screenshot from 2022-11-22 10-36-31](https://user-images.githubusercontent.com/54083498/203207489-403ec549-af78-4844-afc0-f50f6789ebab.png)
