### PR TITLE
Fix loss of precision in ScoreProcessor.ComputeAccuracy()

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
@@ -354,6 +355,28 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(totalScore, Is.EqualTo(750_000)); // 500K from accuracy (100%), and 250K from combo (50%).
         }
 #pragma warning restore CS0618
+
+        [Test]
+        public void TestAccuracyWhenNearPerfect()
+        {
+            const int count_judgements = 1000;
+            const int count_misses = 1;
+
+            double actual = new TestScoreProcessor().ComputeAccuracy(new ScoreInfo
+            {
+                Statistics = new Dictionary<HitResult, int>
+                {
+                    { HitResult.Great, count_judgements - count_misses },
+                    { HitResult.Miss, count_misses }
+                }
+            });
+
+            const double expected = (count_judgements - count_misses) / (double)count_judgements;
+
+            Assert.That(actual, Is.Not.EqualTo(0.0));
+            Assert.That(actual, Is.Not.EqualTo(1.0));
+            Assert.That(actual, Is.EqualTo(expected).Within(Precision.FLOAT_EPSILON));
+        }
 
         private class TestRuleset : Ruleset
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -285,7 +285,7 @@ namespace osu.Game.Rulesets.Scoring
             // We only extract scoring values from the score's statistics. This is because accuracy is always relative to the point of pass or fail rather than relative to the whole beatmap.
             extractScoringValues(scoreInfo.Statistics, out var current, out var maximum);
 
-            return maximum.BaseScore > 0 ? current.BaseScore / maximum.BaseScore : 1;
+            return maximum.BaseScore > 0 ? (double)current.BaseScore / maximum.BaseScore : 1;
         }
 
         /// <summary>


### PR DESCRIPTION
Afaik this is only used in the `upgrade-scores` command of `osu-queue-score-statistics`.