### PR TITLE
Add solo statistics watcher component to deliver incremental global user statistics updates

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneSoloStatisticsWatcher.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneSoloStatisticsWatcher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
@@ -12,6 +13,7 @@ using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Solo;
 using osu.Game.Online.Spectator;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Scoring;
 using osu.Game.Users;
@@ -33,9 +35,12 @@ namespace osu.Game.Tests.Visual.Online
         private Action<GetUsersRequest>? handleGetUsersRequest;
         private Action<GetUserRequest>? handleGetUserRequest;
 
+        private readonly Dictionary<(int userId, string rulesetName), UserStatistics> serverSideStatistics = new Dictionary<(int userId, string rulesetName), UserStatistics>();
+
         [SetUpSteps]
         public void SetUpSteps()
         {
+            AddStep("clear server-side stats", () => serverSideStatistics.Clear());
             AddStep("set up request handling", () =>
             {
                 handleGetUserRequest = null;
@@ -46,11 +51,52 @@ namespace osu.Game.Tests.Visual.Online
                     switch (request)
                     {
                         case GetUsersRequest getUsersRequest:
-                            handleGetUsersRequest?.Invoke(getUsersRequest);
+                            if (handleGetUsersRequest != null)
+                            {
+                                handleGetUsersRequest?.Invoke(getUsersRequest);
+                            }
+                            else
+                            {
+                                int userId = getUsersRequest.UserIds.Single();
+                                var response = new GetUsersResponse
+                                {
+                                    Users = new List<APIUser>
+                                    {
+                                        new APIUser
+                                        {
+                                            Id = userId,
+                                            RulesetsStatistics = new Dictionary<string, UserStatistics>
+                                            {
+                                                ["osu"] = tryGetStatistics(userId, "osu"),
+                                                ["taiko"] = tryGetStatistics(userId, "taiko"),
+                                                ["fruits"] = tryGetStatistics(userId, "fruits"),
+                                                ["mania"] = tryGetStatistics(userId, "mania"),
+                                            }
+                                        }
+                                    }
+                                };
+                                getUsersRequest.TriggerSuccess(response);
+                            }
+
                             return true;
 
                         case GetUserRequest getUserRequest:
-                            handleGetUserRequest?.Invoke(getUserRequest);
+                            if (handleGetUserRequest != null)
+                            {
+                                handleGetUserRequest.Invoke(getUserRequest);
+                            }
+                            else
+                            {
+                                int userId = int.Parse(getUserRequest.Lookup);
+                                string rulesetName = getUserRequest.Ruleset.ShortName;
+                                var response = new APIUser
+                                {
+                                    Id = userId,
+                                    Statistics = tryGetStatistics(userId, rulesetName)
+                                };
+                                getUserRequest.TriggerSuccess(response);
+                            }
+
                             return true;
 
                         default:
@@ -65,120 +111,90 @@ namespace osu.Game.Tests.Visual.Online
             });
         }
 
+        private UserStatistics tryGetStatistics(int userId, string rulesetName)
+            => serverSideStatistics.TryGetValue((userId, rulesetName), out var stats) ? stats : new UserStatistics();
+
         [Test]
         public void TestStatisticsUpdateFiredAfterRegistrationAddedAndScoreProcessed()
         {
-            AddStep("fetch initial stats", () =>
-            {
-                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1234));
-                dummyAPI.LocalUser.Value = new APIUser { Id = 1234 };
-            });
+            int userId = getUserId();
+            long scoreId = getScoreId();
+            setUpUser(userId);
+
+            var ruleset = new OsuRuleset().RulesetInfo;
 
             SoloStatisticsUpdate? update = null;
+            registerForUpdates(scoreId, ruleset, receivedUpdate => update = receivedUpdate);
 
-            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
-                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
-                {
-                    Ruleset = new OsuRuleset().RulesetInfo,
-                    OnlineID = 5678
-                },
-                receivedUpdate => update = receivedUpdate));
+            feignScoreProcessing(userId, ruleset, 5_000_000);
 
