### PR TITLE
Add new display modes for accuracy counter

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Judgements;
@@ -137,6 +138,29 @@ namespace osu.Game.Tests.Gameplay
             Assert.That(score.MaximumStatistics[HitResult.SmallTickHit], Is.EqualTo(2));
             Assert.That(score.MaximumStatistics[HitResult.SmallBonus], Is.EqualTo(1));
             Assert.That(score.MaximumStatistics[HitResult.LargeBonus], Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestAccuracyModes()
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                HitObjects = Enumerable.Range(0, 4).Select(_ => new TestHitObject(HitResult.Great)).ToList<HitObject>()
+            };
+
+            var scoreProcessor = new ScoreProcessor(new OsuRuleset());
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            Assert.That(scoreProcessor.Accuracy.Value, Is.EqualTo(1));
+            Assert.That(scoreProcessor.MinimumAccuracy.Value, Is.EqualTo(0));
+            Assert.That(scoreProcessor.MaximumAccuracy.Value, Is.EqualTo(1));
+
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], beatmap.HitObjects[0].CreateJudgement()) { Type = HitResult.Ok });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], beatmap.HitObjects[1].CreateJudgement()) { Type = HitResult.Great });
+
+            Assert.That(scoreProcessor.Accuracy.Value, Is.EqualTo((double)(100 + 300) / (2 * 300)).Within(Precision.DOUBLE_EPSILON));
+            Assert.That(scoreProcessor.MinimumAccuracy.Value, Is.EqualTo((double)(100 + 300) / (4 * 300)).Within(Precision.DOUBLE_EPSILON));
+            Assert.That(scoreProcessor.MaximumAccuracy.Value, Is.EqualTo((double)(100 + 3 * 300) / (4 * 300)).Within(Precision.DOUBLE_EPSILON));
         }
 
         private class TestJudgement : Judgement

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -42,12 +42,12 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The accuracy which increase from 0%.
         /// </summary>
-        public readonly BindableDouble IncreaseAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+        public readonly BindableDouble MinimumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
         /// The accuracy which Decrease from 100%.
         /// </summary>
-        public readonly BindableDouble DecreaseAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+        public readonly BindableDouble MaximumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
         /// The current combo.
@@ -274,8 +274,8 @@ namespace osu.Game.Rulesets.Scoring
         private void updateScore()
         {
             Accuracy.Value = currentMaximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / currentMaximumScoringValues.BaseScore : 1;
-            IncreaseAccuracy.Value = maximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / maximumScoringValues.BaseScore : 0;
-            DecreaseAccuracy.Value = maximumScoringValues.BaseScore > 0
+            MinimumAccuracy.Value = maximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / maximumScoringValues.BaseScore : 0;
+            MaximumAccuracy.Value = maximumScoringValues.BaseScore > 0
                 ? (double)(maximumScoringValues.BaseScore - (currentMaximumScoringValues.BaseScore - currentScoringValues.BaseScore)) / maximumScoringValues.BaseScore
                 : 1;
             TotalScore.Value = computeScore(Mode.Value, currentScoringValues, maximumScoringValues);

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -278,7 +278,7 @@ namespace osu.Game.Rulesets.Scoring
             Accuracy.Value = currentMaximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / currentMaximumScoringValues.BaseScore : 1;
             MinimumAccuracy.Value = maximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / maximumScoringValues.BaseScore : 0;
             MaximumAccuracy.Value = maximumScoringValues.BaseScore > 0
-                ? (double)(maximumScoringValues.BaseScore - (currentMaximumScoringValues.BaseScore - currentScoringValues.BaseScore)) / maximumScoringValues.BaseScore
+                ? (double)(currentScoringValues.BaseScore + (maximumScoringValues.BaseScore - currentMaximumScoringValues.BaseScore)) / maximumScoringValues.BaseScore
                 : 1;
             TotalScore.Value = computeScore(Mode.Value, currentScoringValues, maximumScoringValues);
         }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -40,6 +40,16 @@ namespace osu.Game.Rulesets.Scoring
         public readonly BindableDouble Accuracy = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
+        /// The accuracy which increase from 0%.
+        /// </summary>
+        public readonly BindableDouble IncreaseAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+
+        /// <summary>
+        /// The accuracy which Decrease from 100%.
+        /// </summary>
+        public readonly BindableDouble DecreaseAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+
+        /// <summary>
         /// The current combo.
         /// </summary>
         public readonly BindableInt Combo = new BindableInt();
