### PR TITLE
Improve reliability of solo statistics watcher

### DIFF
--- a/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
+++ b/osu.Game/Online/Solo/SoloStatisticsWatcher.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Online.Solo
             if (!api.IsLoggedIn)
                 return;
 
-            if (!score.Ruleset.IsLegacyRuleset())
+            if (!score.Ruleset.IsLegacyRuleset() || score.OnlineID <= 0)
                 return;
 
             var callback = new StatisticsUpdateCallback(score, onUpdateReady);

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Screens.Ranking
         [Resolved]
         private SoloStatisticsWatcher soloStatisticsWatcher { get; set; } = null!;
 
+        private IDisposable? statisticsSubscription;
         private readonly Bindable<SoloStatisticsUpdate?> statisticsUpdate = new Bindable<SoloStatisticsUpdate?>();
 
         public SoloResultsScreen(ScoreInfo score, bool allowRetry)
@@ -44,7 +45,7 @@ namespace osu.Game.Screens.Ranking
             base.LoadComplete();
 
             if (ShowUserStatistics)
-                soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => statisticsUpdate.Value = update);
+                statisticsSubscription = soloStatisticsWatcher.RegisterForStatisticsUpdateAfter(Score, update => statisticsUpdate.Value = update);
         }
 
         protected override StatisticsPanel CreateStatisticsPanel()
@@ -75,6 +76,7 @@ namespace osu.Game.Screens.Ranking
             base.Dispose(isDisposing);
 
             getScoreRequest?.Cancel();
+            statisticsSubscription?.Dispose();
         }
     }
 }

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,15 +24,15 @@ namespace osu.Game.Screens.Ranking
         /// </summary>
         public bool ShowUserStatistics { get; init; }
 
-        private GetScoresRequest getScoreRequest;
+        private GetScoresRequest? getScoreRequest;
 
         [Resolved]
-        private RulesetStore rulesets { get; set; }
+        private RulesetStore rulesets { get; set; } = null!;
 
         [Resolved]
-        private SoloStatisticsWatcher soloStatisticsWatcher { get; set; }
+        private SoloStatisticsWatcher soloStatisticsWatcher { get; set; } = null!;
 
-        private readonly Bindable<SoloStatisticsUpdate> statisticsUpdate = new Bindable<SoloStatisticsUpdate>();
+        private readonly Bindable<SoloStatisticsUpdate?> statisticsUpdate = new Bindable<SoloStatisticsUpdate?>();
 
         public SoloResultsScreen(ScoreInfo score, bool allowRetry)
             : base(score, allowRetry)
@@ -62,7 +60,7 @@ namespace osu.Game.Screens.Ranking
             return base.CreateStatisticsPanel();
         }
 
-        protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
+        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>>? scoresCallback)
         {
             if (Score.BeatmapInfo.OnlineID <= 0 || Score.BeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
                 return null;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21837
- Closes https://github.com/ppy/osu/issues/21839

Grab-bag of fixes and improvements that I clumped together to reduce noise and merge conflict count. Recommend reviewing per-commit.

### e9d32fca18151036b7d2ba95fc7bae8f771671d7: Fix various failures in initial statistics fetch

- If the local user is restricted, then attempting to fetch their data  from the `/users` endpoint would result in an empty response.
- Even if the user was successfully fetched, their `RulesetsStatistics` may not be populated (and instead be `null`). Curiously this was not picked up by static analysis until the first issue was fixed.

### a0a26b1e8c257b40dc66ad62be754afcd8a7edda: Ignore statistics update subscriptions with invalid score ID

If score submission fails, the score will not receive a correct online ID from web, but will still be passed on to the solo statistics watcher on the results screen. This could lead to the watcher subscribing to changes with score ID equal to the default of -1. If this happened more than once, that would cause a crash due to duplicate keys in the `callbacks` dictionary.

### 04f9a354c3fb6e695e4cad4bfddd31b5ac8c03e7: Convert `SoloResultsScreen` to NRT

Needed for next commit.

### 3c0b8af8f1dbf19dbd9496c85d3555354fff7e3d: Allow unsubscribing from solo statistics updates

This is more of a safety item rather than actual issue. To avoid potential duplicate key in dictionary errors (and also avoid being slightly memory-leaky), allow `SoloStatisticsWatcher` consumers to dispose of the subscriptions they take out.

Can revert that last one on request. I think it's good to have, though, in theory.