### PR TITLE
Make all non-web tooltips lowercase

### DIFF
--- a/osu.Game/Beatmaps/Drawables/BeatmapDownloadButton.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapDownloadButton.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Beatmaps.Drawables
                 {
                     case DownloadState.LocallyAvailable:
                         button.Enabled.Value = true;
-                        button.TooltipText = "Go to beatmap";
+                        button.TooltipText = "go to beatmap";
                         break;
 
                     default:

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/GoToBeatmapButton.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             this.beatmapSet = beatmapSet;
 
             Icon.Icon = FontAwesome.Solid.AngleDoubleRight;
-            TooltipText = "Go to beatmap";
+            TooltipText = "go to beatmap";
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Collections
 
                         addOrRemoveButton.Enabled.Value = !beatmap.IsDefault;
                         addOrRemoveButton.Icon = beatmapInCollection ? FontAwesome.Solid.MinusSquare : FontAwesome.Solid.PlusSquare;
-                        addOrRemoveButton.TooltipText = beatmapInCollection ? "Remove selected beatmap" : "Add selected beatmap";
+                        addOrRemoveButton.TooltipText = beatmapInCollection ? "remove selected beatmap" : "add selected beatmap";
 
                         updateButtonVisibility();
                     }, true);

--- a/osu.Game/Graphics/UserInterface/DownloadButton.cs
+++ b/osu.Game/Graphics/UserInterface/DownloadButton.cs
@@ -49,19 +49,19 @@ namespace osu.Game.Graphics.UserInterface
                     Background.FadeColour(colours.Gray4, 500, Easing.InOutExpo);
                     Icon.MoveToX(0, 500, Easing.InOutExpo);
                     checkmark.ScaleTo(Vector2.Zero, 500, Easing.InOutExpo);
-                    TooltipText = "Download";
+                    TooltipText = "download";
                     break;
 
                 case DownloadState.Downloading:
                     Background.FadeColour(colours.Blue, 500, Easing.InOutExpo);
                     Icon.MoveToX(0, 500, Easing.InOutExpo);
                     checkmark.ScaleTo(Vector2.Zero, 500, Easing.InOutExpo);
-                    TooltipText = "Downloading...";
+                    TooltipText = "downloading...";
                     break;
 
                 case DownloadState.Importing:
                     Background.FadeColour(colours.Yellow, 500, Easing.InOutExpo);
-                    TooltipText = "Importing";
+                    TooltipText = "importing";
                     break;
 
                 case DownloadState.LocallyAvailable:

--- a/osu.Game/Graphics/UserInterface/DownloadButton.cs
+++ b/osu.Game/Graphics/UserInterface/DownloadButton.cs
@@ -49,19 +49,19 @@ namespace osu.Game.Graphics.UserInterface
                     Background.FadeColour(colours.Gray4, 500, Easing.InOutExpo);
                     Icon.MoveToX(0, 500, Easing.InOutExpo);
                     checkmark.ScaleTo(Vector2.Zero, 500, Easing.InOutExpo);
-                    TooltipText = "download";
+                    TooltipText = BeatmapsetsStrings.PanelDownloadAll;
                     break;
 
                 case DownloadState.Downloading:
                     Background.FadeColour(colours.Blue, 500, Easing.InOutExpo);
                     Icon.MoveToX(0, 500, Easing.InOutExpo);
                     checkmark.ScaleTo(Vector2.Zero, 500, Easing.InOutExpo);
-                    TooltipText = "downloading...";
+                    TooltipText = CommonStrings.Downloading.ToLower();
                     break;
 
                 case DownloadState.Importing:
                     Background.FadeColour(colours.Yellow, 500, Easing.InOutExpo);
-                    TooltipText = "importing";
+                    TooltipText = CommonStrings.Importing.ToLower();
                     break;
 
                 case DownloadState.LocallyAvailable:

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -40,9 +40,9 @@ namespace osu.Game.Localisation
         public static LocalisableString DisableMouseWheelVolumeAdjust => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust"), @"Disable mouse wheel adjusting volume during gameplay");
 
         /// <summary>
-        /// "volume can still be adjusted using the mouse wheel by holding "Alt""
+        /// "volume can still be adjusted using the mouse wheel by holding "alt""
         /// </summary>
