### PR TITLE
DDKK and KKDD support for osu!taiko touchscreen controls

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -13,6 +13,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osuTK;
 using osuTK.Graphics;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -45,8 +46,10 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Container should handle input everywhere.
             RelativeSizeAxes = Axes.Both;
 
-            const float centre_region = 0.80f;
+            const TaikoTouchControls touchControls = TaikoTouchControls.KKDD;
 
+            const float centre_region = 0.80f;
+            
             Children = new Drawable[]
             {
                 new Container
@@ -65,27 +68,51 @@ namespace osu.Game.Rulesets.Taiko.UI
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                leftRim = new QuarterCircle(TaikoAction.LeftCentre, colours.Pink)
+                                leftRim = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.LeftRim :
+                                                            touchControls == TaikoTouchControls.DDKK ? TaikoAction.LeftCentre :
+                                                          /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.LeftRim,
+
+                                                            touchControls == TaikoTouchControls.KDDK ? colours.Blue :
+                                                            touchControls == TaikoTouchControls.DDKK ? colours.Pink :
+                                                          /*touchControls == TaikoTouchControls.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                 },
-                                rightRim = new QuarterCircle(TaikoAction.RightRim, colours.Blue)
+                                rightRim = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.RightRim :
+                                                             touchControls == TaikoTouchControls.DDKK ? TaikoAction.RightRim :
+                                                           /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.RightCentre,
+
+                                                             touchControls == TaikoTouchControls.KDDK ? colours.Blue :
+                                                             touchControls == TaikoTouchControls.DDKK ? colours.Blue :
+                                                           /*touchControls == TaikoTouchControls.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = 2,
                                     Rotation = 90,
                                 },
-                                leftCentre = new QuarterCircle(TaikoAction.RightCentre, colours.Pink)
+                                leftCentre = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.LeftCentre :
+                                                               touchControls == TaikoTouchControls.DDKK ? TaikoAction.RightCentre :
+                                                             /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.RightRim,
+
+                                                               touchControls == TaikoTouchControls.KDDK ? colours.Pink :
+                                                               touchControls == TaikoTouchControls.DDKK ? colours.Pink :
+                                                             /*touchControls == TaikoTouchControls.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                     Scale = new Vector2(centre_region),
                                 },
-                                rightCentre = new QuarterCircle(TaikoAction.LeftRim, colours.Blue)
+                                rightCentre = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.RightCentre :
+                                                                touchControls == TaikoTouchControls.DDKK ? TaikoAction.LeftRim :
+                                                              /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.LeftCentre,
+
+                                                                touchControls == TaikoTouchControls.KDDK ? colours.Pink :
+                                                                touchControls == TaikoTouchControls.DDKK ? colours.Blue :
+                                                              /*touchControls == TaikoTouchControls.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
@@ -136,22 +163,34 @@ namespace osu.Game.Rulesets.Taiko.UI
             handleUp(e.Touch.Source);
             base.OnTouchUp(e);
         }
-        private TaikoAction KDDKtoDDKK(TaikoAction input) {
-            switch(input) {
-                case TaikoAction.LeftRim: return TaikoAction.LeftCentre;
-                case TaikoAction.LeftCentre: return TaikoAction.RightCentre;
-                case TaikoAction.RightCentre: return TaikoAction.LeftRim;
-              //case TaikoAction.RightRim: return TaikoAction.RightRim;
+        private TaikoAction convertInput(TaikoAction input, TaikoTouchControls controlType) {
+            switch(controlType) {
+                default:
+                    return input; // Using default controls; Nothing needs to be done
+                case TaikoTouchControls.DDKK:
+                    switch(input) {
+                        case TaikoAction.LeftRim: return TaikoAction.LeftCentre;
+                        case TaikoAction.LeftCentre: return TaikoAction.RightCentre;
+                        case TaikoAction.RightCentre: return TaikoAction.LeftRim;
+                      //case TaikoAction.RightRim: return TaikoAction.RightRim;
+                    }
+                    return TaikoAction.RightRim;
+                case TaikoTouchControls.KKDD:
+                    switch(input) {
+                        case TaikoAction.RightRim: return TaikoAction.RightCentre;
+                        case TaikoAction.LeftCentre: return TaikoAction.RightRim;
+                        case TaikoAction.RightCentre: return TaikoAction.LeftCentre;
+                      //case TaikoAction.LeftRim: return TaikoAction.LeftRim;
+                    }
+                    return TaikoAction.LeftRim;
             }
-            return TaikoAction.RightRim;
-            
         }
         private void handleDown(object source, Vector2 position)
         {
             Show();
 
-            TaikoAction taikoAction = KDDKtoDDKK(getTaikoActionFromInput(position));
-            
+            TaikoAction taikoAction = convertInput(getTaikoActionFromInput(position), TaikoTouchControls.KKDD);
+
             // Not too sure how this can happen, but let's avoid throwing.
             if (trackedActions.ContainsKey(source))
                 return;

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Framework.Allocation;
@@ -14,6 +16,7 @@ using osu.Game.Graphics;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Configuration;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
@@ -37,8 +40,10 @@ namespace osu.Game.Rulesets.Taiko.UI
         private QuarterCircle leftRim = null!;
         private QuarterCircle rightRim = null!;
 
+        private Bindable<TaikoTouchControlType> touchControlsType;
+
         [BackgroundDependencyLoader]
-        private void load(TaikoInputManager taikoInputManager, OsuColour colours)
+        private void load(TaikoInputManager taikoInputManager, OsuColour colours, OsuConfigManager config)
         {
             Debug.Assert(taikoInputManager.KeyBindingContainer != null);
             keyBindingContainer = taikoInputManager.KeyBindingContainer;
@@ -46,7 +51,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Container should handle input everywhere.
             RelativeSizeAxes = Axes.Both;
 
-            const TaikoTouchControlType touchControls = TaikoTouchControlType.KKDD;
+            touchControlsType = config.GetBindable<TaikoTouchControlType>(OsuSetting.TaikoTouchControlType);
 
             const float centre_region = 0.80f;
             
@@ -68,51 +73,51 @@ namespace osu.Game.Rulesets.Taiko.UI
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                leftRim = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.LeftRim :
-                                                            touchControls == TaikoTouchControlType.DDKK ? TaikoAction.LeftCentre :
-                                                          /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.LeftRim,
+                                leftRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.LeftRim :
+                                                            touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.LeftCentre :
+                                                          /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.LeftRim,
 
-                                                            touchControls == TaikoTouchControlType.KDDK ? colours.Blue :
-                                                            touchControls == TaikoTouchControlType.DDKK ? colours.Pink :
-                                                          /*touchControls == TaikoTouchControlType.KKDD*/ colours.Blue)
+                                                            touchControlsType.Value == TaikoTouchControlType.Default ? colours.Blue :
+                                                            touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Pink :
+                                                          /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                 },
-                                rightRim = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.RightRim :
-                                                             touchControls == TaikoTouchControlType.DDKK ? TaikoAction.RightRim :
-                                                           /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.RightCentre,
+                                rightRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.RightRim :
+                                                             touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.RightRim :
+                                                           /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.RightCentre,
 
