### PR TITLE
Add support for disabling "hit lighting" with osu! argon skin

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -5,9 +5,11 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -21,6 +23,9 @@ namespace osu.Game.Rulesets.Osu.Tests
     public partial class TestSceneHitCircle : OsuSkinnableTestScene
     {
         private int depthIndex;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; }
 
         [Test]
         public void TestHits()
@@ -54,6 +59,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void TestHittingLate()
         {
             AddStep("Hit stream late", () => SetContents(_ => testStream(5, true, 150)));
+        }
+
+        [Test]
+        public void TestHitLighting()
+        {
+            AddToggleStep("toggle hit lighting", v => config.SetValue(OsuSetting.HitLighting, v));
+            AddStep("Hit Big Single", () => SetContents(_ => testSingle(2, true)));
         }
 
         private Drawable testSingle(float circleSize, bool auto = false, double timeOffset = 0, Vector2? positionOffset = null)

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -43,6 +44,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
         private readonly IBindable<int> indexInCurrentCombo = new Bindable<int>();
         private readonly FlashPiece flash;
+
+        private Bindable<bool> configHitLighting = null!;
 
         [Resolved]
         private DrawableHitObject drawableObject { get; set; } = null!;
@@ -96,12 +99,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
             var drawableOsuObject = (DrawableOsuHitObject)drawableObject;
 
             accentColour.BindTo(drawableObject.AccentColour);
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+
+            configHitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
         }
 
         protected override void LoadComplete()
@@ -140,11 +145,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     case ArmedState.Hit:
                         // Fade out time is at a maximum of 800. Must match `DrawableHitCircle`'s arbitrary lifetime spec.
                         const double fade_out_time = 800;
-
                         const double flash_in_duration = 150;
                         const double resize_duration = 400;
 
                         const float shrink_size = 0.8f;
+
+                        // When the user has hit lighting disabled, we won't be showing the bright white flash.
+                        // To make things look good, the surrounding animations are also slightly adjusted.
+                        bool showFlash = configHitLighting.Value;
 
                         // Animating with the number present is distracting.
                         // The number disappearing is hidden by the bright flash.
@@ -176,15 +184,27 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         using (BeginDelayedSequence(flash_in_duration / 12))
                         {
                             outerGradient.ResizeTo(OUTER_GRADIENT_SIZE * shrink_size, resize_duration, Easing.OutElasticHalf);
-                            outerGradient
-                                .FadeColour(Color4.White, 80)
-                                .Then()
-                                .FadeOut(flash_in_duration);
+
+                            if (showFlash)
+                            {
+                                outerGradient
+                                    .FadeColour(Color4.White, 80)
+                                    .Then()
+                                    .FadeOut(flash_in_duration);
+                            }
+                            else
+                            {
+                                outerGradient
+                                    .FadeColour(Color4.White, flash_in_duration * 8)
+                                    .FadeOut(flash_in_duration * 2);
+                            }
                         }
 
-                        flash.FadeTo(1, flash_in_duration, Easing.OutQuint);
+                        if (showFlash)
+                            flash.FadeTo(1, flash_in_duration, Easing.OutQuint);
 
-                        this.FadeOut(fade_out_time, Easing.OutQuad);
+                        this.FadeOut(showFlash ? fade_out_time : fade_out_time / 2, Easing.OutQuad);
+
                         break;
                 }
             }


### PR DESCRIPTION
- Alternative to and closes #22392.
- Closes #21824.

https://user-images.githubusercontent.com/191335/214499427-59d89d95-86c3-4094-b3ab-0a994666d53f.mp4

Same beatmap and timings as #22392 for comparison:

https://user-images.githubusercontent.com/191335/214501036-b9d8e6f7-339e-492e-a1ae-2293a4175304.mp4

Comparison:

https://user-images.githubusercontent.com/191335/214503671-13d431d4-f90b-4fe4-80f8-f0f21e229727.mp4

