### PR TITLE
Refresh background on file change in editor

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -99,6 +99,18 @@ namespace osu.Game.Screens.Backgrounds
             }
         }
 
+        /// <summary>
+        /// Reloads beatmap's background.
+        /// </summary>
+        public void RefreshBackground()
+        {
+            Schedule(() =>
+            {
+                cancellationSource?.Cancel();
+                LoadComponentAsync(new BeatmapBackground(beatmap), switchBackground, (cancellationSource = new CancellationTokenSource()).Token);
+            });
+        }
+
         private void switchBackground(BeatmapBackground b)
         {
             float newDepth = 0;

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -34,7 +32,7 @@ namespace osu.Game.Screens.Edit.Setup
         private EditorBeatmap editorBeatmap { get; set; }
 
         [Resolved]
-        private Editor editor { get; set; }
+        private Editor? editor { get; set; }
 
         [Resolved]
         private SetupScreenHeader header { get; set; }
@@ -96,7 +94,7 @@ namespace osu.Game.Screens.Edit.Setup
             working.Value.Metadata.BackgroundFile = destination.Name;
             header.Background.UpdateBackground();
 
-            editor.ApplyToBackground(bg => bg.RefreshBackground());
+            editor?.ApplyToBackground(bg => bg.RefreshBackground());
 
             return true;
         }

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void backgroundChanged(ValueChangedEvent<FileInfo?> file)
         {
-            if (!ChangeBackgroundImage(file.NewValue!))
+            if (file.NewValue == null || !ChangeBackgroundImage(file.NewValue))
                 backgroundChooser.Current.Value = file.OldValue;
 
             updatePlaceholderText();
@@ -138,7 +138,7 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void audioTrackChanged(ValueChangedEvent<FileInfo?> file)
         {
-            if (!ChangeAudioTrack(file.NewValue!))
+            if (file.NewValue == null || !ChangeAudioTrack(file.NewValue))
                 audioTrackChooser.Current.Value = file.OldValue;
 
             updatePlaceholderText();

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -34,6 +34,9 @@ namespace osu.Game.Screens.Edit.Setup
         private EditorBeatmap editorBeatmap { get; set; }
 
         [Resolved]
+        private Editor editor { get; set; }
+
+        [Resolved]
         private SetupScreenHeader header { get; set; }
 
         [BackgroundDependencyLoader]
@@ -92,6 +95,8 @@ namespace osu.Game.Screens.Edit.Setup
 
             working.Value.Metadata.BackgroundFile = destination.Name;
             header.Background.UpdateBackground();
+
+            editor.ApplyToBackground(bg => bg.RefreshBackground());
 
             return true;
         }

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -14,28 +14,28 @@ namespace osu.Game.Screens.Edit.Setup
 {
     internal partial class ResourcesSection : SetupSection
     {
-        private LabelledFileChooser audioTrackChooser;
-        private LabelledFileChooser backgroundChooser;
+        private LabelledFileChooser audioTrackChooser = null!;
+        private LabelledFileChooser backgroundChooser = null!;
 
         public override LocalisableString Title => EditorSetupStrings.ResourcesHeader;
 
         [Resolved]
-        private MusicController music { get; set; }
+        private MusicController music { get; set; } = null!;
 
         [Resolved]
-        private BeatmapManager beatmaps { get; set; }
+        private BeatmapManager beatmaps { get; set; } = null!;
 
         [Resolved]
-        private IBindable<WorkingBeatmap> working { get; set; }
+        private IBindable<WorkingBeatmap> working { get; set; } = null!;
 
         [Resolved]
-        private EditorBeatmap editorBeatmap { get; set; }
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
 
         [Resolved]
         private Editor? editor { get; set; }
 
         [Resolved]
-        private SetupScreenHeader header { get; set; }
+        private SetupScreenHeader header { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -128,17 +128,17 @@ namespace osu.Game.Screens.Edit.Setup
             return true;
         }
 
-        private void backgroundChanged(ValueChangedEvent<FileInfo> file)
+        private void backgroundChanged(ValueChangedEvent<FileInfo?> file)
         {
-            if (!ChangeBackgroundImage(file.NewValue))
+            if (!ChangeBackgroundImage(file.NewValue!))
                 backgroundChooser.Current.Value = file.OldValue;
 
             updatePlaceholderText();
         }
 
-        private void audioTrackChanged(ValueChangedEvent<FileInfo> file)
+        private void audioTrackChanged(ValueChangedEvent<FileInfo?> file)
         {
-            if (!ChangeAudioTrack(file.NewValue))
+            if (!ChangeAudioTrack(file.NewValue!))
                 audioTrackChooser.Current.Value = file.OldValue;
 
             updatePlaceholderText();


### PR DESCRIPTION
I could not find a way to do this with available things (`WorkingBeatmap` setter will ignore the change because cached beatmap is the same which we are changing so the check there won't see any changes and will always return) so exposed a method for refresh without checks.