### PR TITLE
Fix intermittent failure in multiplayer queue mode tests

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -16,6 +16,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
@@ -85,6 +86,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
 
             AddUntilStep("wait for join", () => MultiplayerClient.RoomJoined);
+            AddUntilStep("wait for ongoing operation to complete", () => !(CurrentScreen as OnlinePlayScreen).ChildrenOfType<OngoingOperationTracker>().Single().InProgress.Value);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneAllPlayersQueueMode.cs
@@ -15,7 +15,6 @@ using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
-using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.Play;
@@ -44,14 +43,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest]
-        /*
-         * TearDown : System.TimeoutException : "wait for ongoing operation to complete" timed out
-         *   --TearDown
-         *      at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
-         *      at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
-         *      at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
-         */
         public void TestItemAddedToTheEndOfQueue()
         {
             addItem(() => OtherBeatmap);
@@ -64,7 +55,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestNextItemSelectedAfterGameplayFinish()
         {
             addItem(() => OtherBeatmap);
@@ -82,7 +72,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestItemsNotClearedWhenSwitchToHostOnlyMode()
         {
             addItem(() => OtherBeatmap);
@@ -98,7 +87,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestCorrectItemSelectedAfterNewItemAdded()
         {
             addItem(() => OtherBeatmap);
@@ -106,7 +94,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestCorrectRulesetSelectedAfterNewItemAdded()
         {
             addItem(() => OtherBeatmap, new CatchRuleset().RulesetInfo);
@@ -124,7 +111,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestCorrectModsSelectedAfterNewItemAdded()
         {
             addItem(() => OtherBeatmap, mods: new Mod[] { new OsuModDoubleTime() });
@@ -153,7 +139,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for song select", () => (songSelect = CurrentSubScreen as Screens.Select.SongSelect) != null);
             AddUntilStep("wait for loaded", () => songSelect.AsNonNull().BeatmapSetsLoaded);
-            AddUntilStep("wait for ongoing operation to complete", () => !(CurrentScreen as OnlinePlayScreen).ChildrenOfType<OngoingOperationTracker>().Single().InProgress.Value);
 
             if (ruleset != null)
                 AddStep($"set {ruleset.Name} ruleset", () => songSelect.AsNonNull().Ruleset.Value = ruleset);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneHostOnlyQueueMode.cs
@@ -50,14 +50,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest]
-        /*
-         * TearDown : System.TimeoutException : "wait for ongoing operation to complete" timed out
-         *   --TearDown
-         *      at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
-         *      at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
-         *      at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
-         */
         public void TestItemStillSelectedAfterChangeToSameBeatmap()
         {
             selectNewItem(() => InitialBeatmap);
@@ -66,7 +58,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestItemStillSelectedAfterChangeToOtherBeatmap()
         {
             selectNewItem(() => OtherBeatmap);
@@ -75,7 +66,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestOnlyLastItemChangedAfterGameplayFinished()
         {
             RunGameplay();
@@ -90,7 +80,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
-        [FlakyTest] // See above
         public void TestAddItemsAsHost()
         {
             addItem(() => OtherBeatmap);
@@ -115,7 +104,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for song select", () => CurrentSubScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
 
             BeatmapInfo otherBeatmap = null;
-            AddUntilStep("wait for ongoing operation to complete", () => !(CurrentScreen as OnlinePlayScreen).ChildrenOfType<OngoingOperationTracker>().Single().InProgress.Value);
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(otherBeatmap = beatmap()));
 
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
@@ -131,7 +119,6 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for song select", () => CurrentSubScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
-            AddUntilStep("wait for ongoing operation to complete", () => !(CurrentScreen as OnlinePlayScreen).ChildrenOfType<OngoingOperationTracker>().Single().InProgress.Value);
             AddStep("select other beatmap", () => ((Screens.Select.SongSelect)CurrentSubScreen).FinaliseSelection(beatmap()));
             AddUntilStep("wait for return to match", () => CurrentSubScreen is MultiplayerMatchSubScreen);
         }


### PR DESCRIPTION
```
Failed TestCorrectModsSelectedAfterNewItemAdded [10 s]
  Error Message:
   TearDown : System.TimeoutException : "wait for ongoing operation to complete" timed out
  Stack Trace:
  --TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0()
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered)
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition)
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test)
   at osu.Game.Tests.Visual.OsuTestScene.OsuTestSceneTestRunner.RunTestBlocking(TestScene test) in D:\a\osu\osu\osu.Game\Tests\Visual\OsuTestScene.cs:line 523
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
```

https://github.com/ppy/osu/actions/runs/4021688110/jobs/6910777818

This one took me a good while to investigate, as it was very hard to reproduce locally and had to resort to GitHub Actions. But in summary, joining a room comes with an on-going operation issued by `MultiplayerMatchSettingsOverlay`, and that doesn't get disposed until `CreateRoom` finishes successfully and the task continuation in `joinMultiplayerRoom` is executed.

Now the problem here is, the test passes the "wait for join" step only when `RoomJoined = true`, that doesn't cover the async task continuation that invokes `onSuccess` for the settings overlay to dispose the operation.

What's worse is that the test already proceeds to song select, which halts `MultiplayerMatchSettingsOverlay` from receiving updates, therefore even when the async task continuation is executed and the event is invoked, the overlay has scheduled it so the operation will never be disposed.

This brings an edge case in game where, if the async task continuation in `joinMultiplayerRoom` had indeed been delayed and the user went to song select beforehand, they'll get stuck in an indefinitely loading song select screen until they leave and come back again. We could solve that by disabling the buttons themselves when in ongoing operation, but I'm not sure about immediately changing that yet.

cc/ @ppy/team-client 