### PR TITLE
Fix android crash when using non-Gregorian calendars

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -58,4 +58,7 @@
     <!-- Realm needs to be directly referenced in all Xamarin projects, as it will not pull in its transitive dependencies otherwise. -->
     <PackageReference Include="Realm" Version="10.18.0" />
   </ItemGroup>
+  <ItemGroup>
+    <LinkDescription Include="$(MSBuildThisFileDirectory)\osu.Android\Linker.xml"/>
+  </ItemGroup>
 </Project>

--- a/osu.Android/Linker.xml
+++ b/osu.Android/Linker.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<linker>
+    <assembly fullname="mscorlib">
+        <!-- see https://github.com/ppy/osu/issues/21516 -->
+        <type fullname="System.Globalization.*Calendar"/>
+    </assembly>
+</linker>

--- a/osu.iOS/Linker.xml
+++ b/osu.iOS/Linker.xml
@@ -24,4 +24,8 @@
     <assembly fullname="osu.Game.Rulesets.Osu">
         <type fullname="*" />
     </assembly>
+    <assembly fullname="mscorlib">
+        <!-- see https://github.com/ppy/osu/issues/21516 -->
+        <type fullname="System.Globalization.*Calendar"/>
+    </assembly>
 </linker>


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/21516

Regressed with https://github.com/ppy/osu/pull/21164. That PR changed the logic to use the system culture, which would try to load `System.Globalization.ThaiBuddhistCalendar`, but that calendar was removed by the linker.

This PR just adds all the calendars to linker exceptions for both Android and iOS ([just in case](https://github.com/xamarin/Xamarin.Forms/issues/4037)).

We've had linker issues on Android before: https://github.com/ppy/osu/pull/20872.