### PR TITLE
Disallow placing before track start

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/ManiaPlacementBlueprintTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/ManiaPlacementBlueprintTestScene.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 AccentColour = { Value = Color4.OrangeRed },
-                Clock = new FramedClock(new StopwatchClock()), // No scroll
+                Clock = new FramedClock(ColumnClock), // No scroll
             });
         }
 
@@ -54,6 +54,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             return new SnapResult(pos, time, column);
         }
+
+        protected virtual IClock ColumnClock => new StopwatchClock();
 
         protected override Container CreateHitObjectContainer() => new ScrollingTestContainer(ScrollingDirection.Down) { RelativeSizeAxes = Axes.Both };
 

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneNotePlacementBlueprint.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing;
+using osu.Framework.Timing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
@@ -36,21 +37,11 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         [Test]
         public void TestPlaceBeforeCurrentTimeDownwards()
         {
-            AddStep("move mouse before current time", () =>
+            AddStep("seek", () =>
             {
-                var column = this.ChildrenOfType<Column>().Single();
-                InputManager.MoveMouseTo(column.ScreenSpacePositionAtTime(-100));
+                EditorClock.Seek(200);
             });
-
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
-
-            AddAssert("note start time < 0", () => getNote().StartTime < 0);
-        }
-
-        [Test]
-        public void TestPlaceAfterCurrentTimeDownwards()
-        {
-            AddStep("move mouse after current time", () =>
+            AddStep("move mouse before current time", () =>
             {
                 var column = this.ChildrenOfType<Column>().Single();
                 InputManager.MoveMouseTo(column.ScreenSpacePositionAtTime(100));
@@ -58,8 +49,28 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("click", () => InputManager.Click(MouseButton.Left));
 
-            AddAssert("note start time > 0", () => getNote().StartTime > 0);
+            AddAssert("note start time < 0", () => getNote().StartTime < 200);
         }
+
+        [Test]
+        public void TestPlaceAfterCurrentTimeDownwards()
+        {
+            AddStep("seek", () =>
+            {
+                EditorClock.Seek(200);
+            });
+            AddStep("move mouse after current time", () =>
+            {
+                var column = this.ChildrenOfType<Column>().Single();
+                InputManager.MoveMouseTo(column.ScreenSpacePositionAtTime(300));
+            });
+
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("note start time > 0", () => getNote().StartTime > 200);
+        }
+
+        protected override IClock ColumnClock { get; } = new ManualClock { CurrentTime = 200 };
 
         private Note getNote() => this.ChildrenOfType<DrawableNote>().FirstOrDefault()?.HitObject;
 

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestScenePlacementBeforeTrackStart.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestScenePlacementBeforeTrackStart.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor
+{
+    public partial class TestScenePlacementBeforeTrackStart : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new ManiaRuleset();
+
+        [Test]
+        public void TestPlacement()
+        {
+            AddStep("Seek to 0", () => EditorClock.Seek(0));
+            AddStep("Select note", () => InputManager.Key(Key.Number2));
+            AddStep("Hover negative span", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<Container>().First(x => x.Name == "Icons").Children[0]);
+            });
+            AddStep("Click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("No notes placed", () => EditorBeatmap.HitObjects.All(x => x.StartTime >= 0));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -113,14 +113,14 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestHitObjectPlacement()
         {
-            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(500, new TimingControlPoint()));
+            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(200, new TimingControlPoint()));
             AddStep("Change to placement mode", () => InputManager.Key(Key.Number2));
             AddStep("Move to playfield", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre));
             AddStep("Place single hitcircle", () => InputManager.Click(MouseButton.Left));
 
             SaveEditor();
 
-            AddAssert("Beatmap has correct timing point", () => EditorBeatmap.ControlPointInfo.TimingPoints.Single().Time == 500);
+            AddAssert("Beatmap has correct timing point", () => EditorBeatmap.ControlPointInfo.TimingPoints.Single().Time == 200);
 
             // After placement these must be non-default as defaults are read-only.
             AddAssert("Placed object has non-default control points", () =>
@@ -129,7 +129,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             ReloadEditorToSameBeatmap();
 
-            AddAssert("Beatmap still has correct timing point", () => EditorBeatmap.ControlPointInfo.TimingPoints.Single().Time == 500);
+            AddAssert("Beatmap still has correct timing point", () => EditorBeatmap.ControlPointInfo.TimingPoints.Single().Time == 200);
 
             // After placement these must be non-default as defaults are read-only.
             AddAssert("Placed object still has non-default control points", () =>
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Editing
             double lastStarRating = 0;
             double lastLength = 0;
 
-            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(500, new TimingControlPoint()));
+            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(200, new TimingControlPoint()));
             AddStep("Change to placement mode", () => InputManager.Key(Key.Number2));
             AddStep("Move to playfield", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre));
             AddStep("Place single hitcircle", () => InputManager.Click(MouseButton.Left));

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -101,6 +101,8 @@ namespace osu.Game.Rulesets.Edit
                     break;
             }
 
+            commit = commit && HitObject.StartTime >= 0;
+
             placementHandler.EndPlacement(HitObject, commit);
             PlacementActive = PlacementState.Finished;
         }

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Tests.Visual
         protected readonly Container HitObjectContainer;
         protected PlacementBlueprint CurrentBlueprint { get; private set; }
 
+        protected EditorClock EditorClock { get; private set; }
+
         protected PlacementBlueprintTestScene()
         {
             base.Content.Add(HitObjectContainer = CreateHitObjectContainer().With(c => c.Clock = new FramedClock(new StopwatchClock())));
@@ -32,9 +34,9 @@ namespace osu.Game.Tests.Visual
 
             var playable = GetPlayableBeatmap();
 
-            var editorClock = new EditorClock();
-            base.Content.Add(editorClock);
-            dependencies.CacheAs(editorClock);
+            EditorClock = new EditorClock();
+            base.Content.Add(EditorClock);
+            dependencies.CacheAs(EditorClock);
 
             var editorBeatmap = new EditorBeatmap(playable);
             // Not adding to hierarchy as we don't satisfy its dependencies. Probably not good.


### PR DESCRIPTION
Checks of the correctness of objects after placement are usually performed near `EndPlacement` and passed there, so i added extra check inside it to avoid copying across blueprints.

Partial fix for #21944 - you can still drag objects to negative time.