### PR TITLE
Fix some clickable elements having no hover and click sounds

### DIFF
--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -44,8 +44,11 @@ namespace osu.Game.Graphics.Containers
                 content.AutoSizeAxes = AutoSizeAxes;
             }
 
-            AddInternal(content);
-            Add(CreateHoverSounds(sampleSet));
+            AddRangeInternal(new Drawable[]
+            {
+                content,
+                CreateHoverSounds(sampleSet)
+            });
         }
 
         protected override void ClearInternal(bool disposeChildren = true) =>

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (buttons.Contains(e.Button) && Contains(e.ScreenSpaceMousePosition))
+            if (buttons.Contains(e.Button))
             {
                 var channel = Enabled.Value ? sampleClick?.GetChannel() : sampleClickDisabled?.GetChannel();
 

--- a/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
+using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
@@ -17,6 +18,8 @@ namespace osu.Game.Graphics.UserInterface
     public abstract partial class HoverSampleDebounceComponent : CompositeDrawable
     {
         private Bindable<double?> lastPlaybackTime;
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.ReceivePositionalInputAt(screenSpacePos) ?? false;
 
         [BackgroundDependencyLoader]
         private void load(SessionStatics statics)

--- a/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
@@ -5,7 +5,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osuTK;
@@ -15,7 +15,7 @@ namespace osu.Game.Graphics.UserInterface
     /// <summary>
     /// Handles debouncing hover sounds at a global level to ensure the effects are not overwhelming.
     /// </summary>
-    public abstract partial class HoverSampleDebounceComponent : CompositeDrawable
+    public abstract partial class HoverSampleDebounceComponent : Component
     {
         private Bindable<double?> lastPlaybackTime;
 

--- a/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleDebounceComponent.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Graphics.UserInterface
     {
         private Bindable<double?> lastPlaybackTime;
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.ReceivePositionalInputAt(screenSpacePos) ?? false;
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.ReceivePositionalInputAt(screenSpacePos) == true;
 
         [BackgroundDependencyLoader]
         private void load(SessionStatics statics)

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Graphics.UserInterface
             });
 
             if (hoverSounds.HasValue)
-                Add(new HoverClickSounds(hoverSounds.Value) { Enabled = { BindTarget = Enabled } });
+                AddInternal(new HoverClickSounds(hoverSounds.Value) { Enabled = { BindTarget = Enabled } });
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         protected void ApplyDefaultsToHitObject() => HitObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.ReceivePositionalInputAt(screenSpacePos) ?? false;
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parent?.ReceivePositionalInputAt(screenSpacePos) == true;
 
         protected override bool Handle(UIEvent e)
         {

--- a/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselHeader.cs
@@ -46,7 +46,8 @@ namespace osu.Game.Screens.Select.Carousel
                 Children = new Drawable[]
                 {
                     Content,
-                    hoverLayer = new HoverLayer()
+                    hoverLayer = new HoverLayer(),
+                    new HeaderSounds(),
                 }
             };
         }
@@ -91,10 +92,8 @@ namespace osu.Game.Screens.Select.Carousel
             }
         }
 
-        public partial class HoverLayer : HoverSampleDebounceComponent
+        public partial class HoverLayer : CompositeDrawable
         {
-            private Sample? sampleHover;
-
             private Box box = null!;
 
             public HoverLayer()
@@ -103,7 +102,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             [BackgroundDependencyLoader]
-            private void load(AudioManager audio, OsuColour colours)
+            private void load(OsuColour colours)
             {
                 InternalChild = box = new Box
                 {
@@ -112,8 +111,6 @@ namespace osu.Game.Screens.Select.Carousel
                     Blending = BlendingParameters.Additive,
                     RelativeSizeAxes = Axes.Both,
                 };
-
-                sampleHover = audio.Samples.Get("UI/default-hover");
             }
 
             public bool InsetForBorder
@@ -146,6 +143,17 @@ namespace osu.Game.Screens.Select.Carousel
             {
                 box.FadeOut(1000, Easing.OutQuint);
                 base.OnHoverLost(e);
+            }
+        }
+
+        private partial class HeaderSounds : HoverSampleDebounceComponent
+        {
+            private Sample? sampleHover;
+
+            [BackgroundDependencyLoader]
+            private void load(AudioManager audio)
+            {
+                sampleHover = audio.Samples.Get("UI/default-hover");
             }
 
             public override void PlayHoverSample()


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/21676

In the issue, I said I would make the sound components `0x0` size but am not sure now. My reason was that their draw area is nonsensical now as they now depend on the parent's `Content` draw area.