### PR TITLE
Allow random mod to flip sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -65,6 +65,11 @@ namespace osu.Game.Rulesets.Osu.Mods
                     flowDirection = !flowDirection;
                 }
 
+                if (positionInfos[i].HitObject is Slider slider && random.NextDouble() < 0.5)
+                {
+                    OsuHitObjectGenerationUtils.FlipSlider(slider);
+                }
+
                 if (i == 0)
                 {
                     positionInfos[i].DistanceFromPrevious = (float)(random.NextDouble() * OsuPlayfield.BASE_SIZE.Y / 2);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 if (positionInfos[i].HitObject is Slider slider && random.NextDouble() < 0.5)
                 {
-                    OsuHitObjectGenerationUtils.FlipSlider(slider);
+                    OsuHitObjectGenerationUtils.FlipSliderHorizontally(slider);
                 }
 
                 if (i == 0)

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -166,9 +166,9 @@ namespace osu.Game.Rulesets.Osu.Utils
         }
 
         /// <summary>
-        /// Flips the slider about its start position.
+        /// Flips the slider about its start position horizontally.
         /// </summary>
-        public static void FlipSlider(Slider slider)
+        public static void FlipSliderHorizontally(Slider slider)
         {
             void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(slider.Position.X - (nested.X - slider.Position.X), nested.Y);
             static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -116,18 +116,10 @@ namespace osu.Game.Rulesets.Osu.Utils
         {
             osuObject.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - osuObject.X, osuObject.Position.Y);
 
-            if (!(osuObject is Slider slider))
+            if (osuObject is not Slider slider)
                 return;
 
-            // No need to update the head and tail circles, since slider handles that when the new slider path is set
-            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
-            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - h.Position.X, h.Position.Y));
-
-            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray();
-            foreach (var point in controlPoints)
-                point.Position = new Vector2(-point.Position.X, point.Position.Y);
-
-            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+            FlipSliderHorizontally(slider);
         }
 
         /// <summary>
@@ -138,18 +130,13 @@ namespace osu.Game.Rulesets.Osu.Utils
         {
             osuObject.Position = new Vector2(osuObject.Position.X, OsuPlayfield.BASE_SIZE.Y - osuObject.Y);
 
-            if (!(osuObject is Slider slider))
+            if (osuObject is not Slider slider)
                 return;
 
-            // No need to update the head and tail circles, since slider handles that when the new slider path is set
-            slider.NestedHitObjects.OfType<SliderTick>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
-            slider.NestedHitObjects.OfType<SliderRepeat>().ForEach(h => h.Position = new Vector2(h.Position.X, OsuPlayfield.BASE_SIZE.Y - h.Position.Y));
+            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.X, slider.Y - (nested.Y - slider.Y));
+            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(point.Position.X, -point.Position.Y);
 
-            var controlPoints = slider.Path.ControlPoints.Select(p => new PathControlPoint(p.Position, p.Type)).ToArray();
-            foreach (var point in controlPoints)
-                point.Position = new Vector2(point.Position.X, -point.Position.Y);
-
-            slider.Path = new SliderPath(controlPoints, slider.Path.ExpectedDistance.Value);
+            modifySlider(slider, flipNestedObject, flipControlPoint);
         }
 
         /// <summary>
@@ -170,7 +157,7 @@ namespace osu.Game.Rulesets.Osu.Utils
         /// </summary>
         public static void FlipSliderHorizontally(Slider slider)
         {
-            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(slider.Position.X - (nested.X - slider.Position.X), nested.Y);
+            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(slider.X - (nested.X - slider.X), nested.Y);
             static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
 
             modifySlider(slider, flipNestedObject, flipControlPoint);


### PR DESCRIPTION
Just a minor addition to the random mod.
This was suggested in https://github.com/ppy/osu/pull/18769#issuecomment-1185450883.
Sliders now get flipped (horizontally, but it doesn't really matter because sliders are being rotated) with a 50% chance.

To reduce redundancies in the code, I added `modifySlider()` and updated `RotateSlider()`, `ReflectVertically()` and `ReflectHorizontally()` to use those newly created methods.