### PR TITLE
Fix legacy judgement animation not matching perfectly

### DIFF
--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -65,11 +65,14 @@ namespace osu.Game.Skinning
                 default:
 
                     this.ScaleTo(0.6f).Then()
-                        .ScaleTo(1.1f, fade_in_length * 0.8f).Then()
-                        // this is actually correct to match stable; there were overlapping transforms.
-                        .ScaleTo(0.9f).Delay(fade_in_length * 0.2f)
-                        .ScaleTo(1.1f).ScaleTo(0.9f, fade_in_length * 0.2f).Then()
-                        .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f);
+                        .ScaleTo(1.1f, fade_in_length * 0.8f).Then() // t = 0.8
+                        .Delay(fade_in_length * 0.2f) // t = 1.0
+                        .ScaleTo(0.9f, fade_in_length * 0.2f).Then() // t = 1.2
+
+                        // stable dictates scale of 0.9->1 over time 1.0 to 1.4, but we are already at 1.2.
+                        // so we need to force the current value to be correct at 1.2 (0.95) then complete the
+                        // second half of the transform.
+                        .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f); // t = 1.4
                     break;
             }
         }


### PR DESCRIPTION
This will be the final attempt to get it right. I was seemingly drunk last time I wrote the logic.

Closes #21892.

Testing at 10% rate on both sides:

https://user-images.githubusercontent.com/191335/213142678-1a54b25a-9814-4bce-af73-91e9d1fecc65.mp4

