### PR TITLE
Add very basic skin editor undo / redo support

### DIFF
--- a/osu.Game.Tests/Editing/BeatmapEditorChangeHandlerTest.cs
+++ b/osu.Game.Tests/Editing/BeatmapEditorChangeHandlerTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -12,7 +10,7 @@ using osu.Game.Screens.Edit;
 namespace osu.Game.Tests.Editing
 {
     [TestFixture]
-    public class EditorChangeHandlerTest
+    public class BeatmapEditorChangeHandlerTest
     {
         private int stateChangedFired;
 
@@ -169,7 +167,7 @@ namespace osu.Game.Tests.Editing
                 },
             });
 
-            var changeHandler = new EditorChangeHandler(beatmap);
+            var changeHandler = new BeatmapEditorChangeHandler(beatmap);
 
             changeHandler.OnStateChange += () => stateChangedFired++;
             return (changeHandler, beatmap);

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -66,10 +66,16 @@ namespace osu.Game.Extensions
 
                 foreach (var (_, property) in component.GetSettingsSourceProperties())
                 {
-                    if (!info.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
-                        continue;
+                    var bindable = ((IBindable)property.GetValue(component)!);
 
-                    skinnable.CopyAdjustedSetting(((IBindable)property.GetValue(component)!), settingValue);
+                    if (!info.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
+                    {
+                        // TODO: We probably want to restore default if not included in serialisation information.
+                        // This is not simple to do as SetDefault() is only found in the typed Bindable<T> interface right now.
+                        continue;
+                    }
+
+                    skinnable.CopyAdjustedSetting(bindable, settingValue);
                 }
             }
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -481,8 +481,16 @@ namespace osu.Game.Overlays.SkinEditor
             remove => throw new NotImplementedException();
         }
 
-        public void BeginChange() => changeHandler?.BeginChange();
-        public void EndChange() => changeHandler?.EndChange();
+        private IEditorChangeHandler? beginChangeHandler;
+
+        public void BeginChange()
+        {
+            // Change handler may change between begin and end, which can cause unbalanced operations.
+            // Let's track the one that was used when beginning the change so we can call EndChange on it specifically.
+            (beginChangeHandler = changeHandler)?.BeginChange();
+        }
+
+        public void EndChange() => beginChangeHandler?.EndChange();
         public void SaveState() => changeHandler?.SaveState();
 
         #endregion

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -329,8 +329,6 @@ namespace osu.Game.Overlays.SkinEditor
 
             SelectedComponents.Clear();
             SelectedComponents.Add(component);
-
-            changeHandler?.SaveState();
         }
 
         private void populateSettings()
@@ -406,8 +404,6 @@ namespace osu.Game.Overlays.SkinEditor
         {
             foreach (var item in items)
                 availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);
-
-            changeHandler?.SaveState();
         }
 
         #region Drag & drop import handling

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -477,8 +477,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         public event Action? OnStateChange
         {
-            add => changeHandler!.OnStateChange += value;
-            remove => changeHandler!.OnStateChange -= value;
+            add => throw new NotImplementedException();
+            remove => throw new NotImplementedException();
         }
 
         public void BeginChange() => changeHandler?.BeginChange();

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -24,6 +24,7 @@ using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Overlays.OSD;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Skinning;
@@ -31,7 +32,7 @@ using osu.Game.Skinning;
 namespace osu.Game.Overlays.SkinEditor
 {
     [Cached(typeof(SkinEditor))]
-    public partial class SkinEditor : VisibilityContainer, ICanAcceptFiles, IKeyBindingHandler<PlatformAction>
+    public partial class SkinEditor : VisibilityContainer, ICanAcceptFiles, IKeyBindingHandler<PlatformAction>, IEditorChangeHandler
     {
         public const double TRANSITION_DURATION = 300;
 
@@ -71,6 +72,11 @@ namespace osu.Game.Overlays.SkinEditor
 
         private EditorSidebar componentsSidebar = null!;
         private EditorSidebar settingsSidebar = null!;
+
+        private SkinEditorChangeHandler? changeHandler;
+
+        private EditorMenuItem undoMenuItem = null!;
+        private EditorMenuItem redoMenuItem = null!;
 
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
@@ -130,6 +136,14 @@ namespace osu.Game.Overlays.SkinEditor
                                                     new EditorMenuItemSpacer(),
                                                     new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, () => skinEditorOverlay?.Hide()),
                                                 },
