### PR TITLE
Fix player rank data not being re-fetched after a tournament's ruleset is changed

### DIFF
--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Tournament.Screens.Setup
                 new LabelledDropdown<RulesetInfo>
                 {
                     Label = "Ruleset",
-                    Description = "Decides what stats are displayed and which ranks are retrieved for players.",
+                    Description = "Decides what stats are displayed and which ranks are retrieved for players. This requires a restart to reload data for an existing bracket.",
                     Items = rulesets.AvailableRulesets,
                     Current = LadderInfo.Ruleset,
                 },

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -159,6 +159,18 @@ namespace osu.Game.Tournament
                     SaveChanges();
 
                 ladder.CurrentMatch.Value = ladder.Matches.FirstOrDefault(p => p.Current.Value);
+
+                ladder.Ruleset.BindValueChanged(r =>
+                {
+                    // Refetch player rank data on next startup as the ruleset has changed.
+                    foreach (var team in ladder.Teams)
+                    {
+                        foreach (var player in team.Players)
+                            player.Rank = null;
+                    }
+
+                    SaveChanges();
+                });
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22207 (the major part of it).