-            AddStep("feign score processing",
-                () => handleGetUserRequest =
-                    req => req.TriggerSuccess(createIncrementalUserResponse(1234, 5_000_000)));
-
-            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1234, 5678));
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(userId, scoreId));
             AddUntilStep("update received", () => update != null);
-            AddAssert("values before are correct", () => update?.Before.TotalScore, () => Is.EqualTo(4_000_000));
-            AddAssert("values after are correct", () => update?.After.TotalScore, () => Is.EqualTo(5_000_000));
+            AddAssert("values before are correct", () => update!.Before.TotalScore, () => Is.EqualTo(4_000_000));
+            AddAssert("values after are correct", () => update!.After.TotalScore, () => Is.EqualTo(5_000_000));
         }
 
         [Test]
         public void TestStatisticsUpdateFiredAfterScoreProcessedAndRegistrationAdded()
         {
-            AddStep("fetch initial stats", () =>
-            {
-                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1235));
-                dummyAPI.LocalUser.Value = new APIUser { Id = 1235 };
-            });
+            int userId = getUserId();
+            setUpUser(userId);
 
-            AddStep("feign score processing",
-                () => handleGetUserRequest =
-                    req => req.TriggerSuccess(createIncrementalUserResponse(1235, 5_000_000)));
-            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1235, 5678));
+            long scoreId = getScoreId();
+            var ruleset = new OsuRuleset().RulesetInfo;
+
+            // note ordering - in this test processing completes *before* the registration is added.
+            feignScoreProcessing(userId, ruleset, 5_000_000);
 
             SoloStatisticsUpdate? update = null;
+            registerForUpdates(scoreId, ruleset, receivedUpdate => update = receivedUpdate);
 
-            // note ordering - this test checks that even if the registration is late, it will receive data.
-            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
-                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
-                {
-                    Ruleset = new OsuRuleset().RulesetInfo,
-                    OnlineID = 5678
-                },
-                receivedUpdate => update = receivedUpdate));
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(userId, scoreId));
             AddUntilStep("update received", () => update != null);
-            AddAssert("values before are correct", () => update?.Before.TotalScore, () => Is.EqualTo(4_000_000));
-            AddAssert("values after are correct", () => update?.After.TotalScore, () => Is.EqualTo(5_000_000));
+            AddAssert("values before are correct", () => update!.Before.TotalScore, () => Is.EqualTo(4_000_000));
+            AddAssert("values after are correct", () => update!.After.TotalScore, () => Is.EqualTo(5_000_000));
         }
 
         [Test]
         public void TestStatisticsUpdateNotFiredIfUserLoggedOut()
         {
-            AddStep("fetch initial stats", () =>
-            {
-                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1236));
-                dummyAPI.LocalUser.Value = new APIUser { Id = 1236 };
-            });
+            int userId = getUserId();
+            setUpUser(userId);
+
+            long scoreId = getScoreId();
+            var ruleset = new OsuRuleset().RulesetInfo;
 
             SoloStatisticsUpdate? update = null;
+            registerForUpdates(scoreId, ruleset, receivedUpdate => update = receivedUpdate);
 
-            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
-                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
-                {
-                    Ruleset = new OsuRuleset().RulesetInfo,
-                    OnlineID = 5678
-                },
-                receivedUpdate => update = receivedUpdate));
-
-            AddStep("feign score processing",
-                () => handleGetUserRequest =
-                    req => req.TriggerSuccess(createIncrementalUserResponse(1236, 5_000_000)));
+            feignScoreProcessing(userId, ruleset, 5_000_000);
 
             AddStep("log out user", () => dummyAPI.Logout());
 
-            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1236, 5678));
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(userId, scoreId));
             AddWaitStep("wait a bit", 5);
             AddAssert("update not received", () => update == null);
