### PR TITLE
Remove assignments to Child/Children in OsuClickableContainer subclasses

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -48,7 +48,8 @@ namespace osu.Game.Tests.Visual.Online
         {
             AddStep("setup overlay", () =>
             {
-                Child = overlay = new BeatmapListingOverlay { State = { Value = Visibility.Visible } };
+                overlay = new BeatmapListingOverlay { State = { Value = Visibility.Visible } };
+                Add(overlay);
                 setsForResponse.Clear();
             });
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneButtonsInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneButtonsInput.cs
@@ -31,6 +31,29 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         public TestSceneButtonsInput()
         {
+            clickableContainer = new OsuClickableContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 40,
+                Enabled = { Value = true },
+                Masking = true,
+                CornerRadius = 20,
+            };
+            clickableContainer.AddRange(new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.Red
+                },
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "Rounded clickable container"
+                }
+            });
+
             Add(new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Y,
@@ -39,28 +62,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Direction = FillDirection.Vertical,
                 Children = new Drawable[]
                 {
-                    clickableContainer = new OsuClickableContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Height = 40,
-                        Enabled = { Value = true },
-                        Masking = true,
-                        CornerRadius = 20,
-                        Children = new Drawable[]
-                        {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4.Red
-                            },
-                            new OsuSpriteText
-                            {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                Text = "Rounded clickable container"
-                            }
-                        }
-                    },
+                    clickableContainer,
                     settingsButton = new SettingsButton
                     {
                         Enabled = { Value = true },

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuHoverContainer.cs
@@ -22,17 +22,19 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            Child = hoverContainer = new OsuHoverTestContainer
+            hoverContainer = new OsuHoverTestContainer
             {
                 Enabled = { Value = true },
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(100),
-                Child = colourContainer = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
             };
+            colourContainer = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+            };
+            hoverContainer.Add(colourContainer);
+            Add(hoverContainer);
 
             doMoveOut();
         });

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             FillFlowContainer titleBadgeArea = null!;
             GridContainer artistContainer = null!;
 
-            Child = content.With(c =>
+            Add(content.With(c =>
             {
                 c.MainContent = new Container
                 {
@@ -238,7 +238,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     Child = new BeatmapCardDifficultyList(BeatmapSet)
                 };
                 c.Expanded.BindTarget = Expanded;
-            });
+            }));
 
             if (BeatmapSet.HasVideo)
                 leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(20) });

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             FillFlowContainer titleBadgeArea = null!;
             GridContainer artistContainer = null!;
 
-            Child = content.With(c =>
+            Add(content.With(c =>
             {
                 c.MainContent = new Container
                 {
@@ -219,7 +219,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                     Child = new BeatmapCardDifficultyList(BeatmapSet)
                 };
                 c.Expanded.BindTarget = Expanded;
-            });
+            }));
 
             if (BeatmapSet.HasVideo)
                 leftIconArea.Add(new VideoIconPill { IconSize = new Vector2(20) });

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             // needed for touch input to work when card is not hovered/expanded
             AlwaysPresent = true;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 icon = new SpriteIcon
                 {
@@ -57,7 +57,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
                 {
                     Size = new Vector2(14)
                 }
-            };
+            });
 
             Action = () => Playing.Toggle();
         }

--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Graphics.Containers
         }
 
         protected override void ClearInternal(bool disposeChildren = true) =>
-            throw new InvalidOperationException($"Clearing {nameof(InternalChildren)} will cause critical failure. Use {nameof(Clear)} instead.");
+            throw new InvalidOperationException($"Clearing {nameof(InternalChildren)} will cause critical failure.");
+
+        public override void Clear(bool disposeChildren) =>
+            throw new InvalidOperationException($"Clearing {nameof(Children)} will cause critical failure.");
     }
 }

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             RelativeSizeAxes = Axes.X;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 backgroundContainer = new Container
                 {
@@ -169,7 +169,7 @@ namespace osu.Game.Graphics.UserInterface
                     ShadowColour = new Color4(0, 0, 0, 0.1f),
                     Colour = Color4.White,
                 },
