### PR TITLE
Adjust Android package versioning to .NET 6

### DIFF
--- a/osu.Android/AndroidManifest.xml
+++ b/osu.Android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" package="sh.ppy.osulazer" android:installLocation="auto" android:versionName="0.1.0">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="sh.ppy.osulazer" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:allowBackup="true" android:supportsRtl="true" android:label="osu!" android:icon="@drawable/lazer" />
 </manifest>

--- a/osu.Android/osu.Android.csproj
+++ b/osu.Android/osu.Android.csproj
@@ -8,6 +8,9 @@
     <UseMauiEssentials>true</UseMauiEssentials>
     <!-- This currently causes random lockups during gameplay. https://github.com/mono/mono/issues/18973 -->
     <EnableLLVM>false</EnableLLVM>
+    <Version>0.0.0</Version>
+    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+    <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj" />


### PR DESCRIPTION
With .NET 6, the way Xamarin package versioning works has changed.

- The `ApplicationVersion` MSBuild property aims to replace `android:versionCode` in the manifest.
- The `ApplicationDisplayVersion` MSBuild property aims to replace `android:versionName` in the manifest.

More about this can be read in [Xamarin docs](https://github.com/xamarin/xamarin-android/blob/ec712da8c1ce03f71578e08cafb6a767cdb90cd5/Documentation/guides/OneDotNetSingleProject.md).

To this end:

- Manual `version{Code,Name}` specs are removed from `AndroidManifest.xml`, as they were preventing MSBuild properties from functioning properly.
- `Version` now defaults to 0.0.0, so that local builds don't appear like they were deployed. See `OsuGameBase.IsDeployedBuild`:

  https://github.com/ppy/osu/blob/5e8ca11deda78d1641101f7656566edd2d9f3ff2/osu.Game/OsuGameBase.cs#L111

- `ApplicationDisplayVersion` now defaults to `Version`. This addresses the Android portion of #21498.
- `ApplicationVersion` can now be specified by command line, but still needs to be supplied manually for version detection to work correctly. See `OsuGameAndroid.AssemblyVersion` for more info:

  https://github.com/ppy/osu/blob/5e8ca11deda78d1641101f7656566edd2d9f3ff2/osu.Android/OsuGameAndroid.cs#L39-L62

Putting the pieces together, the complete publish command to deploy a new build should look something like so:

    dotnet publish -f net6.0-android \
                   -r android-arm64 \
                   -c Release \
                   -p:Version=2022.1228.0 \
                   -p:ApplicationVersion=202212280