### PR TITLE
Call spectator `EndPlaying()` immediately after score submission

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Screens.Play
             score.ScoreInfo.Date = DateTimeOffset.Now;
 
             await submitScore(score).ConfigureAwait(false);
+            spectatorClient.EndPlaying(GameplayState);
         }
 
         [Resolved]


### PR DESCRIPTION
As it turns out, in current `master`, if a gameplay session ends normally (i.e. by the player completing the beatmap in full), then the spectator server `EndPlaying()` method will not be called until `SubmittingPlayer.OnExiting()`, which in practice turns out to be the moment where the user exits from the post-gameplay results screen back to song select.

There is seemingly no reasonable cause for not calling this earlier. In fact the solo spectator flow looks more broken without this call than with, because without it the spectator view just hangs until the spectated player exits results, and *only then* shows results, rather than do it upon normal gameplay completion.

---

This is relevant to https://github.com/ppy/osu/issues/18877, as I'm looking to hook into `EndPlaying()` to be able to dispatch messages to clients about their scores being processed to completion [as suggested](https://github.com/ppy/osu/issues/18877#issuecomment-1348554175). The fact that it was being called that late was breaking my flow as in my code the dispatch was registered *after* the score was completely processed at the queue. It's still a race I have to handle to some degree, but it's another reason to move this offending call earlier.

It is *also* relevant to https://github.com/ppy/osu-server-spectator/pull/154 & https://github.com/ppy/osu-server-spectator/pull/155 as the replay upload flow also hooks into `EndPlaying()`. @smoogipoo would appreciate you looking at this pull for this reason.

I'm not sure if this needs testing as testing timing is a pain. If it's deemed that this is the correct change to apply and it needs tests, then I'll figure out a way to add some. I did check that all tests are passing locally, though.