### PR TITLE
Adjust argon hit lighting further

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -151,10 +151,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
                         const float shrink_size = 0.8f;
 
-                        // When the user has hit lighting disabled, we won't be showing the bright white flash.
-                        // To make things look good, the surrounding animations are also slightly adjusted.
-                        bool showFlash = configHitLighting.Value;
-
                         // Animating with the number present is distracting.
                         // The number disappearing is hidden by the bright flash.
                         number.FadeOut(flash_in_duration / 2);
@@ -186,25 +182,28 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         {
                             outerGradient.ResizeTo(OUTER_GRADIENT_SIZE * shrink_size, resize_duration, Easing.OutElasticHalf);
 
-                            if (showFlash)
-                            {
-                                outerGradient
-                                    .FadeColour(Color4.White, 80)
-                                    .Then()
-                                    .FadeOut(flash_in_duration);
-                            }
-                            else
-                            {
-                                outerGradient
-                                    .FadeColour(Color4.White, flash_in_duration * 8)
-                                    .FadeOut(flash_in_duration * 2);
-                            }
+                            outerGradient
+                                .FadeColour(Color4.White, 80)
+                                .Then()
+                                .FadeOut(flash_in_duration);
                         }
 
-                        if (showFlash)
+                        if (configHitLighting.Value)
+                        {
+                            flash.HitLighting = true;
                             flash.FadeTo(1, flash_in_duration, Easing.OutQuint);
 
-                        this.FadeOut(showFlash ? fade_out_time : fade_out_time / 2, Easing.OutQuad);
+                            this.FadeOut(fade_out_time, Easing.OutQuad);
+                        }
+                        else
+                        {
+                            flash.HitLighting = false;
+                            flash.FadeTo(1, flash_in_duration, Easing.OutQuint)
+                                 .Then()
+                                 .FadeOut(flash_in_duration, Easing.OutQuint);
+
+                            this.FadeOut(fade_out_time * 0.8f, Easing.OutQuad);
+                        }
 
                         break;
                 }
@@ -236,6 +235,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 Child.AlwaysPresent = true;
             }
 
+            public bool HitLighting { get; set; }
+
             protected override void Update()
             {
                 base.Update();
@@ -244,7 +245,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = Colour,
-                    Radius = OsuHitObject.OBJECT_RADIUS * 1.2f,
+                    Radius = OsuHitObject.OBJECT_RADIUS * (HitLighting ? 1.2f : 0.6f),
                 };
             }
         }


### PR DESCRIPTION
In retrospect, the new hit lighting was taking too much away from argon. The "hit lighting" toggle is *only* supposed to remove the afterimage lighting which is present on classic skins.

I've refactored this to intrude less on the visual design of argon while removing all traces of afterimage lighting.

Any further tweaking that players want from the skin (ie. making animations shorter) will come with future settings. Hit lighting should not be doing this.