### PR TITLE
Fix intermittent failure in score submission tests

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -181,7 +181,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
             AddStep("exit", () => Player.Exit());
 
-            AddAssert("ensure failing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == false);
+            AddUntilStep("wait for submission", () => Player.SubmittedScore != null);
+            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Passed == false);
         }
 
         [Test]
@@ -209,7 +210,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             addFakeHit();
 
             AddStep("exit", () => Player.Exit());
-            AddAssert("ensure failing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == false);
+
+            AddUntilStep("wait for submission", () => Player.SubmittedScore != null);
+            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Passed == false);
         }
 
         [Test]


### PR DESCRIPTION
Obvious one after dealing with other intermittent test failures. Test relies on `SumbittedScore` to determine score state, and that gets set when score submission is fired, which is wrapped up in an async task:
https://github.com/ppy/osu/blob/ad2582a3ab8d4da2497bb4fa559bbe22246cd3a7/osu.Game/Screens/Play/SubmittingPlayer.cs#L162-L166

And the test can never expect an async task to fire immediately, so it must wait for `SubmittedScore` to be set first.

The same applies to tests that expect no submission (where if the task doesn't execute immediately, the test may incorrectly pass with regressed code). But such tests would fail 99% in such cases so it doesn't matter.