### PR TITLE
Fix intermittent failure in GCC seeking test

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -73,16 +73,6 @@ namespace osu.Game.Tests.Gameplay
         }
 
         [Test]
-        [FlakyTest]
-        /*
-         * Fail rate around 0.15%
-         *
-         * TearDown : osu.Framework.Testing.Drawables.Steps.AssertButton+TracedException : gameplay clock time = 2500
-         * --TearDown
-         *    at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
-         *    at osu.Framework.Threading.Scheduler.Update()
-         *    at osu.Framework.Graphics.Drawable.UpdateSubTree()
-         */
         public void TestSeekPerformsInGameplayTime(
             [Values(1.0, 0.5, 2.0)] double clockRate,
             [Values(0.0, 200.0, -200.0)] double userOffset,
@@ -91,6 +81,9 @@ namespace osu.Game.Tests.Gameplay
         {
             ClockBackedTestWorkingBeatmap working = null;
             GameplayClockContainer gameplayClockContainer = null;
+
+            // ReSharper disable once NotAccessedVariable
+            BindableDouble trackAdjustment = null; // keeping a reference for track adjustment
 
             if (setAudioOffsetBeforeConstruction)
                 AddStep($"preset audio offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
@@ -103,16 +96,16 @@ namespace osu.Game.Tests.Gameplay
                 gameplayClockContainer.Reset(startClock: !whileStopped);
             });
 
-            AddStep($"set clock rate to {clockRate}", () => working.Track.AddAdjustment(AdjustableProperty.Frequency, new BindableDouble(clockRate)));
+            AddStep($"set clock rate to {clockRate}", () => working.Track.AddAdjustment(AdjustableProperty.Frequency, trackAdjustment = new BindableDouble(clockRate)));
 
             if (!setAudioOffsetBeforeConstruction)
                 AddStep($"set audio offset to {userOffset}", () => localConfig.SetValue(OsuSetting.AudioOffset, userOffset));
 
             AddStep("seek to 2500", () => gameplayClockContainer.Seek(2500));
-            AddStep("gameplay clock time = 2500", () => Assert.AreEqual(gameplayClockContainer.CurrentTime, 2500, 10f));
+            AddAssert("gameplay clock time = 2500", () => gameplayClockContainer.CurrentTime, () => Is.EqualTo(2500).Within(10f));
 
             AddStep("seek to 10000", () => gameplayClockContainer.Seek(10000));
-            AddStep("gameplay clock time = 10000", () => Assert.AreEqual(gameplayClockContainer.CurrentTime, 10000, 10f));
+            AddAssert("gameplay clock time = 10000", () => gameplayClockContainer.CurrentTime, () => Is.EqualTo(10000).Within(10f));
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
```
  Expected: -200.0d +/- 10.0d
  But was:  2500.0d
  Off by:   -2700.0d

TearDown : NUnit.Framework.AssertionException :   Expected: -200.0d +/- 10.0d
  But was:  2500.0d
  Off by:   -2700.0d
   at osu.Game.Tests.Gameplay.TestSceneMasterGameplayClockContainer.<>c__DisplayClass5_0.<TestSeekPerformsInGameplayTime>b__5() in /opt/buildagent/work/ecd860037212ac52/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs:line 112
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
```

https://teamcity.ppy.sh/test/9221269594490241205?currentProjectId=Osu&expandTestHistoryInvestigationsSection=true&expandTestHistoryChartSection=true

`AggregateBindable` stores adjustment bindables via weak references, and there's nothing else keeping a strong reference of the bindable used for adjusting the track in the test, so it's susceptible to GC collection. And if it gets collected between seek and assertion, then it could lead to incorrect current time.