### PR TITLE
Update appearance of profile cover area to match web

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileHeader.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Profile;
@@ -19,6 +20,9 @@ namespace osu.Game.Tests.Visual.Online
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
 
+        [Resolved]
+        private OsuConfigManager configManager { get; set; } = null!;
+
         private ProfileHeader header = null!;
 
         [SetUpSteps]
@@ -31,6 +35,22 @@ namespace osu.Game.Tests.Visual.Online
         public void TestBasic()
         {
             AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
+        }
+
+        [Test]
+        public void TestProfileCoverExpanded()
+        {
+            AddStep("Set cover to expanded", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, true));
+            AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
+            AddUntilStep("Cover is expanded", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestProfileCoverCollapsed()
+        {
+            AddStep("Set cover to collapsed", () => configManager.SetValue(OsuSetting.ProfileCoverExpanded, false));
+            AddStep("Show example user", () => header.User.Value = new UserProfileData(TestSceneUserProfileOverlay.TEST_USER, new OsuRuleset().RulesetInfo));
+            AddUntilStep("Cover is collapsed", () => header.ChildrenOfType<UserCoverBackground>().Single().Height, () => Is.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tests.Visual.Online
         {
             Username = @"Somebody",
             Id = 1,
-            CountryCode = CountryCode.Unknown,
+            CountryCode = CountryCode.JP,
             CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c1.jpg",
             JoinDate = DateTimeOffset.Now.AddDays(-1),
             LastVisit = DateTimeOffset.Now,
@@ -143,7 +143,8 @@ namespace osu.Game.Tests.Visual.Online
             {
                 Available = 10,
                 Total = 50
-            }
+            },
+            SupportLevel = 2,
         };
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -58,6 +58,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.BeatmapListingCardSize, BeatmapCardSize.Normal);
 
+            SetDefault(OsuSetting.ProfileCoverExpanded, true);
+
             SetDefault(OsuSetting.ToolbarClockDisplayMode, ToolbarClockDisplayMode.Full);
 
             // Online settings
@@ -375,5 +377,6 @@ namespace osu.Game.Configuration
         LastProcessedMetadataId,
         SafeAreaConsiderations,
         ComboColourNormalisationAmount,
+        ProfileCoverExpanded,
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -15,11 +14,11 @@ using osuTK;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
-    public partial class ExpandDetailsButton : ProfileHeaderButton
+    public partial class ToggleCoverButton : ProfileHeaderButton
     {
-        public readonly BindableBool DetailsVisible = new BindableBool();
+        public readonly BindableBool CoverVisible = new BindableBool();
 
-        public override LocalisableString TooltipText => DetailsVisible.Value ? CommonStrings.ButtonsCollapse : CommonStrings.ButtonsExpand;
+        public override LocalisableString TooltipText => CoverVisible.Value ? UsersStrings.ShowCoverTo0 : UsersStrings.ShowCoverTo1;
 
         private SpriteIcon icon = null!;
         private Sample? sampleOpen;
@@ -27,12 +26,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverClickSounds();
 
-        public ExpandDetailsButton()
+        public ToggleCoverButton()
         {
             Action = () =>
             {
-                DetailsVisible.Toggle();
-                (DetailsVisible.Value ? sampleOpen : sampleClose)?.Play();
+                CoverVisible.Toggle();
+                (CoverVisible.Value ? sampleOpen : sampleClose)?.Play();
             };
         }
 
@@ -40,19 +39,21 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private void load(OverlayColourProvider colourProvider, AudioManager audio)
         {
             IdleColour = colourProvider.Background2;
-            HoverColour = colourProvider.Background2.Lighten(0.2f);
+            HoverColour = colourProvider.Background1;
 
             sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
             sampleClose = audio.Samples.Get(@"UI/dropdown-close");
 
+            AutoSizeAxes = Axes.None;
+            Size = new Vector2(30);
             Child = icon = new SpriteIcon
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(20, 12)
+                Size = new Vector2(10.5f, 12)
             };
 
-            DetailsVisible.BindValueChanged(visible => updateState(visible.NewValue), true);
+            CoverVisible.BindValueChanged(visible => updateState(visible.NewValue), true);
         }
 
         private void updateState(bool detailsVisible) => icon.Icon = detailsVisible ? FontAwesome.Solid.ChevronUp : FontAwesome.Solid.ChevronDown;

--- a/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class ToggleCoverButton : ProfileHeaderButton
     {
-        public readonly BindableBool CoverVisible = new BindableBool();
+        public readonly BindableBool CoverVisible = new BindableBool(true);
 
         public override LocalisableString TooltipText => CoverVisible.Value ? UsersStrings.ShowCoverTo0 : UsersStrings.ShowCoverTo1;
 

--- a/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
@@ -16,9 +16,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class ToggleCoverButton : ProfileHeaderButton
     {
-        public readonly BindableBool CoverVisible = new BindableBool(true);
+        public readonly BindableBool CoverExpanded = new BindableBool(true);
 
-        public override LocalisableString TooltipText => CoverVisible.Value ? UsersStrings.ShowCoverTo0 : UsersStrings.ShowCoverTo1;
+        public override LocalisableString TooltipText => CoverExpanded.Value ? UsersStrings.ShowCoverTo0 : UsersStrings.ShowCoverTo1;
 
         private SpriteIcon icon = null!;
         private Sample? sampleOpen;
@@ -30,8 +30,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             Action = () =>
             {
-                CoverVisible.Toggle();
-                (CoverVisible.Value ? sampleOpen : sampleClose)?.Play();
+                CoverExpanded.Toggle();
+                (CoverExpanded.Value ? sampleOpen : sampleClose)?.Play();
             };
         }
 
@@ -53,7 +53,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 Size = new Vector2(10.5f, 12)
             };
 
-            CoverVisible.BindValueChanged(visible => updateState(visible.NewValue), true);
+            CoverExpanded.BindValueChanged(visible => updateState(visible.NewValue), true);
         }
 
         private void updateState(bool detailsVisible) => icon.Icon = detailsVisible ? FontAwesome.Solid.ChevronUp : FontAwesome.Solid.ChevronDown;

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -45,6 +45,8 @@ namespace osu.Game.Overlays.Profile.Header
 
         private Bindable<bool> coverExpanded = null!;
 
