### PR TITLE
Fix changelog single build dates disappearing before being off screen

### DIFF
--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -68,11 +68,15 @@ namespace osu.Game.Overlays.Changelog
             Anchor = Anchor.TopCentre,
             Origin = Anchor.TopCentre,
             AutoSizeAxes = Axes.Both,
-            Direction = FillDirection.Horizontal,
+            Direction = FillDirection.Vertical,
             Margin = new MarginPadding { Top = 20 },
-            Children = new Drawable[]
+            Child = new FillFlowContainer
             {
-                new OsuHoverContainer
+                Anchor = Anchor.TopCentre,
+                Origin = Anchor.TopCentre,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Child = new OsuHoverContainer
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,

--- a/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
@@ -104,27 +104,29 @@ namespace osu.Game.Overlays.Changelog
             {
                 var fill = base.CreateHeader();
 
-                foreach (var existing in fill.Children.OfType<OsuHoverContainer>())
+                var nestedFill = fill.Children.OfType<FillFlowContainer>().First();
+
+                var buildDisplay = nestedFill.Children.OfType<OsuHoverContainer>().First();
+
+                buildDisplay.Scale = new Vector2(1.25f);
+                buildDisplay.Action = null;
+
+                fill.Add(date = new OsuSpriteText
                 {
-                    existing.Scale = new Vector2(1.25f);
-                    existing.Action = null;
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Text = Build.CreatedAt.Date.ToString("dd MMMM yyyy"),
+                    Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
+                    Margin = new MarginPadding { Top = 5 },
+                    Scale = new Vector2(1.25f),
+                });
 
-                    existing.Add(date = new OsuSpriteText
-                    {
-                        Text = Build.CreatedAt.Date.ToString("dd MMMM yyyy"),
-                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
-                        Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.TopCentre,
-                        Margin = new MarginPadding { Top = 5 },
-                    });
-                }
-
-                fill.Insert(-1, new NavigationIconButton(Build.Versions?.Previous)
+                nestedFill.Insert(-1, new NavigationIconButton(Build.Versions?.Previous)
                 {
                     Icon = FontAwesome.Solid.ChevronLeft,
                     SelectBuild = b => SelectBuild(b)
                 });
-                fill.Insert(1, new NavigationIconButton(Build.Versions?.Next)
+                nestedFill.Insert(1, new NavigationIconButton(Build.Versions?.Next)
                 {
                     Icon = FontAwesome.Solid.ChevronRight,
                     SelectBuild = b => SelectBuild(b)

--- a/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -104,9 +103,9 @@ namespace osu.Game.Overlays.Changelog
             {
                 var fill = base.CreateHeader();
 
-                var nestedFill = fill.Children.OfType<FillFlowContainer>().First();
+                var nestedFill = (FillFlowContainer)fill.Child;
 
-                var buildDisplay = nestedFill.Children.OfType<OsuHoverContainer>().First();
+                var buildDisplay = (OsuHoverContainer)nestedFill.Child;
 
                 buildDisplay.Scale = new Vector2(1.25f);
                 buildDisplay.Action = null;


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/19891

There's a slight spacing difference, but this PR matches web better since the header is the correct height now.

| Before | After |
| --- | --- |
| ![osu_2022-12-11_20-15-17](https://user-images.githubusercontent.com/35318437/206959417-e5dbc5e3-26a9-4b1f-b12f-0ca86fcc8eae.jpg) | ![osu_2022-12-11_20-18-36](https://user-images.githubusercontent.com/35318437/206959736-a66f5c5c-6dfb-46a5-b8e0-5cc7a228538c.jpg) |