### PR TITLE
Localise most visible parts of editor

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenuItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
@@ -13,12 +11,12 @@ namespace osu.Game.Graphics.UserInterface
     {
         public readonly MenuItemType Type;
 
-        public OsuMenuItem(string text, MenuItemType type = MenuItemType.Standard)
+        public OsuMenuItem(LocalisableString text, MenuItemType type = MenuItemType.Standard)
             : this(text, type, null)
         {
         }
 
-        public OsuMenuItem(LocalisableString text, MenuItemType type, Action action)
+        public OsuMenuItem(LocalisableString text, MenuItemType type, Action? action)
             : base(text, action)
         {
             Type = type;

--- a/osu.Game/Graphics/UserInterface/StatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/StatefulMenuItem.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -25,7 +24,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="text">The text to display.</param>
         /// <param name="changeStateFunc">A function that mutates a state to another state after this <see cref="StatefulMenuItem"/> is pressed.</param>
         /// <param name="type">The type of action which this <see cref="StatefulMenuItem"/> performs.</param>
-        protected StatefulMenuItem(string text, Func<object, object> changeStateFunc, MenuItemType type = MenuItemType.Standard)
+        protected StatefulMenuItem(LocalisableString text, Func<object, object> changeStateFunc, MenuItemType type = MenuItemType.Standard)
             : this(text, changeStateFunc, type, null)
         {
         }
@@ -37,7 +36,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="changeStateFunc">A function that mutates a state to another state after this <see cref="StatefulMenuItem"/> is pressed.</param>
         /// <param name="type">The type of action which this <see cref="StatefulMenuItem"/> performs.</param>
         /// <param name="action">A delegate to be invoked when this <see cref="StatefulMenuItem"/> is pressed.</param>
-        protected StatefulMenuItem(string text, Func<object, object> changeStateFunc, MenuItemType type, Action<object> action)
+        protected StatefulMenuItem(LocalisableString text, Func<object, object>? changeStateFunc, MenuItemType type, Action<object>? action)
             : base(text, type)
         {
             Action.Value = () =>
@@ -69,7 +68,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="text">The text to display.</param>
         /// <param name="changeStateFunc">A function that mutates a state to another state after this <see cref="StatefulMenuItem"/> is pressed.</param>
         /// <param name="type">The type of action which this <see cref="StatefulMenuItem"/> performs.</param>
-        protected StatefulMenuItem(string text, Func<T, T> changeStateFunc, MenuItemType type = MenuItemType.Standard)
+        protected StatefulMenuItem(LocalisableString text, Func<T, T>? changeStateFunc, MenuItemType type = MenuItemType.Standard)
             : this(text, changeStateFunc, type, null)
         {
         }
@@ -81,7 +80,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="changeStateFunc">A function that mutates a state to another state after this <see cref="StatefulMenuItem"/> is pressed.</param>
         /// <param name="type">The type of action which this <see cref="StatefulMenuItem"/> performs.</param>
         /// <param name="action">A delegate to be invoked when this <see cref="StatefulMenuItem"/> is pressed.</param>
-        protected StatefulMenuItem(string text, Func<T, T> changeStateFunc, MenuItemType type, Action<T> action)
+        protected StatefulMenuItem(LocalisableString text, Func<T, T>? changeStateFunc, MenuItemType type, Action<T>? action)
             : base(text, o => changeStateFunc?.Invoke((T)o) ?? o, type, o => action?.Invoke((T)o))
         {
             base.State.BindValueChanged(state =>

--- a/osu.Game/Graphics/UserInterface/ToggleMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/ToggleMenuItem.cs
@@ -1,10 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -18,7 +17,7 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         /// <param name="text">The text to display.</param>
         /// <param name="type">The type of action which this <see cref="ToggleMenuItem"/> performs.</param>
-        public ToggleMenuItem(string text, MenuItemType type = MenuItemType.Standard)
+        public ToggleMenuItem(LocalisableString text, MenuItemType type = MenuItemType.Standard)
             : this(text, type, null)
         {
         }
@@ -29,7 +28,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <param name="text">The text to display.</param>
         /// <param name="type">The type of action which this <see cref="ToggleMenuItem"/> performs.</param>
         /// <param name="action">A delegate to be invoked when this <see cref="ToggleMenuItem"/> is pressed.</param>
-        public ToggleMenuItem(string text, MenuItemType type, Action<bool> action)
+        public ToggleMenuItem(LocalisableString text, MenuItemType type, Action<bool>? action)
             : base(text, value => !value, type, action)
         {
         }

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -104,6 +104,56 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString Description => new TranslatableString(getKey(@"description"), @"Description");
 
+        /// <summary>
+        /// "File"
+        /// </summary>
+        public static LocalisableString MenuBarFile => new TranslatableString(getKey(@"menu_bar_file"), @"File");
+
+        /// <summary>
+        /// "Edit"
+        /// </summary>
+        public static LocalisableString MenuBarEdit => new TranslatableString(getKey(@"menu_bar_edit"), @"Edit");
+
+        /// <summary>
+        /// "View"
+        /// </summary>
+        public static LocalisableString MenuBarView => new TranslatableString(getKey(@"menu_bar_view"), @"View");
+
+        /// <summary>
+        /// "Undo"
+        /// </summary>
+        public static LocalisableString Undo => new TranslatableString(getKey(@"undo"), @"Undo");
+
+        /// <summary>
+        /// "Redo"
+        /// </summary>
+        public static LocalisableString Redo => new TranslatableString(getKey(@"redo"), @"Redo");
+
+        /// <summary>
+        /// "Cut"
+        /// </summary>
+        public static LocalisableString Cut => new TranslatableString(getKey(@"cut"), @"Cut");
+
+        /// <summary>
+        /// "Copy"
+        /// </summary>
+        public static LocalisableString Copy => new TranslatableString(getKey(@"copy"), @"Copy");
+
+        /// <summary>
+        /// "Paste"
+        /// </summary>
+        public static LocalisableString Paste => new TranslatableString(getKey(@"paste"), @"Paste");
+
+        /// <summary>
+        /// "Clone"
+        /// </summary>
+        public static LocalisableString Clone => new TranslatableString(getKey(@"clone"), @"Clone");
+
+        /// <summary>
+        /// "Exit"
+        /// </summary>
+        public static LocalisableString Exit => new TranslatableString(getKey(@"exit"), @"Exit");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/EditorDialogsStrings.cs
+++ b/osu.Game/Localisation/EditorDialogsStrings.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class EditorDialogsStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.EditorDialogs";
+
+        /// <summary>
+        /// "Would you like to create a blank difficulty?"
+        /// </summary>
+        public static LocalisableString NewDifficultyDialogHeader => new TranslatableString(getKey(@"new_difficulty_dialog_header"), @"Would you like to create a blank difficulty?");
+
+        /// <summary>
+        /// "Yeah, let&#39;s start from scratch!"
+        /// </summary>
+        public static LocalisableString CreateNew => new TranslatableString(getKey(@"create_new"), @"Yeah, let's start from scratch!");
+
+        /// <summary>
+        /// "No, create an exact copy of this difficulty"
+        /// </summary>
+        public static LocalisableString CreateCopy => new TranslatableString(getKey(@"create_copy"), @"No, create an exact copy of this difficulty");
+
+        /// <summary>
+        /// "I changed my mind, I want to keep editing this difficulty"
+        /// </summary>
+        public static LocalisableString KeepEditing => new TranslatableString(getKey(@"keep_editing"), @"I changed my mind, I want to keep editing this difficulty");
+
+        /// <summary>
+        /// "Did you want to save your changes?"
+        /// </summary>
+        public static LocalisableString SaveDialogHeader => new TranslatableString(getKey(@"save_dialog_header"), @"Did you want to save your changes?");
+
+        /// <summary>
+        /// "Save my masterpiece!"
+        /// </summary>
+        public static LocalisableString Save => new TranslatableString(getKey(@"save"), @"Save my masterpiece!");
+
+        /// <summary>
+        /// "Forget all changes"
+        /// </summary>
+        public static LocalisableString ForgetAllChanges => new TranslatableString(getKey(@"forget_all_changes"), @"Forget all changes");
+
+        /// <summary>
+        /// "Oops, continue editing"
+        /// </summary>
+        public static LocalisableString ContinueEditing => new TranslatableString(getKey(@"continue_editing"), @"Oops, continue editing");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/EditorSetupStrings.cs
+++ b/osu.Game/Localisation/EditorSetupStrings.cs
@@ -42,7 +42,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "If enabled, an &quot;Are you ready? 3, 2, 1, GO!&quot; countdown will be inserted at the beginning of the beatmap, assuming there is enough time to do so."
         /// </summary>
-        public static LocalisableString CountdownDescription => new TranslatableString(getKey(@"countdown_description"), @"If enabled, an ""Are you ready? 3, 2, 1, GO!"" countdown will be inserted at the beginning of the beatmap, assuming there is enough time to do so.");
+        public static LocalisableString CountdownDescription => new TranslatableString(getKey(@"countdown_description"),
+            @"If enabled, an ""Are you ready? 3, 2, 1, GO!"" countdown will be inserted at the beginning of the beatmap, assuming there is enough time to do so.");
 
         /// <summary>
         /// "Countdown speed"
@@ -52,7 +53,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "If the countdown sounds off-time, use this to make it appear one or more beats early."
         /// </summary>
-        public static LocalisableString CountdownOffsetDescription => new TranslatableString(getKey(@"countdown_offset_description"), @"If the countdown sounds off-time, use this to make it appear one or more beats early.");
+        public static LocalisableString CountdownOffsetDescription =>
+            new TranslatableString(getKey(@"countdown_offset_description"), @"If the countdown sounds off-time, use this to make it appear one or more beats early.");
 
         /// <summary>
         /// "Countdown offset"
@@ -67,7 +69,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Allows storyboards to use the full screen space, rather than be confined to a 4:3 area."
         /// </summary>
-        public static LocalisableString WidescreenSupportDescription => new TranslatableString(getKey(@"widescreen_support_description"), @"Allows storyboards to use the full screen space, rather than be confined to a 4:3 area.");
+        public static LocalisableString WidescreenSupportDescription =>
+            new TranslatableString(getKey(@"widescreen_support_description"), @"Allows storyboards to use the full screen space, rather than be confined to a 4:3 area.");
 
         /// <summary>
         /// "Epilepsy warning"
@@ -77,7 +80,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Recommended if the storyboard or video contain scenes with rapidly flashing colours."
         /// </summary>
-        public static LocalisableString EpilepsyWarningDescription => new TranslatableString(getKey(@"epilepsy_warning_description"), @"Recommended if the storyboard or video contain scenes with rapidly flashing colours.");
+        public static LocalisableString EpilepsyWarningDescription =>
+            new TranslatableString(getKey(@"epilepsy_warning_description"), @"Recommended if the storyboard or video contain scenes with rapidly flashing colours.");
 
         /// <summary>
         /// "Letterbox during breaks"
@@ -87,7 +91,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Adds horizontal letterboxing to give a cinematic look during breaks."
         /// </summary>
-        public static LocalisableString LetterboxDuringBreaksDescription => new TranslatableString(getKey(@"letterbox_during_breaks_description"), @"Adds horizontal letterboxing to give a cinematic look during breaks.");
+        public static LocalisableString LetterboxDuringBreaksDescription =>
+            new TranslatableString(getKey(@"letterbox_during_breaks_description"), @"Adds horizontal letterboxing to give a cinematic look during breaks.");
 
         /// <summary>
         /// "Samples match playback rate"
@@ -97,7 +102,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "When enabled, all samples will speed up or slow down when rate-changing mods are enabled."
         /// </summary>
-        public static LocalisableString SamplesMatchPlaybackRateDescription => new TranslatableString(getKey(@"samples_match_playback_rate_description"), @"When enabled, all samples will speed up or slow down when rate-changing mods are enabled.");
+        public static LocalisableString SamplesMatchPlaybackRateDescription => new TranslatableString(getKey(@"samples_match_playback_rate_description"),
+            @"When enabled, all samples will speed up or slow down when rate-changing mods are enabled.");
 
         /// <summary>
         /// "The size of all hit objects"
@@ -117,7 +123,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "The harshness of hit windows and difficulty of special objects (ie. spinners)"
         /// </summary>
-        public static LocalisableString OverallDifficultyDescription => new TranslatableString(getKey(@"overall_difficulty_description"), @"The harshness of hit windows and difficulty of special objects (ie. spinners)");
+        public static LocalisableString OverallDifficultyDescription =>
+            new TranslatableString(getKey(@"overall_difficulty_description"), @"The harshness of hit windows and difficulty of special objects (ie. spinners)");
 
         /// <summary>
         /// "Metadata"
@@ -198,6 +205,11 @@ namespace osu.Game.Localisation
         /// "Difficulty"
         /// </summary>
         public static LocalisableString DifficultyHeader => new TranslatableString(getKey(@"difficulty_header"), @"Difficulty");
+
+        /// <summary>
+        /// "Drag image here to set beatmap background!"
+        /// </summary>
+        public static LocalisableString DragToSetBackground => new TranslatableString(getKey(@"drag_to_set_background"), @"Drag image here to set beatmap background!");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -1,0 +1,164 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class EditorStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.Editor";
+
+        /// <summary>
+        /// "File"
+        /// </summary>
+        public static LocalisableString File => new TranslatableString(getKey(@"file"), @"File");
+
+        /// <summary>
+        /// "Edit"
+        /// </summary>
+        public static LocalisableString Edit => new TranslatableString(getKey(@"edit"), @"Edit");
+
+        /// <summary>
+        /// "Undo"
+        /// </summary>
+        public static LocalisableString Undo => new TranslatableString(getKey(@"undo"), @"Undo");
+
+        /// <summary>
+        /// "Redo"
+        /// </summary>
+        public static LocalisableString Redo => new TranslatableString(getKey(@"redo"), @"Redo");
+
+        /// <summary>
+        /// "Cut"
+        /// </summary>
+        public static LocalisableString Cut => new TranslatableString(getKey(@"cut"), @"Cut");
+
+        /// <summary>
+        /// "Copy"
+        /// </summary>
+        public static LocalisableString Copy => new TranslatableString(getKey(@"copy"), @"Copy");
+
+        /// <summary>
+        /// "Paste"
+        /// </summary>
+        public static LocalisableString Paste => new TranslatableString(getKey(@"paste"), @"Paste");
+
+        /// <summary>
+        /// "Clone"
+        /// </summary>
+        public static LocalisableString Clone => new TranslatableString(getKey(@"clone"), @"Clone");
+
+        /// <summary>
+        /// "View"
+        /// </summary>
+        public static LocalisableString View => new TranslatableString(getKey(@"view"), @"View");
+
+        /// <summary>
+        /// "Background dim"
+        /// </summary>
+        public static LocalisableString BackgroundDim => new TranslatableString(getKey(@"background_dim"), @"Background dim");
+
+        /// <summary>
+        /// "Waveform opacity"
+        /// </summary>
+        public static LocalisableString WaveformOpacity => new TranslatableString(getKey(@"waveform_opacity"), @"Waveform opacity");
+
+        /// <summary>
+        /// "Show hit markers"
+        /// </summary>
+        public static LocalisableString ShowHitMarkers => new TranslatableString(getKey(@"show_hit_markers"), @"Show hit markers");
+
+        /// <summary>
+        /// "Timing"
+        /// </summary>
+        public static LocalisableString Timing => new TranslatableString(getKey(@"timing"), @"Timing");
+
+        /// <summary>
+        /// "Set preview point to current time"
+        /// </summary>
+        public static LocalisableString SetPreviewPointToCurrent => new TranslatableString(getKey(@"set_preview_point_to_current"), @"Set preview point to current time");
+
+        /// <summary>
+        /// "Save"
+        /// </summary>
+        public static LocalisableString Save => new TranslatableString(getKey(@"save"), @"Save");
+
+        /// <summary>
+        /// "Export package"
+        /// </summary>
+        public static LocalisableString ExportPackage => new TranslatableString(getKey(@"export_package"), @"Export package");
+
+        /// <summary>
+        /// "Create new difficulty"
+        /// </summary>
+        public static LocalisableString CreateNewDifficulty => new TranslatableString(getKey(@"create_new_difficulty"), @"Create new difficulty");
+
+        /// <summary>
+        /// "Change difficulty"
+        /// </summary>
+        public static LocalisableString ChangeDifficulty => new TranslatableString(getKey(@"change_difficulty"), @"Change difficulty");
+
+        /// <summary>
+        /// "Delete difficulty"
+        /// </summary>
+        public static LocalisableString DeleteDifficulty => new TranslatableString(getKey(@"delete_difficulty"), @"Delete difficulty");
+
+        /// <summary>
+        /// "Exit"
+        /// </summary>
+        public static LocalisableString Exit => new TranslatableString(getKey(@"exit"), @"Exit");
+
+        /// <summary>
+        /// "setup"
+        /// </summary>
+        public static LocalisableString SetupScreen => new TranslatableString(getKey(@"setup_screen"), @"setup");
+
+        /// <summary>
+        /// "compose"
+        /// </summary>
+        public static LocalisableString ComposeScreen => new TranslatableString(getKey(@"compose_screen"), @"compose");
+
+        /// <summary>
+        /// "design"
+        /// </summary>
+        public static LocalisableString DesignScreen => new TranslatableString(getKey(@"design_screen"), @"design");
+
+        /// <summary>
+        /// "timing"
+        /// </summary>
+        public static LocalisableString TimingScreen => new TranslatableString(getKey(@"timing_screen"), @"timing");
+
+        /// <summary>
+        /// "verify"
+        /// </summary>
+        public static LocalisableString VerifyScreen => new TranslatableString(getKey(@"verify_screen"), @"verify");
+
+        /// <summary>
+        /// "Playback speed"
+        /// </summary>
+        public static LocalisableString PlaybackSpeed => new TranslatableString(getKey(@"playback_speed"), @"Playback speed");
+
+        /// <summary>
+        /// "Test!"
+        /// </summary>
+        public static LocalisableString TestBeatmap => new TranslatableString(getKey(@"test_beatmap"), @"Test!");
+
+        /// <summary>
+        /// "Waveform"
+        /// </summary>
+        public static LocalisableString TimelineWaveform => new TranslatableString(getKey(@"timeline_waveform"), @"Waveform");
+
+        /// <summary>
+        /// "Ticks"
+        /// </summary>
+        public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
+
+        /// <summary>
+        /// "BPM"
+        /// </summary>
+        public static LocalisableString TimelineBpm => new TranslatableString(getKey(@"timeline_bpm"), @"BPM");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -55,11 +55,6 @@ namespace osu.Game.Localisation
         public static LocalisableString View => new TranslatableString(getKey(@"view"), @"View");
 
         /// <summary>
-        /// "Background dim"
-        /// </summary>
-        public static LocalisableString BackgroundDim => new TranslatableString(getKey(@"background_dim"), @"Background dim");
-
-        /// <summary>
         /// "Waveform opacity"
         /// </summary>
         public static LocalisableString WaveformOpacity => new TranslatableString(getKey(@"waveform_opacity"), @"Waveform opacity");
@@ -78,11 +73,6 @@ namespace osu.Game.Localisation
         /// "Set preview point to current time"
         /// </summary>
         public static LocalisableString SetPreviewPointToCurrent => new TranslatableString(getKey(@"set_preview_point_to_current"), @"Set preview point to current time");
-
-        /// <summary>
-        /// "Save"
-        /// </summary>
-        public static LocalisableString Save => new TranslatableString(getKey(@"save"), @"Save");
 
         /// <summary>
         /// "Export package"
@@ -153,11 +143,6 @@ namespace osu.Game.Localisation
         /// "Ticks"
         /// </summary>
         public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
-
-        /// <summary>
-        /// "BPM"
-        /// </summary>
-        public static LocalisableString TimelineBpm => new TranslatableString(getKey(@"timeline_bpm"), @"BPM");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -10,51 +10,6 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.Editor";
 
         /// <summary>
-        /// "File"
-        /// </summary>
-        public static LocalisableString File => new TranslatableString(getKey(@"file"), @"File");
-
-        /// <summary>
-        /// "Edit"
-        /// </summary>
-        public static LocalisableString Edit => new TranslatableString(getKey(@"edit"), @"Edit");
-
-        /// <summary>
-        /// "Undo"
-        /// </summary>
-        public static LocalisableString Undo => new TranslatableString(getKey(@"undo"), @"Undo");
-
-        /// <summary>
-        /// "Redo"
-        /// </summary>
-        public static LocalisableString Redo => new TranslatableString(getKey(@"redo"), @"Redo");
-
-        /// <summary>
-        /// "Cut"
-        /// </summary>
-        public static LocalisableString Cut => new TranslatableString(getKey(@"cut"), @"Cut");
-
-        /// <summary>
-        /// "Copy"
-        /// </summary>
-        public static LocalisableString Copy => new TranslatableString(getKey(@"copy"), @"Copy");
-
-        /// <summary>
-        /// "Paste"
-        /// </summary>
-        public static LocalisableString Paste => new TranslatableString(getKey(@"paste"), @"Paste");
-
-        /// <summary>
-        /// "Clone"
-        /// </summary>
-        public static LocalisableString Clone => new TranslatableString(getKey(@"clone"), @"Clone");
-
-        /// <summary>
-        /// "View"
-        /// </summary>
-        public static LocalisableString View => new TranslatableString(getKey(@"view"), @"View");
-
-        /// <summary>
         /// "Waveform opacity"
         /// </summary>
         public static LocalisableString WaveformOpacity => new TranslatableString(getKey(@"waveform_opacity"), @"Waveform opacity");
@@ -93,11 +48,6 @@ namespace osu.Game.Localisation
         /// "Delete difficulty"
         /// </summary>
         public static LocalisableString DeleteDifficulty => new TranslatableString(getKey(@"delete_difficulty"), @"Delete difficulty");
-
-        /// <summary>
-        /// "Exit"
-        /// </summary>
-        public static LocalisableString Exit => new TranslatableString(getKey(@"exit"), @"Exit");
 
         /// <summary>
         /// "setup"

--- a/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
+++ b/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
@@ -5,17 +5,18 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
     internal class BackgroundDimMenuItem : MenuItem
     {
-        private readonly Bindable<float> backgroudDim;
+        private readonly Bindable<float> backgroundDim;
 
         private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
 
-        public BackgroundDimMenuItem(Bindable<float> backgroudDim)
-            : base("Background dim")
+        public BackgroundDimMenuItem(Bindable<float> backgroundDim)
+            : base(EditorStrings.BackgroundDim)
         {
             Items = new[]
             {
@@ -25,8 +26,8 @@ namespace osu.Game.Screens.Edit
                 createMenuItem(0.75f),
             };
 
-            this.backgroudDim = backgroudDim;
-            backgroudDim.BindValueChanged(dim =>
+            this.backgroundDim = backgroundDim;
+            backgroundDim.BindValueChanged(dim =>
             {
                 foreach (var kvp in menuItemLookup)
                     kvp.Value.State.Value = kvp.Key == dim.NewValue ? TernaryState.True : TernaryState.False;
@@ -40,6 +41,6 @@ namespace osu.Game.Screens.Edit
             return item;
         }
 
-        private void updateOpacity(float dim) => backgroudDim.Value = dim;
+        private void updateOpacity(float dim) => backgroundDim.Value = dim;
     }
 }

--- a/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
+++ b/osu.Game/Screens/Edit/BackgroundDimMenuItem.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit
         private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
 
         public BackgroundDimMenuItem(Bindable<float> backgroundDim)
-            : base(EditorStrings.BackgroundDim)
+            : base(GameplaySettingsStrings.BackgroundDim)
         {
             Items = new[]
             {

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuItem.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuItem.cs
@@ -9,15 +9,13 @@ namespace osu.Game.Screens.Edit.Components.Menus
 {
     public class EditorMenuItem : OsuMenuItem
     {
-        private const int min_text_length = 40;
-
         public EditorMenuItem(LocalisableString text, MenuItemType type = MenuItemType.Standard)
-            : base(LocalisableString.Interpolate($"{text,-min_text_length}"), type)
+            : base(text, type)
         {
         }
 
         public EditorMenuItem(LocalisableString text, MenuItemType type, Action action)
-            : base(LocalisableString.Interpolate($"{text,-min_text_length}"), type, action)
+            : base(text, type, action)
         {
         }
     }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuItem.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuItem.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Edit.Components.Menus
@@ -10,13 +11,13 @@ namespace osu.Game.Screens.Edit.Components.Menus
     {
         private const int min_text_length = 40;
 
-        public EditorMenuItem(string text, MenuItemType type = MenuItemType.Standard)
-            : base(text.PadRight(min_text_length), type)
+        public EditorMenuItem(LocalisableString text, MenuItemType type = MenuItemType.Standard)
+            : base(LocalisableString.Interpolate($"{text,-min_text_length}"), type)
         {
         }
 
-        public EditorMenuItem(string text, MenuItemType type, Action action)
-            : base(text.PadRight(min_text_length), type, action)
+        public EditorMenuItem(LocalisableString text, MenuItemType type, Action action)
+            : base(LocalisableString.Interpolate($"{text,-min_text_length}"), type, action)
         {
         }
     }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorScreenSwitcherControl.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorScreenSwitcherControl.cs
@@ -56,11 +56,6 @@ namespace osu.Game.Screens.Edit.Components.Menus
                 Bar.Expire();
             }
 
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-            }
-
             protected override void OnActivated()
             {
                 base.OnActivated();

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -16,6 +16,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK.Input;
 
@@ -47,7 +48,7 @@ namespace osu.Game.Screens.Edit.Components
                 new OsuSpriteText
                 {
                     Origin = Anchor.BottomLeft,
-                    Text = "Playback speed",
+                    Text = EditorStrings.PlaybackSpeed,
                     RelativePositionAxes = Axes.Y,
                     Y = 0.5f,
                     Padding = new MarginPadding { Left = 45 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/TestGameplayButton.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/TestGameplayButton.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary
@@ -30,7 +31,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary
 
             Content.CornerRadius = 0;
 
-            Text = "Test!";
+            Text = EditorStrings.TestBeatmap;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
+using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
@@ -86,7 +87,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                             },
                                             controlPointsCheckbox = new OsuCheckbox
                                             {
-                                                LabelText = EditorStrings.TimelineBpm,
+                                                LabelText = BeatmapsetsStrings.ShowStatsBpm,
                                                 Current = { Value = true },
                                             },
                                         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -75,17 +76,17 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                         {
                                             waveformCheckbox = new OsuCheckbox
                                             {
-                                                LabelText = "Waveform",
+                                                LabelText = EditorStrings.TimelineWaveform,
                                                 Current = { Value = true },
                                             },
                                             ticksCheckbox = new OsuCheckbox
                                             {
-                                                LabelText = "Ticks",
+                                                LabelText = EditorStrings.TimelineTicks,
                                                 Current = { Value = true },
                                             },
                                             controlPointsCheckbox = new OsuCheckbox
                                             {
-                                                LabelText = "BPM",
+                                                LabelText = EditorStrings.TimelineBpm,
                                                 Current = { Value = true },
                                             },
                                         }

--- a/osu.Game/Screens/Edit/CreateNewDifficultyDialog.cs
+++ b/osu.Game/Screens/Edit/CreateNewDifficultyDialog.cs
@@ -1,10 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
@@ -20,7 +19,7 @@ namespace osu.Game.Screens.Edit
 
         public CreateNewDifficultyDialog(CreateNewDifficulty createNewDifficulty)
         {
-            HeaderText = "Would you like to create a blank difficulty?";
+            HeaderText = EditorDialogsStrings.NewDifficultyDialogHeader;
 
             Icon = FontAwesome.Regular.Clone;
 
@@ -28,17 +27,17 @@ namespace osu.Game.Screens.Edit
             {
                 new PopupDialogOkButton
                 {
-                    Text = "Yeah, let's start from scratch!",
+                    Text = EditorDialogsStrings.CreateNew,
                     Action = () => createNewDifficulty.Invoke(false)
                 },
                 new PopupDialogCancelButton
                 {
-                    Text = "No, create an exact copy of this difficulty",
+                    Text = EditorDialogsStrings.CreateCopy,
                     Action = () => createNewDifficulty.Invoke(true)
                 },
                 new PopupDialogCancelButton
                 {
-                    Text = "I changed my mind, I want to keep editing this difficulty",
+                    Text = EditorDialogsStrings.KeepEditing,
                     Action = () => { }
                 }
             };

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -51,7 +51,7 @@ using osu.Game.Screens.Edit.Verify;
 using osu.Game.Screens.Play;
 using osu.Game.Users;
 using osuTK.Input;
-using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
+using WebCommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Edit
 {
@@ -294,24 +294,24 @@ namespace osu.Game.Screens.Edit
                                 RelativeSizeAxes = Axes.Both,
                                 Items = new[]
                                 {
-                                    new MenuItem(EditorStrings.File)
+                                    new MenuItem(CommonStrings.MenuBarFile)
                                     {
                                         Items = createFileMenuItems()
                                     },
-                                    new MenuItem(EditorStrings.Edit)
+                                    new MenuItem(CommonStrings.MenuBarEdit)
                                     {
                                         Items = new[]
                                         {
-                                            undoMenuItem = new EditorMenuItem(EditorStrings.Undo, MenuItemType.Standard, Undo),
-                                            redoMenuItem = new EditorMenuItem(EditorStrings.Redo, MenuItemType.Standard, Redo),
+                                            undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo),
+                                            redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo),
                                             new EditorMenuItemSpacer(),
-                                            cutMenuItem = new EditorMenuItem(EditorStrings.Cut, MenuItemType.Standard, Cut),
-                                            copyMenuItem = new EditorMenuItem(EditorStrings.Copy, MenuItemType.Standard, Copy),
-                                            pasteMenuItem = new EditorMenuItem(EditorStrings.Paste, MenuItemType.Standard, Paste),
-                                            cloneMenuItem = new EditorMenuItem(EditorStrings.Clone, MenuItemType.Standard, Clone),
+                                            cutMenuItem = new EditorMenuItem(CommonStrings.Cut, MenuItemType.Standard, Cut),
+                                            copyMenuItem = new EditorMenuItem(CommonStrings.Copy, MenuItemType.Standard, Copy),
+                                            pasteMenuItem = new EditorMenuItem(CommonStrings.Paste, MenuItemType.Standard, Paste),
+                                            cloneMenuItem = new EditorMenuItem(CommonStrings.Clone, MenuItemType.Standard, Clone),
                                         }
                                     },
-                                    new MenuItem(EditorStrings.View)
+                                    new MenuItem(CommonStrings.MenuBarView)
                                     {
                                         Items = new MenuItem[]
                                         {
@@ -344,7 +344,6 @@ namespace osu.Game.Screens.Edit
                     bottomBar = new BottomBar(),
                 }
             });
-
             changeHandler?.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);
             changeHandler?.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
 
@@ -952,7 +951,7 @@ namespace osu.Game.Screens.Edit
 
         private List<MenuItem> createFileMenuItems() => new List<MenuItem>
         {
-            new EditorMenuItem(CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
+            new EditorMenuItem(WebCommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
             new EditorMenuItem(EditorStrings.ExportPackage, MenuItemType.Standard, exportBeatmap) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
             new EditorMenuItemSpacer(),
             createDifficultyCreationMenu(),
@@ -960,7 +959,7 @@ namespace osu.Game.Screens.Edit
             new EditorMenuItemSpacer(),
             new EditorMenuItem(EditorStrings.DeleteDifficulty, MenuItemType.Standard, deleteDifficulty) { Action = { Disabled = Beatmap.Value.BeatmapSetInfo.Beatmaps.Count < 2 } },
             new EditorMenuItemSpacer(),
-            new EditorMenuItem(EditorStrings.Exit, MenuItemType.Standard, this.Exit)
+            new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, this.Exit)
         };
 
         private void exportBeatmap()

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -51,6 +51,7 @@ using osu.Game.Screens.Edit.Verify;
 using osu.Game.Screens.Play;
 using osu.Game.Users;
 using osuTK.Input;
+using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Edit
 {
@@ -951,7 +952,7 @@ namespace osu.Game.Screens.Edit
 
         private List<MenuItem> createFileMenuItems() => new List<MenuItem>
         {
-            new EditorMenuItem(EditorStrings.Save, MenuItemType.Standard, () => Save()),
+            new EditorMenuItem(CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
             new EditorMenuItem(EditorStrings.ExportPackage, MenuItemType.Standard, exportBeatmap) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
             new EditorMenuItemSpacer(),
             createDifficultyCreationMenu(),

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -51,7 +51,6 @@ using osu.Game.Screens.Edit.Verify;
 using osu.Game.Screens.Play;
 using osu.Game.Users;
 using osuTK.Input;
-using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Edit
 {
@@ -294,40 +293,40 @@ namespace osu.Game.Screens.Edit
                                 RelativeSizeAxes = Axes.Both,
                                 Items = new[]
                                 {
-                                    new MenuItem("File")
+                                    new MenuItem(EditorStrings.File)
                                     {
                                         Items = createFileMenuItems()
                                     },
-                                    new MenuItem(CommonStrings.ButtonsEdit)
+                                    new MenuItem(EditorStrings.Edit)
                                     {
                                         Items = new[]
                                         {
-                                            undoMenuItem = new EditorMenuItem("Undo", MenuItemType.Standard, Undo),
-                                            redoMenuItem = new EditorMenuItem("Redo", MenuItemType.Standard, Redo),
+                                            undoMenuItem = new EditorMenuItem(EditorStrings.Undo, MenuItemType.Standard, Undo),
+                                            redoMenuItem = new EditorMenuItem(EditorStrings.Redo, MenuItemType.Standard, Redo),
                                             new EditorMenuItemSpacer(),
-                                            cutMenuItem = new EditorMenuItem("Cut", MenuItemType.Standard, Cut),
-                                            copyMenuItem = new EditorMenuItem("Copy", MenuItemType.Standard, Copy),
-                                            pasteMenuItem = new EditorMenuItem("Paste", MenuItemType.Standard, Paste),
-                                            cloneMenuItem = new EditorMenuItem("Clone", MenuItemType.Standard, Clone),
+                                            cutMenuItem = new EditorMenuItem(EditorStrings.Cut, MenuItemType.Standard, Cut),
+                                            copyMenuItem = new EditorMenuItem(EditorStrings.Copy, MenuItemType.Standard, Copy),
+                                            pasteMenuItem = new EditorMenuItem(EditorStrings.Paste, MenuItemType.Standard, Paste),
+                                            cloneMenuItem = new EditorMenuItem(EditorStrings.Clone, MenuItemType.Standard, Clone),
                                         }
                                     },
-                                    new MenuItem("View")
+                                    new MenuItem(EditorStrings.View)
                                     {
                                         Items = new MenuItem[]
                                         {
                                             new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
                                             new BackgroundDimMenuItem(editorBackgroundDim),
-                                            new ToggleMenuItem("Show hit markers")
+                                            new ToggleMenuItem(EditorStrings.ShowHitMarkers)
                                             {
                                                 State = { BindTarget = editorHitMarkers },
                                             }
                                         }
                                     },
-                                    new MenuItem("Timing")
+                                    new MenuItem(EditorStrings.Timing)
                                     {
                                         Items = new MenuItem[]
                                         {
-                                            new EditorMenuItem("Set preview point to current time", MenuItemType.Standard, SetPreviewPointToCurrentTime)
+                                            new EditorMenuItem(EditorStrings.SetPreviewPointToCurrent, MenuItemType.Standard, SetPreviewPointToCurrentTime)
                                         }
                                     }
                                 }
@@ -716,7 +715,7 @@ namespace osu.Game.Screens.Edit
 
             if (!(refetchedBeatmap is DummyWorkingBeatmap))
             {
-                Logger.Log("Editor providing re-fetched beatmap post edit session");
+                Logger.Log(@"Editor providing re-fetched beatmap post edit session");
                 Beatmap.Value = refetchedBeatmap;
             }
         }
@@ -952,15 +951,15 @@ namespace osu.Game.Screens.Edit
 
         private List<MenuItem> createFileMenuItems() => new List<MenuItem>
         {
-            new EditorMenuItem("Save", MenuItemType.Standard, () => Save()),
-            new EditorMenuItem("Export package", MenuItemType.Standard, exportBeatmap) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
+            new EditorMenuItem(EditorStrings.Save, MenuItemType.Standard, () => Save()),
+            new EditorMenuItem(EditorStrings.ExportPackage, MenuItemType.Standard, exportBeatmap) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
             new EditorMenuItemSpacer(),
             createDifficultyCreationMenu(),
             createDifficultySwitchMenu(),
             new EditorMenuItemSpacer(),
-            new EditorMenuItem("Delete difficulty", MenuItemType.Standard, deleteDifficulty) { Action = { Disabled = Beatmap.Value.BeatmapSetInfo.Beatmaps.Count < 2 } },
+            new EditorMenuItem(EditorStrings.DeleteDifficulty, MenuItemType.Standard, deleteDifficulty) { Action = { Disabled = Beatmap.Value.BeatmapSetInfo.Beatmaps.Count < 2 } },
             new EditorMenuItemSpacer(),
-            new EditorMenuItem("Exit", MenuItemType.Standard, this.Exit)
+            new EditorMenuItem(EditorStrings.Exit, MenuItemType.Standard, this.Exit)
         };
 
         private void exportBeatmap()
@@ -1009,7 +1008,7 @@ namespace osu.Game.Screens.Edit
             foreach (var ruleset in rulesets.AvailableRulesets)
                 rulesetItems.Add(new EditorMenuItem(ruleset.Name, MenuItemType.Standard, () => CreateNewDifficulty(ruleset)));
 
-            return new EditorMenuItem("Create new difficulty") { Items = rulesetItems };
+            return new EditorMenuItem(EditorStrings.CreateNewDifficulty) { Items = rulesetItems };
         }
 
         protected void CreateNewDifficulty(RulesetInfo rulesetInfo)
@@ -1045,7 +1044,7 @@ namespace osu.Game.Screens.Edit
                 }
             }
 
-            return new EditorMenuItem("Change difficulty") { Items = difficultyItems };
+            return new EditorMenuItem(EditorStrings.ChangeDifficulty) { Items = difficultyItems };
         }
 
         protected void SwitchToDifficulty(BeatmapInfo nextBeatmap) => loader?.ScheduleSwitchToExistingDifficulty(nextBeatmap, GetState(nextBeatmap.Ruleset));

--- a/osu.Game/Screens/Edit/EditorScreenMode.cs
+++ b/osu.Game/Screens/Edit/EditorScreenMode.cs
@@ -1,27 +1,26 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
     public enum EditorScreenMode
     {
-        [Description("setup")]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.SetupScreen))]
         SongSetup,
 
-        [Description("compose")]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ComposeScreen))]
         Compose,
 
-        [Description("design")]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.DesignScreen))]
         Design,
 
-        [Description("timing")]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.TimingScreen))]
         Timing,
 
