### PR TITLE
Bump `dorny/test-reporter` action to 1.6.0

### DIFF
--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Annotate CI run with test results
-        uses: dorny/test-reporter@v1.4.2
+        uses: dorny/test-reporter@v1.6.0
         with:
           artifact: osu-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           name: Test Results (${{matrix.os.prettyname}}, ${{matrix.threadingMode}})


### PR DESCRIPTION
Mirror image of https://github.com/ppy/osu-framework/pull/5564.

See aforementioned pull's description for rationale.