### PR TITLE
Immediately send ack request when joining new channels

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -529,6 +529,10 @@ namespace osu.Game.Online.Chat
                         {
                             Logger.Log($"Joined public channel {channel}");
                             joinChannel(channel, fetchInitialMessages);
+
+                            // Required after joining public channels to mark the user as online in them.
+                            // Todo: Temporary workaround for https://github.com/ppy/osu-web/issues/9602
+                            SendAck();
                         };
                         req.Failure += e =>
                         {


### PR DESCRIPTION
Workaround for https://github.com/ppy/osu-web/issues/9602

Otherwise, when joining a new channel, we won't receive messages back from the websocket and can't resolve them.