### PR TITLE
Fix extended values in difficulty adjust being truncated to 10 on beatmap change

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModDifficultyAdjustSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModDifficultyAdjustSettings.cs
@@ -127,6 +127,21 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestExtendedLimitsRetainedAfterBoundCopyCreation()
+        {
+            setExtendedLimits(true);
+            setSliderValue("Circle Size", 11);
+
+            checkSliderAtValue("Circle Size", 11);
+            checkBindableAtValue("Circle Size", 11);
+
+            AddStep("create bound copy", () => _ = modDifficultyAdjust.CircleSize.GetBoundCopy());
+
+            checkSliderAtValue("Circle Size", 11);
+            checkBindableAtValue("Circle Size", 11);
+        }
+
+        [Test]
         public void TestResetToDefault()
         {
             setBeatmapWithDifficultyParameters(2);

--- a/osu.Game/Rulesets/Mods/DifficultyBindable.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyBindable.cs
@@ -118,11 +118,18 @@ namespace osu.Game.Rulesets.Mods
             if (!(them is DifficultyBindable otherDifficultyBindable))
                 throw new InvalidOperationException($"Cannot bind to a non-{nameof(DifficultyBindable)}.");
 
+            // ensure that MaxValue and ExtendedMaxValue are copied across first before continuing.
+            // not doing so may cause the value of CurrentNumber to be truncated to 10.
+            otherDifficultyBindable.CopyTo(this);
+
+            // set up mutual binding for ExtendedLimits to correctly set the upper bound of CurrentNumber.
             ExtendedLimits.BindTarget = otherDifficultyBindable.ExtendedLimits;
 
-            // the actual values need to be copied after the max value constraints.
+            // set up mutual binding for CurrentNumber. this must happen after all of the above.
             CurrentNumber.BindTarget = otherDifficultyBindable.CurrentNumber;
 
+            // finish up the binding by setting up weak references via the base call.
+            // unfortunately this will call `.CopyTo()` again, but fixing that is problematic and messy.
             base.BindTo(them);
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21539.

Regressed in a2438428a23639a9100f21e3723849325ae136c1. [It was not fine to reorder the base call :(](https://github.com/ppy/osu/pull/21298#discussion_r1030838494)

The failure site exposing this is here:

https://github.com/ppy/osu/blob/e47f933cdc8757d01fc04e3ce3ceaf5f9f0f9e12/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs#L41-L53

The `.GetBoundCopy()` call here would cause `CurrentNumber` to be clamped to 10, on _both_ sides of the bind.

Cause is similar (but not 100% exactly the same) as https://github.com/ppy/osu-framework/pull/5542. All bounds that may clamp the values in the bindable need to be transferred prior to the value, to ensure clamping does not occur in the process of copying values across.

This PR uses the solution from the review comment linked above, with requisite test coverage. I won't pretend it's not ugly, but I don't know how to make it not-ugly without upending more stuff than could be considered reasonable.