### PR TITLE
Use hard links on windows when importing beatmaps from a legacy osu! install

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -564,7 +564,7 @@ namespace osu.Game.Tests.Database
 
                 var imported = await importer.Import(
                     progressNotification,
-                    new ImportTask(zipStream, string.Empty)
+                    new[] { new ImportTask(zipStream, string.Empty) }
                 );
 
                 realm.Run(r => r.Refresh());

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -1052,7 +1052,7 @@ namespace osu.Game.Tests.Database
         {
             string? temp = path ?? TestResources.GetTestBeatmapForImport(virtualTrack);
 
-            var importedSet = await importer.Import(new ImportTask(temp), batchImport);
+            var importedSet = await importer.Import(new ImportTask(temp), new ImportParameters { Batch = batchImport });
 
             Assert.NotNull(importedSet);
             Debug.Assert(importedSet != null);

--- a/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestSceneOnlinePlayBeatmapAvailabilityTracker.cs
@@ -226,12 +226,12 @@ namespace osu.Game.Tests.Online
                     this.testBeatmapManager = testBeatmapManager;
                 }
 
-                public override Live<BeatmapSetInfo> ImportModel(BeatmapSetInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default)
+                public override Live<BeatmapSetInfo> ImportModel(BeatmapSetInfo item, ArchiveReader archive = null, ImportParameters parameters = default, CancellationToken cancellationToken = default)
                 {
                     if (!testBeatmapManager.AllowImport.Wait(TimeSpan.FromSeconds(10), cancellationToken))
                         throw new TimeoutException("Timeout waiting for import to be allowed.");
 
-                    return (testBeatmapManager.CurrentImport = base.ImportModel(item, archive, batchImport, cancellationToken));
+                    return (testBeatmapManager.CurrentImport = base.ImportModel(item, archive, parameters, cancellationToken));
                 }
             }
         }

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
@@ -360,7 +361,7 @@ namespace osu.Game.Tests.Skins.IO
         private async Task<Live<SkinInfo>> loadSkinIntoOsu(OsuGameBase osu, ImportTask import, bool batchImport = false)
         {
             var skinManager = osu.Dependencies.Get<SkinManager>();
-            return await skinManager.Import(import, batchImport);
+            return await skinManager.Import(import, new ImportParameters { Batch = batchImport });
         }
     }
 }

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -12,7 +12,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Platform;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Beatmaps
 
         public override async Task<Live<BeatmapSetInfo>?> ImportAsUpdate(ProgressNotification notification, ImportTask importTask, BeatmapSetInfo original)
         {
-            var imported = await Import(notification, importTask);
+            var imported = await Import(notification, new[] { importTask });
 
             if (!imported.Any())
                 return null;

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -203,10 +203,10 @@ namespace osu.Game.Beatmaps
             }
         }
 
-        protected override void PostImport(BeatmapSetInfo model, Realm realm, bool batchImport)
+        protected override void PostImport(BeatmapSetInfo model, Realm realm, ImportParameters parameters)
         {
-            base.PostImport(model, realm, batchImport);
-            ProcessBeatmap?.Invoke((model, batchImport));
+            base.PostImport(model, realm, parameters);
+            ProcessBeatmap?.Invoke((model, parameters.Batch));
         }
 
         private void validateOnlineIds(BeatmapSetInfo beatmapSet, Realm realm)

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -456,9 +456,9 @@ namespace osu.Game.Beatmaps
 
         public Task Import(params string[] paths) => beatmapImporter.Import(paths);
 
-        public Task Import(params ImportTask[] tasks) => beatmapImporter.Import(tasks);
+        public Task Import(ImportTask[] tasks, ImportParameters parameters = default) => beatmapImporter.Import(tasks, parameters);
 
-        public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => beatmapImporter.Import(notification, tasks);
+        public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) => beatmapImporter.Import(notification, tasks, parameters);
 
         public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, ImportParameters parameters = default, CancellationToken cancellationToken = default) =>
             beatmapImporter.Import(task, parameters, cancellationToken);

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -526,24 +526,4 @@ namespace osu.Game.Beatmaps
 
         public override string HumanisedModelName => "beatmap";
     }
-
-    public struct ImportParameters
-    {
-        /// <summary>
-        /// Whether this import is part of a larger batch.
-        /// </summary>
-        /// <remarks>
-        /// May skip intensive pre-import checks in favour of faster processing.
-        ///
-        /// More specifically, imports will be skipped before they begin, given an existing model matches on hash and filenames. Should generally only be used for large batch imports, as it may defy user expectations when updating an existing model.
-        ///
-        /// Will also change scheduling behaviour to run at a lower priority.
-        /// </remarks>
-        public bool Batch { get; set; }
-
-        /// <summary>
-        /// Whether this import should use hard links rather than file copy operations if available.
-        /// </summary>
-        public bool PreferHardLinks { get; set; }
-    }
 }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -460,11 +460,11 @@ namespace osu.Game.Beatmaps
 
         public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => beatmapImporter.Import(notification, tasks);
 
