### PR TITLE
Add ability to quickly report players in chat

### DIFF
--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -24,12 +24,12 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString MentionUser => new TranslatableString(getKey(@"mention_user"), @"Mention");
 
-        private static string getKey(string key) => $"{prefix}:{key}";
-
         /// <summary>
         /// "Report User"
         /// </summary>
 
         public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report User");
+
+        private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Localisation
         public static LocalisableString MentionUser => new TranslatableString(getKey(@"mention_user"), @"Mention");
 
         /// <summary>
-        /// "Report User"
+        /// "Report"
         /// </summary>
 
         public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report");

--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -25,5 +25,11 @@ namespace osu.Game.Localisation
         public static LocalisableString MentionUser => new TranslatableString(getKey(@"mention_user"), @"Mention");
 
         private static string getKey(string key) => $"{prefix}:{key}";
+
+        /// <summary>
+        /// "Report User"
+        /// </summary>
+
+        public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report User");
     }
 }

--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Localisation
         /// "Report User"
         /// </summary>
 
-        public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report User");
+        public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/ChatStrings.cs
+++ b/osu.Game/Localisation/ChatStrings.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Report"
         /// </summary>
-
         public static LocalisableString ReportUser => new TranslatableString(getKey(@"report_user"), @"Report");
 
         private static string getKey(string key) => $"{prefix}:{key}";

--- a/osu.Game/Overlays/Chat/DrawableUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableUsername.cs
@@ -152,6 +152,8 @@ namespace osu.Game.Overlays.Chat
             {
                 if (user.Equals(APIUser.SYSTEM_USER))
                     return Array.Empty<MenuItem>();
+                
+                string username = user.Username.Replace(" ", "_");
 
                 List<MenuItem> items = new List<MenuItem>
                 {
@@ -165,7 +167,7 @@ namespace osu.Game.Overlays.Chat
                 {
                     items.Add(new OsuMenuItem(ChatStrings.MentionUser, MenuItemType.Standard, () =>
                     {
-                        currentChannel.Value.TextBoxMessage.Value += $"@{user.Username} ";
+                        currentChannel.Value.TextBoxMessage.Value += $"@{username} ";
                     }));
                 };
 
@@ -173,7 +175,7 @@ namespace osu.Game.Overlays.Chat
                 {
                     items.Add(new OsuMenuItem(ChatStrings.ReportUser, MenuItemType.Destructive, () =>
                     {
-                        currentChannel.Value.TextBoxMessage.Value += $"!report {user.Username} ";
+                        currentChannel.Value.TextBoxMessage.Value += $"!report {username} ";
                     }));
                 };
                 

--- a/osu.Game/Overlays/Chat/DrawableUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableUsername.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Chat
                     {
                         currentChannel.Value.TextBoxMessage.Value += $"@{username} ";
                     }));
-                };
+                }
 
                 if (currentChannel?.Value != null && (!user.Equals(api.LocalUser.Value)))
                 {
@@ -177,9 +177,8 @@ namespace osu.Game.Overlays.Chat
                     {
                         currentChannel.Value.TextBoxMessage.Value += $"!report {username} ";
                     }));
-                };
+                }
                 
-
                 return items.ToArray();
             }
         }

--- a/osu.Game/Overlays/Chat/DrawableUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableUsername.cs
@@ -169,6 +169,14 @@ namespace osu.Game.Overlays.Chat
                     }));
                 }
 
+                if (currentChannel?.Value != null)
+                {
+                    items.Add(new OsuMenuItem(ChatStrings.ReportUser, MenuItemType.Destructive, () =>
+                    {
+                        currentChannel.Value.TextBoxMessage.Value += $"!report {user.Username} for ";
+                    }));
+                }
+
                 return items.ToArray();
             }
         }

--- a/osu.Game/Overlays/Chat/DrawableUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableUsername.cs
@@ -167,15 +167,16 @@ namespace osu.Game.Overlays.Chat
                     {
                         currentChannel.Value.TextBoxMessage.Value += $"@{user.Username} ";
                     }));
-                }
+                };
 
-                if (currentChannel?.Value != null)
+                if (currentChannel?.Value != null && (!user.Equals(api.LocalUser.Value)))
                 {
                     items.Add(new OsuMenuItem(ChatStrings.ReportUser, MenuItemType.Destructive, () =>
                     {
-                        currentChannel.Value.TextBoxMessage.Value += $"!report {user.Username} for ";
+                        currentChannel.Value.TextBoxMessage.Value += $"!report {user.Username} ";
                     }));
-                }
+                };
+                
 
                 return items.ToArray();
             }

--- a/osu.Game/Overlays/Chat/DrawableUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableUsername.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Overlays.Chat
                 if (!user.Equals(api.LocalUser.Value))
                     items.Add(new OsuMenuItem(UsersStrings.CardSendMessage, MenuItemType.Standard, openUserChannel));
 
-                if (currentChannel?.Value != null)
+                if (currentChannel?.Value != null && (!user.Equals(api.LocalUser.Value)))
                 {
                     items.Add(new OsuMenuItem(ChatStrings.MentionUser, MenuItemType.Standard, () =>
                     {


### PR DESCRIPTION
This allows players to simply right click the username and fill out the rest of the chat message

Relies on #22083 to be implemented correctly, otherwise the !report legacy command needs to be done in a private channel... which kind of defeats the purpose. 

https://user-images.githubusercontent.com/90729492/217854331-87aefd40-e15e-492e-9b41-d18c28a2b870.mp4