### PR TITLE
fixed: Insufficient logging on importing scores without associated beatmaps

### DIFF
--- a/osu.Game/Scoring/Legacy/DatabasedLegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/DatabasedLegacyScoreDecoder.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using osu.Game.Beatmaps;
+using osu.Game.Online.API;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Scoring.Legacy
@@ -17,10 +18,11 @@ namespace osu.Game.Scoring.Legacy
         private readonly IRulesetStore rulesets;
         private readonly BeatmapManager beatmaps;
 
-        public DatabasedLegacyScoreDecoder(IRulesetStore rulesets, BeatmapManager beatmaps)
+        public DatabasedLegacyScoreDecoder(IRulesetStore rulesets, BeatmapManager beatmaps, IAPIProvider api = null)
         {
             this.rulesets = rulesets;
             this.beatmaps = beatmaps;
+            API = api;
         }
 
         protected override Ruleset GetRuleset(int rulesetId) => rulesets.GetRuleset(rulesetId)?.CreateInstance();

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Scoring
             {
                 try
                 {
-                    return new DatabasedLegacyScoreDecoder(rulesets, beatmaps()).Parse(stream).ScoreInfo;
+                    return new DatabasedLegacyScoreDecoder(rulesets, beatmaps(), api).Parse(stream).ScoreInfo;
                 }
                 catch (LegacyScoreDecoder.BeatmapNotFoundException e)
                 {


### PR DESCRIPTION
### Fix for issue #21910 
Now it provides details about beatmap's author, title and diff name if user is authorized
![image](https://user-images.githubusercontent.com/50776304/211250284-3cf0c952-242b-419a-b453-ffe04ee81f9e.png)