-                                                             touchControls == TaikoTouchControlType.KDDK ? colours.Blue :
-                                                             touchControls == TaikoTouchControlType.DDKK ? colours.Blue :
-                                                           /*touchControls == TaikoTouchControlType.KKDD*/ colours.Pink)
+                                                             touchControlsType.Value == TaikoTouchControlType.Default ? colours.Blue :
+                                                             touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Blue :
+                                                           /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = 2,
                                     Rotation = 90,
                                 },
-                                leftCentre = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.LeftCentre :
-                                                               touchControls == TaikoTouchControlType.DDKK ? TaikoAction.RightCentre :
-                                                             /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.RightRim,
+                                leftCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.LeftCentre :
+                                                               touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.RightCentre :
+                                                             /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.RightRim,
 
-                                                               touchControls == TaikoTouchControlType.KDDK ? colours.Pink :
-                                                               touchControls == TaikoTouchControlType.DDKK ? colours.Pink :
-                                                             /*touchControls == TaikoTouchControlType.KKDD*/ colours.Blue)
+                                                               touchControlsType.Value == TaikoTouchControlType.Default ? colours.Pink :
+                                                               touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Pink :
+                                                             /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                     Scale = new Vector2(centre_region),
                                 },
-                                rightCentre = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.RightCentre :
-                                                                touchControls == TaikoTouchControlType.DDKK ? TaikoAction.LeftRim :
-                                                              /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.LeftCentre,
+                                rightCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.RightCentre :
+                                                                touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.LeftRim :
+                                                              /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.LeftCentre,
 
