### PR TITLE
Add `TestingBeatmap` and `ModdingBeatmap` activities to beatmap editor screens

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -169,7 +169,7 @@ namespace osu.Desktop
                 case UserActivity.InGame game:
                     return game.BeatmapInfo;
 
-                case UserActivity.Editing edit:
+                case UserActivity.EditingBeatmap edit:
                     return edit.BeatmapInfo;
             }
 
@@ -183,10 +183,10 @@ namespace osu.Desktop
                 case UserActivity.InGame game:
                     return game.BeatmapInfo.ToString() ?? string.Empty;
 
-                case UserActivity.Editing edit:
+                case UserActivity.EditingBeatmap edit:
                     return edit.BeatmapInfo.ToString() ?? string.Empty;
 
-                case UserActivity.Watching watching:
+                case UserActivity.WatchingReplay watching:
                     return watching.BeatmapInfo.ToString();
 
                 case UserActivity.InLobby lobby:

--- a/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneNowPlayingCommand.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestEditActivity()
         {
-            AddStep("Set activity", () => api.Activity.Value = new UserActivity.Editing(new BeatmapInfo()));
+            AddStep("Set activity", () => api.Activity.Value = new UserActivity.EditingBeatmap(new BeatmapInfo()));
 
             AddStep("Run command", () => Add(new NowPlayingCommand(new Channel())));
 

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
             AddStep("editing beatmap", () => activity.Value = new UserActivity.EditingBeatmap(null));
             AddStep("modding beatmap", () => activity.Value = new UserActivity.ModdingBeatmap());
+            AddStep("testing beatmap", () => activity.Value = new UserActivity.TestingBeatmap(null, null));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -109,15 +109,15 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("set online status", () => status.Value = new UserStatusOnline());
 
             AddStep("idle", () => activity.Value = null);
-            AddStep("watching", () => activity.Value = new UserActivity.Watching(createScore(@"nats")));
-            AddStep("spectating", () => activity.Value = new UserActivity.Spectating(createScore(@"mrekk")));
+            AddStep("watching replay", () => activity.Value = new UserActivity.WatchingReplay(createScore(@"nats")));
+            AddStep("spectating user", () => activity.Value = new UserActivity.SpectatingUser(createScore(@"mrekk")));
             AddStep("solo (osu!)", () => activity.Value = soloGameStatusForRuleset(0));
             AddStep("solo (osu!taiko)", () => activity.Value = soloGameStatusForRuleset(1));
             AddStep("solo (osu!catch)", () => activity.Value = soloGameStatusForRuleset(2));
             AddStep("solo (osu!mania)", () => activity.Value = soloGameStatusForRuleset(3));
             AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
-            AddStep("editing", () => activity.Value = new UserActivity.Editing(null));
-            AddStep("modding", () => activity.Value = new UserActivity.Modding());
+            AddStep("editing beatmap", () => activity.Value = new UserActivity.EditingBeatmap(null));
+            AddStep("modding beatmap", () => activity.Value = new UserActivity.ModdingBeatmap());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("solo (osu!mania)", () => activity.Value = soloGameStatusForRuleset(3));
             AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
             AddStep("editing beatmap", () => activity.Value = new UserActivity.EditingBeatmap(null));
-            AddStep("modding beatmap", () => activity.Value = new UserActivity.ModdingBeatmap());
+            AddStep("modding beatmap", () => activity.Value = new UserActivity.ModdingBeatmap(null));
             AddStep("testing beatmap", () => activity.Value = new UserActivity.TestingBeatmap(null, null));
         }
 

--- a/osu.Game/Online/Chat/NowPlayingCommand.cs
+++ b/osu.Game/Online/Chat/NowPlayingCommand.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.Chat
                     beatmapInfo = game.BeatmapInfo;
                     break;
 
-                case UserActivity.Editing edit:
+                case UserActivity.EditingBeatmap edit:
                     verb = "editing";
                     beatmapInfo = edit.BeatmapInfo;
                     break;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Screens.Edit
 
         private bool isNewBeatmap;
 
-        protected override UserActivity InitialActivity => new UserActivity.Editing(Beatmap.Value.BeatmapInfo);
+        protected override UserActivity InitialActivity => new UserActivity.EditingBeatmap(Beatmap.Value.BeatmapInfo);
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -157,7 +157,16 @@ namespace osu.Game.Screens.Edit
 
         private bool isNewBeatmap;
 
-        protected override UserActivity InitialActivity => new UserActivity.EditingBeatmap(Beatmap.Value.BeatmapInfo);
+        protected override UserActivity InitialActivity
+        {
+            get
+            {
+                if (Beatmap.Value.Metadata.Author.OnlineID == api.LocalUser.Value.OnlineID)
+                    return new UserActivity.EditingBeatmap(Beatmap.Value.BeatmapInfo);
+
+                return new UserActivity.ModdingBeatmap(Beatmap.Value.BeatmapInfo);
+            }
+        }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
 using osu.Game.Screens.Play;
