### PR TITLE
Add option to allow timing screen not to track timing groups

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -178,6 +178,8 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LastProcessedMetadataId, -1);
 
             SetDefault(OsuSetting.ComboColourNormalisationAmount, 0.2f, 0f, 1f, 0.01f);
+
+            SetDefault(OsuSetting.TrackTimingPoint, true);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -375,5 +377,6 @@ namespace osu.Game.Configuration
         LastProcessedMetadataId,
         SafeAreaConsiderations,
         ComboColourNormalisationAmount,
+        TrackTimingPoint,
     }
 }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -30,6 +30,11 @@ namespace osu.Game.Localisation
         public static LocalisableString SetPreviewPointToCurrent => new TranslatableString(getKey(@"set_preview_point_to_current"), @"Set preview point to current time");
 
         /// <summary>
+        /// "Track timing point in Timing screen"
+        /// </summary>
+        public static LocalisableString TrackTimingPoint => new TranslatableString(getKey(@"track_timing_point"), @"Track timing point in Timing screen");
+
+        /// <summary>
         /// "Export package"
         /// </summary>
         public static LocalisableString ExportPackage => new TranslatableString(getKey(@"export_package"), @"Export package");

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -176,6 +176,7 @@ namespace osu.Game.Screens.Edit
 
         private Bindable<float> editorBackgroundDim;
         private Bindable<bool> editorHitMarkers;
+        private Bindable<bool> trackTimingPoint;
 
         public Editor(EditorLoader loader = null)
         {
@@ -263,6 +264,7 @@ namespace osu.Game.Screens.Edit
 
             editorBackgroundDim = config.GetBindable<float>(OsuSetting.EditorDim);
             editorHitMarkers = config.GetBindable<bool>(OsuSetting.EditorShowHitMarkers);
+            trackTimingPoint = config.GetBindable<bool>(OsuSetting.TrackTimingPoint);
 
             AddInternal(new OsuContextMenuContainer
             {
@@ -327,7 +329,11 @@ namespace osu.Game.Screens.Edit
                                     {
                                         Items = new MenuItem[]
                                         {
-                                            new EditorMenuItem(EditorStrings.SetPreviewPointToCurrent, MenuItemType.Standard, SetPreviewPointToCurrentTime)
+                                            new EditorMenuItem(EditorStrings.SetPreviewPointToCurrent, MenuItemType.Standard, SetPreviewPointToCurrentTime),
+                                            new ToggleMenuItem(EditorStrings.TrackTimingPoint)
+                                            {
+                                                State = { BindTarget = trackTimingPoint },
+                                            }
                                         }
                                     }
                                 }

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -10,6 +10,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -26,7 +27,15 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private EditorClock clock { get; set; } = null!;
 
+        private Bindable<bool> trackTimingPoint = null!;
+
         public const float TIMING_COLUMN_WIDTH = 230;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            trackTimingPoint = config.GetBindable<bool>(OsuSetting.TrackTimingPoint);
+        }
 
         public IEnumerable<ControlPointGroup> ControlGroups
         {
@@ -44,8 +53,13 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         Action = () =>
                         {
+                            var previousGroup = selectedGroup.Value;
+
                             selectedGroup.Value = group;
-                            clock.SeekSmoothlyTo(group.Time);
+
+                            // previousGroup may null.
+                            if (trackTimingPoint.Value || (previousGroup != null && selectedGroup.Value.Equals(previousGroup)))
+                                clock.SeekSmoothlyTo(group.Time);
                         }
                     });
                 }

--- a/osu.Game/Screens/Edit/Timing/TimingScreen.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingScreen.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -67,9 +68,13 @@ namespace osu.Game.Screens.Edit.Timing
             [Resolved]
             private IEditorChangeHandler? changeHandler { get; set; }
 
+            private Bindable<bool> trackTimingPoint = null!;
+
             [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colours)
+            private void load(OverlayColourProvider colours, OsuConfigManager config)
             {
+                trackTimingPoint = config.GetBindable<bool>(OsuSetting.TrackTimingPoint);
+
                 RelativeSizeAxes = Axes.Both;
 
                 const float margins = 10;
@@ -170,6 +175,9 @@ namespace osu.Game.Screens.Edit.Timing
             /// </summary>
             private void trackActivePoint()
             {
+                if (!trackTimingPoint.Value)
+                    return;
+
                 // For simplicity only match on the first type of the active control point.
                 if (selectedGroup.Value == null)
                     trackedType = null;


### PR DESCRIPTION
This can be annoying if you want to set a timing point a bit forward, or just modify a timing point's information slightly, so add an option to turn it off.

Turning this option off will:
- timing point will not track by current time.
- need double click to seek to timing point.

The test case should contain them, can test there

https://user-images.githubusercontent.com/34775378/213169919-8bab5db5-73bc-4ed1-9d24-ff83dc3e1541.mp4