### PR TITLE
Reload waveform on track replacement in editor

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Beatmaps
         // TODO: remove once the fallback lookup is not required (and access via `working.BeatmapInfo.Metadata` directly).
         public BeatmapMetadata Metadata => BeatmapInfo.Metadata;
 
-        public Waveform Waveform => waveform.Value;
-
         public Storyboard Storyboard => storyboard.Value;
 
         public Texture Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
@@ -48,7 +46,7 @@ namespace osu.Game.Beatmaps
 
         private readonly object beatmapFetchLock = new object();
 
-        private Lazy<Waveform> waveform;
+        private Waveform waveform;
         private readonly Lazy<Storyboard> storyboard;
         private readonly Lazy<ISkin> skin;
         private Track track; // track is not Lazy as we allow transferring and loading multiple times.
@@ -60,7 +58,6 @@ namespace osu.Game.Beatmaps
             BeatmapInfo = beatmapInfo;
             BeatmapSetInfo = beatmapInfo.BeatmapSet ?? new BeatmapSetInfo();
 
-            waveform = new Lazy<Waveform>(GetWaveform);
             storyboard = new Lazy<Storyboard>(GetStoryboard);
             skin = new Lazy<ISkin>(GetSkin);
         }
@@ -168,6 +165,18 @@ namespace osu.Game.Beatmaps
 
             return audioManager.Tracks.GetVirtual(length);
         }
+
+        #endregion
+
+        #region Waveform
+
+        public Waveform Waveform => waveform ??= GetWaveform();
+
+        /// <summary>
+        /// Reloads waveform of beatmap's track even if one is already cached.
+        /// </summary>
+        /// <returns>Newly loaded waveform.</returns>
+        public Waveform LoadWaveform() => waveform = GetWaveform();
 
         #endregion
 
@@ -328,12 +337,6 @@ namespace osu.Game.Beatmaps
         protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
         #endregion
-
-        public void InvalidateWaveform()
-        {
-            if (waveform.IsValueCreated)
-                waveform = new Lazy<Waveform>(GetWaveform);
-        }
 
         public override string ToString() => BeatmapInfo.ToString();
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -46,10 +46,11 @@ namespace osu.Game.Beatmaps
 
         private readonly object beatmapFetchLock = new object();
 
-        private Waveform waveform;
         private readonly Lazy<Storyboard> storyboard;
         private readonly Lazy<ISkin> skin;
+
         private Track track; // track is not Lazy as we allow transferring and loading multiple times.
+        private Waveform waveform; // waveform is also not Lazy as the track may change.
 
         protected WorkingBeatmap(BeatmapInfo beatmapInfo, AudioManager audioManager)
         {
@@ -107,10 +108,12 @@ namespace osu.Game.Beatmaps
 
         public Track LoadTrack()
         {
-            // track could be changed, clearing waveform cache
+            track = GetBeatmapTrack() ?? GetVirtualTrack(1000);
+
+            // the track may have changed, recycle the current waveform.
+            waveform?.Dispose();
             waveform = null;
 
-            track = GetBeatmapTrack() ?? GetVirtualTrack(1000);
             return track;
         }
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Beatmaps
 
         private readonly object beatmapFetchLock = new object();
 
-        private readonly Lazy<Waveform> waveform;
+        private Lazy<Waveform> waveform;
         private readonly Lazy<Storyboard> storyboard;
         private readonly Lazy<ISkin> skin;
         private Track track; // track is not Lazy as we allow transferring and loading multiple times.
@@ -328,6 +328,12 @@ namespace osu.Game.Beatmaps
         protected virtual IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap, Ruleset ruleset) => ruleset.CreateBeatmapConverter(beatmap);
 
         #endregion
+
+        public void InvalidateWaveform()
+        {
+            if (waveform.IsValueCreated)
+                waveform = new Lazy<Waveform>(GetWaveform);
+        }
 
         public override string ToString() => BeatmapInfo.ToString();
 

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -105,7 +105,14 @@ namespace osu.Game.Beatmaps
 
         public virtual bool TrackLoaded => track != null;
 
