### PR TITLE
Only show global rankings on solo results screen when progressing from gameplay

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1159,7 +1159,10 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <param name="score">The <see cref="ScoreInfo"/> to be displayed in the results screen.</param>
         /// <returns>The <see cref="ResultsScreen"/>.</returns>
-        protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true);
+        protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score, true)
+        {
+            ShowUserStatistics = true
+        };
 
         private void fadeOut(bool instant = false)
         {

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Screens.Ranking
 {
     public partial class SoloResultsScreen : ResultsScreen
     {
+        /// <summary>
+        /// Whether the user's personal statistics should be shown on the extended statistics panel
+        /// after clicking the score panel associated with the <see cref="ResultsScreen.Score"/> being presented.
+        /// </summary>
+        public bool ShowUserStatistics { get; init; }
+
         private GetScoresRequest getScoreRequest;
 
         [Resolved]
@@ -39,13 +45,22 @@ namespace osu.Game.Screens.Ranking
         {
             base.LoadComplete();
 
-            soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => statisticsUpdate.Value = update);
+            if (ShowUserStatistics)
+                soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => statisticsUpdate.Value = update);
         }
 
-        protected override StatisticsPanel CreateStatisticsPanel() => new SoloStatisticsPanel(Score)
+        protected override StatisticsPanel CreateStatisticsPanel()
         {
-            StatisticsUpdate = { BindTarget = statisticsUpdate }
-        };
+            if (ShowUserStatistics)
+            {
+                return new SoloStatisticsPanel(Score)
+                {
+                    StatisticsUpdate = { BindTarget = statisticsUpdate }
+                };
+            }
+
+            return base.CreateStatisticsPanel();
+        }
 
         protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
         {


### PR DESCRIPTION
Reported on the pp discord. Pretty big oversight; I failed to check who was using `SoloResultsScreen`. The display can't work (and doesn't make sense) after a replay, or when presenting a local score.

Decided to use an init property for this rather than a ctor param because I highly dislike boolean ctor params. And yes I know that it's a bit of a mix-and-match now because the base class uses ctor params. I'm willing to refactor that whenever convenient (probably not before next release) to use init properties everywhere but the base class has many usages to test and I wanted to get this out quickly because it's a pretty major issue.