### PR TITLE
Update DrawableHitObject state based on entry result during LoadComplete

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -135,6 +136,31 @@ namespace osu.Game.Tests.Gameplay
                 dho.MissForcefully();
             });
             AddAssert("DHO state is correct", () => dho.State.Value == ArmedState.Miss);
+        }
+
+        [Test]
+        public void TestResultSetBeforeLoadComplete()
+        {
+            TestDrawableHitObject dho = null;
+            HitObjectLifetimeEntry lifetimeEntry = null;
+            AddStep("Create lifetime entry", () =>
+            {
+                var hitObject = new HitObject { StartTime = Time.Current };
+                lifetimeEntry = new HitObjectLifetimeEntry(hitObject)
+                {
+                    Result = new JudgementResult(hitObject, hitObject.CreateJudgement())
+                    {
+                        Type = HitResult.Great
+                    }
+                };
+            });
+            AddStep("Create DHO and apply entry", () =>
+            {
+                dho = new TestDrawableHitObject();
+                dho.Apply(lifetimeEntry);
+                Child = dho;
+            });
+            AddAssert("DHO state is correct", () => dho.State.Value, () => Is.EqualTo(ArmedState.Hit));
         }
 
         private partial class TestDrawableHitObject : DrawableHitObject

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             comboColourBrightness.BindValueChanged(_ => UpdateComboColour());
 
             // Apply transforms
-            updateStateBasedOnResults();
+            updateStateFromResult();
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             // If not loaded, the state update happens in LoadComplete().
             if (IsLoaded)
             {
-                updateStateBasedOnResults();
+                updateStateFromResult();
 
                 // Combo colour may have been applied via a bindable flow while no object entry was attached.
                 // Update here to ensure we're in a good state.
@@ -274,7 +274,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
         }
 
-        private void updateStateBasedOnResults()
+        private void updateStateFromResult()
         {
             if (Result.IsHit)
                 updateState(ArmedState.Hit, true);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             comboColourBrightness.BindValueChanged(_ => UpdateComboColour());
 
             // Apply transforms
-            updateState(State.Value, true);
+            updateStateBasedOnResults();
         }
 
         /// <summary>
@@ -266,17 +266,22 @@ namespace osu.Game.Rulesets.Objects.Drawables
             // If not loaded, the state update happens in LoadComplete().
             if (IsLoaded)
             {
-                if (Result.IsHit)
-                    updateState(ArmedState.Hit, true);
-                else if (Result.HasResult)
-                    updateState(ArmedState.Miss, true);
-                else
-                    updateState(ArmedState.Idle, true);
+                updateStateBasedOnResults();
 
                 // Combo colour may have been applied via a bindable flow while no object entry was attached.
                 // Update here to ensure we're in a good state.
                 UpdateComboColour();
             }
+        }
+
+        private void updateStateBasedOnResults()
+        {
+            if (Result.IsHit)
+                updateState(ArmedState.Hit, true);
+            else if (Result.HasResult)
+                updateState(ArmedState.Miss, true);
+            else
+                updateState(ArmedState.Idle, true);
         }
 
         protected sealed override void OnFree(HitObjectLifetimeEntry entry)


### PR DESCRIPTION
When a drawable is created due to the pool being empty, `OnApply()` wouldn't update the DHO's state due to an expected state update through `LoadComplete()`. However, `LoadComplete()` doesn't take into consideration the result of the HitObject assigned to the DrawableHitObject and using `ArmedState.Idle` unconditionally., which may lead to the drawable having the inappropriate transforms if it is assigned to a HitObject in the past. (Noticable when selecting all in editor)

This PR changes that so that `updateState` in `LoadComplete `also takes the entry result into consideration.

__**Footage of the problem that this PR fixes in action:**__
(Note that a new DrawableSlideTap is created and assigned to the earlier object)

 https://user-images.githubusercontent.com/12001167/204157319-922ec2cc-fb77-4b6c-86d2-587ab7746879.mp4