-        public Track LoadTrack() => track = GetBeatmapTrack() ?? GetVirtualTrack(1000);
+        public Track LoadTrack()
+        {
+            // track could be changed, clearing waveform cache
+            waveform = null;
+
+            track = GetBeatmapTrack() ?? GetVirtualTrack(1000);
+            return track;
+        }
 
         public void PrepareTrackForPreview(bool looping, double offsetFromPreviewPoint = 0)
         {
@@ -171,12 +178,6 @@ namespace osu.Game.Beatmaps
         #region Waveform
 
         public Waveform Waveform => waveform ??= GetWaveform();
-
-        /// <summary>
-        /// Reloads waveform of beatmap's track even if one is already cached.
-        /// </summary>
-        /// <returns>Newly loaded waveform.</returns>
-        public Waveform LoadWaveform() => waveform = GetWaveform();
 
         #endregion
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -141,12 +141,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
 
             track.BindTo(editorClock.Track);
-            track.BindValueChanged(_ =>
-            {
-                waveform.Waveform = beatmap.Value.Waveform;
-            }, true);
-
-            waveform.Waveform = beatmap.Value.Waveform;
+            track.BindValueChanged(_ => waveform.Waveform = beatmap.Value.Waveform, true);
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
         }

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit.Setup
             }
 
             working.Value.Metadata.AudioFile = destination.Name;
-            working.Value.LoadWaveform();
+
             editorBeatmap.SaveState();
             music.ReloadCurrentTrack();
 

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit.Setup
             }
 
             working.Value.Metadata.AudioFile = destination.Name;
-            working.Value.InvalidateWaveform();
+            working.Value.LoadWaveform();
             editorBeatmap.SaveState();
             music.ReloadCurrentTrack();
 

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit.Setup
             }
 
             working.Value.Metadata.AudioFile = destination.Name;
-
+            working.Value.InvalidateWaveform();
             editorBeatmap.SaveState();
             music.ReloadCurrentTrack();
 

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -29,9 +30,13 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
 
+        [Resolved]
+        private MusicController musicController { get; set; } = null!;
+
         private readonly BindableBool isHandlingTapping = new BindableBool();
 
         private MetronomeDisplay metronome = null!;
+        private Container<WaveformComparisonDisplay> waveformContainer = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuColour colours)
@@ -88,7 +93,11 @@ namespace osu.Game.Screens.Edit.Timing
                                                     Anchor = Anchor.CentreLeft,
                                                     Origin = Anchor.CentreLeft,
                                                 },
-                                                new WaveformComparisonDisplay(),
+                                                waveformContainer = new Container<WaveformComparisonDisplay>
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Child = new WaveformComparisonDisplay(),
+                                                }
                                             }
                                         },
                                     }
@@ -179,6 +188,13 @@ namespace osu.Game.Screens.Edit.Timing
                 if (handling.NewValue)
                     start();
             }, true);
+
+            musicController.TrackChanged += onTrackReload;
+        }
+
+        private void onTrackReload(WorkingBeatmap beatmap, TrackChangeDirection tcd)
+        {
+            waveformContainer.Child = new WaveformComparisonDisplay();
         }
 
         private void start()
@@ -231,6 +247,12 @@ namespace osu.Game.Screens.Edit.Timing
                 return;
 
             timing.BeatLength = 60000 / (timing.BPM + adjust);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            musicController.TrackChanged -= onTrackReload;
+            base.Dispose(isDisposing);
         }
 
         private partial class InlineButton : OsuButton

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -189,6 +189,10 @@ namespace osu.Game.Screens.Edit.Timing
             }, true);
 
             track.BindTo(clock.Track);
+        }
+
+        protected override void LoadComplete()
+        {
             track.ValueChanged += _ => waveformContainer.Child = new WaveformComparisonDisplay();
         }
 

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -30,15 +29,12 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
 
