### PR TITLE
Fix test browsers on longer working after framework update

### DIFF
--- a/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestBrowser.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tournament.Tests
                 {
                     Colour = OsuColour.Gray(0.5f),
                     Depth = 10
-                }, AddInternal);
+                }, Add);
 
                 // Have to construct this here, rather than in the constructor, because
                 // we depend on some dependencies to be loaded within OsuGameBase.load().

--- a/osu.Game/Tests/OsuTestBrowser.cs
+++ b/osu.Game/Tests/OsuTestBrowser.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests
             {
                 Depth = 10,
                 RelativeSizeAxes = Axes.Both,
-            }, AddInternal);
+            }, Add);
 
             // Have to construct this here, rather than in the constructor, because
             // we depend on some dependencies to be loaded within OsuGameBase.load().


### PR DESCRIPTION
Remaining cases of `AddInternal` usage in `Game` classes throwing exception after https://github.com/ppy/osu/pull/22303 was merged.