### PR TITLE
Enable NRT in user profile overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneHistoricalSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game.Tests/Visual/Online/TestSceneKudosuHistory.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneKudosuHistory.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Overlays.Profile.Sections.Kudosu;
 using System.Collections.Generic;
 using System;

--- a/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneProfileRulesetSelector.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Rulesets.Catch;
@@ -24,7 +22,7 @@ namespace osu.Game.Tests.Visual.Online
         public TestSceneProfileRulesetSelector()
         {
             ProfileRulesetSelector selector;
-            var user = new Bindable<APIUser>();
+            var user = new Bindable<APIUser?>();
 
             Child = selector = new ProfileRulesetSelector
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneUserHistoryGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserHistoryGraph.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -20,7 +18,7 @@ namespace osu.Game.Tests.Visual.Online
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
 
-        private ProfileHeader header;
+        private ProfileHeader header = null!;
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfilePreviousUsernames.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfilePreviousUsernames.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -14,7 +12,7 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public partial class TestSceneUserProfilePreviousUsernames : OsuTestScene
     {
-        private PreviousUsernames container;
+        private PreviousUsernames container = null!;
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -50,7 +48,7 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("Is hidden", () => container.Alpha == 0);
         }
 
-        private static readonly APIUser[] users =
+        private static readonly APIUser?[] users =
         {
             new APIUser { Id = 1, PreviousUsernames = new[] { "username1" } },
             new APIUser { Id = 2, PreviousUsernames = new[] { "longusername", "longerusername" } },

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileRecentSection.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileRecentSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileScores.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileScores.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserRanks.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneProfileSubsectionHeader.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneProfileSubsectionHeader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Game.Overlays.Profile.Sections;
 using osu.Framework.Testing;
@@ -18,7 +16,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
 
-        private ProfileSubsectionHeader header;
+        private ProfileSubsectionHeader header = null!;
 
         [Test]
         public void TestHiddenCounter()

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using Humanizer;
 using osu.Framework.Allocation;
@@ -25,15 +23,15 @@ namespace osu.Game.Overlays.Profile.Header
 {
     public partial class BottomHeaderContainer : CompositeDrawable
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
-        private LinkFlowContainer topLinkContainer;
-        private LinkFlowContainer bottomLinkContainer;
+        private LinkFlowContainer topLinkContainer = null!;
+        private LinkFlowContainer bottomLinkContainer = null!;
 
         private Color4 iconColour;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
 
         public BottomHeaderContainer()
         {
@@ -78,7 +76,7 @@ namespace osu.Game.Overlays.Profile.Header
             User.BindValueChanged(user => updateDisplay(user.NewValue));
         }
 
-        private void updateDisplay(APIUser user)
+        private void updateDisplay(APIUser? user)
         {
             topLinkContainer.Clear();
             bottomLinkContainer.Clear();
@@ -164,7 +162,7 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void addSpacer(OsuTextFlowContainer textFlow) => textFlow.AddArbitraryDrawable(new Container { Width = 15 });
 
-        private bool tryAddInfo(IconUsage icon, string content, string link = null)
+        private bool tryAddInfo(IconUsage icon, string content, string? link = null)
         {
             if (string.IsNullOrEmpty(content)) return false;
 

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -20,10 +18,10 @@ namespace osu.Game.Overlays.Profile.Header
     public partial class CentreHeaderContainer : CompositeDrawable
     {
         public readonly BindableBool DetailsVisible = new BindableBool(true);
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
-        private OverlinedInfoContainer hiddenDetailGlobal;
-        private OverlinedInfoContainer hiddenDetailCountry;
+        private OverlinedInfoContainer hiddenDetailGlobal = null!;
+        private OverlinedInfoContainer hiddenDetailCountry = null!;
 
         public CentreHeaderContainer()
         {
@@ -146,7 +144,7 @@ namespace osu.Game.Overlays.Profile.Header
             User.BindValueChanged(user => updateDisplay(user.NewValue));
         }
 
-        private void updateDisplay(APIUser user)
+        private void updateDisplay(APIUser? user)
         {
             hiddenDetailGlobal.Content = user?.Statistics?.GlobalRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";
             hiddenDetailCountry.Content = user?.Statistics?.CountryRank?.ToLocalisableString("\\##,##0") ?? (LocalisableString)"-";

--- a/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExpandDetailsButton.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -23,9 +21,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         public override LocalisableString TooltipText => DetailsVisible.Value ? CommonStrings.ButtonsCollapse : CommonStrings.ButtonsExpand;
 
-        private SpriteIcon icon;
-        private Sample sampleOpen;
-        private Sample sampleClose;
+        private SpriteIcon icon = null!;
+        private Sample? sampleOpen;
+        private Sample? sampleClose;
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds();
 

--- a/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/FollowersButton.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -14,7 +12,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class FollowersButton : ProfileHeaderStatisticsButton
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public override LocalisableString TooltipText => FriendsStrings.ButtonsDisabled;
 

--- a/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelBadge.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -20,11 +18,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class LevelBadge : CompositeDrawable, IHasTooltip
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public LocalisableString TooltipText { get; private set; }
 
-        private OsuSpriteText levelText;
+        private OsuSpriteText levelText = null!;
 
         public LevelBadge()
         {
@@ -53,10 +51,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
             User.BindValueChanged(user => updateLevel(user.NewValue));
         }
 
-        private void updateLevel(APIUser user)
+        private void updateLevel(APIUser? user)
         {
-            levelText.Text = user?.Statistics?.Level.Current.ToString() ?? "0";
-            TooltipText = UsersStrings.ShowStatsLevel(user?.Statistics?.Level.Current.ToString());
+            string level = user?.Statistics?.Level.Current.ToString() ?? "0";
+            levelText.Text = level;
+            TooltipText = UsersStrings.ShowStatsLevel(level);
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/LevelProgressBar.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -21,12 +19,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class LevelProgressBar : CompositeDrawable, IHasTooltip
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public LocalisableString TooltipText { get; }
 
-        private Bar levelProgressBar;
-        private OsuSpriteText levelProgressText;
+        private Bar levelProgressBar = null!;
+        private OsuSpriteText levelProgressText = null!;
 
         public LevelProgressBar()
         {
@@ -61,7 +59,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             User.BindValueChanged(user => updateProgress(user.NewValue));
         }
 
-        private void updateProgress(APIUser user)
+        private void updateProgress(APIUser? user)
         {
             levelProgressBar.Length = user?.Statistics?.Level.Progress / 100f ?? 0;
             levelProgressText.Text = user?.Statistics?.Level.Progress.ToLocalisableString("0'%'") ?? default;

--- a/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MappingSubscribersButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
@@ -14,7 +12,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class MappingSubscribersButton : ProfileHeaderStatisticsButton
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public override LocalisableString TooltipText => FollowsStrings.MappingFollowers;
 

--- a/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -18,21 +16,21 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class MessageUserButton : ProfileHeaderButton
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public override LocalisableString TooltipText => UsersStrings.CardSendMessage;
 
-        [Resolved(CanBeNull = true)]
-        private ChannelManager channelManager { get; set; }
-
-        [Resolved(CanBeNull = true)]
-        private UserProfileOverlay userOverlay { get; set; }
-
-        [Resolved(CanBeNull = true)]
-        private ChatOverlay chatOverlay { get; set; }
+        [Resolved]
+        private ChannelManager? channelManager { get; set; }
 
         [Resolved]
-        private IAPIProvider apiProvider { get; set; }
+        private UserProfileOverlay? userOverlay { get; set; }
+
+        [Resolved]
+        private ChatOverlay? chatOverlay { get; set; }
+
+        [Resolved]
+        private IAPIProvider apiProvider { get; set; } = null!;
 
         public MessageUserButton()
         {
@@ -56,7 +54,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 chatOverlay?.Show();
             };
 
-            User.ValueChanged += e => Content.Alpha = !e.NewValue.PMFriendsOnly && apiProvider.LocalUser.Value.Id != e.NewValue.Id ? 1 : 0;
+            User.ValueChanged += e => Content.Alpha = e.NewValue != null && !e.NewValue.PMFriendsOnly && apiProvider.LocalUser.Value.Id != e.NewValue.Id ? 1 : 0;
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedInfoContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/OverlinedTotalPlayTime.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,11 +14,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class OverlinedTotalPlayTime : CompositeDrawable, IHasTooltip
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         public LocalisableString TooltipText { get; set; }
 
-        private OverlinedInfoContainer info;
+        private OverlinedInfoContainer info = null!;
 
         public OverlinedTotalPlayTime()
         {
@@ -41,7 +39,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             User.BindValueChanged(updateTime, true);
         }
 
-        private void updateTime(ValueChangedEvent<APIUser> user)
+        private void updateTime(ValueChangedEvent<APIUser?> user)
         {
             TooltipText = (user.NewValue?.Statistics?.PlayTime ?? 0) / 3600 + " hours";
             info.Content = formatTime(user.NewValue?.Statistics?.PlayTime);

--- a/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/PreviousUsernames.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -27,7 +25,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private const int width = 310;
         private const int move_offset = 15;
 
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         private readonly TextFlowContainer text;
         private readonly Box background;
@@ -109,11 +107,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
             User.BindValueChanged(onUserChanged, true);
         }
 
-        private void onUserChanged(ValueChangedEvent<APIUser> user)
+        private void onUserChanged(ValueChangedEvent<APIUser?> user)
         {
             text.Text = string.Empty;
 
-            string[] usernames = user.NewValue?.PreviousUsernames;
+            string[]? usernames = user.NewValue?.PreviousUsernames;
 
             if (usernames?.Any() ?? false)
             {
@@ -149,7 +147,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         private partial class HoverIconContainer : Container
         {
-            public Action ActivateHover;
+            public Action? ActivateHover;
 
             public HoverIconContainer()
             {

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderStatisticsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderStatisticsButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetSelector.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetSelector.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
@@ -12,12 +11,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class ProfileRulesetSelector : OverlayRulesetSelector
     {
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            User.BindValueChanged(u => SetDefaultRuleset(Rulesets.GetRuleset(u.NewValue?.PlayMode ?? "osu")), true);
+            User.BindValueChanged(u => SetDefaultRuleset(Rulesets.GetRuleset(u.NewValue?.PlayMode ?? "osu").AsNonNull()), true);
         }
 
         public void SetDefaultRuleset(RulesetInfo ruleset)

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileRulesetTabItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/RankGraph.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         private const int ranked_days = 88;
 
-        public readonly Bindable<UserStatistics> Statistics = new Bindable<UserStatistics>();
+        public readonly Bindable<UserStatistics?> Statistics = new Bindable<UserStatistics?>();
 
         private readonly OsuSpriteText placeholder;
 
@@ -42,11 +40,11 @@ namespace osu.Game.Overlays.Profile.Header.Components
             Statistics.BindValueChanged(statistics => updateStatistics(statistics.NewValue), true);
         }
 
-        private void updateStatistics(UserStatistics statistics)
+        private void updateStatistics(UserStatistics? statistics)
         {
             // checking both IsRanked and RankHistory is required.
             // see https://github.com/ppy/osu-web/blob/154ceafba0f35a1dd935df53ec98ae2ea5615f9f/resources/assets/lib/profile-page/rank-chart.tsx#L46
-            int[] userRanks = statistics?.IsRanked == true ? statistics.RankHistory?.Data : null;
+            int[]? userRanks = statistics?.IsRanked == true ? statistics.RankHistory?.Data : null;
             Data = userRanks?.Select((x, index) => new KeyValuePair<int, int>(index, x)).Where(x => x.Value != 0).ToArray();
         }
 

--- a/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -82,10 +80,10 @@ namespace osu.Game.Overlays.Profile.Header.Components
         }
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game)
+        [BackgroundDependencyLoader]
+        private void load(OsuGame? game)
         {
             background.Colour = colours.Pink;
 

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -25,14 +23,14 @@ namespace osu.Game.Overlays.Profile.Header
     public partial class DetailHeaderContainer : CompositeDrawable
     {
         private readonly Dictionary<ScoreRank, ScoreRankInfo> scoreRankInfos = new Dictionary<ScoreRank, ScoreRankInfo>();
-        private OverlinedInfoContainer medalInfo;
-        private OverlinedInfoContainer ppInfo;
-        private OverlinedInfoContainer detailGlobalRank;
-        private OverlinedInfoContainer detailCountryRank;
-        private FillFlowContainer fillFlow;
-        private RankGraph rankGraph;
+        private OverlinedInfoContainer medalInfo = null!;
+        private OverlinedInfoContainer ppInfo = null!;
+        private OverlinedInfoContainer detailGlobalRank = null!;
+        private OverlinedInfoContainer detailCountryRank = null!;
+        private FillFlowContainer? fillFlow;
+        private RankGraph rankGraph = null!;
 
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         private bool expanded = true;
 
@@ -173,7 +171,7 @@ namespace osu.Game.Overlays.Profile.Header
             };
         }
 
-        private void updateDisplay(APIUser user)
+        private void updateDisplay(APIUser? user)
         {
             medalInfo.Content = user?.Achievements?.Length.ToString() ?? "0";
             ppInfo.Content = user?.Statistics?.PP?.ToLocalisableString("#,##0") ?? (LocalisableString)"0";

--- a/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/MedalHeaderContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -20,9 +18,9 @@ namespace osu.Game.Overlays.Profile.Header
 {
     public partial class MedalHeaderContainer : CompositeDrawable
     {
-        private FillFlowContainer badgeFlowContainer;
+        private FillFlowContainer badgeFlowContainer = null!;
 
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -66,16 +64,16 @@ namespace osu.Game.Overlays.Profile.Header
             };
         }
 
-        private CancellationTokenSource cancellationTokenSource;
+        private CancellationTokenSource? cancellationTokenSource;
 
-        private void updateDisplay(APIUser user)
+        private void updateDisplay(APIUser? user)
         {
             cancellationTokenSource?.Cancel();
             cancellationTokenSource = new CancellationTokenSource();
 
             badgeFlowContainer.Clear();
 
-            var badges = user.Badges;
+            var badges = user?.Badges;
 
             if (badges?.Length > 0)
             {

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -29,19 +27,19 @@ namespace osu.Game.Overlays.Profile.Header
     {
         private const float avatar_size = 110;
 
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
 
-        private SupporterIcon supporterTag;
-        private UpdateableAvatar avatar;
-        private OsuSpriteText usernameText;
-        private ExternalLinkButton openUserExternally;
-        private OsuSpriteText titleText;
-        private UpdateableFlag userFlag;
-        private OsuSpriteText userCountryText;
-        private FillFlowContainer userStats;
+        private SupporterIcon supporterTag = null!;
+        private UpdateableAvatar avatar = null!;
+        private OsuSpriteText usernameText = null!;
+        private ExternalLinkButton openUserExternally = null!;
+        private OsuSpriteText titleText = null!;
+        private UpdateableFlag userFlag = null!;
+        private OsuSpriteText userCountryText = null!;
+        private FillFlowContainer userStats = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -176,7 +174,7 @@ namespace osu.Game.Overlays.Profile.Header
             User.BindValueChanged(user => updateUser(user.NewValue));
         }
 
-        private void updateUser(APIUser user)
+        private void updateUser(APIUser? user)
         {
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -20,9 +18,9 @@ namespace osu.Game.Overlays.Profile
 {
     public partial class ProfileHeader : TabControlOverlayHeader<LocalisableString>
     {
-        private UserCoverBackground coverContainer;
+        private UserCoverBackground coverContainer = null!;
 
-        public Bindable<APIUser> User = new Bindable<APIUser>();
+        public Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         private CentreHeaderContainer centreHeaderContainer;
         private DetailHeaderContainer detailHeaderContainer;
@@ -102,7 +100,7 @@ namespace osu.Game.Overlays.Profile
 
         protected override OverlayTitle CreateTitle() => new ProfileHeaderTitle();
 
-        private void updateDisplay(APIUser user) => coverContainer.User = user;
+        private void updateDisplay(APIUser? user) => coverContainer.User = user;
 
         private partial class ProfileHeaderTitle : OverlayTitle
         {

--- a/osu.Game/Overlays/Profile/ProfileSection.cs
+++ b/osu.Game/Overlays/Profile/ProfileSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -31,7 +29,7 @@ namespace osu.Game.Overlays.Profile
 
         protected override Container<Drawable> Content => content;
 
-        public readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         protected ProfileSection()
         {

--- a/osu.Game/Overlays/Profile/Sections/AboutSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/AboutSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 

--- a/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -25,8 +23,8 @@ namespace osu.Game.Overlays.Profile.Sections
             AutoSizeAxes = Axes.Both;
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(BeatmapSetOverlay beatmapSetOverlay)
+        [BackgroundDependencyLoader]
+        private void load(BeatmapSetOverlay? beatmapSetOverlay)
         {
             Action = () =>
             {

--- a/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Beatmaps/PaginatedBeatmapContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -24,7 +22,7 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
 
         protected override int InitialItemsCount => type == BeatmapSetType.Graveyard ? 2 : 6;
 
-        public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<APIUser> user, LocalisableString headerText)
+        public PaginatedBeatmapContainer(BeatmapSetType type, Bindable<APIUser?> user, LocalisableString headerText)
             : base(user, headerText)
         {
             this.type = type;
@@ -66,10 +64,10 @@ namespace osu.Game.Overlays.Profile.Sections.Beatmaps
             }
         }
 
-        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(PaginationParameters pagination) =>
-            new GetUserBeatmapsRequest(User.Value.Id, type, pagination);
+        protected override APIRequest<List<APIBeatmapSet>> CreateRequest(APIUser user, PaginationParameters pagination) =>
+            new GetUserBeatmapsRequest(user.Id, type, pagination);
 
-        protected override Drawable CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
+        protected override Drawable? CreateDrawableItem(APIBeatmapSet model) => model.OnlineID > 0
             ? new BeatmapCardNormal(model)
             {
                 Anchor = Anchor.TopCentre,

--- a/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapsSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests;
 using osu.Game.Overlays.Profile.Sections.Beatmaps;

--- a/osu.Game/Overlays/Profile/Sections/CounterPill.cs
+++ b/osu.Game/Overlays/Profile/Sections/CounterPill.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -18,7 +16,7 @@ namespace osu.Game.Overlays.Profile.Sections
     {
         public readonly BindableInt Current = new BindableInt();
 
-        private OsuSpriteText counter;
+        private OsuSpriteText counter = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)

--- a/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ChartProfileSubsection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
@@ -15,14 +13,14 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public abstract partial class ChartProfileSubsection : ProfileSubsection
     {
-        private ProfileLineChart chart;
+        private ProfileLineChart chart = null!;
 
         /// <summary>
         /// Text describing the value being plotted on the graph, which will be displayed as a prefix to the value in the history graph tooltip.
         /// </summary>
         protected abstract LocalisableString GraphCounterName { get; }
 
-        protected ChartProfileSubsection(Bindable<APIUser> user, LocalisableString headerText)
+        protected ChartProfileSubsection(Bindable<APIUser?> user, LocalisableString headerText)
             : base(user, headerText)
         {
         }
@@ -46,7 +44,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
             User.BindValueChanged(onUserChanged, true);
         }
 
-        private void onUserChanged(ValueChangedEvent<APIUser> e)
+        private void onUserChanged(ValueChangedEvent<APIUser?> e)
         {
             var values = GetValues(e.NewValue);
 
@@ -86,6 +84,6 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
             return filledHistoryEntries.ToArray();
         }
 
-        protected abstract APIUserHistoryCount[] GetValues(APIUser user);
+        protected abstract APIUserHistoryCount[]? GetValues(APIUser? user);
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/DrawableMostPlayedBeatmap.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PaginatedMostPlayedBeatmapContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -18,7 +16,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public partial class PaginatedMostPlayedBeatmapContainer : PaginatedProfileSubsection<APIUserMostPlayedBeatmap>
     {
-        public PaginatedMostPlayedBeatmapContainer(Bindable<APIUser> user)
+        public PaginatedMostPlayedBeatmapContainer(Bindable<APIUser?> user)
             : base(user, UsersStrings.ShowExtraHistoricalMostPlayedTitle)
         {
         }
@@ -31,8 +29,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 
         protected override int GetCount(APIUser user) => user.BeatmapPlayCountsCount;
 
-        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(PaginationParameters pagination) =>
-            new GetUserMostPlayedBeatmapsRequest(User.Value.Id, pagination);
+        protected override APIRequest<List<APIUserMostPlayedBeatmap>> CreateRequest(APIUser user, PaginationParameters pagination) =>
+            new GetUserMostPlayedBeatmapsRequest(user.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIUserMostPlayedBeatmap mostPlayed) =>
             new DrawableMostPlayedBeatmap(mostPlayed);

--- a/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/PlayHistorySubsection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
@@ -14,11 +12,11 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
     {
         protected override LocalisableString GraphCounterName => UsersStrings.ShowExtraHistoricalMonthlyPlaycountsCountLabel;
 
-        public PlayHistorySubsection(Bindable<APIUser> user)
+        public PlayHistorySubsection(Bindable<APIUser?> user)
             : base(user, UsersStrings.ShowExtraHistoricalMonthlyPlaycountsTitle)
         {
         }
 
-        protected override APIUserHistoryCount[] GetValues(APIUser user) => user?.MonthlyPlayCounts;
+        protected override APIUserHistoryCount[]? GetValues(APIUser? user) => user?.MonthlyPlayCounts;
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ProfileLineChart.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics;
-using JetBrains.Annotations;
 using System;
 using System.Linq;
 using osu.Game.Graphics.Sprites;
@@ -22,9 +19,8 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
 {
     public partial class ProfileLineChart : CompositeDrawable
     {
-        private APIUserHistoryCount[] values;
+        private APIUserHistoryCount[] values = Array.Empty<APIUserHistoryCount>();
 
-        [NotNull]
         public APIUserHistoryCount[] Values
         {
             get => values;

--- a/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/ReplaysSubsection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
@@ -14,11 +12,11 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
     {
         protected override LocalisableString GraphCounterName => UsersStrings.ShowExtraHistoricalReplaysWatchedCountsCountLabel;
 
-        public ReplaysSubsection(Bindable<APIUser> user)
+        public ReplaysSubsection(Bindable<APIUser?> user)
             : base(user, UsersStrings.ShowExtraHistoricalReplaysWatchedCountsTitle)
         {
         }
 
-        protected override APIUserHistoryCount[] GetValues(APIUser user) => user?.ReplaysWatchedCounts;
+        protected override APIUserHistoryCount[]? GetValues(APIUser? user) => user?.ReplaysWatchedCounts;
     }
 }

--- a/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
+++ b/osu.Game/Overlays/Profile/Sections/Historical/UserHistoryGraph.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
@@ -17,8 +14,7 @@ namespace osu.Game.Overlays.Profile.Sections.Historical
     {
         private readonly LocalisableString tooltipCounterName;
 
-        [CanBeNull]
-        public APIUserHistoryCount[] Values
+        public APIUserHistoryCount[]? Values
         {
             set => Data = value?.Select(v => new KeyValuePair<DateTime, long>(v.Date, v.Count)).ToArray();
         }

--- a/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/HistoricalSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests;

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/DrawableKudosuHistoryItem.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/DrawableKudosuHistoryItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,7 +18,7 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
         private const int height = 25;
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         private readonly APIKudosuHistory historyItem;
         private readonly LinkFlowContainer linkFlowContainer;

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/KudosuInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osuTK;
 using osu.Framework.Graphics;
@@ -22,9 +20,9 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
 {
     public partial class KudosuInfo : Container
     {
-        private readonly Bindable<APIUser> user = new Bindable<APIUser>();
+        private readonly Bindable<APIUser?> user = new Bindable<APIUser?>();
 
-        public KudosuInfo(Bindable<APIUser> user)
+        public KudosuInfo(Bindable<APIUser?> user)
         {
             this.user.BindTo(user);
             CountSection total;

--- a/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Kudosu/PaginatedKudosuHistoryContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Bindables;
@@ -16,13 +14,13 @@ namespace osu.Game.Overlays.Profile.Sections.Kudosu
 {
     public partial class PaginatedKudosuHistoryContainer : PaginatedProfileSubsection<APIKudosuHistory>
     {
-        public PaginatedKudosuHistoryContainer(Bindable<APIUser> user)
+        public PaginatedKudosuHistoryContainer(Bindable<APIUser?> user)
             : base(user, missingText: UsersStrings.ShowExtraKudosuEntryEmpty)
         {
         }
 
-        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(PaginationParameters pagination)
-            => new GetUserKudosuHistoryRequest(User.Value.Id, pagination);
+        protected override APIRequest<List<APIKudosuHistory>> CreateRequest(APIUser user, PaginationParameters pagination)
+            => new GetUserKudosuHistoryRequest(user.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIKudosuHistory item) => new DrawableKudosuHistoryItem(item);
     }

--- a/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/KudosuSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Game.Overlays.Profile.Sections.Kudosu;
 using osu.Framework.Localisation;

--- a/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/MedalsSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 

--- a/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/PaginatedProfileSubsection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -35,20 +33,20 @@ namespace osu.Game.Overlays.Profile.Sections
         protected virtual int InitialItemsCount => 5;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
 
         protected PaginationParameters? CurrentPage { get; private set; }
 
-        protected ReverseChildIDFillFlowContainer<Drawable> ItemsContainer { get; private set; }
+        protected ReverseChildIDFillFlowContainer<Drawable> ItemsContainer { get; private set; } = null!;
 
-        private APIRequest<List<TModel>> retrievalRequest;
-        private CancellationTokenSource loadCancellation;
+        private APIRequest<List<TModel>>? retrievalRequest;
+        private CancellationTokenSource? loadCancellation;
 
-        private ShowMoreButton moreButton;
-        private OsuSpriteText missing;
+        private ShowMoreButton moreButton = null!;
+        private OsuSpriteText missing = null!;
         private readonly LocalisableString? missingText;
 
-        protected PaginatedProfileSubsection(Bindable<APIUser> user, LocalisableString? headerText = null, LocalisableString? missingText = null)
+        protected PaginatedProfileSubsection(Bindable<APIUser?> user, LocalisableString? headerText = null, LocalisableString? missingText = null)
             : base(user, headerText, CounterVisibilityState.AlwaysVisible)
         {
             this.missingText = missingText;
@@ -94,7 +92,7 @@ namespace osu.Game.Overlays.Profile.Sections
             User.BindValueChanged(onUserChanged, true);
         }
 
-        private void onUserChanged(ValueChangedEvent<APIUser> e)
+        private void onUserChanged(ValueChangedEvent<APIUser?> e)
         {
             loadCancellation?.Cancel();
             retrievalRequest?.Cancel();
@@ -111,17 +109,20 @@ namespace osu.Game.Overlays.Profile.Sections
 
         private void showMore()
         {
+            if (User.Value == null)
+                return;
+
             loadCancellation = new CancellationTokenSource();
 
             CurrentPage = CurrentPage?.TakeNext(ItemsPerPage) ?? new PaginationParameters(InitialItemsCount);
 
-            retrievalRequest = CreateRequest(CurrentPage.Value);
-            retrievalRequest.Success += UpdateItems;
+            retrievalRequest = CreateRequest(User.Value, CurrentPage.Value);
+            retrievalRequest.Success += items => UpdateItems(items, loadCancellation);
 
             api.Queue(retrievalRequest);
         }
 
-        protected virtual void UpdateItems(List<TModel> items) => Schedule(() =>
+        protected virtual void UpdateItems(List<TModel> items, CancellationTokenSource cancellationTokenSource) => Schedule(() =>
         {
             OnItemsReceived(items);
 
@@ -136,7 +137,7 @@ namespace osu.Game.Overlays.Profile.Sections
                 return;
             }
 
-            LoadComponentsAsync(items.Select(CreateDrawableItem).Where(d => d != null), drawables =>
+            LoadComponentsAsync(items.Select(CreateDrawableItem).Where(d => d != null).Cast<Drawable>(), drawables =>
             {
                 missing.Hide();
 
@@ -144,7 +145,7 @@ namespace osu.Game.Overlays.Profile.Sections
                 moreButton.IsLoading = false;
 
                 ItemsContainer.AddRange(drawables);
-            }, loadCancellation.Token);
+            }, cancellationTokenSource.Token);
         });
 
         protected virtual int GetCount(APIUser user) => 0;
@@ -153,9 +154,9 @@ namespace osu.Game.Overlays.Profile.Sections
         {
         }
 
-        protected abstract APIRequest<List<TModel>> CreateRequest(PaginationParameters pagination);
+        protected abstract APIRequest<List<TModel>> CreateRequest(APIUser user, PaginationParameters pagination);
 
-        protected abstract Drawable CreateDrawableItem(TModel model);
+        protected abstract Drawable? CreateDrawableItem(TModel model);
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Game/Overlays/Profile/Sections/ProfileItemContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileItemContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileSubsection.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using JetBrains.Annotations;
 using osu.Framework.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 
@@ -15,14 +12,14 @@ namespace osu.Game.Overlays.Profile.Sections
 {
     public abstract partial class ProfileSubsection : FillFlowContainer
     {
-        protected readonly Bindable<APIUser> User = new Bindable<APIUser>();
+        protected readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
 
         private readonly LocalisableString headerText;
         private readonly CounterVisibilityState counterVisibilityState;
 
-        private ProfileSubsectionHeader header;
+        private ProfileSubsectionHeader header = null!;
 
-        protected ProfileSubsection(Bindable<APIUser> user, LocalisableString? headerText = null, CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
+        protected ProfileSubsection(Bindable<APIUser?> user, LocalisableString? headerText = null, CounterVisibilityState counterVisibilityState = CounterVisibilityState.AlwaysHidden)
         {
             this.headerText = headerText ?? string.Empty;
             this.counterVisibilityState = counterVisibilityState;
@@ -46,7 +43,6 @@ namespace osu.Game.Overlays.Profile.Sections
             };
         }
 
-        [NotNull]
         protected abstract Drawable CreateContent();
 
         protected void SetCount(int value) => header.Current.Value = value;

--- a/osu.Game/Overlays/Profile/Sections/ProfileSubsectionHeader.cs
+++ b/osu.Game/Overlays/Profile/Sections/ProfileSubsectionHeader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics;
@@ -30,7 +28,7 @@ namespace osu.Game.Overlays.Profile.Sections
         private readonly LocalisableString text;
         private readonly CounterVisibilityState counterState;
 
-        private CounterPill counterPill;
+        private CounterPill counterPill = null!;
 
         public ProfileSubsectionHeader(LocalisableString text, CounterVisibilityState counterState)
         {

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -34,10 +32,10 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
         protected readonly SoloScoreInfo Score;
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         public DrawableProfileScore(SoloScoreInfo score)
         {
@@ -84,7 +82,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                                         Spacing = new Vector2(0, 2),
                                         Children = new Drawable[]
                                         {
-                                            new ScoreBeatmapMetadataContainer(Score.Beatmap),
+                                            new ScoreBeatmapMetadataContainer(Score.Beatmap.AsNonNull()),
                                             new FillFlowContainer
                                             {
                                                 AutoSizeAxes = Axes.Both,
@@ -94,7 +92,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                                                 {
                                                     new OsuSpriteText
                                                     {
-                                                        Text = $"{Score.Beatmap?.DifficultyName}",
+                                                        Text = $"{Score.Beatmap.AsNonNull().DifficultyName}",
                                                         Font = OsuFont.GetFont(size: 12, weight: FontWeight.Regular),
                                                         Colour = colours.Yellow
                                                     },
@@ -199,7 +197,6 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             });
         }
 
-        [NotNull]
         protected virtual Drawable CreateRightContent() => CreateDrawableAccuracy();
 
         protected Drawable CreateDrawableAccuracy() => new Container

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileWeightedScore.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/PaginatedScoreContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.API.Requests;
 using System;
@@ -21,7 +19,7 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
     {
         private readonly ScoreType type;
 
-        public PaginatedScoreContainer(ScoreType type, Bindable<APIUser> user, LocalisableString headerText)
+        public PaginatedScoreContainer(ScoreType type, Bindable<APIUser?> user, LocalisableString headerText)
             : base(user, headerText)
         {
             this.type = type;
@@ -62,8 +60,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
             base.OnItemsReceived(items);
         }
 
-        protected override APIRequest<List<SoloScoreInfo>> CreateRequest(PaginationParameters pagination) =>
-            new GetUserScoresRequest(User.Value.Id, type, pagination);
+        protected override APIRequest<List<SoloScoreInfo>> CreateRequest(APIUser user, PaginationParameters pagination) =>
+            new GetUserScoresRequest(user.Id, type, pagination);
 
         private int drawableItemIndex;
 

--- a/osu.Game/Overlays/Profile/Sections/RanksSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RanksSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Overlays.Profile.Sections.Ranks;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Localisation;

--- a/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -24,14 +23,14 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         private const int font_size = 14;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private IRulesetStore rulesets { get; set; }
+        private IRulesetStore rulesets { get; set; } = null!;
 
         private readonly APIRecentActivity activity;
 
-        private LinkFlowContainer content;
+        private LinkFlowContainer content = null!;
 
         public DrawableRecentActivity(APIRecentActivity activity)
         {
@@ -216,15 +215,15 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
             rulesets.AvailableRulesets.FirstOrDefault(r => r.ShortName == activity.Mode)?.Name ?? activity.Mode;
 
         private void addUserLink()
-            => content.AddLink(activity.User?.Username, LinkAction.OpenUserProfile, getLinkArgument(activity.User?.Url), creationParameters: t => t.Font = getLinkFont(FontWeight.Bold));
+            => content.AddLink(activity.User.AsNonNull().Username, LinkAction.OpenUserProfile, getLinkArgument(activity.User.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont(FontWeight.Bold));
 
         private void addBeatmapLink()
-            => content.AddLink(activity.Beatmap?.Title, LinkAction.OpenBeatmap, getLinkArgument(activity.Beatmap?.Url), creationParameters: t => t.Font = getLinkFont());
+            => content.AddLink(activity.Beatmap.AsNonNull().Title, LinkAction.OpenBeatmap, getLinkArgument(activity.Beatmap.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont());
 
         private void addBeatmapsetLink()
-            => content.AddLink(activity.Beatmapset?.Title, LinkAction.OpenBeatmapSet, getLinkArgument(activity.Beatmapset?.Url), creationParameters: t => t.Font = getLinkFont());
+            => content.AddLink(activity.Beatmapset.AsNonNull().Title, LinkAction.OpenBeatmapSet, getLinkArgument(activity.Beatmapset.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont());
 
-        private string getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.WebsiteRootUrl}{url}").Argument.ToString();
+        private string getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.WebsiteRootUrl}{url}").Argument.ToString().AsNonNull();
 
         private FontUsage getLinkFont(FontWeight fontWeight = FontWeight.Regular)
             => OsuFont.GetFont(size: font_size, weight: fontWeight, italics: true);

--- a/osu.Game/Overlays/Profile/Sections/Recent/MedalIcon.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/MedalIcon.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/PaginatedRecentActivityContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Game.Online.API.Requests;
 using osu.Framework.Bindables;
@@ -18,7 +16,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
 {
     public partial class PaginatedRecentActivityContainer : PaginatedProfileSubsection<APIRecentActivity>
     {
-        public PaginatedRecentActivityContainer(Bindable<APIUser> user)
+        public PaginatedRecentActivityContainer(Bindable<APIUser?> user)
             : base(user, missingText: EventsStrings.Empty)
         {
         }
@@ -29,8 +27,8 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
             ItemsContainer.Spacing = new Vector2(0, 8);
         }
 
-        protected override APIRequest<List<APIRecentActivity>> CreateRequest(PaginationParameters pagination) =>
-            new GetUserRecentActivitiesRequest(User.Value.Id, pagination);
+        protected override APIRequest<List<APIRecentActivity>> CreateRequest(APIUser user, PaginationParameters pagination) =>
+            new GetUserRecentActivitiesRequest(user.Id, pagination);
 
         protected override Drawable CreateDrawableItem(APIRecentActivity model) => new DrawableRecentActivity(model);
     }

--- a/osu.Game/Overlays/Profile/Sections/RecentSection.cs
+++ b/osu.Game/Overlays/Profile/Sections/RecentSection.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Localisation;
 using osu.Game.Overlays.Profile.Sections.Recent;
 using osu.Game.Resources.Localisation.Web;

--- a/osu.Game/Overlays/Profile/UserGraph.cs
+++ b/osu.Game/Overlays/Profile/UserGraph.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -26,12 +23,12 @@ namespace osu.Game.Overlays.Profile
     /// </summary>
     /// <typeparam name="TKey">Type of data to be used for X-axis of the graph.</typeparam>
     /// <typeparam name="TValue">Type of data to be used for Y-axis of the graph.</typeparam>
-    public abstract partial class UserGraph<TKey, TValue> : Container, IHasCustomTooltip<UserGraphTooltipContent>
+    public abstract partial class UserGraph<TKey, TValue> : Container, IHasCustomTooltip<UserGraphTooltipContent?>
     {
         protected const float FADE_DURATION = 150;
 
         private readonly UserLineGraph graph;
-        private KeyValuePair<TKey, TValue>[] data;
+        private KeyValuePair<TKey, TValue>[]? data;
         private int hoveredIndex = -1;
 
         protected UserGraph()
@@ -83,8 +80,7 @@ namespace osu.Game.Overlays.Profile
         /// <summary>
         /// Set of values which will be used to create a graph.
         /// </summary>
-        [CanBeNull]
-        protected KeyValuePair<TKey, TValue>[] Data
+        protected KeyValuePair<TKey, TValue>[]? Data
         {
             set
             {
@@ -120,9 +116,9 @@ namespace osu.Game.Overlays.Profile
         protected virtual void ShowGraph() => graph.FadeIn(FADE_DURATION, Easing.Out);
         protected virtual void HideGraph() => graph.FadeOut(FADE_DURATION, Easing.Out);
 
-        public ITooltip<UserGraphTooltipContent> GetCustomTooltip() => new UserGraphTooltip();
+        public ITooltip<UserGraphTooltipContent?> GetCustomTooltip() => new UserGraphTooltip();
 
-        public UserGraphTooltipContent TooltipContent
+        public UserGraphTooltipContent? TooltipContent
         {
             get
             {
@@ -143,7 +139,7 @@ namespace osu.Game.Overlays.Profile
             private readonly Box ballBg;
             private readonly Box line;
 
-            public Action<int> OnBallMove;
+            public Action<int>? OnBallMove;
 
             public UserLineGraph()
             {
@@ -191,7 +187,7 @@ namespace osu.Game.Overlays.Profile
                 Vector2 position = calculateBallPosition(index);
                 movingBall.MoveToY(position.Y, duration, Easing.OutQuint);
                 bar.MoveToX(position.X, duration, Easing.OutQuint);
-                OnBallMove.Invoke(index);
+                OnBallMove?.Invoke(index);
             }
 
             public void ShowBar() => bar.FadeIn(FADE_DURATION);
@@ -207,7 +203,7 @@ namespace osu.Game.Overlays.Profile
             }
         }
 
-        private partial class UserGraphTooltip : VisibilityContainer, ITooltip<UserGraphTooltipContent>
+        private partial class UserGraphTooltip : VisibilityContainer, ITooltip<UserGraphTooltipContent?>
         {
             protected readonly OsuSpriteText Label, Counter, BottomText;
             private readonly Box background;
@@ -267,8 +263,11 @@ namespace osu.Game.Overlays.Profile
                 background.Colour = colours.Gray1;
             }
 
-            public void SetContent(UserGraphTooltipContent content)
+            public void SetContent(UserGraphTooltipContent? content)
             {
+                if (content == null)
+                    return;
+
                 Label.Text = content.Name;
                 Counter.Text = content.Count;
                 BottomText.Text = content.Time;

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -24,11 +23,11 @@ namespace osu.Game.Overlays
 {
     public partial class UserProfileOverlay : FullscreenOverlay<ProfileHeader>
     {
-        private ProfileSection lastSection;
-        private ProfileSection[] sections;
-        private GetUserRequest userReq;
-        private ProfileSectionsContainer sectionsContainer;
-        private ProfileSectionTabControl tabs;
+        private ProfileSection? lastSection;
+        private ProfileSection[]? sections;
+        private GetUserRequest? userReq;
+        private ProfileSectionsContainer? sectionsContainer;
+        private ProfileSectionTabControl? tabs;
 
         public const float CONTENT_X_MARGIN = 70;
 
@@ -133,6 +132,8 @@ namespace osu.Game.Overlays
 
         private void userLoadComplete(APIUser user)
         {
+            Debug.Assert(sections != null && sectionsContainer != null && tabs != null);
+
             Header.User.Value = user;
 
             if (user.ProfileOrder != null)

--- a/osu.Game/Users/UserCoverBackground.cs
+++ b/osu.Game/Users/UserCoverBackground.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -17,15 +15,15 @@ using osuTK.Graphics;
 
 namespace osu.Game.Users
 {
-    public partial class UserCoverBackground : ModelBackedDrawable<APIUser>
+    public partial class UserCoverBackground : ModelBackedDrawable<APIUser?>
     {
-        public APIUser User
+        public APIUser? User
         {
             get => Model;
             set => Model = value;
         }
 
-        protected override Drawable CreateDrawable(APIUser user) => new Cover(user);
+        protected override Drawable CreateDrawable(APIUser? user) => new Cover(user);
 
         protected override double LoadDelay => 300;
 
@@ -40,9 +38,9 @@ namespace osu.Game.Users
         [LongRunningLoad]
         private partial class Cover : CompositeDrawable
         {
-            private readonly APIUser user;
+            private readonly APIUser? user;
 
-            public Cover(APIUser user)
+            public Cover(APIUser? user)
             {
                 this.user = user;
 


### PR DESCRIPTION
This is the first of two preparatory PRs that I have before I can deliver #3606 (and then after that, a design update of the overlay to match web).

First of all I do apologise for the size of this and number of files touched but doing this any other way is kinda difficult. Most of the changes are menial, with a few exceptions that I will be annotating with self-review comments. I recommend reading those first before reading the rest as some of them will affect the other files too.

Normally I probably wouldn't bother but the next pull in sequence is going to end up touching almost all of these files too and I generally would like the assurances NRT when working on this overlay. The reasoning for this can be found in [this review comment](https://github.com/ppy/osu/issues/3606#issuecomment-1367395497) - basically everywhere there's an `Bindable<APIUser?>` in this pull, I next need a `Bindable<UserProfile?>`.