### PR TITLE
Use new lazer API endpoint

### DIFF
--- a/osu.Game/Online/ProductionEndpointConfiguration.cs
+++ b/osu.Game/Online/ProductionEndpointConfiguration.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Online
     {
         public ProductionEndpointConfiguration()
         {
-            WebsiteRootUrl = APIEndpointUrl = @"https://osu.ppy.sh";
+            WebsiteRootUrl = APIEndpointUrl = @"https://lazer.ppy.sh";
             APIClientSecret = @"FGc9GAtyHzeQDshWP5Ah7dega8hJACAJpQtw6OXk";
             APIClientID = "5";
             SpectatorEndpointUrl = "https://spectator.ppy.sh/spectator";


### PR DESCRIPTION
This is a temporary change to target the new experimental/next deploy.  The main change that should result from this is having the user profile show the pp^next values from the new domain.