-            };
+            });
 
             updateGlow();
 

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Graphics.UserInterface
             Content.Masking = true;
             Content.Anchor = Content.Origin = Anchor.Centre;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 backgroundLayer = new Container
                 {
@@ -123,7 +123,7 @@ namespace osu.Game.Graphics.UserInterface
                     Blending = BlendingParameters.Additive,
                     Alpha = 0,
                 },
-            };
+            });
 
             if (width != null)
             {

--- a/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
+++ b/osu.Game/Graphics/UserInterface/TwoLayerButton.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Graphics.UserInterface
             Size = SIZE_RETRACTED;
             Shear = shear;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 c2 = new Container
                 {
@@ -155,7 +155,7 @@ namespace osu.Game.Graphics.UserInterface
                         }
                     }
                 },
-            };
+            });
         }
 
         public IconUsage Icon

--- a/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourDisplay.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Masking = true;
                 Action = this.ShowPopover;
 
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     fill = new Box
                     {
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                         Origin = Anchor.Centre,
                         Font = OsuFont.Default.With(size: 12)
                     }
-                };
+                });
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Graphics/UserInterfaceV2/ColourPalette.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/ColourPalette.cs
@@ -132,6 +132,30 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 AutoSizeAxes = Axes.Y;
                 Width = 100;
+                circularButton = new OsuClickableContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 100,
+                    CornerRadius = 50,
+                    Masking = true,
+                    BorderThickness = 5,
+                };
+                circularButton.AddRange(new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.Transparent,
+                        AlwaysPresent = true
+                    },
+                    new SpriteIcon
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(20),
+                        Icon = FontAwesome.Solid.Plus
+                    }
+                });
 
                 InternalChild = new FillFlowContainer
                 {
@@ -141,30 +165,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Spacing = new Vector2(0, 10),
                     Children = new Drawable[]
                     {
-                        circularButton = new OsuClickableContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 100,
-                            CornerRadius = 50,
-                            Masking = true,
-                            BorderThickness = 5,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Colour4.Transparent,
-                                    AlwaysPresent = true
-                                },
-                                new SpriteIcon
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Size = new Vector2(20),
-                                    Icon = FontAwesome.Solid.Plus
-                                }
-                            }
-                        },
+                        circularButton,
                         new OsuSpriteText
                         {
                             Anchor = Anchor.TopCentre,

--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Online.Leaderboards
 
             ClickableAvatar innerAvatar;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 new RankLabel(rank)
                 {
@@ -250,7 +250,7 @@ namespace osu.Game.Online.Leaderboards
                         },
                     },
                 },
-            };
+            });
 
             innerAvatar.OnLoadComplete += d => d.FadeInFromZero(200);
         }

--- a/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
+++ b/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
@@ -19,16 +19,18 @@ namespace osu.Game.Online.Placeholders
         {
             OsuTextFlowContainer textFlow;
 
-            AddArbitraryDrawable(new OsuAnimatedButton
+            OsuAnimatedButton animatedButton = new OsuAnimatedButton
             {
                 AutoSizeAxes = Framework.Graphics.Axes.Both,
-                Child = textFlow = new OsuTextFlowContainer(cp => cp.Font = cp.Font.With(size: TEXT_SIZE))
-                {
-                    AutoSizeAxes = Framework.Graphics.Axes.Both,
-                    Margin = new Framework.Graphics.MarginPadding(5)
-                },
                 Action = () => Action?.Invoke()
+            };
+            animatedButton.Add(textFlow = new OsuTextFlowContainer(cp => cp.Font = cp.Font.With(size: TEXT_SIZE))
+            {
+                AutoSizeAxes = Framework.Graphics.Axes.Both,
+                Margin = new Framework.Graphics.MarginPadding(5)
             });
+
+            AddArbitraryDrawable(animatedButton);
 
             textFlow.AddIcon(icon, i =>
             {

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 Size = new Vector2(size);
                 Margin = new MarginPadding { Horizontal = tile_spacing / 2 };
 
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     background = new Container
                     {
@@ -282,7 +282,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Size = new Vector2(size - tile_icon_padding * 2),
                         Margin = new MarginPadding { Bottom = 1 },
                     },
-                };
+                });
             }
 
             protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
