### PR TITLE
Fix advanced statistics display potentially performing invalid difficulty calculation 

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -160,9 +160,12 @@ namespace osu.Game
 
         protected Bindable<WorkingBeatmap> Beatmap { get; private set; } // cached via load() method
 
+        /// <summary>
+        /// The current ruleset selection for the local user.
+        /// </summary>
         [Cached]
         [Cached(typeof(IBindable<RulesetInfo>))]
-        protected readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
+        protected internal readonly Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
 
         /// <summary>
         /// The current mod selection for the local user.

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -150,7 +150,14 @@ namespace osu.Game.Screens.Select.Details
 
         private CancellationTokenSource starDifficultyCancellationSource;
 
-        private void updateStarDifficulty()
+        /// <summary>
+        /// Updates the displayed star difficulty statistics with the values provided by the currently-selected beatmap, ruleset, and selected mods.
+        /// </summary>
+        /// <remarks>
+        /// This is scheduled to avoid scenarios wherein a ruleset changes first before selected mods do,
+        /// potentially resulting in failure during difficulty calculation due to incomplete bindable state updates.
+        /// </remarks>
+        private void updateStarDifficulty() => Scheduler.AddOnce(() =>
         {
             starDifficultyCancellationSource?.Cancel();
 
@@ -172,7 +179,7 @@ namespace osu.Game.Screens.Select.Details
 
                 starDifficulty.Value = ((float)normalDifficulty.Value.Stars, (float)moddedDifficulty.Value.Stars);
             }), starDifficultyCancellationSource.Token, TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Current);
-        }
+        });
 
         protected override void Dispose(bool isDisposing)
         {


### PR DESCRIPTION
- Closes #21978 
- Alternative to / closes #22028 

Once again, this is thoroughly explained in both https://github.com/ppy/osu/issues/21978#issuecomment-1371285287 and https://github.com/ppy/osu/issues/21978#issuecomment-1371351230. This solution instead focuses on improving the display itself to not fall through such issues, without touching external components (in response to https://github.com/ppy/osu/pull/22028#discussion_r1061870247). Initially, I felt this is more of a hacky workaround than a fix, but now that I look at it again, it's already bad that `SongSelect` decouples part of the bindables instead of all of them, resulting in the initial issue altogether. Therefore I'm PR'ing this solution as an alternative to the other PR mentioned above.

We might want to consider decoupling the selected mods bindable as well to not update until ruleset is updated first (potentially just follow the same 200ms delay). But I'm going with this solution in the interim so as to not complicate matters immediately.