-        public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) =>
-            beatmapImporter.Import(task, batchImport, cancellationToken);
+        public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, ImportParameters parameters = default, CancellationToken cancellationToken = default) =>
+            beatmapImporter.Import(task, parameters, cancellationToken);
 
         public Live<BeatmapSetInfo>? Import(BeatmapSetInfo item, ArchiveReader? archive = null, CancellationToken cancellationToken = default) =>
-            beatmapImporter.ImportModel(item, archive, false, cancellationToken);
+            beatmapImporter.ImportModel(item, archive, default, cancellationToken);
 
         public IEnumerable<string> HandledExtensions => beatmapImporter.HandledExtensions;
 
@@ -525,5 +525,25 @@ namespace osu.Game.Beatmaps
         #endregion
 
         public override string HumanisedModelName => "beatmap";
+    }
+
+    public struct ImportParameters
+    {
+        /// <summary>
+        /// Whether this import is part of a larger batch.
+        /// </summary>
+        /// <remarks>
+        /// May skip intensive pre-import checks in favour of faster processing.
+        ///
+        /// More specifically, imports will be skipped before they begin, given an existing model matches on hash and filenames. Should generally only be used for large batch imports, as it may defy user expectations when updating an existing model.
+        ///
+        /// Will also change scheduling behaviour to run at a lower priority.
+        /// </remarks>
+        public bool Batch { get; set; }
+
+        /// <summary>
+        /// Whether this import should use hard links rather than file copy operations if available.
+        /// </summary>
+        public bool PreferHardLinks { get; set; }
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -141,6 +141,9 @@ namespace osu.Game.Beatmaps
                 try
                 {
                     string fileStorePath = BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path);
+
+                    // TODO: check validity of file
+
                     var stream = GetStream(fileStorePath);
 
                     if (stream == null)

--- a/osu.Game/Database/ICanAcceptFiles.cs
+++ b/osu.Game/Database/ICanAcceptFiles.cs
@@ -5,7 +5,6 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using osu.Game.Beatmaps;
 
 namespace osu.Game.Database
 {

--- a/osu.Game/Database/ICanAcceptFiles.cs
+++ b/osu.Game/Database/ICanAcceptFiles.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using osu.Game.Beatmaps;
 
 namespace osu.Game.Database
 {
@@ -31,7 +32,8 @@ namespace osu.Game.Database
         /// This will post notifications tracking progress.
         /// </remarks>
         /// <param name="tasks">The import tasks from which the files should be imported.</param>
-        Task Import(params ImportTask[] tasks);
+        /// <param name="parameters">Parameters to further configure the import process.</param>
+        Task Import(ImportTask[] tasks, ImportParameters parameters = default);
 
         /// <summary>
         /// An array of accepted file extensions (in the standard format of ".abc").

--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using osu.Game.Beatmaps;
 using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Database
@@ -20,8 +21,9 @@ namespace osu.Game.Database
         /// </summary>
         /// <param name="notification">The notification to update.</param>
         /// <param name="tasks">The import tasks.</param>
+        /// <param name="parameters">Parameters to further configure the import process.</param>
         /// <returns>The imported models.</returns>
-        Task<IEnumerable<Live<TModel>>> Import(ProgressNotification notification, params ImportTask[] tasks);
+        Task<IEnumerable<Live<TModel>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default);
 
         /// <summary>
         /// Process a single import as an update for an existing model.

--- a/osu.Game/Database/IModelImporter.cs
+++ b/osu.Game/Database/IModelImporter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using osu.Game.Beatmaps;
 using osu.Game.Overlays.Notifications;
 
 namespace osu.Game.Database

--- a/osu.Game/Database/ImportParameters.cs
+++ b/osu.Game/Database/ImportParameters.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Database
+{
+    public struct ImportParameters
+    {
+        /// <summary>
+        /// Whether this import is part of a larger batch.
+        /// </summary>
+        /// <remarks>
+        /// May skip intensive pre-import checks in favour of faster processing.
+        ///
+        /// More specifically, imports will be skipped before they begin, given an existing model matches on hash and filenames. Should generally only be used for large batch imports, as it may defy user expectations when updating an existing model.
+        ///
+        /// Will also change scheduling behaviour to run at a lower priority.
+        /// </remarks>
+        public bool Batch { get; set; }
+
+        /// <summary>
+        /// Whether this import should use hard links rather than file copy operations if available.
+        /// </summary>
+        public bool PreferHardLinks { get; set; }
+    }
+}

--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework;
@@ -57,22 +56,15 @@ namespace osu.Game.Database
 
         public bool CheckHardLinkAvailability()
         {
-            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
-                return false;
-
             var stableStorage = GetCurrentStableStorage();
 
             if (stableStorage == null || gameHost is not DesktopGameHost desktopGameHost)
                 return false;
 
-            const string test_filename = "_hard_link_test";
+            string testExistingPath = stableStorage.GetFullPath(string.Empty);
+            string testDestinationPath = desktopGameHost.Storage.GetFullPath(string.Empty);
 
-            desktopGameHost.Storage.Delete(test_filename);
-
-            string testExistingPath = stableStorage.GetFullPath(stableStorage.GetFiles(string.Empty).First());
-            string testDestinationPath = desktopGameHost.Storage.GetFullPath(test_filename);
-
-            return HardLinkHelper.CreateHardLink(testDestinationPath, testExistingPath, IntPtr.Zero);
+            return HardLinkHelper.CheckAvailability(testDestinationPath, testExistingPath);
         }
 
         public virtual async Task<int> GetImportCount(StableContent content, CancellationToken cancellationToken)

--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Database
             string testExistingPath = stableStorage.GetFullPath(stableStorage.GetFiles(string.Empty).First());
             string testDestinationPath = desktopGameHost.Storage.GetFullPath(test_filename);
 
-            return RealmFileStore.CreateHardLink(testDestinationPath, testExistingPath, IntPtr.Zero);
+            return HardLinkHelper.CreateHardLink(testDestinationPath, testExistingPath, IntPtr.Zero);
         }
 
         public virtual async Task<int> GetImportCount(StableContent content, CancellationToken cancellationToken)

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Game.Beatmaps;
 using osu.Game.IO;
 
 namespace osu.Game.Database
@@ -57,7 +58,12 @@ namespace osu.Game.Database
                 return Task.CompletedTask;
             }
 
