### PR TITLE
Ensure score submission completion before notifying spectator server when exiting play early

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -13,6 +13,7 @@ using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Scoring;
@@ -158,8 +159,11 @@ namespace osu.Game.Screens.Play
 
             if (LoadedBeatmapSuccessfully)
             {
-                submitScore(Score.DeepClone());
-                spectatorClient.EndPlaying(GameplayState);
+                Task.Run(async () =>
+                {
+                    await submitScore(Score.DeepClone()).ConfigureAwait(false);
+                    spectatorClient.EndPlaying(GameplayState);
+                }).FireAndForget();
             }
 
             return exiting;


### PR DESCRIPTION
- Related to https://github.com/ppy/osu/issues/18877

When a `SubmittingPlayer` gameplay session ends with the successful completion of a beatmap, `PrepareScoreForResultsAsync()` ensures that the score submission request is sent to and responded to by `osu-web` before calling `ISpectatorClient.EndPlaying()`:

https://github.com/ppy/osu/blob/b09c00d71bfb162c28734235674581ab51482ecc/osu.Game/Screens/Play/SubmittingPlayer.cs#L132-L133

While previously this was mostly an implementation detail, this becomes important when considering that more and more server-side flows (replay upload, notifying about score processing completion) hook into `EndPlaying()`, and assume that by the point that message arrives at `osu-spectator-server`, the score has already been submitted and has been assigned a score ID that corresponds to the score submission token.

As it turns out, in the early-exit path (when the user exits the play midway through, retries, or just fails), the same ordering guarantees were not provided. The score's submission ran concurrently to the spectator client `EndPlaying()` call, therefore creating a network race (note the lack of `await`):

https://github.com/ppy/osu/blob/b09c00d71bfb162c28734235674581ab51482ecc/osu.Game/Screens/Play/SubmittingPlayer.cs#L161-L162

`osu-server-spectator` components that implciitly relied on the ordering provided by the happy path, could therefore fail to unmap the score submission token to a score ID.

Note that as written, the `osu-server-spectator` replay upload flow is not really affected by this, as it self-corrects by essentially polling the database and trying to unmap the score submission token to a score ID for up to 30 seconds. However, this change would have the benefit of reducing the polls required in such cases to just one DB retrieval.

This change aims  to bring both paths to parity by waiting for the score submission request even when early-exiting the player instance.

---

I considered adding test coverage for the ordering but it's not instantly doable. I'll do it on request if this is deemed to be the correct direction and test coverage is deemed required.