+        private FillFlowContainer flow = null!;
+
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuConfigManager configManager)
         {
@@ -77,7 +79,7 @@ namespace osu.Game.Overlays.Profile.Header
                             AutoSizeAxes = Axes.Y,
                             Children = new Drawable[]
                             {
-                                new FillFlowContainer
+                                flow = new FillFlowContainer
                                 {
                                     Direction = FillDirection.Horizontal,
                                     Padding = new MarginPadding
@@ -85,7 +87,6 @@ namespace osu.Game.Overlays.Profile.Header
                                         Left = UserProfileOverlay.CONTENT_X_MARGIN,
                                         Vertical = vertical_padding
                                     },
-                                    Spacing = new Vector2(20, 0),
                                     Height = content_height + 2 * vertical_padding,
                                     RelativeSizeAxes = Axes.X,
                                     Children = new Drawable[]
@@ -219,9 +220,12 @@ namespace osu.Game.Overlays.Profile.Header
         {
             const float transition_duration = 250;
 
-            cover.ResizeHeightTo(coverToggle.CoverExpanded.Value ? 250 : 0, transition_duration, Easing.OutQuint);
-            avatar.ResizeTo(new Vector2(coverToggle.CoverExpanded.Value ? 120 : content_height), transition_duration, Easing.OutQuint);
-            avatar.TransformTo(nameof(avatar.CornerRadius), coverToggle.CoverExpanded.Value ? 40f : 20f, transition_duration, Easing.OutQuint);
+            bool expanded = coverToggle.CoverExpanded.Value;
+
+            cover.ResizeHeightTo(expanded ? 250 : 0, transition_duration, Easing.OutQuint);
+            avatar.ResizeTo(new Vector2(expanded ? 120 : content_height), transition_duration, Easing.OutQuint);
+            avatar.TransformTo(nameof(avatar.CornerRadius), expanded ? 40f : 20f, transition_duration, Easing.OutQuint);
+            flow.TransformTo(nameof(flow.Spacing), new Vector2(expanded ? 20f : 10f), transition_duration, Easing.OutQuint);
         }
 
         private partial class ProfileCoverBackground : UserCoverBackground

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -218,7 +218,7 @@ namespace osu.Game.Overlays.Profile.Header
 
         private void updateCoverState()
         {
-            const float transition_duration = 250;
+            const float transition_duration = 500;
 
             bool expanded = coverToggle.CoverExpanded.Value;
 

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -65,108 +65,122 @@ namespace osu.Game.Overlays.Profile.Header
                             RelativeSizeAxes = Axes.X,
                             Height = 250,
                         },
-                        new FillFlowContainer
+                        new Container
                         {
-                            Direction = FillDirection.Horizontal,
-                            Padding = new MarginPadding
-                            {
-                                Left = UserProfileOverlay.CONTENT_X_MARGIN,
-                                Vertical = 10
-                            },
-                            Spacing = new Vector2(20, 0),
-                            Height = 85,
                             RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
                             Children = new Drawable[]
                             {
-                                avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
+                                new FillFlowContainer
                                 {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    Size = new Vector2(avatar_size),
-                                    Masking = true,
-                                    CornerRadius = avatar_size * 0.25f,
-                                    EdgeEffect = new EdgeEffectParameters
+                                    Direction = FillDirection.Horizontal,
+                                    Padding = new MarginPadding
                                     {
-                                        Type = EdgeEffectType.Shadow,
-                                        Offset = new Vector2(0, 1),
-                                        Radius = 3,
-                                        Colour = Colour4.Black.Opacity(0.25f),
+                                        Left = UserProfileOverlay.CONTENT_X_MARGIN,
+                                        Vertical = 10
+                                    },
+                                    Spacing = new Vector2(20, 0),
+                                    Height = 85,
+                                    RelativeSizeAxes = Axes.X,
+                                    Children = new Drawable[]
+                                    {
+                                        avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
+                                        {
+                                            Anchor = Anchor.BottomLeft,
+                                            Origin = Anchor.BottomLeft,
+                                            Size = new Vector2(avatar_size),
+                                            Masking = true,
+                                            CornerRadius = avatar_size * 0.25f,
+                                            EdgeEffect = new EdgeEffectParameters
+                                            {
+                                                Type = EdgeEffectType.Shadow,
+                                                Offset = new Vector2(0, 1),
+                                                Radius = 3,
+                                                Colour = Colour4.Black.Opacity(0.25f),
+                                            }
+                                        },
+                                        new OsuContextMenuContainer
+                                        {
+                                            Anchor = Anchor.BottomLeft,
+                                            Origin = Anchor.BottomLeft,
+                                            RelativeSizeAxes = Axes.Y,
+                                            AutoSizeAxes = Axes.X,
+                                            Child = new FillFlowContainer
+                                            {
+                                                AutoSizeAxes = Axes.Both,
+                                                Direction = FillDirection.Vertical,
+                                                Anchor = Anchor.CentreLeft,
+                                                Origin = Anchor.CentreLeft,
+                                                Children = new Drawable[]
+                                                {
+                                                    new FillFlowContainer
+                                                    {
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Spacing = new Vector2(5, 0),
+                                                        Children = new Drawable[]
+                                                        {
+                                                            usernameText = new OsuSpriteText
+                                                            {
+                                                                Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                                            },
+                                                            supporterTag = new SupporterIcon
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                                Height = 15,
+                                                            },
+                                                            openUserExternally = new ExternalLinkButton
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                            },
+                                                            groupBadgeFlow = new GroupBadgeFlow
+                                                            {
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                            },
+                                                        }
+                                                    },
+                                                    titleText = new OsuSpriteText
+                                                    {
+                                                        Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
+                                                        Margin = new MarginPadding { Bottom = 5 }
+                                                    },
+                                                    new FillFlowContainer
+                                                    {
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            userFlag = new UpdateableFlag
+                                                            {
+                                                                Size = new Vector2(28, 20),
+                                                                ShowPlaceholderOnUnknown = false,
+                                                            },
+                                                            userCountryText = new OsuSpriteText
+                                                            {
+                                                                Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
+                                                                Margin = new MarginPadding { Left = 5 },
+                                                                Origin = Anchor.CentreLeft,
+                                                                Anchor = Anchor.CentreLeft,
+                                                            }
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                        },
                                     }
                                 },
-                                new OsuContextMenuContainer
+                                new ToggleCoverButton
                                 {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    RelativeSizeAxes = Axes.Y,
-                                    AutoSizeAxes = Axes.X,
-                                    Child = new FillFlowContainer
-                                    {
-                                        AutoSizeAxes = Axes.Both,
-                                        Direction = FillDirection.Vertical,
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        Children = new Drawable[]
-                                        {
-                                            new FillFlowContainer
-                                            {
-                                                AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Horizontal,
-                                                Spacing = new Vector2(5, 0),
-                                                Children = new Drawable[]
-                                                {
-                                                    usernameText = new OsuSpriteText
-                                                    {
-                                                        Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
-                                                    },
-                                                    supporterTag = new SupporterIcon
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                        Height = 15,
-                                                    },
-                                                    openUserExternally = new ExternalLinkButton
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                    },
-                                                    groupBadgeFlow = new GroupBadgeFlow
-                                                    {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
-                                                    }
-                                                }
-                                            },
-                                            titleText = new OsuSpriteText
-                                            {
-                                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
-                                                Margin = new MarginPadding { Bottom = 5 }
-                                            },
-                                            new FillFlowContainer
-                                            {
-                                                AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Horizontal,
-                                                Children = new Drawable[]
-                                                {
-                                                    userFlag = new UpdateableFlag
-                                                    {
-                                                        Size = new Vector2(28, 20),
-                                                        ShowPlaceholderOnUnknown = false,
-                                                    },
-                                                    userCountryText = new OsuSpriteText
-                                                    {
-                                                        Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
-                                                        Margin = new MarginPadding { Left = 5 },
-                                                        Origin = Anchor.CentreLeft,
-                                                        Anchor = Anchor.CentreLeft,
-                                                    }
-                                                }
-                                            },
-                                        }
-                                    },
+                                    Anchor = Anchor.CentreRight,
+                                    Origin = Anchor.CentreRight,
+                                    Margin = new MarginPadding { Right = 10 }
                                 }
-                            }
-                        }
-                    }
+                            },
+                        },
+                    },
                 },
             };
 

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -22,7 +23,7 @@ namespace osu.Game.Overlays.Profile.Header
 {
     public partial class TopHeaderContainer : CompositeDrawable
     {
-        private const float avatar_size = 110;
+        private const float avatar_size = 120;
 
         public readonly Bindable<UserProfileData?> User = new Bindable<UserProfileData?>();
 
@@ -67,60 +68,66 @@ namespace osu.Game.Overlays.Profile.Header
                         new FillFlowContainer
                         {
                             Direction = FillDirection.Horizontal,
-                            Margin = new MarginPadding
+                            Padding = new MarginPadding
                             {
                                 Left = UserProfileOverlay.CONTENT_X_MARGIN,
                                 Vertical = 10
                             },
-                            Height = avatar_size,
+                            Spacing = new Vector2(20, 0),
+                            Height = 85,
                             RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
                             Children = new Drawable[]
                             {
                                 avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
                                 {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
                                     Size = new Vector2(avatar_size),
                                     Masking = true,
                                     CornerRadius = avatar_size * 0.25f,
+                                    EdgeEffect = new EdgeEffectParameters
+                                    {
+                                        Type = EdgeEffectType.Shadow,
+                                        Offset = new Vector2(0, 1),
+                                        Radius = 3,
+                                        Colour = Colour4.Black.Opacity(0.25f),
+                                    }
                                 },
                                 new OsuContextMenuContainer
                                 {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
                                     RelativeSizeAxes = Axes.Y,
                                     AutoSizeAxes = Axes.X,
-                                    Child = new Container
+                                    Child = new FillFlowContainer
                                     {
-                                        RelativeSizeAxes = Axes.Y,
-                                        AutoSizeAxes = Axes.X,
-                                        Padding = new MarginPadding { Left = 10 },
+                                        AutoSizeAxes = Axes.Both,
+                                        Direction = FillDirection.Vertical,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
                                         Children = new Drawable[]
                                         {
                                             new FillFlowContainer
                                             {
                                                 AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Vertical,
+                                                Direction = FillDirection.Horizontal,
+                                                Spacing = new Vector2(5, 0),
                                                 Children = new Drawable[]
                                                 {
-                                                    new FillFlowContainer
+                                                    usernameText = new OsuSpriteText
                                                     {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Direction = FillDirection.Horizontal,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            usernameText = new OsuSpriteText
-                                                            {
-                                                                Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
-                                                            },
-                                                            openUserExternally = new ExternalLinkButton
-                                                            {
-                                                                Margin = new MarginPadding { Left = 5 },
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                            },
-                                                        }
+                                                        Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
                                                     },
-                                                    titleText = new OsuSpriteText
+                                                    supporterTag = new SupporterIcon
                                                     {
-                                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.Regular)
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
+                                                        Height = 15,
+                                                    },
+                                                    openUserExternally = new ExternalLinkButton
+                                                    {
+                                                        Anchor = Anchor.CentreLeft,
+                                                        Origin = Anchor.CentreLeft,
                                                     },
                                                     groupBadgeFlow = new GroupBadgeFlow
                                                     {
@@ -129,52 +136,33 @@ namespace osu.Game.Overlays.Profile.Header
                                                     }
                                                 }
                                             },
+                                            titleText = new OsuSpriteText
+                                            {
+                                                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
+                                                Margin = new MarginPadding { Bottom = 5 }
+                                            },
                                             new FillFlowContainer
                                             {
-                                                Origin = Anchor.BottomLeft,
-                                                Anchor = Anchor.BottomLeft,
-                                                Direction = FillDirection.Vertical,
                                                 AutoSizeAxes = Axes.Both,
+                                                Direction = FillDirection.Horizontal,
                                                 Children = new Drawable[]
                                                 {
-                                                    supporterTag = new SupporterIcon
+                                                    userFlag = new UpdateableFlag
                                                     {
-                                                        Height = 20,
-                                                        Margin = new MarginPadding { Top = 5 }
+                                                        Size = new Vector2(28, 20),
+                                                        ShowPlaceholderOnUnknown = false,
                                                     },
-                                                    new Box
+                                                    userCountryText = new OsuSpriteText
                                                     {
-                                                        RelativeSizeAxes = Axes.X,
-                                                        Height = 1.5f,
-                                                        Margin = new MarginPadding { Top = 10 },
-                                                        Colour = colourProvider.Light1,
-                                                    },
-                                                    new FillFlowContainer
-                                                    {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Margin = new MarginPadding { Top = 5 },
-                                                        Direction = FillDirection.Horizontal,
-                                                        Children = new Drawable[]
-                                                        {
-                                                            userFlag = new UpdateableFlag
-                                                            {
-                                                                Size = new Vector2(28, 20),
-                                                                ShowPlaceholderOnUnknown = false,
-                                                            },
-                                                            userCountryText = new OsuSpriteText
-                                                            {
-                                                                Font = OsuFont.GetFont(size: 17.5f, weight: FontWeight.Regular),
-                                                                Margin = new MarginPadding { Left = 10 },
-                                                                Origin = Anchor.CentreLeft,
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Colour = colourProvider.Light1,
-                                                            }
-                                                        }
-                                                    },
+                                                        Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
+                                                        Margin = new MarginPadding { Left = 5 },
+                                                        Origin = Anchor.CentreLeft,
+                                                        Anchor = Anchor.CentreLeft,
+                                                    }
                                                 }
-                                            }
+                                            },
                                         }
-                                    }
+                                    },
                                 }
                             }
                         }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Profile.Header.Components;
