### PR TITLE
Change advanced statistics display to calculate difficulty via bindables

### DIFF
--- a/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
+++ b/osu.Game.Tests/Beatmaps/TestSceneBeatmapDifficultyCache.cs
@@ -32,7 +32,8 @@ namespace osu.Game.Tests.Beatmaps
 
         private TestBeatmapDifficultyCache difficultyCache;
 
-        private IBindable<StarDifficulty?> starDifficultyBindable;
+        private IBindable<StarDifficulty?> normalStarDifficultyBindable;
+        private IBindable<StarDifficulty?> moddedStarDifficultyBindable;
 
         [BackgroundDependencyLoader]
         private void load(OsuGameBase osu)
@@ -49,10 +50,12 @@ namespace osu.Game.Tests.Beatmaps
 
                 Child = difficultyCache = new TestBeatmapDifficultyCache();
 
-                starDifficultyBindable = difficultyCache.GetBindableDifficulty(importedSet.Beatmaps.First());
+                normalStarDifficultyBindable = difficultyCache.GetBindableDifficulty(importedSet.Beatmaps.First(), false);
+                moddedStarDifficultyBindable = difficultyCache.GetBindableDifficulty(importedSet.Beatmaps.First());
             });
 
-            AddUntilStep($"star difficulty -> {BASE_STARS}", () => starDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS);
         }
 
         [Test]
@@ -67,13 +70,16 @@ namespace osu.Game.Tests.Beatmaps
             });
 
             AddStep("change selected mod to DT", () => SelectedMods.Value = new[] { dt = new OsuModDoubleTime { SpeedChange = { Value = 1.5 } } });
-            AddUntilStep($"star difficulty -> {BASE_STARS + 1.5}", () => starDifficultyBindable.Value?.Stars == BASE_STARS + 1.5);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS + 1.5}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS + 1.5);
 
             AddStep("change DT speed to 1.25", () => dt.SpeedChange.Value = 1.25);
-            AddUntilStep($"star difficulty -> {BASE_STARS + 1.25}", () => starDifficultyBindable.Value?.Stars == BASE_STARS + 1.25);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS + 1.25}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS + 1.25);
 
             AddStep("change selected mod to NC", () => SelectedMods.Value = new[] { new OsuModNightcore { SpeedChange = { Value = 1.75 } } });
-            AddUntilStep($"star difficulty -> {BASE_STARS + 1.75}", () => starDifficultyBindable.Value?.Stars == BASE_STARS + 1.75);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS + 1.75}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS + 1.75);
         }
 
         [Test]
@@ -88,15 +94,17 @@ namespace osu.Game.Tests.Beatmaps
             });
 
             AddStep("change selected mod to DA", () => SelectedMods.Value = new[] { difficultyAdjust = new OsuModDifficultyAdjust() });
-            AddUntilStep($"star difficulty -> {BASE_STARS}", () => starDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS);
 
             AddStep("change DA difficulty to 0.5", () => difficultyAdjust.OverallDifficulty.Value = 0.5f);
-            AddUntilStep($"star difficulty -> {BASE_STARS * 0.5f}", () => starDifficultyBindable.Value?.Stars == BASE_STARS / 2);
+            AddUntilStep($"normal star difficulty = {BASE_STARS}", () => normalStarDifficultyBindable.Value?.Stars == BASE_STARS);
+            AddUntilStep($"modded star difficulty = {BASE_STARS * 0.5f}", () => moddedStarDifficultyBindable.Value?.Stars == BASE_STARS / 2);
 
             // hash code of 0 (the value) conflicts with the hash code of null (the initial/default value).
             // it's important that the mod reference and its underlying bindable references stay the same to demonstrate this failure.
             AddStep("change DA difficulty to 0", () => difficultyAdjust.OverallDifficulty.Value = 0);
-            AddUntilStep("star difficulty -> 0", () => starDifficultyBindable.Value?.Stars == 0);
+            AddUntilStep("modded star difficulty = 0", () => moddedStarDifficultyBindable.Value?.Stars == 0);
         }
 
         [Test]

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Beatmaps
             public BindableStarDifficulty(IBeatmapInfo beatmapInfo, bool applyMods, CancellationToken cancellationToken)
             {
                 BeatmapInfo = beatmapInfo;
-                this.ApplyMods = applyMods;
+                ApplyMods = applyMods;
                 CancellationToken = cancellationToken;
             }
         }

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -87,10 +87,10 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Retrieves a bindable containing the star difficulty of a <see cref="BeatmapInfo"/> that follows the currently-selected ruleset, and mods if <paramref name="applyMods"/> is <c>true</c>.
+        /// Retrieves a bindable containing the star difficulty of a <see cref="BeatmapInfo"/> that follows the currently-selected ruleset, along with mods if <paramref name="applyMods"/> is <c>true</c>.
         /// </summary>
         /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to get the difficulty of.</param>
