### PR TITLE
Fix expanded beatmap cards sometimes being hidden by next profile section

### DIFF
--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -240,7 +240,9 @@ namespace osu.Game.Graphics.Containers
                 headerBackgroundContainer.Height = expandableHeaderSize + fixedHeaderSize;
                 headerBackgroundContainer.Y = ExpandableHeader?.Y ?? 0;
 
-                float smallestSectionHeight = Children.Count > 0 ? Children.Min(d => d.Height) : 0;
+                var flowChildren = scrollContentContainer.FlowingChildren.OfType<T>();
+
+                float smallestSectionHeight = flowChildren.Any() ? flowChildren.Min(d => d.Height) : 0;
 
                 // scroll offset is our fixed header height if we have it plus 10% of content height
                 // plus 5% to fix floating point errors and to not have a section instantly unselect when scrolling upwards
@@ -249,7 +251,7 @@ namespace osu.Game.Graphics.Containers
 
                 float scrollCentre = fixedHeaderSize + scrollContainer.DisplayableContent * scroll_y_centre + selectionLenienceAboveSection;
 
-                var presentChildren = Children.Where(c => c.IsPresent);
+                var presentChildren = flowChildren.Where(c => c.IsPresent);
 
                 if (lastClickedSection != null)
                     SelectedSection.Value = lastClickedSection;

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -205,7 +205,9 @@ namespace osu.Game.Overlays
 
             protected override UserTrackingScrollContainer CreateScrollContainer() => new OverlayScrollContainer();
 
-            protected override FlowContainer<ProfileSection> CreateScrollContentContainer() => new FillFlowContainer<ProfileSection>
+            // Reverse child ID is required so expanding beatmap panels can appear above sections below them.
+            // This can also be done by setting Depth when adding new sections above if using ReverseChildID turns out to have any issues.
+            protected override FlowContainer<ProfileSection> CreateScrollContentContainer() => new ReverseChildIDFillFlowContainer<ProfileSection>
             {
                 Direction = FillDirection.Vertical,
                 AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
![osu! 2022-12-07 at 07 33 35](https://user-images.githubusercontent.com/191335/206116919-5a73920e-5a5e-4a54-99f7-efb5fbc17662.png)

Closes #21554.