### PR TITLE
Update mod icon designs

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
@@ -12,6 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override string Name => "Fade In";
         public override string Acronym => "FI";
+        public override IconUsage? Icon => OsuIcon.ModFadeIn;
         public override LocalisableString Description => @"Keys appear out of nowhere!";
         public override double ScoreMultiplier => 1;
 

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 1;
         public override string Name => "One Key";
         public override string Acronym => "1K";
+        public override IconUsage? Icon => OsuIcon.ModKey1;
         public override LocalisableString Description => @"Play with one key.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 2;
         public override string Name => "Two Keys";
         public override string Acronym => "2K";
+        public override IconUsage? Icon => OsuIcon.ModKey2;
         public override LocalisableString Description => @"Play with two keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 3;
         public override string Name => "Three Keys";
         public override string Acronym => "3K";
+        public override IconUsage? Icon => OsuIcon.ModKey3;
         public override LocalisableString Description => @"Play with three keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 4;
         public override string Name => "Four Keys";
         public override string Acronym => "4K";
+        public override IconUsage? Icon => OsuIcon.ModKey4;
         public override LocalisableString Description => @"Play with four keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 5;
         public override string Name => "Five Keys";
         public override string Acronym => "5K";
+        public override IconUsage? Icon => OsuIcon.ModKey5;
         public override LocalisableString Description => @"Play with five keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 6;
         public override string Name => "Six Keys";
         public override string Acronym => "6K";
+        public override IconUsage? Icon => OsuIcon.ModKey6;
         public override LocalisableString Description => @"Play with six keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 7;
         public override string Name => "Seven Keys";
         public override string Acronym => "7K";
+        public override IconUsage? Icon => OsuIcon.ModKey7;
         public override LocalisableString Description => @"Play with seven keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 8;
         public override string Name => "Eight Keys";
         public override string Acronym => "8K";
+        public override IconUsage? Icon => OsuIcon.ModKey8;
         public override LocalisableString Description => @"Play with eight keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override int KeyCount => 9;
         public override string Name => "Nine Keys";
         public override string Acronym => "9K";
