### PR TITLE
Use `TriangleBorder` shader in `Triangles` background

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneTrianglesBackground.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneTrianglesBackground.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Tests.Visual.Background
             base.LoadComplete();
 
             AddSliderStep("Triangle scale", 0f, 10f, 1f, s => triangles.TriangleScale = s);
+            AddSliderStep("Seed", 0, 1000, 0, s => triangles.Reset(s));
         }
     }
 }


### PR DESCRIPTION
One step towards https://github.com/ppy/osu/issues/21515 and hopefully merging 2 triangle backgrounds into a single abstract class.

Visually no difference, performance is basically the same.
| master | pr |
| ----------- | ----------- |
| ![master](https://user-images.githubusercontent.com/22874522/214213566-e0b7246d-1d8d-47ea-89a6-a1e7bba9b4f0.png) | ![pr](https://user-images.githubusercontent.com/22874522/214213585-9bbbd2cb-233d-4745-869a-4b74b8e3d31e.png) |