### PR TITLE
Link beatmap set title and artist to listing search

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -353,7 +353,10 @@ namespace osu.Game
                     break;
 
                 case LinkAction.SearchBeatmapSet:
-                    SearchBeatmapSet(argString);
+                    if (link.Argument is RomanisableString romanisable)
+                        SearchBeatmapSet(romanisable.GetPreferred(frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowUnicode).Value));
+                    else
+                        SearchBeatmapSet(argString);
                     break;
 
                 case LinkAction.OpenEditorTimestamp:

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -354,7 +354,7 @@ namespace osu.Game
 
                 case LinkAction.SearchBeatmapSet:
                     if (link.Argument is RomanisableString romanisable)
-                        SearchBeatmapSet(romanisable.GetPreferred(frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowUnicode).Value));
+                        SearchBeatmapSet(romanisable.GetPreferred(Localisation.CurrentParameters.Value.PreferOriginalScript));
                     else
                         SearchBeatmapSet(argString);
                     break;

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -249,42 +249,27 @@ namespace osu.Game.Overlays.BeatmapSet
 
                     title.AddLink(titleText, LinkAction.SearchBeatmapSet, titleText);
 
-                    title.AddArbitraryDrawable(new Container
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Child = externalLink = new ExternalLinkButton
-                        {
-                            Margin = new MarginPadding { Left = 5 },
-                        }
-                    });
+                    title.AddArbitraryDrawable(Empty().With(d => d.Width = 5));
+                    title.AddArbitraryDrawable(externalLink = new ExternalLinkButton());
 
                     if (setInfo.NewValue.HasExplicitContent)
                     {
-                        title.AddArbitraryDrawable(new Container
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Child = new ExplicitContentBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
-                        });
+                        title.AddArbitraryDrawable(Empty().With(d => d.Width = 10));
+                        title.AddArbitraryDrawable(new ExplicitContentBeatmapBadge());
                     }
 
                     if (setInfo.NewValue.FeaturedInSpotlight)
                     {
-                        title.AddArbitraryDrawable(new Container
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Child = new SpotlightBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
-                        });
+                        title.AddArbitraryDrawable(Empty().With(d => d.Width = 10));
+                        title.AddArbitraryDrawable(new SpotlightBeatmapBadge());
                     }
 
                     artist.AddLink(artistText, LinkAction.SearchBeatmapSet, artistText);
 
                     if (setInfo.NewValue.TrackId != null)
                     {
-                        artist.AddArbitraryDrawable(new Container
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Child = new FeaturedArtistBeatmapBadge { Margin = new MarginPadding { Left = 10 } }
-                        });
+                        artist.AddArbitraryDrawable(Empty().With(d => d.Width = 10));
+                        artist.AddArbitraryDrawable(new FeaturedArtistBeatmapBadge());
                     }
 
                     updateExternalLink();

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -48,9 +48,10 @@ namespace osu.Game.Overlays.BeatmapSet
         private readonly LinkFlowContainer title, artist;
         private readonly AuthorInfo author;
 
-        private readonly ExplicitContentBeatmapBadge explicitContent;
-        private readonly SpotlightBeatmapBadge spotlight;
-        private readonly FeaturedArtistBeatmapBadge featuredArtist;
+        private ExplicitContentBeatmapBadge explicitContent;
+        private SpotlightBeatmapBadge spotlight;
+        private FeaturedArtistBeatmapBadge featuredArtist;
+        private ExternalLinkButton externalLink;
 
         private readonly FillFlowContainer downloadButtonsContainer;
         private readonly BeatmapAvailability beatmapAvailability;
@@ -69,8 +70,6 @@ namespace osu.Game.Overlays.BeatmapSet
 
         public BeatmapSetHeaderContent()
         {
-            ExternalLinkButton externalLink;
-
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
             InternalChild = new Container
@@ -124,64 +123,19 @@ namespace osu.Game.Overlays.BeatmapSet
                                             AutoSizeAxes = Axes.Y,
                                             Child = Picker = new BeatmapPicker(),
                                         },