-        /// <param name="applyMods">Whether mods should be applied in the star difficulty calculation.</param>
+        /// <param name="applyMods">Whether the currently-selected mods should be applied to the star difficulty calculation in this bindable.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops updating the star difficulty for the given <see cref="BeatmapInfo"/>.</param>
         /// <returns>A bindable that is updated to contain the star difficulty when it becomes available. Will be null while in an initial calculating state (but not during updates to ruleset and mods if a stale value is already propagated).</returns>
         public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, bool applyMods = true, CancellationToken cancellationToken = default)

--- a/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficultyCache.cs
@@ -87,14 +87,15 @@ namespace osu.Game.Beatmaps
         }
 
         /// <summary>
-        /// Retrieves a bindable containing the star difficulty of a <see cref="BeatmapInfo"/> that follows the currently-selected ruleset and mods.
+        /// Retrieves a bindable containing the star difficulty of a <see cref="BeatmapInfo"/> that follows the currently-selected ruleset, and mods if <paramref name="applyMods"/> is <c>true</c>.
         /// </summary>
         /// <param name="beatmapInfo">The <see cref="BeatmapInfo"/> to get the difficulty of.</param>
+        /// <param name="applyMods">Whether mods should be applied in the star difficulty calculation.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> which stops updating the star difficulty for the given <see cref="BeatmapInfo"/>.</param>
         /// <returns>A bindable that is updated to contain the star difficulty when it becomes available. Will be null while in an initial calculating state (but not during updates to ruleset and mods if a stale value is already propagated).</returns>
-        public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, CancellationToken cancellationToken = default)
+        public IBindable<StarDifficulty?> GetBindableDifficulty(IBeatmapInfo beatmapInfo, bool applyMods = true, CancellationToken cancellationToken = default)
         {
-            var bindable = new BindableStarDifficulty(beatmapInfo, cancellationToken);
+            var bindable = new BindableStarDifficulty(beatmapInfo, applyMods, cancellationToken);
 
             updateBindable(bindable, currentRuleset.Value, currentMods.Value, cancellationToken);
 
@@ -203,7 +204,7 @@ namespace osu.Game.Beatmaps
         {
             // GetDifficultyAsync will fall back to existing data from IBeatmapInfo if not locally available
             // (contrary to GetAsync)
-            GetDifficultyAsync(bindable.BeatmapInfo, rulesetInfo, mods, cancellationToken)
+            GetDifficultyAsync(bindable.BeatmapInfo, rulesetInfo, bindable.ApplyMods ? mods : null, cancellationToken)
                 .ContinueWith(task =>
                 {
                     // We're on a threadpool thread, but we should exit back to the update thread so consumers can safely handle value-changed events.
@@ -309,11 +310,14 @@ namespace osu.Game.Beatmaps
         private class BindableStarDifficulty : Bindable<StarDifficulty?>
         {
             public readonly IBeatmapInfo BeatmapInfo;
+            public readonly bool ApplyMods;
+
             public readonly CancellationToken CancellationToken;
 
-            public BindableStarDifficulty(IBeatmapInfo beatmapInfo, CancellationToken cancellationToken)
+            public BindableStarDifficulty(IBeatmapInfo beatmapInfo, bool applyMods, CancellationToken cancellationToken)
             {
                 BeatmapInfo = beatmapInfo;
+                this.ApplyMods = applyMods;
                 CancellationToken = cancellationToken;
             }
         }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.Select
                     difficultyColourBar.Colour = colours.ForStarDifficulty(s.NewValue);
                 }, true);
 
-                starDifficulty = difficultyCache.GetBindableDifficulty(working.BeatmapInfo, (cancellationSource = new CancellationTokenSource()).Token);
+                starDifficulty = difficultyCache.GetBindableDifficulty(working.BeatmapInfo, cancellationToken: (cancellationSource = new CancellationTokenSource()).Token);
                 starDifficulty.BindValueChanged(s =>
                 {
                     starRatingDisplay.Current.Value = s.NewValue ?? default;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -211,7 +211,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (Item.State.Value != CarouselItemState.Collapsed)
             {
                 // We've potentially cancelled the computation above so a new bindable is required.
-                starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmapInfo, (starDifficultyCancellationSource = new CancellationTokenSource()).Token);
+                starDifficultyBindable = difficultyCache.GetBindableDifficulty(beatmapInfo, cancellationToken: (starDifficultyCancellationSource = new CancellationTokenSource()).Token);
                 starDifficultyBindable.BindValueChanged(d =>
                 {
                     starCounter.Current = (float)(d.NewValue?.Stars ?? 0);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21978

This is thoroughly explained in both https://github.com/ppy/osu/issues/21978#issuecomment-1371285287 and https://github.com/ppy/osu/issues/21978#issuecomment-1371351230. I can't think of a better solution to this issue, and there are other components that already update their display prematurely (mainly ones that use `GetBindableDifficulty`), so I've went with it and it looks to be working well as far as I've tested.