### PR TITLE
Add argon "pro" skin

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Overlays.Settings.Sections
             dropdownItems.Clear();
 
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.ARGON_SKIN).ToLive(realm));
+            dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.ARGON_PRO_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.TRIANGLES_SKIN).ToLive(realm));
             dropdownItems.Add(sender.Single(s => s.ID == SkinInfo.CLASSIC_SKIN).ToLive(realm));
 

--- a/osu.Game/Skinning/ArgonProSkin.cs
+++ b/osu.Game/Skinning/ArgonProSkin.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using JetBrains.Annotations;
+using osu.Framework.Audio.Sample;
+using osu.Game.Audio;
+using osu.Game.Extensions;
+using osu.Game.IO;
+
+namespace osu.Game.Skinning
+{
+    public class ArgonProSkin : ArgonSkin
+    {
+        public new static SkinInfo CreateInfo() => new SkinInfo
+        {
+            ID = Skinning.SkinInfo.ARGON_PRO_SKIN,
+            Name = "osu! \"argon\" pro (2022)",
+            Creator = "team osu!",
+            Protected = true,
+            InstantiationInfo = typeof(ArgonProSkin).GetInvariantInstantiationInfo()
+        };
+
+        public override ISample? GetSample(ISampleInfo sampleInfo)
+        {
+            foreach (string lookup in sampleInfo.LookupNames)
+            {
+                string remappedLookup = lookup.Replace("Gameplay/", "Gameplay/Pro/");
+
+                var sample = Samples?.Get(remappedLookup) ?? Resources.AudioManager?.Samples.Get(remappedLookup);
+                if (sample != null)
+                    return sample;
+            }
+
+            return null;
+        }
+
+        public ArgonProSkin(IStorageResourceProvider resources)
+            : this(CreateInfo(), resources)
+        {
+        }
+
+        [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
+        public ArgonProSkin(SkinInfo skin, IStorageResourceProvider resources)
+            : base(skin, resources)
+        {
+        }
+    }
+}

--- a/osu.Game/Skinning/ArgonProSkin.cs
+++ b/osu.Game/Skinning/ArgonProSkin.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Skinning
         {
             foreach (string lookup in sampleInfo.LookupNames)
             {
-                string remappedLookup = lookup.Replace("Gameplay/", "Gameplay/Pro/");
+                string remappedLookup = lookup.Replace(@"Gameplay/", @"Gameplay/ArgonPro/");
 
                 var sample = Samples?.Get(remappedLookup) ?? Resources.AudioManager?.Samples.Get(remappedLookup);
                 if (sample != null)

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Skinning
             InstantiationInfo = typeof(ArgonSkin).GetInvariantInstantiationInfo()
         };
 
-        private readonly IStorageResourceProvider resources;
+        protected readonly IStorageResourceProvider Resources;
 
         public ArgonSkin(IStorageResourceProvider resources)
             : this(CreateInfo(), resources)
@@ -41,7 +41,7 @@ namespace osu.Game.Skinning
         public ArgonSkin(SkinInfo skin, IStorageResourceProvider resources)
             : base(skin, resources)
         {
-            this.resources = resources;
+            Resources = resources;
 
             Configuration.CustomComboColours = new List<Color4>
             {
@@ -72,7 +72,7 @@ namespace osu.Game.Skinning
         {
             foreach (string lookup in sampleInfo.LookupNames)
             {
-                var sample = Samples?.Get(lookup) ?? resources.AudioManager?.Samples.Get(lookup);
+                var sample = Samples?.Get(lookup) ?? Resources.AudioManager?.Samples.Get(lookup);
                 if (sample != null)
                     return sample;
             }

--- a/osu.Game/Skinning/SkinInfo.cs
+++ b/osu.Game/Skinning/SkinInfo.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Skinning
     {
         internal static readonly Guid TRIANGLES_SKIN = new Guid("2991CFD8-2140-469A-BCB9-2EC23FBCE4AD");
         internal static readonly Guid ARGON_SKIN = new Guid("CFFA69DE-B3E3-4DEE-8563-3C4F425C05D0");
+        internal static readonly Guid ARGON_PRO_SKIN = new Guid("9FC9CF5D-0F16-4C71-8256-98868321AC43");
         internal static readonly Guid CLASSIC_SKIN = new Guid("81F02CD3-EEC6-4865-AC23-FAE26A386187");
         internal static readonly Guid RANDOM_SKIN = new Guid("D39DFEFB-477C-4372-B1EA-2BCEA5FB8908");
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Skinning
                 DefaultClassicSkin = new DefaultLegacySkin(this),
                 trianglesSkin = new TrianglesSkin(this),
                 argonSkin = new ArgonSkin(this),
+                new ArgonProSkin(this),
             };
 
             // Ensure the default entries are present.

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -111,6 +111,7 @@ namespace osu.Game.Skinning
                 // Temporarily used to exclude undesirable ISkin implementations
                 static bool isUserSkin(ISkin skin)
                     => skin.GetType() == typeof(TrianglesSkin)
+                       || skin.GetType() == typeof(ArgonProSkin)
                        || skin.GetType() == typeof(ArgonSkin)
                        || skin.GetType() == typeof(DefaultLegacySkin)
                        || skin.GetType() == typeof(LegacySkin);

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.18.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2022.1219.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1207.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2022.1221.0" />
     <PackageReference Include="Sentry" Version="3.23.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Adds a new argon "pro" skin variant that inherits from "argon".

Initially the only difference will be the new "pro" hitsounds, but this provides a home for potential "pro"-targeting skin modifications in the future.

- [x] depends on ppy/osu-resources#235