### PR TITLE
Simplify and rename `SkinnableTargetComponentsContainer`

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Skinning;
 using osuTK.Graphics;
 
@@ -32,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                 switch (targetComponent.Lookup)
                 {
                     case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
-                        var components = base.GetDrawableComponent(lookup) as SkinnableTargetComponentsContainer;
+                        var components = base.GetDrawableComponent(lookup) as Container;
 
                         if (providesComboCounter && components != null)
                         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -1,13 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
@@ -28,10 +27,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public partial class TestSceneBeatmapSkinFallbacks : OsuPlayerTestScene
     {
-        private ISkin currentBeatmapSkin;
+        private ISkin currentBeatmapSkin = null!;
 
         [Resolved]
-        private SkinManager skinManager { get; set; }
+        private SkinManager skinManager { get; set; } = null!;
 
         protected override bool HasCustomSteps => true;
 
@@ -65,7 +64,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             var actualInfo = actualComponentsContainer.CreateSkinnableInfo();
 
-            var expectedComponentsContainer = (DefaultSkinComponentsContainer)expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target));
+            var expectedComponentsContainer = expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target)) as Container;
             if (expectedComponentsContainer == null)
                 return false;
 
@@ -92,7 +91,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             return almostEqual(actualInfo, expectedInfo);
         }
 
-        private static bool almostEqual(SkinnableInfo info, SkinnableInfo other) =>
+        private static bool almostEqual(SkinnableInfo info, SkinnableInfo? other) =>
             other != null
             && info.Type == other.Type
             && info.Anchor == other.Anchor
@@ -102,7 +101,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             && Precision.AlmostEquals(info.Rotation, other.Rotation)
             && info.Children.SequenceEqual(other.Children, new FuncEqualityComparer<SkinnableInfo>(almostEqual));
 
-        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
             => new CustomSkinWorkingBeatmap(beatmap, storyboard, Clock, Audio, currentBeatmapSkin);
 
         protected override Ruleset CreatePlayerRuleset() => new TestOsuRuleset();
@@ -111,7 +110,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             private readonly ISkin beatmapSkin;
 
