### PR TITLE
Add legacy taiko swell (spinner)

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableSwell.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
+                Scale = new osuTK.Vector2(0.5f),
             }));
         }
 

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableSwellExpireDelay.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableSwellExpireDelay.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Replays;
+using osu.Game.Rulesets.Taiko.Tests.Judgements;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Skinning
+{
+    public partial class TestSceneDrawableSwellExpireDelay : JudgementTest
+    {
+        [Test]
+        public void TestExpireDelay()
+        {
+            const double swell_start = 1000;
+            const double swell_duration = 1000;
+
+            Swell swell = new Swell
+            {
+                StartTime = swell_start,
+                Duration = swell_duration,
+            };
+
+            Hit hit = new Hit { StartTime = swell_start + swell_duration + 50 };
+
+            List<ReplayFrame> frames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(0),
+                new TaikoReplayFrame(2100, TaikoAction.LeftCentre),
+            };
+
+            PerformTest(frames, CreateBeatmap(swell, hit));
+
+            AssertResult<Hit>(0, HitResult.Ok);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -6,14 +6,9 @@
 using System;
 using System.Linq;
 using JetBrains.Annotations;
-using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -23,20 +18,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
     public partial class DrawableSwell : DrawableTaikoHitObject<Swell>
     {
-        private const float target_ring_thick_border = 1.4f;
-        private const float target_ring_thin_border = 1f;
-        private const float target_ring_scale = 5f;
-        private const float inner_ring_alpha = 0.65f;
-
         /// <summary>
         /// Offset away from the start time of the swell at which the ring starts appearing.
         /// </summary>
         private const double ring_appear_offset = 100;
 
+        private readonly SkinnableDrawable spinnerBody;
         private readonly Container<DrawableSwellTick> ticks;
-        private readonly Container bodyContainer;
-        private readonly CircularContainer targetRing;
-        private readonly CircularContainer expandingRing;
 
         public override bool DisplayResult => false;
 
@@ -50,82 +38,17 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             FillMode = FillMode.Fit;
 
-            Content.Add(bodyContainer = new Container
+            Content.Add(spinnerBody = new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell), _ => new DefaultSwell())
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Depth = 1,
-                Children = new Drawable[]
-                {
-                    expandingRing = new CircularContainer
-                    {
-                        Name = "Expanding ring",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Alpha = 0,
-                        RelativeSizeAxes = Axes.Both,
-                        Blending = BlendingParameters.Additive,
-                        Masking = true,
-                        Children = new[]
-                        {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Alpha = inner_ring_alpha,
-                            }
-                        }
-                    },
-                    targetRing = new CircularContainer
-                    {
-                        Name = "Target ring (thick border)",
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                        Masking = true,
-                        BorderThickness = target_ring_thick_border,
-                        Blending = BlendingParameters.Additive,
-                        Children = new Drawable[]
-                        {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Alpha = 0,
-                                AlwaysPresent = true
-                            },
-                            new CircularContainer
-                            {
-                                Name = "Target ring (thin border)",
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                RelativeSizeAxes = Axes.Both,
-                                Masking = true,
-                                BorderThickness = target_ring_thin_border,
-                                BorderColour = Color4.White,
-                                Children = new[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Alpha = 0,
-                                        AlwaysPresent = true
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
             });
 
             AddInternal(ticks = new Container<DrawableSwellTick> { RelativeSizeAxes = Axes.Both });
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            expandingRing.Colour = colours.YellowLight;
-            targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
-        }
-
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell),
+        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.SwellCirclePiece),
             _ => new SwellCirclePiece
             {
                 // to allow for rotation transform
@@ -190,16 +113,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                 int numHits = ticks.Count(r => r.IsHit);
 
-                float completion = (float)numHits / HitObject.RequiredHits;
-
-                expandingRing
-                    .FadeTo(expandingRing.Alpha + Math.Clamp(completion / 16, 0.1f, 0.6f), 50)
-                    .Then()
-                    .FadeTo(completion / 8, 2000, Easing.OutQuint);
-
-                MainPiece.Drawable.RotateTo((float)(completion * HitObject.Duration / 8), 4000, Easing.OutQuint);
-
-                expandingRing.ScaleTo(1f + Math.Min(target_ring_scale - 1f, (target_ring_scale - 1f) * completion * 1.3f), 260, Easing.OutQuint);
+                (spinnerBody.Drawable as ISkinnableSwell)?.OnUserInput(this, numHits, MainPiece);
 
                 if (numHits == HitObject.RequiredHits)
                     ApplyResult(r => r.Type = r.Judgement.MaxResult);
@@ -231,24 +145,24 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.UpdateStartTimeStateTransforms();
 
-            using (BeginDelayedSequence(-ring_appear_offset))
-                targetRing.ScaleTo(target_ring_scale, 400, Easing.OutQuint);
+            (spinnerBody.Drawable as ISkinnableSwell)?.ApplyPassiveTransforms(this, MainPiece);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
         {
-            const double transition_duration = 300;
-
             switch (state)
             {
                 case ArmedState.Idle:
-                    expandingRing.FadeTo(0);
+                    HandleUserInput = true;
                     break;
 
                 case ArmedState.Miss:
                 case ArmedState.Hit:
-                    this.FadeOut(transition_duration, Easing.Out);
-                    bodyContainer.ScaleTo(1.4f, transition_duration);
+                    // Postpone drawable hitobject expiration until it has animated/faded out. Inputs on the object are disallowed during this delay.
+                    LifetimeEnd = Time.Current + 1200;
+                    HandleUserInput = false;
+
+                    (spinnerBody.Drawable as ISkinnableSwell)?.OnHitObjectEnd(state, MainPiece);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             FillMode = FillMode.Fit;
 
-            Content.Add(spinnerBody = new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell), _ => new DefaultSwell())
+            Content.Add(spinnerBody = new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.SwellBody), _ => new DefaultSwell())
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                 int numHits = ticks.Count(r => r.IsHit);
 
-                (spinnerBody.Drawable as ISkinnableSwell)?.OnUserInput(this, numHits, MainPiece);
+                (spinnerBody.Drawable as ISkinnableSwell)?.AnimateSwellProgress(this, numHits, MainPiece);
 
                 if (numHits == HitObject.RequiredHits)
                     ApplyResult(r => r.Type = r.Judgement.MaxResult);
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.UpdateStartTimeStateTransforms();
 
-            (spinnerBody.Drawable as ISkinnableSwell)?.ApplyPassiveTransforms(this, MainPiece);
+            (spinnerBody.Drawable as ISkinnableSwell)?.AnimateSwellStart(this, MainPiece);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)
@@ -153,16 +153,19 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Idle:
+                    // Only for rewind support. Reallows user inputs if swell is rewound from being hit/missed to being idle.
                     HandleUserInput = true;
                     break;
 
                 case ArmedState.Miss:
                 case ArmedState.Hit:
+                    const int clear_animation_duration = 1200;
+
                     // Postpone drawable hitobject expiration until it has animated/faded out. Inputs on the object are disallowed during this delay.
-                    LifetimeEnd = Time.Current + 1200;
+                    LifetimeEnd = Time.Current + clear_animation_duration;
                     HandleUserInput = false;
 
-                    (spinnerBody.Drawable as ISkinnableSwell)?.OnHitObjectEnd(state, MainPiece);
+                    (spinnerBody.Drawable as ISkinnableSwell)?.AnimateSwellCompletion(state, MainPiece);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Taiko/Objects/ISkinnableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/ISkinnableSwell.cs
@@ -9,14 +9,10 @@ namespace osu.Game.Rulesets.Taiko.Objects
 {
     public interface ISkinnableSwell
     {
-        void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece);
+        void AnimateSwellProgress(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece);
 
-        void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece);
+        void AnimateSwellCompletion(ArmedState state, SkinnableDrawable mainPiece);
 
-        /// <summary>
-        /// Applies passive transforms on HitObject start. Gets called every time DrawableTaikoHitobject
-        /// changes state. This happens on creation, and when the object is completed (as in hit or missed).
-        /// </summary>
-        void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece);
+        void AnimateSwellStart(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/ISkinnableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/ISkinnableSwell.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Taiko.Objects
+{
+    public interface ISkinnableSwell
+    {
+        void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece);
+
+        void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece);
+
+        /// <summary>
+        /// Applies passive transforms on HitObject start. Gets called every time DrawableTaikoHitobject
+        /// changes state. This happens on creation, and when the object is completed (as in hit or missed).
+        /// </summary>
+        void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece);
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/TaikoArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/TaikoArgonSkinTransformer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
                         case TaikoSkinComponents.TaikoExplosionOk:
                             return new ArgonHitExplosion(taikoComponent.Component);
 
