### PR TITLE
Make `LargeBonus` a valid `HitResult` in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -209,9 +209,8 @@ namespace osu.Game.Rulesets.Taiko
                 HitResult.Great,
                 HitResult.Ok,
 
-                HitResult.SmallTickHit,
-
                 HitResult.SmallBonus,
+                HitResult.LargeBonus,
             };
         }
 
@@ -220,6 +219,9 @@ namespace osu.Game.Rulesets.Taiko
             switch (result)
             {
                 case HitResult.SmallBonus:
+                    return "drum tick";
+
+                case HitResult.LargeBonus:
                     return "bonus";
             }
 


### PR DESCRIPTION
This has been an issue since #18764, but the added `JudgementCounter` in #21620 makes it very clear.
The counter before showed an `s tick` counter that didn't receive any results, and a `bonus` counter that only counted `SmallBonus`.

Drum ticks were switched from `SmallTickHit` -> `SmallBonus` in the original PR, so the `drum tick` display name applies to it here.
Both strong hits and finished swells became `LargeBonus`, so we keep the generic `bonus` name, and add them to the list of valid results.

 

