### PR TITLE
Remove triangle effect from latency certifier buttons

### DIFF
--- a/osu.Game/Screens/Utility/ButtonWithKeyBind.cs
+++ b/osu.Game/Screens/Utility/ButtonWithKeyBind.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Screens.Utility
             Height = 100;
             SpriteText.Colour = overlayColourProvider.Background6;
             SpriteText.Font = OsuFont.TorusAlternate.With(size: 34);
+
+            Triangles?.Hide();
         }
     }
 }


### PR DESCRIPTION
Having the triangle animation present broke the whole purpose of the screen, as it would animate slower than normal when the update rate is limited. This is due to `TrianglesV2` processing its animations in `Update` assuming the clock `ElapsedTime` value is accurate (which I'd argue, we should be able to assume). In this special case it is not, though.

Closes #21546.