### PR TITLE
Add overall ranking display to solo results screen

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -46,6 +46,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.Chat;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Solo;
 using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
@@ -193,6 +194,7 @@ namespace osu.Game
         protected MultiplayerClient MultiplayerClient { get; private set; }
 
         private MetadataClient metadataClient;
+        private SoloStatisticsWatcher soloStatisticsWatcher;
 
         private RealmAccess realm;
 
@@ -301,6 +303,7 @@ namespace osu.Game
             dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(MultiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
+            dependencies.CacheAs(soloStatisticsWatcher = new SoloStatisticsWatcher());
 
             AddInternal(new BeatmapOnlineChangeIngest(beatmapUpdater, realm, metadataClient));
 
@@ -346,6 +349,7 @@ namespace osu.Game
             AddInternal(spectatorClient);
             AddInternal(MultiplayerClient);
             AddInternal(metadataClient);
+            AddInternal(soloStatisticsWatcher);
 
             AddInternal(rulesetConfigCache);
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -96,11 +96,11 @@ namespace osu.Game.Screens.Ranking
                                 RelativeSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    statisticsPanel = new StatisticsPanel
+                                    statisticsPanel = CreateStatisticsPanel().With(panel =>
                                     {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Score = { BindTarget = SelectedScore }
-                                    },
+                                        panel.RelativeSizeAxes = Axes.Both;
+                                        panel.Score.BindTarget = SelectedScore;
+                                    }),
                                     ScorePanelList = new ScorePanelList
                                     {
                                         RelativeSizeAxes = Axes.Both,
@@ -230,6 +230,11 @@ namespace osu.Game.Screens.Ranking
         /// <param name="scoresCallback">A callback which should be called when fetching is completed. Scheduling is not required.</param>
         /// <returns>An <see cref="APIRequest"/> responsible for the fetch operation. This will be queued and performed automatically.</returns>
         protected virtual APIRequest FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+
+        /// <summary>
+        /// Creates the <see cref="StatisticsPanel"/> to be used to display extended information about scores.
+        /// </summary>
+        protected virtual StatisticsPanel CreateStatisticsPanel() => new StatisticsPanel();
 
         private void fetchScoresCallback(IEnumerable<ScoreInfo> scores) => Schedule(() =>
         {

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -7,11 +7,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
 
 namespace osu.Game.Screens.Ranking
 {
@@ -22,10 +25,27 @@ namespace osu.Game.Screens.Ranking
         [Resolved]
         private RulesetStore rulesets { get; set; }
 
+        [Resolved]
+        private SoloStatisticsWatcher soloStatisticsWatcher { get; set; }
+
+        private readonly Bindable<SoloStatisticsUpdate> statisticsUpdate = new Bindable<SoloStatisticsUpdate>();
+
         public SoloResultsScreen(ScoreInfo score, bool allowRetry)
             : base(score, allowRetry)
         {
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => statisticsUpdate.Value = update);
+        }
+
+        protected override StatisticsPanel CreateStatisticsPanel() => new SoloStatisticsPanel(Score)
+        {
+            StatisticsUpdate = { BindTarget = statisticsUpdate }
+        };
 
         protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
         {

--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -27,7 +27,10 @@ namespace osu.Game.Screens.Ranking.Statistics
         {
             var rows = base.CreateStatisticRows(newScore, playableBeatmap);
 
-            if (newScore.UserID == achievedScore.UserID && newScore.OnlineID == achievedScore.OnlineID)
+            if (newScore.UserID > 1
+                && newScore.UserID == achievedScore.UserID
+                && newScore.OnlineID > 0
+                && newScore.OnlineID == achievedScore.OnlineID)
             {
                 rows = rows.Append(new StatisticRow
                 {

--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Online.Solo;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics.User;
+
+namespace osu.Game.Screens.Ranking.Statistics
+{
+    public partial class SoloStatisticsPanel : StatisticsPanel
+    {
+        private readonly ScoreInfo achievedScore;
+
+        public SoloStatisticsPanel(ScoreInfo achievedScore)
+        {
+            this.achievedScore = achievedScore;
+        }
+
+        public Bindable<SoloStatisticsUpdate?> StatisticsUpdate { get; } = new Bindable<SoloStatisticsUpdate?>();
+
+        protected override ICollection<StatisticRow> CreateStatisticRows(ScoreInfo newScore, IBeatmap playableBeatmap)
+        {
+            var rows = base.CreateStatisticRows(newScore, playableBeatmap);
+
+            if (newScore.UserID == achievedScore.UserID && newScore.OnlineID == achievedScore.OnlineID)
+            {
+                rows = rows.Append(new StatisticRow
+                {
+                    Columns = new[]
+                    {
+                        new StatisticItem("Overall Ranking", () => new OverallRanking
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Width = 0.5f,
+                            StatisticsUpdate = { BindTarget = StatisticsUpdate }
+                        })
+                    }
+                }).ToArray();
+            }
+
+            return rows;
+        }
+    }
+}

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 bool hitEventsAvailable = newScore.HitEvents.Count != 0;
                 Container<Drawable> container;
 
-                var statisticRows = newScore.Ruleset.CreateInstance().CreateStatisticsForScore(newScore, task.GetResultSafely());
+                var statisticRows = CreateStatisticRows(newScore, task.GetResultSafely());
 
                 if (!hitEventsAvailable && statisticRows.SelectMany(r => r.Columns).All(c => c.RequiresHitEvents))
                 {
@@ -217,6 +217,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                 }, localCancellationSource.Token);
             }), localCancellationSource.Token);
         }
+
+        /// <summary>
+        /// Creates the <see cref="StatisticRow"/>s to be displayed in this panel for a given <paramref name="newScore"/>.
+        /// </summary>
+        /// <param name="newScore">The score to create the rows for.</param>
+        /// <param name="playableBeatmap">The beatmap on which the score was set.</param>
+        protected virtual ICollection<StatisticRow> CreateStatisticRows(ScoreInfo newScore, IBeatmap playableBeatmap)
+            => newScore.Ruleset.CreateInstance().CreateStatisticsForScore(newScore, playableBeatmap);
 
         protected override bool OnClick(ClickEvent e)
         {


### PR DESCRIPTION
- Continuation to https://github.com/ppy/osu/issues/18877
- [x] Depends on https://github.com/ppy/osu/pull/21776
- [x] Depends on https://github.com/ppy/osu-server-spectator/pull/157 (to actually work in game)

![osu_2022-12-24_14-04-46](https://user-images.githubusercontent.com/20418176/209438822-52a78762-487f-4a5f-a302-65c7862acfec.jpg)

I'm not going to say that this closes the issue because the scope of the issue is way larger, but this is the first deployable increment in this series that users would be able to see.

Works only in solo, as multiplayer and playlists do not submit scores the same way. Appearance is largely best-effort. I stuck it as the last thing on the screen because I tried adding it first and it looked bad, so this was the other easily available option.

If deployment of this is deemed too risky for whatever reason, then this can wait for the release after the next. No changes up to here in this series game-side have had any user-facing effect.