### PR TITLE
Move stable import buttons under debug section in favour of first-run "import" screen

### DIFF
--- a/osu.Game/Localisation/MaintenanceSettingsStrings.cs
+++ b/osu.Game/Localisation/MaintenanceSettingsStrings.cs
@@ -55,11 +55,6 @@ namespace osu.Game.Localisation
         public static LocalisableString RestartAndReOpenRequiredForCompletion => new TranslatableString(getKey(@"restart_and_re_open_required_for_completion"), @"To complete this operation, osu! will close. Please open it again to use the new data location.");
 
         /// <summary>
-        /// "Import beatmaps from stable"
-        /// </summary>
-        public static LocalisableString ImportBeatmapsFromStable => new TranslatableString(getKey(@"import_beatmaps_from_stable"), @"Import beatmaps from stable");
-
-        /// <summary>
         /// "Delete ALL beatmaps"
         /// </summary>
         public static LocalisableString DeleteAllBeatmaps => new TranslatableString(getKey(@"delete_all_beatmaps"), @"Delete ALL beatmaps");
@@ -70,29 +65,14 @@ namespace osu.Game.Localisation
         public static LocalisableString DeleteAllBeatmapVideos => new TranslatableString(getKey(@"delete_all_beatmap_videos"), @"Delete ALL beatmap videos");
 
         /// <summary>
-        /// "Import scores from stable"
-        /// </summary>
-        public static LocalisableString ImportScoresFromStable => new TranslatableString(getKey(@"import_scores_from_stable"), @"Import scores from stable");
-
-        /// <summary>
         /// "Delete ALL scores"
         /// </summary>
         public static LocalisableString DeleteAllScores => new TranslatableString(getKey(@"delete_all_scores"), @"Delete ALL scores");
 
         /// <summary>
-        /// "Import skins from stable"
-        /// </summary>
-        public static LocalisableString ImportSkinsFromStable => new TranslatableString(getKey(@"import_skins_from_stable"), @"Import skins from stable");
-
-        /// <summary>
         /// "Delete ALL skins"
         /// </summary>
         public static LocalisableString DeleteAllSkins => new TranslatableString(getKey(@"delete_all_skins"), @"Delete ALL skins");