+using osu.Game.Users;
 
 namespace osu.Game.Screens.Edit.GameplayTest
 {
@@ -14,6 +15,8 @@ namespace osu.Game.Screens.Edit.GameplayTest
     {
         private readonly Editor editor;
         private readonly EditorState editorState;
+
+        protected override UserActivity InitialActivity => new UserActivity.TestingBeatmap(Beatmap.Value.BeatmapInfo, Ruleset.Value);
 
         [Resolved]
         private MusicController musicController { get; set; } = null!;

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Play
 
         private readonly bool replayIsFailedScore;
 
-        protected override UserActivity InitialActivity => new UserActivity.Watching(Score.ScoreInfo);
+        protected override UserActivity InitialActivity => new UserActivity.WatchingReplay(Score.ScoreInfo);
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure()

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Play
     {
         private readonly Score score;
 
-        protected override UserActivity InitialActivity => new UserActivity.Spectating(Score.ScoreInfo);
+        protected override UserActivity InitialActivity => new UserActivity.SpectatingUser(Score.ScoreInfo);
 
         public SoloSpectatorPlayer(Score score, PlayerConfiguration configuration = null)
             : base(score, configuration)

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -18,10 +18,15 @@ namespace osu.Game.Users
 
         public virtual Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDarker;
 
-        public class ModdingBeatmap : UserActivity
+        public class ModdingBeatmap : EditingBeatmap
         {
             public override string GetStatus(bool hideIdentifiableInformation = false) => "Modding a beatmap";
             public override Color4 GetAppropriateColour(OsuColour colours) => colours.PurpleDark;
+
+            public ModdingBeatmap(IBeatmapInfo info)
+                : base(info)
+            {
+            }
         }
 
         public class ChoosingBeatmap : UserActivity

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -80,6 +80,16 @@ namespace osu.Game.Users
             }
         }
 
+        public class TestingBeatmap : InGame
+        {
+            public override string GetStatus(bool hideIdentifiableInformation = false) => "Testing a beatmap";
+
+            public TestingBeatmap(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)
+                : base(beatmapInfo, ruleset)
+            {
+            }
+        }
+
         public class EditingBeatmap : UserActivity
         {
             public IBeatmapInfo BeatmapInfo { get; }

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -18,9 +18,9 @@ namespace osu.Game.Users
 
         public virtual Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDarker;
 
-        public class Modding : UserActivity
+        public class ModdingBeatmap : UserActivity
         {
-            public override string GetStatus(bool hideIdentifiableInformation = false) => "Modding a map";
+            public override string GetStatus(bool hideIdentifiableInformation = false) => "Modding a beatmap";
             public override Color4 GetAppropriateColour(OsuColour colours) => colours.PurpleDark;
         }
 
@@ -80,11 +80,11 @@ namespace osu.Game.Users
             }
         }
 
-        public class Editing : UserActivity
+        public class EditingBeatmap : UserActivity
         {
             public IBeatmapInfo BeatmapInfo { get; }
 
-            public Editing(IBeatmapInfo info)
+            public EditingBeatmap(IBeatmapInfo info)
             {
                 BeatmapInfo = info;
             }
@@ -92,7 +92,7 @@ namespace osu.Game.Users
             public override string GetStatus(bool hideIdentifiableInformation = false) => @"Editing a beatmap";
         }
 
-        public class Watching : UserActivity
+        public class WatchingReplay : UserActivity
         {
             private readonly ScoreInfo score;
 
@@ -100,7 +100,7 @@ namespace osu.Game.Users
 
             public BeatmapInfo BeatmapInfo => score.BeatmapInfo;
 
-            public Watching(ScoreInfo score)
+            public WatchingReplay(ScoreInfo score)
             {
                 this.score = score;
             }
@@ -108,11 +108,11 @@ namespace osu.Game.Users
             public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Watching a replay" : $@"Watching {Username}'s replay";
         }
 
-        public class Spectating : Watching
+        public class SpectatingUser : WatchingReplay
         {
             public override string GetStatus(bool hideIdentifiableInformation = false) => hideIdentifiableInformation ? @"Spectating a user" : $@"Spectating {Username}";
 
-            public Spectating(ScoreInfo score)
+            public SpectatingUser(ScoreInfo score)
                 : base(score)
             {
             }


### PR DESCRIPTION
Made class names more specific as we may want to add an "editing skin" activity in the future.

The editing activity logic is a bit different from stable. Stable seems to check for username, while this PR checks for online ID. Seems better for cases where users change their names. I also want to add a check if a beatmap is ranked and display "editing" instead of "modding" as it is already final/non-moddable, but keeping it simple for now.