### PR TITLE
Allow aspect ratios smaller than the default in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
-            drawableTaikoRuleset.LockPlayfieldAspect.Value = false;
+            drawableTaikoRuleset.LockPlayfieldMaxAspect.Value = false;
 
             var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             playfield.ClassicHitTargetPosition.Value = true;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         public new BindableDouble TimeRange => base.TimeRange;
 
-        public readonly BindableBool LockPlayfieldAspect = new BindableBool(true);
+        public readonly BindableBool LockPlayfieldMaxAspect = new BindableBool(true);
 
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Overlapping;
 
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer
         {
-            LockPlayfieldAspect = { BindTarget = LockPlayfieldAspect }
+            LockPlayfieldMaxAspect = { BindTarget = LockPlayfieldMaxAspect }
         };
 
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             float height = default_relative_height;
 
-            if (LockPlayfieldAspect.Value)
+            if (LockPlayfieldAspect.Value && Parent.ChildSize.X / Parent.ChildSize.Y > default_aspect)
                 height *= Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
 
             Height = height;

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
         private const float default_aspect = 16f / 9f;
 
-        public readonly IBindable<bool> LockPlayfieldAspect = new BindableBool(true);
+        public readonly IBindable<bool> LockPlayfieldMaxAspect = new BindableBool(true);
 
         protected override void Update()
         {
@@ -21,7 +21,12 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             float height = default_relative_height;
 
-            if (LockPlayfieldAspect.Value && Parent.ChildSize.X / Parent.ChildSize.Y > default_aspect)
+            // Players coming from stable expect to be able to change the aspect ratio regardless of the window size.
+            // We originally wanted to limit this more, but there was considerable pushback from the community.
+            //
+            // As a middle-ground, the aspect ratio can still be adjusted in the downwards direction but has a maximum limit.
+            // This is still a bit weird, because readability changes with window size, but it is what it is.
+            if (LockPlayfieldMaxAspect.Value && Parent.ChildSize.X / Parent.ChildSize.Y > default_aspect)
                 height *= Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
 
             Height = height;


### PR DESCRIPTION
With the release of the lazer subserver there's been an influx of people trying it out, and one of the biggest concerns for taiko players is that the 4:3 aspect ratio isn't supported in lazer without the classic mod.
This was most likely done to prevent aspect ratio exploits, as in ultra wide resolutions, to see more notes or see them for longer.
To prevent exploits but still please 4:3 players, this PR allows aspect ratios below 16:9, and only locks wider aspect ratios.