### PR TITLE
Fix osu!mania hold notes occasionally getting in a visually incorrect hit state

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -262,12 +262,22 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                         tick.MissForcefully();
                 }
 
-                ApplyResult(r => r.Type = Tail.IsHit ? r.Judgement.MaxResult : r.Judgement.MinResult);
-                endHold();
+                if (Tail.IsHit)
+                    ApplyResult(r => r.Type = r.Judgement.MaxResult);
+                else
+                    MissForcefully();
             }
 
             if (Tail.Judged && !Tail.IsHit)
                 HoldBrokenTime = Time.Current;
+        }
+
+        public override void MissForcefully()
+        {
+            base.MissForcefully();
+
+            // Important that this is always called when a result is applied.
+            endHold();
         }
 
         public bool OnPressed(KeyBindingPressEvent<ManiaAction> e)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableManiaHitObject.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         /// <summary>
         /// Causes this <see cref="DrawableManiaHitObject"/> to get missed, disregarding all conditions in implementations of <see cref="DrawableHitObject.CheckForResult"/>.
         /// </summary>
-        public void MissForcefully() => ApplyResult(r => r.Type = r.Judgement.MinResult);
+        public virtual void MissForcefully() => ApplyResult(r => r.Type = r.Judgement.MinResult);
     }
 
     public abstract class DrawableManiaHitObject<TObject> : DrawableManiaHitObject


### PR DESCRIPTION
To correctly end a mania hold note, `endHold()` needs to be called. This
was not happening in a very specific scenario:

- The hold note's head is not hit
- The user pressed the column's key within the hold note's tail's window, but does so to hit the next object (a note in proximity to the hold note's tail).
- The hit policy forces a miss on the hold note, but `endHold()` is not called
- `CheckForResult` is not called after this point due to `Judged` being `true`.

As discussed IRL, this is probably not the full breadth of what needs to be fixed here. This scenario could only occur in the first place because `DrawableHoldNote` does not block (ie. return `true`) unless the head note is hit, which means a single input to the column is both beginning the hold *and* actuating the next note. I'll look at fixing this in a follow-up PR with test coverage of that scenario.

Closes #21311.