### PR TITLE
Add support for `Watching` and `Spectating` activities in `ReplayPlayer` and `SoloSpectatingPlayer`

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -98,7 +98,7 @@ namespace osu.Desktop
 
             if (status.Value is UserStatusOnline && activity.Value != null)
             {
-                presence.State = truncate(activity.Value.Status);
+                presence.State = truncate(privacyMode.Value == DiscordRichPresenceMode.Limited ? activity.Value.LimitedStatus : activity.Value.Status);
                 presence.Details = truncate(getDetails(activity.Value));
 
                 if (getBeatmap(activity.Value) is IBeatmapInfo beatmap && beatmap.OnlineID > 0)
@@ -185,6 +185,9 @@ namespace osu.Desktop
 
                 case UserActivity.Editing edit:
                     return edit.BeatmapInfo.ToString() ?? string.Empty;
+
+                case UserActivity.Watching watching:
+                    return watching.BeatmapInfo.ToString();
 
                 case UserActivity.InLobby lobby:
                     return privacyMode.Value == DiscordRichPresenceMode.Limited ? string.Empty : lobby.Room.Name.Value;

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -98,7 +98,7 @@ namespace osu.Desktop
 
             if (status.Value is UserStatusOnline && activity.Value != null)
             {
-                presence.State = truncate(privacyMode.Value == DiscordRichPresenceMode.Limited ? activity.Value.LimitedStatus : activity.Value.Status);
+                presence.State = truncate(activity.Value.GetStatus(privacyMode.Value == DiscordRichPresenceMode.Limited));
                 presence.Details = truncate(getDetails(activity.Value));
 
                 if (getBeatmap(activity.Value) is IBeatmapInfo beatmap && beatmap.OnlineID > 0)

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -107,6 +107,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("set online status", () => status.Value = new UserStatusOnline());
 
             AddStep("idle", () => activity.Value = null);
+            AddStep("watching", () => activity.Value = new UserActivity.Watching());
             AddStep("spectating", () => activity.Value = new UserActivity.Spectating());
             AddStep("solo (osu!)", () => activity.Value = soloGameStatusForRuleset(0));
             AddStep("solo (osu!taiko)", () => activity.Value = soloGameStatusForRuleset(1));

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -11,6 +11,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osu.Game.Tests.Beatmaps;
 using osu.Game.Users;
 using osuTK;
 
@@ -107,8 +109,8 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("set online status", () => status.Value = new UserStatusOnline());
 
             AddStep("idle", () => activity.Value = null);
-            AddStep("watching", () => activity.Value = new UserActivity.Watching());
-            AddStep("spectating", () => activity.Value = new UserActivity.Spectating());
+            AddStep("watching", () => activity.Value = new UserActivity.Watching(createScore(@"nats")));
+            AddStep("spectating", () => activity.Value = new UserActivity.Spectating(createScore(@"mrekk")));
             AddStep("solo (osu!)", () => activity.Value = soloGameStatusForRuleset(0));
             AddStep("solo (osu!taiko)", () => activity.Value = soloGameStatusForRuleset(1));
             AddStep("solo (osu!catch)", () => activity.Value = soloGameStatusForRuleset(2));
@@ -132,6 +134,14 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         private UserActivity soloGameStatusForRuleset(int rulesetId) => new UserActivity.InSoloGame(null, rulesetStore.GetRuleset(rulesetId));
+
+        private ScoreInfo createScore(string name) => new ScoreInfo(new TestBeatmap(Ruleset.Value).BeatmapInfo)
+        {
+            User = new APIUser
+            {
+                Username = name,
+            }
+        };
 
         private partial class TestUserListPanel : UserListPanel
         {

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Play
 
         private readonly bool replayIsFailedScore;
 
-        protected override UserActivity InitialActivity => new UserActivity.Watching();
+        protected override UserActivity InitialActivity => new UserActivity.Watching(Score.ScoreInfo);
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure()

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Ranking;
+using osu.Game.Users;
 
 namespace osu.Game.Screens.Play
 {
@@ -23,6 +24,8 @@ namespace osu.Game.Screens.Play
         private readonly Func<IBeatmap, IReadOnlyList<Mod>, Score> createScore;
 
         private readonly bool replayIsFailedScore;
+
+        protected override UserActivity InitialActivity => new UserActivity.Watching();
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure()

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
-        protected override UserActivity InitialActivity => new UserActivity.Spectating();
+        protected override UserActivity InitialActivity => new UserActivity.Spectating(Score.ScoreInfo);
 
         public SoloSpectatorPlayer(Score score, PlayerConfiguration configuration = null)
             : base(score, configuration)

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -7,12 +7,15 @@ using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
+using osu.Game.Users;
 
 namespace osu.Game.Screens.Play
 {
     public partial class SoloSpectatorPlayer : SpectatorPlayer
     {
         private readonly Score score;
+
+        protected override UserActivity InitialActivity => new UserActivity.Spectating(score.ScoreInfo.User);
 
         public SoloSpectatorPlayer(Score score, PlayerConfiguration configuration = null)
             : base(score, configuration)

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
-        protected override UserActivity InitialActivity => new UserActivity.Spectating(score.ScoreInfo.User);
+        protected override UserActivity InitialActivity => new UserActivity.Spectating();
 
         public SoloSpectatorPlayer(Score score, PlayerConfiguration configuration = null)
             : base(score, configuration)

--- a/osu.Game/Users/ExtendedUserPanel.cs
+++ b/osu.Game/Users/ExtendedUserPanel.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Users
                 // Set status message based on activity (if we have one) and status is not offline
                 if (activity != null && !(status is UserStatusOffline))
                 {
-                    statusMessage.Text = activity.Status;
+                    statusMessage.Text = activity.GetStatus();
                     statusIcon.FadeColour(activity.GetAppropriateColour(Colours), 500, Easing.OutQuint);
                     return;
                 }

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
@@ -15,24 +14,19 @@ namespace osu.Game.Users
 {
     public abstract class UserActivity
     {
-        public abstract string Status { get; }
-
-        /// <summary>
-        /// This property is used when the <see cref="DiscordRichPresenceMode"/> is <see cref="DiscordRichPresenceMode.Limited"/>
-        /// </summary>
-        public virtual string LimitedStatus => Status;
+        public abstract string GetStatus(bool hideIdentifiableInformation = false);
 
         public virtual Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDarker;
 
         public class Modding : UserActivity
         {
-            public override string Status => "Modding a map";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => "Modding a map";
             public override Color4 GetAppropriateColour(OsuColour colours) => colours.PurpleDark;
         }
 
         public class ChoosingBeatmap : UserActivity
         {
-            public override string Status => "Choosing a beatmap";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => "Choosing a beatmap";
         }
 
         public abstract class InGame : UserActivity
@@ -47,7 +41,7 @@ namespace osu.Game.Users
                 Ruleset = ruleset;
             }
 
-            public override string Status => Ruleset.CreateInstance().PlayingVerb;
+            public override string GetStatus(bool hideIdentifiableInformation = false) => Ruleset.CreateInstance().PlayingVerb;
         }
 
         public class InMultiplayerGame : InGame
@@ -57,7 +51,7 @@ namespace osu.Game.Users
             {
             }
 
-            public override string Status => $@"{base.Status} with others";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => $@"{base.GetStatus(hideIdentifiableInformation)} with others";
         }
 
         public class SpectatingMultiplayerGame : InGame
@@ -67,7 +61,7 @@ namespace osu.Game.Users
             {
             }
 
-            public override string Status => $"Watching others {base.Status.ToLowerInvariant()}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => $"Watching others {base.GetStatus(hideIdentifiableInformation).ToLowerInvariant()}";
         }
 
         public class InPlaylistGame : InGame
@@ -95,7 +89,7 @@ namespace osu.Game.Users
                 BeatmapInfo = info;
             }
 
-            public override string Status => @"Editing a beatmap";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @"Editing a beatmap";
         }
 
         public class Watching : UserActivity
@@ -111,12 +105,12 @@ namespace osu.Game.Users
                 this.score = score;
             }
 
-            public override string Status => $@"Watching {Username}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Watching a game" : $@"Watching {Username}";
         }
 
         public class Spectating : Watching
         {
-            public override string Status => $@"Spectating {Username}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Spectating a game" : $@"Spectating {Username}";
 
             public Spectating(ScoreInfo score)
                 : base(score)
@@ -126,12 +120,12 @@ namespace osu.Game.Users
 
         public class SearchingForLobby : UserActivity
         {
-            public override string Status => @"Looking for a lobby";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @"Looking for a lobby";
         }
 
         public class InLobby : UserActivity
         {
-            public override string Status => @"In a lobby";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => @"In a lobby";
 
             public readonly Room Room;
 

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -5,7 +5,6 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
@@ -91,16 +90,17 @@ namespace osu.Game.Users
             public override string Status => @"Editing a beatmap";
         }
 
-        public class Spectating : UserActivity
+        public class Watching : UserActivity
         {
-            private readonly APIUser user;
+            protected virtual string Verb => @"Watching";
 
-            public Spectating(APIUser user)
-            {
-                this.user = user;
-            }
+            public override string Status => @$"{Verb} a game";
+        }
 
-            public override string Status => @$"Spectating {user.Username}";
+        public class Spectating : Watching
+        {
+            protected override string Verb => @"Spectating";
+            public override string Status => @$"{Verb} a game";
         }
 
         public class SearchingForLobby : UserActivity

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -105,12 +105,12 @@ namespace osu.Game.Users
                 this.score = score;
             }
 
