### PR TITLE
Fix incorrect async continuation causing tournament client to not enable save button

### DIFF
--- a/osu.Game.Tournament/SaveChangesOverlay.cs
+++ b/osu.Game.Tournament/SaveChangesOverlay.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tournament
 
         private async Task checkForChanges()
         {
-            string serialisedLadder = await Task.Run(() => tournamentGame.GetSerialisedLadder()).ConfigureAwait(false);
+            string serialisedLadder = await Task.Run(() => tournamentGame.GetSerialisedLadder()).ConfigureAwait(true);
 
             // If a save hasn't been triggered by the user yet, populate the initial value
             lastSerialisedLadder ??= serialisedLadder;


### PR DESCRIPTION
Closes #22304. Needs to get into today's release.