-                                                                touchControls == TaikoTouchControlType.KDDK ? colours.Pink :
-                                                                touchControls == TaikoTouchControlType.DDKK ? colours.Blue :
-                                                              /*touchControls == TaikoTouchControlType.KKDD*/ colours.Pink)
+                                                                touchControlsType.Value == TaikoTouchControlType.Default ? colours.Pink :
+                                                                touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Blue :
+                                                              /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
@@ -189,7 +194,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             Show();
 
-            TaikoAction taikoAction = convertInput(getTaikoActionFromInput(position), TaikoTouchControlType.KKDD);
+            TaikoAction taikoAction = convertInput(getTaikoActionFromInput(position), touchControlsType.Value);
 
             // Not too sure how this can happen, but let's avoid throwing.
             if (trackedActions.ContainsKey(source))

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Container should handle input everywhere.
             RelativeSizeAxes = Axes.Both;
 
-            const TaikoTouchControls touchControls = TaikoTouchControls.KKDD;
+            const TaikoTouchControlType touchControls = TaikoTouchControlType.KKDD;
 
             const float centre_region = 0.80f;
             
@@ -68,51 +68,51 @@ namespace osu.Game.Rulesets.Taiko.UI
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                leftRim = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.LeftRim :
-                                                            touchControls == TaikoTouchControls.DDKK ? TaikoAction.LeftCentre :
-                                                          /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.LeftRim,
+                                leftRim = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.LeftRim :
+                                                            touchControls == TaikoTouchControlType.DDKK ? TaikoAction.LeftCentre :
+                                                          /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.LeftRim,
 
