### PR TITLE
Don't display custom rulesets in online overlays

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchRulesetFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchRulesetFilterRow.cs
@@ -28,7 +28,14 @@ namespace osu.Game.Overlays.BeatmapListing
                 AddTabItem(new RulesetFilterTabItemAny());
 
                 foreach (var r in rulesets.AvailableRulesets)
+                {
+                    // Don't display non-legacy rulesets
+                    int id = r.OnlineID;
+                    if (id < 0 || id > 3)
+                        continue;
+
                     AddItem(r);
+                }
             }
         }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchRulesetFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchRulesetFilterRow.cs
@@ -6,6 +6,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Extensions;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 
@@ -30,8 +31,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 foreach (var r in rulesets.AvailableRulesets)
                 {
                     // Don't display non-legacy rulesets
-                    int id = r.OnlineID;
-                    if (id < 0 || id > 3)
+                    if (!r.IsLegacyRuleset())
                         continue;
 
                     AddItem(r);

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Overlays
 {
     public partial class OverlayRulesetSelector : RulesetSelector
     {
-        // Since this component is used in online overlays and currently web-side doesn't support non-legacy rulesets - let's disable them for now.
+        // Since this component is used in online overlays and currently web-side doesn't support non-legacy rulesets, let's disable them for now.
         protected override bool LegacyOnly => true;
 
         public OverlayRulesetSelector()

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Overlays
     public partial class OverlayRulesetSelector : RulesetSelector
     {
         public OverlayRulesetSelector()
+            : base(true)
         {
             AutoSizeAxes = Axes.Both;
         }

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -13,8 +13,10 @@ namespace osu.Game.Overlays
 {
     public partial class OverlayRulesetSelector : RulesetSelector
     {
+        // Since this component is used in online overlays and currently web-side doesn't support non-legacy rulesets - let's disable them for now.
+        protected override bool LegacyOnly => true;
+
         public OverlayRulesetSelector()
-            : base(true)
         {
             AutoSizeAxes = Axes.Both;
         }

--- a/osu.Game/Rulesets/RulesetSelector.cs
+++ b/osu.Game/Rulesets/RulesetSelector.cs
@@ -6,6 +6,7 @@
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
+using osu.Game.Extensions;
 
 namespace osu.Game.Rulesets
 {
@@ -28,9 +29,7 @@ namespace osu.Game.Rulesets
         {
             foreach (var ruleset in Rulesets.AvailableRulesets)
             {
-                int id = ruleset.OnlineID;
-
-                if ((id < 0 || id > 3) && legacyOnly)
+                if (!ruleset.IsLegacyRuleset() && legacyOnly)
                     continue;
 
                 try

--- a/osu.Game/Rulesets/RulesetSelector.cs
+++ b/osu.Game/Rulesets/RulesetSelector.cs
@@ -16,11 +16,23 @@ namespace osu.Game.Rulesets
 
         protected override Dropdown<RulesetInfo> CreateDropdown() => null;
 
+        private readonly bool legacyOnly;
+
+        public RulesetSelector(bool legacyOnly = false)
+        {
+            this.legacyOnly = legacyOnly;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
             foreach (var ruleset in Rulesets.AvailableRulesets)
             {
+                int id = ruleset.OnlineID;
+
+                if ((id < 0 || id > 3) && legacyOnly)
+                    continue;
+
                 try
                 {
                     AddItem(ruleset);

--- a/osu.Game/Rulesets/RulesetSelector.cs
+++ b/osu.Game/Rulesets/RulesetSelector.cs
@@ -17,19 +17,14 @@ namespace osu.Game.Rulesets
 
         protected override Dropdown<RulesetInfo> CreateDropdown() => null;
 
-        private readonly bool legacyOnly;
-
-        public RulesetSelector(bool legacyOnly = false)
-        {
-            this.legacyOnly = legacyOnly;
-        }
+        protected virtual bool LegacyOnly => false;
 
         [BackgroundDependencyLoader]
         private void load()
         {
             foreach (var ruleset in Rulesets.AvailableRulesets)
             {
-                if (!ruleset.IsLegacyRuleset() && legacyOnly)
+                if (!ruleset.IsLegacyRuleset() && LegacyOnly)
                     continue;
 
                 try


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22158

~~Using `ILegacyRuleset` would be cleaner, however `RulesetStore.AvailableRulesets` returns `RulesetInfo`s instead of `Ruleset`s, and creating ruleset instances would probably be a waste.~~

Affects:
- `UserProfileOverlay`
- `BeatmapListingOverlay`
- `RankingsOverlay`