+++ b/osu.Game/Overlays/BeatmapSet/Buttons/PreviewButton.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
         {
             Height = 42;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 background = new Box
                 {
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.BeatmapSet.Buttons
                     Origin = Anchor.Centre,
                     Size = new Vector2(18),
                 },
-            };
+            });
 
             Action = () => playButton.TriggerClick();
             Playing.ValueChanged += playing => progress.FadeTo(playing.NewValue ? 1 : 0, 100);

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -63,51 +63,58 @@ namespace osu.Game.Overlays.Changelog
             }
         }
 
-        protected virtual FillFlowContainer CreateHeader() => new FillFlowContainer
+        protected virtual FillFlowContainer CreateHeader()
         {
-            Anchor = Anchor.TopCentre,
-            Origin = Anchor.TopCentre,
-            AutoSizeAxes = Axes.Both,
-            Direction = FillDirection.Vertical,
-            Margin = new MarginPadding { Top = 20 },
-            Child = new FillFlowContainer
+            OsuHoverContainer hoverContainer = new OsuHoverContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Action = () => SelectBuild?.Invoke(Build),
+            };
+
+            FillFlowContainer<SpriteText> flowContainer = new FillFlowContainer<SpriteText>
+            {
+                AutoSizeAxes = Axes.Both,
+                Margin = new MarginPadding { Horizontal = 40 },
+                Children = new[]
+                {
+                    new OsuSpriteText
+                    {
+                        Text = Build.UpdateStream.DisplayName,
+                        Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 19),
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = " ",
+                        Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 19),
+                    },
+                    new OsuSpriteText
+                    {
+                        Text = Build.DisplayVersion,
+                        Font = OsuFont.GetFont(weight: FontWeight.Light, size: 19),
+                        Colour = Build.UpdateStream.Colour,
+                    }
+                }
+            };
+            hoverContainer.Add(flowContainer);
+
+            return new FillFlowContainer
             {
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,
                 AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Child = new OsuHoverContainer
+                Direction = FillDirection.Vertical,
+                Margin = new MarginPadding { Top = 20 },
+                Child = new FillFlowContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
                     AutoSizeAxes = Axes.Both,
-                    Action = () => SelectBuild?.Invoke(Build),
-                    Child = new FillFlowContainer<SpriteText>
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Margin = new MarginPadding { Horizontal = 40 },
-                        Children = new[]
-                        {
-                            new OsuSpriteText
-                            {
-                                Text = Build.UpdateStream.DisplayName,
-                                Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 19),
-                            },
-                            new OsuSpriteText
-                            {
-                                Text = " ",
-                                Font = OsuFont.GetFont(weight: FontWeight.Medium, size: 19),
-                            },
-                            new OsuSpriteText
-                            {
-                                Text = Build.DisplayVersion,
-                                Font = OsuFont.GetFont(weight: FontWeight.Light, size: 19),
-                                Colour = Build.UpdateStream.Colour,
-                            },
-                        }
-                    }
-                },
-            }
-        };
+                    Direction = FillDirection.Horizontal,
+                    Child = hoverContainer,
+                }
+            };
+        }
     }
 }

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
             Height = 30;
             RelativeSizeAxes = Axes.X;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 hoverBox = new Box
                 {
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
                         },
                     },
                 },
-            };
+            });
 
             Action = () => OnRequestSelect?.Invoke(Channel);
         }

--- a/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
+++ b/osu.Game/Overlays/Chat/Listing/ChannelListingItem.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Overlays.Chat.Listing
             RelativeSizeAxes = Content.RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Content.AutoSizeAxes = Axes.Y;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 hoverBox = new Box
                 {
@@ -143,7 +143,7 @@ namespace osu.Game.Overlays.Chat.Listing
                         },
                     },
                 },
