### PR TITLE
Fix skin component previews on toolbox buttons having incorrect size for one frame

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -148,9 +148,9 @@ namespace osu.Game.Overlays.SkinEditor
                 component.Origin = Anchor.Centre;
             }
 
-            protected override void Update()
+            protected override void UpdateAfterChildren()
             {
-                base.Update();
+                base.UpdateAfterChildren();
 
                 if (component.DrawSize != Vector2.Zero)
                 {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![O65iKjjM79](https://user-images.githubusercontent.com/35318437/218233244-300a050f-eff6-4d61-a17c-9fde9206a352.gif) | ![osu Game Tests_0wnLInPNmY](https://user-images.githubusercontent.com/35318437/218233177-5844cf0b-08c9-47fb-bd20-848694254c94.gif) |