-                                        new FillFlowContainer
+                                        title = new MetadataFlowContainer(s =>
                                         {
-                                            Direction = FillDirection.Horizontal,
-                                            AutoSizeAxes = Axes.Both,
+                                            s.Font = OsuFont.GetFont(size: 30, weight: FontWeight.SemiBold, italics: true);
+                                        })
+                                        {
                                             Margin = new MarginPadding { Top = 15 },
-                                            Children = new Drawable[]
-                                            {
-                                                title = new MetadataFlowContainer(s =>
-                                                {
-                                                    s.Font = OsuFont.GetFont(size: 30, weight: FontWeight.SemiBold, italics: true);
-                                                })
-                                                {
-                                                    AutoSizeAxes = Axes.Both,
-                                                },
-                                                externalLink = new ExternalLinkButton
-                                                {
-                                                    Anchor = Anchor.BottomLeft,
-                                                    Origin = Anchor.BottomLeft,
-                                                    Margin = new MarginPadding { Left = 5, Bottom = 4 }, // To better lineup with the font
-                                                },
-                                                explicitContent = new ExplicitContentBeatmapBadge
-                                                {
-                                                    Alpha = 0f,
-                                                    Anchor = Anchor.BottomLeft,
-                                                    Origin = Anchor.BottomLeft,
-                                                    Margin = new MarginPadding { Left = 10, Bottom = 4 },
-                                                },
-                                                spotlight = new SpotlightBeatmapBadge
-                                                {
-                                                    Alpha = 0f,
-                                                    Anchor = Anchor.BottomLeft,
-                                                    Origin = Anchor.BottomLeft,
-                                                    Margin = new MarginPadding { Left = 10, Bottom = 4 },
-                                                }
-                                            }
                                         },
-                                        new FillFlowContainer
+                                        artist = new MetadataFlowContainer(s =>
                                         {
-                                            Direction = FillDirection.Horizontal,
-                                            AutoSizeAxes = Axes.Both,
+                                            s.Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, italics: true);
+                                        })
+                                        {
                                             Margin = new MarginPadding { Bottom = 20 },
-                                            Children = new Drawable[]
-                                            {
-                                                artist = new MetadataFlowContainer(s =>
-                                                {
-                                                    s.Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, italics: true);
-                                                })
-                                                {
-                                                    AutoSizeAxes = Axes.Both,
-                                                },
-                                                featuredArtist = new FeaturedArtistBeatmapBadge
-                                                {
-                                                    Alpha = 0f,
-                                                    Anchor = Anchor.BottomLeft,
-                                                    Origin = Anchor.BottomLeft,
-                                                    Margin = new MarginPadding { Left = 10 }
-                                                }
-                                            }
                                         },
                                         new Container
                                         {
@@ -247,10 +201,15 @@ namespace osu.Game.Overlays.BeatmapSet
             Picker.Beatmap.ValueChanged += b =>
             {
                 Details.BeatmapInfo = b.NewValue;
-                externalLink.Link = $@"{api.WebsiteRootUrl}/beatmapsets/{BeatmapSet.Value?.OnlineID}#{b.NewValue?.Ruleset.ShortName}/{b.NewValue?.OnlineID}";
+                updateExternalLink();
 
                 onlineStatusPill.Status = b.NewValue?.Status ?? BeatmapOnlineStatus.None;
             };
+        }
+
+        private void updateExternalLink()
+        {
+            if (externalLink != null) externalLink.Link = $@"{api.WebsiteRootUrl}/beatmapsets/{BeatmapSet.Value?.OnlineID}#{Picker.Beatmap.Value?.Ruleset.ShortName}/{Picker.Beatmap.Value?.OnlineID}";
         }
 
         [BackgroundDependencyLoader]
@@ -292,8 +251,49 @@ namespace osu.Game.Overlays.BeatmapSet
                     artist.Clear();
 
                     title.AddLink(titleText, LinkAction.SearchBeatmapSet, titleText);
+
+                    title.AddArbitraryDrawable(new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Child = externalLink = new ExternalLinkButton
+                        {
+                            Margin = new MarginPadding { Left = 5 },
+                        }
+                    });
+
+                    title.AddArbitraryDrawable(new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Child = explicitContent = new ExplicitContentBeatmapBadge
+                        {
+                            Alpha = 0f,
+                            Margin = new MarginPadding { Left = 10 },
+                        }
+                    });
+
+                    title.AddArbitraryDrawable(new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Child = spotlight = new SpotlightBeatmapBadge
+                        {
+                            Alpha = 0f,
+                            Margin = new MarginPadding { Left = 10 },
+                        }
+                    });
+
                     artist.AddLink(artistText, LinkAction.SearchBeatmapSet, artistText);
 
+                    artist.AddArbitraryDrawable(new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Child = featuredArtist = new FeaturedArtistBeatmapBadge
+                        {
+                            Alpha = 0f,
+                            Margin = new MarginPadding { Left = 10 }
+                        }
+                    });
+
+                    updateExternalLink();
                     explicitContent.Alpha = setInfo.NewValue.HasExplicitContent ? 1 : 0;
                     spotlight.Alpha = setInfo.NewValue.FeaturedInSpotlight ? 1 : 0;
                     featuredArtist.Alpha = setInfo.NewValue.TrackId != null ? 1 : 0;
