### PR TITLE
Taiko: Make hits snap to hit target

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -209,6 +209,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
+                    if (Result.Type == HitResult.Great)
+                        MainPiece.X = -X;
+
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()
                         .MoveToY(gravity_travel_height * 2, gravity_time * 2, Easing.In);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
-                    MainPiece.X = -X; // Visually snap hit object to hit target
+                    MainPiece.MoveToX(-X, 0.008f, Easing.None); // Visually snap hit object to hit target
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -209,8 +209,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
-                    // TODO: This "0.015" value should probably be replaced with whatever value Stable uses 
-                    MainPiece.MoveToX(-X, 0.015, Easing.None); // Visually snap hit object to hit target
+                    MainPiece.X = -X; // Visually snap hit object to hit target
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
                     if (Result.Type == HitResult.Great)
-                        MainPiece.X = -X;
+                        MainPiece.X = -X; // Visually snap hit object to hit target
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -209,8 +209,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
-                    if (Result.Type == HitResult.Great)
-                        MainPiece.X = -X; // Visually snap hit object to hit target
+                    MainPiece.X = -X; // Visually snap hit object to hit target
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -209,7 +209,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
-                    MainPiece.MoveToX(-X, 0.008f, Easing.None); // Visually snap hit object to hit target
+                    // TODO: This "0.015" value should probably be replaced with whatever value Stable uses 
+                    MainPiece.MoveToX(-X, 0.015, Easing.None); // Visually snap hit object to hit target
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)
                         .Then()


### PR DESCRIPTION
In the current implementation, when hit, Taiko's notes do not snap to the hit target as they do in Stable when you get a great hit, and this makes any long stream feel awkward to play due to your hitcircle positions wiggling around even though your accuracy is perfectly fine. This leads to the mode feeling very floaty

I'm not sure how well a video conveys this compared to actually playing, but here is a side-by-side comparison video showing the difference using the exact same play. Keep your eyes specifically on the hit target:

https://user-images.githubusercontent.com/48618519/211902042-3561fea3-ba1c-41ae-9119-4e49ff68983b.mp4