### PR TITLE
Fix expanded beatmap cards getting cut off at the end of profile sections

### DIFF
--- a/osu.Game/Overlays/Profile/ProfileSection.cs
+++ b/osu.Game/Overlays/Profile/ProfileSection.cs
@@ -36,21 +36,24 @@ namespace osu.Game.Overlays.Profile
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
 
-            Masking = true;
-            CornerRadius = 10;
-            EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Shadow,
-                Offset = new Vector2(0, 1),
-                Radius = 3,
-                Colour = Colour4.Black.Opacity(0.25f)
-            };
-
             InternalChildren = new Drawable[]
             {
-                background = new Box
+                new Container
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    CornerRadius = 10,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Offset = new Vector2(0, 1),
+                        Radius = 3,
+                        Colour = Colour4.Black.Opacity(0.25f)
+                    },
+                    Child = background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
                 },
                 new FillFlowContainer
                 {


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu/pull/22200

| Before | After |
| --- | --- |
| ![osu!_bXBty86BiX](https://user-images.githubusercontent.com/35318437/216752194-e7836bad-43ee-40f6-8242-f7e1bf5a9a96.png) | ![osu!_jTQX3Wcr8x](https://user-images.githubusercontent.com/35318437/216752145-975790e5-594d-400b-8333-2f0f9fd48e62.png) |