### PR TITLE
Fix skin editor component list having uneven padding

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Overlays.SkinEditor
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
-                Spacing = new Vector2(2)
+                Spacing = new Vector2(EditorSidebar.PADDING)
             };
 
             reloadComponents();

--- a/osu.Game/Screens/Edit/Components/EditorSidebar.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebar.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Screens.Edit.Components
     {
         public const float WIDTH = 250;
 
+        public const float PADDING = 3;
+
         private readonly Box background;
 
         protected override Container<EditorSidebarSection> Content { get; }
@@ -35,13 +37,13 @@ namespace osu.Game.Screens.Edit.Components
                 },
                 new OsuScrollContainer
                 {
-                    Padding = new MarginPadding { Left = 20 },
                     ScrollbarOverlapsContent = false,
                     RelativeSizeAxes = Axes.Both,
                     Child = Content = new FillFlowContainer<EditorSidebarSection>
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(PADDING),
                         Direction = FillDirection.Vertical,
                     },
                 }


### PR DESCRIPTION
| before | after |
| -- | -- |
|![osu! 2023-02-03 at 07 57 04](https://user-images.githubusercontent.com/191335/216543883-34a2dc27-a798-4a70-b420-e9865d8c9723.png)|![osu! 2023-02-03 at 07 56 27](https://user-images.githubusercontent.com/191335/216543740-32180113-c8b1-4b76-8114-fd57153eb2a7.png)|