### PR TITLE
Fix `WaveformComparisonDisplay` does not take into account start time of control points

### DIFF
--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Screens.Edit.Timing
             if (!displayLocked.Value)
             {
                 float trackLength = (float)beatmap.Value.Track.Length;
-                int totalBeatsAvailable = (int)(trackLength / timingPoint.BeatLength);
+                int totalBeatsAvailable = (int)((trackLength - timingPoint.Time) / timingPoint.BeatLength);
 
                 Scheduler.AddOnce(showFromBeat, (int)(e.MousePosition.X / DrawWidth * totalBeatsAvailable));
             }


### PR DESCRIPTION
A bug that i noticed while writing #21754.

- Place a control point in the beginning of a song. Check the last beat number in WCD, let's call it "x".
- Place one more point near the end. Notice that WCD still thinks that there are X beats after the point, allowing you to scroll far beyond the end of the track.

![изображение](https://user-images.githubusercontent.com/53872073/211024609-7f5fc2bd-a865-4ac2-bf64-d7e47ca176e0.png)


Working on "CP start time - track end" span instead of full track length seems to help: 
![изображение](https://user-images.githubusercontent.com/53872073/211023186-a416bfc4-470e-4460-b1cf-e10fa083ba02.png)
