### PR TITLE
Fix friends list duplicating after connection failure

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -259,7 +259,11 @@ namespace osu.Game.Online.API
 
             var friendsReq = new GetFriendsRequest();
             friendsReq.Failure += _ => state.Value = APIState.Failing;
-            friendsReq.Success += res => friends.AddRange(res);
+            friendsReq.Success += res =>
+            {
+                friends.Clear();
+                friends.AddRange(res);
+            };
 
             if (!handleRequest(friendsReq))
             {


### PR DESCRIPTION
- Should fix https://github.com/ppy/osu/issues/22036

I've still kept the `friends.Clear` call on `Logout`, since user gets set to guest in there, so the friends list should be updated to a sane state (empty) as well.