### PR TITLE
Fix incorrect accuracy display on overall ranking view

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneOverallRanking.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneOverallRanking.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 new UserStatistics
                 {
                     GlobalRank = 12_345,
-                    Accuracy = 0.9899,
+                    Accuracy = 98.99,
                     MaxCombo = 2_322,
                     RankedScore = 23_123_543_456,
                     TotalScore = 123_123_543_456,
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 new UserStatistics
                 {
                     GlobalRank = 1_234,
-                    Accuracy = 0.9907,
+                    Accuracy = 99.07,
                     MaxCombo = 2_352,
                     RankedScore = 23_124_231_435,
                     TotalScore = 123_124_231_435,
@@ -53,7 +53,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 new UserStatistics
                 {
                     GlobalRank = 1_234,
-                    Accuracy = 0.9907,
+                    Accuracy = 99.07,
                     MaxCombo = 2_352,
                     RankedScore = 23_124_231_435,
                     TotalScore = 123_124_231_435,
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 new UserStatistics
                 {
                     GlobalRank = 12_345,
-                    Accuracy = 0.9899,
+                    Accuracy = 98.99,
                     MaxCombo = 2_322,
                     RankedScore = 23_123_543_456,
                     TotalScore = 123_123_543_456,
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.Ranking
             var statistics = new UserStatistics
             {
                 GlobalRank = 12_345,
-                Accuracy = 0.9899,
+                Accuracy = 98.99,
                 MaxCombo = 2_322,
                 RankedScore = 23_123_543_456,
                 TotalScore = 123_123_543_456,
@@ -93,7 +93,7 @@ namespace osu.Game.Tests.Visual.Ranking
             var statistics = new UserStatistics
             {
                 GlobalRank = null,
-                Accuracy = 0.9899,
+                Accuracy = 98.99,
                 MaxCombo = 2_322,
                 RankedScore = 23_123_543_456,
                 TotalScore = 123_123_543_456,

--- a/osu.Game/Screens/Ranking/Statistics/User/AccuracyChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/AccuracyChangeRow.cs
@@ -16,11 +16,11 @@ namespace osu.Game.Screens.Ranking.Statistics.User
 
         protected override LocalisableString Label => UsersStrings.ShowStatsHitAccuracy;
 
-        protected override LocalisableString FormatCurrentValue(double current) => current.FormatAccuracy();
+        protected override LocalisableString FormatCurrentValue(double current) => (current / 100).FormatAccuracy();
 
         protected override int CalculateDifference(double previous, double current, out LocalisableString formattedDifference)
         {
-            double difference = current - previous;
+            double difference = (current - previous) / 100;
 
             if (difference < 0)
                 formattedDifference = difference.FormatAccuracy();


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21843

Horribly incorrect assumption wrt range of the value. I didn't notice this because on dev the accuracy wasn't populating and was always 0.

Compare:

https://github.com/ppy/osu/blob/4bc26dbb487241e2bbae73751dbe9e93a4e427da/osu.Game/Users/UserStatistics.cs#L53-L54

and also [api docs](https://osu.ppy.sh/docs/index.html#userstatistics).