### PR TITLE
Fix touches not being handled outside `OsuTouchInputMapper` when using screen scaling

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
 using osu.Game.Configuration;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -37,6 +38,8 @@ namespace osu.Game.Rulesets.Osu.UI
             // This is mostly just doing the same as what is done in RulesetInputManager to match behaviour.
             mouseDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
         }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         protected override void OnTouchMove(TouchMoveEvent e)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Rulesets.Osu.UI
             mouseDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableButtons);
         }
 
+        // Required to handle touches outside of the playfield when screen scaling is enabled.
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         protected override void OnTouchMove(TouchMoveEvent e)


### PR DESCRIPTION
- Prerequisite for #22375

Discovered when testing the aforementioned PR.

When using screen scaling, the `OsuInputManager` and its child `OsuTouchInputMapper` don't occupy the entire screen. This means touches outside it are not handled and are instead converted to mouse input, leading to the cursor jumping wildly between the two touchpoints (see image).

This behaviour breaks the following point from https://github.com/ppy/osu/pull/22233:
> - Only tracks positional input on the most recent touch, reducing most cases of cursor "jitter" when there are two fingers on the screen

This PR/fix is important for #22375 as tapping outside the playfield is the main input method there. Using screen scaling to move the playfield left or right to have more tapping space is amicable for that specific use case, but is currently broken as described.

![image](https://user-images.githubusercontent.com/16479013/214147319-6810eaa8-2855-444d-b8ab-c546054f8f7b.png)
