### PR TITLE
Add modes text to groups tooltip

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -89,6 +89,7 @@ namespace osu.Game.Tests.Visual.Online
             Groups = new[]
             {
                 new APIUserGroup { Colour = "#EB47D0", ShortName = "DEV", Name = "Developers" },
+                new APIUserGroup { Colour = "#A347EB", ShortName = "BN", Name = "Beatmap Nominators", Playmodes = new[] { "mania" } },
                 new APIUserGroup { Colour = "#A347EB", ShortName = "BN", Name = "Beatmap Nominators", Playmodes = new[] { "osu", "taiko" } }
             },
             ProfileOrder = new[]

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 var badgeModesList = group.Playmodes.Select(p => rulesets.GetRuleset(p)?.Name).ToList();
 
                 string modesDisplay = string.Join(", ", badgeModesList);
-                this.TooltipText += $" ({modesDisplay})";
+                TooltipText += $" ({modesDisplay})";
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class GroupBadge : Container, IHasTooltip
     {
-        public LocalisableString TooltipText { get; set; }
+        public LocalisableString TooltipText { get; private set; }
 
         public int TextSize { get; set; } = 12;
 

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class GroupBadge : Container, IHasTooltip
     {
-        public LocalisableString TooltipText { get; }
+        public LocalisableString TooltipText { get; set; }
 
         public int TextSize { get; set; } = 12;
 
@@ -34,7 +34,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
             Masking = true;
             CornerRadius = 8;
 
+
             TooltipText = group.Name;
+
         }
 
         [BackgroundDependencyLoader]
@@ -78,6 +80,14 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             icon.Size = new Vector2(TextSize - 1);
                         })).ToList()
                 );
+            }
+
+            if (group.Playmodes?.Length > 0)
+            {
+                var badgeModesList = group.Playmodes.Select(p => rulesets.GetRuleset(p)?.Name).ToList();
+
+                string modesDisplay = string.Join(", ", badgeModesList);
+                this.TooltipText += $" ({modesDisplay})";
             }
         }
     }

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -78,10 +78,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             icon.Size = new Vector2(TextSize - 1);
                         })).ToList()
                 );
-            }
 
-            if (group.Playmodes?.Length > 0)
-            {
                 var badgeModesList = group.Playmodes.Select(p => rulesets.GetRuleset(p)?.Name).ToList();
 
                 string modesDisplay = string.Join(", ", badgeModesList);

--- a/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/GroupBadge.cs
@@ -34,9 +34,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             Masking = true;
             CornerRadius = 8;
 
-
             TooltipText = group.Name;
-
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
- Resolves one of the items in https://github.com/ppy/osu/issues/22331

Tried to match it as close to website
Normal groups stay the same
![image](https://user-images.githubusercontent.com/30161277/213900864-2ec3e5d0-d2a4-4db6-a4cc-bb1a21c309a5.png)
Groups with 1 mode display as they should
![image](https://user-images.githubusercontent.com/30161277/213900872-9a1101dd-f37a-42a8-9bab-4d43bfd6cb5f.png)
It even works with 2 mode groups
![image](https://user-images.githubusercontent.com/30161277/213900881-20e3858a-0dcf-47f0-ab5e-41b4ceb7df9e.png)
