### PR TITLE
Pause imports during active gameplay

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -62,6 +62,7 @@ namespace osu.Game.Beatmaps
             BeatmapTrackStore = audioManager.GetTrackStore(userResources);
 
             beatmapImporter = CreateBeatmapImporter(storage, realm);
+            beatmapImporter.PauseImports.BindTo(PauseImports);
             beatmapImporter.ProcessBeatmap = args => ProcessBeatmap?.Invoke(args);
             beatmapImporter.PostNotification = obj => PostNotification?.Invoke(obj);
 
@@ -458,7 +459,8 @@ namespace osu.Game.Beatmaps
 
         public Task Import(ImportTask[] tasks, ImportParameters parameters = default) => beatmapImporter.Import(tasks, parameters);
 
-        public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) => beatmapImporter.Import(notification, tasks, parameters);
+        public Task<IEnumerable<Live<BeatmapSetInfo>>> Import(ProgressNotification notification, ImportTask[] tasks, ImportParameters parameters = default) =>
+            beatmapImporter.Import(notification, tasks, parameters);
 
         public Task<Live<BeatmapSetInfo>?> Import(ImportTask task, ImportParameters parameters = default, CancellationToken cancellationToken = default) =>
             beatmapImporter.Import(task, parameters, cancellationToken);

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -44,6 +44,16 @@ namespace osu.Game.Beatmaps
 
         public Action<(BeatmapSetInfo beatmapSet, bool isBatch)>? ProcessBeatmap { private get; set; }
 
+        public override bool PauseImports
+        {
+            get => base.PauseImports;
+            set
+            {
+                base.PauseImports = value;
+                beatmapImporter.PauseImports = value;
+            }
+        }
+
         public BeatmapManager(Storage storage, RealmAccess realm, IAPIProvider? api, AudioManager audioManager, IResourceStore<byte[]> gameResources, GameHost? host = null,
                               WorkingBeatmap? defaultBeatmap = null, BeatmapDifficultyCache? difficultyCache = null, bool performOnlineLookups = false)
             : base(storage, realm)
@@ -62,7 +72,6 @@ namespace osu.Game.Beatmaps
             BeatmapTrackStore = audioManager.GetTrackStore(userResources);
 
             beatmapImporter = CreateBeatmapImporter(storage, realm);
-            beatmapImporter.PauseImports.BindTo(PauseImports);
             beatmapImporter.ProcessBeatmap = args => ProcessBeatmap?.Invoke(args);
             beatmapImporter.PostNotification = obj => PostNotification?.Invoke(obj);
 

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -18,6 +19,11 @@ namespace osu.Game.Database
     public class ModelManager<TModel> : IModelManager<TModel>, IModelFileManager<TModel, RealmNamedFileUsage>
         where TModel : RealmObject, IHasRealmFiles, IHasGuidPrimaryKey, ISoftDelete
     {
+        /// <summary>
+        /// Temporarily pause imports to avoid performance overheads affecting gameplay scenarios.
+        /// </summary>
+        public readonly BindableBool PauseImports = new BindableBool();
+
         protected RealmAccess Realm { get; }
 
         private readonly RealmFileStore realmFileStore;

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -22,7 +21,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Temporarily pause imports to avoid performance overheads affecting gameplay scenarios.
         /// </summary>
-        public readonly BindableBool PauseImports = new BindableBool();
+        public virtual bool PauseImports { get; set; }
 
         protected RealmAccess Realm { get; }
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -569,6 +569,7 @@ namespace osu.Game.Database
                 Thread.Sleep(500);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             Logger.Log($@"{GetType().Name} is being resumed.");
         }
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
@@ -60,7 +59,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Temporarily pause imports to avoid performance overheads affecting gameplay scenarios.
         /// </summary>
-        public readonly BindableBool PauseImports = new BindableBool();
+        public bool PauseImports { get; set; }
 
         public abstract IEnumerable<string> HandledExtensions { get; }
 
