### PR TITLE
Fix preview track disposal potentially leaving game track muted

### DIFF
--- a/osu.Game/Audio/PreviewTrack.cs
+++ b/osu.Game/Audio/PreviewTrack.cs
@@ -109,6 +109,8 @@ namespace osu.Game.Audio
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
+            Stop();
             Track?.Dispose();
         }
     }


### PR DESCRIPTION
- Closes #21518 

`PreviewTrackManager` relies on an event invoked on stop to determine whether to unmute game-wide track. When a preview track is disposed while in playing state, that event is not fired and thus the game-wide track remains muted indefinitely.

It would be nicer if the preview track remains in playing state and the corresponding card in the new listing size displays the status of the track, but that'll require considerable effort to get working (`PreviewTrackManager` would be refactored to house tracks instead of each play button loading it separately).