### PR TITLE
Fix crashes on quick-retrying when holding note in mania

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -134,6 +134,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
         protected override void Dispose(bool isDisposing)
         {
+            // must happen before children are disposed in base call to prevent illegal accesses to the hit explosion pool.
+            NewResult -= OnNewResult;
+
             base.Dispose(isDisposing);
 
             if (skin != null)

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -156,6 +156,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
         protected override void Dispose(bool isDisposing)
         {
+            // must happen before children are disposed in base call to prevent illegal accesses to the judgement pool.
+            NewResult -= OnNewResult;
+
             base.Dispose(isDisposing);
 
             if (currentSkin != null)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21748

The actual nullref in question was being thrown framework-side [here](https://github.com/ppy/osu-framework/blob/master/osu.Framework/Graphics/Pooling/DrawablePool.cs#L200), but the root cause was that the `NewResult` event handlers in both components touched in this pull attempted to retrieve drawables from pools after the pools were disposed. Simple unsubscriptions (with a slight ordering complication, as indicated by the inline comments) fix this.