+using osu.Game.Users;
 using osu.Game.Users.Drawables;
 using osuTK;
 
@@ -28,6 +29,7 @@ namespace osu.Game.Overlays.Profile.Header
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
+        private UserCoverBackground cover = null!;
         private SupporterIcon supporterTag = null!;
         private UpdateableAvatar avatar = null!;
         private OsuSpriteText usernameText = null!;
@@ -40,7 +42,8 @@ namespace osu.Game.Overlays.Profile.Header
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            Height = 150;
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
 
             InternalChildren = new Drawable[]
             {
@@ -51,52 +54,73 @@ namespace osu.Game.Overlays.Profile.Header
                 },
                 new FillFlowContainer
                 {
-                    Direction = FillDirection.Horizontal,
-                    Margin = new MarginPadding { Left = UserProfileOverlay.CONTENT_X_MARGIN },
-                    Height = avatar_size,
-                    AutoSizeAxes = Axes.X,
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
+                        cover = new ProfileCoverBackground
                         {
-                            Size = new Vector2(avatar_size),
-                            Masking = true,
-                            CornerRadius = avatar_size * 0.25f,
+                            RelativeSizeAxes = Axes.X,
+                            Height = 250,
                         },
-                        new OsuContextMenuContainer
+                        new FillFlowContainer
                         {
-                            RelativeSizeAxes = Axes.Y,
-                            AutoSizeAxes = Axes.X,
-                            Child = new Container
+                            Direction = FillDirection.Horizontal,
+                            Margin = new MarginPadding
                             {
-                                RelativeSizeAxes = Axes.Y,
-                                AutoSizeAxes = Axes.X,
-                                Padding = new MarginPadding { Left = 10 },
-                                Children = new Drawable[]
+                                Left = UserProfileOverlay.CONTENT_X_MARGIN,
+                                Vertical = 10
+                            },
+                            Height = avatar_size,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new Drawable[]
+                            {
+                                avatar = new UpdateableAvatar(isInteractive: false, showGuestOnNull: false)
                                 {
-                                    new FillFlowContainer
+                                    Size = new Vector2(avatar_size),
+                                    Masking = true,
+                                    CornerRadius = avatar_size * 0.25f,
+                                },
+                                new OsuContextMenuContainer
+                                {
+                                    RelativeSizeAxes = Axes.Y,
+                                    AutoSizeAxes = Axes.X,
+                                    Child = new Container
                                     {
-                                        AutoSizeAxes = Axes.Both,
-                                        Direction = FillDirection.Vertical,
+                                        RelativeSizeAxes = Axes.Y,
+                                        AutoSizeAxes = Axes.X,
+                                        Padding = new MarginPadding { Left = 10 },
                                         Children = new Drawable[]
                                         {
                                             new FillFlowContainer
                                             {
                                                 AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Horizontal,
-                                                Spacing = new Vector2(5),
+                                                Direction = FillDirection.Vertical,
                                                 Children = new Drawable[]
                                                 {
-                                                    usernameText = new OsuSpriteText
+                                                    new FillFlowContainer
                                                     {
-                                                        Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Direction = FillDirection.Horizontal,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            usernameText = new OsuSpriteText
+                                                            {
+                                                                Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                                            },
+                                                            openUserExternally = new ExternalLinkButton
+                                                            {
+                                                                Margin = new MarginPadding { Left = 5 },
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Origin = Anchor.CentreLeft,
+                                                            },
+                                                        }
                                                     },
-                                                    openUserExternally = new ExternalLinkButton
+                                                    titleText = new OsuSpriteText
                                                     {
-                                                        Anchor = Anchor.CentreLeft,
-                                                        Origin = Anchor.CentreLeft,
+                                                        Font = OsuFont.GetFont(size: 18, weight: FontWeight.Regular)
                                                     },
                                                     groupBadgeFlow = new GroupBadgeFlow
                                                     {
@@ -105,54 +129,50 @@ namespace osu.Game.Overlays.Profile.Header
                                                     }
                                                 }
                                             },
-                                            titleText = new OsuSpriteText
-                                            {
-                                                Font = OsuFont.GetFont(size: 18, weight: FontWeight.Regular)
-                                            },
-                                        }
-                                    },
-                                    new FillFlowContainer
-                                    {
-                                        Origin = Anchor.BottomLeft,
-                                        Anchor = Anchor.BottomLeft,
-                                        Direction = FillDirection.Vertical,
-                                        AutoSizeAxes = Axes.Both,
-                                        Children = new Drawable[]
-                                        {
-                                            supporterTag = new SupporterIcon
-                                            {
-                                                Height = 20,
-                                                Margin = new MarginPadding { Top = 5 }
-                                            },
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.X,
-                                                Height = 1.5f,
-                                                Margin = new MarginPadding { Top = 10 },
-                                                Colour = colourProvider.Light1,
-                                            },
                                             new FillFlowContainer
                                             {
+                                                Origin = Anchor.BottomLeft,
+                                                Anchor = Anchor.BottomLeft,
+                                                Direction = FillDirection.Vertical,
                                                 AutoSizeAxes = Axes.Both,
-                                                Margin = new MarginPadding { Top = 5 },
-                                                Direction = FillDirection.Horizontal,
                                                 Children = new Drawable[]
                                                 {
-                                                    userFlag = new UpdateableFlag
+                                                    supporterTag = new SupporterIcon
                                                     {
-                                                        Size = new Vector2(28, 20),
-                                                        ShowPlaceholderOnUnknown = false,
+                                                        Height = 20,
+                                                        Margin = new MarginPadding { Top = 5 }
                                                     },
-                                                    userCountryText = new OsuSpriteText
+                                                    new Box
                                                     {
-                                                        Font = OsuFont.GetFont(size: 17.5f, weight: FontWeight.Regular),
-                                                        Margin = new MarginPadding { Left = 10 },
-                                                        Origin = Anchor.CentreLeft,
-                                                        Anchor = Anchor.CentreLeft,
+                                                        RelativeSizeAxes = Axes.X,
+                                                        Height = 1.5f,
+                                                        Margin = new MarginPadding { Top = 10 },
                                                         Colour = colourProvider.Light1,
-                                                    }
+                                                    },
+                                                    new FillFlowContainer
+                                                    {
+                                                        AutoSizeAxes = Axes.Both,
+                                                        Margin = new MarginPadding { Top = 5 },
+                                                        Direction = FillDirection.Horizontal,
+                                                        Children = new Drawable[]
+                                                        {
+                                                            userFlag = new UpdateableFlag
+                                                            {
+                                                                Size = new Vector2(28, 20),
+                                                                ShowPlaceholderOnUnknown = false,
+                                                            },
+                                                            userCountryText = new OsuSpriteText
+                                                            {
+                                                                Font = OsuFont.GetFont(size: 17.5f, weight: FontWeight.Regular),
+                                                                Margin = new MarginPadding { Left = 10 },
+                                                                Origin = Anchor.CentreLeft,
+                                                                Anchor = Anchor.CentreLeft,
+                                                                Colour = colourProvider.Light1,
+                                                            }
+                                                        }
+                                                    },
                                                 }
-                                            },
+                                            }
                                         }
                                     }
                                 }
