### PR TITLE
Ensure pause sample loop is stopped on exiting player

### DIFF
--- a/osu.Game/Screens/Play/PauseOverlay.cs
+++ b/osu.Game/Screens/Play/PauseOverlay.cs
@@ -44,6 +44,14 @@ namespace osu.Game.Screens.Play
             });
         }
 
+        public void StopAllSamples()
+        {
+            if (!IsLoaded)
+                return;
+
+            pauseLoop.Stop();
+        }
+
         protected override void PopIn()
         {
             base.PopIn();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1073,7 +1073,10 @@ namespace osu.Game.Screens.Play
         public override bool OnExiting(ScreenExitEvent e)
         {
             screenSuspension?.RemoveAndDisposeImmediately();
+
+            // Eagerly clean these up as disposal of child components is asynchronous and may leave sounds playing beyond user expectations.
             failAnimationLayer?.Stop();
+            PauseOverlay.StopAllSamples();
 
             if (LoadedBeatmapSuccessfully)
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1076,7 +1076,7 @@ namespace osu.Game.Screens.Play
 
             // Eagerly clean these up as disposal of child components is asynchronous and may leave sounds playing beyond user expectations.
             failAnimationLayer?.Stop();
-            PauseOverlay.StopAllSamples();
+            PauseOverlay?.StopAllSamples();
 
             if (LoadedBeatmapSuccessfully)
             {


### PR DESCRIPTION
This reduces reliance on disposal flow to see that the sample is stopped.

Closes #22446 (but doesn't resolve the underlying issue, which will be tracked further at a framework level).