### PR TITLE
Fix beatmap leaderboard potentially showing incorrect leaderboard

### DIFF
--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -104,6 +104,9 @@ namespace osu.Game.Screens.Select.Leaderboards
 
         protected override APIRequest? FetchScores(CancellationToken cancellationToken)
         {
+            scoreRetrievalRequest?.Cancel();
+            scoreRetrievalRequest = null;
+
             var fetchBeatmapInfo = BeatmapInfo;
 
             if (fetchBeatmapInfo == null)
@@ -151,8 +154,6 @@ namespace osu.Game.Screens.Select.Leaderboards
                 requestMods = new Mod[] { new ModNoMod() };
             else if (filterMods)
                 requestMods = mods.Value;
-
-            scoreRetrievalRequest?.Cancel();
 
             var newRequest = new GetScoresRequest(fetchBeatmapInfo, fetchRuleset, Scope, requestMods);
             newRequest.Success += response => Schedule(() =>


### PR DESCRIPTION
Request needs to be cancelled before any calls to `SetErrorState`, else it may still lead to callbacks and scores being displayed for a stale beatmap lookup.

While tests could definitely be added for this, I'm not sure how beneficial they will be at this point. There's no current setup for request-dependent leaderboard tests, so that would need to be added along with artificial delays. I'm willing to add if desired.

Closes #22002 (again).