-            return Task.Run(async () => await Importer.Import(GetStableImportPaths(storage).ToArray()).ConfigureAwait(false));
+            return Task.Run(async () =>
+            {
+                var tasks = GetStableImportPaths(storage).Select(p => new ImportTask(p)).ToArray();
+
+                await Importer.Import(tasks, new ImportParameters { Batch = true, PreferHardLinks = true }).ConfigureAwait(false);
+            });
         }
 
         /// <summary>

--- a/osu.Game/Database/LegacyModelImporter.cs
+++ b/osu.Game/Database/LegacyModelImporter.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Game.Beatmaps;
 using osu.Game.IO;
 
 namespace osu.Game.Database

--- a/osu.Game/Database/ModelDownloader.cs
+++ b/osu.Game/Database/ModelDownloader.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Database
                     if (originalModel != null)
                         importSuccessful = (await importer.ImportAsUpdate(notification, new ImportTask(filename), originalModel)) != null;
                     else
-                        importSuccessful = (await importer.Import(notification, new ImportTask(filename))).Any();
+                        importSuccessful = (await importer.Import(notification, new[] { new ImportTask(filename) })).Any();
 
                     // for now a failed import will be marked as a failed download for simplicity.
                     if (!importSuccessful)

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -304,7 +304,7 @@ namespace osu.Game.Database
                     foreach (var filenames in getShortenedFilenames(archive))
                     {
                         using (Stream s = archive.GetStream(filenames.original))
-                            files.Add(new RealmNamedFileUsage(Files.Add(s, realm, false), filenames.shortened));
+                            files.Add(new RealmNamedFileUsage(Files.Add(s, realm, false, parameters.PreferHardLinks), filenames.shortened));
                     }
                 }
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -13,7 +13,6 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
-using osu.Game.Beatmaps;
 using osu.Game.Extensions;
 using osu.Game.IO.Archives;
 using osu.Game.Models;

--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -5,6 +5,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.Win32.SafeHandles;
 using osu.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
@@ -77,12 +79,58 @@ namespace osu.Game.Database
             data.Seek(0, SeekOrigin.Begin);
         }
 