-        private readonly IBindable<Track> track = new Bindable<Track>();
-
         private readonly BindableBool isHandlingTapping = new BindableBool();
 
         private MetronomeDisplay metronome = null!;
-        private Container<WaveformComparisonDisplay> waveformContainer = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuColour colours, EditorClock clock)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
             const float padding = 10;
 
@@ -92,11 +88,7 @@ namespace osu.Game.Screens.Edit.Timing
                                                     Anchor = Anchor.CentreLeft,
                                                     Origin = Anchor.CentreLeft,
                                                 },
-                                                waveformContainer = new Container<WaveformComparisonDisplay>
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Child = new WaveformComparisonDisplay(),
-                                                }
+                                                new WaveformComparisonDisplay()
                                             }
                                         },
                                     }
@@ -187,13 +179,6 @@ namespace osu.Game.Screens.Edit.Timing
                 if (handling.NewValue)
                     start();
             }, true);
-
-            track.BindTo(clock.Track);
-        }
-
-        protected override void LoadComplete()
-        {
-            track.ValueChanged += _ => waveformContainer.Child = new WaveformComparisonDisplay();
         }
 
         private void start()

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -3,13 +3,13 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -30,8 +30,7 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
 
-        [Resolved]
-        private MusicController musicController { get; set; } = null!;
+        private readonly IBindable<Track> track = new Bindable<Track>();
 
         private readonly BindableBool isHandlingTapping = new BindableBool();
 
@@ -39,7 +38,7 @@ namespace osu.Game.Screens.Edit.Timing
         private Container<WaveformComparisonDisplay> waveformContainer = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours, EditorClock clock)
         {
             const float padding = 10;
 
@@ -189,12 +188,8 @@ namespace osu.Game.Screens.Edit.Timing
                     start();
             }, true);
 
-            musicController.TrackChanged += onTrackReload;
-        }
-
-        private void onTrackReload(WorkingBeatmap beatmap, TrackChangeDirection tcd)
-        {
-            waveformContainer.Child = new WaveformComparisonDisplay();
+            track.BindTo(clock.Track);
+            track.ValueChanged += _ => waveformContainer.Child = new WaveformComparisonDisplay();
         }
 
         private void start()
@@ -247,12 +242,6 @@ namespace osu.Game.Screens.Edit.Timing
                 return;
 
             timing.BeatLength = 60000 / (timing.BPM + adjust);
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            musicController.TrackChanged -= onTrackReload;
-            base.Dispose(isDisposing);
         }
 
         private partial class InlineButton : OsuButton

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
@@ -294,13 +295,18 @@ namespace osu.Game.Screens.Edit.Timing
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
 
+            [Resolved]
+            private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+            private readonly IBindable<Track> track = new Bindable<Track>();
+
             public WaveformRow(bool isMainRow)
             {
                 this.isMainRow = isMainRow;
             }
 
             [BackgroundDependencyLoader]
-            private void load(IBindable<WorkingBeatmap> beatmap)
+            private void load(EditorClock clock)
             {
                 InternalChildren = new Drawable[]
                 {
@@ -330,6 +336,13 @@ namespace osu.Game.Screens.Edit.Timing
                         Colour = colourProvider.Content2
                     }
                 };
+
+                track.BindTo(clock.Track);
+            }
+
+            protected override void LoadComplete()
+            {
+                track.ValueChanged += _ => waveformGraph.Waveform = beatmap.Value.Waveform;
             }
 
             public int BeatIndex { set => beatIndexText.Text = value.ToString(); }


### PR DESCRIPTION
Close #18713.
The issue was in lazy storage of waveform in working beatmap - even when track is changed, cache was not reset, so always returned old waveform (or even null one). Couldn't think of anything better than to just expose a method for this.
7089bb6 is needed because the event fires on track reload, while previously used bindable doesn't.