-                        case TaikoSkinComponents.Swell:
+                        case TaikoSkinComponents.SwellCirclePiece:
                             return new ArgonSwellCirclePiece();
                     }
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultSwell.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
         }
 
-        public void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
+        public void AnimateSwellProgress(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
         {
             float completion = (float)numHits / swell.HitObject.RequiredHits;
 
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
                 .FadeTo(completion / 8, 2000, Easing.OutQuint);
         }
 
-        public void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece)
+        public void AnimateSwellCompletion(ArmedState state, SkinnableDrawable mainPiece)
         {
             const double transition_duration = 300;
 
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             mainPiece.FadeOut(transition_duration, Easing.OutQuad);
         }
 
-        public void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
+        public void AnimateSwellStart(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
         {
             if (swell.IsHit == false)
                 expandingRing.FadeTo(0);

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultSwell.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Taiko.Skinning.Default
+{
+    public partial class DefaultSwell : Container, ISkinnableSwell
+    {
+        private const float target_ring_thick_border = 1.4f;
+        private const float target_ring_thin_border = 1f;
+        private const float target_ring_scale = 5f;
+        private const float inner_ring_alpha = 0.65f;
+
+        private readonly Container bodyContainer;
+        private readonly CircularContainer targetRing;
+        private readonly CircularContainer expandingRing;
+
+        public DefaultSwell()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+
+            Content.Add(bodyContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Depth = 1,
+                Children = new Drawable[]
+                {
+                    expandingRing = new CircularContainer
+                    {
+                        Name = "Expanding ring",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0,
+                        RelativeSizeAxes = Axes.Both,
+                        Blending = BlendingParameters.Additive,
+                        Masking = true,
+                        Children = new[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = inner_ring_alpha,
+                            }
+                        }
+                    },
+                    targetRing = new CircularContainer
+                    {
+                        Name = "Target ring (thick border)",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        BorderThickness = target_ring_thick_border,
+                        Blending = BlendingParameters.Additive,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
+                                AlwaysPresent = true
+                            },
+                            new CircularContainer
+                            {
+                                Name = "Target ring (thin border)",
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                                Masking = true,
+                                BorderThickness = target_ring_thin_border,
+                                BorderColour = Color4.White,
+                                Children = new[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0,
+                                        AlwaysPresent = true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            expandingRing.Colour = colours.YellowLight;
+            targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
+        }
+
+        public void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
+        {
+            float completion = (float)numHits / swell.HitObject.RequiredHits;
+
+            mainPiece.Drawable.RotateTo((float)(completion * swell.HitObject.Duration / 8), 4000, Easing.OutQuint);
+
+            expandingRing.ScaleTo(1f + Math.Min(target_ring_scale - 1f, (target_ring_scale - 1f) * completion * 1.3f), 260, Easing.OutQuint);
+
+            expandingRing
+                .FadeTo(expandingRing.Alpha + Math.Clamp(completion / 16, 0.1f, 0.6f), 50)
+                .Then()
+                .FadeTo(completion / 8, 2000, Easing.OutQuint);
+        }
+
+        public void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece)
+        {
+            const double transition_duration = 300;
+
+            bodyContainer.FadeOut(transition_duration, Easing.OutQuad);
+            bodyContainer.ScaleTo(1.4f, transition_duration);
+            mainPiece.FadeOut(transition_duration, Easing.OutQuad);
+        }
+
+        public void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
+        {
+            if (swell.IsHit == false)
+                expandingRing.FadeTo(0);
+
+            const double ring_appear_offset = 100;
+
+            targetRing.Delay(ring_appear_offset).ScaleTo(target_ring_scale, 400, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwell.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwell.cs
@@ -91,13 +91,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             clearSample = skin.GetSample(new SampleInfo("spinner-osu"));
         }
 
-        public void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
+        public void AnimateSwellProgress(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
         {
             remainingHitsCountdown.Text = $"{swell.HitObject.RequiredHits - numHits}";
             spinnerCircle.RotateTo(180f * numHits, 1000, Easing.OutQuint);
         }
 
-        public void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece)
+        public void AnimateSwellCompletion(ArmedState state, SkinnableDrawable mainPiece)
         {
             const double clear_transition_duration = 300;
 
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             }
         }
 
-        public void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
+        public void AnimateSwellStart(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
         {
             if (swell.IsHit == false)
             {

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwell.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwell.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Skinning;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Framework.Audio.Sample;
+using osu.Game.Audio;
+using osuTK;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
+{
+    public partial class LegacySwell : Container, ISkinnableSwell
+    {
+        private Container bodyContainer = null!;
+        private Sprite spinnerCircle = null!;
+        private Sprite shrinkingRing = null!;
+        private Sprite clearAnimation = null!;
+        private ISample? clearSample;
+        private LegacySpriteText remainingHitsCountdown = null!;
+
+        private bool samplePlayed;
+
+        public LegacySwell()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin, SkinManager skinManager)
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Position = new Vector2(200f, 100f),
+
+                Children = new Drawable[]
+                {
+                    bodyContainer = new Container
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0,
+
+                        Children = new Drawable[]
+                        {
+                            spinnerCircle = new Sprite
+                            {
+                                Texture = skin.GetTexture("spinner-circle"),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Scale = new Vector2(0.8f),
+                            },
+                            shrinkingRing = new Sprite
+                            {
+                                Texture = skin.GetTexture("spinner-approachcircle") ?? skinManager.DefaultClassicSkin.GetTexture("spinner-approachcircle"),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Scale = Vector2.One,
+                            },
+                            remainingHitsCountdown = new LegacySpriteText(LegacyFont.Combo)
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Position = new Vector2(0f, 165f),
+                                Scale = Vector2.One,
+                            },
+                        }
+                    },
+                    clearAnimation = new Sprite
+                    {
+                        // File extension is included here because of a GetTexture limitation, see #21543
+                        Texture = skin.GetTexture("spinner-osu.png"),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Position = new Vector2(0f, -165f),
+                        Scale = new Vector2(0.3f),
+                        Alpha = 0,
+                    },
+                }
+            };
+
+            clearSample = skin.GetSample(new SampleInfo("spinner-osu"));
+        }
+
+        public void OnUserInput(DrawableTaikoHitObject<Swell> swell, int numHits, SkinnableDrawable mainPiece)
+        {
+            remainingHitsCountdown.Text = $"{swell.HitObject.RequiredHits - numHits}";
+            spinnerCircle.RotateTo(180f * numHits, 1000, Easing.OutQuint);
+        }
+
+        public void OnHitObjectEnd(ArmedState state, SkinnableDrawable mainPiece)
+        {
+            const double clear_transition_duration = 300;
+
+            bodyContainer.FadeOut(clear_transition_duration, Easing.OutQuad);
+
+            if (state == ArmedState.Hit)
+            {
+                if (!samplePlayed)
+                {
+                    clearSample?.Play();
+                    samplePlayed = true;
+                }
+
+                clearAnimation
+                    .FadeIn(clear_transition_duration, Easing.InQuad)
+                    .ScaleTo(0.8f, clear_transition_duration, Easing.InQuad)
+                    .Delay(700).FadeOut(200, Easing.OutQuad);
+            }
+        }
+
+        public void ApplyPassiveTransforms(DrawableTaikoHitObject<Swell> swell, SkinnableDrawable mainPiece)
+        {
+            if (swell.IsHit == false)
+            {
+                remainingHitsCountdown.Text = $"{swell.HitObject.RequiredHits}";
+                samplePlayed = false;
+            }
+
+            const double body_transition_duration = 100;
+
+            mainPiece.FadeOut(body_transition_duration);
+            bodyContainer.FadeIn(body_transition_duration);
+            shrinkingRing.ResizeTo(0.1f, swell.HitObject.Duration);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwellCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacySwellCirclePiece.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
+{
+    internal partial class LegacySwellCirclePiece : Sprite
+    {
+        [BackgroundDependencyLoader]
+        private void load(ISkinSource skin, SkinManager skinManager)
+        {
+            Texture = skin.GetTexture("spinner-warning") ?? skinManager.DefaultClassicSkin.GetTexture("spinner-circle");
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Scale = skin.GetTexture("spinner-warning") != null ? Vector2.One : new Vector2(0.18f);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -63,7 +63,15 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         return this.GetAnimation("sliderscorepoint", false, false);
 
                     case TaikoSkinComponents.Swell:
-                        // todo: support taiko legacy swell (https://github.com/ppy/osu/issues/13601).
+                        if (GetTexture("spinner-circle") != null)
+                            return new LegacySwell();
+
+                        return null;
+
+                    case TaikoSkinComponents.SwellCirclePiece:
+                        if (GetTexture("spinner-circle") != null)
+                            return new LegacySwellCirclePiece();
+
                         return null;
 
                     case TaikoSkinComponents.HitTarget:

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                     case TaikoSkinComponents.DrumRollTick:
                         return this.GetAnimation("sliderscorepoint", false, false);
 
-                    case TaikoSkinComponents.Swell:
+                    case TaikoSkinComponents.SwellBody:
                         if (GetTexture("spinner-circle") != null)
                             return new LegacySwell();
 

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Taiko
         RimHit,
         DrumRollBody,
         DrumRollTick,
-        Swell,
+        SwellBody,
         SwellCirclePiece,
         HitTarget,
         PlayfieldBackgroundLeft,

--- a/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSkinComponents.cs
@@ -11,6 +11,7 @@ namespace osu.Game.Rulesets.Taiko
         DrumRollBody,
         DrumRollTick,
         Swell,
+        SwellCirclePiece,
         HitTarget,
         PlayfieldBackgroundLeft,
         PlayfieldBackgroundRight,


### PR DESCRIPTION
Closes #13601.

I tried to structure this so that there's a clear divide between gameplay logic and visuals to keep `DrawableSwell` from getting too big. `DrawableSwell` contains all of the gameplay logic and creates two `SkinnableDrawable`: the swell circle piece and the swell body. All of the individual pieces that make up the swell body are then constructed or retrieved in `DefaultSwell` / `LegacySwell`, where all visual animations/fades/changes to the swell (both the swell body and swell circle piece) also happen.

Did my best to make this look as close to stable as I could, but discrepancies are possible. 

https://user-images.githubusercontent.com/56885706/206882237-5fcaad2f-0af1-4571-86b4-e4572f11ffdd.mp4

