### PR TITLE
Add score processed callback to spectator client

### DIFF
--- a/osu.Game/Online/Spectator/ISpectatorClient.cs
+++ b/osu.Game/Online/Spectator/ISpectatorClient.cs
@@ -32,5 +32,12 @@ namespace osu.Game.Online.Spectator
         /// <param name="userId">The user.</param>
         /// <param name="data">The frame data.</param>
         Task UserSentFrames(int userId, FrameDataBundle data);
+
+        /// <summary>
+        /// Signals that a user's submitted score was fully processed.
+        /// </summary>
+        /// <param name="userId">The ID of the user who achieved the score.</param>
+        /// <param name="scoreId">The ID of the score.</param>
+        Task UserScoreProcessed(int userId, long scoreId);
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Online.Spectator
                     connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserBeganPlaying), ((ISpectatorClient)this).UserBeganPlaying);
                     connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
                     connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
+                    connection.On<int, long>(nameof(ISpectatorClient.UserScoreProcessed), ((ISpectatorClient)this).UserScoreProcessed);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -65,6 +65,11 @@ namespace osu.Game.Online.Spectator
         public virtual event Action<int, SpectatorState>? OnUserFinishedPlaying;
 
         /// <summary>
+        /// Called whenever a user-submitted score has been fully processed.
+        /// </summary>
+        public virtual event Action<int, long>? OnUserScoreProcessed;
+
+        /// <summary>
         /// A dictionary containing all users currently being watched, with the number of watching components for each user.
         /// </summary>
         private readonly Dictionary<int, int> watchedUsersRefCounts = new Dictionary<int, int>();
@@ -156,6 +161,13 @@ namespace osu.Game.Online.Spectator
                 data.Frames[^1].Header = data.Header;
 
             Schedule(() => OnNewFrames?.Invoke(userId, data));
+
+            return Task.CompletedTask;
+        }
+
+        Task ISpectatorClient.UserScoreProcessed(int userId, long scoreId)
+        {
+            Schedule(() => OnUserScoreProcessed?.Invoke(userId, scoreId));
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Another small piece to facilitate https://github.com/ppy/osu/issues/18877.

This isn't all, of course. More will come, but for now I'm getting this out so that the `osu-spectator-server` pull I'm about to open can be tested if someone wants to do so.