### PR TITLE
Spinners can show a huge negative spm number #21221

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCalculator.cs
@@ -52,6 +52,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 result.Value = (currentRotation - record.Rotation) / (Time.Current - record.Time) * 1000 * 60 / 360;
             }
 
+            if (result.Value < 0)
+            {
+                result.Value = 0;
+            }
+            
             records.Enqueue(new RotationRecord { Rotation = currentRotation, Time = Time.Current });
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerSpmCalculator.cs
@@ -51,12 +51,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
                 result.Value = (currentRotation - record.Rotation) / (Time.Current - record.Time) * 1000 * 60 / 360;
             }
-
-            if (result.Value < 0)
-            {
-                result.Value = 0;
-            }
             
+            result.Value = max(result.Value, 0);  
             records.Enqueue(new RotationRecord { Rotation = currentRotation, Time = Time.Current });
         }
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Rulesets.Scoring
     public partial class ScoreProcessor : JudgementProcessor
     {
         private const double max_score = 1000000;
+        private const double min_score = 0;
+
 
         /// <summary>
         /// Invoked when this <see cref="ScoreProcessor"/> was reset from a replay frame.
@@ -420,6 +422,11 @@ namespace osu.Game.Rulesets.Scoring
 
             // Populate total score after everything else.
             score.TotalScore = ComputeScore(ScoringMode.Standardised, score);
+            
+            if (score.TotalScore < min_score)
+            {
+                score.TotalScore = 0;
+            }
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -422,11 +422,7 @@ namespace osu.Game.Rulesets.Scoring
 
             // Populate total score after everything else.
             score.TotalScore = ComputeScore(ScoringMode.Standardised, score);
-            
-            if (score.TotalScore < min_score)
-            {
-                score.TotalScore = 0;
-            }
+            score.TotalScore = max(score.TotalScore, min_score);
         }
 
         /// <summary>


### PR DESCRIPTION
Clamped negative values for SPM in issue: https://github.com/ppy/osu/issues/21221

If spins per minute or rotations per minute exceed a certain amount, the data is perhaps not handling that scenario in the correct manner. 