### PR TITLE
Fix BPM counter value being affected by non-mod-related playback rate changes

### DIFF
--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Screens.Play.HUD
         [Resolved]
         private IGameplayClock gameplayClock { get; set; } = null!;
 
+        [Resolved]
+        private Player player { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
@@ -38,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
             base.Update();
 
             //We don't want it going to 0 when we pause. so we block the updates
-            if (gameplayClock.IsPaused.Value) return;
+            if (gameplayClock.IsPaused.Value || player.GameplayState.HasFailed) return;
 
             // We want to check Rate every update to cover windup/down
             Current.Value = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(gameplayClock.CurrentTime).BPM * gameplayClock.Rate;

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Screens.Play.HUD
         [Resolved]
         private IGameplayClock gameplayClock { get; set; } = null!;
 
-        [Resolved]
-        private Player player { get; set; } = null!;
-
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
@@ -40,11 +37,8 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.Update();
 
-            //We don't want it going to 0 when we pause. so we block the updates
-            if (gameplayClock.IsPaused.Value || player.GameplayState.HasFailed) return;
-
             // We want to check Rate every update to cover windup/down
-            Current.Value = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(gameplayClock.CurrentTime).BPM * gameplayClock.Rate;
+            Current.Value = beatmap.Value.Beatmap.ControlPointInfo.TimingPointAt(gameplayClock.CurrentTime).BPM * gameplayClock.GetTrueGameplayRate();
         }
 
         protected override OsuSpriteText CreateSpriteText()


### PR DESCRIPTION
There is no reason for this to be the case since the fail speed reduction is merely aesthetic in nature, and it makes it annoying to see what BPM you were playing at before failing.

Before :
![osu_2023-02-04_00-03-45](https://user-images.githubusercontent.com/74463310/216727276-0151c110-41e6-4fce-8440-1deeab9f1117.png)

After:
![osu_2023-02-04_00-02-37](https://user-images.githubusercontent.com/74463310/216727280-a0924c0f-9d27-49cf-9d89-d9a01f9ae9f1.png)

