### PR TITLE
Add preview time setting check

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
@@ -22,26 +22,6 @@ namespace osu.Game.Tests.Editing.Checks
         public void Setup()
         {
             check = new CheckPreviewTime();
-            beatmap = new Beatmap<HitObject>
-            {
-                BeatmapInfo = new BeatmapInfo
-                {
-                    Metadata = new BeatmapMetadata { PreviewTime = -1 },
-                    BeatmapSet = new BeatmapSetInfo(new List<BeatmapInfo>
-                    {
-                        new BeatmapInfo
-                        {
-                            DifficultyName = "Test1",
-                            Metadata = new BeatmapMetadata { PreviewTime = 5 },
-                        },
-                        new BeatmapInfo
-                        {
-                            DifficultyName = "Test2",
-                            Metadata = new BeatmapMetadata { PreviewTime = 10 },
-                        },
-                    })
-                }
-            };
         }
 
         [Test]

--- a/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Checks;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Beatmaps;
+
+namespace osu.Game.Tests.Editing.Checks
+{
+    public class CheckPreviewTimeTest
+    {
+        private CheckPreviewTime check = null!;
+
+        private IBeatmap beatmap = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            check = new CheckPreviewTime();
+            beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Metadata = new BeatmapMetadata { PreviewTime = -1 },
+                    BeatmapSet = new BeatmapSetInfo(new List<BeatmapInfo>
+                    {
+                        new BeatmapInfo
+                        {
+                            DifficultyName = "Test1",
+                            Metadata = new BeatmapMetadata { PreviewTime = 5 },
+                        },
+                        new BeatmapInfo
+                        {
+                            DifficultyName = "Test2",
+                            Metadata = new BeatmapMetadata { PreviewTime = 10 },
+                        },
+                    })
+                }
+            };
+        }
+
+        [Test]
+        public void TestPreviewTimeNotSet()
+        {
+            setNoPreviewTimeBeatmap();
+            var content = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(content).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckPreviewTime.IssueTemplateHasNoPreviewTime);
+        }
+
+        [Test]
+        public void TestPreviewTimeconflict()
+        {
+            setPreviewTimeConflictBeatmap();
+
+            var content = new BeatmapVerifierContext(beatmap, new TestWorkingBeatmap(beatmap));
+
+            var issues = check.Run(content).ToList();
+
+            Assert.That(issues, Has.Count.EqualTo(1));
+            Assert.That(issues.Single().Template is CheckPreviewTime.IssueTemplatePreviewTimeConflict);
+            Assert.That(issues.Single().Arguments.Single().ToString() == "Test1");
+        }
+
+        private void setNoPreviewTimeBeatmap()
+        {
+            beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Metadata = new BeatmapMetadata { PreviewTime = -1 },
+                }
+            };
+        }
+
+        private void setPreviewTimeConflictBeatmap()
+        {
+            beatmap = new Beatmap<HitObject>
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Metadata = new BeatmapMetadata { PreviewTime = 10 },
+                    BeatmapSet = new BeatmapSetInfo(new List<BeatmapInfo>
+                    {
+                        new BeatmapInfo
+                        {
+                            DifficultyName = "Test1",
+                            Metadata = new BeatmapMetadata { PreviewTime = 5 },
+                        },
+                        new BeatmapInfo
+                        {
+                            DifficultyName = "Test2",
+                            Metadata = new BeatmapMetadata { PreviewTime = 10 },
+                        },
+                    })
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckPreviewTimeTest.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             Assert.That(issues, Has.Count.EqualTo(1));
             Assert.That(issues.Single().Template is CheckPreviewTime.IssueTemplatePreviewTimeConflict);
-            Assert.That(issues.Single().Arguments.Single().ToString() == "Test1");
+            Assert.That(issues.Single().Arguments.FirstOrDefault()?.ToString() == "Test1");
         }
 
         private void setNoPreviewTimeBeatmap()

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Rulesets.Edit
             new CheckUnsnappedObjects(),
             new CheckConcurrentObjects(),
             new CheckZeroLengthObjects(),
+
+            // Timing
+            new CheckPreviewTime(),
         };
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -23,21 +23,15 @@ namespace osu.Game.Rulesets.Edit.Checks
             int previewTime = context.Beatmap.BeatmapInfo.Metadata.PreviewTime;
 
             if (previewTime == -1)
