### PR TITLE
Fix hit circle late-miss fading differences compared to stable

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
@@ -36,6 +36,32 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
+        public void TestHitCircleClassicAndFullHiddenMods()
+        {
+            AddStep("Create hit circle", () =>
+            {
+                SelectedMods.Value = new Mod[] { new OsuModHidden(), new OsuModClassic() };
+                createCircle();
+            });
+
+            AddUntilStep("Wait until circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Transparent when missed", () => alphaAtMiss == 0);
+        }
+
+        [Test]
+        public void TestHitCircleClassicAndApproachCircleOnlyHiddenMods()
+        {
+            AddStep("Create hit circle", () =>
+            {
+                SelectedMods.Value = new Mod[] { new OsuModHidden { OnlyFadeApproachCircles = { Value = true } }, new OsuModClassic() };
+                createCircle();
+            });
+
+            AddUntilStep("Wait until circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Transparent when missed", () => alphaAtMiss == 0);
+        }
+
+        [Test]
         public void TestHitCircleNoMod()
         {
             AddStep("Create hit circle", () =>

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using NUnit.Framework;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public partial class TestSceneHitCircleLateFade : OsuTestScene
+    {
+        [Test]
+        public void TestFadeOutIntoMiss()
+        {
+            float? alphaAtMiss = null;
+
+            AddStep("Create hit circle", () =>
+            {
+                alphaAtMiss = null;
+
+                DrawableHitCircle drawableHitCircle = new DrawableHitCircle(new HitCircle
+                {
+                    StartTime = Time.Current + 500,
+                    Position = new Vector2(250)
+                });
+
+                drawableHitCircle.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+                drawableHitCircle.OnNewResult += (_, _) =>
+                {
+                    alphaAtMiss = drawableHitCircle.Alpha;
+                };
+
+                Child = drawableHitCircle;
+            });
+
+            AddUntilStep("Wait until circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Transparent when missed", () => alphaAtMiss == 0);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
@@ -3,10 +3,16 @@
 
 #nullable disable
 
+using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Tests.Visual;
@@ -16,33 +22,111 @@ namespace osu.Game.Rulesets.Osu.Tests
 {
     public partial class TestSceneHitCircleLateFade : OsuTestScene
     {
-        [Test]
-        public void TestFadeOutIntoMiss()
-        {
-            float? alphaAtMiss = null;
+        private float? alphaAtMiss;
 
+        [Test]
+        public void TestHitCircleClassicMod()
+        {
             AddStep("Create hit circle", () =>
             {
-                alphaAtMiss = null;
-
-                DrawableHitCircle drawableHitCircle = new DrawableHitCircle(new HitCircle
-                {
-                    StartTime = Time.Current + 500,
-                    Position = new Vector2(250)
-                });
-
-                drawableHitCircle.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-
-                drawableHitCircle.OnNewResult += (_, _) =>
-                {
-                    alphaAtMiss = drawableHitCircle.Alpha;
-                };
-
-                Child = drawableHitCircle;
+                SelectedMods.Value = new Mod[] { new OsuModClassic() };
+                createCircle();
             });
 
             AddUntilStep("Wait until circle is missed", () => alphaAtMiss.IsNotNull());
             AddAssert("Transparent when missed", () => alphaAtMiss == 0);
+        }
+
+        [Test]
+        public void TestHitCircleNoMod()
+        {
+            AddStep("Create hit circle", () =>
+            {
+                SelectedMods.Value = Array.Empty<Mod>();
+                createCircle();
+            });
+
+            AddUntilStep("Wait until circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Opaque when missed", () => alphaAtMiss == 1);
+        }
+
+        [Test]
+        public void TestSliderClassicMod()
+        {
+            AddStep("Create slider", () =>
+            {
+                SelectedMods.Value = new Mod[] { new OsuModClassic() };
+                createSlider();
+            });
+
+            AddUntilStep("Wait until head circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Head circle transparent when missed", () => alphaAtMiss == 0);
+        }
+
+        [Test]
+        public void TestSliderNoMod()
+        {
+            AddStep("Create slider", () =>
+            {
+                SelectedMods.Value = Array.Empty<Mod>();
+                createSlider();
+            });
+
+            AddUntilStep("Wait until head circle is missed", () => alphaAtMiss.IsNotNull());
+            AddAssert("Head circle opaque when missed", () => alphaAtMiss == 1);
+        }
+
+        private void createCircle()
+        {
+            alphaAtMiss = null;
+
+            DrawableHitCircle drawableHitCircle = new DrawableHitCircle(new HitCircle
+            {
+                StartTime = Time.Current + 500,
+                Position = new Vector2(250)
+            });
+
+            foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                mod.ApplyToDrawableHitObject(drawableHitCircle);
+
+            drawableHitCircle.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            drawableHitCircle.OnNewResult += (_, _) =>
+            {
+                alphaAtMiss = drawableHitCircle.Alpha;
+            };
+
+            Child = drawableHitCircle;
+        }
+
+        private void createSlider()
+        {
+            alphaAtMiss = null;
+
+            DrawableSlider drawableSlider = new DrawableSlider(new Slider
+            {
+                StartTime = Time.Current + 500,
+                Position = new Vector2(250),
+                Path = new SliderPath(PathType.Linear, new[]
+                {
+                    Vector2.Zero,
+                    new Vector2(0, 100),
+                })
+            });
+
+            drawableSlider.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            drawableSlider.OnLoadComplete += _ =>
+            {
+                foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
+                    mod.ApplyToDrawableHitObject(drawableSlider.HeadCircle);
+
+                drawableSlider.HeadCircle.OnNewResult += (_, _) =>
+                {
+                    alphaAtMiss = drawableSlider.HeadCircle.Alpha;
+                };
+            };
+            Child = drawableSlider;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
 
-            usingHiddenFading = !drawableRuleset.Mods.OfType<OsuModHidden>().FirstOrDefault()?.OnlyFadeApproachCircles.Value ?? false;
+            usingHiddenFading = (drawableRuleset.Mods.OfType<OsuModHidden>().SingleOrDefault()?.OnlyFadeApproachCircles.Value ?? true) != true;
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject obj)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
 
-            usingHiddenFading = (drawableRuleset.Mods.OfType<OsuModHidden>().SingleOrDefault()?.OnlyFadeApproachCircles.Value ?? true) != true;
+            usingHiddenFading = drawableRuleset.Mods.OfType<OsuModHidden>().SingleOrDefault()?.OnlyFadeApproachCircles.Value == false;
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject obj)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -11,6 +12,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -30,6 +32,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         [SettingSource("Always play a slider's tail sample", "Always plays a slider's tail sample regardless of whether it was hit or not.")]
         public Bindable<bool> AlwaysPlayTailSample { get; } = new BindableBool(true);
+
+        [SettingSource("Fade out hit circles earlier", "Make hit circles fade out into a miss, rather than after it.")]
+        public Bindable<bool> FadeHitCircleEarly { get; } = new Bindable<bool>(true);
 
         public void ApplyToHitObject(HitObject hitObject)
         {
@@ -59,12 +64,32 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 case DrawableSliderHead head:
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
+                    if (FadeHitCircleEarly.Value)
+                        applyEarlyFading(head);
                     break;
 
                 case DrawableSliderTail tail:
                     tail.SamplePlaysOnlyOnHit = !AlwaysPlayTailSample.Value;
                     break;
+
+                case DrawableHitCircle circle:
+                    if (FadeHitCircleEarly.Value)
+                        applyEarlyFading(circle);
+                    break;
             }
+        }
+
+        private void applyEarlyFading(DrawableHitCircle circle)
+        {
+            circle.ApplyCustomUpdateState += (o, _) =>
+            {
+                using (o.BeginAbsoluteSequence(o.StateUpdateTime))
+                {
+                    double mehWindow = o.HitObject.HitWindows.WindowFor(HitResult.Meh);
+                    double lateMissFadeTime = mehWindow / 4 + 15;
+                    o.Delay(mehWindow - lateMissFadeTime).FadeOut(lateMissFadeTime);
+                }
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Fade out hit circles earlier", "Make hit circles fade out into a miss, rather than after it.")]
         public Bindable<bool> FadeHitCircleEarly { get; } = new Bindable<bool>(true);
 
+        private bool hiddenModActive;
+
         public void ApplyToHitObject(HitObject hitObject)
         {
             switch (hitObject)
@@ -56,6 +58,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
+
+            hiddenModActive = drawableRuleset.Mods.OfType<ModHidden>().Any();
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject obj)
@@ -64,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 case DrawableSliderHead head:
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
-                    if (FadeHitCircleEarly.Value)
+                    if (FadeHitCircleEarly.Value && !hiddenModActive)
                         applyEarlyFading(head);
                     break;
 
@@ -73,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                     break;
 
                 case DrawableHitCircle circle:
-                    if (FadeHitCircleEarly.Value)
+                    if (FadeHitCircleEarly.Value && !hiddenModActive)
                         applyEarlyFading(circle);
                     break;
             }
@@ -85,9 +89,9 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 using (o.BeginAbsoluteSequence(o.StateUpdateTime))
                 {
-                    double mehWindow = o.HitObject.HitWindows.WindowFor(HitResult.Meh);
-                    double lateMissFadeTime = mehWindow / 4 + 15;
-                    o.Delay(mehWindow - lateMissFadeTime).FadeOut(lateMissFadeTime);
+                    double okWindow = o.HitObject.HitWindows.WindowFor(HitResult.Ok);
+                    double lateMissFadeTime = o.HitObject.HitWindows.WindowFor(HitResult.Meh) - okWindow;
+                    o.Delay(okWindow).FadeOut(lateMissFadeTime);
                 }
             };
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Fade out hit circles earlier", "Make hit circles fade out into a miss, rather than after it.")]
         public Bindable<bool> FadeHitCircleEarly { get; } = new Bindable<bool>(true);
 
-        private bool hiddenModActive;
+        private bool usingHiddenFading;
 
         public void ApplyToHitObject(HitObject hitObject)
         {
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             if (ClassicNoteLock.Value)
                 osuRuleset.Playfield.HitPolicy = new ObjectOrderedHitPolicy();
 
-            hiddenModActive = drawableRuleset.Mods.OfType<ModHidden>().Any();
+            usingHiddenFading = !drawableRuleset.Mods.OfType<OsuModHidden>().FirstOrDefault()?.OnlyFadeApproachCircles.Value ?? false;
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject obj)
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 case DrawableSliderHead head:
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
-                    if (FadeHitCircleEarly.Value && !hiddenModActive)
+                    if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(head);
                     break;
 
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                     break;
 
                 case DrawableHitCircle circle:
-                    if (FadeHitCircleEarly.Value && !hiddenModActive)
+                    if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(circle);
                     break;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -200,10 +200,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // always fade out at the circle's start time (to match user expectations).
             ApproachCircle.FadeOut(50);
-
-            double mehWindow = HitObject.HitWindows.WindowFor(HitResult.Meh);
-            double lateMissFadeTime = mehWindow / 4 + 15;
-            this.Delay(mehWindow - lateMissFadeTime).FadeOut(lateMissFadeTime);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -200,6 +200,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // always fade out at the circle's start time (to match user expectations).
             ApproachCircle.FadeOut(50);
+
+            double mehWindow = HitObject.HitWindows.WindowFor(HitResult.Meh);
+            double lateMissFadeTime = mehWindow / 4 + 15;
+            this.Delay(mehWindow - lateMissFadeTime).FadeOut(lateMissFadeTime);
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)


### PR DESCRIPTION
In stable, if a hit circle is not hit on time it fades out until it becomes impossible to hit and registers as a miss. In lazer, a hit circle doesn't start to fade out until it's already registered as a miss. This PR changes the lazer fading to match stable.
I measured the stable fade times as accurately as I could via video, but ultimately the equation I used involved some guesswork. A plot of the fade times I measured is [here](https://www.desmos.com/calculator/cnczmb2l1w).

https://user-images.githubusercontent.com/42323315/217131006-62a18b27-5c42-47bf-948d-070cb5cc2ead.mp4


This PR should close #22121. The issue seems to boil down to fading differences between versions. They also seemed to imply that the classic mod changed how fading worked, but when comparing videos (see issue comments) there were no differences. These changes might also resolve #6088 which seems to discuss the same issue.

I don't think a test was needed for this PR, but I included one just in case. Disregard if unnecessary.