### PR TITLE
Removed unused constant in TwoLayerButton.cs

### DIFF
--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -30,8 +30,7 @@ namespace osu.Game.Graphics.UserInterface
         public Box TextLayer;
 
         private const int transform_time = 600;
-        private const int pulse_length = 250;
-
+        
         private const float shear_width = 5f;
 
         private static readonly Vector2 shear = new Vector2(shear_width / Footer.HEIGHT, 0);


### PR DESCRIPTION
Removed  private const int pulse_length = 250; because it seems to not be utilized anywhere. This may perhaps lead to some ambiguity? What parameter actually controls pulse duration?