-        [Description("verify")]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.VerifyScreen))]
         Verify,
     }
 }

--- a/osu.Game/Screens/Edit/PromptForSaveDialog.cs
+++ b/osu.Game/Screens/Edit/PromptForSaveDialog.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
@@ -13,7 +12,7 @@ namespace osu.Game.Screens.Edit
     {
         public PromptForSaveDialog(Action exit, Action saveAndExit, Action cancel)
         {
-            HeaderText = "Did you want to save your changes?";
+            HeaderText = EditorDialogsStrings.SaveDialogHeader;
 
             Icon = FontAwesome.Regular.Save;
 
@@ -21,17 +20,17 @@ namespace osu.Game.Screens.Edit
             {
                 new PopupDialogOkButton
                 {
-                    Text = @"Save my masterpiece!",
+                    Text = EditorDialogsStrings.Save,
                     Action = saveAndExit
                 },
                 new PopupDialogDangerousButton
                 {
-                    Text = @"Forget all changes",
+                    Text = EditorDialogsStrings.ForgetAllChanges,
                     Action = exit
                 },
                 new PopupDialogCancelButton
                 {
-                    Text = @"Oops, continue editing",
+                    Text = EditorDialogsStrings.ContinueEditing,
                     Action = cancel
                 },
             };

--- a/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -61,7 +62,7 @@ namespace osu.Game.Screens.Edit.Setup
                         },
                         new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(size: 24))
                         {
-                            Text = "Drag image here to set beatmap background!",
+                            Text = EditorSetupStrings.DragToSetBackground,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             AutoSizeAxes = Axes.Both

--- a/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Edit
 {
@@ -17,7 +18,7 @@ namespace osu.Game.Screens.Edit
         private readonly Dictionary<float, TernaryStateRadioMenuItem> menuItemLookup = new Dictionary<float, TernaryStateRadioMenuItem>();
 
         public WaveformOpacityMenuItem(Bindable<float> waveformOpacity)
-            : base("Waveform opacity")
+            : base(EditorStrings.WaveformOpacity)
         {
             Items = new[]
             {


### PR DESCRIPTION
i.e. menu, timeline, screens switcher, test, playback, exit and create dialogs.

- `Edit` menu item was intentionally splitted due to different translation at least in my language.
- `LocalisableString.Interpolate($"{text,-min_text_length}"` thing is a replacement for `PadRight`, tested to work as it should. 