### PR TITLE
Tint "argon" slider ball with combo colour

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
@@ -1,33 +1,62 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public partial class ArgonFollowCircle : FollowCircle
     {
+        private readonly CircularContainer circleContainer;
+        private readonly Box circleFill;
+
+        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+
+        [Resolved(canBeNull: true)]
+        private DrawableHitObject? parentObject { get; set; }
+
         public ArgonFollowCircle()
         {
-            InternalChild = new CircularContainer
+            InternalChild = circleContainer = new CircularContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
                 BorderThickness = 4,
-                BorderColour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
                 Blending = BlendingParameters.Additive,
-                Child = new Box
+                Child = circleFill = new Box
                 {
-                    Colour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
                     RelativeSizeAxes = Axes.Both,
                     Alpha = 0.3f,
                 }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (parentObject != null)
+                accentColour.BindTo(parentObject.AccentColour);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            accentColour.BindValueChanged(colour =>
+            {
+                circleContainer.BorderColour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.5f));
+                circleFill.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.5f));
+            }, true);
         }
 
         protected override void OnSliderPress()

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderBall.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -21,6 +23,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         private readonly Vector2 defaultIconScale = new Vector2(0.6f, 0.8f);
 
+        private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
+
         [Resolved(canBeNull: true)]
         private DrawableHitObject? parentObject { get; set; }
 
@@ -37,7 +41,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             {
                 fill = new Box
                 {
-                    Colour = ColourInfo.GradientVertical(Colour4.FromHex("FC618F"), Colour4.FromHex("BB1A41")),
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -53,9 +56,21 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             };
         }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (parentObject != null)
+                accentColour.BindTo(parentObject.AccentColour);
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            accentColour.BindValueChanged(colour =>
+            {
+                fill.Colour = ColourInfo.GradientVertical(colour.NewValue, colour.NewValue.Darken(0.5f));
+            }, true);
 
             if (parentObject != null)
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21986

I've initially only tinted the slider ball, but mixing it with the follow circle colour gave a bit of a weird look due to the additive layer:

https://user-images.githubusercontent.com/22781491/210564725-64e79521-4b19-49e9-88f6-3ae06d481f17.mp4

So I've went ahead and tinted the follow circle as well (https://github.com/ppy/osu/commit/760b2d98df1908064a89b54cffcec2befecff943), thus resulting in the following:

https://user-images.githubusercontent.com/22781491/210564834-f438bc6d-9a86-4f5c-aa6a-b6b77ebb8a42.mp4

I think it looks better, but I'm not confident on the feel of it. Maybe it would be better having the follow circle lighter to distinguish from the slider ball, not sure.