+
+            AddStep("log in user", () => dummyAPI.Login("user", "password"));
         }
 
         [Test]
         public void TestStatisticsUpdateNotFiredIfAnotherUserLoggedIn()
         {
-            AddStep("fetch initial stats", () =>
-            {
-                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1237));
-                dummyAPI.LocalUser.Value = new APIUser { Id = 1237 };
-            });
+            int userId = getUserId();
+            setUpUser(userId);
+
+            long scoreId = getScoreId();
+            var ruleset = new OsuRuleset().RulesetInfo;
 
             SoloStatisticsUpdate? update = null;
+            registerForUpdates(scoreId, ruleset, receivedUpdate => update = receivedUpdate);
 
-            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
-                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
-                {
-                    Ruleset = new OsuRuleset().RulesetInfo,
-                    OnlineID = 5678
-                },
-                receivedUpdate => update = receivedUpdate));
+            feignScoreProcessing(userId, ruleset, 5_000_000);
 
-            AddStep("feign score processing",
-                () => handleGetUserRequest =
-                    req => req.TriggerSuccess(createIncrementalUserResponse(1237, 5_000_000)));
+            AddStep("change user", () => dummyAPI.LocalUser.Value = new APIUser { Id = getUserId() });
 
-            AddStep("log out user", () => dummyAPI.LocalUser.Value = new APIUser { Id = 5555 });
-
-            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1237, 5678));
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(userId, scoreId));
             AddWaitStep("wait a bit", 5);
             AddAssert("update not received", () => update == null);
         }
@@ -186,56 +202,51 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestStatisticsUpdateNotFiredIfScoreIdDoesNotMatch()
         {
-            AddStep("fetch initial stats", () =>
-            {
-                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1238));
-                dummyAPI.LocalUser.Value = new APIUser { Id = 1238 };
-            });
+            int userId = getUserId();
+            setUpUser(userId);
+
+            long scoreId = getScoreId();
+            var ruleset = new OsuRuleset().RulesetInfo;
 
             SoloStatisticsUpdate? update = null;
+            registerForUpdates(scoreId, ruleset, receivedUpdate => update = receivedUpdate);
 
-            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
-                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
-                {
-                    Ruleset = new OsuRuleset().RulesetInfo,
-                    OnlineID = 5678
-                },
-                receivedUpdate => update = receivedUpdate));
+            feignScoreProcessing(userId, ruleset, 5_000_000);
 
-            AddStep("feign score processing",
-                () => handleGetUserRequest =
-                    req => req.TriggerSuccess(createIncrementalUserResponse(1238, 5_000_000)));
-
-            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1238, 9012));
+            AddStep("signal another score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(userId, getScoreId()));
             AddWaitStep("wait a bit", 5);
             AddAssert("update not received", () => update == null);
         }
 
-        private GetUsersResponse createInitialUserResponse(int userId) => new GetUsersResponse
-        {
-            Users = new List<APIUser>
-            {
-                new APIUser
-                {
-                    Id = userId,
-                    RulesetsStatistics = new Dictionary<string, UserStatistics>
-                    {
-                        ["osu"] = new UserStatistics { TotalScore = 4_000_000 },
-                        ["taiko"] = new UserStatistics { TotalScore = 3_000_000 },
-                        ["fruits"] = new UserStatistics { TotalScore = 2_000_000 },
-                        ["mania"] = new UserStatistics { TotalScore = 1_000_000 }
-                    }
-                }
-            }
-        };
+        private int nextUserId = 2000;
+        private long nextScoreId = 50000;
 