-
-        /// <summary>
-        /// "Import collections from stable"
-        /// </summary>
-        public static LocalisableString ImportCollectionsFromStable => new TranslatableString(getKey(@"import_collections_from_stable"), @"Import collections from stable");
 
         /// <summary>
         /// "Delete ALL collections"

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -22,11 +23,12 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public DebugSection()
         {
-            Children = new Drawable[]
-            {
-                new GeneralSettings(),
-                new MemorySettings(),
-            };
+            Add(new GeneralSettings());
+
+            if (DebugUtils.IsDebugBuild)
+                Add(new BatchImportSettings());
+
+            Add(new MemorySettings());
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/BatchImportSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/BatchImportSettings.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+
+namespace osu.Game.Overlays.Settings.Sections.DebugSettings
+{
+    public partial class BatchImportSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => @"Batch Import";
+
+        private SettingsButton importBeatmapsButton = null!;
+        private SettingsButton importCollectionsButton = null!;
+        private SettingsButton importScoresButton = null!;
+        private SettingsButton importSkinsButton = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(LegacyImportManager? legacyImportManager)
+        {
+            if (legacyImportManager?.SupportsImportFromStable != true)
+                return;
+
+            AddRange(new[]
+            {
+                importBeatmapsButton = new SettingsButton
+                {
+                    Text = @"Import beatmaps from stable",
+                    Action = () =>
+                    {
+                        importBeatmapsButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Beatmaps).ContinueWith(_ => Schedule(() => importBeatmapsButton.Enabled.Value = true));
+                    }
+                },
+                importSkinsButton = new SettingsButton
+                {
+                    Text = @"Import skins from stable",
+                    Action = () =>
+                    {
+                        importSkinsButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Skins).ContinueWith(_ => Schedule(() => importSkinsButton.Enabled.Value = true));
+                    }
+                },
+                importCollectionsButton = new SettingsButton
+                {
+                    Text = @"Import collections from stable",
+                    Action = () =>
+                    {
+                        importCollectionsButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(_ => Schedule(() => importCollectionsButton.Enabled.Value = true));
+                    }
+                },
+                importScoresButton = new SettingsButton
+                {
+                    Text = @"Import scores from stable",
+                    Action = () =>
+                    {
+                        importScoresButton.Enabled.Value = false;
+                        legacyImportManager.ImportFromStableAsync(StableContent.Scores).ContinueWith(_ => Schedule(() => importScoresButton.Enabled.Value = true));
+                    }
+                },
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/BeatmapSettings.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
-using osu.Game.Database;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance
@@ -15,28 +14,14 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         protected override LocalisableString Header => CommonStrings.Beatmaps;
 
-        private SettingsButton importBeatmapsButton = null!;
         private SettingsButton deleteBeatmapsButton = null!;
         private SettingsButton deleteBeatmapVideosButton = null!;
         private SettingsButton restoreButton = null!;
         private SettingsButton undeleteButton = null!;
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapManager beatmaps, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
+        private void load(BeatmapManager beatmaps, IDialogOverlay? dialogOverlay)
         {
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importBeatmapsButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportBeatmapsFromStable,
-                    Action = () =>
-                    {
-                        importBeatmapsButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Beatmaps).ContinueWith(_ => Schedule(() => importBeatmapsButton.Enabled.Value = true));
-                    }
-                });
-            }
-
             Add(deleteBeatmapsButton = new DangerousSettingsButton
             {
                 Text = MaintenanceSettingsStrings.DeleteAllBeatmaps,

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/CollectionsSettings.cs
@@ -14,8 +14,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         protected override LocalisableString Header => CommonStrings.Collections;
 
-        private SettingsButton importCollectionsButton = null!;
-
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
@@ -23,21 +21,8 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         private INotificationOverlay? notificationOverlay { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
+        private void load(IDialogOverlay? dialogOverlay)
         {
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importCollectionsButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportCollectionsFromStable,
-                    Action = () =>
-                    {
-                        importCollectionsButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Collections).ContinueWith(_ => Schedule(() => importCollectionsButton.Enabled.Value = true));
-                    }
-                });
-            }
-
             Add(new DangerousSettingsButton
             {
                 Text = MaintenanceSettingsStrings.DeleteAllCollections,

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/ScoreSettings.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
-using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Scoring;
 
@@ -14,25 +13,11 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         protected override LocalisableString Header => CommonStrings.Scores;
 
-        private SettingsButton importScoresButton = null!;
         private SettingsButton deleteScoresButton = null!;
 
         [BackgroundDependencyLoader]
-        private void load(ScoreManager scores, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
+        private void load(ScoreManager scores, IDialogOverlay? dialogOverlay)
         {
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importScoresButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportScoresFromStable,
-                    Action = () =>
-                    {
-                        importScoresButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Scores).ContinueWith(_ => Schedule(() => importScoresButton.Enabled.Value = true));
-                    }
-                });
-            }
-
             Add(deleteScoresButton = new DangerousSettingsButton
             {
                 Text = MaintenanceSettingsStrings.DeleteAllScores,

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/SkinSettings.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
-using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Skinning;
 
@@ -14,25 +13,11 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         protected override LocalisableString Header => CommonStrings.Skins;
 
-        private SettingsButton importSkinsButton = null!;
         private SettingsButton deleteSkinsButton = null!;
 
         [BackgroundDependencyLoader]
-        private void load(SkinManager skins, LegacyImportManager? legacyImportManager, IDialogOverlay? dialogOverlay)
+        private void load(SkinManager skins, IDialogOverlay? dialogOverlay)
         {
-            if (legacyImportManager?.SupportsImportFromStable == true)
-            {
-                Add(importSkinsButton = new SettingsButton
-                {
-                    Text = MaintenanceSettingsStrings.ImportSkinsFromStable,
-                    Action = () =>
-                    {
-                        importSkinsButton.Enabled.Value = false;
-                        legacyImportManager.ImportFromStableAsync(StableContent.Skins).ContinueWith(_ => Schedule(() => importSkinsButton.Enabled.Value = true));
-                    }
-                });
-            }
-
             Add(deleteSkinsButton = new DangerousSettingsButton
             {
                 Text = MaintenanceSettingsStrings.DeleteAllSkins,


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/21908

As per https://github.com/ppy/osu/discussions/21908#discussioncomment-4631416, I've moved the buttons to the "debug" section and made it only display on debug builds (section name is completely arbitrary).

That said, I'm not 100% sure on the state of the "debug" settings section with this PR as-is, since there are settings placed under it that should be visible in release builds, but the entire section is supposed to be only visible in debug builds. I was planning on hiding memory settings on release builds as well and move general settings under "maintenance" section, but interested in feedback.