### PR TITLE
Fix: scores updates on beatmap change

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -25,6 +26,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
+using osu.Game.Scoring;
 using osu.Game.Skinning;
 using osu.Game.Utils;
 
@@ -453,6 +455,12 @@ namespace osu.Game.Beatmaps
 
                     if (transferCollections)
                         beatmapInfo.TransferCollectionReferences(r, oldMd5Hash);
+
+                    //Unlinking all scores from this beatmap
+                    r.All<ScoreInfo>().Where(s => s.BeatmapInfoID == beatmapInfo.ID).ForEach(s => s.BeatmapInfo = new BeatmapInfo());
+
+                    //Linking all the previos scores
+                    r.All<ScoreInfo>().Where(s => s.OriginalBeatmapHash == beatmapInfo.Hash).ForEach(s => s.BeatmapInfo = beatmapInfo);
 
                     ProcessBeatmap?.Invoke((liveBeatmapSet, false));
                 });

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -70,6 +70,7 @@ namespace osu.Game.Database
         /// 23   2022-08-01    Added LastLocalUpdate to BeatmapInfo.
         /// 24   2022-08-22    Added MaximumStatistics to ScoreInfo.
         /// 25   2022-09-18    Remove skins to add with new naming.
+        /// 26   2023-02-05    Added OriginalBeatmapHash to ScoreInfo.
         /// </summary>
         private const int schema_version = 25;
 
@@ -865,6 +866,20 @@ namespace osu.Game.Database
                 case 25:
                     // Remove the default skins so they can be added back by SkinManager with updated naming.
                     migration.NewRealm.RemoveRange(migration.NewRealm.All<SkinInfo>().Where(s => s.Protected));
+                    break;
+                case 26:
+                    // Adding origin beatmap hash property to ensure the score corresponds to the version of beatmap it should
+                    // See: https://github.com/ppy/osu/issues/22062
+                    string ScoreInfoName = getMappedOrOriginalName(typeof(ScoreInfo));
+
+                    var oldScoreInfos = migration.OldRealm.DynamicApi.All(ScoreInfoName);
+                    var newScoreInfos = migration.NewRealm.All<ScoreInfo>();
+
+                    for (int i = 0; i < newScoreInfos.Count(); i++)
+                    {
+                        newScoreInfos.ElementAt(i).OriginalBeatmapHash = oldScoreInfos.ElementAt(i).BeatmapInfo.Hash;
+                    }
+
                     break;
             }
         }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Database
         /// 25   2022-09-18    Remove skins to add with new naming.
         /// 26   2023-02-05    Added OriginalBeatmapHash to ScoreInfo.
         /// </summary>
-        private const int schema_version = 25;
+        private const int schema_version = 26;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -66,6 +66,8 @@ namespace osu.Game.Scoring
         [MapTo("MaximumStatistics")]
         public string MaximumStatisticsJson { get; set; } = string.Empty;
 
+        public string OriginalBeatmapHash { get; set; } = string.Empty;
+
         public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)
         {
             Ruleset = ruleset ?? new RulesetInfo();


### PR DESCRIPTION
Should resolve #22062 
Still under development.  Would be glad if you give me some advise on this.
Progress:

- [x] Add `OriginalBeatmapHash` to `ScoreInfo`
- [x] Update db schema_version, migration
- [ ] Update score creating to include `OriginalBeatmapHash`
- [ ] Find solution to remove and add `BeatmapInfo` to `ScoreInfo` on map update (web and editor)
