### PR TITLE
Add keywords to ease search of "first object visibility" setting

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/ModsSettings.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     LabelText = GameplaySettingsStrings.IncreaseFirstObjectVisibility,
                     Current = config.GetBindable<bool>(OsuSetting.IncreaseFirstObjectVisibility),
+                    Keywords = new[] { @"approach", @"circle", @"hidden" },
                 },
             };
         }


### PR DESCRIPTION
Coming from https://twitter.com/__badu_/status/1607937497635364865?s=46&t=G7zU1iXGa1C71hABPmebBw, osu!(stable) uses different wording for this setting (`Show approach circle on first "Hidden" object`). Added some keywords to cover some of the wording from stable in this setting.