### PR TITLE
Fix song select potentially operating on `Carousel` before it is fully loaded

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -596,6 +596,9 @@ namespace osu.Game.Screens.Select
 
         public void FlushPendingFilterOperations()
         {
+            if (!IsLoaded)
+                return;
+
             if (PendingFilter?.Completed == false)
             {
                 applyActiveCriteria(false);

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -860,12 +860,9 @@ namespace osu.Game.Screens.Select
             Logger.Log($"decoupled ruleset transferred (\"{decoupledRuleset.Value}\" -> \"{Ruleset.Value}\")");
             rulesetNoDebounce = decoupledRuleset.Value = Ruleset.Value;
 
-            if (Carousel.IsLoaded)
-            {
-                // if we have a pending filter operation, we want to run it now.
-                // it could change selection (ie. if the ruleset has been changed).
-                Carousel.FlushPendingFilterOperations();
-            }
+            // if we have a pending filter operation, we want to run it now.
+            // it could change selection (ie. if the ruleset has been changed).
+            Carousel.FlushPendingFilterOperations();
 
             return true;
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -860,9 +860,13 @@ namespace osu.Game.Screens.Select
             Logger.Log($"decoupled ruleset transferred (\"{decoupledRuleset.Value}\" -> \"{Ruleset.Value}\")");
             rulesetNoDebounce = decoupledRuleset.Value = Ruleset.Value;
 
-            // if we have a pending filter operation, we want to run it now.
-            // it could change selection (ie. if the ruleset has been changed).
-            Carousel.FlushPendingFilterOperations();
+            if (Carousel.IsLoaded)
+            {
+                // if we have a pending filter operation, we want to run it now.
+                // it could change selection (ie. if the ruleset has been changed).
+                Carousel.FlushPendingFilterOperations();
+            }
+
             return true;
         }
 


### PR DESCRIPTION
Should fix test failures like https://github.com/ppy/osu/actions/runs/3939620830/jobs/6739690253.

Alternatively, the `IsLoaded` check could be moved inside the called method.