### PR TITLE
Fix intermittent failure in beatmap carousel tests

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -93,9 +94,11 @@ namespace osu.Game.Tests.Resources
             {
                 // Create random metadata, then we can check if sorting works based on these
                 Artist = "Some Artist " + RNG.Next(0, 9),
-                Title = $"Some Song (set id {setId}) {Guid.NewGuid()}",
+                Title = $"Some Song (set id {setId:000}) {Guid.NewGuid()}",
                 Author = { Username = "Some Guy " + RNG.Next(0, 9) },
             };
+
+            Logger.Log($"🛠️ Generating beatmap set \"{metadata}\" for test consumption.");
 
             var beatmapSet = new BeatmapSetInfo
             {

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -16,7 +16,9 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
@@ -926,10 +928,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // 10 sets that go osu! -> taiko -> catch -> osu! -> ...
             for (int i = 0; i < 10; i++)
-            {
-                var rulesetInfo = rulesets.AvailableRulesets.ElementAt(i % 3);
-                sets.Add(TestResources.CreateTestBeatmapSetInfo(5, new[] { rulesetInfo }));
-            }
+                sets.Add(TestResources.CreateTestBeatmapSetInfo(5, new[] { getRuleset(i) }));
 
             // Sort mode is important to keep the ruleset order
             loadBeatmaps(sets, () => new FilterCriteria { Sort = SortMode.Title });
@@ -937,12 +936,28 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             for (int i = 1; i < 10; i++)
             {
-                var rulesetInfo = rulesets.AvailableRulesets.ElementAt(i % 3);
+                var rulesetInfo = getRuleset(i % 3);
+
                 AddStep($"Set ruleset to {rulesetInfo.ShortName}", () =>
                 {
                     carousel.Filter(new FilterCriteria { Ruleset = rulesetInfo, Sort = SortMode.Title }, false);
                 });
                 waitForSelection(i + 1, 1);
+            }
+
+            static RulesetInfo getRuleset(int index)
+            {
+                switch (index % 3)
+                {
+                    default:
+                        return new OsuRuleset().RulesetInfo;
+
+                    case 1:
+                        return new TaikoRuleset().RulesetInfo;
+
+                    case 2:
+                        return new CatchRuleset().RulesetInfo;
+                }
             }
         }
 
@@ -953,10 +968,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // 10 sets that go taiko, osu!, osu!, osu!, taiko, osu!, osu!, osu!, ...
             for (int i = 0; i < 10; i++)
-            {
-                var rulesetInfo = rulesets.AvailableRulesets.ElementAt(i % 4 == 0 ? 1 : 0);
-                sets.Add(TestResources.CreateTestBeatmapSetInfo(5, new[] { rulesetInfo }));
-            }
+                sets.Add(TestResources.CreateTestBeatmapSetInfo(5, new[] { getRuleset(i) }));
 
             // Sort mode is important to keep the ruleset order
             loadBeatmaps(sets, () => new FilterCriteria { Sort = SortMode.Title });
@@ -973,6 +985,18 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false);
                 });
+            }
+
+            static RulesetInfo getRuleset(int index)
+            {
+                switch (index % 4)
+                {
+                    case 0:
+                        return new TaikoRuleset().RulesetInfo;
+
+                    default:
+                        return new OsuRuleset().RulesetInfo;
+                }
             }
         }
 

--- a/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelContent.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens.Select.Carousel
 
         private readonly CarouselBeatmapSet carouselSet;
 
+        private FillFlowContainer<DifficultyIcon> iconFlow = null!;
+
         public SetPanelContent(CarouselBeatmapSet carouselSet)
         {
             this.carouselSet = carouselSet;
@@ -82,18 +84,23 @@ namespace osu.Game.Screens.Select.Carousel
                                 TextPadding = new MarginPadding { Horizontal = 8, Vertical = 2 },
                                 Status = beatmapSet.Status
                             },
-                            new FillFlowContainer<DifficultyIcon>
+                            iconFlow = new FillFlowContainer<DifficultyIcon>
                             {
                                 AutoSizeAxes = Axes.Both,
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
                                 Spacing = new Vector2(3),
-                                ChildrenEnumerable = getDifficultyIcons(),
                             },
                         }
                     }
                 }
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            iconFlow.ChildrenEnumerable = getDifficultyIcons();
         }
 
         private const int maximum_difficulty_icons = 18;


### PR DESCRIPTION
https://teamcity.ppy.sh/buildConfiguration/Osu_Build/20489?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

```
TearDown : System.AggregateException : One or more errors occurred. (Collection was modified; enumeration operation may not execute.)
  ----> System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
--TearDown
   at osu.Framework.Testing.TestScene.checkForErrors()
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
--InvalidOperationException
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.OfTypeIterator[TResult](IEnumerable source)+MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at osu.Game.Screens.Select.Carousel.SetPanelContent.getDifficultyIcons() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Screens/Select/Carousel/SetPanelContent.cs:line 105
   at osu.Game.Screens.Select.Carousel.SetPanelContent.load() in /opt/buildagent/work/ecd860037212ac52/osu.Game/Screens/Select/Carousel/SetPanelContent.cs:line 39
```

I've managed to reproduce this semi-reliably by placing a thread sleep of 1ms at `SetPanelContent`'s BDL, apply 100 repetitions on `TestCarouselSelectsBackwardsWhenDistanceIsShorter`, then use rider's functionality of running the test until failure.

After a bit of effort in logging pieces of information, it appears that this is occurring in the following scenario:
 - Test adds beatmapsets to carousel, and carousel beatmapset cards are loading
 - Test changes ruleset to taiko
 - Beatmap carousel re-sorts each beatmapset items list due to change in filter criteria caused by ruleset switch
 - While carousel is re-sorting, one card is loading and it's iterating through the beatmapset's items list for loading difficulty icons

And after carousel is done re-sorting the beatmapset that the card is loading difficulty icons for, the exception gets thrown as per above.

Simplest fix as far as I can see is to just postpone loading difficulty icons until `LoadComplete`, where it should be safe to iterate through the beatmapset items. Need more opinions on the fix though (slight concern I have with this is shifting load overhead to the update thread, but I hope it's not that much on just difficulty icons).

One other way would be to retrieve icons in constructor and load them in BDL, but not sure it's worth the complexity.

In addition, I've pushed two other changes to make the test actually work for me locally when running it separately (not as part of the whole test fixture).