### PR TITLE
Always hide cursor in osu!catch gameplay

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchCursorContainer.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchCursorContainer.cs
@@ -6,9 +6,9 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public partial class CatchRelaxCursorContainer : GameplayCursorContainer
+    public partial class CatchCursorContainer : GameplayCursorContainer
     {
-        // Just hide the cursor in relax.
+        // Just hide the cursor.
         // The main goal here is to show that we have a cursor so the game never shows the global one.
         protected override Drawable CreateCursor() => Empty();
     }

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -3,14 +3,12 @@
 
 #nullable disable
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -52,13 +52,7 @@ namespace osu.Game.Rulesets.Catch.UI
             this.difficulty = difficulty;
         }
 
-        protected override GameplayCursorContainer CreateCursor()
-        {
-            if (Mods != null && Mods.Any(m => m is ModRelax))
-                return new CatchRelaxCursorContainer();
-
-            return base.CreateCursor();
-        }
+        protected override GameplayCursorContainer CreateCursor() => new CatchCursorContainer();
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
- Closes #21088

Simply don't draw the cursor when playing catch. This more closely matches osu!stable behaviour.

Opening as per discussion in #21623 