+                                            },
+                                            new MenuItem(CommonStrings.MenuBarEdit)
+                                            {
+                                                Items = new[]
+                                                {
+                                                    undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo),
+                                                    redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo),
+                                                }
                                             },
                                         }
                                     },
@@ -210,6 +224,14 @@ namespace osu.Game.Overlays.SkinEditor
         {
             switch (e.Action)
             {
+                case PlatformAction.Undo:
+                    Undo();
+                    return true;
+
+                case PlatformAction.Redo:
+                    Redo();
+                    return true;
+
                 case PlatformAction.Save:
                     if (e.Repeat)
                         return false;
@@ -229,6 +251,8 @@ namespace osu.Game.Overlays.SkinEditor
         {
             this.targetScreen = targetScreen;
 
+            changeHandler?.Dispose();
+
             SelectedComponents.Clear();
 
             // Immediately clear the previous blueprint container to ensure it doesn't try to interact with the old target.
@@ -240,6 +264,10 @@ namespace osu.Game.Overlays.SkinEditor
             void loadBlueprintContainer()
             {
                 Debug.Assert(content != null);
+
+                changeHandler = new SkinEditorChangeHandler(targetScreen);
+                changeHandler.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);
+                changeHandler.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
 
                 content.Child = new SkinBlueprintContainer(targetScreen);
 
@@ -301,6 +329,8 @@ namespace osu.Game.Overlays.SkinEditor
 
             SelectedComponents.Clear();
             SelectedComponents.Add(component);
+
+            changeHandler?.SaveState();
         }
 
         private void populateSettings()
@@ -332,6 +362,10 @@ namespace osu.Game.Overlays.SkinEditor
                 getTarget(t.Target)?.Reload();
             }
         }
+
+        protected void Undo() => changeHandler?.RestoreState(-1);
+
+        protected void Redo() => changeHandler?.RestoreState(1);
 
         public void Save()
         {
@@ -371,6 +405,8 @@ namespace osu.Game.Overlays.SkinEditor
         {
             foreach (var item in items)
                 availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);
+
+            changeHandler?.SaveState();
         }
 
         #region Drag & drop import handling
@@ -435,5 +471,19 @@ namespace osu.Game.Overlays.SkinEditor
             {
             }
         }
+
+        #region Delegation of IEditorChangeHandler
+
+        public event Action? OnStateChange
+        {
+            add => changeHandler!.OnStateChange += value;
+            remove => changeHandler!.OnStateChange -= value;
+        }
+
+        public void BeginChange() => changeHandler?.BeginChange();
+        public void EndChange() => changeHandler?.EndChange();
+        public void SaveState() => changeHandler?.SaveState();
+
+        #endregion
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.SkinEditor
             // In the future we'll want this to cover all changes, even to skin's `InstantiationInfo`.
             // We'll also need to consider cases where multiple targets are on screen at the same time.
 
