### PR TITLE
Update status icon design

### DIFF
--- a/osu.Game/Overlays/Login/UserDropdown.cs
+++ b/osu.Game/Overlays/Login/UserDropdown.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -78,7 +79,7 @@ namespace osu.Game.Overlays.Login
         {
             public const float LABEL_LEFT_MARGIN = 20;
 
-            private readonly SpriteIcon statusIcon;
+            private readonly StatusIcon statusIcon;
 
             public Color4 StatusColour
             {
@@ -101,11 +102,10 @@ namespace osu.Game.Overlays.Login
                 Icon.Size = new Vector2(14);
                 Icon.Margin = new MarginPadding(0);
 
-                Foreground.Add(statusIcon = new SpriteIcon
+                Foreground.Add(statusIcon = new StatusIcon
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    Icon = FontAwesome.Regular.Circle,
                     Size = new Vector2(14),
                 });
 

--- a/osu.Game/Overlays/Login/UserDropdown.cs
+++ b/osu.Game/Overlays/Login/UserDropdown.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Effects;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;

--- a/osu.Game/Users/Drawables/StatusIcon.cs
+++ b/osu.Game/Users/Drawables/StatusIcon.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Users.Drawables
         {
             Size = new Vector2(25);
             BorderThickness = 4;
-            BorderColour = Colour;
+            BorderColour = Colour4.White; // the colour is being applied through Colour - since it's multiplicative it applies to the border as well
             Masking = true;
             Child = new Box
             {

--- a/osu.Game/Users/Drawables/StatusIcon.cs
+++ b/osu.Game/Users/Drawables/StatusIcon.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Game.Users.Drawables
+{
+    public partial class StatusIcon : CircularContainer
+    {
+        public StatusIcon()
+        {
+            Size = new Vector2(25);
+            BorderThickness = 4;
+            BorderColour = Colour;
+            Masking = true;
+            Child = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Colour4.White.Opacity(0)
+            };
+        }
+    }
+}

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Users.Drawables;
 using osu.Framework.Input.Events;
 using osu.Game.Online.API.Requests.Responses;
@@ -25,7 +24,7 @@ namespace osu.Game.Users
 
         protected TextFlowContainer LastVisitMessage { get; private set; }
 
-        private SpriteIcon statusIcon;
+        private StatusIcon statusIcon;
         private OsuSpriteText statusMessage;
 
         protected ExtendedUserPanel(APIUser user)
@@ -59,11 +58,7 @@ namespace osu.Game.Users
             Action = Action,
         };
 
-        protected SpriteIcon CreateStatusIcon() => statusIcon = new SpriteIcon
-        {
-            Icon = FontAwesome.Regular.Circle,
-            Size = new Vector2(25)
-        };
+        protected Container CreateStatusIcon() => statusIcon = new StatusIcon();
 
         protected FillFlowContainer CreateStatusMessage(bool rightAlignedChildren)
         {


### PR DESCRIPTION
Part of the user panel design update #22130

Before:
![image](https://user-images.githubusercontent.com/8269193/212380863-0686a657-e7bd-4ffc-8a68-27787a5d0fcb.png)

After:
![image](https://user-images.githubusercontent.com/8269193/212380456-039c6e70-c52b-413d-bd34-0825abede240.png)

Designs on figma look a bit more thick somehow, but according to figma the border thickness is the same (4px)
