### PR TITLE
Fix settings overlay sometimes changing section unexpectedly when interacting with a dropdown

### DIFF
--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -199,7 +199,6 @@ namespace osu.Game.Graphics.Containers
         protected void InvalidateScrollPosition()
         {
             lastKnownScroll = null;
-            lastClickedSection = null;
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
Applied the fix suggested in https://github.com/ppy/osu/issues/21615. I'm not 100% sure this will fix it but looks like it should. I can't seem to reproduce this one as it requires some special positioning of elements on the screen.

Closes #21615, in theory.