-        private APIUser createIncrementalUserResponse(int userId, long totalScore) => new APIUser
+        private int getUserId() => ++nextUserId;
+        private long getScoreId() => ++nextScoreId;
+
+        private void setUpUser(int userId)
         {
-            Id = userId,
-            Statistics = new UserStatistics
+            AddStep("fetch initial stats", () =>
             {
-                TotalScore = totalScore
-            }
-        };
+                serverSideStatistics[(userId, "osu")] = new UserStatistics { TotalScore = 4_000_000 };
+                serverSideStatistics[(userId, "taiko")] = new UserStatistics { TotalScore = 3_000_000 };
+                serverSideStatistics[(userId, "fruits")] = new UserStatistics { TotalScore = 2_000_000 };
+                serverSideStatistics[(userId, "mania")] = new UserStatistics { TotalScore = 1_000_000 };
+
+                dummyAPI.LocalUser.Value = new APIUser { Id = userId };
+            });
+        }
+
+        private void registerForUpdates(long scoreId, RulesetInfo rulesetInfo, Action<SoloStatisticsUpdate> onUpdateReady) =>
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = rulesetInfo,
+                    OnlineID = scoreId
+                },
+                onUpdateReady));
+
+        private void feignScoreProcessing(int userId, RulesetInfo rulesetInfo, long newTotalScore)
+            => AddStep("feign score processing", () => serverSideStatistics[(userId, rulesetInfo.ShortName)] = new UserStatistics { TotalScore = newTotalScore });
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneSoloStatisticsWatcher.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneSoloStatisticsWatcher.cs
@@ -1,0 +1,241 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Testing;
+using osu.Game.Models;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Solo;
+using osu.Game.Online.Spectator;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Tests.Visual.Online
+{
+    [HeadlessTest]
+    public partial class TestSceneSoloStatisticsWatcher : OsuTestScene
+    {
+        protected override bool UseOnlineAPI => false;
+
+        private SoloStatisticsWatcher watcher = null!;
+
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; } = null!;
+
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        private Action<GetUsersRequest>? handleGetUsersRequest;
+        private Action<GetUserRequest>? handleGetUserRequest;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("set up request handling", () =>
+            {
+                handleGetUserRequest = null;
+                handleGetUsersRequest = null;
+
+                dummyAPI.HandleRequest = request =>
+                {
+                    switch (request)
+                    {
+                        case GetUsersRequest getUsersRequest:
+                            handleGetUsersRequest?.Invoke(getUsersRequest);
+                            return true;
+
+                        case GetUserRequest getUserRequest:
+                            handleGetUserRequest?.Invoke(getUserRequest);
+                            return true;
+
+                        default:
+                            return false;
+                    }
+                };
+            });
+
+            AddStep("create watcher", () =>
+            {
+                Child = watcher = new SoloStatisticsWatcher();
+            });
+        }
+
+        [Test]
+        public void TestStatisticsUpdateFiredAfterRegistrationAddedAndScoreProcessed()
+        {
+            AddStep("fetch initial stats", () =>
+            {
+                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1234));
+                dummyAPI.LocalUser.Value = new APIUser { Id = 1234 };
+            });
+
+            SoloStatisticsUpdate? update = null;
+
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    OnlineID = 5678
+                },
+                receivedUpdate => update = receivedUpdate));
+
+            AddStep("feign score processing",
+                () => handleGetUserRequest =
+                    req => req.TriggerSuccess(createIncrementalUserResponse(1234, 5_000_000)));
+
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1234, 5678));
+            AddUntilStep("update received", () => update != null);
+            AddAssert("values before are correct", () => update?.Before.TotalScore, () => Is.EqualTo(4_000_000));
+            AddAssert("values after are correct", () => update?.After.TotalScore, () => Is.EqualTo(5_000_000));
+        }
+
+        [Test]
+        public void TestStatisticsUpdateFiredAfterScoreProcessedAndRegistrationAdded()
+        {
+            AddStep("fetch initial stats", () =>
+            {
+                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1235));
+                dummyAPI.LocalUser.Value = new APIUser { Id = 1235 };
+            });
+
+            AddStep("feign score processing",
+                () => handleGetUserRequest =
+                    req => req.TriggerSuccess(createIncrementalUserResponse(1235, 5_000_000)));
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1235, 5678));
+
+            SoloStatisticsUpdate? update = null;
+
+            // note ordering - this test checks that even if the registration is late, it will receive data.
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    OnlineID = 5678
+                },
+                receivedUpdate => update = receivedUpdate));
+            AddUntilStep("update received", () => update != null);
+            AddAssert("values before are correct", () => update?.Before.TotalScore, () => Is.EqualTo(4_000_000));
+            AddAssert("values after are correct", () => update?.After.TotalScore, () => Is.EqualTo(5_000_000));
+        }
+
+        [Test]
+        public void TestStatisticsUpdateNotFiredIfUserLoggedOut()
+        {
+            AddStep("fetch initial stats", () =>
+            {
+                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1236));
+                dummyAPI.LocalUser.Value = new APIUser { Id = 1236 };
+            });
+
+            SoloStatisticsUpdate? update = null;
+
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    OnlineID = 5678
+                },
+                receivedUpdate => update = receivedUpdate));
+
+            AddStep("feign score processing",
+                () => handleGetUserRequest =
+                    req => req.TriggerSuccess(createIncrementalUserResponse(1236, 5_000_000)));
+
+            AddStep("log out user", () => dummyAPI.Logout());
+
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1236, 5678));
+            AddWaitStep("wait a bit", 5);
+            AddAssert("update not received", () => update == null);
+        }
+
+        [Test]
+        public void TestStatisticsUpdateNotFiredIfAnotherUserLoggedIn()
+        {
+            AddStep("fetch initial stats", () =>
+            {
+                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1237));
+                dummyAPI.LocalUser.Value = new APIUser { Id = 1237 };
+            });
+
+            SoloStatisticsUpdate? update = null;
+
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    OnlineID = 5678
+                },
+                receivedUpdate => update = receivedUpdate));
+
+            AddStep("feign score processing",
+                () => handleGetUserRequest =
+                    req => req.TriggerSuccess(createIncrementalUserResponse(1237, 5_000_000)));
+
+            AddStep("log out user", () => dummyAPI.LocalUser.Value = new APIUser { Id = 5555 });
+
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1237, 5678));
+            AddWaitStep("wait a bit", 5);
+            AddAssert("update not received", () => update == null);
+        }
+
+        [Test]
+        public void TestStatisticsUpdateNotFiredIfScoreIdDoesNotMatch()
+        {
+            AddStep("fetch initial stats", () =>
+            {
+                handleGetUsersRequest = req => req.TriggerSuccess(createInitialUserResponse(1238));
+                dummyAPI.LocalUser.Value = new APIUser { Id = 1238 };
+            });
+
+            SoloStatisticsUpdate? update = null;
+
+            AddStep("register for updates", () => watcher.RegisterForStatisticsUpdateAfter(
+                new ScoreInfo(Beatmap.Value.BeatmapInfo, new OsuRuleset().RulesetInfo, new RealmUser())
+                {
+                    Ruleset = new OsuRuleset().RulesetInfo,
+                    OnlineID = 5678
+                },
+                receivedUpdate => update = receivedUpdate));
+
+            AddStep("feign score processing",
+                () => handleGetUserRequest =
+                    req => req.TriggerSuccess(createIncrementalUserResponse(1238, 5_000_000)));
+
+            AddStep("signal score processed", () => ((ISpectatorClient)spectatorClient).UserScoreProcessed(1238, 9012));
+            AddWaitStep("wait a bit", 5);
+            AddAssert("update not received", () => update == null);
+        }
+
+        private GetUsersResponse createInitialUserResponse(int userId) => new GetUsersResponse
+        {
+            Users = new List<APIUser>
+            {
+                new APIUser
+                {
+                    Id = userId,
+                    RulesetsStatistics = new Dictionary<string, UserStatistics>
+                    {
+                        ["osu"] = new UserStatistics { TotalScore = 4_000_000 },
+                        ["taiko"] = new UserStatistics { TotalScore = 3_000_000 },
+                        ["fruits"] = new UserStatistics { TotalScore = 2_000_000 },
+                        ["mania"] = new UserStatistics { TotalScore = 1_000_000 }
+                    }
+                }
+            }
+        };
+
+        private APIUser createIncrementalUserResponse(int userId, long totalScore) => new APIUser
+        {
+            Id = userId,
+            Statistics = new UserStatistics
+            {
+                TotalScore = totalScore
+            }
+        };
+    }
+}

