### PR TITLE
Fix wrong paths to macOS log folder in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -59,7 +59,7 @@ body:
         The default places to find the logs on desktop platforms are as follows:
           - `%AppData%/osu/logs` *on Windows*
           - `~/.local/share/osu/logs` *on Linux*
-          - `~/Library/Application Support/osu/files` *on macOS*
+          - `~/Library/Application Support/osu/logs` *on macOS*
 
         If you have selected a custom location for the game files, you can find the `logs` folder there.
 

--- a/.github/ISSUE_TEMPLATE/bug-issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug-issue.yml
@@ -58,7 +58,8 @@ body:
 
         The default places to find the logs on desktop platforms are as follows:
           - `%AppData%/osu/logs` *on Windows*
-          - `~/.local/share/osu/logs` *on Linux & macOS*
+          - `~/.local/share/osu/logs` *on Linux*
+          - `~/Library/Application Support/osu/files` *on macOS*
 
         If you have selected a custom location for the game files, you can find the `logs` folder there.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ Issues, bug reports and feature suggestions are welcomed, though please keep in 
 
   * the in-game logs, which are located at:
     * `%AppData%/osu/logs` (on Windows),
-    * `~/.local/share/osu/logs` (on Linux and macOS),
+    * `~/.local/share/osu/logs` (on Linux),
+    * `~/Library/Application Support/osu/logs` (on macOS),
     * `Android/data/sh.ppy.osulazer/files/logs` (on Android),
     * on iOS they can be obtained by connecting your device to your desktop and [copying the `logs` directory from the app's own document storage using iTunes](https://support.apple.com/en-us/HT201301#copy-to-computer),
   * your system specifications (including the operating system and platform you are playing on),


### PR DESCRIPTION
Wrong since ppy/osu-framework@2eb1c60d6e72d8b2c478cf4376470ca614ef3f88.