### PR TITLE
Avoid showing skin save message when changing scenes after making no changes

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Overlays.SkinEditor
                                             {
                                                 Items = new[]
                                                 {
-                                                    new EditorMenuItem(Resources.Localisation.Web.CommonStrings.ButtonsSave, MenuItemType.Standard, Save),
+                                                    new EditorMenuItem(Resources.Localisation.Web.CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
                                                     new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, revert),
                                                     new EditorMenuItemSpacer(),
                                                     new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, () => skinEditorOverlay?.Hide()),
@@ -333,7 +333,7 @@ namespace osu.Game.Overlays.SkinEditor
             }
         }
 
-        public void Save()
+        public void Save(bool userTriggered = true)
         {
             if (!hasBegunMutating)
                 return;
@@ -343,8 +343,9 @@ namespace osu.Game.Overlays.SkinEditor
             foreach (var t in targetContainers)
                 currentSkin.Value.UpdateDrawableTarget(t);
 
-            skins.Save(skins.CurrentSkin.Value);
-            onScreenDisplay?.Display(new SkinEditorToast(ToastStrings.SkinSaved, currentSkin.Value.SkinInfo.ToString() ?? "Unknown"));
+            // In the case the save was user triggered, always show the save message to make them feel confident.
+            if (skins.Save(skins.CurrentSkin.Value) || userTriggered)
+                onScreenDisplay?.Display(new SkinEditorToast(ToastStrings.SkinSaved, currentSkin.Value.SkinInfo.ToString() ?? "Unknown"));
         }
 
         protected override bool OnHover(HoverEvent e) => true;

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             if (skinEditor == null) return;
 
-            skinEditor.Save(false);
+            skinEditor.Save(userTriggered: false);
 
             // ensure the toolbar is re-hidden even if a new screen decides to try and show it.
             updateComponentVisibility();

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             if (skinEditor == null) return;
 
-            skinEditor.Save();
+            skinEditor.Save(false);
 
             // ensure the toolbar is re-hidden even if a new screen decides to try and show it.
             updateComponentVisibility();

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Skinning
         private Skin createInstance(SkinInfo item) => item.CreateInstance(skinResources);
 
         /// <summary>
-        /// Save a skin. Updates any drawable layouts that are out of date.
+        /// Save a skin, serialising any changes to skin layouts to relevant JSON structures.
         /// </summary>
         /// <returns>Whether any change actually occurred.</returns>
         public bool Save(Skin skin)

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -179,8 +179,14 @@ namespace osu.Game.Skinning
 
         private Skin createInstance(SkinInfo item) => item.CreateInstance(skinResources);
 
-        public void Save(Skin skin)
+        /// <summary>
+        /// Save a skin. Updates any drawable layouts that are out of date.
+        /// </summary>
+        /// <returns>Whether any change actually occurred.</returns>
+        public bool Save(Skin skin)
         {
+            bool hadChanges = false;
+
             skin.SkinInfo.PerformWrite(s =>
             {
                 // Update for safety
@@ -212,8 +218,14 @@ namespace osu.Game.Skinning
                     }
                 }
 
-                s.Hash = ComputeHash(s);
+                string newHash = ComputeHash(s);
+
+                hadChanges = newHash != s.Hash;
+
+                s.Hash = newHash;
             });
+
+            return hadChanges;
         }
     }
 }

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -192,12 +192,16 @@ namespace osu.Game.Skinning
             });
         }
 
-        public void Save(Skin skin)
+        /// <summary>
+        /// Save a skin. Updates any drawable layouts that are out of date.
+        /// </summary>
+        /// <returns>Whether any change actually occurred.</returns>
+        public bool Save(Skin skin)
         {
             if (!skin.SkinInfo.IsManaged)
                 throw new InvalidOperationException($"Attempting to save a skin which is not yet tracked. Call {nameof(EnsureMutableSkin)} first.");
 
-            skinImporter.Save(skin);
+            return skinImporter.Save(skin);
         }
 
         /// <summary>

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Skinning
         }
 
         /// <summary>
-        /// Save a skin. Updates any drawable layouts that are out of date.
+        /// Save a skin, serialising any changes to skin layouts to relevant JSON structures.
         /// </summary>
         /// <returns>Whether any change actually occurred.</returns>
         public bool Save(Skin skin)


### PR DESCRIPTION
- [x] Depends on #22490 

This got pretty annoying when moving between screens in the editor (it would show the "changes saved" on each screen change). Now it will only show when changes have actually occurred.