### PR TITLE
Fix "show max judgement" setting not applying initially on judgement counter display

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
@@ -127,6 +127,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestMaxValueStartsHidden()
+        {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay
+            {
+                ShowMaxJudgement = { Value = false }
+            });
+            AddAssert("Check max hidden", () => counterDisplay.CounterFlow.ChildrenOfType<JudgementCounter>().First().Alpha == 0);
+        }
+
+        [Test]
         public void TestCycleDisplayModes()
         {
             AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
@@ -25,35 +25,33 @@ namespace osu.Game.Tests.Visual.Gameplay
         private JudgementTally judgementTally = null!;
         private TestJudgementCounterDisplay counterDisplay = null!;
 
+        private DependencyProvidingContainer content = null!;
+
+        protected override Container<Drawable> Content => content;
+
         private readonly Bindable<JudgementResult> lastJudgementResult = new Bindable<JudgementResult>();
 
         private int iteration;
 
         [SetUpSteps]
-        public void SetupSteps() => AddStep("Create components", () =>
+        public void SetUpSteps() => AddStep("Create components", () =>
         {
             var ruleset = CreateRuleset();
 
             Debug.Assert(ruleset != null);
 
             scoreProcessor = new ScoreProcessor(ruleset);
-            Child = new DependencyProvidingContainer
+            base.Content.Child = new DependencyProvidingContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 CachedDependencies = new (Type, object)[] { (typeof(ScoreProcessor), scoreProcessor), (typeof(Ruleset), ruleset) },
                 Children = new Drawable[]
                 {
                     judgementTally = new JudgementTally(),
-                    new DependencyProvidingContainer
+                    content = new DependencyProvidingContainer
                     {
                         RelativeSizeAxes = Axes.Both,
                         CachedDependencies = new (Type, object)[] { (typeof(JudgementTally), judgementTally) },
-                        Child = counterDisplay = new TestJudgementCounterDisplay
-                        {
-                            Margin = new MarginPadding { Top = 100 },
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre
-                        }
                     }
                 },
             };
@@ -78,6 +76,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestAddJudgementsToCounters()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddRepeatStep("Add judgement", () => applyOneJudgement(HitResult.Great), 2);
             AddRepeatStep("Add judgement", () => applyOneJudgement(HitResult.Miss), 2);
             AddRepeatStep("Add judgement", () => applyOneJudgement(HitResult.Meh), 2);
@@ -86,6 +86,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestAddWhilstHidden()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddRepeatStep("Add judgement", () => applyOneJudgement(HitResult.LargeTickHit), 2);
             AddAssert("Check value added whilst hidden", () => hiddenCount() == 2);
             AddStep("Show all judgements", () => counterDisplay.Mode.Value = JudgementCounterDisplay.DisplayMode.All);
@@ -94,6 +96,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestChangeFlowDirection()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddStep("Set direction vertical", () => counterDisplay.FlowDirection.Value = Direction.Vertical);
             AddStep("Set direction horizontal", () => counterDisplay.FlowDirection.Value = Direction.Horizontal);
         }
@@ -101,6 +105,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestToggleJudgementNames()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddStep("Hide judgement names", () => counterDisplay.ShowJudgementNames.Value = false);
             AddWaitStep("wait some", 2);
             AddAssert("Assert hidden", () => counterDisplay.CounterFlow.Children.First().ResultName.Alpha == 0);
@@ -112,6 +118,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestHideMaxValue()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddStep("Hide max judgement", () => counterDisplay.ShowMaxJudgement.Value = false);
             AddWaitStep("wait some", 2);
             AddAssert("Check max hidden", () => counterDisplay.CounterFlow.ChildrenOfType<JudgementCounter>().First().Alpha == 0);
@@ -121,6 +129,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestCycleDisplayModes()
         {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+
             AddStep("Show basic judgements", () => counterDisplay.Mode.Value = JudgementCounterDisplay.DisplayMode.Simple);
             AddWaitStep("wait some", 2);
             AddAssert("Check only basic", () => counterDisplay.CounterFlow.ChildrenOfType<JudgementCounter>().Last().Alpha == 0);
@@ -139,6 +149,13 @@ namespace osu.Game.Tests.Visual.Gameplay
         private partial class TestJudgementCounterDisplay : JudgementCounterDisplay
         {
             public new FillFlowContainer<JudgementCounter> CounterFlow => base.CounterFlow;
+
+            public TestJudgementCounterDisplay()
+            {
+                Margin = new MarginPadding { Top = 100 };
+                Anchor = Anchor.TopCentre;
+                Origin = Anchor.TopCentre;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
@@ -68,10 +68,12 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
 
             Mode.BindValueChanged(_ => updateMode(), true);
 
-            ShowMaxJudgement.BindValueChanged(value =>
+            ShowMaxJudgement.BindValueChanged(showMax =>
             {
                 var firstChild = CounterFlow.Children.FirstOrDefault();
-                firstChild.FadeTo(value.NewValue ? 1 : 0, TRANSFORM_DURATION, Easing.OutQuint);
+
+                if (firstChild != null)
+                    firstChild.State.Value = showMax.NewValue ? Visibility.Visible : Visibility.Hidden;
             }, true);
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22282

Both `JudgementCounterDisplay` (via the `ShowMaxJudgement` callback) and the `JudgementCounter.Pop{In,Out}` methods were operating on the alpha of the `JudgementCounter`. This meant that if the counter display was created with max judgement initially hidden, it would be hidden by the `ShowMaxJudgement` callback first, but then _unhidden_ by `PopIn()`.

Fixed by only operating on the `State` of the counter, which resolves the conflict.

@mk56-spn advise you take a look at this. It's a pretty common footgun when applying transforms to `this` in a drawable. I wanted to get rid of that, but that breaks tests and it's a real pain to fix that so I decided I didn't care enough, I just want this to not go out broken in a release.