### PR TITLE
Add the ability to move a skin element by 10 pixels when holding shift

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -104,22 +104,24 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
+            int delta = e.ShiftPressed ? 10 : 1;
+
             switch (e.Key)
             {
                 case Key.Left:
-                    moveSelection(new Vector2(-1, 0));
+                    moveSelection(new Vector2(-delta, 0));
                     return true;
 
                 case Key.Right:
-                    moveSelection(new Vector2(1, 0));
+                    moveSelection(new Vector2(delta, 0));
                     return true;
 
                 case Key.Up:
-                    moveSelection(new Vector2(0, -1));
+                    moveSelection(new Vector2(0, -delta));
                     return true;
 
                 case Key.Down:
-                    moveSelection(new Vector2(0, 1));
+                    moveSelection(new Vector2(0, delta));
                     return true;
             }
 


### PR DESCRIPTION
Allows you to move a skin element by 10px when holding shift and using the arrow keys.