-            {
                 yield return new IssueTemplateHasNoPreviewTime(this).Create();
-            }
 
             foreach (var diff in diffList)
             {
                 if (diff.Equals(context.Beatmap.BeatmapInfo))
-                {
                     continue;
-                }
 
                 if (diff.Metadata.PreviewTime != previewTime)
-                {
                     yield return new IssueTemplatePreviewTimeConflict(this).Create(diff.DifficultyName, previewTime, diff.Metadata.PreviewTime);
-                }
             }
         }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 {
     public class CheckPreviewTime : ICheck
     {
-        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Check Preview Time Consistency");
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Inconsistent or unset preview time");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         public class IssueTemplatePreviewTimeConflict : IssueTemplate
         {
             public IssueTemplatePreviewTimeConflict(ICheck check)
-                : base(check, IssueType.Warning, "Audio preview time {1} doesn't match \"{0}\"'s preview time {2}")
+                : base(check, IssueType.Problem, "Audio preview time {1} doesn't match \"{0}\"'s preview time. {2}")
             {
             }
 
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         public class IssueTemplateHasNoPreviewTime : IssueTemplate
         {
             public IssueTemplateHasNoPreviewTime(ICheck check)
-                : base(check, IssueType.Warning, "A preview point for this map is not set. Consider settings one from the Timing menu")
+                : base(check, IssueType.Problem, "A preview point for this map is not set. Consider settings one from the Timing menu.")
             {
             }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -38,15 +38,15 @@ namespace osu.Game.Rulesets.Edit.Checks
         public class IssueTemplatePreviewTimeConflict : IssueTemplate
         {
             public IssueTemplatePreviewTimeConflict(ICheck check)
-                : base(check, IssueType.Problem, "Audio preview time {1} doesn't match \"{0}\"'s preview time. {2}")
+                : base(check, IssueType.Problem, "Audio preview time ({1}) doesn't match the time specified in \"{0}\" ({2})")
             {
             }
 
             public Issue Create(string diffName, int originalTime, int conflictTime) =>
                 // preview time should show (not set) when it is not set.
                 new Issue(this, diffName,
-                    originalTime != -1 ? $"({originalTime:N0})" : "(not set)",
-                    conflictTime != -1 ? $"({conflictTime:N0})" : "(not set)");
+                    originalTime != -1 ? $"{originalTime:N0} ms" : "not set",
+                    conflictTime != -1 ? $"{conflictTime:N0} ms" : "not set");
         }
 
         public class IssueTemplateHasNoPreviewTime : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Edit.Checks
         public class IssueTemplateHasNoPreviewTime : IssueTemplate
         {
             public IssueTemplateHasNoPreviewTime(ICheck check)
-                : base(check, IssueType.Problem, "A preview point for this map is not set. Consider settings one from the Timing menu.")
+                : base(check, IssueType.Problem, "A preview point for this map is not set. Consider setting one from the Timing menu.")
             {
             }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit.Checks.Components;
+
+namespace osu.Game.Rulesets.Edit.Checks
+{
+    public class CheckPreviewTime : ICheck
+    {
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Timing, "Check Preview Time Consistency");
+
+        public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
+        {
+            new IssueTemplatePreviewTimeConflict(this),
+            new IssueTemplateHasNoPreviewTime(this),
+        };
+
+        public IEnumerable<Issue> Run(BeatmapVerifierContext context)
+        {
+            var diffList = context.Beatmap.BeatmapInfo.BeatmapSet?.Beatmaps ?? new List<BeatmapInfo>();
+            int previewTime = context.Beatmap.BeatmapInfo.Metadata.PreviewTime;
+
+            if (previewTime == -1)
+            {
+                yield return new IssueTemplateHasNoPreviewTime(this).Create();
+            }
+
+            foreach (var diff in diffList)
+            {
+                if (diff.Equals(context.Beatmap.BeatmapInfo))
+                {
+                    continue;
+                }
+
+                if (diff.Metadata.PreviewTime != previewTime)
+                {
+                    yield return new IssueTemplatePreviewTimeConflict(this).Create(diff.DifficultyName);
+                }
+            }
+        }
+
+        public class IssueTemplatePreviewTimeConflict : IssueTemplate
+        {
+            public IssueTemplatePreviewTimeConflict(ICheck check)
+                : base(check, IssueType.Warning, "Audio preview time conflicts with {0} diff")
+            {
+            }
+
+            public Issue Create(string diffName) => new Issue(this, diffName);
+        }
+
+        public class IssueTemplateHasNoPreviewTime : IssueTemplate
+        {
+            public IssueTemplateHasNoPreviewTime(ICheck check)
+                : base(check, IssueType.Warning, "A preview point for this map is not set. Consider settings one from the Timing menu")
+            {
+            }
+
+            public Issue Create() => new Issue(this);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckPreviewTime.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
                 if (diff.Metadata.PreviewTime != previewTime)
                 {
-                    yield return new IssueTemplatePreviewTimeConflict(this).Create(diff.DifficultyName);
+                    yield return new IssueTemplatePreviewTimeConflict(this).Create(diff.DifficultyName, previewTime, diff.Metadata.PreviewTime);
                 }
             }
         }
@@ -44,11 +44,15 @@ namespace osu.Game.Rulesets.Edit.Checks
         public class IssueTemplatePreviewTimeConflict : IssueTemplate
         {
             public IssueTemplatePreviewTimeConflict(ICheck check)
-                : base(check, IssueType.Warning, "Audio preview time conflicts with {0} diff")
+                : base(check, IssueType.Warning, "Audio preview time {1} doesn't match \"{0}\"'s preview time {2}")
             {
             }
 
-            public Issue Create(string diffName) => new Issue(this, diffName);
+            public Issue Create(string diffName, int originalTime, int conflictTime) =>
+                // preview time should show (not set) when it is not set.
+                new Issue(this, diffName,
+                    originalTime != -1 ? $"({originalTime:N0})" : "(not set)",
+                    conflictTime != -1 ? $"({conflictTime:N0})" : "(not set)");
         }
 
         public class IssueTemplateHasNoPreviewTime : IssueTemplate


### PR DESCRIPTION
related #12091

After lazer can [set the preview point](https://github.com/ppy/osu/pull/21650), the corresponding check should also be added.

so add a check for it.

Regarding #12091 [saying that this check doesn't work for some reason](https://github.com/ppy/osu/issues/12091#issuecomment-878760791), but my test results feel valid?
Not sure what's wrong, but I wrote a test

![image](https://user-images.githubusercontent.com/34775378/213234076-4bfbb13b-6d56-4651-8e4f-730be98fe511.png)
![image](https://user-images.githubusercontent.com/34775378/213234204-d82f3f22-f56c-44ec-9987-8b6dfef8a178.png)