@@ -349,6 +349,9 @@ namespace osu.Game.Overlays.BeatmapSet
             public MetadataFlowContainer(Action<SpriteText> defaultCreationParameters = null)
                 : base(defaultCreationParameters)
             {
+                TextAnchor = Anchor.CentreLeft;
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
             }
 
             protected override DrawableLinkCompiler CreateLinkCompiler(ITextPart textPart) => new MetadataLinkCompiler(textPart);

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -48,9 +48,6 @@ namespace osu.Game.Overlays.BeatmapSet
         private readonly LinkFlowContainer title, artist;
         private readonly AuthorInfo author;
 
-        private ExplicitContentBeatmapBadge explicitContent;
-        private SpotlightBeatmapBadge spotlight;
-        private FeaturedArtistBeatmapBadge featuredArtist;
         private ExternalLinkButton externalLink;
 
         private readonly FillFlowContainer downloadButtonsContainer;
@@ -266,7 +263,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         title.AddArbitraryDrawable(new Container
                         {
                             AutoSizeAxes = Axes.Both,
-                            Child = explicitContent = new ExplicitContentBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
+                            Child = new ExplicitContentBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
                         });
                     }
 
@@ -275,7 +272,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         title.AddArbitraryDrawable(new Container
                         {
                             AutoSizeAxes = Axes.Both,
-                            Child = spotlight = new SpotlightBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
+                            Child = new SpotlightBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
                         });
                     }
 
@@ -286,7 +283,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         artist.AddArbitraryDrawable(new Container
                         {
                             AutoSizeAxes = Axes.Both,
-                            Child = featuredArtist = new FeaturedArtistBeatmapBadge { Margin = new MarginPadding { Left = 10 } }
+                            Child = new FeaturedArtistBeatmapBadge { Margin = new MarginPadding { Left = 10 } }
                         });
                     }
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Game.Graphics.Cursor;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
@@ -24,6 +26,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.BeatmapSet.Buttons;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
@@ -128,7 +131,7 @@ namespace osu.Game.Overlays.BeatmapSet
                                             Margin = new MarginPadding { Top = 15 },
                                             Children = new Drawable[]
                                             {
-                                                title = new LinkFlowContainer(s =>
+                                                title = new MetadataFlowContainer(s =>
                                                 {
                                                     s.Font = OsuFont.GetFont(size: 30, weight: FontWeight.SemiBold, italics: true);
                                                 })
@@ -164,7 +167,7 @@ namespace osu.Game.Overlays.BeatmapSet
                                             Margin = new MarginPadding { Bottom = 20 },
                                             Children = new Drawable[]
                                             {
-                                                artist = new LinkFlowContainer(s =>
+                                                artist = new MetadataFlowContainer(s =>
                                                 {
                                                     s.Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, italics: true);
                                                 })
@@ -338,6 +341,30 @@ namespace osu.Game.Overlays.BeatmapSet
                     if (BeatmapSet.Value.HasVideo)
                         downloadButtonsContainer.Add(new HeaderDownloadButton(BeatmapSet.Value, true));
                     break;
+            }
+        }
+
+        public partial class MetadataFlowContainer : LinkFlowContainer
+        {
+            public MetadataFlowContainer(Action<SpriteText> defaultCreationParameters = null)
+                : base(defaultCreationParameters)
+            {
+            }
+
+            protected override DrawableLinkCompiler CreateLinkCompiler(ITextPart textPart) => new MetadataLinkCompiler(textPart);
+
+            public partial class MetadataLinkCompiler : DrawableLinkCompiler
+            {
+                public MetadataLinkCompiler(ITextPart part)
+                    : base(part)
+                {
+                }
+
+                [BackgroundDependencyLoader]
+                private void load()
+                {
+                    IdleColour = Color4.White;
+                }
             }
         }
     }

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -261,42 +261,36 @@ namespace osu.Game.Overlays.BeatmapSet
                         }
                     });
 
-                    title.AddArbitraryDrawable(new Container
+                    if (setInfo.NewValue.HasExplicitContent)
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Child = explicitContent = new ExplicitContentBeatmapBadge
+                        title.AddArbitraryDrawable(new Container
                         {
-                            Alpha = 0f,
-                            Margin = new MarginPadding { Left = 10 },
-                        }
-                    });
+                            AutoSizeAxes = Axes.Both,
+                            Child = explicitContent = new ExplicitContentBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
+                        });
+                    }
 
-                    title.AddArbitraryDrawable(new Container
+                    if (setInfo.NewValue.FeaturedInSpotlight)
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Child = spotlight = new SpotlightBeatmapBadge
+                        title.AddArbitraryDrawable(new Container
                         {
-                            Alpha = 0f,
-                            Margin = new MarginPadding { Left = 10 },
-                        }
-                    });
+                            AutoSizeAxes = Axes.Both,
+                            Child = spotlight = new SpotlightBeatmapBadge { Margin = new MarginPadding { Left = 10 } },
+                        });
+                    }
 
                     artist.AddLink(artistText, LinkAction.SearchBeatmapSet, artistText);
 
