### PR TITLE
Add empty space tap-streaming support for osu! ruleset on touchscreen devices

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -29,7 +29,7 @@ using osuTK.Graphics;
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public partial class TestSceneTouchInput : OsuManualInputManagerTestScene
+    public partial class TestSceneOsuTouchInput : OsuManualInputManagerTestScene
     {
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -191,9 +191,10 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
-        public void TestStreamInputWithInitialTouchDown()
+        public void TestStreamInputWithInitialTouchDownLeft()
         {
             // In this scenario, the user is wanting to use stream input but we start with one finger still on the screen.
+            // That finger is mapped to a left action.
 
             addHitCircleAt(TouchSource.Touch2);
 
@@ -202,7 +203,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            // hits circle
+            // hits circle as right action
             beginTouch(TouchSource.Touch2);
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
@@ -234,6 +235,56 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
+        }
+
+        [Test]
+        public void TestStreamInputWithInitialTouchDownRight()
+        {
+            // In this scenario, the user is wanting to use stream input but we start with one finger still on the screen.
+            // That finger is mapped to a right action.
+
+            beginTouch(TouchSource.Touch1);
+            beginTouch(TouchSource.Touch2);
+
+            assertKeyCounter(1, 1);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+
+            endTouch(TouchSource.Touch1);
+
+            addHitCircleAt(TouchSource.Touch1);
+
+            // hits circle as left action
+            beginTouch(TouchSource.Touch1);
+            assertKeyCounter(2, 1);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch1);
+
+            endTouch(TouchSource.Touch2);
+
+            // stream using other two fingers while touch1 tracks
+            beginTouch(TouchSource.Touch2);
+            assertKeyCounter(2, 2);
+            checkPressed(OsuAction.RightButton);
+            // left button is automatically released
+            checkNotPressed(OsuAction.LeftButton);
+            checkPosition(TouchSource.Touch1);
+
+            beginTouch(TouchSource.Touch3);
+            assertKeyCounter(3, 2);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch1);
+
+            endTouch(TouchSource.Touch2);
+            checkNotPressed(OsuAction.RightButton);
+
+            beginTouch(TouchSource.Touch2);
+            assertKeyCounter(3, 3);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch1);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -148,8 +148,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             beginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
-            // Importantly, this is different from the simple case because an object was interacted with
-            // in the first touch, but not the second touch.
+            // Importantly, this is different from the simple case because an object was interacted with in the first touch, but not the second touch.
+            // left button is automatically released.
             checkNotPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             // Also importantly, the positional part of the second touch is ignored.
@@ -188,6 +188,52 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch1);
             endTouch(TouchSource.Touch4);
+        }
+
+        [Test]
+        public void TestStreamInputWithInitialTouchDown()
+        {
+            // In this scenario, the user is wanting to use stream input but we start with one finger still on the screen.
+
+            addHitCircleAt(TouchSource.Touch2);
+
+            beginTouch(TouchSource.Touch1);
+            assertKeyCounter(1, 0);
+            checkPressed(OsuAction.LeftButton);
+            checkPosition(TouchSource.Touch1);
+
+            // hits circle
+            beginTouch(TouchSource.Touch2);
+            assertKeyCounter(1, 1);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch2);
+
+            endTouch(TouchSource.Touch1);
+            checkNotPressed(OsuAction.LeftButton);
+
+            // stream using other two fingers while touch2 tracks
+            beginTouch(TouchSource.Touch1);
+            assertKeyCounter(2, 1);
+            checkPressed(OsuAction.LeftButton);
+            // right button is automatically released
+            checkNotPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch2);
+
+            beginTouch(TouchSource.Touch3);
+            assertKeyCounter(2, 2);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch2);
+
+            endTouch(TouchSource.Touch1);
+            checkNotPressed(OsuAction.LeftButton);
+
+            beginTouch(TouchSource.Touch1);
+            assertKeyCounter(3, 2);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            checkPosition(TouchSource.Touch2);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneTouchInput.cs
@@ -14,11 +14,13 @@ using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
 using osuTK;
@@ -70,6 +72,10 @@ namespace osu.Game.Rulesets.Osu.Tests
                                     Origin = Anchor.CentreLeft,
                                     Depth = float.MinValue,
                                     X = 100,
+                                },
+                                new OsuCursorContainer
+                                {
+                                    Depth = float.MinValue,
                                 }
                             },
                         }
@@ -77,6 +83,40 @@ namespace osu.Game.Rulesets.Osu.Tests
                     new TouchVisualiser(),
                 };
             });
