### PR TITLE
Fix settings toolbox group not animating on expansion

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsToolboxGroup.cs
@@ -56,6 +56,16 @@ namespace osu.Game.Tests.Visual.UserInterface
         });
 
         [Test]
+        public void TestDisplay()
+        {
+            AddRepeatStep("toggle expanded state", () =>
+            {
+                InputManager.MoveMouseTo(group.ChildrenOfType<IconButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            }, 5);
+        }
+
+        [Test]
         public void TestClickExpandButtonMultipleTimes()
         {
             AddAssert("group expanded by default", () => group.Expanded.Value);

--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -126,7 +126,8 @@ namespace osu.Game.Overlays
         {
             base.LoadComplete();
 
-            Expanded.BindValueChanged(updateExpandedState, true);
+            Expanded.BindValueChanged(_ => updateExpandedState(true));
+            updateExpandedState(false);
 
             this.Delay(600).Schedule(updateFadeState);
         }
@@ -161,21 +162,25 @@ namespace osu.Game.Overlays
             return base.OnInvalidate(invalidation, source);
         }
 
-        private void updateExpandedState(ValueChangedEvent<bool> expanded)
+        private void updateExpandedState(bool animate)
         {
             // clearing transforms is necessary to avoid a previous height transform
             // potentially continuing to get processed while content has changed to autosize.
             content.ClearTransforms();
 
-            if (expanded.NewValue)
+            if (Expanded.Value)
+            {
                 content.AutoSizeAxes = Axes.Y;
+                content.AutoSizeDuration = animate ? transition_duration : 0;
+                content.AutoSizeEasing = Easing.OutQuint;
+            }
             else
             {
                 content.AutoSizeAxes = Axes.None;
-                content.ResizeHeightTo(0, transition_duration, Easing.OutQuint);
+                content.ResizeHeightTo(0, animate ? transition_duration : 0, Easing.OutQuint);
             }
 
-            headerContent.FadeColour(expanded.NewValue ? Color4.White : OsuColour.Gray(0.5f), 200, Easing.OutQuint);
+            headerContent.FadeColour(Expanded.Value ? Color4.White : OsuColour.Gray(0.5f), 200, Easing.OutQuint);
         }
 
         private void updateFadeState()


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu/pull/20740
- Alternative to https://github.com/ppy/osu/pull/21821

Uses a simplified solution free from scheduling, transform mutation, and whatnot. Works well.

Before:

https://user-images.githubusercontent.com/22781491/210772698-b50a9f70-2635-4f9a-a5ba-f5c21cd04dfe.mp4

After:

https://user-images.githubusercontent.com/22781491/210772888-02ff0da4-35bd-4989-97da-3bf411155537.mp4