+        public static int GetFileLinkCount(string filePath)
+        {
+            int result = 0;
+            SafeFileHandle handle = CreateFile(filePath, FileAccess.Read, FileShare.Read, IntPtr.Zero, FileMode.Open, FileAttributes.Archive, IntPtr.Zero);
+
+            ByHandleFileInformation fileInfo;
+
+            if (GetFileInformationByHandle(handle, out fileInfo))
+                result = (int)fileInfo.NumberOfLinks;
+            CloseHandle(handle);
+
+            return result;
+        }
+
         [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
         private static extern bool CreateHardLink(
             string lpFileName,
             string lpExistingFileName,
             IntPtr lpSecurityAttributes
         );
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ByHandleFileInformation
+        {
+            public readonly uint FileAttributes;
+            public readonly FILETIME CreationTime;
+            public readonly FILETIME LastAccessTime;
+            public readonly FILETIME LastWriteTime;
+            public readonly uint VolumeSerialNumber;
+            public readonly uint FileSizeHigh;
+            public readonly uint FileSizeLow;
+            public readonly uint NumberOfLinks;
+            public readonly uint FileIndexHigh;
+            public readonly uint FileIndexLow;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            [MarshalAs(UnmanagedType.U4)] FileAccess dwDesiredAccess,
+            [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
+            [MarshalAs(UnmanagedType.U4)] FileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetFileInformationByHandle(SafeFileHandle handle, out ByHandleFileInformation lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(SafeHandle hObject);
 
         private bool checkFileExistsAndMatchesHash(RealmFile file)
         {

--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -4,9 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
-using Microsoft.Win32.SafeHandles;
 using osu.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
@@ -14,6 +11,7 @@ using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Extensions;
+using osu.Game.IO;
 using osu.Game.Models;
 using Realms;
 
@@ -68,7 +66,7 @@ namespace osu.Game.Database
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows && data is FileStream fs && preferHardLinks)
             {
                 // attempt to do a fast hard link rather than copy.
-                if (CreateHardLink(Storage.GetFullPath(file.GetStoragePath()), fs.Name, IntPtr.Zero))
+                if (HardLinkHelper.CreateHardLink(Storage.GetFullPath(file.GetStoragePath()), fs.Name, IntPtr.Zero))
                     return;
             }
 
@@ -128,63 +126,5 @@ namespace osu.Game.Database
 
             Logger.Log($@"Finished realm file store cleanup ({removedFiles} of {totalFiles} deleted)");
         }
-
-        #region Windows hard link support
-
-        // For future use (to detect if a file is a hard link with other references existing on disk).
-        public static int GetFileLinkCount(string filePath)
-        {
-            int result = 0;
-            SafeFileHandle handle = CreateFile(filePath, FileAccess.Read, FileShare.Read, IntPtr.Zero, FileMode.Open, FileAttributes.Archive, IntPtr.Zero);
-
-            ByHandleFileInformation fileInfo;
-
-            if (GetFileInformationByHandle(handle, out fileInfo))
-                result = (int)fileInfo.NumberOfLinks;
-            CloseHandle(handle);
-
-            return result;
-        }
-
-        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
-        public static extern bool CreateHardLink(
-            string lpFileName,
-            string lpExistingFileName,
-            IntPtr lpSecurityAttributes
-        );
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ByHandleFileInformation
-        {
-            public readonly uint FileAttributes;
-            public readonly FILETIME CreationTime;
-            public readonly FILETIME LastAccessTime;
-            public readonly FILETIME LastWriteTime;
-            public readonly uint VolumeSerialNumber;
-            public readonly uint FileSizeHigh;
-            public readonly uint FileSizeLow;
-            public readonly uint NumberOfLinks;
-            public readonly uint FileIndexHigh;
-            public readonly uint FileIndexLow;
-        }
-
-        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern SafeFileHandle CreateFile(
-            string lpFileName,
-            [MarshalAs(UnmanagedType.U4)] FileAccess dwDesiredAccess,
-            [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
-            IntPtr lpSecurityAttributes,
-            [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
-            [MarshalAs(UnmanagedType.U4)] FileAttributes dwFlagsAndAttributes,
-            IntPtr hTemplateFile);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern bool GetFileInformationByHandle(SafeFileHandle handle, out ByHandleFileInformation lpFileInformation);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CloseHandle(SafeHandle hObject);
-
-        #endregion
     }
 }

--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Database
         /// <param name="data">The file data stream.</param>
         /// <param name="realm">The realm instance to add to. Should already be in a transaction.</param>
         /// <param name="addToRealm">Whether the <see cref="RealmFile"/> should immediately be added to the underlying realm. If <c>false</c> is provided here, the instance must be manually added.</param>
-        public RealmFile Add(Stream data, Realm realm, bool addToRealm = true)
+        /// <param name="preferHardLinks">Whether this import should use hard links rather than file copy operations if available.</param>
+        public RealmFile Add(Stream data, Realm realm, bool addToRealm = true, bool preferHardLinks = false)
         {
             string hash = data.ComputeSHA2Hash();
 
@@ -54,7 +55,7 @@ namespace osu.Game.Database
             var file = existing ?? new RealmFile { Hash = hash };
 
             if (!checkFileExistsAndMatchesHash(file))
-                copyToStore(file, data);
+                copyToStore(file, data, preferHardLinks);
 
             if (addToRealm && !file.IsManaged)
                 realm.Add(file);
@@ -62,9 +63,9 @@ namespace osu.Game.Database
             return file;
         }
 
-        private void copyToStore(RealmFile file, Stream data)
+        private void copyToStore(RealmFile file, Stream data, bool preferHardLinks)
         {
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows && data is FileStream fs)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows && data is FileStream fs && preferHardLinks)
             {
                 // attempt to do a fast hard link rather than copy.
                 if (CreateHardLink(Storage.GetFullPath(file.GetStoragePath()), fs.Name, IntPtr.Zero))
@@ -79,6 +80,58 @@ namespace osu.Game.Database
             data.Seek(0, SeekOrigin.Begin);
         }
 
+        private bool checkFileExistsAndMatchesHash(RealmFile file)
+        {
+            string path = file.GetStoragePath();
+
+            // we may be re-adding a file to fix missing store entries.
+            if (!Storage.Exists(path))
+                return false;
+
+            // even if the file already exists, check the existing checksum for safety.
+            using (var stream = Storage.GetStream(path))
+                return stream.ComputeSHA2Hash() == file.Hash;
+        }
+
+        public void Cleanup()
+        {
+            Logger.Log(@"Beginning realm file store cleanup");
+
+            int totalFiles = 0;
+            int removedFiles = 0;
+
+            // can potentially be run asynchronously, although we will need to consider operation order for disk deletion vs realm removal.
+            realm.Write(r =>
+            {
+                // TODO: consider using a realm native query to avoid iterating all files (https://github.com/realm/realm-dotnet/issues/2659#issuecomment-927823707)
+                var files = r.All<RealmFile>().ToList();
+
+                foreach (var file in files)
+                {
+                    totalFiles++;
+
+                    if (file.BacklinksCount > 0)
+                        continue;
+
+                    try
+                    {
+                        removedFiles++;
+                        Storage.Delete(file.GetStoragePath());
+                        r.Remove(file);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, $@"Could not delete databased file {file.Hash}");
+                    }
+                }
+            });
+
+            Logger.Log($@"Finished realm file store cleanup ({removedFiles} of {totalFiles} deleted)");
+        }
+
+        #region Windows hard link support
+
+        // For future use (to detect if a file is a hard link with other references existing on disk).
         public static int GetFileLinkCount(string filePath)
         {
             int result = 0;
@@ -132,53 +185,6 @@ namespace osu.Game.Database
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool CloseHandle(SafeHandle hObject);
 
-        private bool checkFileExistsAndMatchesHash(RealmFile file)
-        {
-            string path = file.GetStoragePath();
-
-            // we may be re-adding a file to fix missing store entries.
-            if (!Storage.Exists(path))
-                return false;
-
-            // even if the file already exists, check the existing checksum for safety.
-            using (var stream = Storage.GetStream(path))
-                return stream.ComputeSHA2Hash() == file.Hash;
-        }
-
-        public void Cleanup()
-        {
-            Logger.Log(@"Beginning realm file store cleanup");
-
-            int totalFiles = 0;
-            int removedFiles = 0;
-
-            // can potentially be run asynchronously, although we will need to consider operation order for disk deletion vs realm removal.
-            realm.Write(r =>
-            {
-                // TODO: consider using a realm native query to avoid iterating all files (https://github.com/realm/realm-dotnet/issues/2659#issuecomment-927823707)
-                var files = r.All<RealmFile>().ToList();
-
-                foreach (var file in files)
-                {
-                    totalFiles++;
-
-                    if (file.BacklinksCount > 0)
-                        continue;
-
-                    try
-                    {
-                        removedFiles++;
-                        Storage.Delete(file.GetStoragePath());
-                        r.Remove(file);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.Error(e, $@"Could not delete databased file {file.Hash}");
-                    }
-                }
-            });
-
-            Logger.Log($@"Finished realm file store cleanup ({removedFiles} of {totalFiles} deleted)");
-        }
+        #endregion
     }
 }

