### PR TITLE
Fix storyboard outro time potentially running too long

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -214,7 +214,9 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(oneTime.EndTime, Is.EqualTo(4000 + loop_duration));
 
                 StoryboardSprite manyTimes = background.Elements.OfType<StoryboardSprite>().Single(s => s.Path == "many-times.png");
-                Assert.That(manyTimes.EndTime, Is.EqualTo(9000 + 40 * loop_duration));
+                // It is intentional that we don't consider the loop count (40) as part of the end time calculation to match stable's handling.
+                // If we were to include the loop count, storyboards which loop for stupid long loop counts would continue playing the outro forever.
+                Assert.That(manyTimes.EndTime, Is.EqualTo(9000 + loop_duration));
             }
         }
     }

--- a/osu.Game/Storyboards/CommandLoop.cs
+++ b/osu.Game/Storyboards/CommandLoop.cs
@@ -18,7 +18,12 @@ namespace osu.Game.Storyboards
         public readonly int TotalIterations;
 
         public override double StartTime => LoopStartTime + CommandsStartTime;
-        public override double EndTime => StartTime + CommandsDuration * TotalIterations;
+
+        public override double EndTime =>
+            // In an ideal world, we would multiply the command duration by TotalIterations here.
+            // Unfortunately this would clash with how stable handled end times, and results in some storyboards playing outro
+            // sequences for minutes or hours.
+            StartTime + CommandsDuration;
 
         /// <summary>
         /// Construct a new command loop.

--- a/osu.Game/Storyboards/CommandTimelineGroup.cs
+++ b/osu.Game/Storyboards/CommandTimelineGroup.cs
@@ -85,9 +85,6 @@ namespace osu.Game.Storyboards
         public virtual double EndTime => CommandsEndTime;
 
         [JsonIgnore]
-        public double Duration => EndTime - StartTime;
-
-        [JsonIgnore]
         public bool HasCommands
         {
             get


### PR DESCRIPTION
If a storyboard has a loop with a very high loop count (under the premise of it being ignored, ie. how stable handles this case), lazer would try to play out the full length of the loop.

This change brings handling in line with stable.

Can be tested with the tutorial ("new beginnings").

Closes #21008