### PR TITLE
Fix incorrect culture used when parsing timeline popup textbox content

### DIFF
--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -94,7 +94,20 @@ namespace osu.Game.Screens.Edit.Timing
 
                 try
                 {
-                    slider.Current.Parse(t.Text);
+                    switch (slider.Current)
+                    {
+                        case Bindable<int> bindableInt:
+                            bindableInt.Value = int.Parse(t.Text);
+                            break;
+
+                        case Bindable<double> bindableDouble:
+                            bindableDouble.Value = double.Parse(t.Text);
+                            break;
+
+                        default:
+                            slider.Current.Parse(t.Text);
+                            break;
+                    }
                 }
                 catch
                 {

--- a/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderWithTextBoxInput.cs
@@ -58,7 +58,20 @@ namespace osu.Game.Screens.Edit.Timing
 
                 try
                 {
-                    slider.Current.Parse(t.Text);
+                    switch (slider.Current)
+                    {
+                        case Bindable<int> bindableInt:
+                            bindableInt.Value = int.Parse(t.Text);
+                            break;
+
+                        case Bindable<double> bindableDouble:
+                            bindableDouble.Value = double.Parse(t.Text);
+                            break;
+
+                        default:
+                            slider.Current.Parse(t.Text);
+                            break;
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
We may want to consider giving `Bindable.Parse` a `bool useInvariantCulture = true` or similar going forward? But there's precedent for doing this kind of parsing locally:

https://github.com/ppy/osu/blob/7bc8908ca9c026fed1d831eb6e58df7624a8d614/osu.Game/Screens/Edit/Timing/GroupSection.cs#L73-L76

https://github.com/ppy/osu/blob/7bc8908ca9c026fed1d831eb6e58df7624a8d614/osu.Game.Tournament/Components/DateTextBox.cs#L37

Should be tested by someone who has a relevant culture.

Closes https://github.com/ppy/osu/issues/20989.