### PR TITLE
Fix intermittent failure in screen navigation tests

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -195,10 +195,16 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("wait for player", () =>
             {
                 DismissAnyNotifications();
-                return (player = Game.ScreenStack.CurrentScreen as Player) != null;
+                player = Game.ScreenStack.CurrentScreen as Player;
+                return player?.IsLoaded == true;
             });
 
             AddAssert("retry count is 0", () => player.RestartCount == 0);
+
+            // todo: see https://github.com/ppy/osu/issues/22220
+            // tests are supposed to be immune to this edge case by the logic in TestPlayer,
+            // but we're running a full game instance here, so we have to work around it manually.
+            AddStep("end spectator before retry", () => Game.SpectatorClient.EndPlaying(player.GameplayState));
 
             AddStep("attempt to retry", () => player.ChildrenOfType<HotkeyRetryOverlay>().First().Action());
             AddUntilStep("wait for old player gone", () => Game.ScreenStack.CurrentScreen != player);

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Online.Spectator
         /// <summary>
         /// Whether the local user is playing.
         /// </summary>
-        protected bool IsPlaying { get; private set; }
+        protected internal bool IsPlaying { get; private set; }
 
         /// <summary>
         /// Called whenever new frames arrive from the server.

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -189,7 +189,7 @@ namespace osu.Game
 
         private RulesetConfigCache rulesetConfigCache;
 
-        private SpectatorClient spectatorClient;
+        protected SpectatorClient SpectatorClient { get; private set; }
 
         protected MultiplayerClient MultiplayerClient { get; private set; }
 
@@ -300,7 +300,7 @@ namespace osu.Game
 
             // TODO: OsuGame or OsuGameBase?
             dependencies.CacheAs(beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage));
-            dependencies.CacheAs(spectatorClient = new OnlineSpectatorClient(endpoints));
+            dependencies.CacheAs(SpectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(MultiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
             dependencies.CacheAs(soloStatisticsWatcher = new SoloStatisticsWatcher());
@@ -346,7 +346,7 @@ namespace osu.Game
             if (API is APIAccess apiAccess)
                 base.Content.Add(apiAccess);
 
-            base.Content.Add(spectatorClient);
+            base.Content.Add(SpectatorClient);
             base.Content.Add(MultiplayerClient);
             base.Content.Add(metadataClient);
             base.Content.Add(soloStatisticsWatcher);

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -20,6 +20,7 @@ using osu.Game.Database;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
+using osu.Game.Online.Spectator;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -147,6 +148,8 @@ namespace osu.Game.Tests.Visual
             public new Bindable<RulesetInfo> Ruleset => base.Ruleset;
 
             public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
+
+            public new SpectatorClient SpectatorClient => base.SpectatorClient;
 
             // if we don't apply these changes, when running under nUnit the version that gets populated is that of nUnit.
             public override Version AssemblyVersion => new Version(0, 0);

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Screens;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.Spectator;
@@ -101,6 +102,19 @@ namespace osu.Game.Tests.Visual
                 return;
 
             ScoreProcessor.NewJudgement += r => Results.Add(r);
+        }
+
+        public override bool OnExiting(ScreenExitEvent e)
+        {
+            bool exiting = base.OnExiting(e);
+
+            // SubmittingPlayer performs EndPlaying on a fire-and-forget async task, which allows for the chance of BeginPlaying to be called before EndPlaying is called here.
+            // Until this is handled properly at game-side, ensure EndPlaying is called before exiting player.
+            // see: https://github.com/ppy/osu/issues/22220
+            if (LoadedBeatmapSuccessfully)
+                spectatorClient?.EndPlaying(GameplayState);
+
+            return exiting;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
```
TearDown : System.AggregateException : One or more errors occurred. (Cannot invoke BeginPlaying when already playing)
  ----> System.InvalidOperationException : Cannot invoke BeginPlaying when already playing
Data:
  Sentry:Mechanism: AppDomain.UnhandledException
  Sentry:Handled: False
--TearDown
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at osu.Framework.Extensions.TaskExtensions.WaitSafely(Task task)
```

https://github.com/frenzibyte/osu/actions/runs/3913119373/jobs/6688620934
https://teamcity.ppy.sh/test/2989819594862160493?currentProjectId=Osu&expandTestHistoryChartSection=true

See https://github.com/ppy/osu/issues/22220 for more information. I've included two changes here, one for handling restarts on `TestPlayer` instances by enforcing `EndPlaying` before exiting screen (extra safety in addition to disposal logic), and another for the failure in `TestSceneScreenNavigation` specifically, since that one is based of a full game instance, which would use `SoloPlayer` instead of `TestPlayer`.

Not fully confident on the test-side fix (dumpster fire for sure), but I can't think of any better way for it so...

For reproduction, simply add a task delay in `SubmittingPlayer.OnExitting` before performing score submission.