+        public override IconUsage? Icon => OsuIcon.ModKey9;
         public override LocalisableString Description => @"Play with nine keys.";
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -10,6 +12,7 @@ namespace osu.Game.Rulesets.Osu.Mods
     {
         public override string Name => "Touch Device";
         public override string Acronym => "TD";
+        public override IconUsage? Icon => OsuIcon.ModTouchDevice;
         public override LocalisableString Description => "Automatically applied to plays on devices with a touchscreen.";
         public override double ScoreMultiplier => 1;
 

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -156,13 +156,13 @@ namespace osu.Game.Graphics
                     return Lime1;
 
                 case ModType.Conversion:
-                    return Purple1;
+                    return Purple0;
 
                 case ModType.Fun:
-                    return Pink1;
+                    return Pink0;
 
                 case ModType.System:
-                    return Gray7;
+                    return Gray5;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(modType), modType, "Unknown mod type");

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Graphics
     public static class OsuIcon
     {
         public static IconUsage Get(int icon) => new IconUsage((char)icon, "osuFont");
+        public static IconUsage GetMod(int icon) => new IconUsage((char)icon, "osuModsFont");
 
         // ruleset icons in circles
         public static IconUsage RulesetOsu => Get(0xe000);
@@ -75,22 +76,36 @@ namespace osu.Game.Graphics
         public static IconUsage ExpertMania => Get(0xe028);
 
         // mod icons
-        public static IconUsage ModPerfect => Get(0xe049);
-        public static IconUsage ModAutopilot => Get(0xe03a);
-        public static IconUsage ModAuto => Get(0xe03b);
-        public static IconUsage ModCinema => Get(0xe03c);
-        public static IconUsage ModDoubleTime => Get(0xe03d);
-        public static IconUsage ModEasy => Get(0xe03e);
-        public static IconUsage ModFlashlight => Get(0xe03f);
-        public static IconUsage ModHalftime => Get(0xe040);
-        public static IconUsage ModHardRock => Get(0xe041);
-        public static IconUsage ModHidden => Get(0xe042);
-        public static IconUsage ModNightcore => Get(0xe043);
-        public static IconUsage ModNoFail => Get(0xe044);
-        public static IconUsage ModRelax => Get(0xe045);
-        public static IconUsage ModSpunOut => Get(0xe046);
-        public static IconUsage ModSuddenDeath => Get(0xe047);
-        public static IconUsage ModTarget => Get(0xe048);
-        public static IconUsage ModBg => Get(0xe04a);
+        public static IconUsage ModBg => GetMod(0xe800);
+        public static IconUsage ModKey1 => GetMod(0xe801);
+        public static IconUsage ModKey2 => GetMod(0xe802);
+        public static IconUsage ModKey3 => GetMod(0xe803);
+        public static IconUsage ModKey4 => GetMod(0xe804);
+        public static IconUsage ModKey5 => GetMod(0xe805);
+        public static IconUsage ModKey6 => GetMod(0xe806);
+        public static IconUsage ModKey7 => GetMod(0xe807);
+        public static IconUsage ModKey8 => GetMod(0xe808);
+        public static IconUsage ModKey9 => GetMod(0xe809);
+        public static IconUsage ModAuto => GetMod(0xe80a);
+        public static IconUsage ModAutopilot => GetMod(0xe80b);
+        public static IconUsage ModCinema => GetMod(0xe80c);
+        public static IconUsage ModDoubleTime => GetMod(0xe80d);
+        public static IconUsage ModEasy => GetMod(0xe80e);
+        public static IconUsage ModFadeIn => GetMod(0xe80f);
+        public static IconUsage ModFlashlight => GetMod(0xe810);
+        public static IconUsage ModHalftime => GetMod(0xe811);
+        public static IconUsage ModHardRock => GetMod(0xe812);
+        public static IconUsage ModHidden => GetMod(0xe813);
+        public static IconUsage ModMirror => GetMod(0xe814);
+        public static IconUsage ModNightcore => GetMod(0xe815);
+        public static IconUsage ModNoFail => GetMod(0xe816);
+        public static IconUsage ModNoMod => GetMod(0xe817);
+        public static IconUsage ModPerfect => GetMod(0xe818);
+        public static IconUsage ModRandom => GetMod(0xe819);
+        public static IconUsage ModRelax => GetMod(0xe81a);
+        public static IconUsage ModSpunOut => GetMod(0xe81b);
+        public static IconUsage ModSuddenDeath => GetMod(0xe81c);
+        public static IconUsage ModTarget => GetMod(0xe81d);
+        public static IconUsage ModTouchDevice => GetMod(0xe81e);
     }
 }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -429,6 +429,7 @@ namespace osu.Game
         protected virtual void InitialiseFonts()
         {
             AddFont(Resources, @"Fonts/osuFont");
+            AddFont(Resources, @"Fonts/osuModsFont");
 
             AddFont(Resources, @"Fonts/Torus/Torus-Regular");
             AddFont(Resources, @"Fonts/Torus/Torus-Light");

--- a/osu.Game/Rulesets/Mods/ModMirror.cs
+++ b/osu.Game/Rulesets/Mods/ModMirror.cs
@@ -1,12 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+
 namespace osu.Game.Rulesets.Mods
 {
     public abstract class ModMirror : Mod
     {
         public override string Name => "Mirror";
         public override string Acronym => "MR";
+        public override IconUsage? Icon => OsuIcon.ModMirror;
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1;
     }

--- a/osu.Game/Rulesets/Mods/ModNoMod.cs
+++ b/osu.Game/Rulesets/Mods/ModNoMod.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "NM";
         public override LocalisableString Description => "No mods applied.";
         public override double ScoreMultiplier => 1;
-        public override IconUsage? Icon => FontAwesome.Solid.Ban;
+        public override IconUsage? Icon => OsuIcon.ModNoMod;
         public override ModType Type => ModType.System;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModRandom.cs
+++ b/osu.Game/Rulesets/Mods/ModRandom.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Random";
         public override string Acronym => "RD";
         public override ModType Type => ModType.Conversion;
-        public override IconUsage? Icon => OsuIcon.Dice;
+        public override IconUsage? Icon => OsuIcon.ModRandom;
         public override double ScoreMultiplier => 1;
 
         [SettingSource("Seed", "Use a custom seed instead of a random one", SettingControlType = typeof(SettingsNumberBox))]

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -81,7 +81,6 @@ namespace osu.Game.Rulesets.UI
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Colour = OsuColour.Gray(84),
                     Alpha = 0,
                     Font = OsuFont.Numeric.With(null, 22f),
                     UseFullGlyphHeight = false,
@@ -91,7 +90,6 @@ namespace osu.Game.Rulesets.UI
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Colour = OsuColour.Gray(84),
                     Size = new Vector2(45),
                     Icon = FontAwesome.Solid.Question
                 },
@@ -109,7 +107,11 @@ namespace osu.Game.Rulesets.UI
 
         private void updateMod(IMod value)
         {
+            var foregroundColour = value.Type == ModType.System ? Color4Extensions.FromHex(@"fc2") : colours.Gray5;
+
+            modAcronym.Colour = foregroundColour;
             modAcronym.Text = value.Acronym;
+            modIcon.Colour = foregroundColour;
             modIcon.Icon = value.Icon ?? FontAwesome.Solid.Question;
 
             if (value.Icon is null)

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -27,11 +27,22 @@ namespace osu.Game.Rulesets.UI
     {
         public readonly BindableBool Selected = new BindableBool();
 
-        private readonly SpriteIcon modIcon;
+        private readonly SpriteText modIcon;
         private readonly SpriteText modAcronym;
         private readonly SpriteIcon background;
 
         private const float size = 80;
+
+        /// <remarks>
+        /// The font size for the mods font should be the height of the mod background.
+        /// The aspect ratio of the mod background is 10:7.
+        /// </remarks>
+        private const float mods_icon_font_size = size * .7f;
+
+        /// <remarks>
+        /// Other fonts are scaled down to match the apparent height of icons in the mods font.
+        /// </remarks>
+        private const float other_icon_font_size = mods_icon_font_size * .75f;
 
         public virtual LocalisableString TooltipText => showTooltip ? ((mod as Mod)?.IconTooltip ?? mod.Name) : null;
 
@@ -84,14 +95,14 @@ namespace osu.Game.Rulesets.UI
                     Alpha = 0,
                     Font = OsuFont.Numeric.With(null, 22f),
                     UseFullGlyphHeight = false,
-                    Text = mod.Acronym
                 },
-                modIcon = new SpriteIcon
+                modIcon = new OsuSpriteText
                 {
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
-                    Size = new Vector2(45),
-                    Icon = FontAwesome.Solid.Question
+                    Alpha = 0,
+                    Shadow = false,
+                    UseFullGlyphHeight = false,
                 },
             };
         }
