### PR TITLE
Fix hover propagating through toolbar buttons

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneToolbar.cs
@@ -201,6 +201,22 @@ namespace osu.Game.Tests.Visual.Menus
             AddAssert("volume not changed", () => Audio.Volume.Value == 0.5);
         }
 
+        [Test]
+        public void TestRulesetSelectorOverflow()
+        {
+            AddStep("set toolbar width", () =>
+            {
+                toolbar.RelativeSizeAxes = Axes.None;
+                toolbar.Width = 0;
+            });
+            AddStep("move mouse over news toggle button", () =>
+            {
+                var button = toolbar.ChildrenOfType<ToolbarNewsButton>().Single();
+                InputManager.MoveMouseTo(button);
+            });
+            AddAssert("no ruleset toggle buttons hovered", () => !toolbar.ChildrenOfType<ToolbarRulesetTabButton>().Any(button => button.IsHovered));
+        }
+
         public partial class TestToolbar : Toolbar
         {
             public new Bindable<OverlayActivation> OverlayActivationMode => base.OverlayActivationMode as Bindable<OverlayActivation>;

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -179,7 +179,7 @@ namespace osu.Game.Overlays.Toolbar
             HoverBackground.FadeIn(200);
             tooltipContainer.FadeIn(100);
 
-            return base.OnHover(e);
+            return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21920.

Weirdly enough this was seemingly fixed once before in ancient times in https://github.com/ppy/osu/commit/3891f467a34562d2d921fe996654802d0b29ab0b, but then unfixed again in https://github.com/ppy/osu/commit/566e09083f06b87591c7745d82adf0d831a6066f. The second change is no longer needed since the toolbar became opaque in https://github.com/ppy/osu/pull/9447.

Added test coverage since this happened twice.