### PR TITLE
Adjust song select background dimming to be more evenly applied

### DIFF
--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Graphics.Containers
         /// </summary>
         public const float BREAK_LIGHTEN_AMOUNT = 0.3f;
 
-        protected const double BACKGROUND_FADE_DURATION = 800;
+        public const double BACKGROUND_FADE_DURATION = 800;
 
         /// <summary>
         /// Whether or not user-configured settings relating to brightness of elements should be ignored

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -417,7 +417,7 @@ namespace osu.Game.Screens.Play
             lowPassFilter.CutoffTo(1000, 650, Easing.OutQuint);
             highPassFilter.CutoffTo(300).Then().CutoffTo(0, 1250); // 1250 is to line up with the appearance of MetadataInfo (750 delay + 500 fade-in)
 
-            ApplyToBackground(b => b?.FadeColour(Color4.White, 800, Easing.OutQuint));
+            ApplyToBackground(b => b.FadeColour(Color4.White, 800, Easing.OutQuint));
         }
 
         protected virtual void ContentOut()

--- a/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
+++ b/osu.Game/Screens/Play/ScreenWithBeatmapBackground.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics;
+using osu.Framework.Screens;
 using osu.Game.Screens.Backgrounds;
 
 namespace osu.Game.Screens.Play
@@ -12,6 +12,11 @@ namespace osu.Game.Screens.Play
     {
         protected override BackgroundScreen CreateBackground() => new BackgroundScreenBeatmap(Beatmap.Value);
 
-        public void ApplyToBackground(Action<BackgroundScreenBeatmap> action) => base.ApplyToBackground(b => action.Invoke((BackgroundScreenBeatmap)b));
+        public void ApplyToBackground(Action<BackgroundScreenBeatmap> action)
+        {
+            Debug.Assert(this.IsCurrentScreen());
+
+            base.ApplyToBackground(b => action.Invoke((BackgroundScreenBeatmap)b));
+        }
     }
 }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -31,6 +31,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
@@ -148,7 +149,7 @@ namespace osu.Game.Screens.Select
                 if (!this.IsCurrentScreen())
                     return;
 
-                ApplyToBackground(b => b.BlurAmount.Value = e.NewValue ? BACKGROUND_BLUR : 0);
+                ApplyToBackground(applyBlurToBackground);
             });
 
             LoadComponentAsync(Carousel = new BeatmapCarousel
@@ -194,6 +195,7 @@ namespace osu.Game.Screens.Select
                                     {
                                         ParallaxAmount = 0.005f,
                                         RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0,
                                         Anchor = Anchor.Centre,
                                         Origin = Anchor.Centre,
                                         Child = new WedgeBackground
@@ -766,10 +768,10 @@ namespace osu.Game.Screens.Select
             ApplyToBackground(backgroundModeBeatmap =>
             {
                 backgroundModeBeatmap.Beatmap = beatmap;
-                backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
                 backgroundModeBeatmap.IgnoreUserSettings.Value = true;
-                backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = 0.4f;
                 backgroundModeBeatmap.FadeColour(Color4.White, 250);
+
+                applyBlurToBackground(backgroundModeBeatmap);
             });
 
             beatmapInfoWedge.Beatmap = beatmap;
@@ -785,6 +787,14 @@ namespace osu.Game.Screens.Select
                 beatmapOptionsButton.Enabled.Value = false;
                 BeatmapOptions.Hide();
             }
+        }
+
+        private void applyBlurToBackground(BackgroundScreenBeatmap backgroundModeBeatmap)
+        {
+            backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
+            backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = configBackgroundBlur.Value ? 0 : 0.4f;
+
+            wedgeBackground.FadeTo(configBackgroundBlur.Value ? 0.5f : 0.2f, UserDimContainer.BACKGROUND_FADE_DURATION, Easing.OutQuint);
         }
 
         private readonly WeakReference<ITrack?> lastTrack = new WeakReference<ITrack?>(null);

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -765,14 +765,18 @@ namespace osu.Game.Screens.Select
         /// <param name="beatmap">The working beatmap.</param>
         private void updateComponentFromBeatmap(WorkingBeatmap beatmap)
         {
-            ApplyToBackground(backgroundModeBeatmap =>
+            // If not the current screen, this will be applied in OnResuming.
+            if (this.IsCurrentScreen())
             {
-                backgroundModeBeatmap.Beatmap = beatmap;
-                backgroundModeBeatmap.IgnoreUserSettings.Value = true;
-                backgroundModeBeatmap.FadeColour(Color4.White, 250);
+                ApplyToBackground(backgroundModeBeatmap =>
+                {
+                    backgroundModeBeatmap.Beatmap = beatmap;
+                    backgroundModeBeatmap.IgnoreUserSettings.Value = true;
+                    backgroundModeBeatmap.FadeColour(Color4.White, 250);
 
-                applyBlurToBackground(backgroundModeBeatmap);
-            });
+                    applyBlurToBackground(backgroundModeBeatmap);
+                });
+            }
 
             beatmapInfoWedge.Beatmap = beatmap;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -767,6 +767,8 @@ namespace osu.Game.Screens.Select
             {
                 backgroundModeBeatmap.Beatmap = beatmap;
                 backgroundModeBeatmap.BlurAmount.Value = configBackgroundBlur.Value ? BACKGROUND_BLUR : 0f;
+                backgroundModeBeatmap.IgnoreUserSettings.Value = true;
+                backgroundModeBeatmap.DimWhenUserSettingsIgnored.Value = 0.4f;
                 backgroundModeBeatmap.FadeColour(Color4.White, 250);
             });
 

