### PR TITLE
Fix exports failing if a directory exists with the proposed filename

### DIFF
--- a/osu.Game/Database/LegacyExporter.cs
+++ b/osu.Game/Database/LegacyExporter.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using osu.Framework.Platform;
 using osu.Game.Extensions;
 using osu.Game.Utils;
@@ -43,7 +44,10 @@ namespace osu.Game.Database
         {
             string itemFilename = GetFilename(item).GetValidFilename();
 
-            IEnumerable<string> existingExports = exportStorage.GetFiles("", $"{itemFilename}*{FileExtension}");
+            IEnumerable<string> existingExports =
+                exportStorage
+                    .GetFiles(string.Empty, $"{itemFilename}*{FileExtension}")
+                    .Concat(exportStorage.GetDirectories(string.Empty));
 
             string filename = NamingUtils.GetNextBestFilename(existingExports, $"{itemFilename}{FileExtension}");
             using (var stream = exportStorage.CreateFileSafely(filename))


### PR DESCRIPTION
Found this while testing skinning subsystem. Directories were not provided as existing filenames, so if there was a matching directory with the full skin filename (including the `.osk` extension in the folder name) the export would fail to manifest with the final filename, leaving behind a temporary GUID suffixed file.

Not sure if this is worth adding a test for..

```csharp
[runtime] 2023-02-15 06:24:35 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 9 more times...
[runtime] 2023-02-15 06:24:35 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 8 more times...
[runtime] 2023-02-15 06:24:36 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 7 more times...
[runtime] 2023-02-15 06:24:36 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 6 more times...
[runtime] 2023-02-15 06:24:36 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 5 more times...
[runtime] 2023-02-15 06:24:36 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 4 more times...
[runtime] 2023-02-15 06:24:37 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 3 more times...
[runtime] 2023-02-15 06:24:37 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 2 more times...
[runtime] 2023-02-15 06:24:37 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 1 more times...
[runtime] 2023-02-15 06:24:37 [verbose]: Operation failed (The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.). Retrying 0 more times...
[runtime] 2023-02-15 06:24:38 [error]: Could not export current skin: The file '/Users/dean/Games/osu-development/exports/osu_ _argon_ (2022) (modified) (25) (Unknown).osk' already exists.
```

Before:

https://user-images.githubusercontent.com/191335/218958178-b245e7ab-6e58-451e-94cb-61b9949f19aa.mp4

After:

https://user-images.githubusercontent.com/191335/218957974-123129c2-9784-4baa-aed4-7636edfcfa4f.mp4

