### PR TITLE
Decrease transition duration of extended difficulty list during hide

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardContent.cs
@@ -138,9 +138,18 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             // This avoids depth issues where a hovered (scaled) card to the right of another card would be beneath the card to the left.
             this.ScaleTo(Expanded.Value ? 1.03f : 1, 500, Easing.OutQuint);
 
-            background.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
-            dropdownContent.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
-            borderContainer.FadeTo(Expanded.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            if (Expanded.Value)
+            {
+                background.FadeIn(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+                dropdownContent.FadeIn(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+                borderContainer.FadeIn(BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            }
+            else
+            {
+                background.FadeOut(BeatmapCard.TRANSITION_DURATION / 3f, Easing.OutQuint);
+                dropdownContent.FadeOut(BeatmapCard.TRANSITION_DURATION / 3f, Easing.OutQuint);
+                borderContainer.FadeOut(BeatmapCard.TRANSITION_DURATION / 3f, Easing.OutQuint);
+            }
 
             content.TweenEdgeEffectTo(new EdgeEffectParameters
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21962

Went with a duration that's roughly similar to web but on the scale of the original duration. The duration is quite short so applying it to both pop-in and pop-out looks bad, therefore I've chosen to do it on pop-out only. Still feels a lot better.

Before:

https://user-images.githubusercontent.com/22781491/210767886-e242efe7-00e6-45e3-b64b-273f7b33d297.mp4

After:

https://user-images.githubusercontent.com/22781491/210768204-9138a730-9cd6-4c03-992b-6c45c75c1c19.mp4