### PR TITLE
Limit SFX panning on results screen

### DIFF
--- a/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
+++ b/osu.Game/Graphics/Cursor/MenuCursorContainer.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Graphics.Cursor
             SampleChannel channel = tapSample.GetChannel();
 
             // Scale to [-0.75, 0.75] so that the sample isn't fully panned left or right (sounds weird)
-            channel.Balance.Value = ((activeCursor.X / DrawWidth) * 2 - 1) * 0.75;
+            channel.Balance.Value = ((activeCursor.X / DrawWidth) * 2 - 1) * OsuGameBase.SFX_STEREO_STRENGTH;
             channel.Frequency.Value = baseFrequency - (random_range / 2f) + RNG.NextDouble(random_range);
             channel.Volume.Value = baseFrequency;
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -83,6 +83,8 @@ namespace osu.Game
 
         public const int SAMPLE_CONCURRENCY = 6;
 
+        public const double SFX_STEREO_STRENGTH = 0.75;
+
         /// <summary>
         /// Length of debounce (in milliseconds) for commonly occuring sample playbacks that could stack.
         /// </summary>

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Screens.Ranking
         protected override void Update()
         {
             base.Update();
-            audioContent.Balance.Value = (ScreenSpaceDrawQuad.Centre.X / game.ScreenSpaceDrawQuad.Width) * 2 - 1;
+            audioContent.Balance.Value = ((ScreenSpaceDrawQuad.Centre.X / game.ScreenSpaceDrawQuad.Width) * 2 - 1) * OsuGameBase.SFX_STEREO_STRENGTH;
         }
 
         private void playAppearSample()


### PR DESCRIPTION
I missed this when adding the results screen panning effect - caps at 75% left/right, as to not be completely panned L/R.

This may alleviate #21380 a bit, but I doubt it goes far enough to completely address it.

Would be nice to revisit the result screen to split up the (audio) components and apply panning only to parts (i.e. leave the applause and riser/wind-up SFX centered while the rest is panned), but that's for another day.