-            public CustomSkinWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard, IFrameBasedClock referenceClock, AudioManager audio, ISkin beatmapSkin)
+            public CustomSkinWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard, IFrameBasedClock referenceClock, AudioManager audio, ISkin beatmapSkin)
                 : base(beatmap, storyboard, referenceClock, audio)
             {
                 this.beatmapSkin = beatmapSkin;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -58,14 +58,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected bool AssertComponentsFromExpectedSource(GlobalSkinComponentLookup.LookupType target, ISkin expectedSource)
         {
             var actualComponentsContainer = Player.ChildrenOfType<SkinnableTargetContainer>().First(s => s.Target == target)
-                                                  .ChildrenOfType<SkinnableTargetComponentsContainer>().SingleOrDefault();
+                                                  .ChildrenOfType<Container>().SingleOrDefault();
 
             if (actualComponentsContainer == null)
                 return false;
 
             var actualInfo = actualComponentsContainer.CreateSkinnableInfo();
 
-            var expectedComponentsContainer = (SkinnableTargetComponentsContainer)expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target));
+            var expectedComponentsContainer = (DefaultSkinComponentsContainer)expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target));
             if (expectedComponentsContainer == null)
                 return false;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -56,8 +56,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected bool AssertComponentsFromExpectedSource(GlobalSkinComponentLookup.LookupType target, ISkin expectedSource)
         {
-            var actualComponentsContainer = Player.ChildrenOfType<SkinnableTargetContainer>().First(s => s.Target == target)
-                                                  .ChildrenOfType<Container>().SingleOrDefault();
+            var targetContainer = Player.ChildrenOfType<SkinnableTargetContainer>().First(s => s.Target == target);
+            var actualComponentsContainer = targetContainer.ChildrenOfType<Container>().SingleOrDefault(c => c.Parent == targetContainer);
 
             if (actualComponentsContainer == null)
                 return false;

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Skinning
                     switch (globalLookup.Lookup)
                     {
                         case GlobalSkinComponentLookup.LookupType.SongSelect:
-                            var songSelectComponents = new SkinnableTargetComponentsContainer(_ =>
+                            var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
                             {
                                 // do stuff when we need to.
                             });
@@ -102,7 +102,7 @@ namespace osu.Game.Skinning
                             return songSelectComponents;
 
                         case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
-                            var skinnableTargetWrapper = new SkinnableTargetComponentsContainer(container =>
+                            var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();

--- a/osu.Game/Skinning/DefaultSkinComponentsContainer.cs
+++ b/osu.Game/Skinning/DefaultSkinComponentsContainer.cs
@@ -2,39 +2,28 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using Newtonsoft.Json;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A container which groups the components of a <see cref="SkinnableTargetContainer"/> into a single object.
-    /// Optionally also applies a default layout to the components.
+    /// A container which can be used to specify default skin components layouts.
+    /// Handles applying a default layout to the components.
     /// </summary>
-    [Serializable]
-    public partial class SkinnableTargetComponentsContainer : Container, ISkinnableDrawable
+    public partial class DefaultSkinComponentsContainer : Container
     {
-        public bool IsEditable => false;
-
-        public bool UsesFixedAnchor { get; set; }
-
         private readonly Action<Container>? applyDefaults;
 
         /// <summary>
         /// Construct a wrapper with defaults that should be applied once.
         /// </summary>
         /// <param name="applyDefaults">A function to apply the default layout.</param>
-        public SkinnableTargetComponentsContainer(Action<Container> applyDefaults)
-            : this()
-        {
-            this.applyDefaults = applyDefaults;
-        }
-
-        [JsonConstructor]
-        public SkinnableTargetComponentsContainer()
+        public DefaultSkinComponentsContainer(Action<Container> applyDefaults)
         {
             RelativeSizeAxes = Axes.Both;
+
+            this.applyDefaults = applyDefaults;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -347,7 +347,7 @@ namespace osu.Game.Skinning
                     switch (target.Lookup)
                     {
                         case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
-                            var skinnableTargetWrapper = new SkinnableTargetComponentsContainer(container =>
+                            var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<LegacyScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<GameplayAccuracyCounter>().FirstOrDefault();

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -174,8 +175,9 @@ namespace osu.Game.Skinning
                     foreach (var i in skinnableInfo)
                         components.Add(i.CreateInstance());
 
-                    return new SkinnableTargetComponentsContainer
+                    return new Container
                     {
+                        RelativeSizeAxes = Axes.Both,
                         Children = components,
                     };
             }

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -7,13 +7,14 @@ using System.Linq;
 using System.Threading;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Screens.Play.HUD;
 
 namespace osu.Game.Skinning
 {
     public partial class SkinnableTargetContainer : SkinReloadableDrawable, ISkinnableTarget
     {
-        private SkinnableTargetComponentsContainer? content;
+        private Container? content;
 
         public GlobalSkinComponentLookup.LookupType Target { get; }
 
@@ -39,15 +40,16 @@ namespace osu.Game.Skinning
             foreach (var i in skinnableInfo)
                 drawables.Add(i.CreateInstance());
 
-            Reload(new SkinnableTargetComponentsContainer
+            Reload(new Container
             {
+                RelativeSizeAxes = Axes.Both,
                 Children = drawables,
             });
         }
 
-        public void Reload() => Reload(CurrentSkin.GetDrawableComponent(new GlobalSkinComponentLookup(Target)) as SkinnableTargetComponentsContainer);
+        public void Reload() => Reload(CurrentSkin.GetDrawableComponent(new GlobalSkinComponentLookup(Target)) as Container);
 
-        public void Reload(SkinnableTargetComponentsContainer? componentsContainer)
+        public void Reload(Container? componentsContainer)
         {
             ClearInternal();
             components.Clear();

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Skinning
                     switch (target.Lookup)
                     {
                         case GlobalSkinComponentLookup.LookupType.SongSelect:
-                            var songSelectComponents = new SkinnableTargetComponentsContainer(_ =>
+                            var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
                             {
                                 // do stuff when we need to.
                             });
@@ -80,7 +80,7 @@ namespace osu.Game.Skinning
                             return songSelectComponents;
 
                         case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
-                            var skinnableTargetWrapper = new SkinnableTargetComponentsContainer(container =>
+                            var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();


### PR DESCRIPTION
This class was very weird. It was likely originally made with an intention of being used for serialisation purposes, but never has.

In fact, if we want to serialise a container we already have `ISkinnableTarget` (soon to become `ISerialisableDrawableContainer` or similar).

The main purpose it has is to correctly apply layout from skin implementations, so I've stripped it back to only do that, and renamed it appropriately. As a result, the *only* remaining usages are `new`.