### PR TITLE
Fix multiple highlighting issues with beatmap listing tab items

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -103,8 +103,7 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             private readonly Box selectedUnderline;
 
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; }
+            protected override bool HighlightOnHoverWhenActive => true;
 
             public MultipleSelectionFilterTabItem(T value)
                 : base(value)
@@ -125,7 +124,7 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 base.UpdateState();
                 selectedUnderline.FadeTo(Active.Value ? 1 : 0, 200, Easing.OutQuint);
-                selectedUnderline.FadeColour(IsHovered ? colourProvider.Light1 : GetStateColour(), 200, Easing.OutQuint);
+                selectedUnderline.FadeColour(IsHovered ? ColourProvider.Content2 : GetStateColour(), 200, Easing.OutQuint);
             }
 
             protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.BeatmapListing
     public partial class FilterTabItem<T> : TabItem<T>
     {
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        protected OverlayColourProvider ColourProvider { get; private set; }
 
         private OsuSpriteText text;
 
@@ -78,12 +78,16 @@ namespace osu.Game.Overlays.BeatmapListing
         /// </summary>
         protected virtual LocalisableString LabelFor(T value) => (value as Enum)?.GetLocalisableDescription() ?? value.ToString();
 
+        protected virtual bool HighlightOnHoverWhenActive => false;
+
         protected virtual void UpdateState()
         {
-            text.FadeColour(IsHovered ? colourProvider.Light1 : GetStateColour(), 200, Easing.OutQuint);
+            bool highlightHover = IsHovered && (!Active.Value || HighlightOnHoverWhenActive);
+
+            text.FadeColour(highlightHover ? ColourProvider.Content2 : GetStateColour(), 200, Easing.OutQuint);
             text.Font = text.Font.With(weight: Active.Value ? FontWeight.SemiBold : FontWeight.Regular);
         }
 
-        protected virtual Color4 GetStateColour() => Active.Value ? colourProvider.Content1 : colourProvider.Light2;
+        protected virtual Color4 GetStateColour() => Active.Value ? ColourProvider.Content1 : ColourProvider.Light2;
     }
 }


### PR DESCRIPTION
Noticed while reviewing #22044.

 - Use a better colour for highlight than `Light1`, since the current one is nigh impossible to distinguish from the idle colour.
 - Avoid highlighting currently selected item on single-selection tab controls.

Before:

https://user-images.githubusercontent.com/22781491/211011297-b9ecfa1c-5dfd-4159-bb65-90e358429ad0.mp4

After:

https://user-images.githubusercontent.com/22781491/211011333-c0d7cfaa-f7b7-42c3-913a-86af2be776e2.mp4

