### PR TITLE
Fix being able to place zero-length spinners

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
@@ -23,7 +24,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 
         private bool isPlacingEnd;
 
-        [Resolved]
+        [Resolved(CanBeNull = true)]
+        [CanBeNull]
         private IBeatSnapProvider beatSnapProvider { get; set; }
 
         public SpinnerPlacementBlueprint()
@@ -66,7 +68,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
             return true;
         }
 
-        private void updateEndTimeFromCurrent() =>
-            HitObject.EndTime = Math.Max(HitObject.StartTime + beatSnapProvider.GetBeatLengthAtTime(HitObject.StartTime), beatSnapProvider.SnapTime(EditorClock.CurrentTime));
+        private void updateEndTimeFromCurrent()
+        {
+            HitObject.EndTime = beatSnapProvider == null
+                ? Math.Max(HitObject.StartTime, EditorClock.CurrentTime)
+                : Math.Max(HitObject.StartTime + beatSnapProvider.GetBeatLengthAtTime(HitObject.StartTime), beatSnapProvider.SnapTime(EditorClock.CurrentTime));
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
@@ -22,6 +23,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 
         private bool isPlacingEnd;
 
+        [Resolved]
+        private IBeatSnapProvider beatSnapProvider { get; set; }
+
         public SpinnerPlacementBlueprint()
             : base(new Spinner { Position = OsuPlayfield.BASE_SIZE / 2 })
         {
@@ -33,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
             base.Update();
 
             if (isPlacingEnd)
-                HitObject.EndTime = Math.Max(HitObject.StartTime, EditorClock.CurrentTime);
+                updateEndTimeFromCurrent();
 
             piece.UpdateFrom(HitObject);
         }
@@ -45,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
                 if (e.Button != MouseButton.Right)
                     return false;
 
-                HitObject.EndTime = EditorClock.CurrentTime;
+                updateEndTimeFromCurrent();
                 EndPlacement(true);
             }
             else
@@ -61,5 +65,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 
             return true;
         }
+
+        private void updateEndTimeFromCurrent() =>
+            HitObject.EndTime = Math.Max(HitObject.StartTime + beatSnapProvider.GetBeatLengthAtTime(HitObject.StartTime), beatSnapProvider.SnapTime(EditorClock.CurrentTime));
     }
 }

--- a/osu.Game/Rulesets/Edit/IBeatSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IBeatSnapProvider.cs
@@ -1,14 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Edit
 {
     public interface IBeatSnapProvider
     {
         /// <summary>
-        /// Snaps a duration to the closest beat of a timing point applicable at the reference time.
+        /// Snaps a duration to the closest beat of a timing point applicable at the reference time, factoring in the current <see cref="BeatDivisor"/>.
         /// </summary>
         /// <param name="time">The time to snap.</param>
         /// <param name="referenceTime">An optional reference point to use for timing point lookup.</param>
@@ -16,10 +14,10 @@ namespace osu.Game.Rulesets.Edit
         double SnapTime(double time, double? referenceTime = null);
 
         /// <summary>
-        /// Get the most appropriate beat length at a given time.
+        /// Get the most appropriate beat length at a given time, pre-divided by <see cref="BeatDivisor"/>.
         /// </summary>
         /// <param name="referenceTime">A reference time used for lookup.</param>
-        /// <returns>The most appropriate beat length.</returns>
+        /// <returns>The most appropriate beat length, divided by <see cref="BeatDivisor"/>.</returns>
         double GetBeatLengthAtTime(double referenceTime);
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -424,9 +424,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 break;
 
                             case IHasDuration endTimeHitObject:
-                                double snappedTime = Math.Max(hitObject.StartTime, beatSnapProvider.SnapTime(time));
+                                double snappedTime = Math.Max(hitObject.StartTime + beatSnapProvider.GetBeatLengthAtTime(hitObject.StartTime), beatSnapProvider.SnapTime(time));
 
-                                if (endTimeHitObject.EndTime == snappedTime || Precision.AlmostEquals(snappedTime, hitObject.StartTime, beatmap.GetBeatLengthAtTime(snappedTime)))
+                                if (endTimeHitObject.EndTime == snappedTime)
                                     return;
 
                                 endTimeHitObject.Duration = snappedTime - hitObject.StartTime;


### PR DESCRIPTION
This change makes it so the minimum spinner length that can be placed is equal to one beat snap length (matches stable).

It also always snap a spinner's end time using beat snap (matches stable).

Closes #21401.