### PR TITLE
Reflect nested objects in the playfield correctly

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Osu.Utils;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    public class OsuHitObjectGenerationUtilsTest
+    {
+        private static Slider createTestSlider()
+        {
+            var slider = new Slider
+            {
+                Position = new Vector2(128, 128),
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(new Vector2(), PathType.Linear),
+                        new PathControlPoint(new Vector2(-64, -128), PathType.Linear), // absolute position: (64, 0)
+                        new PathControlPoint(new Vector2(-128, 0), PathType.Linear) // absolute position: (0, 128)
+                    }
+                },
+                RepeatCount = 1
+            };
+            slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            return slider;
+        }
+
+        [Test]
+        public void TestReflectSliderHorizontallyAlongPlayfield()
+        {
+            var slider = createTestSlider();
+
+            OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(slider);
+
+            Assert.That(slider.Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 128, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 0, 128)));
+            Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
+            {
+                new Vector2(),
+                new Vector2(64, -128),
+                new Vector2(128, 0)
+            }));
+        }
+
+        [Test]
+        public void TestReflectSliderVerticallyAlongPlayfield()
+        {
+            var slider = createTestSlider();
+
+            OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(slider);
+
+            Assert.That(slider.Position, Is.EqualTo(new Vector2(128, OsuPlayfield.BASE_SIZE.Y - 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(0, OsuPlayfield.BASE_SIZE.Y - 128)));
+            Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
+            {
+                new Vector2(),
+                new Vector2(-64, 128),
+                new Vector2(-128, 0)
+            }));
+        }
+
+        [Test]
+        public void TestFlipSliderInPlaceHorizontally()
+        {
+            var slider = createTestSlider();
+
+            OsuHitObjectGenerationUtils.FlipSliderInPlaceHorizontally(slider);
+
+            Assert.That(slider.Position, Is.EqualTo(new Vector2(128, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(256, 128)));
+            Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
+            {
+                new Vector2(),
+                new Vector2(64, -128),
+                new Vector2(128, 0)
+            }));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHardRock.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var osuObject = (OsuHitObject)hitObject;
 
-            OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
+            OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMirror.cs
@@ -27,16 +27,16 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (Reflection.Value)
             {
                 case MirrorType.Horizontal:
-                    OsuHitObjectGenerationUtils.ReflectHorizontally(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(osuObject);
                     break;
 
                 case MirrorType.Vertical:
-                    OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
                     break;
 
                 case MirrorType.Both:
-                    OsuHitObjectGenerationUtils.ReflectHorizontally(osuObject);
-                    OsuHitObjectGenerationUtils.ReflectVertically(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(osuObject);
+                    OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(osuObject);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 if (positionInfos[i].HitObject is Slider slider && random.NextDouble() < 0.5)
                 {
-                    OsuHitObjectGenerationUtils.FlipSliderHorizontally(slider);
+                    OsuHitObjectGenerationUtils.FlipSliderInPlaceHorizontally(slider);
                 }
 
                 if (i == 0)

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Osu.Utils
             if (osuObject is not Slider slider)
                 return;
 
-            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.X, slider.Y - (nested.Y - slider.Y));
+            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.Position.X, OsuPlayfield.BASE_SIZE.Y - nested.Position.Y);
             static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(point.Position.X, -point.Position.Y);
 
             modifySlider(slider, flipNestedObject, flipControlPoint);

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -112,21 +112,24 @@ namespace osu.Game.Rulesets.Osu.Utils
         /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield horizontally.
         /// </summary>
         /// <param name="osuObject">The object to reflect.</param>
-        public static void ReflectHorizontally(OsuHitObject osuObject)
+        public static void ReflectHorizontallyAlongPlayfield(OsuHitObject osuObject)
         {
             osuObject.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - osuObject.X, osuObject.Position.Y);
 
             if (osuObject is not Slider slider)
                 return;
 
-            FlipSliderHorizontally(slider);
+            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - nested.Position.X, nested.Position.Y);
+            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
+
+            modifySlider(slider, flipNestedObject, flipControlPoint);
         }
 
         /// <summary>
         /// Reflects the position of the <see cref="OsuHitObject"/> in the playfield vertically.
         /// </summary>
         /// <param name="osuObject">The object to reflect.</param>
