### PR TITLE
Fix game overlays not blocking scroll properly

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayContainer.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays.Volume;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+using Box = osu.Framework.Graphics.Shapes.Box;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneOverlayContainer : OsuManualInputManagerTestScene
+    {
+        [SetUp]
+        public void SetUp() => Schedule(() => Child = new TestOverlay
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            RelativeSizeAxes = Axes.Both,
+            Size = new Vector2(0.5f)
+        });
+
+        [Test]
+        public void TestScrollBlocked()
+        {
+            OsuScrollContainer scroll = null!;
+
+            AddStep("add scroll container", () =>
+            {
+                Add(scroll = new OsuScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Depth = float.MaxValue,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = DrawHeight * 10,
+                        Colour = ColourInfo.GradientVertical(Colour4.Black, Colour4.White),
+                    }
+                });
+            });
+
+            AddStep("perform scroll", () =>
+            {
+                InputManager.MoveMouseTo(Content);
+                InputManager.ScrollVerticalBy(-10);
+            });
+
+            AddAssert("scroll didn't receive input", () => scroll.Current == 0);
+        }
+
+        [Test]
+        public void TestAltScrollNotBlocked()
+        {
+            bool scrollReceived = false;
+
+            AddStep("add volume control receptor", () => Add(new VolumeControlReceptor
+            {
+                RelativeSizeAxes = Axes.Both,
+                Depth = float.MaxValue,
+                ScrollActionRequested = (_, _, _) => scrollReceived = true,
+            }));
+
+            AddStep("hold alt", () => InputManager.PressKey(Key.AltLeft));
+            AddStep("perform scroll", () =>
+            {
+                InputManager.MoveMouseTo(Content);
+                InputManager.ScrollVerticalBy(10);
+            });
+
+            AddAssert("receptor received scroll input", () => scrollReceived);
+            AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
+        }
+
+        private partial class TestOverlay : OsuFocusedOverlayContainer
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                State.Value = Visibility.Visible;
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = "Overlay content",
+                        Colour = Color4.Black,
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Graphics.Containers
         protected virtual string PopInSampleName => "UI/overlay-pop-in";
         protected virtual string PopOutSampleName => "UI/overlay-pop-out";
 
-        protected override bool BlockScrollInput => false;
-
         protected override bool BlockNonPositionalInput => true;
 
         /// <summary>
@@ -88,6 +86,15 @@ namespace osu.Game.Graphics.Containers
                 Hide();
 
             base.OnMouseUp(e);
+        }
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            // allow for controlling volume when alt is held.
+            // mostly for compatibility with osu-stable.
+            if (e.AltPressed) return false;
+
+            return true;
         }
 
         public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/22111

Game overlays started not blocking scroll input since https://github.com/ppy/osu/pull/12375 (https://github.com/ppy/osu/pull/12375/commits/0eab9daf13bb406d2b82c1f624dbb7e483f0ab40) to allow for alt-scroll input to pass through all the way to the receptor for increasing/decreasing volume.

And while it was working, overlays that are not fully covered by a `ScrollContainer` (i.e. chat overlay) cause scroll input to leak to the currently active screen as seen in #22111. 

This is now fixed by blocking scroll input *only* when alt is not pressed, since no other component would presumably be handling such keybinding other than the volume receptor itself.