### PR TITLE
Apply draw colour to segmented graph

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSegmentedGraph.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSegmentedGraph.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
@@ -52,7 +53,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("beatmap density with granularity of 200", () => beatmapDensity());
             AddStep("beatmap density with granularity of 300", () => beatmapDensity(300));
             AddStep("reversed values from 1-10", () => graph.Values = Enumerable.Range(1, 10).Reverse().ToArray());
-            AddStep("change colour", () =>
+            AddStep("change tier colours", () =>
             {
                 graph.TierColours = new[]
                 {
@@ -62,7 +63,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Colour4.Blue
                 };
             });
-            AddStep("reset colour", () =>
+            AddStep("reset tier colours", () =>
             {
                 graph.TierColours = new[]
                 {
@@ -74,6 +75,12 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Colour4.Green
                 };
             });
+
+            AddStep("set graph colour to blue", () => graph.Colour = Colour4.Blue);
+            AddStep("set graph colour to transparent", () => graph.Colour = Colour4.Transparent);
+            AddStep("set graph colour to vertical gradient", () => graph.Colour = ColourInfo.GradientVertical(Colour4.White, Colour4.Black));
+            AddStep("set graph colour to horizontal gradient", () => graph.Colour = ColourInfo.GradientHorizontal(Colour4.White, Colour4.Black));
+            AddStep("reset graph colour", () => graph.Colour = Colour4.White);
         }
 
         private void sinFunction(int size = 100)

--- a/osu.Game/Graphics/UserInterface/SegmentedGraph.cs
+++ b/osu.Game/Graphics/UserInterface/SegmentedGraph.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
@@ -158,16 +157,18 @@ namespace osu.Game.Graphics.UserInterface
 
         private ColourInfo getSegmentColour(SegmentInfo segment)
         {
-            var tierColour = segment.Tier >= 0 ? tierColours[segment.Tier] : new Colour4(0, 0, 0, 0);
-            var ourColour = DrawColourInfo.Colour;
-
-            return new ColourInfo
+            var segmentColour = new ColourInfo
             {
-                TopLeft = tierColour * Interpolation.ValueAt<Colour4>(segment.Start, ourColour.TopLeft, ourColour.TopRight, 0, 1),
-                TopRight = tierColour * Interpolation.ValueAt<Colour4>(segment.End, ourColour.TopLeft, ourColour.TopRight, 0, 1),
-                BottomLeft = tierColour * Interpolation.ValueAt<Colour4>(segment.Start, ourColour.BottomLeft, ourColour.BottomRight, 0, 1),
-                BottomRight = tierColour * Interpolation.ValueAt<Colour4>(segment.End, ourColour.BottomLeft, ourColour.BottomRight, 0, 1)
+                TopLeft = DrawColourInfo.Colour.Interpolate(new Vector2(segment.Start, 0f)),
+                TopRight = DrawColourInfo.Colour.Interpolate(new Vector2(segment.End, 0f)),
+                BottomLeft = DrawColourInfo.Colour.Interpolate(new Vector2(segment.Start, 1f)),
+                BottomRight = DrawColourInfo.Colour.Interpolate(new Vector2(segment.End, 1f))
             };
+
+            var tierColour = segment.Tier >= 0 ? tierColours[segment.Tier] : new Colour4(0, 0, 0, 0);
+            segmentColour.ApplyChild(tierColour);
+
+            return segmentColour;
         }
 
         protected override DrawNode CreateDrawNode() => new SegmentedGraphDrawNode(this);

--- a/osu.Game/Graphics/UserInterface/SegmentedGraph.cs
+++ b/osu.Game/Graphics/UserInterface/SegmentedGraph.cs
@@ -7,10 +7,12 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
@@ -154,7 +156,19 @@ namespace osu.Game.Graphics.UserInterface
             segments.Sort();
         }
 
-        private Colour4 getTierColour(int tier) => tier >= 0 ? tierColours[tier] : new Colour4(0, 0, 0, 0);
+        private ColourInfo getSegmentColour(SegmentInfo segment)
+        {
+            var tierColour = segment.Tier >= 0 ? tierColours[segment.Tier] : new Colour4(0, 0, 0, 0);
+            var ourColour = DrawColourInfo.Colour;
+
+            return new ColourInfo
+            {
+                TopLeft = tierColour * Interpolation.ValueAt<Colour4>(segment.Start, ourColour.TopLeft, ourColour.TopRight, 0, 1),
+                TopRight = tierColour * Interpolation.ValueAt<Colour4>(segment.End, ourColour.TopLeft, ourColour.TopRight, 0, 1),
+                BottomLeft = tierColour * Interpolation.ValueAt<Colour4>(segment.Start, ourColour.BottomLeft, ourColour.BottomRight, 0, 1),
+                BottomRight = tierColour * Interpolation.ValueAt<Colour4>(segment.End, ourColour.BottomLeft, ourColour.BottomRight, 0, 1)
+            };
+        }
 
         protected override DrawNode CreateDrawNode() => new SegmentedGraphDrawNode(this);
 
@@ -240,7 +254,7 @@ namespace osu.Game.Graphics.UserInterface
                             Vector2Extensions.Transform(topRight, DrawInfo.Matrix),
                             Vector2Extensions.Transform(bottomLeft, DrawInfo.Matrix),
                             Vector2Extensions.Transform(bottomRight, DrawInfo.Matrix)),
-                        Source.getTierColour(segment.Tier));
+                        Source.getSegmentColour(segment));
                 }
 
                 shader.Unbind();


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/ppy/osu/pull/22144#pullrequestreview-1260761746, wherein the new argon song progress bar would not hide along with the rest of the HUD.

The segmented graph entirely ignored `DrawColourInfo`, which meant that the drawable's draw colour did not change how it was drawn at all. In particular, this meant that if the graph was hidden at a higher level, therefore having a transparent draw colour - which is the case with gameplay HUD - it would still continue to draw the exact same way regardless.

The fix is rather self-explanatory and easy. I even made it fully support gradiented colours because I could:

https://user-images.githubusercontent.com/20418176/213306903-4c93501c-d8af-4661-b9c2-d4f317f8545c.mp4