### PR TITLE
Fix argon hit circles occasionally going missing during editor seeking

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -64,21 +64,18 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 outerGradient = new Circle // renders the outer bright gradient
                 {
                     Size = new Vector2(OUTER_GRADIENT_SIZE),
-                    Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 innerGradient = new Circle // renders the inner bright gradient
                 {
                     Size = new Vector2(INNER_GRADIENT_SIZE),
-                    Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
                 innerFill = new Circle // renders the inner dark fill
                 {
                     Size = new Vector2(INNER_FILL_SIZE),
-                    Alpha = 1,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 },
@@ -123,13 +120,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                 // Accent colour may be changed many times during a paused gameplay state.
                 // Schedule the change to avoid transforms piling up.
-                Scheduler.AddOnce(updateStateTransforms);
+                Scheduler.AddOnce(() =>
+                {
+                    updateStateTransforms(drawableObject, drawableObject.State.Value);
+
+                    ApplyTransformsAt(double.MinValue, true);
+                    ClearTransformsAfter(double.MinValue, true);
+                });
             }, true);
 
             drawableObject.ApplyCustomUpdateState += updateStateTransforms;
         }
-
-        private void updateStateTransforms() => updateStateTransforms(drawableObject, drawableObject.State.Value);
 
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -122,10 +122,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 // Schedule the change to avoid transforms piling up.
                 Scheduler.AddOnce(() =>
                 {
-                    updateStateTransforms(drawableObject, drawableObject.State.Value);
-
                     ApplyTransformsAt(double.MinValue, true);
                     ClearTransformsAfter(double.MinValue, true);
+
+                    updateStateTransforms(drawableObject, drawableObject.State.Value);
                 });
             }, true);
 


### PR DESCRIPTION
At some point I want to refactor this class to remove the need for resetting transforms on `AccentColour` change. It's a bit pesky.

Closes #21089.