### PR TITLE
Fix kiai flash opacity on legacy skins being too intense

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -66,17 +67,28 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             // the conditional above handles the case where a sliderendcircle.png is retrieved from the skin, but sliderendcircleoverlay.png doesn't exist.
             // expected behaviour in this scenario is not showing the overlay, rather than using hitcircleoverlay.png.
 
+            Color4 objectColour = drawableOsuObject!.AccentColour.Value;
+            int add = Math.Max(25, 300 - (int)(objectColour.R * 255) - (int)(objectColour.G * 255) - (int)(objectColour.B * 255));
+
+            Color4 finalColour = new Color4(
+                (byte)Math.Min((byte)(objectColour.R * 255) + add, 255),
+                (byte)Math.Min((byte)(objectColour.G * 255) + add, 255),
+                (byte)Math.Min((byte)(objectColour.B * 255) + add, 255),
+                255);
+
             InternalChildren = new[]
             {
                 CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Colour = finalColour,
                 },
                 OverlayLayer = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Colour = finalColour,
                     Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
                     {
                         Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -30,8 +30,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private readonly bool hasNumber;
 
-        protected Drawable CircleSprite = null!;
-        protected Drawable OverlaySprite = null!;
+        protected LegacyKiaiFlashingDrawable CircleSprite = null!;
+        protected LegacyKiaiFlashingDrawable OverlaySprite = null!;
 
         protected Container OverlayLayer { get; private set; } = null!;
 
@@ -66,29 +66,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             // at this point, any further texture fetches should be correctly using the priority source if the base texture was retrieved using it.
             // the conditional above handles the case where a sliderendcircle.png is retrieved from the skin, but sliderendcircleoverlay.png doesn't exist.
             // expected behaviour in this scenario is not showing the overlay, rather than using hitcircleoverlay.png.
-
-            Color4 objectColour = drawableOsuObject!.AccentColour.Value;
-            int add = Math.Max(25, 300 - (int)(objectColour.R * 255) - (int)(objectColour.G * 255) - (int)(objectColour.B * 255));
-
-            Color4 finalColour = new Color4(
-                (byte)Math.Min((byte)(objectColour.R * 255) + add, 255),
-                (byte)Math.Min((byte)(objectColour.G * 255) + add, 255),
-                (byte)Math.Min((byte)(objectColour.B * 255) + add, 255),
-                255);
-
             InternalChildren = new[]
             {
                 CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Colour = finalColour,
                 },
                 OverlayLayer = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Colour = finalColour,
                     Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d))
                     {
                         Anchor = Anchor.Centre,
@@ -126,7 +114,21 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             base.LoadComplete();
 
-            accentColour.BindValueChanged(colour => CircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue), true);
+            accentColour.BindValueChanged(colour =>
+            {
+                Color4 objectColour = colour.NewValue;
+                int add = Math.Max(25, 300 - (int)(objectColour.R * 255) - (int)(objectColour.G * 255) - (int)(objectColour.B * 255));
+
+                var kiaiTintColour = new Color4(
+                    (byte)Math.Min((byte)(objectColour.R * 255) + add, 255),
+                    (byte)Math.Min((byte)(objectColour.G * 255) + add, 255),
+                    (byte)Math.Min((byte)(objectColour.B * 255) + add, 255),
+                    255);
+
+                CircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue);
+                OverlaySprite.KiaiGlowColour = CircleSprite.KiaiGlowColour = LegacyColourCompatibility.DisallowZeroAlpha(kiaiTintColour);
+            }, true);
+
             if (hasNumber)
                 indexInCurrentCombo.BindValueChanged(index => hitCircleText.Text = (index.NewValue + 1).ToString(), true);
 

--- a/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
+++ b/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Skinning
     {
         private readonly Drawable flashingDrawable;
 
-        private const float flash_opacity = 0.55f;
+        private const float flash_opacity = 0.3f;
 
         public LegacyKiaiFlashingDrawable(Func<Drawable?> creationFunc)
         {

--- a/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
+++ b/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
@@ -6,11 +6,18 @@ using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
+using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
     public partial class LegacyKiaiFlashingDrawable : BeatSyncedContainer
     {
+        public Color4 KiaiGlowColour
+        {
+            get => flashingDrawable.Colour;
+            set => flashingDrawable.Colour = value;
+        }
+
         private readonly Drawable flashingDrawable;
 
         private const float flash_opacity = 0.3f;


### PR DESCRIPTION
This is going to require some further testing, probably by recording video (test scenes are a bit broken as per #22135 so can't use them), but PRing for initial review.

Closes #21747.