### PR TITLE
Fix game-level components not finishing load before game content

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -933,9 +933,9 @@ namespace osu.Game
             loadComponentSingleFile(dashboard = new DashboardOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(news = new NewsOverlay(), overlayContent.Add, true);
             var rankingsOverlay = loadComponentSingleFile(new RankingsOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(channelManager = new ChannelManager(API), AddInternal, true);
+            loadComponentSingleFile(channelManager = new ChannelManager(API), Add, true);
             loadComponentSingleFile(chatOverlay = new ChatOverlay(), overlayContent.Add, true);
-            loadComponentSingleFile(new MessageNotifier(), AddInternal, true);
+            loadComponentSingleFile(new MessageNotifier(), Add, true);
             loadComponentSingleFile(Settings = new SettingsOverlay(), leftFloatingOverlayContent.Add, true);
             loadComponentSingleFile(changelogOverlay = new ChangelogOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(userProfile = new UserProfileOverlay(), overlayContent.Add, true);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -206,7 +206,7 @@ namespace osu.Game
         /// </summary>
         private readonly FramedBeatmapClock beatmapClock = new FramedBeatmapClock(true);
 
-        protected override Container<Drawable> Content => content;
+        protected override Container<Drawable> Content => content ?? base.Content;
 
         private Container content;
 
@@ -296,7 +296,7 @@ namespace osu.Game
             dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API));
 
             // Add after all the above cache operations as it depends on them.
-            AddInternal(difficultyCache);
+            Add(difficultyCache);
 
             // TODO: OsuGame or OsuGameBase?
             dependencies.CacheAs(beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage));
@@ -305,19 +305,19 @@ namespace osu.Game
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
             dependencies.CacheAs(soloStatisticsWatcher = new SoloStatisticsWatcher());
 
-            AddInternal(new BeatmapOnlineChangeIngest(beatmapUpdater, realm, metadataClient));
+            Add(new BeatmapOnlineChangeIngest(beatmapUpdater, realm, metadataClient));
 
             BeatmapManager.ProcessBeatmap = args => beatmapUpdater.Process(args.beatmapSet, !args.isBatch);
 
             dependencies.Cache(userCache = new UserLookupCache());
-            AddInternal(userCache);
+            Add(userCache);
 
             dependencies.Cache(beatmapCache = new BeatmapLookupCache());
-            AddInternal(beatmapCache);
+            Add(beatmapCache);
 
             var scorePerformanceManager = new ScorePerformanceCache();
             dependencies.Cache(scorePerformanceManager);
-            AddInternal(scorePerformanceManager);
+            Add(scorePerformanceManager);
 
             dependencies.CacheAs<IRulesetConfigCache>(rulesetConfigCache = new RulesetConfigCache(realm, RulesetStore));
 
@@ -344,18 +344,28 @@ namespace osu.Game
 
             // add api components to hierarchy.
             if (API is APIAccess apiAccess)
-                AddInternal(apiAccess);
+                Add(apiAccess);
 
-            AddInternal(spectatorClient);
-            AddInternal(MultiplayerClient);
-            AddInternal(metadataClient);
-            AddInternal(soloStatisticsWatcher);
+            Add(spectatorClient);
+            Add(MultiplayerClient);
+            Add(metadataClient);
+            Add(soloStatisticsWatcher);
 
-            AddInternal(rulesetConfigCache);
+            Add(rulesetConfigCache);
+
+            PreviewTrackManager previewTrackManager;
+            dependencies.Cache(previewTrackManager = new PreviewTrackManager(BeatmapManager.BeatmapTrackStore));
+            Add(previewTrackManager);
+
+            Add(MusicController = new MusicController());
+            dependencies.CacheAs(MusicController);
+
+            MusicController.TrackChanged += onTrackChanged;
+            Add(beatmapClock);
 
             GlobalActionContainer globalBindings;
 
-            base.Content.Add(SafeAreaContainer = new SafeAreaContainer
+            Add(SafeAreaContainer = new SafeAreaContainer
             {
                 SafeAreaOverrideEdges = SafeAreaOverrideEdges,
                 RelativeSizeAxes = Axes.Both,
@@ -364,29 +374,21 @@ namespace osu.Game
                     (GlobalCursorDisplay = new GlobalCursorDisplay
                     {
                         RelativeSizeAxes = Axes.Both
-                    }).WithChild(content = new OsuTooltipContainer(GlobalCursorDisplay.MenuCursor)
-                    {
-                        RelativeSizeAxes = Axes.Both
                     }),
                     // to avoid positional input being blocked by children, ensure the GlobalActionContainer is above everything.
                     globalBindings = new GlobalActionContainer(this)
                 })
             });
 
+            GlobalCursorDisplay.Child = content = new OsuTooltipContainer(GlobalCursorDisplay.MenuCursor)
+            {
+                RelativeSizeAxes = Axes.Both
+            };
+
             KeyBindingStore = new RealmKeyBindingStore(realm, keyCombinationProvider);
             KeyBindingStore.Register(globalBindings, RulesetStore.AvailableRulesets);
 
             dependencies.Cache(globalBindings);
-
-            PreviewTrackManager previewTrackManager;
-            dependencies.Cache(previewTrackManager = new PreviewTrackManager(BeatmapManager.BeatmapTrackStore));
-            Add(previewTrackManager);
-
-            AddInternal(MusicController = new MusicController());
-            dependencies.CacheAs(MusicController);
-
-            MusicController.TrackChanged += onTrackChanged;
-            AddInternal(beatmapClock);
 
             Ruleset.BindValueChanged(onRulesetChanged);
             Beatmap.BindValueChanged(onBeatmapChanged);


### PR DESCRIPTION
- Alternative to / closes https://github.com/ppy/osu/pull/22134

This is the underlying reason for the test failure in https://github.com/ppy/osu/pull/22134#issue-1528679023, which has been thoroughly explained in https://github.com/ppy/osu/pull/22134#pullrequestreview-1244458622.

`Game` wraps content in an internal child that's added first on constructor, which means using `AddInternal` anytime onwards would result in the added drawable to actually be placed ahead of game content regardless of whether game content was added last.

With the current behaviour, using `LoadComplete` inside any drawable that descends from game content to interact with game-level components (e.g. `MusicController`) is completely unsafe, as game-level components haven't finished loading yet (this is more likely to happen on headless test scene runs, where test scene is loaded immediately along with game itself, unlike real game scenarios).

That should be fixed with this PR, by changing load order to enforce all game-level components to be fully loaded before game content is.

Before:

![CleanShot 2023-01-11 at 22 15 28](https://user-images.githubusercontent.com/22781491/211897427-c8ce889b-2aab-4082-b796-960fe144df00.png)

After:

![CleanShot 2023-01-11 at 22 16 48](https://user-images.githubusercontent.com/22781491/211897661-a04571c0-8744-403c-8628-af97a52ed71c.png)
