### PR TITLE
Use new ArgumentNullException.ThrowIfNull throw-helper API

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PatternGenerator.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
         protected PatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, IBeatmap originalBeatmap)
             : base(hitObject, beatmap, previousPattern)
         {
-            if (random == null) throw new ArgumentNullException(nameof(random));
-            if (originalBeatmap == null) throw new ArgumentNullException(nameof(originalBeatmap));
+            ArgumentNullException.ThrowIfNull(random);
+            ArgumentNullException.ThrowIfNull(originalBeatmap);
 
             Random = random;
             OriginalBeatmap = originalBeatmap;

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/PatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/PatternGenerator.cs
@@ -33,9 +33,9 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns
 
         protected PatternGenerator(HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern)
         {
-            if (hitObject == null) throw new ArgumentNullException(nameof(hitObject));
-            if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
-            if (previousPattern == null) throw new ArgumentNullException(nameof(previousPattern));
+            ArgumentNullException.ThrowIfNull(hitObject);
+            ArgumentNullException.ThrowIfNull(beatmap);
+            ArgumentNullException.ThrowIfNull(previousPattern);
 
             HitObject = hitObject;
             Beatmap = beatmap;

--- a/osu.Game.Rulesets.Mania/MathUtils/LegacySortHelper.cs
+++ b/osu.Game.Rulesets.Mania/MathUtils/LegacySortHelper.cs
@@ -22,8 +22,7 @@ namespace osu.Game.Rulesets.Mania.MathUtils
 
         public static void Sort(T[] keys, IComparer<T> comparer)
         {
-            if (keys == null)
-                throw new ArgumentNullException(nameof(keys));
+            ArgumentNullException.ThrowIfNull(keys);
 
             if (keys.Length == 0)
                 return;

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -29,8 +29,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public ManiaPlayfield(List<StageDefinition> stageDefinitions)
         {
-            if (stageDefinitions == null)
-                throw new ArgumentNullException(nameof(stageDefinitions));
+            ArgumentNullException.ThrowIfNull(stageDefinitions);
 
             if (stageDefinitions.Count <= 0)
                 throw new ArgumentException("Can't have zero or fewer stages.");

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGeneratorBase.cs
@@ -84,8 +84,8 @@ namespace osu.Game.Rulesets.Osu.Replays
         {
             public int Compare(ReplayFrame? f1, ReplayFrame? f2)
             {
-                if (f1 == null) throw new ArgumentNullException(nameof(f1));
-                if (f2 == null) throw new ArgumentNullException(nameof(f2));
+                ArgumentNullException.ThrowIfNull(f1);
+                ArgumentNullException.ThrowIfNull(f2);
 
                 return f1.Time.CompareTo(f2.Time);
             }

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tournament.Components
 
         public TournamentBeatmapPanel(TournamentBeatmap beatmap, string mod = null)
         {
-            if (beatmap == null) throw new ArgumentNullException(nameof(beatmap));
+            ArgumentNullException.ThrowIfNull(beatmap);
 
             Beatmap = beatmap;
             this.mod = mod;

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -211,8 +211,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public static T BinarySearch<T>(IReadOnlyList<T> list, double time)
             where T : class, IControlPoint
         {
-            if (list == null)
-                throw new ArgumentNullException(nameof(list));
+            ArgumentNullException.ThrowIfNull(list);
 
             if (list.Count == 0)
                 return null;

--- a/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
@@ -15,8 +15,7 @@ namespace osu.Game.Beatmaps.Drawables
 
         public BeatmapBackgroundSprite(IWorkingBeatmap working)
         {
-            if (working == null)
-                throw new ArgumentNullException(nameof(working));
+            ArgumentNullException.ThrowIfNull(working);
 
             this.working = working;
         }

--- a/osu.Game/Beatmaps/Drawables/OnlineBeatmapSetCover.cs
+++ b/osu.Game/Beatmaps/Drawables/OnlineBeatmapSetCover.cs
@@ -18,8 +18,7 @@ namespace osu.Game.Beatmaps.Drawables
 
         public OnlineBeatmapSetCover(IBeatmapSetOnlineInfo set, BeatmapSetCoverType type = BeatmapSetCoverType.Cover)
         {
-            if (set == null)
-                throw new ArgumentNullException(nameof(set));
+            ArgumentNullException.ThrowIfNull(set);
 
             this.set = set;
             this.type = type;

--- a/osu.Game/Beatmaps/Formats/Decoder.cs
+++ b/osu.Game/Beatmaps/Formats/Decoder.cs
@@ -57,8 +57,7 @@ namespace osu.Game.Beatmaps.Formats
         public static Decoder<T> GetDecoder<T>(LineBufferedReader stream)
             where T : new()
         {
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
+            ArgumentNullException.ThrowIfNull(stream);
 
             if (!decoders.TryGetValue(typeof(T), out var typedDecoders))
                 throw new IOException(@"Unknown decoder type");

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -36,8 +36,7 @@ namespace osu.Game.Graphics.Containers
         /// <param name="easing">The easing type of the initial transform.</param>
         public void StartTracking(OsuLogo logo, double duration = 0, Easing easing = Easing.None)
         {
-            if (logo == null)
-                throw new ArgumentNullException(nameof(logo));
+            ArgumentNullException.ThrowIfNull(logo);
 
             if (logo.IsTracking && Logo == null)
                 throw new InvalidOperationException($"Cannot track an instance of {typeof(OsuLogo)} to multiple {typeof(LogoTrackingContainer)}s");

--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -114,8 +114,7 @@ namespace osu.Game.Graphics.UserInterface
             get => current;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
 
                 current.UnbindBindings();
                 current.BindTo(value);

--- a/osu.Game/IO/FileAbstraction/StreamFileAbstraction.cs
+++ b/osu.Game/IO/FileAbstraction/StreamFileAbstraction.cs
@@ -23,8 +23,7 @@ namespace osu.Game.IO.FileAbstraction
 
         public void CloseStream(Stream stream)
         {
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
+            ArgumentNullException.ThrowIfNull(stream);
 
             stream.Close();
         }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -118,8 +118,7 @@ namespace osu.Game.Online.Chat
         /// <param name="name"></param>
         public void OpenChannel(string name)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            ArgumentNullException.ThrowIfNull(name);
 
             CurrentChannel.Value = AvailableChannels.FirstOrDefault(c => c.Name == name) ?? throw new ChannelNotFoundException(name);
         }
@@ -130,8 +129,7 @@ namespace osu.Game.Online.Chat
         /// <param name="user">The user the private channel is opened with.</param>
         public void OpenPrivateChannel(APIUser user)
         {
-            if (user == null)
-                throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             if (user.Id == api.LocalUser.Value.Id)
                 return;

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays
         /// <see cref="APIChangelogBuild.DisplayVersion"/> are specified, the header will instantly display them.</param>
         public void ShowBuild([NotNull] APIChangelogBuild build)
         {
-            if (build == null) throw new ArgumentNullException(nameof(build));
+            ArgumentNullException.ThrowIfNull(build);
 
             Current.Value = build;
             Show();
@@ -78,8 +78,8 @@ namespace osu.Game.Overlays
 
         public void ShowBuild([NotNull] string updateStream, [NotNull] string version)
         {
-            if (updateStream == null) throw new ArgumentNullException(nameof(updateStream));
-            if (version == null) throw new ArgumentNullException(nameof(version));
+            ArgumentNullException.ThrowIfNull(updateStream);
+            ArgumentNullException.ThrowIfNull(version);
 
             performAfterFetch(() =>
             {

--- a/osu.Game/Overlays/OnScreenDisplay.cs
+++ b/osu.Game/Overlays/OnScreenDisplay.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays
         /// <exception cref="InvalidOperationException">If <paramref name="configManager"/> is already being tracked from the same <paramref name="source"/>.</exception>
         public void BeginTracking(object source, ITrackableConfigManager configManager)
         {
-            if (configManager == null) throw new ArgumentNullException(nameof(configManager));
+            ArgumentNullException.ThrowIfNull(configManager);
 
             if (trackedConfigManagers.ContainsKey((source, configManager)))
                 throw new InvalidOperationException($"{nameof(configManager)} is already registered.");
@@ -82,7 +82,7 @@ namespace osu.Game.Overlays
         /// <exception cref="InvalidOperationException">If <paramref name="configManager"/> is not being tracked from the same <paramref name="source"/>.</exception>
         public void StopTracking(object source, ITrackableConfigManager configManager)
         {
-            if (configManager == null) throw new ArgumentNullException(nameof(configManager));
+            ArgumentNullException.ThrowIfNull(configManager);
 
             if (!trackedConfigManagers.TryGetValue((source, configManager), out var existing))
                 return;

--- a/osu.Game/Overlays/Volume/MuteButton.cs
+++ b/osu.Game/Overlays/Volume/MuteButton.cs
@@ -28,8 +28,7 @@ namespace osu.Game.Overlays.Volume
             get => current;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
 
                 current.UnbindBindings();
                 current.BindTo(value);

--- a/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
+++ b/osu.Game/Rulesets/Mods/DifficultyAdjustSettingsControl.cs
@@ -126,8 +126,7 @@ namespace osu.Game.Rulesets.Mods
                 get => this;
                 set
                 {
-                    if (value == null)
-                        throw new ArgumentNullException(nameof(value));
+                    ArgumentNullException.ThrowIfNull(value);
 
                     if (currentBound != null) UnbindFrom(currentBound);
                     BindTo(currentBound = value);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -208,8 +208,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// </summary>
         public void Apply([NotNull] HitObject hitObject)
         {
-            if (hitObject == null)
-                throw new ArgumentNullException($"Cannot apply a null {nameof(HitObject)}.");
+            ArgumentNullException.ThrowIfNull(hitObject);
 
             Apply(new SyntheticHitObjectEntry(hitObject));
         }

--- a/osu.Game/Rulesets/UI/JudgementContainer.cs
+++ b/osu.Game/Rulesets/UI/JudgementContainer.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.UI
     {
         public override void Add(T judgement)
         {
-            if (judgement == null) throw new ArgumentNullException(nameof(judgement));
+            ArgumentNullException.ThrowIfNull(judgement);
 
             // remove any existing judgements for the judged object.
             // this can be the case when rewinding.

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -71,8 +71,8 @@ namespace osu.Game.Scoring
 
             // These properties are known to be non-null, but these final checks ensure a null hasn't come from somewhere (or the refetch has failed).
             // Under no circumstance do we want these to be written to realm as null.
-            if (model.BeatmapInfo == null) throw new ArgumentNullException(nameof(model.BeatmapInfo));
-            if (model.Ruleset == null) throw new ArgumentNullException(nameof(model.Ruleset));
+            ArgumentNullException.ThrowIfNull(model.BeatmapInfo);
+            ArgumentNullException.ThrowIfNull(model.Ruleset);
 
             PopulateMaximumStatistics(model);
 

--- a/osu.Game/Screens/Menu/LogoVisualisation.cs
+++ b/osu.Game/Screens/Menu/LogoVisualisation.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Menu
 
         private void addAmplitudesFromSource(IHasAmplitudes source)
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
 
             var amplitudes = source.CurrentAmplitudes.FrequencyAmplitudes.Span;
 

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -33,8 +33,7 @@ namespace osu.Game.Screens.Play.HUD
             get => current.Current;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
 
                 current.Current = value;
             }

--- a/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
@@ -30,8 +30,7 @@ namespace osu.Game.Screens.Play.HUD
             get => current.Current;
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
 
                 current.Current = value;
             }

--- a/osu.Game/Screens/Play/KeyCounterDisplay.cs
+++ b/osu.Game/Screens/Play/KeyCounterDisplay.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Screens.Play
 
         public override void Add(KeyCounter key)
         {
-            if (key == null) throw new ArgumentNullException(nameof(key));
+            ArgumentNullException.ThrowIfNull(key);
 
             base.Add(key);
             key.IsCounting = IsCounting;

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -27,8 +27,7 @@ namespace osu.Game.Users.Drawables
         [BackgroundDependencyLoader]
         private void load(TextureStore ts)
         {
-            if (ts == null)
-                throw new ArgumentNullException(nameof(ts));
+            ArgumentNullException.ThrowIfNull(ts);
 
             string textureName = countryCode == CountryCode.Unknown ? "__" : countryCode.ToString();
             Texture = ts.Get($@"Flags/{textureName}") ?? ts.Get(@"Flags/__");

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -36,8 +36,7 @@ namespace osu.Game.Users
         protected UserPanel(APIUser user)
             : base(HoverSampleSet.Button)
         {
-            if (user == null)
-                throw new ArgumentNullException(nameof(user));
+            ArgumentNullException.ThrowIfNull(user);
 
             User = user;
         }


### PR DESCRIPTION
Only used the API when it doesn't need more lines of code than before, or when there is a custom exception message (except for one case where I felt that the message was not really helpful. Can revert this change if desired)