-        public static LocalisableString DisableMouseWheelVolumeAdjustTooltip => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust_tooltip"), @"volume can still be adjusted using the mouse wheel by holding ""Alt""");
+        public static LocalisableString DisableMouseWheelVolumeAdjustTooltip => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust_tooltip"), @"volume can still be adjusted using the mouse wheel by holding ""alt""");
 
         /// <summary>
         /// "Disable mouse buttons during gameplay"

--- a/osu.Game/Localisation/MouseSettingsStrings.cs
+++ b/osu.Game/Localisation/MouseSettingsStrings.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Localisation
         public static LocalisableString Mouse => new TranslatableString(getKey(@"mouse"), @"Mouse");
 
         /// <summary>
-        /// "Not applicable in full screen mode"
+        /// "not applicable in full screen mode"
         /// </summary>
-        public static LocalisableString NotApplicableFullscreen => new TranslatableString(getKey(@"not_applicable_full_screen"), @"Not applicable in full screen mode");
+        public static LocalisableString NotApplicableFullscreen => new TranslatableString(getKey(@"not_applicable_full_screen"), @"not applicable in full screen mode");
 
         /// <summary>
         /// "High precision mouse"
@@ -25,9 +25,9 @@ namespace osu.Game.Localisation
         public static LocalisableString HighPrecisionMouse => new TranslatableString(getKey(@"high_precision_mouse"), @"High precision mouse");
 
         /// <summary>
-        /// "Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as &quot;Raw Input&quot;."
+        /// "attempts to bypass any operating system mouse acceleration. on windows, this is equivalent to what used to be known as &quot;raw input&quot;."
         /// </summary>
-        public static LocalisableString HighPrecisionMouseTooltip => new TranslatableString(getKey(@"high_precision_mouse_tooltip"), @"Attempts to bypass any operation system mouse acceleration. On windows, this is equivalent to what used to be known as ""Raw Input"".");
+        public static LocalisableString HighPrecisionMouseTooltip => new TranslatableString(getKey(@"high_precision_mouse_tooltip"), @"attempts to bypass any operating system mouse acceleration. on windows, this is equivalent to what used to be known as ""raw input"".");
 
         /// <summary>
         /// "Confine mouse cursor to window"
@@ -40,9 +40,9 @@ namespace osu.Game.Localisation
         public static LocalisableString DisableMouseWheelVolumeAdjust => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust"), @"Disable mouse wheel adjusting volume during gameplay");
 
         /// <summary>
-        /// "Volume can still be adjusted using the mouse wheel by holding "Alt""
+        /// "volume can still be adjusted using the mouse wheel by holding "Alt""
         /// </summary>
-        public static LocalisableString DisableMouseWheelVolumeAdjustTooltip => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust_tooltip"), @"Volume can still be adjusted using the mouse wheel by holding ""Alt""");
+        public static LocalisableString DisableMouseWheelVolumeAdjustTooltip => new TranslatableString(getKey(@"disable_mouse_wheel_volume_adjust_tooltip"), @"volume can still be adjusted using the mouse wheel by holding ""Alt""");
 
         /// <summary>
         /// "Disable mouse buttons during gameplay"
@@ -50,9 +50,9 @@ namespace osu.Game.Localisation
         public static LocalisableString DisableMouseButtons => new TranslatableString(getKey(@"disable_mouse_buttons"), @"Disable mouse buttons during gameplay");
 
         /// <summary>
-        /// "Enable high precision mouse to adjust sensitivity"
+        /// "enable high precision mouse to adjust sensitivity"
         /// </summary>
-        public static LocalisableString EnableHighPrecisionForSensitivityAdjust => new TranslatableString(getKey(@"enable_high_precision_for_sensitivity_adjust"), @"Enable high precision mouse to adjust sensitivity");
+        public static LocalisableString EnableHighPrecisionForSensitivityAdjust => new TranslatableString(getKey(@"enable_high_precision_for_sensitivity_adjust"), @"enable high precision mouse to adjust sensitivity");
 
         /// <summary>
         /// "Cursor sensitivity"
@@ -60,9 +60,9 @@ namespace osu.Game.Localisation
         public static LocalisableString CursorSensitivity => new TranslatableString(getKey(@"cursor_sensitivity"), @"Cursor sensitivity");
 
         /// <summary>
-        /// "This setting has known issues on your platform. If you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now."
+        /// "this setting has known issues on your platform. if you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now."
         /// </summary>
