### PR TITLE
Actually fix intermittent failure in beatmap options state test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1064,7 +1064,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddAssert("options enabled", () => songSelect.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
             AddStep("delete all beatmaps", () => manager.Delete());
-            AddWaitStep("wait for debounce", 1);
+            AddUntilStep("wait for no beatmap", () => Beatmap.IsDefault);
             AddAssert("options disabled", () => !songSelect.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
         }
 


### PR DESCRIPTION
As it turns out, this failure [came once again](https://github.com/ppy/osu/actions/runs/3948328885/jobs/6758189177) after https://github.com/ppy/osu/pull/22232, and the reason was actually that the deduction I put in that PR was completely wrong.

Song select never debounces update when the next beatmap is `null`, i.e. no beatmaps available. What was actually causing the failure is simply realm notifications taking a bit long to reach the `BeatmapCarousel` component.
 
I haven't dwelt deep as to why that's the case, but I've went ahead with a step that guarantees beatmaps have been removed by checking whether selected beatmap is default/dummy. I could've gone with the brute-force method (waiting until options is disabled), but I'm not sure if I should yet.