-                                                            touchControls == TaikoTouchControls.KDDK ? colours.Blue :
-                                                            touchControls == TaikoTouchControls.DDKK ? colours.Pink :
-                                                          /*touchControls == TaikoTouchControls.KKDD*/ colours.Blue)
+                                                            touchControls == TaikoTouchControlType.KDDK ? colours.Blue :
+                                                            touchControls == TaikoTouchControlType.DDKK ? colours.Pink :
+                                                          /*touchControls == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                 },
-                                rightRim = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.RightRim :
-                                                             touchControls == TaikoTouchControls.DDKK ? TaikoAction.RightRim :
-                                                           /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.RightCentre,
+                                rightRim = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.RightRim :
+                                                             touchControls == TaikoTouchControlType.DDKK ? TaikoAction.RightRim :
+                                                           /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.RightCentre,
 
-                                                             touchControls == TaikoTouchControls.KDDK ? colours.Blue :
-                                                             touchControls == TaikoTouchControls.DDKK ? colours.Blue :
-                                                           /*touchControls == TaikoTouchControls.KKDD*/ colours.Pink)
+                                                             touchControls == TaikoTouchControlType.KDDK ? colours.Blue :
+                                                             touchControls == TaikoTouchControlType.DDKK ? colours.Blue :
+                                                           /*touchControls == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = 2,
                                     Rotation = 90,
                                 },
-                                leftCentre = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.LeftCentre :
-                                                               touchControls == TaikoTouchControls.DDKK ? TaikoAction.RightCentre :
-                                                             /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.RightRim,
+                                leftCentre = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.LeftCentre :
+                                                               touchControls == TaikoTouchControlType.DDKK ? TaikoAction.RightCentre :
+                                                             /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.RightRim,
 
-                                                               touchControls == TaikoTouchControls.KDDK ? colours.Pink :
-                                                               touchControls == TaikoTouchControls.DDKK ? colours.Pink :
-                                                             /*touchControls == TaikoTouchControls.KKDD*/ colours.Blue)
+                                                               touchControls == TaikoTouchControlType.KDDK ? colours.Pink :
+                                                               touchControls == TaikoTouchControlType.DDKK ? colours.Pink :
+                                                             /*touchControls == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                     Scale = new Vector2(centre_region),
                                 },
-                                rightCentre = new QuarterCircle(touchControls == TaikoTouchControls.KDDK ? TaikoAction.RightCentre :
-                                                                touchControls == TaikoTouchControls.DDKK ? TaikoAction.LeftRim :
-                                                              /*touchControls == TaikoTouchControls.KKDD*/ TaikoAction.LeftCentre,
+                                rightCentre = new QuarterCircle(touchControls == TaikoTouchControlType.KDDK ? TaikoAction.RightCentre :
+                                                                touchControls == TaikoTouchControlType.DDKK ? TaikoAction.LeftRim :
+                                                              /*touchControls == TaikoTouchControlType.KKDD*/ TaikoAction.LeftCentre,
 
-                                                                touchControls == TaikoTouchControls.KDDK ? colours.Pink :
-                                                                touchControls == TaikoTouchControls.DDKK ? colours.Blue :
-                                                              /*touchControls == TaikoTouchControls.KKDD*/ colours.Pink)
+                                                                touchControls == TaikoTouchControlType.KDDK ? colours.Pink :
+                                                                touchControls == TaikoTouchControlType.DDKK ? colours.Blue :
+                                                              /*touchControls == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
@@ -163,11 +163,11 @@ namespace osu.Game.Rulesets.Taiko.UI
             handleUp(e.Touch.Source);
             base.OnTouchUp(e);
         }
-        private TaikoAction convertInput(TaikoAction input, TaikoTouchControls controlType) {
+        private TaikoAction convertInput(TaikoAction input, TaikoTouchControlType controlType) {
             switch(controlType) {
                 default:
                     return input; // Using default controls; Nothing needs to be done
-                case TaikoTouchControls.DDKK:
+                case TaikoTouchControlType.DDKK:
                     switch(input) {
                         case TaikoAction.LeftRim: return TaikoAction.LeftCentre;
                         case TaikoAction.LeftCentre: return TaikoAction.RightCentre;
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                       //case TaikoAction.RightRim: return TaikoAction.RightRim;
                     }
                     return TaikoAction.RightRim;
-                case TaikoTouchControls.KKDD:
+                case TaikoTouchControlType.KKDD:
                     switch(input) {
                         case TaikoAction.RightRim: return TaikoAction.RightCentre;
                         case TaikoAction.LeftCentre: return TaikoAction.RightRim;
@@ -189,7 +189,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             Show();
 
-            TaikoAction taikoAction = convertInput(getTaikoActionFromInput(position), TaikoTouchControls.KKDD);
+            TaikoAction taikoAction = convertInput(getTaikoActionFromInput(position), TaikoTouchControlType.KKDD);
 
             // Not too sure how this can happen, but let's avoid throwing.
             if (trackedActions.ContainsKey(source))

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                leftRim = new QuarterCircle(TaikoAction.LeftRim, colours.Blue)
+                                leftRim = new QuarterCircle(TaikoAction.LeftCentre, colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
@@ -78,14 +78,14 @@ namespace osu.Game.Rulesets.Taiko.UI
                                     X = 2,
                                     Rotation = 90,
                                 },
-                                leftCentre = new QuarterCircle(TaikoAction.LeftCentre, colours.Pink)
+                                leftCentre = new QuarterCircle(TaikoAction.RightCentre, colours.Pink)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                     Scale = new Vector2(centre_region),
                                 },
-                                rightCentre = new QuarterCircle(TaikoAction.RightCentre, colours.Pink)
+                                rightCentre = new QuarterCircle(TaikoAction.LeftRim, colours.Blue)
                                 {
                                     Anchor = Anchor.BottomCentre,
                                     Origin = Anchor.BottomRight,
@@ -136,13 +136,22 @@ namespace osu.Game.Rulesets.Taiko.UI
             handleUp(e.Touch.Source);
             base.OnTouchUp(e);
         }
-
+        private TaikoAction KDDKtoDDKK(TaikoAction input) {
+            switch(input) {
+                case TaikoAction.LeftRim: return TaikoAction.LeftCentre;
+                case TaikoAction.LeftCentre: return TaikoAction.RightCentre;
+                case TaikoAction.RightCentre: return TaikoAction.LeftRim;
+              //case TaikoAction.RightRim: return TaikoAction.RightRim;
+            }
+            return TaikoAction.RightRim;
+            
+        }
         private void handleDown(object source, Vector2 position)
         {
             Show();
 
-            TaikoAction taikoAction = getTaikoActionFromInput(position);
-
+            TaikoAction taikoAction = KDDKtoDDKK(getTaikoActionFromInput(position));
+            
             // Not too sure how this can happen, but let's avoid throwing.
             if (trackedActions.ContainsKey(source))
                 return;

--- a/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumTouchInputArea.cs
@@ -73,11 +73,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                leftRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.LeftRim :
+                                leftRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.KDDK ? TaikoAction.LeftRim :
                                                             touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.LeftCentre :
                                                           /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.LeftRim,
 
-                                                            touchControlsType.Value == TaikoTouchControlType.Default ? colours.Blue :
+                                                            touchControlsType.Value == TaikoTouchControlType.KDDK ? colours.Blue :
                                                             touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Pink :
                                                           /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
@@ -85,11 +85,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                                     Origin = Anchor.BottomRight,
                                     X = -2,
                                 },
-                                rightRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.RightRim :
+                                rightRim = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.KDDK ? TaikoAction.RightRim :
                                                              touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.RightRim :
                                                            /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.RightCentre,
 
-                                                             touchControlsType.Value == TaikoTouchControlType.Default ? colours.Blue :
+                                                             touchControlsType.Value == TaikoTouchControlType.KDDK ? colours.Blue :
                                                              touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Blue :
                                                            /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {
@@ -98,11 +98,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                                     X = 2,
                                     Rotation = 90,
                                 },
-                                leftCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.LeftCentre :
+                                leftCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.KDDK ? TaikoAction.LeftCentre :
                                                                touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.RightCentre :
                                                              /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.RightRim,
 
-                                                               touchControlsType.Value == TaikoTouchControlType.Default ? colours.Pink :
+                                                               touchControlsType.Value == TaikoTouchControlType.KDDK ? colours.Pink :
                                                                touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Pink :
                                                              /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Blue)
                                 {
@@ -111,11 +111,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                                     X = -2,
                                     Scale = new Vector2(centre_region),
                                 },
-                                rightCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.Default ? TaikoAction.RightCentre :
+                                rightCentre = new QuarterCircle(touchControlsType.Value == TaikoTouchControlType.KDDK ? TaikoAction.RightCentre :
                                                                 touchControlsType.Value == TaikoTouchControlType.DDKK ? TaikoAction.LeftRim :
                                                               /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ TaikoAction.LeftCentre,
 
-                                                                touchControlsType.Value == TaikoTouchControlType.Default ? colours.Pink :
+                                                                touchControlsType.Value == TaikoTouchControlType.KDDK ? colours.Pink :
                                                                 touchControlsType.Value == TaikoTouchControlType.DDKK ? colours.Blue :
                                                               /*touchControlsType.Value == TaikoTouchControlType.KKDD*/ colours.Pink)
                                 {

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.MouseDisableButtons, false);
             SetDefault(OsuSetting.MouseDisableWheel, false);
             SetDefault(OsuSetting.ConfineMouseMode, OsuConfineMouseMode.DuringGameplay);