--- a/osu.Game/Online/API/Requests/GetUsersRequest.cs
+++ b/osu.Game/Online/API/Requests/GetUsersRequest.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetUsersRequest : APIRequest<GetUsersResponse>
     {
-        private readonly int[] userIds;
+        public readonly int[] UserIds;
 
         private const int max_ids_per_request = 50;
 
@@ -18,9 +18,9 @@ namespace osu.Game.Online.API.Requests
             if (userIds.Length > max_ids_per_request)
                 throw new ArgumentException($"{nameof(GetUsersRequest)} calls only support up to {max_ids_per_request} IDs at once");
 
-            this.userIds = userIds;
+            UserIds = userIds;
         }
 
-        protected override string Target => "users/?ids[]=" + string.Join("&ids[]=", userIds);
+        protected override string Target => "users/?ids[]=" + string.Join("&ids[]=", UserIds);
     }
 }

--- a/osu.Game/Online/Solo/SoloStatisticsUpdate.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsUpdate.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Online.Solo
+{
+    /// <summary>
+    /// Contains data about the change in a user's profile statistics after completing a score.
+    /// </summary>
+    public class SoloStatisticsUpdate
+    {
+        /// <summary>
+        /// The score set by the user that triggered the update.
+        /// </summary>
+        public ScoreInfo Score { get; }
+
+        /// <summary>
+        /// The user's profile statistics prior to the score being set.
+        /// </summary>
+        public UserStatistics Before { get; }
+
+        /// <summary>
+        /// The user's profile statistics after the score was set.
+        /// </summary>
+        public UserStatistics After { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="SoloStatisticsUpdate"/>.
+        /// </summary>
+        /// <param name="score">The score set by the user that triggered the update.</param>
+        /// <param name="before">The user's profile statistics prior to the score being set.</param>
+        /// <param name="after">The user's profile statistics after the score was set.</param>
+        public SoloStatisticsUpdate(ScoreInfo score, UserStatistics before, UserStatistics after)
+        {
+            Score = score;
+            Before = before;
+            After = after;
+        }
+    }
+}

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -1,0 +1,140 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Spectator;
+using osu.Game.Scoring;
+using osu.Game.Users;
+
+namespace osu.Game.Online.Solo
+{
+    /// <summary>
+    /// A persistent component that binds to the spectator server and API in order to deliver updates about the logged in user's gameplay statistics.
+    /// </summary>
+    public partial class SoloStatisticsWatcher : Component
+    {
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        private readonly Dictionary<long, StatisticsUpdateCallback> callbacks = new Dictionary<long, StatisticsUpdateCallback>();
+        private readonly HashSet<long> scoresWithoutCallback = new HashSet<long>();
+
+        private readonly Dictionary<string, UserStatistics> latestStatistics = new Dictionary<string, UserStatistics>();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            api.LocalUser.BindValueChanged(user => onUserChanged(user.NewValue), true);
+            spectatorClient.OnUserScoreProcessed += userScoreProcessed;
+        }
+
+        /// <summary>
+        /// Registers for a user statistics update after the given <paramref name="score"/> has been processed server-side.
+        /// </summary>
+        /// <param name="score">The score to listen for the statistics update for.</param>
+        /// <param name="onUpdateReady">The callback to be invoked once the statistics update has been prepared.</param>
+        public void RegisterForStatisticsUpdateAfter(ScoreInfo score, Action<SoloStatisticsUpdate> onUpdateReady) => Schedule(() =>
+        {
+            if (!api.IsLoggedIn)
+                return;
+
+            var callback = new StatisticsUpdateCallback(score, onUpdateReady);
+
+            if (scoresWithoutCallback.Remove(score.OnlineID))
+            {
+                requestStatisticsUpdate(api.LocalUser.Value.Id, callback);
+                return;
+            }
+
+            callbacks[score.OnlineID] = callback;
+        });
+
+        private void onUserChanged(APIUser? localUser) => Schedule(() =>
+        {
+            callbacks.Clear();
+            scoresWithoutCallback.Clear();
+            latestStatistics.Clear();
+
+            if (!api.IsLoggedIn)
+                return;
+
+            Debug.Assert(localUser != null && localUser.OnlineID > 1);
+
+            var userRequest = new GetUsersRequest(new[] { localUser.OnlineID });
+            userRequest.Success += response => Schedule(() =>
+            {
+                foreach (var rulesetStats in response.Users.Single().RulesetsStatistics)
+                    latestStatistics.Add(rulesetStats.Key, rulesetStats.Value);
+            });
+            api.Queue(userRequest);
+        });
+
+        private void userScoreProcessed(int userId, long scoreId)
+        {
+            if (userId != api.LocalUser.Value?.OnlineID)
+                return;
+
+            if (!callbacks.TryGetValue(scoreId, out var callback))
+            {
+                scoresWithoutCallback.Add(scoreId);
+                return;
+            }
+
+            requestStatisticsUpdate(userId, callback);
+            callbacks.Remove(scoreId);
+        }
+
+        private void requestStatisticsUpdate(int userId, StatisticsUpdateCallback callback)
+        {
+            var request = new GetUserRequest(userId, callback.Score.Ruleset);
+            request.Success += user => Schedule(() => dispatchStatisticsUpdate(callback, user.Statistics));
+            api.Queue(request);
+        }
+
+        private void dispatchStatisticsUpdate(StatisticsUpdateCallback callback, UserStatistics updatedStatistics)
+        {
+            string rulesetName = callback.Score.Ruleset.ShortName;
+
+            if (!latestStatistics.TryGetValue(rulesetName, out var latestRulesetStatistics))
+                return;
+
+            var update = new SoloStatisticsUpdate(callback.Score, latestRulesetStatistics, updatedStatistics);
+            callback.OnUpdateReady.Invoke(update);
+
+            latestStatistics[rulesetName] = updatedStatistics;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (spectatorClient.IsNotNull())
+                spectatorClient.OnUserScoreProcessed -= userScoreProcessed;
+
+            base.Dispose(isDisposing);
+        }
+
+        private class StatisticsUpdateCallback
+        {
+            public ScoreInfo Score { get; }
+            public Action<SoloStatisticsUpdate> OnUpdateReady { get; }
+
+            public StatisticsUpdateCallback(ScoreInfo score, Action<SoloStatisticsUpdate> onUpdateReady)
+            {
+                Score = score;
+                OnUpdateReady = onUpdateReady;
+            }
+        }
+    }
+}

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -49,6 +50,9 @@ namespace osu.Game.Online.Solo
         public void RegisterForStatisticsUpdateAfter(ScoreInfo score, Action<SoloStatisticsUpdate> onUpdateReady) => Schedule(() =>
         {
             if (!api.IsLoggedIn)
+                return;
+
+            if (!score.Ruleset.IsLegacyRuleset())
                 return;
 
             var callback = new StatisticsUpdateCallback(score, onUpdateReady);

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -72,10 +71,8 @@ namespace osu.Game.Online.Solo
             lastProcessedScoreId = null;
             latestStatistics.Clear();
 
-            if (!api.IsLoggedIn)
+            if (localUser == null || localUser.OnlineID <= 1)
                 return;
-
-            Debug.Assert(localUser != null);
 
             var userRequest = new GetUsersRequest(new[] { localUser.OnlineID });
             userRequest.Success += response => Schedule(() =>

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Online.Solo
                 return;
             }
 
-            callbacks[score.OnlineID] = callback;
+            callbacks.Add(score.OnlineID, callback);
         });
 
         private void onUserChanged(APIUser? localUser) => Schedule(() =>

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -77,6 +77,7 @@ namespace osu.Game.Online.Solo
             var userRequest = new GetUsersRequest(new[] { localUser.OnlineID });
             userRequest.Success += response => Schedule(() =>
             {
+                latestStatistics.Clear();
                 foreach (var rulesetStats in response.Users.Single().RulesetsStatistics)
                     latestStatistics.Add(rulesetStats.Key, rulesetStats.Value);
             });

--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Online.Solo
             if (!api.IsLoggedIn)
                 return;
 
-            Debug.Assert(localUser != null && localUser.OnlineID > 1);
+            Debug.Assert(localUser != null);
 
             var userRequest = new GetUsersRequest(new[] { localUser.OnlineID });
             userRequest.Success += response => Schedule(() =>


### PR DESCRIPTION
- Continuation of https://github.com/ppy/osu/issues/18877
- Needs https://github.com/ppy/osu-server-spectator/pull/157 to work

Due to the client-side design that I decided on for this flow (for not much reason other than that it seemed better than the alternative _somehow_) this component is the main workhorse of delivering the updates. The main point is that the watcher subscribes to the events that spectator server sends out on every successful processing of a score, issues API requests to get the user's global stats, and therefore can issue incremental updates to whichever game component wants them.

I'm aware that this is ~~dumbed-down~~ simplistic in places. As written, if an API call fails, there is no retry other than  what `APIAccess` provides. Thus, if you set a score, the API request to get stats after that fails, and then you set another score and the second API request to get stats succeeds, the next differential update issued will merge both scores and send an incremental update that contains the effects of both. The same will happen if an update isn't explicitly requested for a score (which will happen when retrying or failing).

I'm PRing this mostly to see what the response is, as I kinda can't bear to look at this diff anymore since I've been staring at it all day to try and provide all the nice guarantees I wanted out of it (full isolation - i.e. each update after a score sees only the effects of that one score - and recovery after API failures), but I don't think I'm able to reliably make that work client-side. See [relevant discord conversation](https://discord.com/channels/188630481301012481/188630652340404224/1055479527490465832). If the nice guarantees are indeed desired, I'd probably be looking to make the score stats queue send out all of that data via redis.

If wishing to test this full-stack, the following diff can be used to issue simple notifications using this component:

<details>
<summary>diff</summary>

```diff
diff --git a/osu.Game/OsuGameBase.cs b/osu.Game/OsuGameBase.cs
index 7586dc6407..36fd5a4177 100644
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -46,6 +46,7 @@
 using osu.Game.Online.Chat;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Solo;
 using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
@@ -193,6 +194,7 @@ public virtual string Version
         protected MultiplayerClient MultiplayerClient { get; private set; }
 
         private MetadataClient metadataClient;
+        private SoloStatisticsWatcher soloStatisticsWatcher;
 
         private RealmAccess realm;
 
@@ -301,6 +303,7 @@ private void load(ReadableKeyCombinationProvider keyCombinationProvider)
             dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(MultiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
+            dependencies.CacheAs(soloStatisticsWatcher = new SoloStatisticsWatcher());
 
             AddInternal(new BeatmapOnlineChangeIngest(beatmapUpdater, realm, metadataClient));
 
@@ -346,6 +349,7 @@ private void load(ReadableKeyCombinationProvider keyCombinationProvider)
             AddInternal(spectatorClient);
             AddInternal(MultiplayerClient);
             AddInternal(metadataClient);
+            AddInternal(soloStatisticsWatcher);
 
             AddInternal(rulesetConfigCache);
 
diff --git a/osu.Game/Screens/Ranking/SoloResultsScreen.cs b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
index 3774cf16b1..709b26b50c 100644
--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -10,6 +10,9 @@
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.Solo;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 
@@ -22,11 +25,27 @@ public partial class SoloResultsScreen : ResultsScreen
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
+        [Resolved]
+        private SoloStatisticsWatcher soloStatisticsWatcher { get; set; }
+
+        [Resolved]
+        private INotificationOverlay notifications { get; set; }
+
         public SoloResultsScreen(ScoreInfo score, bool allowRetry)
             : base(score, allowRetry)
         {
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => notifications.Post(new SimpleNotification
+            {
+                Text = $"Total score: {update.Before?.TotalScore} -> {update.After.TotalScore}\nPlaytime: {update.Before?.PlayTime} -> {update.After.PlayTime}"
+            }));
+        }
+
         protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
         {
             if (Score.BeatmapInfo.OnlineID <= 0 || Score.BeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
```

</details>