### PR TITLE
Remove texture usage in TrianglesV2 component

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
@@ -54,7 +54,11 @@ namespace osu.Game.Tests.Visual.Background
         {
             base.LoadComplete();
 
-            AddSliderStep("Spawn ratio", 0f, 2f, 1f, s => triangles.SpawnRatio = s);
+            AddSliderStep("Spawn ratio", 0f, 5f, 1f, s =>
+            {
+                triangles.SpawnRatio = s;
+                triangles.Reset(1234);
+            });
             AddSliderStep("Thickness", 0f, 1f, 0.02f, t => triangles.Thickness = t);
         }
     }

--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Shapes;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Graphics.Backgrounds;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Game.Tests.Visual.Background
 {
@@ -42,8 +43,7 @@ namespace osu.Game.Tests.Visual.Background
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             RelativeSizeAxes = Axes.Both,
-                            ColourTop = Color4.White,
-                            ColourBottom = Color4.Red
+                            Colour = ColourInfo.GradientVertical(Color4.White, Color4.Red)
                         }
                     }
                 }

--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
@@ -42,8 +42,7 @@ namespace osu.Game.Tests.Visual.Background
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = ColourInfo.GradientVertical(Color4.White, Color4.Red)
+                            RelativeSizeAxes = Axes.Both
                         }
                     }
                 }
@@ -60,6 +59,10 @@ namespace osu.Game.Tests.Visual.Background
                 triangles.Reset(1234);
             });
             AddSliderStep("Thickness", 0f, 1f, 0.02f, t => triangles.Thickness = t);
+
+            AddStep("White colour", () => triangles.Colour = Color4.White);
+            AddStep("Vertical gradient", () => triangles.Colour = ColourInfo.GradientVertical(Color4.White, Color4.Red));
+            AddStep("Horizontal gradient", () => triangles.Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.Red));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesV2Background.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Tests.Visual.Background
     public partial class TestSceneTrianglesV2Background : OsuTestScene
     {
         private readonly TrianglesV2 triangles;
+        private readonly Box box;
 
         public TestSceneTrianglesV2Background()
         {
@@ -24,25 +25,44 @@ namespace osu.Game.Tests.Visual.Background
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.Gray
                 },
-                new Container
+                new FillFlowContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(500, 100),
-                    Masking = true,
-                    CornerRadius = 40,
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 5),
                     Children = new Drawable[]
                     {
-                        new Box
+                        new Container
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = Color4.Red
+                            Size = new Vector2(500, 100),
+                            Masking = true,
+                            CornerRadius = 40,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4.Red
+                                },
+                                triangles = new TrianglesV2
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    RelativeSizeAxes = Axes.Both
+                                }
+                            }
                         },
-                        triangles = new TrianglesV2
+                        new Container
                         {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            RelativeSizeAxes = Axes.Both
+                            Size = new Vector2(500, 100),
+                            Masking = true,
+                            CornerRadius = 40,
+                            Child = box = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both
+                            }
                         }
                     }
                 }
@@ -53,16 +73,16 @@ namespace osu.Game.Tests.Visual.Background
         {
             base.LoadComplete();
 
-            AddSliderStep("Spawn ratio", 0f, 5f, 1f, s =>
+            AddSliderStep("Spawn ratio", 0f, 10f, 1f, s =>
             {
                 triangles.SpawnRatio = s;
                 triangles.Reset(1234);
             });
             AddSliderStep("Thickness", 0f, 1f, 0.02f, t => triangles.Thickness = t);
 
-            AddStep("White colour", () => triangles.Colour = Color4.White);
-            AddStep("Vertical gradient", () => triangles.Colour = ColourInfo.GradientVertical(Color4.White, Color4.Red));
-            AddStep("Horizontal gradient", () => triangles.Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.Red));
+            AddStep("White colour", () => box.Colour = triangles.Colour = Color4.White);
+            AddStep("Vertical gradient", () => box.Colour = triangles.Colour = ColourInfo.GradientVertical(Color4.White, Color4.Red));
+            AddStep("Horizontal gradient", () => box.Colour = triangles.Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.Red));
         }
     }
 }

--- a/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
+++ b/osu.Game/Graphics/Backgrounds/TrianglesV2.cs
@@ -52,9 +52,6 @@ namespace osu.Game.Graphics.Backgrounds
 
         private readonly List<TriangleParticle> parts = new List<TriangleParticle>();
 
-        [Resolved]
-        private IRenderer renderer { get; set; } = null!;
-
         private Random? stableRandom;
 
         private IShader shader = null!;

--- a/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/RoundedButton.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -79,8 +80,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             Debug.Assert(triangleGradientSecondColour != null);
 
-            Triangles.ColourTop = triangleGradientSecondColour.Value;
-            Triangles.ColourBottom = BackgroundColour;
+            Triangles.Colour = ColourInfo.GradientVertical(triangleGradientSecondColour.Value, BackgroundColour);
         }
 
         protected override bool OnHover(HoverEvent e)


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu/pull/21453
Removes a need for texture creation and now any gradient/colour can be applied as expected without additional properties such as `ColourTop` and `ColourBottom`. End result looks a bit different though.

| master | pr |
| ----------- | ----------- |
| ![master](https://user-images.githubusercontent.com/22874522/204687604-73c1435d-3662-4004-8a78-dd00b019533a.png) | ![pr](https://user-images.githubusercontent.com/22874522/204687636-78041181-6ab1-4188-869e-2255d48c9c7f.png) |

Added box for gradient comparison and it's indeed correct.
![box](https://user-images.githubusercontent.com/22874522/204690980-89e0cc1f-792a-4bbb-9494-a4821286752e.png) 