-            SetDefault(OsuSetting.TaikoTouchControlType, TaikoTouchControlType.Default);
+            SetDefault(OsuSetting.TaikoTouchControlType, TaikoTouchControlType.KDDK);
 
             // Graphics
             SetDefault(OsuSetting.ShowFpsDisplay, false);

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -101,6 +101,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.MouseDisableButtons, false);
             SetDefault(OsuSetting.MouseDisableWheel, false);
             SetDefault(OsuSetting.ConfineMouseMode, OsuConfineMouseMode.DuringGameplay);
+            SetDefault(OsuSetting.TaikoTouchControlType, TaikoTouchControlType.Default);
 
             // Graphics
             SetDefault(OsuSetting.ShowFpsDisplay, false);
@@ -375,5 +376,6 @@ namespace osu.Game.Configuration
         LastProcessedMetadataId,
         SafeAreaConsiderations,
         ComboColourNormalisationAmount,
+        TaikoTouchControlType,
     }
 }

--- a/osu.Game/Configuration/TaikoTouchControlType.cs
+++ b/osu.Game/Configuration/TaikoTouchControlType.cs
@@ -5,7 +5,7 @@
 
 namespace osu.Game.Configuration
 {
-    public enum TaikoTouchControls
+    public enum TaikoTouchControlType
     {
         KDDK,
         DDKK,

--- a/osu.Game/Configuration/TaikoTouchControlType.cs
+++ b/osu.Game/Configuration/TaikoTouchControlType.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Configuration
 {
     public enum TaikoTouchControlType
     {
-        KDDK,
+        Default, // KDDK
         DDKK,
         KKDD
     }

--- a/osu.Game/Configuration/TaikoTouchControlType.cs
+++ b/osu.Game/Configuration/TaikoTouchControlType.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Configuration
 {
     public enum TaikoTouchControlType
     {
-        Default, // KDDK
+        KDDK,
         DDKK,
         KKDD
     }

--- a/osu.Game/Configuration/TaikoTouchControls.cs
+++ b/osu.Game/Configuration/TaikoTouchControls.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+namespace osu.Game.Configuration
+{
+    public enum TaikoTouchControls
+    {
+        KDDK,
+        DDKK,
+        KKDD
+    }
+}

--- a/osu.Game/Localisation/InputSettingsStrings.cs
+++ b/osu.Game/Localisation/InputSettingsStrings.cs
@@ -59,6 +59,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString KeyBindingPanelDescription => new TranslatableString(getKey(@"key_binding_panel_description"), @"Customise your keys!");
 
+        /// <summary>
+        /// "Taiko touch control type"
+        /// </summary>
+        public static LocalisableString TaikoTouchControlType => new TranslatableString(getKey(@"taiko_touch_control_type"), @"Taiko touch control type");
+
         private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -11,6 +11,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings.Sections.Input;
+using osu.Game.Configuration;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
@@ -47,6 +48,7 @@ namespace osu.Game.Overlays.Settings.Sections
             }
         }
 
+
         public partial class HandlerSection : SettingsSubsection
         {
             private readonly InputHandler handler;
@@ -57,7 +59,7 @@ namespace osu.Game.Overlays.Settings.Sections
             }
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(OsuConfigManager osuConfig)
             {
                 Children = new Drawable[]
                 {
@@ -65,6 +67,11 @@ namespace osu.Game.Overlays.Settings.Sections
                     {
                         LabelText = CommonStrings.Enabled,
                         Current = handler.Enabled
+                    },
+                    new SettingsEnumDropdown<TaikoTouchControlType>
+                    {
+                        LabelText = InputSettingsStrings.TaikoTouchControlType,
+                        Current = osuConfig.GetBindable<TaikoTouchControlType>(OsuSetting.TaikoTouchControlType)
                     },
                 };
             }

--- a/osu.Game/Overlays/Settings/Sections/InputSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/InputSection.cs
@@ -48,7 +48,6 @@ namespace osu.Game.Overlays.Settings.Sections
             }
         }
 
-
         public partial class HandlerSection : SettingsSubsection
         {
             private readonly InputHandler handler;


### PR DESCRIPTION
Adds a new dropdown in the Input Settings that allows you to choose between "Default", "DDKK", and "KKDD" control schemes for playing osu!taiko on a touch screen device (This was changed in a subsequent commit to "KDDK", "DDKK", and "KKDD")

![image](https://user-images.githubusercontent.com/48618519/210382559-8e570102-8c46-4316-a579-0d208904ef69.png)

As someone who plays DDKK, playing osu!taiko on my phone was quite uncomfortable with touch controls, so I wanted this to be added to the game

Here is a video demonstrating my additions (excuse the gameplay, playing touch screen controls with a mouse is hard):
https://streamable.com/vofv7e

This is my first time contributing to osu!, so please be kind ^^;

Please let me know if I did anything I wasn't supposed to with the codebase, or if there is anything that needs to be changed; I tried my best to follow the rest of the codebase as a template