### PR TITLE
Adjust taiko (again) to limit minimum aspect ratio to 5:4

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
-            drawableTaikoRuleset.LockPlayfieldMaxAspect.Value = false;
+            drawableTaikoRuleset.LockPlayfieldAspectRange.Value = false;
 
             var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             playfield.ClassicHitTargetPosition.Value = true;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         public new BindableDouble TimeRange => base.TimeRange;
 
-        public readonly BindableBool LockPlayfieldMaxAspect = new BindableBool(true);
+        public readonly BindableBool LockPlayfieldAspectRange = new BindableBool(true);
 
         protected override ScrollVisualisationMethod VisualisationMethod => ScrollVisualisationMethod.Overlapping;
 
@@ -69,6 +69,9 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
             float ratio = DrawHeight / 480;
 
+            if (LockPlayfieldAspectRange.Value)
+                ratio = MathHelper.Clamp(ratio, TaikoPlayfieldAdjustmentContainer.MINIMUM_ASPECT, TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
+
             TimeRange.Value = (Playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate;
         }
 
@@ -90,7 +93,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer
         {
-            LockPlayfieldAspectRange = { BindTarget = LockPlayfieldMaxAspect }
+            LockPlayfieldAspectRange = { BindTarget = LockPlayfieldAspectRange }
         };
 
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer
         {
-            LockPlayfieldMaxAspect = { BindTarget = LockPlayfieldMaxAspect }
+            LockPlayfieldAspectRange = { BindTarget = LockPlayfieldMaxAspect }
         };
 
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.UI;
@@ -11,9 +10,11 @@ namespace osu.Game.Rulesets.Taiko.UI
     public partial class TaikoPlayfieldAdjustmentContainer : PlayfieldAdjustmentContainer
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
-        private const float default_aspect = 16f / 9f;
 
-        public readonly IBindable<bool> LockPlayfieldMaxAspect = new BindableBool(true);
+        private const float default_aspect = 16f / 9f;
+        private const float minimum_aspect = 5f / 4f;
+
+        public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
         protected override void Update()
         {
@@ -24,10 +25,17 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Players coming from stable expect to be able to change the aspect ratio regardless of the window size.
             // We originally wanted to limit this more, but there was considerable pushback from the community.
             //
-            // As a middle-ground, the aspect ratio can still be adjusted in the downwards direction but has a maximum limit.
+            // As a middle-ground, the aspect ratio can still be adjusted in the downwards direction but has a maximum limit (5:4 aspect).
             // This is still a bit weird, because readability changes with window size, but it is what it is.
-            if (LockPlayfieldMaxAspect.Value && Parent.ChildSize.X / Parent.ChildSize.Y > default_aspect)
-                height *= Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
+            if (LockPlayfieldAspectRange.Value)
+            {
+                float currentAspect = Parent.ChildSize.X / Parent.ChildSize.Y;
+
+                if (currentAspect > default_aspect)
+                    height *= currentAspect / default_aspect;
+                else if (currentAspect < minimum_aspect)
+                    height *= currentAspect / minimum_aspect;
+            }
 
             Height = height;
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -11,8 +11,8 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
 
-        private const float default_aspect = 16f / 9f;
-        private const float minimum_aspect = 5f / 4f;
+        public const float MAXIMUM_ASPECT = 16f / 9f;
+        public const float MINIMUM_ASPECT = 5f / 4f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
@@ -31,10 +31,10 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 float currentAspect = Parent.ChildSize.X / Parent.ChildSize.Y;
 
-                if (currentAspect > default_aspect)
-                    height *= currentAspect / default_aspect;
-                else if (currentAspect < minimum_aspect)
-                    height *= currentAspect / minimum_aspect;
+                if (currentAspect > MAXIMUM_ASPECT)
+                    height *= currentAspect / MAXIMUM_ASPECT;
+                else if (currentAspect < MINIMUM_ASPECT)
+                    height *= currentAspect / MINIMUM_ASPECT;
             }
 
             Height = height;


### PR DESCRIPTION
Anything lower than this looks stupid and broken. This should not affect any normal player. If it does, they should be using a "lane cover" mod instead. Or classic mod.

Why change this for a *third or fourth* time? Because to a normal user the current behaviour would look like a bug. This should be a middle ground which I hope everyone can accept.