### PR TITLE
Fix first-run setup overlay crashing on mobile platforms

### DIFF
--- a/osu.Game/Graphics/UserInterface/RangeSlider.cs
+++ b/osu.Game/Graphics/UserInterface/RangeSlider.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Graphics.UserInterface
                 }, true);
             }
 
-            [BackgroundDependencyLoader]
+            [BackgroundDependencyLoader(true)]
             private void load(OverlayColourProvider? colourProvider)
             {
                 if (colourProvider == null) return;


### PR DESCRIPTION
Noticed while working on something else, and seems critical to merge before next release, as it might affect anyone who installed the game for the first time.

```
2022-12-04 21:51:15.990 osu.iOS[1199:197906] [runtime] 2022-12-04 18:51:15 [error]: An unhandled error has occurred.
2022-12-04 21:51:15.990 osu.iOS[1199:197906] [runtime] 2022-12-04 18:51:15 [error]: osu.Framework.Allocation.DependencyNotRegisteredException: The type RangeSlider+BoundSlider has a dependency on OverlayColourProvider, but the dependency is not registered.
2022-12-04 21:51:15.990 osu.iOS[1199:197906] [runtime] 2022-12-04 18:51:15 [error]: at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute+<>c__DisplayClass8_0.<getDependency>b__0 (osu.Framework.Allocation.IReadOnlyDependencyContainer dc) [0x00028] in <ec18e8d5cd704b7faaa5a24e102b706d>:0
2022-12-04 21:51:15.990 osu.iOS[1199:197906] [runtime] 2022-12-04 18:51:15 [error]: at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute+<>c__DisplayClass7_0.<CreateActivator>b__3 (System.Object target, osu.Framework.Allocation.IReadOnlyDependencyContainer dc) [0x00012] in <ec18e8d5cd704b7faaa5a24e102b706d>:0
2022-12-04 21:51:15.991 osu.iOS[1199:197906] [runtime] 2022-12-04 18:51:15 [error]: at osu.Framework.Allocation.DependencyActivator.<Activate>g__activateRecursively|8_0[T] (System.Object obj, osu.Framework.Allocation.IReadOnlyDependencyContainer dependencies, System.Type currentType) [0x0003a] in <ec18e8d5cd704b7faaa5a24e102b706d>:0
```

(coming from load of `SongSelect` in first-run setup overlay)

Since mobile platforms are not using .NET 6 still, NRT annotations are not recognised and thus explicit flags are required for the time being. I'm afraid this will bite us yet again in the future, and I'm not sure of a way to properly handle it without basically disabling this feature completely framework-side and call it a day.