### PR TITLE
Forbid negative time snap in editor

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestScenePlacementBeforeTrackStart.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestScenePlacementBeforeTrackStart.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor
+{
+    public partial class TestScenePlacementBeforeTrackStart : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new ManiaRuleset();
+
+        [Test]
+        public void TestPlacement()
+        {
+            AddStep("Seek to 0", () => EditorClock.Seek(0));
+            AddStep("Select note", () => InputManager.Key(Key.Number2));
+            AddStep("Hover negative span", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<Container>().First(x => x.Name == "Icons").Children[0]);
+            });
+            AddStep("Click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("No notes placed", () => EditorBeatmap.HitObjects.All(x => x.StartTime >= 0));
+        }
+    }
+}

--- a/osu.Game.Tests/Editing/TestSceneSnappingNearZero.cs
+++ b/osu.Game.Tests/Editing/TestSceneSnappingNearZero.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps.ControlPoints;
+
+namespace osu.Game.Tests.Editing
+{
+    [TestFixture]
+    public class TestSceneSnappingNearZero
+    {
+        private readonly ControlPointInfo cpi = new ControlPointInfo();
+
+        [Test]
+        public void TestOnZero()
+        {
+            test(0, 500, 0, 0);
+            test(0, 500, 100, 0);
+            test(0, 500, 250, 500);
+            test(0, 500, 600, 500);
+
+            test(0, 500, -600, 0);
+        }
+
+        [Test]
+        public void TestAlmostOnZero()
+        {
+            test(50, 500, 0, 50);
+            test(50, 500, 50, 50);
+            test(50, 500, 100, 50);
+            test(50, 500, 299, 50);
+            test(50, 500, 300, 550);
+
+            test(50, 500, -500, 50);
+        }
+
+        [Test]
+        public void TestAlmostOnOne()
+        {
+            test(499, 500, -1, 499);
+            test(499, 500, 0, 499);
+            test(499, 500, 1, 499);
+            test(499, 500, 499, 499);
+            test(499, 500, 600, 499);
+            test(499, 500, 800, 999);
+        }
+
+        [Test]
+        public void TestOnOne()
+        {
+            test(500, 500, -500, 0);
+            test(500, 500, 0, 0);
+            test(500, 500, 200, 0);
+            test(500, 500, 400, 500);
+            test(500, 500, 500, 500);
+            test(500, 500, 600, 500);
+            test(500, 500, 900, 1000);
+        }
+
+        [Test]
+        public void TestNegative()
+        {
+            test(-600, 500, -600, 400);
+            test(-600, 500, -100, 400);
+            test(-600, 500, 0, 400);
+            test(-600, 500, 200, 400);
+            test(-600, 500, 400, 400);
+            test(-600, 500, 600, 400);
+            test(-600, 500, 1000, 900);
+        }
+
+        private void test(double pointTime, double beatLength, double from, double expected)
+        {
+            cpi.Clear();
+            cpi.Add(pointTime, new TimingControlPoint { BeatLength = beatLength });
+            Assert.That(cpi.GetClosestSnappedTime(from, 1), Is.EqualTo(expected), $"From: {from}");
+        }
+    }
+}

--- a/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
+++ b/osu.Game.Tests/NonVisual/ClosestBeatDivisorTest.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tests.NonVisual
         public void TestExactDivisors()
         {
             var cpi = new ControlPointInfo();
-            cpi.Add(-1000, new TimingControlPoint { BeatLength = 1000 });
+            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
 
             double[] divisors = { 3, 1, 16, 12, 8, 6, 4, 3, 2, 1 };
 
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.NonVisual
         public void TestExactDivisorsHighBPMStream()
         {
             var cpi = new ControlPointInfo();
-            cpi.Add(-50, new TimingControlPoint { BeatLength = 50 }); // 1200 BPM 1/4 (limit testing)
+            cpi.Add(0, new TimingControlPoint { BeatLength = 50 }); // 1200 BPM 1/4 (limit testing)
 
             // A 1/4 stream should land on 1/1, 1/2 and 1/4 divisors.
             double[] divisors = { 4, 4, 4, 4, 4, 4, 4, 4 };
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.NonVisual
         public void TestApproximateDivisors()
         {
             var cpi = new ControlPointInfo();
-            cpi.Add(-1000, new TimingControlPoint { BeatLength = 1000 });
+            cpi.Add(0, new TimingControlPoint { BeatLength = 1000 });
 
             double[] divisors = { 3.03d, 0.97d, 14, 13, 7.94d, 6.08d, 3.93d, 2.96d, 2.02d, 64 };
             double[] closestDivisors = { 3, 1, 16, 12, 8, 6, 4, 3, 2, 1 };
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.NonVisual
             assertClosestDivisors(divisors, closestDivisors, cpi);
         }
 
-        private void assertClosestDivisors(IReadOnlyList<double> divisors, IReadOnlyList<double> closestDivisors, ControlPointInfo cpi, double step = 1)
+        private static void assertClosestDivisors(IReadOnlyList<double> divisors, IReadOnlyList<double> closestDivisors, ControlPointInfo cpi, double step = 1)
         {
             List<HitObject> hitobjects = new List<HitObject>();
             double offset = cpi.TimingPoints[0].Time;

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -144,7 +144,7 @@ namespace osu.Game.Tests.Visual.Editing
             double lastStarRating = 0;
             double lastLength = 0;
 
-            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(500, new TimingControlPoint()));
+            AddStep("Add timing point", () => EditorBeatmap.ControlPointInfo.Add(200, new TimingControlPoint { BeatLength = 600 }));
             AddStep("Change to placement mode", () => InputManager.Key(Key.Number2));
             AddStep("Move to playfield", () => InputManager.MoveMouseTo(Game.ScreenSpaceDrawQuad.Centre));
             AddStep("Place single hitcircle", () => InputManager.Click(MouseButton.Left));

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -183,9 +183,15 @@ namespace osu.Game.Beatmaps.ControlPoints
         private static double getClosestSnappedTime(TimingControlPoint timingPoint, double time, int beatDivisor)
         {
             double beatLength = timingPoint.BeatLength / beatDivisor;
-            int beatLengths = (int)Math.Round((time - timingPoint.Time) / beatLength, MidpointRounding.AwayFromZero);
+            double beats = (Math.Max(time, 0) - timingPoint.Time) / beatLength;
 
-            return timingPoint.Time + beatLengths * beatLength;
+            int roundedBeats = (int)Math.Round(beats, MidpointRounding.AwayFromZero);
+            double snappedTime = timingPoint.Time + roundedBeats * beatLength;
+
+            if (snappedTime >= 0)
+                return snappedTime;
+
+            return snappedTime + beatLength;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #21944 

Initially i wanted to somehow make it properly round to nearest positive beat, but stuck on dealing with edge cases so ended with `if(n<0) n+=x` thing to avoid overcomplicating.