### PR TITLE
Fix editor exporting beatmap combo colours in wrong order

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -300,7 +300,7 @@ namespace osu.Game.Beatmaps.Formats
             {
                 var comboColour = colours[i];
 
-                writer.Write(FormattableString.Invariant($"Combo{i}: "));
+                writer.Write(FormattableString.Invariant($"Combo{1 + i}: "));
                 writer.Write(FormattableString.Invariant($"{(byte)(comboColour.R * byte.MaxValue)},"));
                 writer.Write(FormattableString.Invariant($"{(byte)(comboColour.G * byte.MaxValue)},"));
                 writer.Write(FormattableString.Invariant($"{(byte)(comboColour.B * byte.MaxValue)},"));


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21984

Stable reads combo colours starting from `Combo1`, meanwhile lazer is exporting the first combo colour as `Combo0`.