### PR TITLE
Fix mute button not blocking outside overlay closing presses

### DIFF
--- a/osu.Game/Overlays/Volume/MuteButton.cs
+++ b/osu.Game/Overlays/Volume/MuteButton.cs
@@ -88,5 +88,11 @@ namespace osu.Game.Overlays.Volume
         {
             Content.TransformTo<Container<Drawable>, ColourInfo>("BorderColour", unhoveredColour, 500, Easing.OutQuint);
         }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            base.OnMouseDown(e);
+            return true;
+        }
     }
 }

--- a/osu.Game/Overlays/Volume/MuteButton.cs
+++ b/osu.Game/Overlays/Volume/MuteButton.cs
@@ -92,6 +92,8 @@ namespace osu.Game.Overlays.Volume
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             base.OnMouseDown(e);
+
+            // Block mouse down to avoid dismissing overlays sitting behind the mute button
             return true;
         }
     }


### PR DESCRIPTION
Not bothering to add a test since the volume overlay will be integrated into the toolbar in the future.

| Before | After |
| --- | --- |
| ![tC6u6yy4qb](https://user-images.githubusercontent.com/35318437/212193871-277507c3-0f1c-41bb-91a9-353f588bf5af.gif) | ![7nUfJtd2fE](https://user-images.githubusercontent.com/35318437/212193681-d0f2cf85-7a60-4935-a089-2232eeff4e25.gif) |