### PR TITLE
Fix intermittent failure in beatmap options state test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1064,6 +1064,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddAssert("options enabled", () => songSelect.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
             AddStep("delete all beatmaps", () => manager.Delete());
+            AddWaitStep("wait for debounce", 1);
             AddAssert("options disabled", () => !songSelect.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
         }
 


### PR DESCRIPTION
I've noticed this one [happening frequently in GH actions](https://github.com/ppy/osu/actions/runs/3894955401/jobs/6649649126), but interestingly doesn't show up on teamcity at all.

Beatmap options button state take 200ms to update their state (because of the debouncing logic in `SongSelect`), this conflicts with the time taken to invoke one assertion. So there's a chance for the debounce logic to actually take effect on the same frame that the assertion was executed but after it.

To accommodate for the time window, a wait step is added before assertion. I could've easily changed it to an until-step, but that would be unnecessarily less precise than a single wait step.