--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Database
         }
 
         [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
-        private static extern bool CreateHardLink(
+        public static extern bool CreateHardLink(
             string lpFileName,
             string lpExistingFileName,
             IntPtr lpSecurityAttributes

--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Database
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows && data is FileStream fs && preferHardLinks)
             {
                 // attempt to do a fast hard link rather than copy.
-                if (HardLinkHelper.CreateHardLink(Storage.GetFullPath(file.GetStoragePath()), fs.Name, IntPtr.Zero))
+                if (HardLinkHelper.CreateHardLink(Storage.GetFullPath(file.GetStoragePath(), true), fs.Name, IntPtr.Zero))
                     return;
             }
 

--- a/osu.Game/IO/HardLinkHelper.cs
+++ b/osu.Game/IO/HardLinkHelper.cs
@@ -70,7 +70,7 @@ namespace osu.Game.IO
             return result;
         }
 
-        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
+        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern bool CreateHardLink(string lpFileName, string lpExistingFileName, IntPtr lpSecurityAttributes);
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]

--- a/osu.Game/IO/HardLinkHelper.cs
+++ b/osu.Game/IO/HardLinkHelper.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.Win32.SafeHandles;
+
+namespace osu.Game.IO
+{
+    internal static class HardLinkHelper
+    {
+        // For future use (to detect if a file is a hard link with other references existing on disk).
+        public static int GetFileLinkCount(string filePath)
+        {
+            int result = 0;
+            SafeFileHandle handle = CreateFile(filePath, FileAccess.Read, FileShare.Read, IntPtr.Zero, FileMode.Open, FileAttributes.Archive, IntPtr.Zero);
+
+            ByHandleFileInformation fileInfo;
+
+            if (GetFileInformationByHandle(handle, out fileInfo))
+                result = (int)fileInfo.NumberOfLinks;
+            CloseHandle(handle);
+
+            return result;
+        }
+
+        [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
+        public static extern bool CreateHardLink(
+            string lpFileName,
+            string lpExistingFileName,
+            IntPtr lpSecurityAttributes
+        );
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ByHandleFileInformation
+        {
+            public readonly uint FileAttributes;
+            public readonly FILETIME CreationTime;
+            public readonly FILETIME LastAccessTime;
+            public readonly FILETIME LastWriteTime;
+            public readonly uint VolumeSerialNumber;
+            public readonly uint FileSizeHigh;
+            public readonly uint FileSizeLow;
+            public readonly uint NumberOfLinks;
+            public readonly uint FileIndexHigh;
+            public readonly uint FileIndexLow;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern SafeFileHandle CreateFile(
+            string lpFileName,
+            [MarshalAs(UnmanagedType.U4)] FileAccess dwDesiredAccess,
+            [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
+            [MarshalAs(UnmanagedType.U4)] FileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetFileInformationByHandle(SafeFileHandle handle, out ByHandleFileInformation lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(SafeHandle hObject);
+    }
+}

--- a/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
+++ b/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
@@ -15,10 +15,10 @@ namespace osu.Game.Localisation
         public static LocalisableString Header => new TranslatableString(getKey(@"header"), @"Import");
 
         /// <summary>
-        /// "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation."
+        /// "If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will not affect your existing installation's files in any way."
         /// </summary>
         public static LocalisableString Description => new TranslatableString(getKey(@"description"),
-            @"If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will create a copy, and not affect your existing installation.");
+            @"If you have an installation of a previous osu! version, you can choose to migrate your existing content. Note that this will not affect your existing installation's files in any way.");
 
         /// <summary>
         /// "previous osu! install"

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -616,14 +616,14 @@ namespace osu.Game
             }, validScreens: validScreens);
         }
 
-        public override Task Import(params ImportTask[] imports)
+        public override Task Import(ImportTask[] imports, ImportParameters parameters = default)
         {
             // encapsulate task as we don't want to begin the import process until in a ready state.
 
             // ReSharper disable once AsyncVoidLambda
             // TODO: This is bad because `new Task` doesn't have a Func<Task?> override.
             // Only used for android imports and a bit of a mess. Probably needs rethinking overall.
-            var importTask = new Task(async () => await base.Import(imports).ConfigureAwait(false));
+            var importTask = new Task(async () => await base.Import(imports, parameters).ConfigureAwait(false));
 
             waitForReady(() => this, _ => importTask.Start());
 

--- a/osu.Game/OsuGameBase_Importing.cs
+++ b/osu.Game/OsuGameBase_Importing.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 
 namespace osu.Game
@@ -44,13 +45,13 @@ namespace osu.Game
             }
         }
 
