### PR TITLE
Fix playlist items having a random selected state after deleting and not animating when rearranging

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsRoomSettingsPlaylist.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -46,10 +47,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("item removed", () => !playlist.Items.Contains(selectedItem));
         }
 
-        [Test]
-        public void TestNextItemSelectedAfterDeletion()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestNextItemSelectedAfterDeletion(bool allowSelection)
         {
-            createPlaylist();
+            createPlaylist(p =>
+            {
+                p.AllowSelection = allowSelection;
+            });
 
             moveToItem(0);
             AddStep("click", () => InputManager.Click(MouseButton.Left));
@@ -57,7 +62,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             moveToDeleteButton(0);
             AddStep("click delete button", () => InputManager.Click(MouseButton.Left));
 
-            AddAssert("item 0 is selected", () => playlist.SelectedItem.Value == playlist.Items[0]);
+            AddAssert("item 0 is " + (allowSelection ? "selected" : "not selected"), () => playlist.SelectedItem.Value == (allowSelection ? playlist.Items[0] : null));
         }
 
         [Test]
@@ -117,7 +122,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             InputManager.MoveMouseTo(item.ChildrenOfType<DrawableRoomPlaylistItem.PlaylistRemoveButton>().ElementAt(0), offset);
         });
 
-        private void createPlaylist()
+        private void createPlaylist(Action<TestPlaylist> setupPlaylist = null)
         {
             AddStep("create playlist", () =>
             {
@@ -154,6 +159,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         }
                     });
                 }
+
+                setupPlaylist?.Invoke(playlist);
             });
 
             AddUntilStep("wait for items to load", () => playlist.ItemMap.Values.All(i => i.IsLoaded));

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -156,6 +156,8 @@ namespace osu.Game.Screens.OnlinePlay
 
         protected override FillFlowContainer<RearrangeableListItem<PlaylistItem>> CreateListFillFlowContainer() => new FillFlowContainer<RearrangeableListItem<PlaylistItem>>
         {
+            LayoutDuration = 200,
+            LayoutEasing = Easing.OutQuint,
             Spacing = new Vector2(0, 2)
         };
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsPlaylist.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
                 Items.Remove(item);
 
-                SelectedItem.Value = nextItem ?? Items.LastOrDefault();
+                if (AllowSelection && SelectedItem.Value == item)
+                    SelectedItem.Value = nextItem ?? Items.LastOrDefault();
             };
         }
     }


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/18549

Regressed in https://github.com/ppy/osu/commit/beb5d61a42cc69841cfdbb1c8de0cc36d5973535 and https://github.com/ppy/osu/commit/8e014ca17ad6bab674db6076e5c0c2bb0eee3c19. The first commit didn't add back the `AllowSelection` check. The second commit was doing some reversing on the fill flow and removed the animation, but was localized to multiplayer in https://github.com/ppy/osu/commit/c38537a51ab1a0e313ee0ed3b73d990c726ff214 so the animation can be added to playlists again.

| Before | After |
| --- | --- |
| See issue | ![Kapture 2023-01-03 at 11 16 33](https://user-images.githubusercontent.com/35318437/210425944-6f811f5c-677e-4e23-a1ef-d0232771a456.gif) |