@@ -169,6 +189,7 @@ namespace osu.Game.Overlays.Profile.Header
         {
             var user = data?.User;
 
+            cover.User = user;
             avatar.User = user;
             usernameText.Text = user?.Username ?? string.Empty;
             openUserExternally.Link = $@"{api.WebsiteRootUrl}/users/{user?.Id ?? 0}";
@@ -178,6 +199,16 @@ namespace osu.Game.Overlays.Profile.Header
             titleText.Text = user?.Title ?? string.Empty;
             titleText.Colour = Color4Extensions.FromHex(user?.Colour ?? "fff");
             groupBadgeFlow.User.Value = user;
+        }
+
+        private partial class ProfileCoverBackground : UserCoverBackground
+        {
+            protected override double LoadDelay => 0;
+
+            public ProfileCoverBackground()
+            {
+                Masking = true;
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.Cursor;
@@ -42,11 +43,15 @@ namespace osu.Game.Overlays.Profile.Header
         private GroupBadgeFlow groupBadgeFlow = null!;
         private ToggleCoverButton coverToggle = null!;
 
+        private Bindable<bool> coverExpanded = null!;
+
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, OsuConfigManager configManager)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+
+            coverExpanded = configManager.GetBindable<bool>(OsuSetting.ProfileCoverExpanded);
 
             InternalChildren = new Drawable[]
             {
@@ -175,7 +180,8 @@ namespace osu.Game.Overlays.Profile.Header
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Margin = new MarginPadding { Right = 10 }
+                                    Margin = new MarginPadding { Right = 10 },
+                                    CoverExpanded = { BindTarget = coverExpanded }
                                 }
                             },
                         },
