### PR TITLE
Move fixed scroll speed change out of classic mod for taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
@@ -9,30 +8,15 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>, IUpdatableByPlayfield
+    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>
     {
-        private DrawableTaikoRuleset? drawableTaikoRuleset;
-
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
-            drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
+            var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
             drawableTaikoRuleset.LockPlayfieldMaxAspect.Value = false;
 
             var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             playfield.ClassicHitTargetPosition.Value = true;
-        }
-
-        public void Update(Playfield playfield)
-        {
-            Debug.Assert(drawableTaikoRuleset != null);
-
-            // Classic taiko scrolls at a constant 100px per 1000ms. More notes become visible as the playfield is lengthened.
-            const float scroll_rate = 10;
-
-            // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
-            float ratio = drawableTaikoRuleset.DrawHeight / 480;
-
-            drawableTaikoRuleset.TimeRange.Value = (playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -43,7 +43,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             : base(ruleset, beatmap, mods)
         {
             Direction.Value = ScrollingDirection.Left;
-            TimeRange.Value = 7000;
         }
 
         [BackgroundDependencyLoader]
@@ -58,6 +57,19 @@ namespace osu.Game.Rulesets.Taiko.UI
             });
 
             KeyBindingInputManager.Add(new DrumTouchInputArea());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Taiko scrolls at a constant 100px per 1000ms. More notes become visible as the playfield is lengthened.
+            const float scroll_rate = 10;
+
+            // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
+            float ratio = DrawHeight / 480;
+
+            TimeRange.Value = (Playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate;
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
Followup to #21883
The assertions made here (i.e. looking identical to classic mod and stable) weren't quite true yet, for that the constant sv scaling must be moved out of the classic mod as well, this was sadly missed on my part.

This PR makes taiko notes scroll at a constant speed, no matter the size of the playfield.
The comment which mentions more notes being visible on a longer playfield shouldn't be of concern because longer playfields currently get clamped anyway.

This is opposite of what master currently does, it scales scroll speed with aspect ratio, so notes become slower on lower aspect ratios to keep the same amount of notes on the screen, which is undesirable, and not the behaviour of stable (which is what the first pr aimed to achieve in the first place.)

To compare:
What we want - https://github.com/ppy/osu/pull/17225 the videos attached here in regards to 4:3, identical scroll speed to 16:9
What we don't want - https://sw1tchbl4d3.com/static/files/what.mp4

For approach: I'm not sure how important order is here, so instead of putting it into `UpdateAfterChildren()` I opted to just use the `Update()` method as the mod previously did, since this value has to be recalculated on every update, and does affect child positioning.