-        public static void ReflectVertically(OsuHitObject osuObject)
+        public static void ReflectVerticallyAlongPlayfield(OsuHitObject osuObject)
         {
             osuObject.Position = new Vector2(osuObject.Position.X, OsuPlayfield.BASE_SIZE.Y - osuObject.Y);
 
@@ -135,6 +138,18 @@ namespace osu.Game.Rulesets.Osu.Utils
 
             void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.Position.X, OsuPlayfield.BASE_SIZE.Y - nested.Position.Y);
             static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(point.Position.X, -point.Position.Y);
+
+            modifySlider(slider, flipNestedObject, flipControlPoint);
+        }
+
+        /// <summary>
+        /// Flips the position of the <see cref="Slider"/> around its start position horizontally.
+        /// </summary>
+        /// <param name="slider">The slider to be flipped.</param>
+        public static void FlipSliderInPlaceHorizontally(Slider slider)
+        {
+            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(slider.X - (nested.X - slider.X), nested.Y);
+            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
 
             modifySlider(slider, flipNestedObject, flipControlPoint);
         }
@@ -150,17 +165,6 @@ namespace osu.Game.Rulesets.Osu.Utils
             void rotateControlPoint(PathControlPoint point) => point.Position = rotateVector(point.Position, rotation);
 
             modifySlider(slider, rotateNestedObject, rotateControlPoint);
-        }
-
-        /// <summary>
-        /// Flips the slider about its start position horizontally.
-        /// </summary>
-        public static void FlipSliderHorizontally(Slider slider)
-        {
-            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(slider.X - (nested.X - slider.X), nested.Y);
-            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
-
-            modifySlider(slider, flipNestedObject, flipControlPoint);
         }
 
         private static void modifySlider(Slider slider, Action<OsuHitObject> modifyNestedObject, Action<PathControlPoint> modifyControlPoint)

--- a/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
+++ b/osu.Game.Rulesets.Osu/Utils/OsuHitObjectGenerationUtils.cs
@@ -119,10 +119,10 @@ namespace osu.Game.Rulesets.Osu.Utils
             if (osuObject is not Slider slider)
                 return;
 
-            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - nested.Position.X, nested.Position.Y);
-            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
+            void reflectNestedObject(OsuHitObject nested) => nested.Position = new Vector2(OsuPlayfield.BASE_SIZE.X - nested.Position.X, nested.Position.Y);
+            static void reflectControlPoint(PathControlPoint point) => point.Position = new Vector2(-point.Position.X, point.Position.Y);
 
-            modifySlider(slider, flipNestedObject, flipControlPoint);
+            modifySlider(slider, reflectNestedObject, reflectControlPoint);
         }
 
         /// <summary>
@@ -136,10 +136,10 @@ namespace osu.Game.Rulesets.Osu.Utils
             if (osuObject is not Slider slider)
                 return;
 
-            void flipNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.Position.X, OsuPlayfield.BASE_SIZE.Y - nested.Position.Y);
-            static void flipControlPoint(PathControlPoint point) => point.Position = new Vector2(point.Position.X, -point.Position.Y);
+            void reflectNestedObject(OsuHitObject nested) => nested.Position = new Vector2(nested.Position.X, OsuPlayfield.BASE_SIZE.Y - nested.Position.Y);
+            static void reflectControlPoint(PathControlPoint point) => point.Position = new Vector2(point.Position.X, -point.Position.Y);
 
-            modifySlider(slider, flipNestedObject, flipControlPoint);
+            modifySlider(slider, reflectNestedObject, reflectControlPoint);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/21561

Fixes a regression in behaviour from https://github.com/ppy/osu/commit/8f3023ffd9c64c91258e3d7642d57f8431c12cd4. The nested hit objects were being reflected incorrectly, causing a strange effect on SR when mirroring mods (such as Hard Rock) were applied [(see this as an example, should be 5.84*).](https://cdn.discordapp.com/attachments/757615676310552598/1050138330739769365/osu_2022-12-07_14-52-36.jpg)

