### PR TITLE
Fix HitObject disappear in Mania Editor

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -250,6 +250,18 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 float yOffset = Math.Max(0, Direction.Value == ScrollingDirection.Up ? -Y : Y);
                 sizingContainer.Height = Math.Clamp(1 - yOffset / DrawHeight, 0, 1);
             }
+        }
+
+        // check child when they not alive.
+        public override void CheckRevert()
+        {
+            base.CheckRevert();
+
+            // Head should alive? just in case.
+            if (!Head.IsAlive)
+            {
+                Head.CheckRevert();
+            }
 
             if (!Tail.IsAlive)
                 Tail.CheckRevert();
@@ -263,6 +275,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
+            // Tail may not updated, so check here.
+            CheckRevert();
+
             if (Tail.AllJudged)
             {
                 foreach (var tick in tickContainer)

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -250,6 +250,15 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 float yOffset = Math.Max(0, Direction.Value == ScrollingDirection.Up ? -Y : Y);
                 sizingContainer.Height = Math.Clamp(1 - yOffset / DrawHeight, 0, 1);
             }
+
+            if (!Tail.IsAlive)
+                Tail.CheckRevert();
+
+            foreach (var tick in tickContainer)
+            {
+                if (!tick.IsAlive)
+                    Tail.CheckRevert();
+            }
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -584,7 +584,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
             CheckRevert();
         }
 
-        public void CheckRevert()
+        /// <summary>
+        /// Check if object is due to revert and reset its state.
+        /// </summary>
+        public virtual void CheckRevert()
         {
             if (Result != null && Result.HasResult)
             {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -581,7 +581,11 @@ namespace osu.Game.Rulesets.Objects.Drawables
         protected override void Update()
         {
             base.Update();
+            CheckRevert();
+        }
 
+        public void CheckRevert()
+        {
             if (Result != null && Result.HasResult)
             {
                 double endTime = HitObject.GetEndTime();


### PR DESCRIPTION
close #21090 
Due to the nested drawable of the slider and the possibility that it will not appear (alive) at the same time, it is necessary to let DrawableHoldNote check its own nested drawable.

It might be a bit controversial to separate `CheckRevert()` from `Update()` logic? Although I feel like he should be there.

I tried writing the beatmap with the patched version and it seems to work fine, but I can't test it though (I really don't know how to adjust the ScrollingHitObjectContainer to achieve the test)