### PR TITLE
Add support for redirection to website during account creation process

### DIFF
--- a/osu.Game/Online/API/RegistrationRequest.cs
+++ b/osu.Game/Online/API/RegistrationRequest.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
 using Newtonsoft.Json;
 
 namespace osu.Game.Online.API
 {
     public class RegistrationRequest : OsuWebRequest
     {
-        internal string Username;
-        internal string Email;
-        internal string Password;
+        internal string Username = string.Empty;
+        internal string Email = string.Empty;
+        internal string Password = string.Empty;
 
         protected override void PrePerform()
         {
@@ -24,18 +23,18 @@ namespace osu.Game.Online.API
 
         public class RegistrationRequestErrors
         {
-            public UserErrors User;
+            public UserErrors? User;
 
             public class UserErrors
             {
                 [JsonProperty("username")]
-                public string[] Username;
+                public string[] Username = Array.Empty<string>();
 
                 [JsonProperty("user_email")]
-                public string[] Email;
+                public string[] Email = Array.Empty<string>();
 
                 [JsonProperty("password")]
-                public string[] Password;
+                public string[] Password = Array.Empty<string>();
             }
         }
     }

--- a/osu.Game/Online/API/RegistrationRequest.cs
+++ b/osu.Game/Online/API/RegistrationRequest.cs
@@ -23,6 +23,16 @@ namespace osu.Game.Online.API
 
         public class RegistrationRequestErrors
         {
+            /// <summary>
+            /// An optional error message.
+            /// </summary>
+            public string? Message;
+
+            /// <summary>
+            /// An optional URL which the user should be directed towards to complete registration.
+            /// </summary>
+            public string? Redirect;
+
             public UserErrors? User;
 
             public class UserErrors

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -47,6 +47,9 @@ namespace osu.Game.Overlays.AccountCreation
         [Resolved]
         private GameHost host { get; set; }
 
+        [Resolved]
+        private OsuGame game { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -194,9 +197,20 @@ namespace osu.Game.Overlays.AccountCreation
                     {
                         if (errors != null)
                         {
-                            usernameDescription.AddErrors(errors.User.Username);
-                            emailAddressDescription.AddErrors(errors.User.Email);
-                            passwordDescription.AddErrors(errors.User.Password);
+                            if (errors.User != null)
+                            {
+                                usernameDescription.AddErrors(errors.User.Username);
+                                emailAddressDescription.AddErrors(errors.User.Email);
+                                passwordDescription.AddErrors(errors.User.Password);
+                            }
+
+                            if (!string.IsNullOrEmpty(errors.Redirect))
+                            {
+                                if (!string.IsNullOrEmpty(errors.Message))
+                                    passwordDescription.AddErrors(new[] { errors.Message });
+
+                                game.OpenUrlExternally(errors.Redirect);
+                            }
                         }
                         else
                         {

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Overlays.AccountCreation
                                 if (!string.IsNullOrEmpty(errors.Message))
                                     passwordDescription.AddErrors(new[] { errors.Message });
 
-                                game.OpenUrlExternally(errors.Redirect);
+                                game.OpenUrlExternally($"{errors.Redirect}?username={usernameTextBox.Text}&email={emailTextBox.Text}");
                             }
                         }
                         else


### PR DESCRIPTION
There may be times when in-client registration is disabled for one reason or another. This allows the client to be aware of this and redirect the user to the website to complete account creation.

https://user-images.githubusercontent.com/191335/212256793-10644968-d7d2-44df-83e3-cdcb98739a38.mp4

Note that the error message osu-web side has been improved since the video, but due to `apt` failures on CI I'm not going to wait to reshoot it.