### PR TITLE
Fix channel listing items overflowing at high ui scaling

### DIFF
--- a/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
+++ b/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.Chat.Listing
         private Box hoverBox = null!;
         private SpriteIcon checkbox = null!;
         private OsuSpriteText channelText = null!;
-        private OsuSpriteText topicText = null!;
+        private OsuTextFlowContainer topicText = null!;
         private IBindable<bool> channelJoined = null!;
 
         [Resolved]
@@ -65,8 +65,8 @@ namespace osu.Game.Overlays.Chat.Listing
 
             Masking = true;
             CornerRadius = 5;
-            RelativeSizeAxes = Axes.X;
-            Height = 20 + (vertical_margin * 2);
+            RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
 
             Children = new Drawable[]
             {
@@ -79,14 +79,19 @@ namespace osu.Game.Overlays.Chat.Listing
                 },
                 new GridContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     ColumnDimensions = new[]
                     {
                         new Dimension(GridSizeMode.Absolute, 40),
                         new Dimension(GridSizeMode.Absolute, 200),
-                        new Dimension(GridSizeMode.Absolute, 400),
+                        new Dimension(maxSize: 400),
                         new Dimension(GridSizeMode.AutoSize),
-                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, 50), // enough for any 5 digit user count
+                    },
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize, minSize: 20 + (vertical_margin * 2)),
                     },
                     Content = new[]
                     {
@@ -108,12 +113,13 @@ namespace osu.Game.Overlays.Chat.Listing
                                 Font = OsuFont.Torus.With(size: text_size, weight: FontWeight.SemiBold),
                                 Margin = new MarginPadding { Bottom = 2 },
                             },
-                            topicText = new OsuSpriteText
+                            topicText = new OsuTextFlowContainer(t => t.Font = OsuFont.Torus.With(size: text_size))
                             {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 Text = Channel.Topic,
-                                Font = OsuFont.Torus.With(size: text_size),
                                 Margin = new MarginPadding { Bottom = 2 },
                             },
                             new SpriteIcon


### PR DESCRIPTION
1.0x (pixel-perfect), 1.6x, transition:

| Before | After |
| --- | --- |
| ![osu!_bTLPgIGv3u](https://user-images.githubusercontent.com/35318437/211222557-d398a062-fae4-41a2-b1fc-77aa97407ae5.png) | ![osu!_w2u3wLkaTT](https://user-images.githubusercontent.com/35318437/211222131-08898934-9092-490e-913c-33705b6b9b95.png) |
| ![osu!_qzl29Gwz77](https://user-images.githubusercontent.com/35318437/211222563-6608150f-c0c6-47aa-aca4-f47b5bfe2463.png) | ![osu!_5GNnjiO3Yd](https://user-images.githubusercontent.com/35318437/211222135-6ebeed8d-d59a-4add-8c47-c89bc839f28d.png) |
| ![osu!_c16y3pK7n1](https://user-images.githubusercontent.com/35318437/211222568-bc0f871f-118b-462a-afd0-c213301c2da5.gif) | ![osu!_zUdYmVxC1b](https://user-images.githubusercontent.com/35318437/211222137-91892455-5af0-4671-a071-87b3b8b9986d.gif) |