### PR TITLE
Implement user group badges

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Id = 2001,
                 Username = "RankedUser",
+                Groups = new[] { new APIUserGroup() { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" } },
                 Statistics = new UserStatistics
                 {
                     IsRanked = true,

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Id = 2001,
                 Username = "RankedUser",
-                Groups = new[] { new APIUserGroup() { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" } },
+                Groups = new[] { new APIUserGroup { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" } },
                 Statistics = new UserStatistics
                 {
                     IsRanked = true,

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Tests.Visual.Online
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,
             ProfileOrder = new[] { "me" },
+            Groups = new[]
+            {
+                new APIUserGroup { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" },
+                new APIUserGroup { Colour = "#A347EB", ShortName = "BN", Name = "Beatmap Nominators", Playmodes = new[] { "osu", "taiko" } }
+            },
             Statistics = new UserStatistics
             {
                 IsRanked = true,

--- a/osu.Game/Online/API/Requests/Responses/APIUser.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUser.cs
@@ -255,6 +255,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [CanBeNull]
         public Dictionary<string, UserStatistics> RulesetsStatistics { get; set; }
 
+        [JsonProperty("groups")]
+        public APIUserGroup[] Groups;
+
         public override string ToString() => Username;
 
         /// <summary>

--- a/osu.Game/Online/API/Requests/Responses/APIUserGroup.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUserGroup.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class APIUserGroup
+    {
+        [JsonProperty(@"colour")]
+        public string Colour { get; set; } = null!;
+
+        [JsonProperty(@"has_listing")]
+        public bool HasListings { get; set; }
+
+        [JsonProperty(@"has_playmodes")]
+        public bool HasPlaymodes { get; set; }
+
+        [JsonProperty(@"id")]
+        public int Id { get; set; }
+
+        [JsonProperty(@"identifier")]
+        public string Identifier { get; set; } = null!;
+
+        [JsonProperty(@"is_probationary")]
+        public bool IsProbationary { get; set; }
+
+        [JsonProperty(@"name")]
+        public string Name { get; set; } = null!;
+
+        [JsonProperty(@"short_name")]
+        public string ShortName { get; set; } = null!;
+
+        [JsonProperty(@"playmodes")]
+        public string[]? Playmodes { get; set; }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             if (group.Playmodes?.Length > 0)
             {
                 innerContainer.AddRange(group.Playmodes.Select(p =>
-                        (rulesets.GetRuleset((string)p)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }).With(icon =>
+                        (rulesets.GetRuleset(p)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }).With(icon =>
                         {
                             icon.Size = new Vector2(TextSize - 1);
                         })).ToList()

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -74,33 +73,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
             if (group.Playmodes?.Length > 0)
             {
                 innerContainer.AddRange(group.Playmodes.Select(p =>
-                        (rulesets.GetRuleset(p)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }).With(icon =>
+                        (rulesets.GetRuleset((string)p)?.CreateInstance().CreateIcon() ?? new SpriteIcon { Icon = FontAwesome.Regular.QuestionCircle }).With(icon =>
                         {
                             icon.Size = new Vector2(TextSize - 1);
                         })).ToList()
                 );
             }
-        }
-    }
-
-    public partial class GroupInfoContainer : FillFlowContainer
-    {
-        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
-
-        public GroupInfoContainer()
-        {
-            AutoSizeAxes = Axes.Both;
-            Direction = FillDirection.Horizontal;
-            Spacing = new Vector2(2);
-
-            User.BindValueChanged(val =>
-            {
-                if (val.NewValue?.Groups?.Length > 0)
-                {
-                    Clear(true);
-                    Children = val.NewValue?.Groups.Select(g => new GroupBadge(g)).ToList();
-                }
-            });
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
@@ -20,13 +20,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
             Direction = FillDirection.Horizontal;
             Spacing = new Vector2(2);
 
-            User.BindValueChanged(val =>
+            User.BindValueChanged(user =>
             {
-                if (val.NewValue?.Groups?.Length > 0)
-                {
-                    Clear(true);
-                    Children = val.NewValue?.Groups.Select(g => new GroupBadge(g)).ToList();
-                }
+                Clear(true);
+
+                if (user.NewValue != null)
+                    AddRange(user.NewValue.Groups.Select(g => new GroupBadge(g)));
             });
         }
     }

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.API.Requests.Responses;
+using osuTK;
+
+namespace osu.Game.Overlays.Profile.Header.Components
+{
+    public partial class GroupBadgeFlow : FillFlowContainer
+    {
+        public readonly Bindable<APIUser?> User = new Bindable<APIUser?>();
+
+        public GroupBadgeFlow()
+        {
+            AutoSizeAxes = Axes.Both;
+            Direction = FillDirection.Horizontal;
+            Spacing = new Vector2(2);
+
+            User.BindValueChanged(val =>
+            {
+                if (val.NewValue?.Groups?.Length > 0)
+                {
+                    Clear(true);
+                    Children = val.NewValue?.Groups.Select(g => new GroupBadge(g)).ToList();
+                }
+            });
+        }
+    }
+}

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadgeFlow.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             {
                 Clear(true);
 
-                if (user.NewValue != null)
+                if (user.NewValue?.Groups != null)
                     AddRange(user.NewValue.Groups.Select(g => new GroupBadge(g)));
             });
         }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Overlays.Profile.Header
         private UpdateableFlag userFlag = null!;
         private OsuSpriteText userCountryText = null!;
         private FillFlowContainer userStats = null!;
+        private GroupInfoContainer groupInfoContainer = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -90,6 +91,7 @@ namespace osu.Game.Overlays.Profile.Header
                                             {
                                                 AutoSizeAxes = Axes.Both,
                                                 Direction = FillDirection.Horizontal,
+                                                Spacing = new Vector2(5),
                                                 Children = new Drawable[]
                                                 {
                                                     usernameText = new OsuSpriteText
@@ -98,10 +100,14 @@ namespace osu.Game.Overlays.Profile.Header
                                                     },
                                                     openUserExternally = new ExternalLinkButton
                                                     {
-                                                        Margin = new MarginPadding { Left = 5 },
                                                         Anchor = Anchor.CentreLeft,
                                                         Origin = Anchor.CentreLeft,
                                                     },
+                                                    groupInfoContainer = new GroupInfoContainer
+                                                    {
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                    }
                                                 }
                                             },
                                             titleText = new OsuSpriteText
@@ -184,6 +190,7 @@ namespace osu.Game.Overlays.Profile.Header
             supporterTag.SupportLevel = user?.SupportLevel ?? 0;
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");
+            groupInfoContainer.User.Value = user;
 
             userStats.Clear();
 

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Overlays.Profile.Header
         private UpdateableFlag userFlag = null!;
         private OsuSpriteText userCountryText = null!;
         private FillFlowContainer userStats = null!;
-        private GroupInfoContainer groupInfoContainer = null!;
+        private GroupBadgeFlow groupBadgeFlow = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -103,7 +103,7 @@ namespace osu.Game.Overlays.Profile.Header
                                                         Anchor = Anchor.CentreLeft,
                                                         Origin = Anchor.CentreLeft,
                                                     },
-                                                    groupInfoContainer = new GroupInfoContainer
+                                                    groupBadgeFlow = new GroupBadgeFlow
                                                     {
                                                         Anchor = Anchor.CentreLeft,
                                                         Origin = Anchor.CentreLeft,
@@ -190,7 +190,7 @@ namespace osu.Game.Overlays.Profile.Header
             supporterTag.SupportLevel = user?.SupportLevel ?? 0;
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");
-            groupInfoContainer.User.Value = user;
+            groupBadgeFlow.User.Value = user;
 
             userStats.Clear();
 


### PR DESCRIPTION
Turns out they weren't implemented yet.

![image](https://user-images.githubusercontent.com/8269193/211695187-9548e686-c8c7-4737-8f3f-63c31783718a.png)

Currently I've only added them to the profile overlay since I'm planning on reworking the user panels later anyway