@@ -189,7 +195,7 @@ namespace osu.Game.Overlays.Profile.Header
             base.LoadComplete();
 
             User.BindValueChanged(user => updateUser(user.NewValue), true);
-            coverToggle.CoverVisible.BindValueChanged(_ => updateCoverState(), true);
+            coverExpanded.BindValueChanged(_ => updateCoverState(), true);
             FinishTransforms(true);
         }
 
@@ -213,9 +219,9 @@ namespace osu.Game.Overlays.Profile.Header
         {
             const float transition_duration = 250;
 
-            cover.ResizeHeightTo(coverToggle.CoverVisible.Value ? 250 : 0, transition_duration, Easing.OutQuint);
-            avatar.ResizeTo(new Vector2(coverToggle.CoverVisible.Value ? 120 : content_height), transition_duration, Easing.OutQuint);
-            avatar.TransformTo(nameof(avatar.CornerRadius), coverToggle.CoverVisible.Value ? 40f : 20f, transition_duration, Easing.OutQuint);
+            cover.ResizeHeightTo(coverToggle.CoverExpanded.Value ? 250 : 0, transition_duration, Easing.OutQuint);
+            avatar.ResizeTo(new Vector2(coverToggle.CoverExpanded.Value ? 120 : content_height), transition_duration, Easing.OutQuint);
+            avatar.TransformTo(nameof(avatar.CornerRadius), coverToggle.CoverExpanded.Value ? 40f : 20f, transition_duration, Easing.OutQuint);
         }
 
         private partial class ProfileCoverBackground : UserCoverBackground

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -3,23 +3,17 @@
 
 using System.Diagnostics;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Overlays.Profile.Header;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Resources.Localisation.Web;
