### PR TITLE
Add mania hidden/fadein combo scaling coverage

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { Coverage = { Value = coverage } }, PassCondition = () => true });
 
         [Test]
-        public void TestComboBasedCoverage([Values] bool coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { ComboBasedCoverage = { Value = coverage } }, PassCondition = () => true });
+        public void TestComboBasedCoverage([Values] bool comboBased) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { ComboBasedCoverage = { Value = comboBased } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -11,12 +11,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.5f)]
-        [TestCase(0.1f)]
-        [TestCase(0.7f)]
-        public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { Coverage = { Value = coverage } }, PassCondition = () => true });
-
-        [Test]
-        public void TestComboBasedCoverage([Values] bool comboBased) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { ComboBasedCoverage = { Value = comboBased } }, PassCondition = () => true });
+        [TestCase(0.5f, 0.5f)]
+        [TestCase(0.1f, 0.1f)]
+        [TestCase(0.7f, 0.7f)]
+        [TestCase(0.1f, 0.7f)]
+        public void TestCoverage(float minCoverage, float maxCoverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { MinCoverage = { Value = minCoverage }, MaxCoverage = { Value = maxCoverage } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -11,9 +11,12 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.5f)]
+        [TestCase(0.3f)]
         [TestCase(0.1f)]
         [TestCase(0.7f)]
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { Coverage = { Value = coverage } }, PassCondition = () => true });
+
+        [Test]
+        public void TestComboBasedCoverage([Values] bool coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { ComboBasedCoverage = { Value = coverage } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.3f)]
+        [TestCase(0.5f)]
         [TestCase(0.1f)]
         [TestCase(0.7f)]
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { Coverage = { Value = coverage } }, PassCondition = () => true });

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -17,6 +17,6 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { Coverage = { Value = coverage } }, PassCondition = () => true });
 
         [Test]
-        public void TestComboBasedCoverage([Values] bool coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { ComboBasedCoverage = { Value = coverage } }, PassCondition = () => true });
+        public void TestComboBasedCoverage([Values] bool comboBased) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { ComboBasedCoverage = { Value = comboBased } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -11,12 +11,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.3f)]
-        [TestCase(0.2f)]
-        [TestCase(0.8f)]
-        public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { Coverage = { Value = coverage } }, PassCondition = () => true });
-
-        [Test]
-        public void TestComboBasedCoverage([Values] bool comboBased) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { ComboBasedCoverage = { Value = comboBased } }, PassCondition = () => true });
+        [TestCase(0.3f, 0.6f)]
+        [TestCase(0.2f, 0.2f)]
+        [TestCase(0.8f, 0.8f)]
+        [TestCase(0.2f, 0.8f)]
+        public void TestCoverage(float minCoverage, float maxCoverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { MinCoverage = { Value = minCoverage }, MaxCoverage = { Value = maxCoverage } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -15,5 +15,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         [TestCase(0.2f)]
         [TestCase(0.8f)]
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { Coverage = { Value = coverage } }, PassCondition = () => true });
+
+        [Test]
+        public void TestComboBasedCoverage([Values] bool coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { ComboBasedCoverage = { Value = coverage } }, PassCondition = () => true });
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.5f)]
+        [TestCase(0.3f)]
         [TestCase(0.2f)]
         [TestCase(0.8f)]
         public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { Coverage = { Value = coverage } }, PassCondition = () => true });

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -20,7 +20,15 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AlongScroll;
 
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
+        public override BindableNumber<float> MinCoverage { get; } = new BindableFloat(0.5f)
+        {
+            Precision = 0.1f,
+            MinValue = 0.1f,
+            MaxValue = 0.7f,
+            Default = 0.5f,
+        };
+
+        public override BindableNumber<float> MaxCoverage { get; } = new BindableFloat(0.5f)
         {
             Precision = 0.1f,
             MinValue = 0.1f,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             Precision = 0.1f,
             MinValue = 0.2f,
             MaxValue = 0.8f,
-            Default = 0.5f,
+            Default = 0.3f,
         };
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
 
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
+        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.3f)
         {
             Precision = 0.1f,
             MinValue = 0.2f,

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -14,7 +14,11 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
 
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.3f)
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
+
+        protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+
+        public override BindableNumber<float> MinCoverage { get; } = new BindableFloat(0.3f)
         {
             Precision = 0.1f,
             MinValue = 0.2f,
@@ -22,8 +26,12 @@ namespace osu.Game.Rulesets.Mania.Mods
             Default = 0.3f,
         };
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
-
-        protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+        public override BindableNumber<float> MaxCoverage { get; } = new BindableFloat(0.6f)
+        {
+            Precision = 0.1f,
+            MinValue = 0.2f,
+            MaxValue = 0.8f,
+            Default = 0.6f,
+        };
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -34,11 +34,11 @@ namespace osu.Game.Rulesets.Mania.Mods
         /// </summary>
         protected abstract CoverExpandDirection ExpandDirection { get; }
 