@@ -559,12 +558,12 @@ namespace osu.Game.Database
 
         private void pauseIfNecessary(CancellationToken cancellationToken)
         {
-            if (!PauseImports.Value)
+            if (!PauseImports)
                 return;
 
             Logger.Log(@"Import is being paused.");
 
-            while (PauseImports.Value)
+            while (PauseImports)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 Thread.Sleep(500);

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -561,7 +561,7 @@ namespace osu.Game.Database
             if (!PauseImports)
                 return;
 
-            Logger.Log(@"Import is being paused.");
+            Logger.Log($@"{GetType().Name} is being paused.");
 
             while (PauseImports)
             {
@@ -569,7 +569,7 @@ namespace osu.Game.Database
                 Thread.Sleep(500);
             }
 
-            Logger.Log(@"Import is being resumed.");
+            Logger.Log($@"{GetType().Name} is being resumed.");
         }
 
         private IEnumerable<string> getIDs(IEnumerable<INamedFile> files)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -307,9 +307,12 @@ namespace osu.Game
             // Transfer any runtime changes back to configuration file.
             SkinManager.CurrentSkinInfo.ValueChanged += skin => configSkin.Value = skin.NewValue.ID.ToString();
 
-            BeatmapManager.PauseImports.BindTo(LocalUserPlaying);
-            SkinManager.PauseImports.BindTo(LocalUserPlaying);
-            ScoreManager.PauseImports.BindTo(LocalUserPlaying);
+            LocalUserPlaying.BindValueChanged(p =>
+            {
+                BeatmapManager.PauseImports = p.NewValue;
+                SkinManager.PauseImports = p.NewValue;
+                ScoreManager.PauseImports = p.NewValue;
+            }, true);
 
             IsActive.BindValueChanged(active => updateActiveState(active.NewValue), true);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -307,6 +307,10 @@ namespace osu.Game
             // Transfer any runtime changes back to configuration file.
             SkinManager.CurrentSkinInfo.ValueChanged += skin => configSkin.Value = skin.NewValue.ID.ToString();
 
+            BeatmapManager.PauseImports.BindTo(LocalUserPlaying);
+            SkinManager.PauseImports.BindTo(LocalUserPlaying);
+            ScoreManager.PauseImports.BindTo(LocalUserPlaying);
+
             IsActive.BindValueChanged(active => updateActiveState(active.NewValue), true);
 
             Audio.AddAdjustment(AdjustableProperty.Volume, inactiveVolumeFade);

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Scoring
             {
                 PostNotification = obj => PostNotification?.Invoke(obj)
             };
+
+            scoreImporter.PauseImports.BindTo(PauseImports);
         }
 
         public Score GetScore(ScoreInfo score) => scoreImporter.GetScore(score);

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -28,6 +28,16 @@ namespace osu.Game.Scoring
         private readonly OsuConfigManager configManager;
         private readonly ScoreImporter scoreImporter;
 
+        public override bool PauseImports
+        {
+            get => base.PauseImports;
+            set
+            {
+                base.PauseImports = value;
+                scoreImporter.PauseImports = value;
+            }
+        }
+
         public ScoreManager(RulesetStore rulesets, Func<BeatmapManager> beatmaps, Storage storage, RealmAccess realm, IAPIProvider api,
                             OsuConfigManager configManager = null)
             : base(storage, realm)
@@ -38,8 +48,6 @@ namespace osu.Game.Scoring
             {
                 PostNotification = obj => PostNotification?.Invoke(obj)
             };
-
-            scoreImporter.PauseImports.BindTo(PauseImports);
         }
 
         public Score GetScore(ScoreInfo score) => scoreImporter.GetScore(score);

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Skinning
                 PostNotification = obj => PostNotification?.Invoke(obj),
             };
 
+            skinImporter.PauseImports.BindTo(PauseImports);
+
             var defaultSkins = new[]
             {
                 DefaultClassicSkin = new DefaultLegacySkin(this),

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -64,6 +64,16 @@ namespace osu.Game.Skinning
 
         private Skin trianglesSkin { get; }
 
+        public override bool PauseImports
+        {
+            get => base.PauseImports;
+            set
+            {
+                base.PauseImports = value;
+                skinImporter.PauseImports = value;
+            }
+        }
+
         public SkinManager(Storage storage, RealmAccess realm, GameHost host, IResourceStore<byte[]> resources, AudioManager audio, Scheduler scheduler)
             : base(storage, realm)
         {
@@ -78,8 +88,6 @@ namespace osu.Game.Skinning
             {
                 PostNotification = obj => PostNotification?.Invoke(obj),
             };
-
-            skinImporter.PauseImports.BindTo(PauseImports);
 
             var defaultSkins = new[]
             {


### PR DESCRIPTION
Imports have some overheads. Eventually we'll try and iron these out, but I think it still makes sense to pause imports during gameplay to avoid any kind of hitching.