### PR TITLE
Attempt to fix channel join / leave loop

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -583,7 +583,8 @@ namespace osu.Game.Online.Chat
 
             if (channel.Joined.Value)
             {
-                api.Queue(new LeaveChannelRequest(channel));
+                if (sendLeaveRequest)
+                    api.Queue(new LeaveChannelRequest(channel));
                 channel.Joined.Value = false;
             }
         }

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Chat
         {
             connector.ChannelJoined += ch => Schedule(() => joinChannel(ch));
 
-            connector.ChannelParted += ch => Schedule(() => LeaveChannel(getChannel(ch)));
+            connector.ChannelParted += ch => Schedule(() => leaveChannel(getChannel(ch), false));
 
             connector.NewMessages += msgs => Schedule(() => addMessages(msgs));
 
@@ -558,7 +558,9 @@ namespace osu.Game.Online.Chat
         /// Leave the specified channel. Can be called from any thread.
         /// </summary>
         /// <param name="channel">The channel to leave.</param>
-        public void LeaveChannel(Channel channel) => Schedule(() =>
+        public void LeaveChannel(Channel channel) => Schedule(() => leaveChannel(channel, true));
+
+        private void leaveChannel(Channel channel, bool sendLeaveRequest)
         {
             if (channel == null) return;
 
@@ -584,7 +586,7 @@ namespace osu.Game.Online.Chat
                 api.Queue(new LeaveChannelRequest(channel));
                 channel.Joined.Value = false;
             }
-        });
+        }
 
         /// <summary>
         /// Opens the most recently closed channel that has not already been reopened,


### PR DESCRIPTION
I don't have a solid way to repro the issue, but this should hopefully help in resolving it. Either way, I think this change brings more correct behaviour (if a websocket message comes through that we have left the channel, I don't believe we should be sending a request to leave that channel again).

Hopefully closes #21461.