### PR TITLE
Use StringSplitOptions.TrimEntries in string.Split() when possible

### DIFF
--- a/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
                                 continue;
 
                             // ReSharper disable once PossibleNullReferenceException
-                            string[] split = line.Split(':');
+                            string[] split = line.Split(':', StringSplitOptions.TrimEntries);
 
                             if (split.Length < 2)
                             {
@@ -55,9 +55,9 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
                             teams.Add(new TournamentTeam
                             {
-                                FullName = { Value = split[1].Trim(), },
-                                Acronym = { Value = split.Length >= 3 ? split[2].Trim() : null, },
-                                FlagName = { Value = split[0].Trim() }
+                                FullName = { Value = split[1], },
+                                Acronym = { Value = split.Length >= 3 ? split[2] : null, },
+                                FlagName = { Value = split[0] }
                             });
                         }
                     }

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -132,13 +132,7 @@ namespace osu.Game.Beatmaps.Formats
 
         protected KeyValuePair<string, string> SplitKeyVal(string line, char separator = ':', bool shouldTrim = true)
         {
-            string[] split = line.Split(separator, 2);
-
-            if (shouldTrim)
-            {
-                for (int i = 0; i < split.Length; i++)
-                    split[i] = split[i].Trim();
-            }
+            string[] split = line.Split(separator, 2, shouldTrim ? StringSplitOptions.TrimEntries : StringSplitOptions.None);
 
             return new KeyValuePair<string, string>
             (


### PR DESCRIPTION
Avoids some allocations