-using osu.Game.Users;
 
 namespace osu.Game.Overlays.Profile
 {
     public partial class ProfileHeader : TabControlOverlayHeader<LocalisableString>
     {
-        private UserCoverBackground coverContainer = null!;
-
         public Bindable<UserProfileData?> User = new Bindable<UserProfileData?>();
 
         private CentreHeaderContainer centreHeaderContainer;
@@ -28,8 +22,6 @@ namespace osu.Game.Overlays.Profile
         public ProfileHeader()
         {
             ContentSidePadding = UserProfileOverlay.CONTENT_X_MARGIN;
-
-            User.ValueChanged += e => updateDisplay(e.NewValue);
 
             TabControl.AddItem(LayoutStrings.HeaderUsersShow);
 
@@ -41,25 +33,7 @@ namespace osu.Game.Overlays.Profile
             Debug.Assert(detailHeaderContainer != null);
         }
 
-        protected override Drawable CreateBackground() =>
-            new Container
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 150,
-                Masking = true,
-                Children = new Drawable[]
-                {
-                    coverContainer = new ProfileCoverBackground
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = ColourInfo.GradientVertical(Color4Extensions.FromHex("222").Opacity(0.8f), Color4Extensions.FromHex("222").Opacity(0.2f))
-                    },
-                }
-            };
+        protected override Drawable CreateBackground() => Empty();
 
         protected override Drawable CreateContent() => new FillFlowContainer
         {
@@ -103,8 +77,6 @@ namespace osu.Game.Overlays.Profile
             User = { BindTarget = User }
         };
 
-        private void updateDisplay(UserProfileData? user) => coverContainer.User = user?.User;
-
         private partial class ProfileHeaderTitle : OverlayTitle
         {
             public ProfileHeaderTitle()
@@ -112,11 +84,6 @@ namespace osu.Game.Overlays.Profile
                 Title = PageTitleStrings.MainUsersControllerDefault;
                 IconTexture = "Icons/Hexacons/profile";
             }
-        }
-
-        private partial class ProfileCoverBackground : UserCoverBackground
-        {
-            protected override double LoadDelay => 0;
         }
     }
 }


### PR DESCRIPTION
This is the last one of the user profile overlay changes I had lying around. Just want to get this over and done with.

https://user-images.githubusercontent.com/20418176/214437785-e9111f38-1af1-41e5-a535-4a0f62788cfb.mp4

Most of the diff is self-explanatory. Notably, web has the state of the cover toggle persisted to user preferences which reside in localstorage. The default is true ([source](https://github.com/ppy/osu-web/blob/a8b13157d5b3ca96033a4ed8f6e11b238e871f68/resources/js/interfaces/user-preferences-json.ts#L18)). I've added an `OsuSetting` for this to reflect the behaviour client side.