### PR TITLE
Improve TrianglesV2 antialiasing

### DIFF
--- a/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
+++ b/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Graphics.Backgrounds
             {
                 base.Draw(renderer);
 
-                if (Source.AimCount == 0)
+                if (Source.AimCount == 0 || thickness == 0)
                     return;
 
                 if (vertexBatch == null || vertexBatch.Size != Source.AimCount)


### PR DESCRIPTION
Currently triangles texel size is being computed using the whole drawable size, which is incorrect (should use the size of a single triangle instead)

**Master:**
Huge drawable size (missing antialiasing due to small texel size)
![big-before](https://user-images.githubusercontent.com/22874522/204409132-449844f4-7877-4ecb-92e4-41a7a838d98b.png)
Small drawable size (blurry triangles due to big texel size)
![small-before](https://user-images.githubusercontent.com/22874522/204409282-63302ffa-130d-4c7c-ad5c-7886378b14e9.png)

**PR**
Both fixed
![big-after](https://user-images.githubusercontent.com/22874522/204409338-1ad2de81-59e5-45e1-8066-05b8d24107bd.png)
![small-after](https://user-images.githubusercontent.com/22874522/204409345-749c0b90-4765-41de-8813-d11efbbdb84f.png)