-        [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
-        public abstract BindableNumber<float> Coverage { get; }
+        [SettingSource("Minimum Coverage", "The minimum proportion of playfield height that notes will be hidden for.")]
+        public abstract BindableNumber<float> MinCoverage { get; }
 
-        [SettingSource("Change coverage based on combo", "Increase the coverage as combo increases.")]
-        public BindableBool ComboBasedCoverage => new BindableBool(true);
+        [SettingSource("Maximum Coverage", "The maximum proportion of playfield height that notes will be hidden for.")]
+        public abstract BindableNumber<float> MaxCoverage { get; }
 
         private readonly BindableInt combo = new BindableInt();
 
@@ -54,10 +54,10 @@ namespace osu.Game.Rulesets.Mania.Mods
             ManiaPlayfield maniaPlayfield = (ManiaPlayfield)drawableRuleset.Playfield;
             coveringWrappers = new List<PlayfieldCoveringWrapper>();
             clock = maniaPlayfield.Clock;
-            currentCoverage = Coverage.Value;
-            coverageRange = Coverage.MaxValue - Coverage.Value;
+            currentCoverage = MinCoverage.Value;
+            coverageRange = Math.Max(0, MaxCoverage.Value - MinCoverage.Value);
 
-            if (ComboBasedCoverage.Value)
+            if (coverageRange > 0)
             {
                 maniaPlayfield.OnUpdate += _ => updateCoverage();
             }
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 {
                     c.RelativeSizeAxes = Axes.Both;
                     c.Direction = ExpandDirection;
-                    c.Coverage = Coverage.Value;
+                    c.Coverage = MinCoverage.Value;
                 });
 
                 hocParent.Add(coveringWrapper);
@@ -103,8 +103,8 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         private float getComboBasedCoverageAmount()
         {
-            float targetCoverage = Coverage.Value + coverageRange * Math.Min(1.0f, combo.Value / combo_to_reach_max_coverage);
-            if (currentCoverage > targetCoverage)
+            float targetCoverage = MinCoverage.Value + coverageRange * Math.Min(1.0f, combo.Value / combo_to_reach_max_coverage);
+            if (currentCoverage > targetCoverage && clock.ElapsedFrameTime > 0)
                 return currentCoverage - coverageRange * (float)clock.ElapsedFrameTime / 500;
             else
                 return targetCoverage;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -11,12 +11,17 @@ using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Scoring;
 using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public abstract class ManiaModPlayfieldCover : ModHidden, IApplicableToDrawableRuleset<ManiaHitObject>
     {
+        private const float COMBO_TO_REACH_MAX_COVERAGE = 400;
+
+        private PlayfieldCoveringWrapper CoveringWrapper = null!;
         public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<ManiaHitObject>) };
 
         /// <summary>
@@ -27,6 +32,19 @@ namespace osu.Game.Rulesets.Mania.Mods
         [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
         public abstract BindableNumber<float> Coverage { get; }
 
+        [SettingSource("Change coverage based on combo", "Increase the coverage as combo increases.")]
+        public BindableBool ComboBasedCoverage => new BindableBool(true);
+
+        protected readonly BindableInt Combo = new BindableInt();
+
+        public override void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        {
+            Combo.BindTo(scoreProcessor.Combo);
+
+            // Default value of ScoreProcessor's Rank in Flashlight Mod should be SS+
+            scoreProcessor.Rank.Value = ScoreRank.XH;
+        }
+
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
         {
             ManiaPlayfield maniaPlayfield = (ManiaPlayfield)drawableRuleset.Playfield;
@@ -35,14 +53,18 @@ namespace osu.Game.Rulesets.Mania.Mods
             {
                 HitObjectContainer hoc = column.HitObjectArea.HitObjectContainer;
                 Container hocParent = (Container)hoc.Parent;
+                if (ComboBasedCoverage.Value)
+                    Combo.ValueChanged += _ => UpdateCoverage();
 
                 hocParent.Remove(hoc, false);
-                hocParent.Add(new PlayfieldCoveringWrapper(hoc).With(c =>
+
+                CoveringWrapper = new PlayfieldCoveringWrapper(hoc).With(c =>
                 {
                     c.RelativeSizeAxes = Axes.Both;
                     c.Direction = ExpandDirection;
                     c.Coverage = Coverage.Value;
-                }));
+                });
+                hocParent.Add(CoveringWrapper);
             }
         }
 
@@ -52,6 +74,16 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {
+        }
+
+        private void UpdateCoverage()
+        {
+            CoveringWrapper.Coverage = GetComboBasedCoverage();
+        }
+
+        private float GetComboBasedCoverage()
+        {
+            return Coverage.Value + (Coverage.MaxValue - Coverage.Value) * Math.Min(1.0f, Combo.Value / COMBO_TO_REACH_MAX_COVERAGE);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHidden;
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {
             // Default value of ScoreProcessor's Rank in Hidden Mod should be SS+
             scoreProcessor.Rank.Value = ScoreRank.XH;


### PR DESCRIPTION
- closes #22355 

Adds dynamic coverage for mania hidden/fadein mod which increases with combo. Enabled by default.

Default hidden coverage has been reduced so that default settings are closer to osu!stable gameplay.

Specific tuning of coverage and `combo_to_reach_max_coverage` will need mania community feedback since mania and hidden are things I am not great at.