-            };
+            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Comments/Buttons/ChevronButton.cs
+++ b/osu.Game/Overlays/Comments/Buttons/ChevronButton.cs
@@ -21,12 +21,13 @@ namespace osu.Game.Overlays.Comments.Buttons
         public ChevronButton()
         {
             Size = new Vector2(40, 22);
-            Child = icon = new SpriteIcon
+            icon = new SpriteIcon
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(12),
             };
+            Add(icon);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Dashboard/Home/DashboardBeatmapPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/DashboardBeatmapPanel.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays.Dashboard.Home
         {
             RelativeSizeAxes = Axes.X;
             Height = 60;
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 new Container
                 {
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays.Dashboard.Home
                         }
                     }
                 }
-            };
+            });
 
             Action = () =>
             {

--- a/osu.Game/Overlays/Dashboard/Home/News/FeaturedNewsItemPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/FeaturedNewsItemPanel.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
             [BackgroundDependencyLoader]
             private void load(GameHost host)
             {
-                Child = new DelayedLoadUnloadWrapper(() => new NewsPostBackground(post.FirstImage)
+                Add(new DelayedLoadUnloadWrapper(() => new NewsPostBackground(post.FirstImage)
                 {
                     RelativeSizeAxes = Axes.Both,
                     FillMode = FillMode.Fill,
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                 })
                 {
                     RelativeSizeAxes = Axes.Both
-                };
+                });
 
                 TooltipText = "view in browser";
                 Action = () => host.OpenUrlExternally("https://osu.ppy.sh/home/news/" + post.Slug);

--- a/osu.Game/Overlays/Dashboard/Home/News/NewsTitleLink.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/NewsTitleLink.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
         [BackgroundDependencyLoader]
         private void load(GameHost host, OverlayColourProvider colourProvider)
         {
-            Child = new TextFlowContainer(t =>
+            Add(new TextFlowContainer(t =>
             {
                 t.Font = OsuFont.GetFont(weight: FontWeight.Bold);
             })
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Text = post.Title
-            };
+            });
 
             HoverColour = colourProvider.Light1;
 

--- a/osu.Game/Overlays/Dashboard/Home/News/ShowMoreNewsPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/News/ShowMoreNewsPanel.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            Child = new HomePanel
+            Add(new HomePanel
             {
                 Child = text = new OsuSpriteText
                 {
@@ -40,7 +40,7 @@ namespace osu.Game.Overlays.Dashboard.Home.News
                     Margin = new MarginPadding { Vertical = 20 },
                     Text = CommonStrings.ButtonsSeeMore
                 }
-            };
+            });
 
             IdleColour = colourProvider.Light1;
             HoverColour = Color4.White;

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Mods
 
             Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0);
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 Background = new Box
                 {
@@ -141,7 +141,7 @@ namespace osu.Game.Overlays.Mods
                         }
                     }
                 }
-            };
+            });
 
             Action = () =>
             {

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays.News.Sidebar
                 RelativeSizeAxes = Axes.X;
                 Height = 15;
                 Action = Expanded.Toggle;
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     new OsuSpriteText
                     {
@@ -109,7 +109,7 @@ namespace osu.Game.Overlays.News.Sidebar
                         Size = new Vector2(10),
                         Icon = FontAwesome.Solid.ChevronDown
                     }
-                };
+                });
             }
 
             protected override void LoadComplete()
@@ -136,12 +136,13 @@ namespace osu.Game.Overlays.News.Sidebar
 
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
-                Child = text = new TextFlowContainer(t => t.Font = OsuFont.GetFont(size: 12))
+                text = new TextFlowContainer(t => t.Font = OsuFont.GetFont(size: 12))
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Text = post.Title
                 };
+                Add(text);
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/News/Sidebar/YearsPanel.cs
+++ b/osu.Game/Overlays/News/Sidebar/YearsPanel.cs
@@ -97,13 +97,13 @@ namespace osu.Game.Overlays.News.Sidebar
                 Width = 0.25f;
                 Height = 15;
 