--- a/osu.Game/Screens/Select/WedgeBackground.cs
+++ b/osu.Game/Screens/Select/WedgeBackground.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.Both,
                     Size = new Vector2(1, 0.5f),
-                    Colour = Color4.Black.Opacity(0.5f),
+                    Colour = Color4.Black.Opacity(0.2f),
                     Shear = new Vector2(0.15f, 0),
                     EdgeSmoothness = new Vector2(2, 0),
                 },
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Select
                     RelativePositionAxes = Axes.Y,
                     Size = new Vector2(1, -0.5f),
                     Position = new Vector2(0, 1),
-                    Colour = Color4.Black.Opacity(0.5f),
+                    Colour = Color4.Black.Opacity(0.2f),
                     Shear = new Vector2(-0.15f, 0),
                     EdgeSmoothness = new Vector2(2, 0),
                 },

--- a/osu.Game/Screens/Select/WedgeBackground.cs
+++ b/osu.Game/Screens/Select/WedgeBackground.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osuTK;
 using osuTK.Graphics;
-using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Screens.Select
 {
@@ -22,7 +19,7 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.Both,
                     Size = new Vector2(1, 0.5f),
-                    Colour = Color4.Black.Opacity(0.2f),
+                    Colour = Color4.Black,
                     Shear = new Vector2(0.15f, 0),
                     EdgeSmoothness = new Vector2(2, 0),
                 },
@@ -32,7 +29,7 @@ namespace osu.Game.Screens.Select
                     RelativePositionAxes = Axes.Y,
                     Size = new Vector2(1, -0.5f),
                     Position = new Vector2(0, 1),
-                    Colour = Color4.Black.Opacity(0.2f),
+                    Colour = Color4.Black,
                     Shear = new Vector2(-0.15f, 0),
                     EdgeSmoothness = new Vector2(2, 0),
                 },


### PR DESCRIPTION
There were a few comments around the place over song select looking too bright when blur is disabled. Which is most definitely is. This is due to dim not being applied at all to the portion of the background which isn't covered by the "wedge" on the left.

To fix this, I've changed the global background dim at song select to match osu-stable, then reduced the additional dimming of the wedge. I tried applying to the blurred version as well, but it looks bad so I fenced the change off to only when blur is not applied. For those interested, reverting the second commit can allow testing with blur on too.

| before | after |
| -- | -- |
|![osu! 2023-02-15 at 05 02 28](https://user-images.githubusercontent.com/191335/218936475-67b558ec-3791-403a-95e7-41f20a0869fb.png)|![osu! 2023-02-15 at 05 15 41](https://user-images.githubusercontent.com/191335/218938750-03a84a82-99fa-40b0-bea3-26ccde4e7fcd.png)|
|![osu! 2023-02-15 at 05 02 41](https://user-images.githubusercontent.com/191335/218936506-aa4111e3-b3e3-4ad0-931b-f68c471aba0b.png)|![osu! 2023-02-15 at 05 15 30](https://user-images.githubusercontent.com/191335/218938704-7cc0026e-b895-4398-8d48-d0fe739563ec.png)|

Closes #22652 indirectly.