### PR TITLE
Make selected tab items more bold (and add underline)

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -12,6 +12,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osuTK;
@@ -100,9 +101,31 @@ namespace osu.Game.Overlays.BeatmapListing
 
         protected partial class MultipleSelectionFilterTabItem : FilterTabItem<T>
         {
+            private readonly Box selectedUnderline;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
+
             public MultipleSelectionFilterTabItem(T value)
                 : base(value)
             {
+                // This doesn't match any actual design, but should make it easier for the user to understand
+                // that filters are applied until we settle on a final design.
+                AddInternal(selectedUnderline = new Box
+                {
+                    Depth = float.MaxValue,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 1.5f,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.CentreLeft,
+                });
+            }
+
+            protected override void UpdateState()
+            {
+                base.UpdateState();
+                selectedUnderline.FadeTo(Active.Value ? 1 : 0, 200, Easing.OutQuint);
+                selectedUnderline.FadeColour(IsHovered ? colourProvider.Light1 : GetStateColour(), 200, Easing.OutQuint);
             }
 
             protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Overlays.BeatmapListing
         private void updateState()
         {
             text.FadeColour(IsHovered ? colourProvider.Light1 : GetStateColour(), 200, Easing.OutQuint);
-            text.Font = text.Font.With(weight: Active.Value ? FontWeight.SemiBold : FontWeight.Regular);
+            text.Font = text.Font.With(weight: Active.Value ? FontWeight.Bold : FontWeight.Regular);
         }
 
         protected virtual Color4 GetStateColour() => Active.Value ? colourProvider.Content1 : colourProvider.Light2;

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -52,33 +52,33 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             base.LoadComplete();
 
-            updateState();
+            UpdateState();
             FinishTransforms(true);
         }
 
         protected override bool OnHover(HoverEvent e)
         {
             base.OnHover(e);
-            updateState();
+            UpdateState();
             return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
             base.OnHoverLost(e);
-            updateState();
+            UpdateState();
         }
 
-        protected override void OnActivated() => updateState();
+        protected override void OnActivated() => UpdateState();
 
-        protected override void OnDeactivated() => updateState();
+        protected override void OnDeactivated() => UpdateState();
 
         /// <summary>
         /// Returns the label text to be used for the supplied <paramref name="value"/>.
         /// </summary>
         protected virtual LocalisableString LabelFor(T value) => (value as Enum)?.GetLocalisableDescription() ?? value.ToString();
 
-        private void updateState()
+        protected virtual void UpdateState()
         {
             text.FadeColour(IsHovered ? colourProvider.Light1 : GetStateColour(), 200, Easing.OutQuint);
             text.Font = text.Font.With(weight: Active.Value ? FontWeight.Bold : FontWeight.Regular);


### PR DESCRIPTION
The previous bold level was not enough to convey selection. This isn't going to resolve the bad UX, but might help to at least some degree, until we maybe get a path forward from designer (or I just come up with something better).

See https://github.com/ppy/osu/issues/22009.


| before | after |
| -- | -- |
|![osu! 2023-01-06 at 11 11 12](https://user-images.githubusercontent.com/191335/211001055-3842748a-2f20-46ad-972d-4458b68ed69d.png)|![osu! 2023-01-06 at 11 38 28](https://user-images.githubusercontent.com/191335/211005334-d61cba75-cc09-4467-ba2b-c05d5472699b.png)|