### PR TITLE
Disable touchscreen controls responding to mouse in scrolling gamemodes

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
@@ -106,39 +106,15 @@ namespace osu.Game.Rulesets.Catch.UI
             return false;
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            return updateAction(e.Button, getTouchCatchActionFromInput(e.ScreenSpaceMousePosition));
-        }
-
         protected override bool OnTouchDown(TouchDownEvent e)
         {
             return updateAction(e.Touch.Source, getTouchCatchActionFromInput(e.ScreenSpaceTouch.Position));
-        }
-
-        protected override bool OnMouseMove(MouseMoveEvent e)
-        {
-            Show();
-
-            TouchCatchAction? action = getTouchCatchActionFromInput(e.ScreenSpaceMousePosition);
-
-            // multiple mouse buttons may be pressed and handling the same action.
-            foreach (MouseButton button in e.PressedButtons)
-                updateAction(button, action);
-
-            return false;
         }
 
         protected override void OnTouchMove(TouchMoveEvent e)
         {
             updateAction(e.Touch.Source, getTouchCatchActionFromInput(e.ScreenSpaceTouch.Position));
             base.OnTouchMove(e);
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            updateAction(e.Button, null);
-            base.OnMouseUp(e);
         }
 
         protected override void OnTouchUp(TouchUpEvent e)

--- a/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchTouchInputMapper.cs
@@ -11,7 +11,6 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Catch.UI
 {

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -206,18 +206,6 @@ namespace osu.Game.Rulesets.Mania.UI
                 keyBindingContainer = maniaInputManager?.KeyBindingContainer;
             }
 
-            protected override bool OnMouseDown(MouseDownEvent e)
-            {
-                keyBindingContainer?.TriggerPressed(column.Action.Value);
-                return base.OnMouseDown(e);
-            }
-
-            protected override void OnMouseUp(MouseUpEvent e)
-            {
-                keyBindingContainer?.TriggerReleased(column.Action.Value);
-                base.OnMouseUp(e);
-            }
-
             protected override bool OnTouchDown(TouchDownEvent e)
             {
                 keyBindingContainer?.TriggerPressed(column.Action.Value);

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -107,24 +107,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             return false;
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            if (!validMouse(e))
-                return false;
-
-            handleDown(e.Button, e.ScreenSpaceMousePosition);
-            return true;
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            if (!validMouse(e))
-                return;
-
-            handleUp(e.Button);
-            base.OnMouseUp(e);
-        }
-
         protected override bool OnTouchDown(TouchDownEvent e)
         {
             handleDown(e.Touch.Source, e.ScreenSpaceTouchDownPosition);


### PR DESCRIPTION
- closes #21574 

Touchscreen controls in scrolling gamemodes will no longer respond to mouse input. This prevents them from showing when they aren't expected to, such as on devices without a touchscreen.

This also means that any touch devices which emulate mouse events instead of correctly reporting touch events will no longer work properly. Per linked discussion with Peppy, extremely few of these devices really exist and worrying about them isn't worth the trouble. 

Related discussion in #21631