### PR TITLE
Turn on featured artist filter by default and add disclaimer when toggling for the first time

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -19,6 +19,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets.Mods;
@@ -513,6 +514,28 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("open room", () => multiplayerComponents.ChildrenOfType<LoungeSubScreen>().Single().Open());
             AddStep("press back button", () => Game.ChildrenOfType<BackButton>().First().Action());
             AddWaitStep("wait two frames", 2);
+        }
+
+        [Test]
+        public void TestFeaturedArtistDisclaimerDialog()
+        {
+            BeatmapListingOverlay getBeatmapListingOverlay() => Game.ChildrenOfType<BeatmapListingOverlay>().FirstOrDefault();
+
+            AddStep("Wait for notifications to load", () => Game.SearchBeatmapSet(string.Empty));
+            AddUntilStep("wait for dialog overlay", () => Game.ChildrenOfType<DialogOverlay>().SingleOrDefault() != null);
+
+            AddUntilStep("Wait for beatmap overlay to load", () => getBeatmapListingOverlay()?.State.Value == Visibility.Visible);
+            AddAssert("featured artist filter is on", () => getBeatmapListingOverlay().ChildrenOfType<BeatmapSearchGeneralFilterRow>().First().Current.Contains(SearchGeneral.FeaturedArtists));
+            AddStep("toggle featured artist filter",
+                () => getBeatmapListingOverlay().ChildrenOfType<FilterTabItem<SearchGeneral>>().First(i => i.Value == SearchGeneral.FeaturedArtists).TriggerClick());
+
+            AddAssert("disclaimer dialog is shown", () => Game.ChildrenOfType<DialogOverlay>().Single().CurrentDialog != null);
+            AddAssert("featured artist filter is still on", () => getBeatmapListingOverlay().ChildrenOfType<BeatmapSearchGeneralFilterRow>().First().Current.Contains(SearchGeneral.FeaturedArtists));
+
+            AddStep("confirm", () => InputManager.Key(Key.Enter));
+            AddAssert("dialog dismissed", () => Game.ChildrenOfType<DialogOverlay>().Single().CurrentDialog == null);
+
+            AddUntilStep("featured artist filter is off", () => !getBeatmapListingOverlay().ChildrenOfType<BeatmapSearchGeneralFilterRow>().First().Current.Contains(SearchGeneral.FeaturedArtists));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -81,6 +81,15 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestFeaturedArtistFilter()
+        {
+            AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
+            AddAssert("featured artist filter is on", () => overlay.ChildrenOfType<BeatmapSearchGeneralFilterRow>().First().Current.Contains(SearchGeneral.FeaturedArtists));
+            AddStep("toggle featured artist filter", () => overlay.ChildrenOfType<FilterTabItem<SearchGeneral>>().First(i => i.Value == SearchGeneral.FeaturedArtists).TriggerClick());
+            AddAssert("featured artist filter is off", () => !overlay.ChildrenOfType<BeatmapSearchGeneralFilterRow>().First().Current.Contains(SearchGeneral.FeaturedArtists));
+        }
+
+        [Test]
         public void TestHideViaBack()
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Configuration
             SetDefault(Static.LoginOverlayDisplayed, false);
             SetDefault(Static.MutedAudioNotificationShownOnce, false);
             SetDefault(Static.LowBatteryNotificationShownOnce, false);
+            SetDefault(Static.FeaturedArtistDisclaimerShownOnce, false);
             SetDefault(Static.LastHoverSoundPlaybackTime, (double?)null);
             SetDefault<APISeasonalBackgrounds>(Static.SeasonalBackgrounds, null);
         }
@@ -42,6 +43,7 @@ namespace osu.Game.Configuration
         LoginOverlayDisplayed,
         MutedAudioNotificationShownOnce,
         LowBatteryNotificationShownOnce,
+        FeaturedArtistDisclaimerShownOnce,
 
         /// <summary>
         /// Info about seasonal backgrounds available fetched from API - see <see cref="APISeasonalBackgrounds"/>.
@@ -53,6 +55,6 @@ namespace osu.Game.Configuration
         /// The last playback time in milliseconds of a hover sample (from <see cref="HoverSounds"/>).
         /// Used to debounce hover sounds game-wide to avoid volume saturation, especially in scrolling views with many UI controls like <see cref="SettingsOverlay"/>.
         /// </summary>
-        LastHoverSoundPlaybackTime
+        LastHoverSoundPlaybackTime,
     }
 }

