### PR TITLE
Fix beatmap cards not showing context menu on user profile

### DIFF
--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Profile.Header.Components;
@@ -104,76 +103,69 @@ namespace osu.Game.Overlays.Profile.Header
                                                 Colour = Colour4.Black.Opacity(0.25f),
                                             }
                                         },
-                                        new OsuContextMenuContainer
+                                        new FillFlowContainer
                                         {
-                                            Anchor = Anchor.BottomLeft,
-                                            Origin = Anchor.BottomLeft,
-                                            RelativeSizeAxes = Axes.Y,
-                                            AutoSizeAxes = Axes.X,
-                                            Child = new FillFlowContainer
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Vertical,
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            Children = new Drawable[]
                                             {
-                                                AutoSizeAxes = Axes.Both,
-                                                Direction = FillDirection.Vertical,
-                                                Anchor = Anchor.CentreLeft,
-                                                Origin = Anchor.CentreLeft,
-                                                Children = new Drawable[]
+                                                new FillFlowContainer
                                                 {
-                                                    new FillFlowContainer
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Direction = FillDirection.Horizontal,
+                                                    Spacing = new Vector2(5, 0),
+                                                    Children = new Drawable[]
                                                     {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Direction = FillDirection.Horizontal,
-                                                        Spacing = new Vector2(5, 0),
-                                                        Children = new Drawable[]
+                                                        usernameText = new OsuSpriteText
                                                         {
-                                                            usernameText = new OsuSpriteText
-                                                            {
-                                                                Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
-                                                            },
-                                                            supporterTag = new SupporterIcon
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                                Height = 15,
-                                                            },
-                                                            openUserExternally = new ExternalLinkButton
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                            },
-                                                            groupBadgeFlow = new GroupBadgeFlow
-                                                            {
-                                                                Anchor = Anchor.CentreLeft,
-                                                                Origin = Anchor.CentreLeft,
-                                                            },
-                                                        }
-                                                    },
-                                                    titleText = new OsuSpriteText
-                                                    {
-                                                        Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
-                                                        Margin = new MarginPadding { Bottom = 5 }
-                                                    },
-                                                    new FillFlowContainer
-                                                    {
-                                                        AutoSizeAxes = Axes.Both,
-                                                        Direction = FillDirection.Horizontal,
-                                                        Children = new Drawable[]
+                                                            Font = OsuFont.GetFont(size: 24, weight: FontWeight.Regular)
+                                                        },
+                                                        supporterTag = new SupporterIcon
                                                         {
-                                                            userFlag = new UpdateableFlag
-                                                            {
-                                                                Size = new Vector2(28, 20),
-                                                                ShowPlaceholderOnUnknown = false,
-                                                            },
-                                                            userCountryText = new OsuSpriteText
-                                                            {
-                                                                Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
-                                                                Margin = new MarginPadding { Left = 5 },
-                                                                Origin = Anchor.CentreLeft,
-                                                                Anchor = Anchor.CentreLeft,
-                                                            }
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft,
+                                                            Height = 15,
+                                                        },
+                                                        openUserExternally = new ExternalLinkButton
+                                                        {
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft,
+                                                        },
+                                                        groupBadgeFlow = new GroupBadgeFlow
+                                                        {
+                                                            Anchor = Anchor.CentreLeft,
+                                                            Origin = Anchor.CentreLeft,
+                                                        },
+                                                    }
+                                                },
+                                                titleText = new OsuSpriteText
+                                                {
+                                                    Font = OsuFont.GetFont(size: 16, weight: FontWeight.Regular),
+                                                    Margin = new MarginPadding { Bottom = 5 }
+                                                },
+                                                new FillFlowContainer
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Direction = FillDirection.Horizontal,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        userFlag = new UpdateableFlag
+                                                        {
+                                                            Size = new Vector2(28, 20),
+                                                            ShowPlaceholderOnUnknown = false,
+                                                        },
+                                                        userCountryText = new OsuSpriteText
+                                                        {
+                                                            Font = OsuFont.GetFont(size: 14f, weight: FontWeight.Regular),
+                                                            Margin = new MarginPadding { Left = 5 },
+                                                            Origin = Anchor.CentreLeft,
+                                                            Anchor = Anchor.CentreLeft,
                                                         }
-                                                    },
-                                                }
-                                            },
+                                                    }
+                                                },
+                                            }
                                         },
                                     }
                                 },

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -14,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online;
@@ -100,17 +101,22 @@ namespace osu.Game.Overlays
                 Origin = Anchor.TopCentre,
             };
 
-            Add(sectionsContainer = new ProfileSectionsContainer
+            Add(new OsuContextMenuContainer
             {
-                ExpandableHeader = Header,
-                FixedHeader = tabs,
-                HeaderBackground = new Box
+                RelativeSizeAxes = Axes.Both,
+                Child = sectionsContainer = new ProfileSectionsContainer
                 {
-                    // this is only visible as the ProfileTabControl background
-                    Colour = ColourProvider.Background5,
-                    RelativeSizeAxes = Axes.Both
-                },
+                    ExpandableHeader = Header,
+                    FixedHeader = tabs,
+                    HeaderBackground = new Box
+                    {
+                        // this is only visible as the ProfileTabControl background
+                        Colour = ColourProvider.Background5,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                }
             });
+
             sectionsContainer.SelectedSection.ValueChanged += section =>
             {
                 if (lastSection != section.NewValue)


### PR DESCRIPTION
Easier to review with no whitespace.

Also fixes the external link button context menu positioning (because the `OsuContextMenuContainer` was added way too locally):

| Before | After |
| --- | --- |
| ![JjWGkhvP1w](https://user-images.githubusercontent.com/35318437/217455415-23116cf0-3e3b-48d9-b9f0-5ef3ea9442ce.gif) | ![osu!_2KLv3JMf2U](https://user-images.githubusercontent.com/35318437/217455188-5812bbc3-8ef8-492f-a693-40f05065f637.gif) |