### PR TITLE
Snap Taiko hit objects to match Stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -2,13 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>
+    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>, IApplicableToDrawableHitObject
     {
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
@@ -17,6 +19,12 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
             var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             playfield.ClassicHitTargetPosition.Value = true;
+        }
+
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            if (drawable is DrawableHit)
+                drawable.SnapJudgementLocation = true;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -207,6 +207,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     const float gravity_time = 300;
                     const float gravity_travel_height = 200;
 
+                    MainPiece.MoveToX(-X); // Visually snap hit object to hit target
+
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 
                     this.MoveToY(-gravity_travel_height, gravity_time, Easing.Out)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -207,7 +207,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     const float gravity_time = 300;
                     const float gravity_travel_height = 200;
 
-                    MainPiece.MoveToX(-X); // Visually snap hit object to hit target
+                    if (SnapJudgementLocation)
+                        MainPiece.MoveToX(-X);
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);
 

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -663,6 +663,15 @@ namespace osu.Game.Rulesets.Objects.Drawables
         public virtual double MaximumJudgementOffset => HitObject.HitWindows?.WindowFor(HitResult.Miss) ?? 0;
 
         /// <summary>
+        /// Whether the location of the hit should be snapped to the hit target before animating.
+        /// </summary>
+        /// <remarks>
+        /// This is how osu-stable worked, but notably is not how TnT works.
+        /// It results in less visual feedback on hit accuracy.
+        /// </remarks>
+        public bool SnapJudgementLocation { get; set; }
+
+        /// <summary>
         /// Applies the <see cref="Result"/> of this <see cref="DrawableHitObject"/>, notifying responders such as
         /// the <see cref="ScoreProcessor"/> of the <see cref="JudgementResult"/>.
         /// </summary>


### PR DESCRIPTION
As said in the title, when hit objects are hit, they should snap to the hit target.

This lack of snapping feels unpleasant to play, as the way the notes "wiggle" back and forth on the hit target makes you feel like your accuracy is bad, even though you are hitting the notes perfectly fine. This leads to the game feeling uncomfortably floaty.

This issue is especially prevalent on longer streams, as I've found myself to notice that the notes are going slightly off-center and end up overcorrecting my positioning, which leads to my accuracy going down significantly

Here is a video demonstrating a comparison between Stable, this proposed change, and current Lazer:

https://user-images.githubusercontent.com/48618519/217514020-7e7d21c1-33df-4d82-bf41-f8b4b6d7eb5b.mp4

I showed this change to some members of the community and this was their feedback:
![image](https://user-images.githubusercontent.com/48618519/217514945-7b55293f-add8-4d44-8adc-490007e8f91c.png)
![image](https://user-images.githubusercontent.com/48618519/212879839-6acfd3b4-ebe8-4d61-a1d9-16e4da5ee051.png)
![image](https://user-images.githubusercontent.com/48618519/212880049-a8b950b3-25b6-46d8-b1fa-4d85629a75c0.png)

I really hope you consider this change, as I strongly believe it would greatly benefit how the Taiko gamemode feels to play, and would make the transition from Stable to Lazer much more comfortable for the Taiko community