### PR TITLE
Clamp star counter and cleanup unused parameters

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
@@ -49,7 +50,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void setStars(float stars)
         {
             starCounter.Current = stars;
-            starCounter.Current = starCounter.Current > 10 ? starCounter.Current = 10 : starCounter.Current = starCounter.Current;
+            starCounter.Current = Math.Clamp(starCounter.Current, 0, 10);
             starsLabel.Text = starCounter.Current.ToString("0.00");
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void setStars(float stars)
         {
             starCounter.Current = stars;
+            starCounter.Current = starCounter.Current > 10 ? starCounter.Current = 10 : starCounter.Current = starCounter.Current;
             starsLabel.Text = starCounter.Current.ToString("0.00");
         }
     }

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Graphics.UserInterface
         public StarCounter(int starCount = max_star_count)
         {
             StarCount = Math.Max(starCount, 0);
+            StarCount = StarCount > 10 ? StarCount = 10 : StarCount = StarCount;
 
             AutoSizeAxes = Axes.Both;
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float star_spacing = 4;
 
-        private const int maxStarCount = 10;
+        private const int max_star_count = 10;
         private float current;
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace osu.Game.Graphics.UserInterface
         /// Shows a float count as stars. Used as star difficulty display.
         /// </summary>
         /// <param name="starCount">Maximum amount of stars to display.</param>
-        public StarCounter(int starCount = maxStarCount)
+        public StarCounter(int starCount = max_star_count)
         {
             StarCount = Math.Max(starCount, 0);
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="starCount">Maximum amount of stars to display.</param>
         public StarCounter(int starCount = max_star_count)
         {
-            StarCount = Math.Clamp(StarCount, 0, 10);
+            StarCount = Math.Clamp(starCount, 0, 10);
 
             AutoSizeAxes = Axes.Both;
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Graphics.UserInterface
         public StarCounter(int starCount = max_star_count)
         {
             StarCount = Math.Max(starCount, 0);
-            StarCount = StarCount > 10 ? StarCount = 10 : StarCount = StarCount;
+            StarCount = Math.Clamp(StarCount, 0, 10);
 
             AutoSizeAxes = Axes.Both;
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Graphics.UserInterface
 
         private const float star_spacing = 4;
 
+        private const int maxStarCount = 10;
         private float current;
 
         /// <summary>
@@ -55,7 +56,7 @@ namespace osu.Game.Graphics.UserInterface
         /// Shows a float count as stars. Used as star difficulty display.
         /// </summary>
         /// <param name="starCount">Maximum amount of stars to display.</param>
-        public StarCounter(int starCount = 10)
+        public StarCounter(int starCount = maxStarCount)
         {
             StarCount = Math.Max(starCount, 0);
 

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -58,7 +58,6 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="starCount">Maximum amount of stars to display.</param>
         public StarCounter(int starCount = max_star_count)
         {
-            StarCount = Math.Max(starCount, 0);
             StarCount = Math.Clamp(StarCount, 0, 10);
 
             AutoSizeAxes = Axes.Both;

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -30,8 +30,6 @@ namespace osu.Game.Graphics.UserInterface
         public Box TextLayer;
 
         private const int transform_time = 600;
-        private const int pulse_length = 250;
-
         private const float shear_width = 5f;
 
         private static readonly Vector2 shear = new Vector2(shear_width / Footer.HEIGHT, 0);


### PR DESCRIPTION
In testing some of the existing game logic, I noticed StarCount and starCounter.Current are unclamped.  Since the maximum star value is set to 10, should values above 10 be allowed? 

Values above 10 do occur when left unclamped: 

[![Star-Value.png](https://i.postimg.cc/d0XZM8pJ/Star-Value.png)](https://postimg.cc/5HB2LFfr)

I've since clamped both StarCount and starCounter.Current to address this: 

[![clamped.png](https://i.postimg.cc/RVXF57J2/clamped.png)](https://postimg.cc/XpB39y8g)