-        public virtual async Task Import(params ImportTask[] tasks)
+        public virtual async Task Import(ImportTask[] tasks, ImportParameters parameters = default)
         {
             var tasksPerExtension = tasks.GroupBy(t => Path.GetExtension(t.Path).ToLowerInvariant());
             await Task.WhenAll(tasksPerExtension.Select(taskGroup =>
             {
                 var importer = fileImporters.FirstOrDefault(i => i.HandledExtensions.Contains(taskGroup.Key));
-                return importer?.Import(taskGroup.ToArray()) ?? Task.CompletedTask;
+                return importer?.Import(taskGroup.ToArray(), parameters) ?? Task.CompletedTask;
             })).ConfigureAwait(false);
         }
 

--- a/osu.Game/OsuGameBase_Importing.cs
+++ b/osu.Game/OsuGameBase_Importing.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 
 namespace osu.Game

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -16,12 +16,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
+using osu.Framework.Screens;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
+using osu.Game.Overlays.Settings.Sections.Maintenance;
 using osu.Game.Screens.Edit.Setup;
 using osuTK;
 
@@ -41,7 +43,7 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         private StableLocatorLabelledTextBox stableLocatorTextBox = null!;
 
-        private OsuTextFlowContainer copyInformation = null!;
+        private LinkFlowContainer copyInformation = null!;
 
         private IEnumerable<ImportCheckbox> contentCheckboxes => Content.Children.OfType<ImportCheckbox>();
 
@@ -50,7 +52,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             Content.Children = new Drawable[]
             {
-                new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
+                new LinkFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     Text = FirstRunOverlayImportFromStableScreenStrings.Description,
@@ -66,7 +68,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                 new ImportCheckbox(CommonStrings.Scores, StableContent.Scores),
                 new ImportCheckbox(CommonStrings.Skins, StableContent.Skins),
                 new ImportCheckbox(CommonStrings.Collections, StableContent.Collections),
-                copyInformation = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
+                copyInformation = new LinkFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
                 {
                     Colour = OverlayColourProvider.Content1,
                     RelativeSizeAxes = Axes.X,
@@ -92,6 +94,9 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             stableLocatorTextBox.Current.BindValueChanged(_ => updateStablePath(), true);
         }
+
+        [Resolved(canBeNull: true)]
+        private OsuGame? game { get; set; }
 
         private void updateStablePath()
         {
@@ -124,11 +129,15 @@ namespace osu.Game.Overlays.FirstRunSetup
                 copyInformation.Text = "Data migration will use \"hard links\". No extra disk space will be used, and you can delete either data folder at any point without affecting the other installation.";
             }
             else if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
-                copyInformation.Text = "Hard links are not supported on this operating system, so a copy of all files will be made during import.";
+                copyInformation.Text = "Lightweight linking of files are not supported on your operating system yet, so a copy of all files will be made during import.";
             else
             {
                 copyInformation.Text =
-                    "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install and the file system is NTFS.";
+                    "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install (and the file system is NTFS). ";
+                copyInformation.AddLink(GeneralSettingsStrings.ChangeFolderLocation, () =>
+                {
+                    game?.PerformFromScreen(menu => menu.Push(new MigrationSelectScreen()));
+                });
             }
         }
 

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -269,7 +270,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                 return Task.CompletedTask;
             }
 