-                Child = new OsuSpriteText
+                Add(new OsuSpriteText
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Font = OsuFont.GetFont(size: 12, weight: isCurrent ? FontWeight.SemiBold : FontWeight.Medium),
                     Text = year.ToString()
-                };
+                });
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Overlays.Notifications
                 RelativeSizeAxes = Axes.Y;
                 Width = 28;
 
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     background = new Box
                     {
@@ -418,7 +418,7 @@ namespace osu.Game.Overlays.Notifications
                         Size = new Vector2(12),
                         Colour = colourProvider.Foreground1,
                     }
-                };
+                });
             }
 
             protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -143,10 +143,10 @@ namespace osu.Game.Overlays.Notifications
             {
                 AutoSizeAxes = Axes.Both;
 
-                Children = new[]
+                AddRange(new[]
                 {
                     text = new OsuSpriteText()
-                };
+                });
             }
 
             public LocalisableString Text

--- a/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DrawableBadge.cs
@@ -29,12 +29,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
         [BackgroundDependencyLoader]
         private void load(LargeTextureStore textures, ILinkHandler? linkHandler)
         {
-            Child = new Sprite
+            Add(new Sprite
             {
                 FillMode = FillMode.Fit,
                 RelativeSizeAxes = Axes.Both,
                 Texture = textures.Get(badge.ImageUrl),
-            };
+            });
 
             if (!string.IsNullOrEmpty(badge.Url))
                 Action = () => linkHandler?.HandleLink(badge.Url);

--- a/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MessageUserButton.cs
@@ -35,14 +35,14 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             Content.Alpha = 0;
 
-            Child = new SpriteIcon
+            Add(new SpriteIcon
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
                 Icon = FontAwesome.Solid.Envelope,
                 FillMode = FillMode.Fit,
                 Size = new Vector2(50, 14)
-            };
+            });
 
             Action = () =>
             {

--- a/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderStatisticsButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ProfileHeaderStatisticsButton.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         protected ProfileHeaderStatisticsButton()
         {
-            Child = new FillFlowContainer
+            Add(new FillFlowContainer
             {
                 AutoSizeAxes = Axes.X,
                 RelativeSizeAxes = Axes.Y,
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                         Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold)
                     }
                 }
-            };
+            });
         }
 
         protected abstract IconUsage Icon { get; }

--- a/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/SupporterIcon.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
         {
             AutoSizeAxes = Axes.X;
 
-            Child = content = new CircularContainer
+            content = new CircularContainer
             {
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X,
@@ -77,6 +77,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                     }
                 }
             };
+            Add(content);
         }
 
         [Resolved]

--- a/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ToggleCoverButton.cs
@@ -46,12 +46,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
             AutoSizeAxes = Axes.None;
             Size = new Vector2(30);
-            Child = icon = new SpriteIcon
+            icon = new SpriteIcon
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Size = new Vector2(10.5f, 12)
             };
+            Add(icon);
 
             CoverExpanded.BindValueChanged(visible => updateState(visible.NewValue), true);
         }

--- a/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
+++ b/osu.Game/Overlays/Profile/Sections/BeatmapMetadataContainer.cs
@@ -31,11 +31,11 @@ namespace osu.Game.Overlays.Profile.Sections
                 beatmapSetOverlay?.FetchAndShowBeatmap(beatmapInfo.OnlineID);
             };
 
-            Child = new FillFlowContainer
+            Add(new FillFlowContainer
             {
                 AutoSizeAxes = Axes.Both,
                 Children = CreateText(beatmapInfo),
-            };
+            });
         }
 
         protected abstract Drawable[] CreateText(IBeatmapInfo beatmapInfo);

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Overlays.Toolbar
             Width = Toolbar.HEIGHT;
             RelativeSizeAxes = Axes.Y;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 HoverBackground = new Box
                 {
@@ -160,7 +160,7 @@ namespace osu.Game.Overlays.Toolbar
                         }
                     }
                 }
