### PR TITLE
Add toggleable catch cursor

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -10,8 +10,11 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Catch.Beatmaps;
+using osu.Game.Rulesets.Catch.Configuration;
 using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Catch.Edit;
 using osu.Game.Rulesets.Catch.Mods;
@@ -20,6 +23,7 @@ using osu.Game.Rulesets.Catch.Scoring;
 using osu.Game.Rulesets.Catch.Skinning.Argon;
 using osu.Game.Rulesets.Catch.Skinning.Legacy;
 using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
@@ -206,5 +210,9 @@ namespace osu.Game.Rulesets.Catch
         public override HitObjectComposer CreateHitObjectComposer() => new CatchHitObjectComposer(this);
 
         public override IBeatmapVerifier CreateBeatmapVerifier() => new CatchBeatmapVerifier();
+
+        public override IRulesetConfigManager? CreateConfig(SettingsStore? settings) => new CatchRulesetConfigManager(settings, RulesetInfo);
+
+        public override RulesetSettingsSubsection? CreateSettings() => new CatchSettingsSubsection(this);
     }
 }

--- a/osu.Game.Rulesets.Catch/CatchSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Catch/CatchSettingsSubsection.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Catch.Configuration;
+
+namespace osu.Game.Rulesets.Catch
+{
+    public partial class CatchSettingsSubsection : RulesetSettingsSubsection
+    {
+        protected override LocalisableString Header => "osu!catch";
+
+        public CatchSettingsSubsection(CatchRuleset ruleset) : base(ruleset)
+        {
+        }
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var config = (CatchRulesetConfigManager)Config;
+
+            Children = new Drawable[]
+            {
+                new SettingsCheckbox
+                {
+                    LabelText = "Show cursor during gameplay",
+                    Current = config.GetBindable<bool>(CatchRulesetSetting.ShowCursorDuringPlay),
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Configuration/CatchRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Catch/Configuration/CatchRulesetConfigManager.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Configuration.Tracking;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Configuration;
+
+namespace osu.Game.Rulesets.Catch.Configuration
+{
+    public class CatchRulesetConfigManager : RulesetConfigManager<CatchRulesetSetting>
+    {
+        public CatchRulesetConfigManager(SettingsStore? settings, RulesetInfo ruleset, int? variant = null)
+            : base(settings, ruleset, variant)
+        {
+        }
+
+        protected override void InitialiseDefaults()
+        {
+            base.InitialiseDefaults();
+
+            SetDefault(CatchRulesetSetting.ShowCursorDuringPlay, false);
+        }
+        public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
+        {
+            new TrackedSetting<bool>(CatchRulesetSetting.ShowCursorDuringPlay,
+                showCursorDuringPlay => new SettingDescription(
+                    rawValue: showCursorDuringPlay,
+                    name: "Show Cursor During Play",
+                    value: showCursorDuringPlay.ToString()
+                )
+            )
+        };
+    }
+
+    public enum CatchRulesetSetting
+    {
+        ShowCursorDuringPlay
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.Catch.UI.Cursor;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 
@@ -57,7 +58,7 @@ namespace osu.Game.Rulesets.Catch.UI
             if (Mods != null && Mods.Any(m => m is ModRelax))
                 return new CatchRelaxCursorContainer();
 
-            return base.CreateCursor();
+            return new CatchCursorContainer();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursor.cs
+++ b/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursor.cs
@@ -1,0 +1,129 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Catch.Configuration;
+using osu.Game.Skinning;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.UI.Cursor
+{
+    public partial class CatchCursor : SkinReloadableDrawable
+    {
+        private const float size = 28;
+
+        private CatchCursorSprite cursorSprite;
+
+        private readonly Bindable<bool> configShowCursorDuringPlay = new Bindable<bool>();
+
+        public CatchCursor()
+        {
+            Origin = Anchor.Centre;
+
+            Size = new Vector2(size);
+        }
+
+        private void OnCursorVisibilityChanged(bool visibility)
+        {
+            if (visibility)
+                this.FadeTo(1, 250, Easing.InQuint);
+            else
+                this.FadeTo(0, 250, Easing.OutQuint);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(CatchRulesetConfigManager rulesetConfig)
+        {
+            InternalChild = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Child = cursorSprite = new DefaultCursor(), //not currently skinnable
+            };
+            rulesetConfig?.BindWith(CatchRulesetSetting.ShowCursorDuringPlay, configShowCursorDuringPlay);
+            configShowCursorDuringPlay.BindValueChanged(show => OnCursorVisibilityChanged(show.NewValue), true);
+        }
+
+        private partial class DefaultCursor : CatchCursorSprite
+        {
+            //placeholder until it is decided what the default catch cursor should be
+            public DefaultCursor()
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                InternalChildren = new[]
+                {
+                    ExpandTarget = new CircularContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        BorderThickness = size / 6,
+                        BorderColour = Color4.White,
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Shadow,
+                            Colour = Color4.Pink.Opacity(0.5f),
+                            Radius = 5,
+                        },
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Alpha = 0,
+                                AlwaysPresent = true,
+                            },
+                            new CircularContainer
+                            {
+                                Origin = Anchor.Centre,
+                                Anchor = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                                Masking = true,
+                                BorderThickness = size / 3,
+                                BorderColour = Color4.White.Opacity(0.5f),
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0,
+                                        AlwaysPresent = true,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    new Circle
+                    {
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        Scale = new Vector2(0.14f),
+                        Colour = new Color4(34, 93, 204, 255),
+                        EdgeEffect = new EdgeEffectParameters
+                        {
+                            Type = EdgeEffectType.Glow,
+                            Radius = 8,
+                            Colour = Color4.White,
+                        },
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursorContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursorContainer.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Catch.UI.Cursor
+{
+    public partial class CatchCursorContainer : GameplayCursorContainer
+    {
+        protected override Drawable CreateCursor() => new CatchCursor();
+    }
+}

--- a/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursorSprite.cs
+++ b/osu.Game.Rulesets.Catch/UI/Cursor/CatchCursorSprite.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Game.Rulesets.Catch.UI.Cursor
+{
+    public abstract partial class CatchCursorSprite : CompositeDrawable
+    {
+        /// <summary>
+        /// The an optional piece of the cursor to expand when in a clicked state.
+        /// If null, the whole cursor will be affected by expansion.
+        /// </summary>
+        public Drawable ExpandTarget { get; protected set; }
+    }
+}


### PR DESCRIPTION
- Closes #21088

This is to address the problems raised in #21088, essentially that the menu cursor is still active during catch gameplay. To fix this I have done the following:
* Implement `CatchCursor` so that the menu cursor is no longer defaulted to.
  * There is only a default non-skinnable implementation currently since I have some concerns noted below.
* Add Catch settings section with the setting 'Show cursor during gameplay' (default off)
  * The only use case I can imagine for having this on is to use the mouse to click touchscreen controls. While that is sub optimal, I don't want to tell someone they are categorically not allowed to do it.

Instead of defining a default _catch_ cursor I feel like the more natural solution would be to refactor the default osu cursor into a default gameplay cursor targetable by any ruleset. Please let me know if this fits within the design, or what other approach should be taken.

Another odd interaction is that if enabled, the cursor only shows when it is in the catch playfield. When hovering over touchscreen buttons, the cursor reverts to the menu cursor. Fixing that is out of scope for this PR but I wanted to mention since it does feel weird with these changes.

Any other feedback is appreciated.