-            Task ICanAcceptFiles.Import(params ImportTask[] tasks) => throw new NotImplementedException();
+            Task ICanAcceptFiles.Import(ImportTask[] tasks, ImportParameters parameters) => throw new NotImplementedException();
 
             protected override void Dispose(bool isDisposing)
             {

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -40,6 +41,8 @@ namespace osu.Game.Overlays.FirstRunSetup
 
         private StableLocatorLabelledTextBox stableLocatorTextBox = null!;
 
+        private OsuTextFlowContainer copyInformation = null!;
+
         private IEnumerable<ImportCheckbox> contentCheckboxes => Content.Children.OfType<ImportCheckbox>();
 
         [BackgroundDependencyLoader(permitNulls: true)]
@@ -63,6 +66,12 @@ namespace osu.Game.Overlays.FirstRunSetup
                 new ImportCheckbox(CommonStrings.Scores, StableContent.Scores),
                 new ImportCheckbox(CommonStrings.Skins, StableContent.Skins),
                 new ImportCheckbox(CommonStrings.Collections, StableContent.Collections),
+                copyInformation = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: CONTENT_FONT_SIZE))
+                {
+                    Colour = OverlayColourProvider.Content1,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y
+                },
                 importButton = new ProgressRoundedButton
                 {
                     Size = button_size,
@@ -109,6 +118,18 @@ namespace osu.Game.Overlays.FirstRunSetup
 
             bool available = legacyImportManager.CheckHardLinkAvailability();
             Logger.Log($"Hard link support is {available}");
+
+            if (available)
+            {
+                copyInformation.Text = "Data migration will use \"hard links\". No extra disk space will be used, and you can delete either data folder at any point without affecting the other installation.";
+            }
+            else if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+                copyInformation.Text = "Hard links are not supported on this operating system, so a copy of all files will be made during import.";
+            else
+            {
+                copyInformation.Text =
+                    "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install and the file system is NTFS.";
+            }
         }
 
         private void runImport()

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Logging;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -105,6 +106,9 @@ namespace osu.Game.Overlays.FirstRunSetup
             toggleInteraction(true);
             stableLocatorTextBox.Current.Value = storage.GetFullPath(string.Empty);
             importButton.Enabled.Value = true;
+
+            bool available = legacyImportManager.CheckHardLinkAvailability();
+            Logger.Log($"Hard link support is {available}");
         }
 
         private void runImport()

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                 copyInformation.Text = "Data migration will use \"hard links\". No extra disk space will be used, and you can delete either data folder at any point without affecting the other installation.";
             }
             else if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
-                copyInformation.Text = "Lightweight linking of files are not supported on your operating system yet, so a copy of all files will be made during import.";
+                copyInformation.Text = "Lightweight linking of files is not supported on your operating system yet, so a copy of all files will be made during import.";
             else
             {
                 copyInformation.Text =

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -145,9 +145,9 @@ namespace osu.Game.Scoring
 #pragma warning restore CS0618
         }
 
-        protected override void PostImport(ScoreInfo model, Realm realm, bool batchImport)
+        protected override void PostImport(ScoreInfo model, Realm realm, ImportParameters parameters)
         {
-            base.PostImport(model, realm, batchImport);
+            base.PostImport(model, realm, parameters);
 
             var userRequest = new GetUserRequest(model.RealmUser.Username);
 

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -179,8 +179,8 @@ namespace osu.Game.Scoring
 
         public Task<Live<ScoreInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, ScoreInfo original) => scoreImporter.ImportAsUpdate(notification, task, original);
 
-        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, bool batchImport = false, CancellationToken cancellationToken = default) =>
-            scoreImporter.ImportModel(item, archive, batchImport, cancellationToken);
+        public Live<ScoreInfo> Import(ScoreInfo item, ArchiveReader archive = null, ImportParameters parameters = default, CancellationToken cancellationToken = default) =>
+            scoreImporter.ImportModel(item, archive, parameters, cancellationToken);
 
         /// <summary>
         /// Populates the <see cref="ScoreInfo.MaximumStatistics"/> for a given <see cref="ScoreInfo"/>.

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -169,13 +169,13 @@ namespace osu.Game.Scoring
 
         public Task Import(params string[] paths) => scoreImporter.Import(paths);
 
-        public Task Import(params ImportTask[] tasks) => scoreImporter.Import(tasks);
+        public Task Import(ImportTask[] imports, ImportParameters parameters = default) => scoreImporter.Import(imports, parameters);
 
         public override bool IsAvailableLocally(ScoreInfo model) => Realm.Run(realm => realm.All<ScoreInfo>().Any(s => s.OnlineID == model.OnlineID));
 
         public IEnumerable<string> HandledExtensions => scoreImporter.HandledExtensions;
 
