### PR TITLE
Fix restart notification still restarting game after cancelling and exiting normally

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -22,8 +22,6 @@ namespace osu.Desktop.Updater
         private Squirrel.UpdateManager? updateManager;
         private INotificationOverlay notificationOverlay = null!;
 
-        public Task PrepareUpdateAsync() => Squirrel.UpdateManager.RestartAppWhenExited();
-
         private static readonly Logger logger = Logger.GetLogger("updater");
 
         /// <summary>
@@ -141,8 +139,7 @@ namespace osu.Desktop.Updater
 
         private bool restartToApplyUpdate()
         {
-            PrepareUpdateAsync()
-                .ContinueWith(_ => Schedule(() => game.AttemptExit()));
+            Schedule(() => game.AttemptExit(() => Squirrel.UpdateManager.RestartAppWhenExited()));
             return true;
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -651,10 +651,14 @@ namespace osu.Game
             Add(performFromMainMenuTask = new PerformFromMenuRunner(action, validScreens, () => ScreenStack.CurrentScreen));
         }
 
-        public override void AttemptExit()
+        public override void AttemptExit(Action invokeWhenExiting = null)
         {
             // Using PerformFromScreen gives the user a chance to interrupt the exit process if needed.
-            PerformFromScreen(menu => menu.Exit());
+            PerformFromScreen(menu =>
+            {
+                ((MainMenu)menu).InvokeWhenExiting = invokeWhenExiting;
+                menu.Exit();
+            });
         }
 
         /// <summary>

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
@@ -475,13 +476,14 @@ namespace osu.Game
         /// Use to programatically exit the game as if the user was triggering via alt-f4.
         /// By default, will keep persisting until an exit occurs (exit may be blocked multiple times).
         /// May be interrupted (see <see cref="OsuGame"/>'s override).
+        /// /// <param name="invokeWhenExiting">Optional delegate to be run when exit is actually performed.</param>
         /// </summary>
-        public virtual void AttemptExit()
+        public virtual void AttemptExit([CanBeNull] Action invokeWhenExiting = null)
         {
             if (!OnExiting())
                 Exit();
             else
-                Scheduler.AddDelayed(AttemptExit, 2000);
+                Scheduler.AddDelayed(() => AttemptExit(invokeWhenExiting), 2000);
         }
 
         public bool Migrate(string path)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Screens.Menu
 
         public override bool AllowExternalScreenChange => true;
 
+        /// <summary>
+        /// Optional delegate to be run when exit is actually performed.
+        /// </summary>
+        public Action InvokeWhenExiting;
+
         private Screen songSelect;
 
         private MenuSideFlashes sideFlashes;
@@ -284,7 +289,17 @@ namespace osu.Game.Screens.Menu
                 if (dialogOverlay.CurrentDialog is ConfirmExitDialog exitDialog)
                     exitDialog.PerformOkAction();
                 else
-                    dialogOverlay.Push(new ConfirmExitDialog(confirmAndExit, () => exitConfirmOverlay.Abort()));
+                {
+                    dialogOverlay.Push(new ConfirmExitDialog(() =>
+                    {
+                        InvokeWhenExiting?.Invoke();
+                        confirmAndExit();
+                    }, () =>
+                    {
+                        exitConfirmOverlay.Abort();
+                        InvokeWhenExiting = null;
+                    }));
+                }
 
                 return true;
             }


### PR DESCRIPTION
- Supersedes https://github.com/ppy/osu/pull/21295
- Addresses https://github.com/ppy/osu/discussions/21003

The param in `OsuGameBase` is not used as the class doesn't have screens/screenstack to work with.