-        public static LocalisableString HighPrecisionPlatformWarning => new TranslatableString(getKey(@"high_precision_platform_warning"), @"This setting has known issues on your platform. If you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now.");
+        public static LocalisableString HighPrecisionPlatformWarning => new TranslatableString(getKey(@"high_precision_platform_warning"), @"this setting has known issues on your platform. if you encounter problems, it is recommended to adjust sensitivity externally and keep this disabled for now.");
 
         /// <summary>
         /// "Always"

--- a/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
+++ b/osu.Game/Screens/Edit/Components/RadioButtons/EditorRadioButton.cs
@@ -101,6 +101,6 @@ namespace osu.Game.Screens.Edit.Components.RadioButtons
             X = 40f
         };
 
-        public LocalisableString TooltipText => Enabled.Value ? string.Empty : "Add at least one timing point first!";
+        public LocalisableString TooltipText => Enabled.Value ? string.Empty : "add at least one timing point first!";
     }
 }

--- a/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
+++ b/osu.Game/Screens/Edit/Verify/InterpretationSection.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Edit.Verify
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                TooltipText = "Affects checks that depend on difficulty level",
+                TooltipText = "affects checks that depend on difficulty level",
                 Current = verify.InterpretedDifficulty.GetBoundCopy()
             });
         }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -461,7 +461,7 @@ namespace osu.Game.Screens.OnlinePlay
                 Size = new Vector2(30, 30),
                 Action = () => RequestResults?.Invoke(Item),
                 Alpha = AllowShowingResults ? 1 : 0,
-                TooltipText = "View results"
+                TooltipText = "view results"
             },
             beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
             editButton = new PlaylistEditButton
@@ -476,7 +476,7 @@ namespace osu.Game.Screens.OnlinePlay
                 Size = new Vector2(30, 30),
                 Alpha = AllowDeletion ? 1 : 0,
                 Action = () => RequestDeletion?.Invoke(Item),
-                TooltipText = "Remove from playlist"
+                TooltipText = "remove from playlist"
             },
         };
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerCountdownButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerCountdownButton.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
 
             base.Action = this.ShowPopover;
 
-            TooltipText = "Countdown settings";
+            TooltipText = "countdown settings";
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/ParticipantPanel.cs
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             public KickButton()
             {
                 Icon = FontAwesome.Solid.UserTimes;
-                TooltipText = "Kick";
+                TooltipText = "kick";
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
             if (Client.LocalUser?.Equals(user) == true)
             {
                 clickableContent.Action = changeTeam;
-                clickableContent.TooltipText = "Change team";
+                clickableContent.TooltipText = "change team";
             }
 
             sampleTeamSwap = audio.Samples.Get(@"Multiplayer/team-swap");

--- a/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
+++ b/osu.Game/Screens/Select/Carousel/UpdateBeatmapSetButton.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Screens.Select.Carousel
             else
             {
                 Enabled.Value = true;
-                TooltipText = "Update beatmap with online changes";
+                TooltipText = "update beatmap with online changes";
 
                 progressFill.ResizeWidthTo(0, 100, Easing.OutQuint);
             }

--- a/osu.Game/Screens/Utility/LatencyCertifierScreen.cs
+++ b/osu.Game/Screens/Utility/LatencyCertifierScreen.cs
@@ -335,7 +335,7 @@ namespace osu.Game.Screens.Utility
                     buttonFlow.Add(new ButtonWithKeyBind(Key.Enter)
                     {
                         Text = "Retry",
-                        TooltipText = "Are you even trying..?",
+                        TooltipText = "are you even trying..?",
                         BackgroundColour = colours.Pink2,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -360,8 +360,8 @@ namespace osu.Game.Screens.Utility
                             changeDifficulty(DifficultyLevel - 1);
                         },
                         TooltipText = isPass
-                            ? $"Chain {rounds_to_complete_certified} rounds to confirm your perception!"
-                            : "You've reached your limits. Go to the previous level to complete certification!",
+                            ? $"chain {rounds_to_complete_certified} rounds to confirm your perception!"
+                            : "you've reached your limits. go to the previous level to complete certification!",
                     });
                 }
             }


### PR DESCRIPTION
Step 1 and 2 of 3 in trying (again) to fix the inconsistent tooltip capitalization throughout the game. The other step requires changing localization files in osu-web (outlined in #21764). This change assumes all tooltip text (excluding mods and countries) should be lowercase, including tooltips that use multiple sentences, e.g.: 
![image](https://user-images.githubusercontent.com/45189851/209230739-59250eec-0f0d-4770-8958-1e6a7a2ba04b.png)