-        public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => scoreImporter.Import(notification, tasks);
+        public Task<IEnumerable<Live<ScoreInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) => scoreImporter.Import(notification, tasks);
 
         public Task<Live<ScoreInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, ScoreInfo original) => scoreImporter.ImportAsUpdate(notification, task, original);
 

--- a/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
@@ -91,7 +92,7 @@ namespace osu.Game.Screens.Edit.Setup
             return Task.CompletedTask;
         }
 
-        Task ICanAcceptFiles.Import(params ImportTask[] tasks) => throw new NotImplementedException();
+        Task ICanAcceptFiles.Import(ImportTask[] tasks, ImportParameters parameters) => throw new NotImplementedException();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
@@ -16,7 +16,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -18,6 +18,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -411,7 +412,7 @@ namespace osu.Game.Skinning.Editor
             return Task.CompletedTask;
         }
 
-        public Task Import(params ImportTask[] tasks) => throw new NotImplementedException();
+        Task ICanAcceptFiles.Import(ImportTask[] tasks, ImportParameters parameters) => throw new NotImplementedException();
 
         public IEnumerable<string> HandledExtensions => new[] { ".jpg", ".jpeg", ".png" };
 

--- a/osu.Game/Skinning/Editor/SkinEditor.cs
+++ b/osu.Game/Skinning/Editor/SkinEditor.cs
@@ -18,7 +18,6 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -22,6 +22,7 @@ using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Audio;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Overlays.Notifications;
@@ -274,11 +275,14 @@ namespace osu.Game.Skinning
 
         public IEnumerable<string> HandledExtensions => skinImporter.HandledExtensions;
 
-        public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) => skinImporter.Import(notification, tasks);
+        public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) =>
+            skinImporter.Import(notification, tasks);
 
-        public Task<Live<SkinInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, SkinInfo original) => skinImporter.ImportAsUpdate(notification, task, original);
+        public Task<Live<SkinInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, SkinInfo original) =>
+            skinImporter.ImportAsUpdate(notification, task, original);
 
-        public Task<Live<SkinInfo>> Import(ImportTask task, bool batchImport = false, CancellationToken cancellationToken = default) => skinImporter.Import(task, batchImport, cancellationToken);
+        public Task<Live<SkinInfo>> Import(ImportTask task, ImportParameters parameters = default, CancellationToken cancellationToken = default) =>
+            skinImporter.Import(task, parameters, cancellationToken);
 
         #endregion
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -22,7 +22,6 @@ using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Audio;
-using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Overlays.Notifications;

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -271,12 +271,12 @@ namespace osu.Game.Skinning
 
         public Task Import(params string[] paths) => skinImporter.Import(paths);
 
-        public Task Import(params ImportTask[] tasks) => skinImporter.Import(tasks);
+        public Task Import(ImportTask[] imports, ImportParameters parameters = default) => skinImporter.Import(imports, parameters);
 
         public IEnumerable<string> HandledExtensions => skinImporter.HandledExtensions;
 
-        public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, params ImportTask[] tasks) =>
-            skinImporter.Import(notification, tasks);
+        public Task<IEnumerable<Live<SkinInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) =>
+            skinImporter.Import(notification, tasks, parameters);
 
         public Task<Live<SkinInfo>> ImportAsUpdate(ProgressNotification notification, ImportTask task, SkinInfo original) =>
             skinImporter.ImportAsUpdate(notification, task, original);


### PR DESCRIPTION
A common user request is to "make lazer share a beatmaps directory with stable". The reasoning users have for this is to

- Not have to download beatmaps twice (when a user is using both stable and lazer actively)
- Not taking up double the space on disk
- Taking took long to import

This change addresses the second and third (to a partial degree) concerns, by using file system level hard link support to create links rather than copies of files.

A work-in-progress document explaining this to users is [under construction](https://gist.github.com/bdach/faf66e74f4b4307d867cbe6e3b44ef60) and will eventually be added to the osu-wiki and linked from the in-game UI. I read through a lot of online explanations but they are all too technical and don't cover the important points that need to be conveyed to an osu! user. The main one is that from a user's perspective, it will still look like lazer is using disk space, but the actual free space will not go down for the drive after import.

https://github.com/ppy/osu/commit/cb16d62700f3c107588c96fef4537501a9de4cc7 contains some unfortunate widespread changes to get the hard link parameter through the import flow. I have no words here, but also don't want to change anything in this PR, so the changes should be as minimal as possible.

As mentioned by the inline comments, this can easily be implemented on unix-based operating systems, but let's leave that for another day as the user base there is much smaller.

Remaining post-merge UX tasks:

- Link to wiki page explaining hard links to the user
- Improve the flow for when a user clicks "change folder location" from the first run overlay. Currently it abruptly switches to another fullscreen overlay, which I'd like to avoid.