-                    artist.AddArbitraryDrawable(new Container
+                    if (setInfo.NewValue.TrackId != null)
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Child = featuredArtist = new FeaturedArtistBeatmapBadge
+                        artist.AddArbitraryDrawable(new Container
                         {
-                            Alpha = 0f,
-                            Margin = new MarginPadding { Left = 10 }
-                        }
-                    });
+                            AutoSizeAxes = Axes.Both,
+                            Child = featuredArtist = new FeaturedArtistBeatmapBadge { Margin = new MarginPadding { Left = 10 } }
+                        });
+                    }
 
                     updateExternalLink();
-                    explicitContent.Alpha = setInfo.NewValue.HasExplicitContent ? 1 : 0;
-                    spotlight.Alpha = setInfo.NewValue.FeaturedInSpotlight ? 1 : 0;
-                    featuredArtist.Alpha = setInfo.NewValue.TrackId != null ? 1 : 0;
 
                     onlineStatusPill.FadeIn(500, Easing.OutQuint);
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -16,11 +16,12 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Chat;
 using osu.Game.Overlays.BeatmapSet.Buttons;
 using osuTK;
 
@@ -41,7 +42,7 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private readonly UpdateableOnlineBeatmapSetCover cover;
         private readonly Box coverGradient;
-        private readonly OsuSpriteText title, artist;
+        private readonly LinkFlowContainer title, artist;
         private readonly AuthorInfo author;
 
         private readonly ExplicitContentBeatmapBadge explicitContent;
@@ -127,9 +128,12 @@ namespace osu.Game.Overlays.BeatmapSet
                                             Margin = new MarginPadding { Top = 15 },
                                             Children = new Drawable[]
                                             {
-                                                title = new OsuSpriteText
+                                                title = new LinkFlowContainer(s =>
                                                 {
-                                                    Font = OsuFont.GetFont(size: 30, weight: FontWeight.SemiBold, italics: true)
+                                                    s.Font = OsuFont.GetFont(size: 30, weight: FontWeight.SemiBold, italics: true);
+                                                })
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
                                                 },
                                                 externalLink = new ExternalLinkButton
                                                 {
@@ -160,9 +164,12 @@ namespace osu.Game.Overlays.BeatmapSet
                                             Margin = new MarginPadding { Bottom = 20 },
                                             Children = new Drawable[]
                                             {
-                                                artist = new OsuSpriteText
+                                                artist = new LinkFlowContainer(s =>
                                                 {
-                                                    Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, italics: true),
+                                                    s.Font = OsuFont.GetFont(size: 20, weight: FontWeight.Medium, italics: true);
+                                                })
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
                                                 },
                                                 featuredArtist = new FeaturedArtistBeatmapBadge
                                                 {
@@ -275,8 +282,14 @@ namespace osu.Game.Overlays.BeatmapSet
 
                     loading.Hide();
 
-                    title.Text = new RomanisableString(setInfo.NewValue.TitleUnicode, setInfo.NewValue.Title);
-                    artist.Text = new RomanisableString(setInfo.NewValue.ArtistUnicode, setInfo.NewValue.Artist);
+                    var titleText = new RomanisableString(setInfo.NewValue.TitleUnicode, setInfo.NewValue.Title);
+                    var artistText = new RomanisableString(setInfo.NewValue.ArtistUnicode, setInfo.NewValue.Artist);
+
+                    title.Clear();
+                    artist.Clear();
+
+                    title.AddLink(titleText, LinkAction.SearchBeatmapSet, titleText);
+                    artist.AddLink(artistText, LinkAction.SearchBeatmapSet, artistText);
 
                     explicitContent.Alpha = setInfo.NewValue.HasExplicitContent ? 1 : 0;
                     spotlight.Alpha = setInfo.NewValue.FeaturedInSpotlight ? 1 : 0;


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/21759
- Addresses comment https://github.com/ppy/osu/issues/3504#issuecomment-552218979 by just fixing the current layout, the design will change anyway

Will do the song select portion in another PR.

For the code, I had to nest every drawable in a container as some behavior in `TextFlowContainer` removes the margin. Also, I removed the alignment workarounds with just a `CentreLeft` for simplicity.

| Before | After |
| --- | --- |
| ![osu!_Qtnw2a8SKL](https://user-images.githubusercontent.com/35318437/209451159-1c601ab4-ec9b-4712-b54a-c2bb1fe76957.gif) | ![osu!_rTaxXm5gT0](https://user-images.githubusercontent.com/35318437/209451123-60065fbd-c886-422b-8260-4287f88f95ad.gif) |