+        }
+
+        [Test]
+        public void TestStreamInputVisual()
+        {
+            addHitCircleAt(TouchSource.Touch1);
+            addHitCircleAt(TouchSource.Touch2);
+
+            beginTouch(TouchSource.Touch1);
+            beginTouch(TouchSource.Touch2);
+
+            endTouch(TouchSource.Touch1);
+
+            int i = 0;
+
+            AddRepeatStep("Alternate", () =>
+            {
+                TouchSource down = i % 2 == 0 ? TouchSource.Touch3 : TouchSource.Touch4;
+                TouchSource up = i % 2 == 0 ? TouchSource.Touch4 : TouchSource.Touch3;
+
+                // sometimes the user will end the previous touch before touching again, sometimes not.
+                if (RNG.NextBool())
+                {
+                    InputManager.BeginTouch(new Touch(down, getSanePositionForSource(down)));
+                    InputManager.EndTouch(new Touch(up, getSanePositionForSource(up)));
+                }
+                else
+                {
+                    InputManager.EndTouch(new Touch(up, getSanePositionForSource(up)));
+                    InputManager.BeginTouch(new Touch(down, getSanePositionForSource(down)));
+                }
+
+                i++;
+            }, 100);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -9,8 +9,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu
 {
@@ -39,6 +41,9 @@ namespace osu.Game.Rulesets.Osu
 
         protected override KeyBindingContainer<OsuAction> CreateKeyBindingContainer(RulesetInfo ruleset, int variant, SimultaneousBindingMode unique)
             => new OsuKeyBindingContainer(ruleset, variant, unique);
+
+        public bool CheckScreenSpaceActionPressJudgeable(Vector2 screenSpacePosition) =>
+            NonPositionalInputQueue.OfType<DrawableHitCircle.HitReceptor>().Any(c => c.ReceivePositionalInputAt(screenSpacePosition));
 
         public OsuInputManager(RulesetInfo ruleset)
             : base(ruleset, 0, SimultaneousBindingMode.Unique)

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -43,6 +43,10 @@ namespace osu.Game.Rulesets.Osu
             => new OsuKeyBindingContainer(ruleset, variant, unique);
 
         public bool CheckScreenSpaceActionPressJudgeable(Vector2 screenSpacePosition) =>
+            // This is a very naive but simple approach.
+            //
+            // Based on user feedback of more nuanced scenarios (where touch doesn't behave as expected),
+            // this can be expanded to a more complex implementation, but I'd still want to keep it as simple as we can.
             NonPositionalInputQueue.OfType<DrawableHitCircle.HitReceptor>().Any(c => c.ReceivePositionalInputAt(screenSpacePosition));
 
         public OsuInputManager(RulesetInfo ruleset)

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Osu.UI
         /// </summary>
         private readonly List<TrackedTouch> trackedTouches = new List<TrackedTouch>();
 
+        private TrackedTouch? positionTrackingTouch;
+
         private readonly OsuInputManager osuInputManager;
 
         private Bindable<bool> mouseDisabled = null!;
@@ -43,8 +45,6 @@ namespace osu.Game.Rulesets.Osu.UI
             base.OnTouchMove(e);
             handleTouchMovement(e);
         }
-
-        private TrackedTouch? positionTrackingTouch;
 
         protected override bool OnTouchDown(TouchDownEvent e)
         {


### PR DESCRIPTION
This is the one that mobile users have been waiting for.

I've tried to keep the implementation as simple as possible. The general rules are:

### If a touch occurs on a hit circle's receptor

- It is tracked as a direct touch and will be used for priority positional tracking.
- It will overwrite any existing direct touch.

### If a touch occurs **outside** all hit circle receptors

- If there is no direct touch, it will be used for positional tracking, replacing any existing non-direct touch.
- If positional tracking is from a direct touch, the **action for the direct touch will be automatically released**.

---

So in short, the caveat here is that the game will give the user one extra input if they tap on a hit circle directly then "stream" using two other fingers. In other words, you can hit stacks of three objects by pressing three fingers in quick succession (one on the circle, two anywhere else) without releasing any, which is not possible with keyboard + mouse.

The only thing I'm not sure about is whether we should always alternate the left/right based on last action to make the key overlay look more balanced, or if it's fine as it is (currently if a user always releases the previous input before tapping again, they will all be `Left`). Maybe for another day. Definitely for another day.

Closes #4201.

https://user-images.githubusercontent.com/191335/214002833-47cbee25-7d68-4488-85c5-86fc6eb1dc72.mp4

