### PR TITLE
Reduce number of value combinations of a test that is taking 2min+ to execute

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -31,9 +31,9 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         [Test]
         public void TestMaximumDistanceTrackingWithoutMovement(
-            [Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
+            [Values(0, 5, 10)]
             float circleSize,
-            [Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)]
+            [Values(0, 5, 10)]
             double velocity)
         {
             const double time_slider_start = 1000;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -31,10 +31,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         [Test]
         public void TestMaximumDistanceTrackingWithoutMovement(
-            [Values(0, 5, 10)]
-            float circleSize,
-            [Values(0, 5, 10)]
-            double velocity)
+            [Values(0, 5, 10)] float circleSize,
+            [Values(0, 5, 10)] double velocity)
         {
             const double time_slider_start = 1000;
 


### PR DESCRIPTION
Probably just `(10, 10)` is enough given the description of #18795 @smoogipoo 