@@ -264,6 +274,10 @@ namespace osu.Game.Rulesets.Scoring
         private void updateScore()
         {
             Accuracy.Value = currentMaximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / currentMaximumScoringValues.BaseScore : 1;
+            IncreaseAccuracy.Value = maximumScoringValues.BaseScore > 0 ? (double)currentScoringValues.BaseScore / maximumScoringValues.BaseScore : 0;
+            DecreaseAccuracy.Value = maximumScoringValues.BaseScore > 0
+                ? (double)(maximumScoringValues.BaseScore - (currentMaximumScoringValues.BaseScore - currentScoringValues.BaseScore)) / maximumScoringValues.BaseScore
+                : 1;
             TotalScore.Value = computeScore(Mode.Value, currentScoringValues, maximumScoringValues);
         }
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -40,12 +40,14 @@ namespace osu.Game.Rulesets.Scoring
         public readonly BindableDouble Accuracy = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
-        /// The accuracy which increase from 0%.
+        /// The minimum achievable accuracy for the whole beatmap at this stage of gameplay.
+        /// Assumes that all objects that have not been judged yet will receive the minimum hit result.
         /// </summary>
         public readonly BindableDouble MinimumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
-        /// The accuracy which Decrease from 100%.
+        /// The maximum achievable accuracy for the whole beatmap at this stage of gameplay.
+        /// Assumes that all objects that have not been judged yet will receive the maximum hit result.
         /// </summary>
         public readonly BindableDouble MaximumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -43,13 +43,13 @@ namespace osu.Game.Rulesets.Scoring
         /// The minimum achievable accuracy for the whole beatmap at this stage of gameplay.
         /// Assumes that all objects that have not been judged yet will receive the minimum hit result.
         /// </summary>
-        public readonly BindableDouble MinimumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+        public readonly BindableDouble MinimumAccuracy = new BindableDouble { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
         /// The maximum achievable accuracy for the whole beatmap at this stage of gameplay.
         /// Assumes that all objects that have not been judged yet will receive the maximum hit result.
         /// </summary>
-        public readonly BindableDouble MaximumAccuracy = new BindableDouble(0) { MinValue = 0, MaxValue = 1 };
+        public readonly BindableDouble MaximumAccuracy = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
 
         /// <summary>
         /// The current combo.

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -15,9 +15,13 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource("Accuracy display mode", "Which accuracy mode should be displayed.")]
         public Bindable<AccuracyDisplayMode> AccuracyDisplay { get; } = new Bindable<AccuracyDisplayMode>();
 
