### PR TITLE
Fix intermittent failure in silenced user messages test

### DIFF
--- a/osu.Game.Tests/Chat/TestSceneChannelManager.cs
+++ b/osu.Game.Tests/Chat/TestSceneChannelManager.cs
@@ -75,6 +75,8 @@ namespace osu.Game.Tests.Chat
                     return false;
                 };
             });
+
+            AddUntilStep("wait for notifications client", () => channelManager.NotificationsConnected);
         }
 
         [Test]

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -64,6 +64,11 @@ namespace osu.Game.Online.Chat
         /// </summary>
         public IBindableList<Channel> AvailableChannels => availableChannels;
 
+        /// <summary>
+        /// Whether the client responsible for channel notifications is connected.
+        /// </summary>
+        public bool NotificationsConnected => connector.IsConnected.Value;
+
         private readonly IAPIProvider api;
         private readonly NotificationsClientConnector connector;
 


### PR DESCRIPTION
The test was failing due to the notifications client connecting in-between test execution, specifically after the "mark user as silenced" step and before the assertion. Once the client finishes connection, it triggers `GetUpdatesRequest` which the test scene handles to return all messages that were posted (the silenced message in this case), and `ChannelManager` would try to replace the initially posted silenced message from the test (being in local echo form) with the message returned from the update request. Therefore the test would fail at the assertion step realising that the silenced message is still there.

An alternative solution would be to remove local echo messages from the `pendingMessages` list if they belong to silenced user ID (i.e. the local user themselves), but not sure how sensible that would read.

https://teamcity.ppy.sh/test/-3693966626134281374?currentProjectId=Osu&expandTestHistoryInvestigationsSection=true&expandTestHistoryChartSection=true