### PR TITLE
Use `Overlays` container rather than `KeyBindingInputManager` for flashlight

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private const double flash_duration = 1000;
 
-        private DrawableRuleset<OsuHitObject> ruleset = null!;
+        private DrawableOsuRuleset ruleset = null!;
 
         protected OsuAction? LastAcceptedAction { get; private set; }
 
@@ -42,8 +43,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            ruleset = drawableRuleset;
-            drawableRuleset.KeyBindingInputManager.Add(new InputInterceptor(this));
+            ruleset = (DrawableOsuRuleset)drawableRuleset;
+            ruleset.InputManager.Add(new InputInterceptor(this));
 
             var periods = new List<Period>();
 

--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             ruleset = (DrawableOsuRuleset)drawableRuleset;
-            ruleset.InputManager.Add(new InputInterceptor(this));
+            ruleset.KeyBindingInputManager.Add(new InputInterceptor(this));
 
             var periods = new List<Period>();
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             // Grab the input manager to disable the user's cursor, and for future use
-            inputManager = ((DrawableOsuRuleset)drawableRuleset).InputManager;
+            inputManager = ((DrawableOsuRuleset)drawableRuleset).KeyBindingInputManager;
             inputManager.AllowUserCursorMovement = false;
 
             // Generate the replay frames the cursor should follow

--- a/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModAutopilot.cs
@@ -11,6 +11,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
@@ -55,7 +56,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             // Grab the input manager to disable the user's cursor, and for future use
-            inputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
+            inputManager = ((DrawableOsuRuleset)drawableRuleset).InputManager;
             inputManager.AllowUserCursorMovement = false;
 
             // Generate the replay frames the cursor should follow

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
@@ -42,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             // grab the input manager for future use.
-            osuInputManager = (OsuInputManager)drawableRuleset.KeyBindingInputManager;
+            osuInputManager = ((DrawableOsuRuleset)drawableRuleset).InputManager;
         }
 
         public void ApplyToPlayer(Player player)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             // grab the input manager for future use.
-            osuInputManager = ((DrawableOsuRuleset)drawableRuleset).InputManager;
+            osuInputManager = ((DrawableOsuRuleset)drawableRuleset).KeyBindingInputManager;
         }
 
         public void ApplyToPlayer(Player player)

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Rulesets.Osu.UI
     {
         protected new OsuRulesetConfigManager Config => (OsuRulesetConfigManager)base.Config;
 
+        public OsuInputManager InputManager { get; private set; }
+
         public new OsuPlayfield Playfield => (OsuPlayfield)base.Playfield;
 
         public DrawableOsuRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
@@ -39,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         protected override Playfield CreatePlayfield() => new OsuPlayfield();
 
-        protected override PassThroughInputManager CreateInputManager() => new OsuInputManager(Ruleset.RulesetInfo);
+        protected override PassThroughInputManager CreateInputManager() => InputManager = new OsuInputManager(Ruleset.RulesetInfo);
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new OsuPlayfieldAdjustmentContainer { AlignWithStoryboard = true };
 

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.UI
     {
         protected new OsuRulesetConfigManager Config => (OsuRulesetConfigManager)base.Config;
 
-        public OsuInputManager InputManager { get; private set; }
+        public new OsuInputManager KeyBindingInputManager => (OsuInputManager)base.KeyBindingInputManager;
 
         public new OsuPlayfield Playfield => (OsuPlayfield)base.Playfield;
 
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         protected override Playfield CreatePlayfield() => new OsuPlayfield();
 
-        protected override PassThroughInputManager CreateInputManager() => InputManager = new OsuInputManager(Ruleset.RulesetInfo);
+        protected override PassThroughInputManager CreateInputManager() => new OsuInputManager(Ruleset.RulesetInfo);
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new OsuPlayfieldAdjustmentContainer { AlignWithStoryboard = true };
 

--- a/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
+++ b/osu.Game.Tests/NonVisual/FirstAvailableHitWindowsTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
+using osu.Framework.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
@@ -93,6 +94,7 @@ namespace osu.Game.Tests.NonVisual
                 remove => throw new InvalidOperationException($"{nameof(RevertResult)} operations not supported in test context");
             }
 
+            public override IAdjustableAudioComponent Audio { get; }
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }
             public override Container FrameStableComponents { get; }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHitErrorMeter.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -281,6 +282,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 remove => throw new InvalidOperationException($"{nameof(RevertResult)} operations not supported in test context");
             }
 
+            public override IAdjustableAudioComponent Audio { get; }
             public override Playfield Playfield { get; }
             public override Container Overlays { get; }
             public override Container FrameStableComponents { get; }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Rulesets.Mods
             flashlight.Colour = Color4.Black;
 
             flashlight.Combo.BindTo(Combo);
