### PR TITLE
Fix flaky test conditions in `TestSceneReplayDownloadButton`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
 
-            AddAssert("state is available", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            checkState(DownloadState.NotDownloaded);
 
             AddStep("click button", () =>
             {
@@ -133,7 +133,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
 
-            AddAssert("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            checkState(DownloadState.NotDownloaded);
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
 
@@ -155,7 +155,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
 
-            AddUntilStep("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            checkState(DownloadState.NotDownloaded);
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
 
@@ -174,17 +174,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
-
-            AddUntilStep("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            checkState(DownloadState.NotDownloaded);
 
             AddStep("import score", () => imported = scoreManager.Import(getScoreInfo(true)));
 
-            AddUntilStep("state is available", () => downloadButton.State.Value == DownloadState.LocallyAvailable);
+            checkState(DownloadState.LocallyAvailable);
             AddAssert("button is enabled", () => downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
 
             AddStep("delete score", () => scoreManager.Delete(imported.Value));
 
-            AddUntilStep("state is not downloaded", () => downloadButton.State.Value == DownloadState.NotDownloaded);
+            checkState(DownloadState.NotDownloaded);
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
 
@@ -202,9 +201,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for load", () => downloadButton.IsLoaded);
 
-            AddAssert("state is unknown", () => downloadButton.State.Value == DownloadState.Unknown);
+            checkState(DownloadState.Unknown);
             AddAssert("button is not enabled", () => !downloadButton.ChildrenOfType<DownloadButton>().First().Enabled.Value);
         }
+
+        private void checkState(DownloadState expectedState) =>
+            AddUntilStep($"state is {expectedState}", () => downloadButton.State.Value, () => Is.EqualTo(expectedState));
 
         private ScoreInfo getScoreInfo(bool replayAvailable, bool hasOnlineId = true) => new ScoreInfo
         {


### PR DESCRIPTION

Top two currently flaky tests ([example in the wild](https://github.com/ppy/osu/actions/runs/3581031846/jobs/6023681906)):

![Safari 2022-11-30 at 08 09 14](https://user-images.githubusercontent.com/191335/204741777-76086e5e-e580-4704-90c4-72ad46ec2bde.png)

Caused by realm taking too long occasionally in the following code:

https://github.com/ppy/osu/blob/7bc8908ca9c026fed1d831eb6e58df7624a8d614/osu.Game/Online/ScoreDownloadTracker.cs#L48-L63

Can be tested using

```diff
diff --git a/osu.Game/Online/ScoreDownloadTracker.cs b/osu.Game/Online/ScoreDownloadTracker.cs
index 4ddcb40368..c547181486 100644
--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -51,14 +51,14 @@ protected override void LoadComplete()
                 && !s.DeletePending), (items, _, _) =>
             {
                 if (items.Any())
-                    Schedule(() => UpdateState(DownloadState.LocallyAvailable));
+                    Scheduler.AddDelayed(() => UpdateState(DownloadState.LocallyAvailable), 500);
                 else
                 {
-                    Schedule(() =>
+                    Scheduler.AddDelayed(() =>
                     {
                         UpdateState(DownloadState.NotDownloaded);
                         attachDownload(Downloader.GetExistingDownload(scoreInfo));
-                    });
+                    }, 500);
                 }
             });
         }

```