### PR TITLE
Output gameplay clock progress in `PlayerTestScene`s

### DIFF
--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Logging;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
@@ -24,6 +25,24 @@ namespace osu.Game.Tests.Visual
         protected TestPlayer Player;
 
         protected OsuConfigManager LocalConfig;
+
+        private double lastReportedTime;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Player?.GameplayClockContainer != null)
+            {
+                int roundedTime = (int)Player.GameplayClockContainer.CurrentTime / 1000;
+
+                if (roundedTime != lastReportedTime)
+                {
+                    lastReportedTime = roundedTime;
+                    Logger.Log($"⏱️ Gameplay clock reached {lastReportedTime * 1000:N0} ms");
+                }
+            }
+        }
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
Potential insight into test failures.

```
[performance] 2023-02-01 14:42:12 [verbose]: TextureAtlas initialised (1024x1024)
[runtime] 2023-02-01 14:42:12 [verbose]: 💨 Class: TestSceneStoryboardWithOutro
[runtime] 2023-02-01 14:42:12 [verbose]: 🔶 Test:  TestStoryboardEndsBeforeCompletion
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #1 exit all screens
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #2 enable storyboard
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #3 set dim level to 0
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #4 reset fail conditions
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #5 set beatmap duration to 0s
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #6 set storyboard duration to 8s
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #7 set ShowResults = true
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #8 set storyboard duration to .1s
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #9 Load player for osu!
[runtime] 2023-02-01 14:42:12 [verbose]: Game-wide working beatmap updated to Unknown - Unknown (Unknown Creator) [Normal]
[runtime] 2023-02-01 14:42:12 [verbose]: ScreenTestScene screen changed → TestSceneStoryboardWithOutro+OutroPlayer
[runtime] 2023-02-01 14:42:12 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:1) loading TestSceneStoryboardWithOutro+OutroPlayer#646
[runtime] 2023-02-01 14:42:12 [verbose]: 🔸 Step #10 player loaded
[runtime] 2023-02-01 14:42:13 [verbose]: Score submission token retrieval failed (Request could not be constructed.)
[runtime] 2023-02-01 14:42:13 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:1) entered TestSceneStoryboardWithOutro+OutroPlayer#646
[runtime] 2023-02-01 14:42:13 [verbose]: 📺 BackgroundScreenStack#305(depth:1) loading BackgroundScreenBeatmap#136
[runtime] 2023-02-01 14:42:13 [verbose]: GameplayClockContainer seeking to -2000
[runtime] 2023-02-01 14:42:13 [verbose]: ⏱️ Gameplay clock reached -2,000 ms
[runtime] 2023-02-01 14:42:13 [verbose]: ⏱️ Gameplay clock reached -1,000 ms
[runtime] 2023-02-01 14:42:13 [verbose]: ✔️ 861 repetitions
[runtime] 2023-02-01 14:42:13 [verbose]: 🔸 Step #11 storyboard ends
[runtime] 2023-02-01 14:42:13 [verbose]: 📺 BackgroundScreenStack#305(depth:1) entered BackgroundScreenBeatmap#136
[runtime] 2023-02-01 14:42:14 [verbose]: ⏱️ Gameplay clock reached 0 ms
[runtime] 2023-02-01 14:42:15 [verbose]: ✔️ 3244 repetitions
[runtime] 2023-02-01 14:42:15 [verbose]: 🔸 Step #12 completion set by processor
[runtime] 2023-02-01 14:42:15 [verbose]: 🔸 Step #13 wait for score shown
[runtime] 2023-02-01 14:42:15 [verbose]: ⏱️ Gameplay clock reached 1,000 ms
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:1) suspended TestSceneStoryboardWithOutro+OutroPlayer#646 (waiting on SoloResultsScreen#578)
[runtime] 2023-02-01 14:42:15 [verbose]: ScreenTestScene screen changed → SoloResultsScreen
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:2) loading SoloResultsScreen#578
[runtime] 2023-02-01 14:42:15 [verbose]: ✔️ 4 repetitions
[runtime] 2023-02-01 14:42:15 [verbose]: 🔸 Step #14 exit all screens
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:1) exit from SoloResultsScreen#578
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:1) resume to TestSceneStoryboardWithOutro+OutroPlayer#646
[runtime] 2023-02-01 14:42:15 [verbose]: ScreenTestScene screen changed ← TestSceneStoryboardWithOutro+OutroPlayer
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 BackgroundScreenStack#305(depth:0) exit from BackgroundScreenBeatmap#136
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 BackgroundScreenStack#305(depth:0) resume to [empty]
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:0) exit from TestSceneStoryboardWithOutro+OutroPlayer#646
[runtime] 2023-02-01 14:42:15 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#588(depth:0) resume to [empty]
[runtime] 2023-02-01 14:42:15 [verbose]: ScreenTestScene screen changed ←
[runtime] 2023-02-01 14:42:15 [verbose]: ✔️ 2 repetitions
[runtime] 2023-02-01 14:42:15 [verbose]: ✅ TestSceneStoryboardWithOutro completed
```