### PR TITLE
Use legacy fade out behavior when hit lighting is disabled for argon and argon pro

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -143,6 +143,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     case ArmedState.Hit:
                         // Fade out time is at a maximum of 800. Must match `DrawableHitCircle`'s arbitrary lifetime spec.
                         const double fade_out_time = 800;
+                        const double legacy_fade_duration = 240;
 
                         const double flash_in_duration = 150;
                         const double resize_duration = 400;
@@ -162,16 +163,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         // a few milliseconds before it's hidden by the flash, so it's pointless overhead to bother with it.
                         innerGradient.FadeOut(flash_in_duration, Easing.OutQuint);
 
-                        // The border is always white, but after hit it gets coloured by the skin/beatmap's colouring.
-                        // A gradient is applied to make the border less prominent over the course of the animation.
-                        // Without this, the border dominates the visual presence of the explosion animation in a bad way.
-                        border.TransformTo(nameof
-                            (BorderColour), ColourInfo.GradientVertical(
-                            accentColour.Value.Opacity(0.5f),
-                            accentColour.Value.Opacity(0)), fade_out_time);
-
                         if (hitLightingEnabled.Value)
                         {
+                            // The border is always white, but after hit it gets coloured by the skin/beatmap's colouring.
+                            // A gradient is applied to make the border less prominent over the course of the animation.
+                            // Without this, the border dominates the visual presence of the explosion animation in a bad way.
+                            border.TransformTo(nameof
+                                (BorderColour), ColourInfo.GradientVertical(
+                                accentColour.Value.Opacity(0.5f),
+                                accentColour.Value.Opacity(0)), fade_out_time);
+
                             // The outer ring shrinks immediately, but accounts for its thickness so it doesn't overlap the inner
                             // gradient layers.
                             border.ResizeTo(Size * shrink_size + new Vector2(border.BorderThickness), resize_duration, Easing.OutElasticHalf);
@@ -194,7 +195,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         else
                         {
                             // If hit lighting is disabled, use legacy fade out behavior for border and outer gradient.
-                            const double legacy_fade_duration = 240;
                             border.FadeOut(legacy_fade_duration);
                             border.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 


### PR DESCRIPTION
#21824

I wanted to use the argon pro skin without the "hit lighting" (aka. the explosion / fade out behavior), but the hit lighting setting is ignored by the skin.

While I was making this change, I struggled to find a way to keep the skin's identity while also removing a lot of the fade effects. Simply shortening the duration of the current effect causes a jarring white flash, and using instant-fade doesn't feel great either. Ultimately I decided to use the legacy fade behavior for the border and the outer-gradient, which feels good.

There may be a better way to keep the skin's identity while also removing the "hit lighting", so I'm open to discussion. But in the meantime, this change should make the skin feel better for people who play with hit lighting disabled.