### PR TITLE
Add legacy taiko glow element

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoKiaiGlow.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             var controlPointInfo = new ControlPointInfo();
 
+            controlPointInfo.Add(0, new TimingControlPoint { BeatLength = 500 });
+
             if (withKiai)
                 controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
 
@@ -28,6 +30,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             {
                 ControlPointInfo = controlPointInfo
             });
+
+            Beatmap.Value.Track.Start();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneTaikoKiaiGlow.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Taiko.Skinning.Legacy;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    public partial class TestSceneTaikoKiaiGlow : TaikoSkinnableTestScene
+    {
+        [Test]
+        public void TestKiaiGlow()
+        {
+            AddStep("Create kiai glow", () => SetContents(_ => new LegacyKiaiGlow()));
+            AddToggleStep("Toggle kiai mode", setUpBeatmap);
+        }
+
+        private void setUpBeatmap(bool withKiai)
+        {
+            var controlPointInfo = new ControlPointInfo();
+
+            if (withKiai)
+                controlPointInfo.Add(0, new EffectControlPoint { KiaiMode = true });
+
+            Beatmap.Value = CreateWorkingBeatmap(new Beatmap
+            {
+                ControlPointInfo = controlPointInfo
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -16,8 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     internal partial class LegacyKiaiGlow : BeatSyncedContainer
     {
-        private const float colour_compensation = 1.58f;
-
         public LegacyKiaiGlow()
         {
             AlwaysPresent = true;
@@ -60,7 +58,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             if (effectPoint.KiaiMode)
-                this.FadeTo(colour_compensation, 180);
+                this.FadeIn(180);
             else
                 this.FadeOut(180);
         }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -2,10 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
@@ -13,8 +14,10 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
-    internal partial class LegacyKiaiGlow : Container
+    internal partial class LegacyKiaiGlow : BeatSyncedContainer
     {
+        private const float colour_compensation = 1.58f;
+
         public LegacyKiaiGlow()
         {
             AlwaysPresent = true;
@@ -29,12 +32,10 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 Texture = skin.GetTexture("taiko-glow"),
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
-                Scale = new Vector2(0.75f),
+                Scale = new Vector2(0.7f),
+                Colour = new Colour4(255, 228, 0, 255),
             };
         }
-
-        [Resolved(CanBeNull = true)]
-        private IBeatSyncProvider? beatSyncProvider { get; set; }
 
         [Resolved(CanBeNull = true)]
         private HealthProcessor? healthProcessor { get; set; }
@@ -45,14 +46,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
             if (healthProcessor != null)
                 healthProcessor.NewJudgement += onNewJudgement;
-
-            if (beatSyncProvider != null)
-            {
-                if (beatSyncProvider.CheckIsKiaiTime())
-                    this.FadeIn(180);
-                else
-                    this.FadeOut(180);
-            }
         }
 
         private void onNewJudgement(JudgementResult result)
@@ -60,8 +53,16 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             if (!result.IsHit)
                 return;
 
-            this.ScaleTo(1.1f, 50)
-                .Then().ScaleTo(1f, 50);
+            this.ScaleTo(1.2f)
+                .Then().ScaleTo(1f, 80, Easing.OutQuad);
+        }
+
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        {
+            if (effectPoint.KiaiMode)
+                this.FadeTo(colour_compensation, 180);
+            else
+                this.FadeOut(180);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -16,15 +16,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     internal partial class LegacyKiaiGlow : BeatSyncedContainer
     {
-        public LegacyKiaiGlow()
-        {
-            AlwaysPresent = true;
-            Alpha = 0;
-        }
+        private bool isKiaiActive;
 
-        [BackgroundDependencyLoader]
-        private void load(ISkinSource skin)
+        [BackgroundDependencyLoader(true)]
+        private void load(ISkinSource skin, HealthProcessor? healthProcessor)
         {
+            Alpha = 0;
+
             Child = new Sprite
             {
                 Texture = skin.GetTexture("taiko-glow"),
@@ -33,14 +31,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 Scale = new Vector2(0.7f),
                 Colour = new Colour4(255, 228, 0, 255),
             };
-        }
-
-        [Resolved(CanBeNull = true)]
-        private HealthProcessor? healthProcessor { get; set; }
-
-        protected override void Update()
-        {
-            base.Update();
 
             if (healthProcessor != null)
                 healthProcessor.NewJudgement += onNewJudgement;
@@ -48,16 +38,21 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
         private void onNewJudgement(JudgementResult result)
         {
-            if (!result.IsHit)
+            if (!result.IsHit || !isKiaiActive)
                 return;
 
-            this.ScaleTo(1.2f)
-                .Then().ScaleTo(1f, 80, Easing.OutQuad);
+            this.ScaleTo(1.2f).Then()
+                .ScaleTo(1f, 80, Easing.OutQuad);
         }
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
-            if (effectPoint.KiaiMode)
+            if (effectPoint.KiaiMode == isKiaiActive)
+                return;
+
+            isKiaiActive = effectPoint.KiaiMode;
+
+            if (isKiaiActive)
                 this.FadeIn(180);
             else
                 this.FadeOut(180);

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
+{
+    internal partial class LegacyKiaiGlow : Container
+    {
+        public LegacyKiaiGlow()
+        {
+            AlwaysPresent = true;
+            Alpha = 0;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin)
+        {
+            Child = new Sprite
+            {
+                Texture = skin.GetTexture("taiko-glow"),
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Scale = new Vector2(0.75f),
+            };
+        }
+
+        [Resolved(CanBeNull = true)]
+        private IBeatSyncProvider? beatSyncProvider { get; set; }
+
+        [Resolved(CanBeNull = true)]
+        private HealthProcessor? healthProcessor { get; set; }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (healthProcessor != null)
+                healthProcessor.NewJudgement += onNewJudgement;
+
+            if (beatSyncProvider != null)
+            {
+                if (beatSyncProvider.CheckIsKiaiTime())
+                    this.FadeIn(180);
+                else
+                    this.FadeOut(180);
+            }
+        }
+
+        private void onNewJudgement(JudgementResult result)
+        {
+            if (!result.IsHit)
+                return;
+
+            this.ScaleTo(1.1f, 50)
+                .Then().ScaleTo(1f, 50);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
@@ -18,16 +19,17 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     {
         private bool isKiaiActive;
 
+        private Sprite sprite = null!;
+
         [BackgroundDependencyLoader(true)]
         private void load(ISkinSource skin, HealthProcessor? healthProcessor)
         {
-            Alpha = 0;
-
-            Child = new Sprite
+            Child = sprite = new Sprite
             {
                 Texture = skin.GetTexture("taiko-glow"),
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
+                Alpha = 0,
                 Scale = new Vector2(0.7f),
                 Colour = new Colour4(255, 228, 0, 255),
             };
@@ -36,26 +38,28 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 healthProcessor.NewJudgement += onNewJudgement;
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            if (isKiaiActive)
+                sprite.Alpha = (float)Math.Min(1, sprite.Alpha + Math.Abs(Clock.ElapsedFrameTime) / 100f);
+            else
+                sprite.Alpha = (float)Math.Max(0, sprite.Alpha - Math.Abs(Clock.ElapsedFrameTime) / 600f);
+        }
+
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        {
+            isKiaiActive = effectPoint.KiaiMode;
+        }
+
         private void onNewJudgement(JudgementResult result)
         {
             if (!result.IsHit || !isKiaiActive)
                 return;
 
-            this.ScaleTo(1.2f).Then()
-                .ScaleTo(1f, 80, Easing.OutQuad);
-        }
-
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
-        {
-            if (effectPoint.KiaiMode == isKiaiActive)
-                return;
-
-            isKiaiActive = effectPoint.KiaiMode;
-
-            if (isKiaiActive)
-                this.FadeIn(180);
-            else
-                this.FadeOut(180);
+            sprite.ScaleTo(0.85f).Then()
+                  .ScaleTo(0.7f, 80, Easing.OutQuad);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyPlayfieldBackgroundRight.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyPlayfieldBackgroundRight.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
@@ -16,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     {
         private Sprite kiai = null!;
 
-        private bool kiaiDisplayed;
+        private bool isKiaiActive;
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)
@@ -41,17 +42,19 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             };
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            if (isKiaiActive)
+                kiai.Alpha = (float)Math.Min(1, kiai.Alpha + Math.Abs(Clock.ElapsedFrameTime) / 200f);
+            else
+                kiai.Alpha = (float)Math.Max(0, kiai.Alpha - Math.Abs(Clock.ElapsedFrameTime) / 200f);
+        }
+
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
-            base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
-
-            if (effectPoint.KiaiMode != kiaiDisplayed)
-            {
-                kiaiDisplayed = effectPoint.KiaiMode;
-
-                kiai.ClearTransforms();
-                kiai.FadeTo(kiaiDisplayed ? 1 : 0, 200);
-            }
+            isKiaiActive = effectPoint.KiaiMode;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -129,6 +129,12 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     case TaikoSkinComponents.Mascot:
                         return new DrawableTaikoMascot();
 
+                    case TaikoSkinComponents.KiaiGlow:
+                        if (GetTexture("taiko-glow") != null)
+                            return new LegacyKiaiGlow();
+
+                        return null;
+
                     default:
                         throw new UnsupportedSkinComponentException(lookup);
                 }

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -21,5 +21,6 @@ namespace osu.Game.Rulesets.Taiko
         TaikoExplosionKiai,
         Scroller,
         Mascot,
+        KiaiGlow
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -112,6 +112,10 @@ namespace osu.Game.Rulesets.Taiko.UI
                             FillMode = FillMode.Fit,
                             Children = new[]
                             {
+                                new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.KiaiGlow), _ => Empty())
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                },
                                 hitExplosionContainer = new Container<HitExplosion>
                                 {
                                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Adds back the legacy effect around `HitTarget` during kiai time. This should visually be on par with stable, except for the fade in/out which was a bit hard to tell without stable code.

Note: I'm 95% sure there's a better way to access `NewJudgement` rather than resolving `HealthProcessor`, but I wasn't able to find a better option myself. Suggestions on this are welcome!


https://user-images.githubusercontent.com/56885706/204674379-a48a167c-4d57-43a6-9fbf-6df920ef78c6.mp4