-            drawableRuleset.KeyBindingInputManager.Add(flashlight);
+            drawableRuleset.Overlays.Add(flashlight);
         }
 
         protected abstract Flashlight CreateFlashlight();

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -67,7 +67,8 @@ namespace osu.Game.Rulesets.Mods
             {
                 MetronomeBeat metronomeBeat;
 
-                drawableRuleset.Overlays.Add(metronomeBeat = new MetronomeBeat(drawableRuleset.Beatmap.HitObjects.First().StartTime));
+                // Importantly, this is added to FrameStableComponents and not Overlays as the latter would cause it to be self-muted by the mod's volume adjustment.
+                drawableRuleset.FrameStableComponents.Add(metronomeBeat = new MetronomeBeat(drawableRuleset.Beatmap.HitObjects.First().StartTime));
 
                 metronomeBeat.AddAdjustment(AdjustableProperty.Volume, metronomeVolumeAdjust);
             }

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -66,6 +66,10 @@ namespace osu.Game.Rulesets.UI
 
         public override Container Overlays { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
+        public override IAdjustableAudioComponent Audio => audioContainer;
+
+        private readonly AudioContainer audioContainer = new AudioContainer { RelativeSizeAxes = Axes.Both };
+
         public override Container FrameStableComponents { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         public override IFrameStableClock FrameStableClock => frameStabilityContainer;
@@ -101,14 +105,6 @@ namespace osu.Game.Rulesets.UI
         private OnScreenDisplay onScreenDisplay;
 
         private DrawableRulesetDependencies dependencies;
-
-        /// <summary>
-        /// Audio adjustments which are applied to the playfield.
-        /// </summary>
-        /// <remarks>
-        /// Does not affect <see cref="Overlays"/>.
-        /// </remarks>
-        public IAdjustableAudioComponent Audio { get; private set; }
 
         /// <summary>
         /// Creates a ruleset visualisation for the provided ruleset and beatmap.
@@ -172,29 +168,21 @@ namespace osu.Game.Rulesets.UI
         [BackgroundDependencyLoader]
         private void load(CancellationToken? cancellationToken)
         {
-            AudioContainer audioContainer;
-
             InternalChild = frameStabilityContainer = new FrameStabilityContainer(GameplayStartTime)
             {
                 FrameStablePlayback = FrameStablePlayback,
                 Children = new Drawable[]
                 {
                     FrameStableComponents,
-                    audioContainer = new AudioContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = KeyBindingInputManager
-                            .WithChildren(new Drawable[]
-                            {
-                                CreatePlayfieldAdjustmentContainer()
-                                    .WithChild(Playfield),
-                                Overlays
-                            }),
-                    },
+                    audioContainer.WithChild(KeyBindingInputManager
+                        .WithChildren(new Drawable[]
+                        {
+                            CreatePlayfieldAdjustmentContainer()
+                                .WithChild(Playfield),
+                            Overlays
+                        })),
                 }
             };
-
-            Audio = audioContainer;
 
             if ((ResumeOverlay = CreateResumeOverlay()) != null)
             {
@@ -439,12 +427,20 @@ namespace osu.Game.Rulesets.UI
         public readonly BindableBool IsPaused = new BindableBool();
 
         /// <summary>
+        /// Audio adjustments which are applied to the playfield.
+        /// </summary>
+        /// <remarks>
+        /// Does not affect <see cref="Overlays"/>.
+        /// </remarks>
+        public abstract IAdjustableAudioComponent Audio { get; }
+
+        /// <summary>
         /// The playfield.
         /// </summary>
         public abstract Playfield Playfield { get; }
 
         /// <summary>
-        /// Content to be placed above hitobjects. Will be affected by frame stability.
+        /// Content to be placed above hitobjects. Will be affected by frame stability and adjustments applied to <see cref="Audio"/>.
         /// </summary>
         public abstract Container Overlays { get; }
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -429,9 +429,6 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// Audio adjustments which are applied to the playfield.
         /// </summary>
-        /// <remarks>
-        /// Does not affect <see cref="Overlays"/>.
-        /// </remarks>
         public abstract IAdjustableAudioComponent Audio { get; }
 
         /// <summary>

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -184,11 +184,13 @@ namespace osu.Game.Rulesets.UI
                     {
                         RelativeSizeAxes = Axes.Both,
                         Child = KeyBindingInputManager
-                            .WithChild(CreatePlayfieldAdjustmentContainer()
-                                .WithChild(Playfield)
-                            ),
+                            .WithChildren(new Drawable[]
+                            {
+                                CreatePlayfieldAdjustmentContainer()
+                                    .WithChild(Playfield),
+                                Overlays
+                            }),
                     },
-                    Overlays,
                 }
             };
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// The key conversion input manager for this DrawableRuleset.
         /// </summary>
-        public PassThroughInputManager KeyBindingInputManager;
+        protected PassThroughInputManager KeyBindingInputManager;
 
         public override double GameplayStartTime => Objects.FirstOrDefault()?.StartTime - 2000 ?? 0;
 


### PR DESCRIPTION
Came across this during review of #21789.

Also tidies up the exposure of `KeyBindingInputManager`.