-            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Watching a game" : $@"Watching {Username}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Watching a replay" : $@"Watching {Username}'s replay";
         }
 
         public class Spectating : Watching
         {
-            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Spectating a game" : $@"Spectating {Username}";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Spectating a user" : $@"Spectating {Username}";
 
             public Spectating(ScoreInfo score)
                 : base(score)

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -5,6 +5,7 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
@@ -92,7 +93,14 @@ namespace osu.Game.Users
 
         public class Spectating : UserActivity
         {
-            public override string Status => @"Spectating a game";
+            private readonly APIUser user;
+
+            public Spectating(APIUser user)
+            {
+                this.user = user;
+            }
+
+            public override string Status => @$"Spectating {user.Username}";
         }
 
         public class SearchingForLobby : UserActivity

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -100,7 +100,6 @@ namespace osu.Game.Users
         public class Spectating : Watching
         {
             protected override string Verb => @"Spectating";
-            public override string Status => @$"{Verb} a game";
         }
 
         public class SearchingForLobby : UserActivity

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -4,9 +4,11 @@
 #nullable disable
 
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
+using osu.Game.Scoring;
 using osuTK.Graphics;
 
 namespace osu.Game.Users
@@ -14,6 +16,12 @@ namespace osu.Game.Users
     public abstract class UserActivity
     {
         public abstract string Status { get; }
+
+        /// <summary>
+        /// This property is used when the <see cref="DiscordRichPresenceMode"/> is <see cref="DiscordRichPresenceMode.Limited"/>
+        /// </summary>
+        public virtual string LimitedStatus => Status;
+
         public virtual Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDarker;
 
         public class Modding : UserActivity
@@ -92,14 +100,32 @@ namespace osu.Game.Users
 
         public class Watching : UserActivity
         {
+            private readonly ScoreInfo score;
+
+            private string username => score.User.Username;
+            private string playingVerb => score.BeatmapInfo.Ruleset.CreateInstance().PlayingVerb;
+
+            public BeatmapInfo BeatmapInfo => score.BeatmapInfo;
+
+            public Watching(ScoreInfo score)
+            {
+                this.score = score;
+            }
+
             protected virtual string Verb => @"Watching";
 
-            public override string Status => @$"{Verb} a game";
+            public override string Status => @$"{Verb} {username} {playingVerb.ToLowerInvariant()}";
+            public override string LimitedStatus => $@"{Verb} a game";
         }
 
         public class Spectating : Watching
         {
             protected override string Verb => @"Spectating";
+
+            public Spectating(ScoreInfo score)
+                : base(score)
+            {
+            }
         }
 
         public class SearchingForLobby : UserActivity

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -102,8 +102,7 @@ namespace osu.Game.Users
         {
             private readonly ScoreInfo score;
 
-            private string username => score.User.Username;
-            private string playingVerb => score.BeatmapInfo.Ruleset.CreateInstance().PlayingVerb;
+            protected string Username => score.User.Username;
 
             public BeatmapInfo BeatmapInfo => score.BeatmapInfo;
 
@@ -112,15 +111,12 @@ namespace osu.Game.Users
                 this.score = score;
             }
 
-            protected virtual string Verb => @"Watching";
-
-            public override string Status => @$"{Verb} {username} {playingVerb.ToLowerInvariant()}";
-            public override string LimitedStatus => $@"{Verb} a game";
+            public override string Status => $@"Watching {Username}";
         }
 
         public class Spectating : Watching
         {
-            protected override string Verb => @"Spectating";
+            public override string Status => $@"Spectating {Username}";
 
             public Spectating(ScoreInfo score)
                 : base(score)


### PR DESCRIPTION
I don't know why this wasn't applied before, when the code to support this is already implemented (for spectating) and even has tests.
Just added the `UserActivity.Watching` activity for replays because it makes more sense to "_watch_ a replay" rather than "_spectating_ a replay".