### PR TITLE
Fix catcher not moving when fully hidden with "No Scope" mod

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
@@ -19,6 +19,36 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
 
         [Test]
+        public void TestAlwaysHidden()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new CatchModNoScope
+                {
+                    HiddenComboCount = { Value = 0 },
+                },
+                Autoplay = true,
+                PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new Fruit
+                        {
+                            X = CatchPlayfield.CENTER_X * 0.5f,
+                            StartTime = 1000,
+                        },
+                        new Fruit
+                        {
+                            X = CatchPlayfield.CENTER_X * 1.5f,
+                            StartTime = 2000,
+                        }
+                    }
+                }
+            });
+        }
+
+        [Test]
         public void TestVisibleDuringBreak()
         {
             CreateModTest(new ModTestData

--- a/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Rulesets.Catch.Mods
             var catchPlayfield = (CatchPlayfield)playfield;
             bool shouldAlwaysShowCatcher = IsBreakTime.Value;
             float targetAlpha = shouldAlwaysShowCatcher ? 1 : ComboBasedAlpha;
+
+            // AlwaysPresent required for catcher to still act on input when fully hidden.
+            catchPlayfield.CatcherArea.AlwaysPresent = true;
             catchPlayfield.CatcherArea.Alpha = (float)Interpolation.Lerp(catchPlayfield.CatcherArea.Alpha, targetAlpha, Math.Clamp(catchPlayfield.Time.Elapsed / TRANSITION_DURATION, 0, 1));
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21987

Went with the path of least resistance here. Alternative way would be moving input handling from `CatcherArea` to `CatchPlayfield`, but I'm not willing to take on the risk of doing that just to fix a bug in the mod.