### PR TITLE
Fix changelog overlay potentially showing up behind mod select overlay

### DIFF
--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -5,12 +5,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
 using osu.Game.Online.API.Requests;
@@ -79,6 +81,8 @@ namespace osu.Game.Overlays
             ArgumentNullException.ThrowIfNull(updateStream);
             ArgumentNullException.ThrowIfNull(version);
 
+            Show();
+
             performAfterFetch(() =>
             {
                 var build = builds.Find(b => b.Version == version && b.UpdateStream.Name == updateStream)
@@ -87,8 +91,6 @@ namespace osu.Game.Overlays
                 if (build != null)
                     ShowBuild(build);
             });
-
-            Show();
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
@@ -125,11 +127,16 @@ namespace osu.Game.Overlays
 
         private Task initialFetchTask;
 
-        private void performAfterFetch(Action action) => Schedule(() =>
+        private void performAfterFetch(Action action)
         {
-            fetchListing()?.ContinueWith(_ =>
-                Schedule(action), TaskContinuationOptions.OnlyOnRanToCompletion);
-        });
+            Debug.Assert(State.Value == Visibility.Visible);
+
+            Schedule(() =>
+            {
+                fetchListing()?.ContinueWith(_ =>
+                    Schedule(action), TaskContinuationOptions.OnlyOnRanToCompletion);
+            });
+        }
 
         private Task fetchListing()
         {

--- a/osu.Game/Overlays/ChangelogOverlay.cs
+++ b/osu.Game/Overlays/ChangelogOverlay.cs
@@ -22,8 +22,6 @@ namespace osu.Game.Overlays
 {
     public partial class ChangelogOverlay : OnlineOverlay<ChangelogHeader>
     {
-        public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
-
         public readonly Bindable<APIChangelogBuild> Current = new Bindable<APIChangelogBuild>();
 
         private List<APIChangelogBuild> builds;

--- a/osu.Game/Overlays/Settings/SettingsFooter.cs
+++ b/osu.Game/Overlays/Settings/SettingsFooter.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.Settings
                     Text = game.Name,
                     Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold),
                 },
-                new BuildDisplay(game.Version, DebugUtils.IsDebugBuild)
+                new BuildDisplay(game.Version)
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
@@ -81,15 +81,13 @@ namespace osu.Game.Overlays.Settings
         private partial class BuildDisplay : OsuAnimatedButton
         {
             private readonly string version;
-            private readonly bool isDebug;
 
             [Resolved]
             private OsuColour colours { get; set; }
 
-            public BuildDisplay(string version, bool isDebug)
+            public BuildDisplay(string version)
             {
                 this.version = version;
-                this.isDebug = isDebug;
 
                 Content.RelativeSizeAxes = Axes.Y;
                 Content.AutoSizeAxes = AutoSizeAxes = Axes.X;
@@ -99,8 +97,7 @@ namespace osu.Game.Overlays.Settings
             [BackgroundDependencyLoader(true)]
             private void load(ChangelogOverlay changelog)
             {
-                if (!isDebug)
-                    Action = () => changelog?.ShowBuild(OsuGameBase.CLIENT_STREAM_NAME, version);
+                Action = () => changelog?.ShowBuild(OsuGameBase.CLIENT_STREAM_NAME, version);
 
                 Add(new OsuSpriteText
                 {
@@ -110,7 +107,7 @@ namespace osu.Game.Overlays.Settings
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Padding = new MarginPadding(5),
-                    Colour = isDebug ? colours.Red : Color4.White,
+                    Colour = DebugUtils.IsDebugBuild ? colours.Red : Color4.White,
                 });
             }
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/22287

Can be tested with settings footer.

As said in https://github.com/ppy/osu/issues/22287#issuecomment-1398110997, https://github.com/ppy/osu/commit/4afbccfcff2544fa4a4e80d765a2bccb270c1658 added the `IsPresent` override, but `performAfterFetch()` is only called in `PopIn` (where it's already present) and `ShowBuild()` (it is followed by a `Show()`, so it'll be `IsPresent` and schedule that method after a few frames I believe).
https://github.com/ppy/osu/blob/a966d6c33089f21683656e167fc70c66c3e6bc70/osu.Game/Overlays/ChangelogOverlay.cs#L84-L93