### PR TITLE
Reduce padding for too nested comments

### DIFF
--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -57,6 +57,11 @@ namespace osu.Game.Overlays.Comments
         /// </summary>
         public bool WasDeleted { get; protected set; }
 
+        /// <summary>
+        /// Tracks this comment's level of nesting. 0 means that this comment has no parents.
+        /// </summary>
+        public int Level { get; private set; }
+
         private FillFlowContainer childCommentsVisibilityContainer = null!;
         private FillFlowContainer childCommentsContainer = null!;
         private LoadRepliesButton loadRepliesButton = null!;
@@ -88,11 +93,15 @@ namespace osu.Game.Overlays.Comments
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, DrawableComment? parentComment)
         {
             LinkFlowContainer username;
             FillFlowContainer info;
             CommentMarkdownContainer message;
+
+            Level = parentComment?.Level + 1 ?? 0;
+
+            float childrenPadding = Level < 6 ? 20 : 5;
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -248,7 +257,7 @@ namespace osu.Game.Overlays.Comments
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
                                 Direction = FillDirection.Vertical,
-                                Padding = new MarginPadding { Left = 20 },
+                                Padding = new MarginPadding { Left = childrenPadding },
                                 Children = new Drawable[]
                                 {
                                     childCommentsContainer = new FillFlowContainer

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays.Comments
         private GridContainer content = null!;
         private VotePill votePill = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
 
         [Resolved]
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Comments
         [Resolved]
         private GameHost host { get; set; } = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
 
         public DrawableComment(Comment comment)


### PR DESCRIPTION
Closes #8012.

Web:
![изображение](https://user-images.githubusercontent.com/53872073/213032650-b5a1cde2-0d2f-4be5-8682-20ae53f9db55.png)

Lazer (this pr):
![изображение](https://user-images.githubusercontent.com/53872073/213032698-ce866ab2-95fb-48f3-9157-62476ded5336.png)

Now both reduce padding for the sixth's children. I intentionally didn't make it zero as in web to still have ability to distinguish levels by eye. Can be set to 0 if required. 