### PR TITLE
Use `LocalisableString`s for date and time formats

### DIFF
--- a/osu.Game/Graphics/DateTooltip.cs
+++ b/osu.Game/Graphics/DateTooltip.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osuTK;
 
@@ -69,8 +70,8 @@ namespace osu.Game.Graphics
         {
             DateTimeOffset localDate = date.ToLocalTime();
 
-            dateText.Text = $"{localDate:d MMMM yyyy} ";
-            timeText.Text = $"{localDate:HH:mm:ss \"UTC\"z}";
+            dateText.Text = LocalisableString.Interpolate($"{localDate:d MMMM yyyy} ");
+            timeText.Text = LocalisableString.Interpolate($"{localDate:HH:mm:ss \"UTC\"z}");
         }
 
         public void Move(Vector2 pos) => Position = pos;

--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -136,9 +136,8 @@ namespace osu.Game.Online.Leaderboards
         {
             if (displayedScore != null)
             {
-                timestampLabel.Text = prefer24HourTime.Value
-                    ? $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy HH:mm}"
-                    : $"Played on {displayedScore.Date.ToLocalTime():d MMMM yyyy h:mm tt}";
+                timestampLabel.Text = LocalisableString.Format("Played on {0}",
+                    displayedScore.Date.ToLocalTime().ToLocalisableString(prefer24HourTime.Value ? @"d MMMM yyyy HH:mm" : @"d MMMM yyyy h:mm tt"));
             }
         }
 

--- a/osu.Game/Overlays/Changelog/ChangelogListing.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogListing.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -51,7 +52,7 @@ namespace osu.Game.Overlays.Changelog
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
                         Margin = new MarginPadding { Top = 20 },
-                        Text = build.CreatedAt.Date.ToString("dd MMMM yyyy"),
+                        Text = build.CreatedAt.Date.ToLocalisableString("dd MMMM yyyy"),
                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 24),
                     });
 

--- a/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSingleBuild.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -114,7 +115,7 @@ namespace osu.Game.Overlays.Changelog
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
-                    Text = Build.CreatedAt.Date.ToString("dd MMMM yyyy"),
+                    Text = Build.CreatedAt.Date.ToLocalisableString("dd MMMM yyyy"),
                     Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
                     Margin = new MarginPadding { Top = 5 },
                     Scale = new Vector2(1.25f),

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -175,9 +176,7 @@ namespace osu.Game.Overlays.Chat
 
         private void updateTimestamp()
         {
-            drawableTimestamp.Text = prefer24HourTime.Value
-                ? $@"{message.Timestamp.LocalDateTime:HH:mm:ss}"
-                : $@"{message.Timestamp.LocalDateTime:hh:mm:ss tt}";
+            drawableTimestamp.Text = message.Timestamp.LocalDateTime.ToLocalisableString(prefer24HourTime.Value ? @"HH:mm:ss" : @"hh:mm:ss tt");
         }
     }
 }

--- a/osu.Game/Overlays/Dashboard/Home/News/FeaturedNewsItemPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/FeaturedNewsItemPanel.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -167,7 +168,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                             Origin = Anchor.TopRight,
                             Font = OsuFont.GetFont(weight: FontWeight.Bold), // using Bold since there is no 800 weight alternative
                             Colour = colourProvider.Light1,
-                            Text = $"{date:dd}"
+                            Text = date.ToLocalisableString(@"dd")
                         },
                         new TextFlowContainer(f =>
                         {
@@ -178,7 +179,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
                             AutoSizeAxes = Axes.Both,
-                            Text = $"{date:MMM yyyy}"
+                            Text = date.ToLocalisableString(@"MMM yyyy")
                         }
                     }
                 };

--- a/osu.Game/Overlays/Dashboard/Home/News/NewsGroupItem.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/NewsGroupItem.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -98,12 +99,12 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                     Margin = new MarginPadding { Vertical = 5 }
                 };
 
-                textFlow.AddText($"{date:dd}", t =>
+                textFlow.AddText(date.ToLocalisableString(@"dd"), t =>
                 {
                     t.Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold);
                 });
 
-                textFlow.AddText($"{date: MMM}", t =>
+                textFlow.AddText(date.ToLocalisableString(@" MMM"), t =>
                 {
                     t.Font = OsuFont.GetFont(size: 14, weight: FontWeight.Regular);
                 });

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -19,6 +19,7 @@ using osu.Framework.Graphics.Sprites;
 using System.Diagnostics;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Platform;
 
 namespace osu.Game.Overlays.News.Sidebar
@@ -99,7 +100,7 @@ namespace osu.Game.Overlays.News.Sidebar
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Bold),
-                        Text = date.ToString("MMM yyyy")
+                        Text = date.ToLocalisableString(@"MMM yyyy")
                     },
                     icon = new SpriteIcon
                     {

--- a/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -69,7 +70,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected override void UpdateDisplay(DateTimeOffset now)
         {
-            realTime.Text = use24HourDisplay ? $"{now:HH:mm:ss}" : $"{now:h:mm:ss tt}";
+            realTime.Text = now.ToLocalisableString(use24HourDisplay ? @"HH:mm:ss" : @"h:mm:ss tt");
             gameTime.Text = $"running {new TimeSpan(TimeSpan.TicksPerSecond * (int)(Clock.CurrentTime / 1000)):c}";
         }
 

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
@@ -309,7 +310,8 @@ namespace osu.Game.Screens.Ranking.Expanded
 
             private void updateDisplay()
             {
-                Text = prefer24HourTime.Value ? $"Played on {time.ToLocalTime():d MMMM yyyy HH:mm}" : $"Played on {time.ToLocalTime():d MMMM yyyy h:mm tt}";
+                Text = LocalisableString.Format("Played on {0}",
+                    time.ToLocalTime().ToLocalisableString(prefer24HourTime.Value ? @"d MMMM yyyy HH:mm" : @"d MMMM yyyy h:mm tt"));
             }
         }
     }


### PR DESCRIPTION
This is mostly to bring attention to https://github.com/ppy/osu/issues/21157 and to show what date formats are used throughout the game. And to make it easy to check how (wrong) dates appear in other languages.