### PR TITLE
Remove `CFBundleVersion` from iOS plist file

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -8,8 +8,6 @@
 	<string>osu!</string>
 	<key>CFBundleDisplayName</key>
 	<string>osu!</string>
-	<key>CFBundleShortVersionString</key>
-	<string>0.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -10,8 +10,6 @@
 	<string>osu!</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
-	<key>CFBundleVersion</key>
-	<string>0.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -4,7 +4,7 @@
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <UseMauiEssentials>true</UseMauiEssentials>
-    <Version>1.0.0</Version>
+    <Version>0.1.0</Version>
     <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">$(Version)</ApplicationVersion>
     <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
   </PropertyGroup>

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -4,8 +4,8 @@
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <UseMauiEssentials>true</UseMauiEssentials>
-    <Version>0.0.0</Version>
-    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+    <Version>1.0.0</Version>
+    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">$(Version)</ApplicationVersion>
     <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
   </PropertyGroup>
   <Import Project="..\osu.iOS.props" />

--- a/osu.iOS/osu.iOS.csproj
+++ b/osu.iOS/osu.iOS.csproj
@@ -4,6 +4,9 @@
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <OutputType>Exe</OutputType>
     <UseMauiEssentials>true</UseMauiEssentials>
+    <Version>0.0.0</Version>
+    <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
+    <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>
   </PropertyGroup>
   <Import Project="..\osu.iOS.props" />
   <ItemGroup>


### PR DESCRIPTION
This allows using `-p:ApplicationVersion:1234.5.6` to specify a version at build / publish time. Without removing it the plist file's value always takes precedence.

Tested on build server to be working as expected.

Closes #21498