### PR TITLE
Reverse order of `Score` and `Health` processing to allow fail conditions to read from updated score

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -344,8 +344,8 @@ namespace osu.Game.Screens.Play
 
             DrawableRuleset.NewResult += r =>
             {
-                HealthProcessor.ApplyResult(r);
                 ScoreProcessor.ApplyResult(r);
+                HealthProcessor.ApplyResult(r);
                 GameplayState.ApplyResult(r);
             };
 


### PR DESCRIPTION
For #18402.

Not sure if this will pass tests, but from reading through the code it looks like it may be okay?