### PR TITLE
Fix beatmap card song preview progress sometimes showing past progress for one frame

### DIFF
--- a/osu.Game/Audio/PreviewTrack.cs
+++ b/osu.Game/Audio/PreviewTrack.cs
@@ -98,6 +98,9 @@ namespace osu.Game.Audio
 
             Track.Stop();
 
+            // Ensure the track is reset immediately on stopping, so the next time it is started it has a correct time value.
+            Track.Seek(0);
+
             Stopped?.Invoke();
         }
 

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -75,9 +75,9 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             Playing.BindValueChanged(updateState, true);
         }
 
-        protected override void UpdateAfterChildren()
+        protected override void Update()
         {
-            base.UpdateAfterChildren();
+            base.Update();
 
             if (Playing.Value && previewTrack != null && previewTrack.TrackLoaded)
                 progress.Value = previewTrack.CurrentTime / previewTrack.Length;

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -75,9 +75,9 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             Playing.BindValueChanged(updateState, true);
         }
 
-        protected override void Update()
+        protected override void UpdateAfterChildren()
         {
-            base.Update();
+            base.UpdateAfterChildren();
 
             if (Playing.Value && previewTrack != null && previewTrack.TrackLoaded)
                 progress.Value = previewTrack.CurrentTime / previewTrack.Length;


### PR DESCRIPTION
Similar to https://github.com/ppy/osu/pull/22607, but harder to reproduce / know if this change fixes it.

Process of reproducing (in master):
- Play ~1/4 of at least two previews and repeat (takes about 10 times until the visual bug happens)

https://user-images.githubusercontent.com/35318437/218588319-e9ad4f31-d194-4edf-9af7-10a4c399283e.mp4

You can reproduce it with one preview, but the behavior will change to pause (same as web) so trying to reproduce via ^ is more correct.