### PR TITLE
Fix iOS workflow still targeting old Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,20 +121,11 @@ jobs:
 
   build-only-ios:
     name: Build only (iOS)
-    # change to macos-latest once GitHub finishes migrating all repositories to macOS 12.
-    runs-on: macos-12
+    runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      # see https://github.com/actions/runner-images/issues/6771#issuecomment-1354713617
-      # remove once all workflow VMs use Xcode 14.1
-      - name: Set Xcode Version
-        shell: bash
-        run: |
-          sudo xcode-select -s "/Applications/Xcode_14.1.app"
-          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
 
       - name: Install .NET 6.0.x
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
This was done back in https://github.com/ppy/osu/pull/21629 when GitHub was in the process of migrating its VMs to macOS Monterey (12) and Xcode 14.1. Now this is no longer needed, and is actually breaking CI right now because latest .NET SDK requires Xcode 14.2.

This raises the question of what's gonna happen when GitHub decides to update to macOS Ventura (13), but given that it's gonna take a long time I don't think it's worth worrying about.