### PR TITLE
Fix welcome screen language buttons not working

### DIFF
--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -46,5 +47,8 @@ namespace osu.Game.Graphics.Containers
             AddInternal(content);
             Add(CreateHoverSounds(sampleSet));
         }
+
+        protected override void ClearInternal(bool disposeChildren = true) =>
+            throw new InvalidOperationException($"Clearing {nameof(InternalChildren)} will cause critical failure. Use {nameof(Clear)} instead.");
     }
 }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenWelcome.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                 [BackgroundDependencyLoader]
                 private void load()
                 {
-                    InternalChildren = new Drawable[]
+                    AddRange(new Drawable[]
                     {
                         backgroundBox = new Box
                         {
@@ -162,7 +162,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                             Colour = colourProvider.Light1,
                             Text = Language.GetDescription(),
                         }
-                    };
+                    });
                 }
 
                 protected override void LoadComplete()


### PR DESCRIPTION
This "regressed" with #21619, but the code was quite broken all along. Setting `InternalChildren` directly removes *both* the `Content` container (which is the direct cause of the failure), as well as the `HoverClickSounds` which are half of the point of `OsuClickableContainer`.

To make this hopefully never again, `OsuClickableContainer.ClearInternal()` (which is called by `InternalChild(ren)?`) will now throw.