@@ -109,20 +120,27 @@ namespace osu.Game.Rulesets.UI
         {
             var foregroundColour = value.Type == ModType.System ? Color4Extensions.FromHex(@"fc2") : colours.Gray5;
 
-            modAcronym.Colour = foregroundColour;
-            modAcronym.Text = value.Acronym;
-            modIcon.Colour = foregroundColour;
-            modIcon.Icon = value.Icon ?? FontAwesome.Solid.Question;
-
-            if (value.Icon is null)
+            if (value.Icon is IconUsage icon)
             {
-                modIcon.FadeOut();
-                modAcronym.FadeIn();
+                modIcon.Colour = foregroundColour;
+                modIcon.Font = new FontUsage
+                (
+                    icon.Family,
+                    icon.Family == @"osuModsFont" ? mods_icon_font_size : other_icon_font_size,
+                    icon.Weight
+                );
+                modIcon.Text = icon.Icon.ToString();
+
+                modIcon.FadeIn();
+                modAcronym.FadeOut();
             }
             else
             {
-                modIcon.FadeIn();
-                modAcronym.FadeOut();
+                modAcronym.Colour = foregroundColour;
+                modAcronym.Text = value.Acronym;
+
+                modIcon.FadeOut();
+                modAcronym.FadeIn();
             }
 
             backgroundColour = colours.ForModType(value.Type);


### PR DESCRIPTION
... to the icons and colors used in "Slightly Updated Mods" section of <https://www.figma.com/file/QuGqnnM2zyhDaz2TyCsON1/New-Mods>, with some changes/extensions:

- "difficulty increase" accent color left as Red1, because the Orange1 color in figma is already being used by the mod presets panel. seems like some kind of design conflict I don't want to figure out in this PR
- "fun" accent color chosen as Pink0, because it looked right to me alongside Purple0 for conversion, and there is no design for it on figma
- all "system" icons get the yellow foreground color so they are visible, but it's not clear to me whether that styling was supposed to be reserved for only NoMod
- the alternate icons for 6K and 8K are not used

I changed the icons to render using `SpriteText` instead of `SpriteIcon` because the latter was scaling glyphs to fit the container regardless of surrounding blank space, causing sizing issues when comparing different mods (most obvious when looking at all the mania key mods together)

this also sets up an avenue for osu-web to render mod icons using the same logic and resources as the client, so they wouldn't have to maintain mod icons separately. this is the main reason I've separated out the mods into a separate font, rather than update osuFont -- I want to try sharing osuModsFont with osu-web at some point.

in osuModsFont, all the icons were exported using the full 100x70 area of the mod background, so the appearance of mods will be identical to what's on figma as long as the font size is the height of the mod. icons from other fonts use a smaller font size to look consistent.

- [x] depends on https://github.com/ppy/osu-resources/pull/241

this is the first time I've touched this project or dotnet at all in like 5 years so I hope I did most of this okay :sweat_smile: 
marking as draft for now because I wasn't able to run the InspectCode script yet.