### PR TITLE
Fix `OsuClickableContainer` sounds not being blocked by nested drawables

### DIFF
--- a/osu.Game/Graphics/Containers/OsuClickableContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuClickableContainer.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Graphics.Containers
 
             AddRangeInternal(new Drawable[]
             {
+                CreateHoverSounds(sampleSet),
                 content,
-                CreateHoverSounds(sampleSet)
             });
         }
 


### PR DESCRIPTION
This became more noticeable when more distinct sounds were added to mostly every single clickable element interaction. For example beatmap cards:

Before:

https://user-images.githubusercontent.com/35318437/218599774-16597dda-909b-4361-9d57-789baf975e27.mp4

After:

https://user-images.githubusercontent.com/35318437/218599358-8caa477f-31d0-44c8-9513-b9d0d497ef9e.mp4

This happens in other places. On leaderboard scores, it's not as noticeable because clicking the avatar or score has the same sounds but this fixes the double samples playing when clicking the avatar.

Applying it on `OsuClickableContainer` only for now as I believe `OsuButton`s won't have nested drawables to click.