-        [BackgroundDependencyLoader]
-        private void load(ScoreProcessor scoreProcessor)
+        [Resolved]
+        private ScoreProcessor scoreProcessor { get; set; } = null!;
+
+        protected override void LoadComplete()
         {
+            base.LoadComplete();
+
             AccuracyDisplay.BindValueChanged(mod =>
             {
                 Current.UnbindBindings();

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -14,12 +14,12 @@ namespace osu.Game.Screens.Play.HUD
     public abstract partial class GameplayAccuracyCounter : PercentageCounter
     {
         [SettingSource("Accuracy Display Mode")]
-        public Bindable<AccuracyType> AccType { get; } = new Bindable<AccuracyType>();
+        public Bindable<AccuracyType> AccuracyDisplay { get; } = new Bindable<AccuracyType>();
 
         [BackgroundDependencyLoader]
         private void load(ScoreProcessor scoreProcessor)
         {
-            AccType.BindValueChanged(mod =>
+            AccuracyDisplay.BindValueChanged(mod =>
             {
                 Current.UnbindBindings();
 

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -41,6 +41,12 @@ namespace osu.Game.Screens.Play.HUD
                         break;
                 }
             }, true);
+
+            // if the accuracy counter is using the "minimum achievable" mode,
+            // then its initial value is 0%, rather than the 100% that the base PercentageCounter assumes.
+            // to counteract this, manually finish transforms on DisplayedCount once after the initial callback above
+            // to stop it from rolling down from 100% to 0%.
+            FinishTransforms(targetMember: nameof(DisplayedCount));
         }
 
         public enum AccuracyDisplayMode

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Screens.Play.HUD
 {
     public abstract partial class GameplayAccuracyCounter : PercentageCounter
     {
-        [SettingSource("Accuracy Display Mode", "Which Accuracy will display")]
-        public Bindable<AccuracyType> AccuracyDisplay { get; } = new Bindable<AccuracyType>();
+        [SettingSource("Accuracy display mode", "Which accuracy mode should be displayed.")]
+        public Bindable<AccuracyDisplayMode> AccuracyDisplay { get; } = new Bindable<AccuracyDisplayMode>();
 
         [BackgroundDependencyLoader]
         private void load(ScoreProcessor scoreProcessor)
@@ -24,31 +24,31 @@ namespace osu.Game.Screens.Play.HUD
 
                 switch (mod.NewValue)
                 {
-                    case AccuracyType.Rolling:
+                    case AccuracyDisplayMode.Standard:
                         Current.BindTo(scoreProcessor.Accuracy);
                         break;
 
-                    case AccuracyType.Increase:
-                        Current.BindTo(scoreProcessor.IncreaseAccuracy);
+                    case AccuracyDisplayMode.MinimumAchievable:
+                        Current.BindTo(scoreProcessor.MinimumAccuracy);
                         break;
 
-                    case AccuracyType.Decrease:
-                        Current.BindTo(scoreProcessor.DecreaseAccuracy);
+                    case AccuracyDisplayMode.MaximumAchievable:
+                        Current.BindTo(scoreProcessor.MaximumAccuracy);
                         break;
                 }
             }, true);
         }
 
-        public enum AccuracyType
+        public enum AccuracyDisplayMode
         {
-            [Description("Rolling")]
-            Rolling,
+            [Description("Standard")]
+            Standard,
 
-            [Description("Best achievable")]
-            Increase,
+            [Description("Maximum achievable")]
+            MaximumAchievable,
 
-            [Description("Worst achievable")]
-            Decrease
+            [Description("Minimum achievable")]
+            MinimumAchievable
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Scoring;
 
@@ -11,10 +13,38 @@ namespace osu.Game.Screens.Play.HUD
 {
     public abstract partial class GameplayAccuracyCounter : PercentageCounter
     {
+        [SettingSource("Accuracy Display Mode")]
+        public Bindable<AccuracyType> AccType { get; } = new Bindable<AccuracyType>();
+
         [BackgroundDependencyLoader]
         private void load(ScoreProcessor scoreProcessor)
         {
-            Current.BindTo(scoreProcessor.Accuracy);
+            AccType.BindValueChanged(mod =>
+            {
+                Current.UnbindBindings();
+
+                switch (mod.NewValue)
+                {
+                    case AccuracyType.Current:
+                        Current.BindTo(scoreProcessor.Accuracy);
+                        break;
+
+                    case AccuracyType.Increase:
+                        Current.BindTo(scoreProcessor.IncreaseAccuracy);
+                        break;
+
+                    case AccuracyType.Decrease:
+                        Current.BindTo(scoreProcessor.DecreaseAccuracy);
+                        break;
+                }
+            }, true);
+        }
+
+        public enum AccuracyType
+        {
+            Current,
+            Increase,
+            Decrease
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.ComponentModel;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Configuration;
@@ -11,7 +12,7 @@ namespace osu.Game.Screens.Play.HUD
 {
     public abstract partial class GameplayAccuracyCounter : PercentageCounter
     {
-        [SettingSource("Accuracy Display Mode")]
+        [SettingSource("Accuracy Display Mode", "Which Accuracy will display")]
         public Bindable<AccuracyType> AccuracyDisplay { get; } = new Bindable<AccuracyType>();
 
         [BackgroundDependencyLoader]
@@ -23,7 +24,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 switch (mod.NewValue)
                 {
-                    case AccuracyType.Current:
+                    case AccuracyType.Rolling:
                         Current.BindTo(scoreProcessor.Accuracy);
                         break;
 
@@ -40,8 +41,13 @@ namespace osu.Game.Screens.Play.HUD
 
         public enum AccuracyType
         {
-            Current,
+            [Description("Rolling")]
+            Rolling,
+
+            [Description("Best achievable")]
             Increase,
+
+            [Description("Worst achievable")]
             Decrease
         }
     }


### PR DESCRIPTION
closes https://github.com/ppy/osu/issues/9336

Increase display mode will show the accuracy that will grow from 0% (ACHIEVEMENT(+) in maimai)

Decrease display mode will show the accuracy that will decrement from 100% (ACHIEVEMENT(-) in maimai)

https://user-images.githubusercontent.com/34775378/210070059-4f11c9f9-13f4-41a8-8f04-ae08558bbcd6.mp4