--- a/osu.Game/Localisation/BeatmapOverlayStrings.cs
+++ b/osu.Game/Localisation/BeatmapOverlayStrings.cs
@@ -15,12 +15,12 @@ namespace osu.Game.Localisation
         public static LocalisableString UserContentDisclaimer => new TranslatableString(getKey(@"user_content_disclaimer"), @"User content disclaimer");
 
         /// <summary>
-        /// "By turning off the &quot;featured artist&quot; filter, all user uploaded content will be displayed.
+        /// "By turning off the &quot;Featured Artist&quot; filter, all user-uploaded content will be displayed.
         ///
         /// This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption."
         /// </summary>
         public static LocalisableString ByTurningOffTheFeatured => new TranslatableString(getKey(@"by_turning_off_the_featured"),
-            @"By turning off the ""featured artist"" filter, all user uploaded content will be displayed.
+            @"By turning off the ""Featured Artist"" filter, all user-uploaded content will be displayed.
 
 This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption.");
 

--- a/osu.Game/Localisation/BeatmapOverlayStrings.cs
+++ b/osu.Game/Localisation/BeatmapOverlayStrings.cs
@@ -12,22 +12,21 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "User content disclaimer"
         /// </summary>
-        public static LocalisableString UserContentDisclaimer => new TranslatableString(getKey(@"user_content_disclaimer"), @"User content disclaimer");
+        public static LocalisableString UserContentDisclaimerHeader => new TranslatableString(getKey(@"user_content_disclaimer"), @"User content disclaimer");
 
         /// <summary>
         /// "By turning off the &quot;Featured Artist&quot; filter, all user-uploaded content will be displayed.
         ///
-        /// This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption."
+        /// This includes content that may not be correctly licensed for osu! usage. Browse at your own risk."
         /// </summary>
-        public static LocalisableString ByTurningOffTheFeatured => new TranslatableString(getKey(@"by_turning_off_the_featured"),
-            @"By turning off the ""Featured Artist"" filter, all user-uploaded content will be displayed.
+        public static LocalisableString UserContentDisclaimerDescription => new TranslatableString(getKey(@"by_turning_off_the_featured"), @"By turning off the ""Featured Artist"" filter, all user-uploaded content will be displayed.
 
-This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption.");
+This includes content that may not be correctly licensed for osu! usage. Browse at your own risk.");
 
         /// <summary>
         /// "I understand"
         /// </summary>
-        public static LocalisableString Understood => new TranslatableString(getKey(@"understood"), @"I understand");
+        public static LocalisableString UserContentConfirmButtonText => new TranslatableString(getKey(@"understood"), @"I understand");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/BeatmapOverlayStrings.cs
+++ b/osu.Game/Localisation/BeatmapOverlayStrings.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class BeatmapOverlayStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.BeatmapOverlayStrings";
+
+        /// <summary>
+        /// "User content disclaimer"
+        /// </summary>
+        public static LocalisableString UserContentDisclaimer => new TranslatableString(getKey(@"user_content_disclaimer"), @"User content disclaimer");
+
+        /// <summary>
+        /// "By turning off the &quot;featured artist&quot; filter, all user uploaded content will be displayed.
+        ///
+        /// This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption."
+        /// </summary>
+        public static LocalisableString ByTurningOffTheFeatured => new TranslatableString(getKey(@"by_turning_off_the_featured"),
+            @"By turning off the ""featured artist"" filter, all user uploaded content will be displayed.
+
+This includes content which may not be correctly licensed for use and as such may not be safe for streaming, sharing, or consumption.");
+
+        /// <summary>
+        /// "I understand"
+        /// </summary>
+        public static LocalisableString Understood => new TranslatableString(getKey(@"understood"), @"I understand");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -146,6 +146,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 }
             });
 
+            generalFilter.Current.Add(SearchGeneral.FeaturedArtists);
             categoryFilter.Current.Value = SearchCategory.Leaderboard;
         }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -87,8 +87,8 @@ namespace osu.Game.Overlays.BeatmapListing
     {
         public FeaturedArtistConfirmDialog(Action confirm)
         {
-            HeaderText = BeatmapOverlayStrings.UserContentDisclaimer;
-            BodyText = BeatmapOverlayStrings.ByTurningOffTheFeatured;
+            HeaderText = BeatmapOverlayStrings.UserContentDisclaimerHeader;
+            BodyText = BeatmapOverlayStrings.UserContentDisclaimerDescription;
 
             Icon = FontAwesome.Solid.ExclamationTriangle;
 
@@ -96,7 +96,7 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 new PopupDialogDangerousButton
                 {
-                    Text = BeatmapOverlayStrings.Understood,
+                    Text = BeatmapOverlayStrings.UserContentConfirmButtonText,
                     Action = confirm
                 },
                 new PopupDialogCancelButton

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -3,10 +3,18 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Resources.Localisation.Web;
 using osuTK.Graphics;
+using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Overlays.BeatmapListing
 {
@@ -32,6 +40,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private partial class FeaturedArtistsTabItem : MultipleSelectionFilterTabItem
         {
+            private Bindable<bool> disclaimerShown;
+
             public FeaturedArtistsTabItem()
                 : base(SearchGeneral.FeaturedArtists)
             {
@@ -40,7 +50,60 @@ namespace osu.Game.Overlays.BeatmapListing
             [Resolved]
             private OsuColour colours { get; set; }
 
+            [Resolved]
+            private SessionStatics sessionStatics { get; set; }
+
+            [Resolved(canBeNull: true)]
+            private IDialogOverlay dialogOverlay { get; set; }
+
             protected override Color4 GetStateColour() => colours.Orange1;
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                disclaimerShown = sessionStatics.GetBindable<bool>(Static.FeaturedArtistDisclaimerShownOnce);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                if (!disclaimerShown.Value && dialogOverlay != null)
+                {
+                    dialogOverlay.Push(new FeaturedArtistConfirmDialog(() =>
+                    {
+                        disclaimerShown.Value = true;
+                        base.OnClick(e);
+                    }));
+
+                    return true;
+                }
+
+                return base.OnClick(e);
+            }
+        }
+    }
+
+    internal partial class FeaturedArtistConfirmDialog : PopupDialog
+    {
+        public FeaturedArtistConfirmDialog(Action confirm)
+        {
+            HeaderText = BeatmapOverlayStrings.UserContentDisclaimer;
+            BodyText = BeatmapOverlayStrings.ByTurningOffTheFeatured;
+
+            Icon = FontAwesome.Solid.ExclamationTriangle;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogDangerousButton
+                {
+                    Text = BeatmapOverlayStrings.Understood,
+                    Action = confirm
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = CommonStrings.ButtonsCancel,
+                },
+            };
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -18,6 +19,7 @@ using osuTK;
 namespace osu.Game.Overlays.BeatmapListing
 {
     public partial class BeatmapSearchMultipleSelectionFilterRow<T> : BeatmapSearchFilterRow<List<T>>
+        where T : Enum
     {
         public new readonly BindableList<T> Current = new BindableList<T>();
 
@@ -31,7 +33,7 @@ namespace osu.Game.Overlays.BeatmapListing
         [BackgroundDependencyLoader]
         private void load()
         {
-            Current.BindTo(filter.Current);
+            filter.Current.BindTo(Current);
         }
 
         protected sealed override Drawable CreateFilter() => filter = CreateMultipleSelectionFilter();
@@ -64,6 +66,14 @@ namespace osu.Game.Overlays.BeatmapListing
 
                 foreach (var item in Children)
                     item.Active.BindValueChanged(active => toggleItem(item.Value, active.NewValue));
+
+                Current.BindCollectionChanged(currentChanged, true);
+            }
+
+            private void currentChanged(object sender, NotifyCollectionChangedEventArgs e)
+            {
+                foreach (var c in Children)
+                    c.Active.Value = Current.Contains(c.Value);
             }
 
             /// <summary>
@@ -79,7 +89,10 @@ namespace osu.Game.Overlays.BeatmapListing
             private void toggleItem(T value, bool active)
             {
                 if (active)
-                    Current.Add(value);
+                {
+                    if (!Current.Contains(value))
+                        Current.Add(value);
+                }
                 else
                     Current.Remove(value);
             }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -198,6 +198,7 @@ namespace osu.Game.Overlays.Dialog
                                     TextAnchor = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
+                                    Padding = new MarginPadding(5),
                                 },
                             },
                         },


### PR DESCRIPTION
Another step in the correct direction for promoting featured artist beatmaps and providing new users with better directed access to licenced content. I hope the overhead of clicking through the dialog will not be too bad once per session, but depending on feedback we can consider adding a "don't show again" or similar.

This is a personal requirement for pushing osu! out to a new audience (aka mobile). We've made huge progress with the featured artist project and I think making it the default visibility is the right next step.

https://user-images.githubusercontent.com/191335/207827249-90cf4328-9777-4b59-a255-ceddbb7d7e24.mp4

