### PR TITLE
Fix osu!mania editor timeline showing bright-white blueprints

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -18,6 +18,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -53,6 +54,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         public TimelineHitObjectBlueprint(HitObject item)
             : base(item)
@@ -165,7 +169,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     break;
 
                 default:
-                    colour = Color4.Gray;
+                    colour = colourProvider.Highlight1;
                     break;
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -165,7 +165,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     break;
 
                 default:
-                    return;
+                    colour = Color4.Gray;
+                    break;
             }
 
             if (IsSelected)


### PR DESCRIPTION
| before | after |
| -- | -- |
|![osu! 2022-12-01 at 08 04 50](https://user-images.githubusercontent.com/191335/204998669-e602177c-283d-4564-9d72-19d5a269fa6f.png)|![osu! 2022-12-01 at 08 04 26](https://user-images.githubusercontent.com/191335/204998593-b0c83b9a-e828-4b5b-bdc6-ff5b1624c628.png)|