### PR TITLE
Allow importing beatmaps via file associations on desktop platforms

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -29,6 +29,7 @@ namespace osu.Desktop
     internal partial class OsuGameDesktop : OsuGame
     {
         private OsuSchemeLinkIPCChannel? osuSchemeLinkIPCChannel;
+        private ArchiveImportIPCChannel? archiveImportIPCChannel;
 
         public OsuGameDesktop(string[]? args = null)
             : base(args)
@@ -123,6 +124,7 @@ namespace osu.Desktop
             LoadComponentAsync(new ElevatedPrivilegesChecker(), Add);
 
             osuSchemeLinkIPCChannel = new OsuSchemeLinkIPCChannel(Host, this);
+            archiveImportIPCChannel = new ArchiveImportIPCChannel(Host, this);
         }
 
         public override void SetHost(GameHost host)
@@ -181,6 +183,7 @@ namespace osu.Desktop
         {
             base.Dispose(isDisposing);
             osuSchemeLinkIPCChannel?.Dispose();
+            archiveImportIPCChannel?.Dispose();
         }
 
         private class SDL2BatteryInfo : BatteryInfo


### PR DESCRIPTION
The existing `ArchiveImportIPCChannel` works fine, so this PR just enables its use in `OsuGameDesktop`.

https://github.com/ppy/osu/pull/18786 mentions that `ArchiveImportIPCChannel` was not enabled because of beatmap invalidation concerns, but that is no longer an issue:

> I've also moved some code around that uses ArchiveImportIPCChannel, but this IPC channel is - as far as I can tell - actually dead right now (as in you can send messages over it, but they are never actually received). This was previously used in the ol' `ArchiveModelManager` which got nuked in https://github.com/ppy/osu/pull/16428. I'm not touching that for the time being to not interfere with work on https://github.com/ppy/osu/issues/18665.