### PR TITLE
Fix intermittent failure in playlists match loading test

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomCreation.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Visual.Playlists
 
             AddUntilStep("Leaderboard shows two aggregate scores", () => match.ChildrenOfType<MatchLeaderboardScore>().Count(s => s.ScoreText.Text != "0") == 2);
 
-            AddStep("start match", () => match.ChildrenOfType<PlaylistsReadyButton>().First().TriggerClick());
+            ClickButtonWhenEnabled<PlaylistsReadyButton>();
             AddUntilStep("player loader loaded", () => Stack.CurrentScreen is PlayerLoader);
         }
 


### PR DESCRIPTION
```
Error Message:
   TearDown : System.TimeoutException : "ensure score is pending deletion" timed out
  Stack Trace:
  --TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
```
https://github.com/ppy/osu/actions/runs/3947065903/jobs/6755467287

Caused by playlists ready button not being enabled in time due to depending on a realm notification for beatmap availability, which can take long to be delivered.