### PR TITLE
Fix beatmaps with multiple `osb` files potentially reading the storyboard from the wrong one

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -20,7 +20,6 @@ using osu.Framework.Statistics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
-using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
@@ -269,7 +268,10 @@ namespace osu.Game.Beatmaps
 
                         Stream storyboardFileStream = null;
 
-                        if (BeatmapSetInfo?.Files.FirstOrDefault(f => f.Filename.Equals($"{BeatmapSetInfo.GetDisplayString()}.osb", StringComparison.OrdinalIgnoreCase))?.Filename is string storyboardFilename)
+                        string mainStoryboardFilename = getMainStoryboardFilename(BeatmapSetInfo.Metadata);
+
+                        if (BeatmapSetInfo?.Files.FirstOrDefault(f => f.Filename.Equals(mainStoryboardFilename, StringComparison.OrdinalIgnoreCase))?.Filename is string
+                            storyboardFilename)
                         {
                             string storyboardFileStorePath = BeatmapSetInfo?.GetPathForFile(storyboardFilename);
                             storyboardFileStream = GetStream(storyboardFileStorePath);
@@ -313,6 +315,33 @@ namespace osu.Game.Beatmaps
             }
 
             public override Stream GetStream(string storagePath) => resources.Files.GetStream(storagePath);
+
+            private string getMainStoryboardFilename(IBeatmapMetadataInfo metadata)
+            {
+                // Matches stable implementation, because it's probably simpler than trying to do anything else.
+                // This may need to be reconsidered after we begin storing storyboards in the new editor.
+                return windowsFilenameStrip(
+                    (metadata.Artist.Length > 0 ? metadata.Artist + @" - " + metadata.Title : Path.GetFileNameWithoutExtension(metadata.AudioFile))
+                    + (metadata.Author.Username.Length > 0 ? @" (" + metadata.Author.Username + @")" : string.Empty)
+                    + @".osb");
+
+                string windowsFilenameStrip(string entry)
+                {
+                    // Inlined from Path.GetInvalidFilenameChars() to ensure the windows characters are used (to match stable).
+                    char[] invalidCharacters =
+                    {
+                        '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+                        '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F', '\x10', '\x11', '\x12',
+                        '\x13', '\x14', '\x15', '\x16', '\x17', '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D',
+                        '\x1E', '\x1F', '\x22', '\x3C', '\x3E', '\x7C', ':', '*', '?', '\\', '/'
+                    };
+
+                    foreach (char c in invalidCharacters)
+                        entry = entry.Replace(c.ToString(), string.Empty);
+
+                    return entry;
+                }
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -20,6 +20,7 @@ using osu.Framework.Statistics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
@@ -268,7 +269,7 @@ namespace osu.Game.Beatmaps
 
                         Stream storyboardFileStream = null;
 
-                        if (BeatmapSetInfo?.Files.FirstOrDefault(f => f.Filename.EndsWith(".osb", StringComparison.OrdinalIgnoreCase))?.Filename is string storyboardFilename)
+                        if (BeatmapSetInfo?.Files.FirstOrDefault(f => f.Filename.Equals($"{BeatmapSetInfo.GetDisplayString()}.osb", StringComparison.OrdinalIgnoreCase))?.Filename is string storyboardFilename)
                         {
                             string storyboardFileStorePath = BeatmapSetInfo?.GetPathForFile(storyboardFilename);
                             storyboardFileStream = GetStream(storyboardFileStorePath);


### PR DESCRIPTION
In stable, the storyboard filename is fixed ([reference](https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/Beatmaps/Beatmap.cs#L1496-L1508)). In lazer, we were always looking for the first `.osb` in the database. In the case a beatmap archive housed more than one `.osb` files, this may load the incorrect one.

Using `GetDisplayString` here feels like it could potentially go wrong in the future, so I'm open to hard-coding this locally (or using string manipulation to remove the ` [creator_name]` portion of the beatmap's filename). Open to opinions on that.

Fixes storyboard playback in https://osu.ppy.sh/beatmapsets/1913687#osu/3947758 which had three `osb` files:

![Finder 2023-01-25 at 08 16 47](https://user-images.githubusercontent.com/191335/214512562-eaa0e36a-4538-484b-8a86-c453ae6e23f4.png)


Closes #22403.