### PR TITLE
Fix gameplay leaderboard showing "-" on non-tracked scores

### DIFF
--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -171,13 +171,13 @@ namespace osu.Game.Screens.Play.HUD
             for (int i = 0; i < Flow.Count; i++)
             {
                 Flow.SetLayoutPosition(orderedByScore[i], i);
-                orderedByScore[i].ScorePosition = CheckValidScorePosition(i + 1) ? i + 1 : null;
+                orderedByScore[i].ScorePosition = CheckValidScorePosition(orderedByScore[i], i + 1) ? i + 1 : null;
             }
 
             sorting.Validate();
         }
 
-        protected virtual bool CheckValidScorePosition(int i) => true;
+        protected virtual bool CheckValidScorePosition(GameplayLeaderboardScore score, int position) => true;
 
         private partial class InputDisabledScrollContainer : OsuScrollContainer
         {

--- a/osu.Game/Screens/Play/HUD/SoloGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/SoloGameplayLeaderboard.cs
@@ -100,16 +100,16 @@ namespace osu.Game.Screens.Play.HUD
             local.DisplayOrder.Value = long.MaxValue;
         }
 
-        protected override bool CheckValidScorePosition(int i)
+        protected override bool CheckValidScorePosition(GameplayLeaderboardScore score, int position)
         {
             // change displayed position to '-' when there are 50 already submitted scores and tracked score is last
-            if (scoreSource.Value != PlayBeatmapDetailArea.TabType.Local)
+            if (score.Tracked && scoreSource.Value != PlayBeatmapDetailArea.TabType.Local)
             {
-                if (i == Flow.Count && Flow.Count > GetScoresRequest.MAX_SCORES_PER_REQUEST)
+                if (position == Flow.Count && Flow.Count > GetScoresRequest.MAX_SCORES_PER_REQUEST)
                     return false;
             }
 
-            return base.CheckValidScorePosition(i);
+            return base.CheckValidScorePosition(score, position);
         }
 
         private void updateVisibility() =>


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/22041

Non-tracked scores have guaranteed positions. Once user reaches position 50, the score below it is guaranteed to be 51 (not sure about scores below number 50 that have equal totals though, out of scope probably).