-            firstTarget = targetScreen?.ChildrenOfType<ISkinnableTarget>().FirstOrDefault();
+            firstTarget = targetScreen.ChildrenOfType<ISkinnableTarget>().FirstOrDefault();
 
             if (firstTarget == null)
                 return;

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Extensions;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Skinning;
+
+namespace osu.Game.Overlays.SkinEditor
+{
+    public partial class SkinEditorChangeHandler : EditorChangeHandler
+    {
+        private readonly Drawable targetScreen;
+
+        private ISkinnableTarget? firstTarget => targetScreen.ChildrenOfType<ISkinnableTarget>().FirstOrDefault();
+
+        public SkinEditorChangeHandler(Drawable targetScreen)
+        {
+            // To keep things simple, we are currently only handling the current target screen for undo / redo.
+            // In the future we'll want this to cover all changes, even to skin's `InstantiationInfo`.
+            // We'll also need to consider cases where multiple targets are on screen at the same time.
+
+            this.targetScreen = targetScreen;
+
+            // Save initial state.
+            SaveState();
+        }
+
+        protected override void WriteCurrentStateToStream(MemoryStream stream)
+        {
+            if (firstTarget == null)
+                return;
+
+            var skinnableInfos = firstTarget.CreateSkinnableInfo().ToArray();
+            string json = JsonConvert.SerializeObject(skinnableInfos, new JsonSerializerSettings { Formatting = Formatting.Indented });
+            stream.Write(Encoding.UTF8.GetBytes(json));
+        }
+
+        protected override void ApplyStateChange(byte[] previousState, byte[] newState)
+        {
+            if (firstTarget == null)
+                return;
+
+            var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SkinnableInfo>>(Encoding.UTF8.GetString(newState));
+
+            if (deserializedContent == null)
+                return;
+
+            SkinnableInfo[] skinnableInfo = deserializedContent.ToArray();
+            Drawable[] targetComponents = firstTarget.Components.OfType<Drawable>().ToArray();
+
+            if (!skinnableInfo.Select(s => s.Type).SequenceEqual(targetComponents.Select(d => d.GetType())))
+            {
+                // Perform a naive full reload for now.
+                firstTarget.Reload(skinnableInfo);
+            }
+            else
+            {
+                int i = 0;
+
+                foreach (var drawable in targetComponents)
+                    drawable.ApplySkinnableInfo(skinnableInfo[i++]);
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -241,6 +241,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void applyOrigins(Anchor origin)
         {
+            OnOperationBegan();
+
             foreach (var item in SelectedItems)
             {
                 var drawable = (Drawable)item;
@@ -255,6 +257,8 @@ namespace osu.Game.Overlays.SkinEditor
 
                 ApplyClosestAnchor(drawable);
             }
+
+            OnOperationEnded();
         }
 
         /// <summary>
@@ -266,6 +270,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void applyFixedAnchors(Anchor anchor)
         {
+            OnOperationBegan();
+
             foreach (var item in SelectedItems)
             {
                 var drawable = (Drawable)item;
@@ -273,15 +279,21 @@ namespace osu.Game.Overlays.SkinEditor
                 item.UsesFixedAnchor = true;
                 applyAnchor(drawable, anchor);
             }
+
+            OnOperationEnded();
         }
 
         private void applyClosestAnchors()
         {
+            OnOperationBegan();
+
             foreach (var item in SelectedItems)
             {
                 item.UsesFixedAnchor = false;
                 ApplyClosestAnchor((Drawable)item);
             }
+
+            OnOperationEnded();
         }
 
         private static Anchor getClosestAnchor(Drawable drawable)

--- a/osu.Game/Overlays/SkinEditor/SkinSettingsToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSettingsToolbox.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
+using osu.Game.Overlays.Settings;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components;
 using osuTK;
 
@@ -13,19 +16,41 @@ namespace osu.Game.Overlays.SkinEditor
 {
     internal partial class SkinSettingsToolbox : EditorSidebarSection
     {
+        [Resolved]
+        private IEditorChangeHandler? changeHandler { get; set; }
+
         protected override Container<Drawable> Content { get; }
+
+        private readonly Drawable component;
 
         public SkinSettingsToolbox(Drawable component)
             : base(SkinEditorStrings.Settings(component.GetType().Name))
         {
+            this.component = component;
+
             base.Content.Add(Content = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(10),
-                Children = component.CreateSettingsControls().ToArray()
             });
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var controls = component.CreateSettingsControls().ToArray();
+
+            Content.AddRange(controls);
+
+            // track any changes to update undo states.
+            foreach (var c in controls.OfType<ISettingsItem>())
+            {
+                // TODO: SettingChanged is called too often for cases like SettingsTextBox and SettingsSlider.
+                // We will want to expose a SettingCommitted or similar to make this work better.
+                c.SettingChanged += () => changeHandler?.SaveState();
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Text;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Screens.Edit
+{
+    public partial class BeatmapEditorChangeHandler : EditorChangeHandler
+    {
+        private readonly LegacyEditorBeatmapPatcher patcher;
+        private readonly EditorBeatmap editorBeatmap;
+
+        /// <summary>
+        /// Creates a new <see cref="EditorChangeHandler"/>.
+        /// </summary>
+        /// <param name="editorBeatmap">The <see cref="EditorBeatmap"/> to track the <see cref="HitObject"/>s of.</param>
+        public BeatmapEditorChangeHandler(EditorBeatmap editorBeatmap)
+        {
+            this.editorBeatmap = editorBeatmap;
+
+            editorBeatmap.TransactionBegan += BeginChange;
+            editorBeatmap.TransactionEnded += EndChange;
+            editorBeatmap.SaveStateTriggered += SaveState;
+
+            patcher = new LegacyEditorBeatmapPatcher(editorBeatmap);
+
+            // Initial state.
+            SaveState();
+        }
+
+        protected override void WriteCurrentStateToStream(MemoryStream stream)
+        {
+            using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
+                new LegacyBeatmapEncoder(editorBeatmap, editorBeatmap.BeatmapSkin).Encode(sw);
+        }
+
+        protected override void ApplyStateChange(byte[] previousState, byte[] newState) =>
+            patcher.Patch(previousState, newState);
+    }
+}

--- a/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/BeatmapEditorChangeHandler.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Screens.Edit
             editorBeatmap.SaveStateTriggered += SaveState;
 
             patcher = new LegacyEditorBeatmapPatcher(editorBeatmap);
-
-            // Initial state.
-            SaveState();
         }
 
         protected override void WriteCurrentStateToStream(MemoryStream stream)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.Edit
 
             if (canSave)
             {
-                changeHandler = new EditorChangeHandler(editorBeatmap);
+                changeHandler = new BeatmapEditorChangeHandler(editorBeatmap);
                 dependencies.CacheAs<IEditorChangeHandler>(changeHandler);
             }
 

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,7 +21,7 @@ namespace osu.Game.Screens.Edit
         public readonly Bindable<bool> CanUndo = new Bindable<bool>();
         public readonly Bindable<bool> CanRedo = new Bindable<bool>();
 
-        public event Action OnStateChange;
+        public event Action? OnStateChange;
 
         private readonly LegacyEditorBeatmapPatcher patcher;
         private readonly List<byte[]> savedStates = new List<byte[]>();

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -96,8 +96,18 @@ namespace osu.Game.Screens.Edit
             updateBindables();
         }
 
+        /// <summary>
+        /// Write a serialised copy of the currently tracked state to the provided stream.
+        /// This will be stored as a state which can be restored in the future.
+        /// </summary>
+        /// <param name="stream">The stream which the state should be written to.</param>
         protected abstract void WriteCurrentStateToStream(MemoryStream stream);
 
+        /// <summary>
+        /// Given a previous and new state, apply any changes required to bring the current state in line with the new state.
+        /// </summary>
+        /// <param name="previousState">The previous (current before this call) serialised state.</param>
+        /// <param name="newState">The new state to be applied.</param>
         protected abstract void ApplyStateChange(byte[] previousState, byte[] newState);
 
         private void updateBindables()

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Screens.Edit
         {
             get
             {
+                ensureStateSaved();
+
                 using (var stream = new MemoryStream(savedStates[currentState]))
                     return stream.ComputeSHA2Hash();
             }
@@ -39,6 +41,19 @@ namespace osu.Game.Screens.Edit
         private bool isRestoring;
 
         public const int MAX_SAVED_STATES = 50;
+
+        public override void BeginChange()
+        {
+            ensureStateSaved();
+
+            base.BeginChange();
+        }
+
+        private void ensureStateSaved()
+        {
+            if (savedStates.Count == 0)
+                SaveState();
+        }
 
         protected override void UpdateState()
         {

--- a/osu.Game/Screens/Edit/IEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/IEditorChangeHandler.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using osu.Framework.Allocation;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Edit
@@ -11,12 +10,13 @@ namespace osu.Game.Screens.Edit
     /// <summary>
     /// Interface for a component that manages changes in the <see cref="Editor"/>.
     /// </summary>
+    [Cached]
     public interface IEditorChangeHandler
     {
         /// <summary>
         /// Fired whenever a state change occurs.
         /// </summary>
-        event Action OnStateChange;
+        event Action? OnStateChange;
 
         /// <summary>
         /// Begins a bulk state change event. <see cref="EndChange"/> should be invoked soon after.

--- a/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
+++ b/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 
@@ -16,17 +14,17 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Fires whenever a transaction begins. Will not fire on nested transactions.
         /// </summary>
-        public event Action TransactionBegan;
+        public event Action? TransactionBegan;
 
         /// <summary>
         /// Fires when the last transaction completes.
         /// </summary>
-        public event Action TransactionEnded;
+        public event Action? TransactionEnded;
 
         /// <summary>
         /// Fires when <see cref="SaveState"/> is called and results in a non-transactional state save.
         /// </summary>
-        public event Action SaveStateTriggered;
+        public event Action? SaveStateTriggered;
 
         public bool TransactionActive => bulkChangesStarted > 0;
 

--- a/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
+++ b/osu.Game/Screens/Edit/TransactionalCommitComponent.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Signal the beginning of a change.
         /// </summary>
-        public void BeginChange()
+        public virtual void BeginChange()
         {
             if (bulkChangesStarted++ == 0)
                 TransactionBegan?.Invoke();

--- a/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
+++ b/osu.Game/Screens/Play/HUD/SkinnableInfo.cs
@@ -69,8 +69,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 var bindable = (IBindable)property.GetValue(component)!;
 
-                if (!bindable.IsDefault)
-                    Settings.Add(property.Name.ToSnakeCase(), bindable.GetUnderlyingSettingValue());
+                Settings.Add(property.Name.ToSnakeCase(), bindable.GetUnderlyingSettingValue());
             }
 
             if (component is Container<Drawable> container)

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -37,6 +37,11 @@ namespace osu.Game.Skinning
         void Reload();
 
         /// <summary>
+        /// Reload this target from the provided skinnable information.
+        /// </summary>
+        public void Reload(SkinnableInfo[] skinnableInfo);
+
+        /// <summary>
         /// Add a new skinnable component to this target.
         /// </summary>
         /// <param name="drawable">The component to add.</param>

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Reload this target from the provided skinnable information.
         /// </summary>
-        public void Reload(SkinnableInfo[] skinnableInfo);
+        void Reload(SkinnableInfo[] skinnableInfo);
 
         /// <summary>
         /// Add a new skinnable component to this target.
@@ -51,6 +51,6 @@ namespace osu.Game.Skinning
         /// Remove an existing skinnable component from this target.
         /// </summary>
         /// <param name="component">The component to remove.</param>
-        public void Remove(ISkinnableDrawable component);
+        void Remove(ISkinnableDrawable component);
     }
 }

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Screens.Play.HUD;
 
 namespace osu.Game.Skinning
 {
@@ -30,16 +32,31 @@ namespace osu.Game.Skinning
             Target = target;
         }
 
-        /// <summary>
-        /// Reload all components in this container from the current skin.
-        /// </summary>
-        public void Reload()
+        public void Reload(SkinnableInfo[] skinnableInfo)
+        {
+            var drawables = new List<Drawable>();
+
+            foreach (var i in skinnableInfo)
+                drawables.Add(i.CreateInstance());
+
+            Reload(new SkinnableTargetComponentsContainer
+            {
+                Children = drawables,
+            });
+        }
+
+        public void Reload() => Reload(CurrentSkin.GetDrawableComponent(new GlobalSkinComponentLookup(Target)) as SkinnableTargetComponentsContainer);
+
+        public void Reload(SkinnableTargetComponentsContainer? componentsContainer)
         {
             ClearInternal();
             components.Clear();
             ComponentsLoaded = false;
 
-            content = CurrentSkin.GetDrawableComponent(new GlobalSkinComponentLookup(Target)) as SkinnableTargetComponentsContainer;
+            if (componentsContainer == null)
+                return;
+
+            content = componentsContainer;
 
             cancellationSource?.Cancel();
             cancellationSource = null;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/12966

I made this work and it seems like it might be okay to get it in in this state? I'm hesitant to write tests or spend more time on this due to the fact that https://github.com/ppy/osu/issues/22388 will likely require deep modifications in how change handling is done (assuming we move every target container to a single json structure or similar).

Put another way, I wasn't sure if I should work on undo/redo support before considering the aforementioned restructure, but getting it working to a MVP level was quick enough that I propose we get this out to users so they can benefit from it while the larger restructuring tasks happen in the background.

Of note: if any new elements are added or removed, *all elements will be recycled*. This is the simplest way of handling this, especially since we don't have any ID for tracking movement of elements around. There may be room to use `SkinnableTargetContainer`'s [bindable `Components` list](https://github.com/ppy/osu/blob/2f30306ea204dfe8809ff0cb26effe6284a0d41a/osu.Game/Skinning/SkinnableTargetContainer.cs#L20) to better handle this in the future.


https://user-images.githubusercontent.com/191335/216571607-ad9e1a0e-47ce-4fff-a06b-ef1cbff1e205.mp4

PRing this to get some initial feedback on direction.

Issues of note:

- [x] Changes to `SettingsSourceAttribute`s do not trigger state saves.