### PR TITLE
Fix hub clients not reconnecting after a connection error

### DIFF
--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Online
             await disconnect(true);
 
             if (ex != null)
-                await handleErrorAndDelay(ex, cancellationToken).ConfigureAwait(false);
+                await handleErrorAndDelay(ex, CancellationToken.None).ConfigureAwait(false);
             else
                 Logger.Log($"{ClientName} disconnected", LoggingTarget.Network);
 


### PR DESCRIPTION
I noticed this locally. It's a recent regression caused by the addition of the `await disconnect()` call above, which cancels the CTS and causes the `Task.Delay()` inside `handleErrorAndDelay` to throw an exception upwards canceling the rest of the method.

Repro step is to connect, then pause the program for ~30sec (e.g. using debugger) to trigger a disconnect, then resume the program.