-            };
+            });
         }
 
         protected override bool OnMouseDown(MouseDownEvent e) => false;

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.Toolbar
             clockDisplayMode = config.GetBindable<ToolbarClockDisplayMode>(OsuSetting.ToolbarClockDisplayMode);
             prefer24HourTime = config.GetBindable<bool>(OsuSetting.Prefer24HourTime);
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 hoverBackground = new Box
                 {
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Toolbar
                         }
                     }
                 }
-            };
+            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Wiki/WikiTableOfContents.cs
+++ b/osu.Game/Overlays/Wiki/WikiTableOfContents.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays.Wiki
 
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
-                Child = textFlow = new OsuTextFlowContainer(t =>
+                textFlow = new OsuTextFlowContainer(t =>
                 {
                     t.Font = OsuFont.GetFont(size: subtitle ? 12 : 15);
                 }).With(f =>
@@ -76,6 +76,7 @@ namespace osu.Game.Overlays.Wiki
                     f.AutoSizeAxes = Axes.Y;
                     f.Margin = new MarginPadding { Bottom = 2 };
                 });
+                Add(textFlow);
                 Padding = new MarginPadding { Left = subtitle ? 10 : 0 };
             }
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -88,14 +88,14 @@ namespace osu.Game.Screens.Edit
                 CornerRadius = 3;
                 Masking = true;
 
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     hoveredBackground = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
                         Alpha = 0,
                     },
-                };
+                });
             }
 
             private Color4 colourHover;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/TeamDisplay.cs
@@ -47,29 +47,30 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
+            box = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                CornerRadius = 5,
+                Masking = true,
+                Scale = new Vector2(0, 1),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Child = new Box
+                {
+                    Colour = Color4.White,
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
             InternalChild = clickableContent = new OsuClickableContainer
             {
                 Width = 15,
                 Alpha = 0,
                 Scale = new Vector2(0, 1),
-                RelativeSizeAxes = Axes.Y,
-                Child = box = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    CornerRadius = 5,
-                    Masking = true,
-                    Scale = new Vector2(0, 1),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Child = new Box
-                    {
-                        Colour = Color4.White,
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    }
-                }
+                RelativeSizeAxes = Axes.Y
             };
+            clickableContent.Add(box);
 
             if (Client.LocalUser?.Equals(user) == true)
             {

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -318,7 +318,7 @@ namespace osu.Game.Screens.Play
 
                 sampleConfirm = audio.Samples.Get(@"UI/submit-select");
 
-                Children = new Drawable[]
+                AddRange(new Drawable[]
                 {
                     background = new Box
                     {
@@ -367,7 +367,7 @@ namespace osu.Game.Screens.Play
                             },
                         }
                     }
-                };
+                });
             }
 
             protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Screens/Ranking/RetryButton.cs
+++ b/osu.Game/Screens/Ranking/RetryButton.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Ranking
         {
             Size = new Vector2(50, 30);
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 background = new Box
                 {
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Ranking
                     Size = new Vector2(13),
                     Icon = FontAwesome.Solid.Redo,
                 },
-            };
+            });
 
             TooltipText = "retry";
         }

--- a/osu.Game/Screens/Select/FooterButton.cs
+++ b/osu.Game/Screens/Select/FooterButton.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Select
         {
             AutoSizeAxes = Axes.Both;
             Shear = SHEAR;
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 box = new Box
                 {
@@ -117,7 +117,7 @@ namespace osu.Game.Screens.Select
                         },
                     },
                 },
-            };
+            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsButton.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Select.Options
             Width = width;
             RelativeSizeAxes = Axes.Y;
 
-            Children = new Drawable[]
+            AddRange(new Drawable[]
             {
                 box = new Container
                 {
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Select.Options
                         },
                     },
                 },
-            };
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #21676
There may still be some instances where `Clear()` is called on `OsuClickableContainer` from assigning to `Child` or `Children`, but I removed as many as I could find. 