### PR TITLE
Don't post notifications from custom log targets

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1040,7 +1040,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target is null or > LoggingTarget.Database) return;
+                if (entry.Level < LogLevel.Important || entry.Target == null || entry.Target > LoggingTarget.Database) return;
 
                 Debug.Assert(entry.Target != null);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1040,9 +1040,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target == null || entry.Target > LoggingTarget.Database) return;
-
-                Debug.Assert(entry.Target != null);
+                if (entry.Level < LogLevel.Important || entry.Target > LoggingTarget.Database || entry.Target == null) return;
 
                 const int short_term_display_limit = 3;
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1040,7 +1040,7 @@ namespace osu.Game
 
             Logger.NewEntry += entry =>
             {
-                if (entry.Level < LogLevel.Important || entry.Target > LoggingTarget.Database) return;
+                if (entry.Level < LogLevel.Important || entry.Target is null or > LoggingTarget.Database) return;
 
                 Debug.Assert(entry.Target != null);
 


### PR DESCRIPTION
This should be enough, though I'm wondering if `Logger.GameIdentifier` should not also be checked. This would only come up when osu is embedded (for example osu!xr, or visual tests, should they want their own notifications), though it might require some changes framework side (perhaps ideally each log entry would have the game specified, though it sounds like it might be more pain than its worth).