### PR TITLE
Change message in first-run setup to only check final location of Songs folder

### DIFF
--- a/osu.Game/Database/LegacyImportManager.cs
+++ b/osu.Game/Database/LegacyImportManager.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Database
 
         public void UpdateStorage(string stablePath) => cachedStorage = new StableStorage(stablePath, gameHost as DesktopGameHost);
 
-        public bool CheckHardLinkAvailability()
+        public bool CheckSongsFolderHardLinkAvailability()
         {
             var stableStorage = GetCurrentStableStorage();
 
             if (stableStorage == null || gameHost is not DesktopGameHost desktopGameHost)
                 return false;
 
-            string testExistingPath = stableStorage.GetFullPath(string.Empty);
+            string testExistingPath = stableStorage.GetSongStorage().GetFullPath(string.Empty);
             string testDestinationPath = desktopGameHost.Storage.GetFullPath(string.Empty);
 
             return HardLinkHelper.CheckAvailability(testDestinationPath, testExistingPath);

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             if (available)
             {
                 copyInformation.Text =
-                    "Beatmap migration will use \"hard links\". No extra disk space will be used, and you can delete beatmaps from either installation at any point without affecting the other. ";
+                    "Data migration will use \"hard links\". No extra disk space will be used, and you can delete either data folder at any point without affecting the other installation. ";
 
                 copyInformation.AddLink("Learn more about how \"hard links\" work", LinkAction.OpenWiki, @"Client/Release_stream/Lazer/File_storage#via-hard-links");
             }
@@ -137,8 +137,8 @@ namespace osu.Game.Overlays.FirstRunSetup
             else
             {
                 copyInformation.Text = RuntimeInfo.OS == RuntimeInfo.Platform.Windows
-                    ? "A second copy of beatmaps will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous Songs folder (and the file system is NTFS). "
-                    : "A second copy of beatmaps will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous Songs folder (and the file system supports hard links). ";
+                    ? "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install (and the file system is NTFS). "
+                    : "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install (and the file system supports hard links). ";
                 copyInformation.AddLink(GeneralSettingsStrings.ChangeFolderLocation, () =>
                 {
                     game?.PerformFromScreen(menu => menu.Push(new MigrationSelectScreen()));

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -122,13 +122,13 @@ namespace osu.Game.Overlays.FirstRunSetup
             stableLocatorTextBox.Current.Value = storage.GetFullPath(string.Empty);
             importButton.Enabled.Value = true;
 
-            bool available = legacyImportManager.CheckHardLinkAvailability();
-            Logger.Log($"Hard link support is {available}");
+            bool available = legacyImportManager.CheckSongsFolderHardLinkAvailability();
+            Logger.Log($"Hard link support for beatmaps is {available}");
 
             if (available)
             {
                 copyInformation.Text =
-                    "Data migration will use \"hard links\". No extra disk space will be used, and you can delete either data folder at any point without affecting the other installation. ";
+                    "Beatmap migration will use \"hard links\". No extra disk space will be used, and you can delete beatmaps from either installation at any point without affecting the other. ";
 
                 copyInformation.AddLink("Learn more about how \"hard links\" work", LinkAction.OpenWiki, @"Client/Release_stream/Lazer/File_storage#via-hard-links");
             }
@@ -137,8 +137,8 @@ namespace osu.Game.Overlays.FirstRunSetup
             else
             {
                 copyInformation.Text = RuntimeInfo.OS == RuntimeInfo.Platform.Windows
-                    ? "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install (and the file system is NTFS). "
-                    : "A second copy of all files will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous osu! install (and the file system supports hard links). ";
+                    ? "A second copy of beatmaps will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous Songs folder (and the file system is NTFS). "
+                    : "A second copy of beatmaps will be made during import. To avoid this, please make sure the lazer data folder is on the same drive as your previous Songs folder (and the file system supports hard links). ";
                 copyInformation.AddLink(GeneralSettingsStrings.ChangeFolderLocation, () =>
                 {
                     game?.PerformFromScreen(menu => menu.Push(new MigrationSelectScreen()));


### PR DESCRIPTION
 * Closes https://github.com/ppy/osu/issues/21904
 
 `ScreenImportFromStable` is currently the only thing that checks hard link availability, so I modified and renamed the method in `LegacyImportManager` to only check `Songs` folder. 
 
 Where the original message mentioned "all files" I changed the message to mention "Beatmaps" instead.