### PR TITLE
Fix migration putting game files in root of disk if no other files exist

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -65,8 +65,9 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                         return;
                     }
 
-                    //We aren't using CreateSubDirectory due to the flaw with a root of a drive
-                    target = Directory.CreateDirectory(Path.Combine(target.FullName, "osu-lazer"));
+                    // Not using CreateSubDirectory as it throws unexpectedly when attempting to create a directory when already at the root of a disk.
+                    // See https://cs.github.com/dotnet/runtime/blob/f1bdd5a6182f43f3928b389b03f7bc26f826c8bc/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryInfo.cs#L88-L94
+                    target = Directory.CreateDirectory(Path.Combine(target.FullName, @"osu-lazer"));
                 }
             }
             catch (Exception e)

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -47,8 +47,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                 var directoryInfos = target.GetDirectories();
                 var fileInfos = target.GetFiles();
 
-                //With an empty disk (mb flash drive), this if could be false
-                if (directoryInfos.Length > 0 || fileInfos.Length > 0)
+                if (directoryInfos.Length > 0 || fileInfos.Length > 0 || target.Parent == null)
                 {
                     // Quick test for whether there's already an osu! install at the target path.
                     if (fileInfos.Any(f => f.Name == OsuGameBase.CLIENT_DATABASE_FILENAME))
@@ -66,11 +65,8 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                         return;
                     }
 
-                    //Check for a root directory
-                    if (target.Parent == null)
-                        target = Directory.CreateDirectory(Path.Combine(target.FullName, "osu-lazer"));
-                    else
-                        target = target.CreateSubdirectory("osu-lazer");
+                    //We aren't using CreateSubDirectory due to the flaw with a root of a drive
+                    target = Directory.CreateDirectory(Path.Combine(target.FullName, "osu-lazer"));
                 }
             }
             catch (Exception e)

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationSelectScreen.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                 var directoryInfos = target.GetDirectories();
                 var fileInfos = target.GetFiles();
 
+                //With an empty disk (mb flash drive), this if could be false
                 if (directoryInfos.Length > 0 || fileInfos.Length > 0)
                 {
                     // Quick test for whether there's already an osu! install at the target path.
@@ -65,7 +66,11 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                         return;
                     }
 
-                    target = target.CreateSubdirectory("osu-lazer");
+                    //Check for a root directory
+                    if (target.Parent == null)
+                        target = Directory.CreateDirectory(Path.Combine(target.FullName, "osu-lazer"));
+                    else
+                        target = target.CreateSubdirectory("osu-lazer");
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
#### Resolve #22345 
Now it creates folder "osu-lazer" if in the root of a drive