### PR TITLE
Add back autosize easing in `SettingsToolboxGroup`

### DIFF
--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays
     {
         private readonly string title;
         public const int CONTAINER_WIDTH = 270;
-        public virtual bool AutoSizeEasingEnabled { get; set; }
+        public virtual bool AutoSizeEasingEnabled { get; set; } = true;
 
         private const float transition_duration = 250;
         private const int header_height = 30;

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Overlays
                 {
                     Direction = FillDirection.Vertical,
                     RelativeSizeAxes = Axes.X,
+                    AutoSizeDuration = transition_duration,
+                    AutoSizeEasing = Easing.OutQuint,
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Overlays
     {
         private readonly string title;
         public const int CONTAINER_WIDTH = 270;
+        public virtual bool AutoSizeEasingEnabled { get; set; }
 
         private const float transition_duration = 250;
         private const int header_height = 30;
@@ -50,6 +51,8 @@ namespace osu.Game.Overlays
         private OsuSpriteText headerText = null!;
 
         private Container headerContent = null!;
+
+        private FillFlowContainer settingsContainer = null!;
 
         private Box background = null!;
 
@@ -81,12 +84,10 @@ namespace osu.Game.Overlays
                     Alpha = 0.1f,
                     Colour = colourProvider?.Background4 ?? Color4.Black,
                 },
-                new FillFlowContainer
+                settingsContainer = new FillFlowContainer
                 {
                     Direction = FillDirection.Vertical,
                     RelativeSizeAxes = Axes.X,
-                    AutoSizeDuration = transition_duration,
-                    AutoSizeEasing = Easing.OutQuint,
                     AutoSizeAxes = Axes.Y,
                     Children = new Drawable[]
                     {
@@ -127,6 +128,9 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            if (AutoSizeEasingEnabled)
+                enableAutoSizeEasing();
 
             Expanded.BindValueChanged(updateExpandedState, true);
 
@@ -186,6 +190,12 @@ namespace osu.Game.Overlays
 
             background.FadeTo(IsHovered ? 1 : 0.1f, fade_duration, Easing.OutQuint);
             expandButton.FadeTo(IsHovered ? 1 : 0, fade_duration, Easing.OutQuint);
+        }
+
+        private void enableAutoSizeEasing()
+        {
+            settingsContainer.AutoSizeDuration = transition_duration;
+            settingsContainer.AutoSizeEasing = Easing.OutQuint;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -42,7 +42,11 @@ namespace osu.Game.Screens.Play.HUD
                     //CollectionSettings = new CollectionSettings(),
                     //DiscussionSettings = new DiscussionSettings(),
                     PlaybackSettings = new PlaybackSettings(),
-                    VisualSettings = new VisualSettings { Expanded = { Value = false } }
+                    VisualSettings = new VisualSettings
+                    {
+                        Expanded = { Value = false },
+                        AutoSizeEasingEnabled = true
+                    }
                 }
             };
         }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -187,7 +187,7 @@ namespace osu.Game.Screens.Play
                         Padding = new MarginPadding { Horizontal = padding },
                         Children = new PlayerSettingsGroup[]
                         {
-                            VisualSettings = new VisualSettings(),
+                            VisualSettings = new VisualSettings { AutoSizeEasingEnabled = false },
                             AudioSettings = new AudioSettings(),
                             new InputSettings()
                         }

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
     {
         public Bindable<ScoreInfo> ReferenceScore { get; } = new Bindable<ScoreInfo>();
 
+        public override bool AutoSizeEasingEnabled => false;
+
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
 
         public AudioSettings()

--- a/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/InputSettings.cs
@@ -12,6 +12,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public partial class InputSettings : PlayerSettingsGroup
     {
+        public override bool AutoSizeEasingEnabled => false;
+
         private readonly PlayerCheckbox mouseButtonsCheckbox;
 
         public InputSettings()

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
 {
     public partial class VisualSettings : PlayerSettingsGroup
     {
+        public override bool AutoSizeEasingEnabled { get; set; }
+
         private readonly PlayerSliderBar<double> dimSliderBar;
         private readonly PlayerSliderBar<double> blurSliderBar;
         private readonly PlayerSliderBar<float> comboColourNormalisationSliderBar;


### PR DESCRIPTION
`ExpandingContainers` currently have no expanding animation, which is the result from removing autosize easing in `SettingsToolboxGroup` in #20740 as part of the change to improve song select -> player loader transition. Now that this transition has been further changed (e.g. #21112), I've played around with adding the autosize easing back in and personally it feels ok even on player loader screen.