### PR TITLE
Fix wiki overlay showing error message when load is cancelled

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Linq;
 using System.Net;
 using NUnit.Framework;
 using osu.Game.Online.API;

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using System.Net;
 using NUnit.Framework;
 using osu.Game.Online.API;
@@ -27,6 +28,15 @@ namespace osu.Game.Tests.Visual.Online
         {
             setUpWikiResponse(responseMainPage);
             AddStep("Show main page", () => wiki.Show());
+        }
+
+        [Test]
+        public void TestCancellationDoesntShowError()
+        {
+            AddStep("Show main page", () => wiki.Show());
+            AddStep("Show another page", () => wiki.ShowPage("Article_styling_criteria/Formatting"));
+
+            AddUntilStep("Current path is not error", () => wiki.CurrentPath != "error");
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -4,8 +4,11 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using System.Net;
 using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -65,7 +68,9 @@ namespace osu.Game.Tests.Visual.Online
         public void TestErrorPage()
         {
             setUpWikiResponse(responseArticlePage);
-            AddStep("Show Error Page", () => wiki.ShowPage("Error"));
+            AddStep("Show nonexistent page", () => wiki.ShowPage("This_page_will_error_out"));
+            AddUntilStep("Wait for error page", () => wiki.CurrentPath == "error");
+            AddUntilStep("Error message correct", () => wiki.ChildrenOfType<SpriteText>().Any(text => text.Text == "\"This_page_will_error_out\"."));
         }
 
         private void setUpWikiResponse(APIWikiPage r, string redirectionPath = null)

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Overlays
     {
         private const string index_path = @"main_page";
 
+        public string CurrentPath => path.Value;
+
         private readonly Bindable<string> path = new Bindable<string>(index_path);
 
         private readonly Bindable<APIWikiPage> wikiData = new Bindable<APIWikiPage>();
@@ -105,6 +107,9 @@ namespace osu.Game.Overlays
             if (e.NewValue == wikiData.Value?.Path)
                 return;
 
+            if (e.NewValue == "error")
+                return;
+
             cancellationToken?.Cancel();
             request?.Cancel();
 
@@ -152,6 +157,7 @@ namespace osu.Game.Overlays
 
         private void onFail()
         {
+            path.Value = "error";
             LoadDisplay(articlePage = new WikiArticlePage($@"{api.WebsiteRootUrl}/wiki/",
                 $"Something went wrong when trying to fetch page \"{path.Value}\".\n\n[Return to the main page](Main_Page)."));
         }

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Overlays
             request.Failure += ex =>
             {
                 if (ex is not OperationCanceledException)
-                    Schedule(onFail);
+                    Schedule(onFail, request.Path);
             };
 
             api.PerformAsync(request);
@@ -155,11 +155,11 @@ namespace osu.Game.Overlays
             }
         }
 
-        private void onFail()
+        private void onFail(string originalPath)
         {
             path.Value = "error";
             LoadDisplay(articlePage = new WikiArticlePage($@"{api.WebsiteRootUrl}/wiki/",
-                $"Something went wrong when trying to fetch page \"{path.Value}\".\n\n[Return to the main page](Main_Page)."));
+                $"Something went wrong when trying to fetch page \"{originalPath}\".\n\n[Return to the main page](Main_Page)."));
         }
 
         private void showParentPage()

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -118,7 +118,11 @@ namespace osu.Game.Overlays
             Loading.Show();
 
             request.Success += response => Schedule(() => onSuccess(response));
-            request.Failure += _ => Schedule(onFail);
+            request.Failure += ex =>
+            {
+                if (ex is not OperationCanceledException)
+                    Schedule(onFail);
+            };
 
             api.PerformAsync(request);
         }


### PR DESCRIPTION
Also addresses https://github.com/ppy/osu/discussions/21726.

Prereq to having a link to the new lazer FAQ page in more places (using the `OsuGame.ShowWiki` function from a clean startup will currently cause an error to momentarily appear).