### PR TITLE
Refactor structure and naming of skin-related classes

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             if (withModifiedSkin)
             {
                 AddStep("change component scale", () => Player.ChildrenOfType<LegacyScoreCounter>().First().Scale = new Vector2(2f));
-                AddStep("update target", () => Player.ChildrenOfType<SkinnableTargetContainer>().ForEach(LegacySkin.UpdateDrawableTarget));
+                AddStep("update target", () => Player.ChildrenOfType<SkinComponentsContainer>().ForEach(LegacySkin.UpdateDrawableTarget));
                 AddStep("exit player", () => Player.Exit());
                 CreateTest();
             }

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -28,9 +28,9 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is SkinComponentsContainerLookup componentLookup)
+            if (lookup is SkinComponentsContainerLookup containerLookup)
             {
-                switch (componentLookup.Target)
+                switch (containerLookup.Target)
                 {
                     case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                         var components = base.GetDrawableComponent(lookup) as Container;

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -28,11 +28,11 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is GlobalSkinComponentLookup targetComponent)
+            if (lookup is SkinComponentsContainerLookup componentLookup)
             {
-                switch (targetComponent.Lookup)
+                switch (componentLookup.Target)
                 {
-                    case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
+                    case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                         var components = base.GetDrawableComponent(lookup) as Container;
 
                         if (providesComboCounter && components != null)

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Skins
                 }
             }
 
-            var editableTypes = SkinnableDrawableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISkinnableDrawable)?.IsEditable == true);
+            var editableTypes = SerialisedDrawableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISkinnableDrawable)?.IsEditable == true);
 
             Assert.That(instantiatedTypes, Is.EquivalentTo(editableTypes));
         }

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Skins
                 var skin = new TestSkin(new SkinInfo(), null, storage);
 
                 Assert.That(skin.DrawableComponentInfo, Has.Count.EqualTo(2));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents], Has.Length.EqualTo(9));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents], Has.Length.EqualTo(9));
             }
         }
 
@@ -101,10 +101,10 @@ namespace osu.Game.Tests.Skins
                 var skin = new TestSkin(new SkinInfo(), null, storage);
 
                 Assert.That(skin.DrawableComponentInfo, Has.Count.EqualTo(2));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents], Has.Length.EqualTo(6));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.SongSelect], Has.Length.EqualTo(1));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents], Has.Length.EqualTo(6));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.SongSelect], Has.Length.EqualTo(1));
 
-                var skinnableInfo = skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.SongSelect].First();
+                var skinnableInfo = skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.SongSelect].First();
 
                 Assert.That(skinnableInfo.Type, Is.EqualTo(typeof(SkinnableSprite)));
                 Assert.That(skinnableInfo.Settings.First().Key, Is.EqualTo("sprite_name"));
@@ -115,10 +115,10 @@ namespace osu.Game.Tests.Skins
             using (var storage = new ZipArchiveReader(stream))
             {
                 var skin = new TestSkin(new SkinInfo(), null, storage);
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents], Has.Length.EqualTo(8));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(UnstableRateCounter)));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(ColourHitErrorMeter)));
-                Assert.That(skin.DrawableComponentInfo[GlobalSkinComponentLookup.LookupType.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(LegacySongProgress)));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents], Has.Length.EqualTo(8));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(UnstableRateCounter)));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(ColourHitErrorMeter)));
+                Assert.That(skin.DrawableComponentInfo[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].Select(i => i.Type), Contains.Item(typeof(LegacySongProgress)));
             }
         }
 

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Skins
                 }
             }
 
-            var editableTypes = SkinnableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISkinnableDrawable)?.IsEditable == true);
+            var editableTypes = SkinnableDrawableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISkinnableDrawable)?.IsEditable == true);
 
             Assert.That(instantiatedTypes, Is.EquivalentTo(editableTypes));
         }

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Skins
                 }
             }
 
-            var editableTypes = SerialisedDrawableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISkinnableDrawable)?.IsEditable == true);
+            var editableTypes = SerialisedDrawableInfo.GetAllAvailableDrawables().Where(t => (Activator.CreateInstance(t) as ISerialisableDrawable)?.IsEditable == true);
 
             Assert.That(instantiatedTypes, Is.EquivalentTo(editableTypes));
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -36,8 +36,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestEmptyLegacyBeatmapSkinFallsBack()
         {
             CreateSkinTest(TrianglesSkin.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
-            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
-            AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(GlobalSkinComponentLookup.LookupType.MainHUDComponents, skinManager.CurrentSkin.Value));
+            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinComponentsContainer>().All(c => c.ComponentsLoaded));
+            AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(SkinComponentsContainerLookup.TargetArea.MainHUDComponents, skinManager.CurrentSkin.Value));
         }
 
         protected void CreateSkinTest(SkinInfo gameCurrentSkin, Func<ISkin> getBeatmapSkin)
@@ -52,9 +52,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
-        protected bool AssertComponentsFromExpectedSource(GlobalSkinComponentLookup.LookupType target, ISkin expectedSource)
+        protected bool AssertComponentsFromExpectedSource(SkinComponentsContainerLookup.TargetArea target, ISkin expectedSource)
         {
-            var targetContainer = Player.ChildrenOfType<SkinnableTargetContainer>().First(s => s.Target == target);
+            var targetContainer = Player.ChildrenOfType<SkinComponentsContainer>().First(s => s.Lookup.Target == target);
             var actualComponentsContainer = targetContainer.ChildrenOfType<Container>().SingleOrDefault(c => c.Parent == targetContainer);
 
             if (actualComponentsContainer == null)
@@ -62,7 +62,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             var actualInfo = actualComponentsContainer.CreateSerialisedInfo();
 
-            var expectedComponentsContainer = expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target)) as Container;
+            var expectedComponentsContainer = expectedSource.GetDrawableComponent(new SkinComponentsContainerLookup(target)) as Container;
             if (expectedComponentsContainer == null)
                 return false;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -13,7 +13,6 @@ using osu.Framework.Timing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
-using osu.Game.Extensions;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -90,15 +90,15 @@ namespace osu.Game.Tests.Visual.Gameplay
             return almostEqual(actualInfo, expectedInfo);
         }
 
-        private static bool almostEqual(SkinnableInfo info, SkinnableInfo? other) =>
+        private static bool almostEqual(SkinnableDrawableInfo drawableInfo, SkinnableDrawableInfo? other) =>
             other != null
-            && info.Type == other.Type
-            && info.Anchor == other.Anchor
-            && info.Origin == other.Origin
-            && Precision.AlmostEquals(info.Position, other.Position, 1)
-            && Precision.AlmostEquals(info.Scale, other.Scale)
-            && Precision.AlmostEquals(info.Rotation, other.Rotation)
-            && info.Children.SequenceEqual(other.Children, new FuncEqualityComparer<SkinnableInfo>(almostEqual));
+            && drawableInfo.Type == other.Type
+            && drawableInfo.Anchor == other.Anchor
+            && drawableInfo.Origin == other.Origin
+            && Precision.AlmostEquals(drawableInfo.Position, other.Position, 1)
+            && Precision.AlmostEquals(drawableInfo.Scale, other.Scale)
+            && Precision.AlmostEquals(drawableInfo.Rotation, other.Rotation)
+            && drawableInfo.Children.SequenceEqual(other.Children, new FuncEqualityComparer<SkinnableDrawableInfo>(almostEqual));
 
         protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
             => new CustomSkinWorkingBeatmap(beatmap, storyboard, Clock, Audio, currentBeatmapSkin);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -19,7 +19,6 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             if (actualComponentsContainer == null)
                 return false;
 
-            var actualInfo = actualComponentsContainer.CreateSkinnableInfo();
+            var actualInfo = actualComponentsContainer.CreateSerialisedInfo();
 
             var expectedComponentsContainer = expectedSource.GetDrawableComponent(new GlobalSkinComponentLookup(target)) as Container;
             if (expectedComponentsContainer == null)
@@ -84,13 +84,13 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             Add(expectedComponentsAdjustmentContainer);
             expectedComponentsAdjustmentContainer.UpdateSubTree();
-            var expectedInfo = expectedComponentsContainer.CreateSkinnableInfo();
+            var expectedInfo = expectedComponentsContainer.CreateSerialisedInfo();
             Remove(expectedComponentsAdjustmentContainer, true);
 
             return almostEqual(actualInfo, expectedInfo);
         }
 
-        private static bool almostEqual(SkinnableDrawableInfo drawableInfo, SkinnableDrawableInfo? other) =>
+        private static bool almostEqual(SerialisedDrawableInfo drawableInfo, SerialisedDrawableInfo? other) =>
             other != null
             && drawableInfo.Type == other.Type
             && drawableInfo.Anchor == other.Anchor
@@ -98,7 +98,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             && Precision.AlmostEquals(drawableInfo.Position, other.Position, 1)
             && Precision.AlmostEquals(drawableInfo.Scale, other.Scale)
             && Precision.AlmostEquals(drawableInfo.Rotation, other.Rotation)
-            && drawableInfo.Children.SequenceEqual(other.Children, new FuncEqualityComparer<SkinnableDrawableInfo>(almostEqual));
+            && drawableInfo.Children.SequenceEqual(other.Children, new FuncEqualityComparer<SerialisedDrawableInfo>(almostEqual));
 
         protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
             => new CustomSkinWorkingBeatmap(beatmap, storyboard, Clock, Audio, currentBeatmapSkin);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -235,8 +235,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             createNew();
 
             AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
-            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().Alpha == 0);
-            AddUntilStep("wait for hud load", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
+            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Alpha == 0);
+            AddUntilStep("wait for hud load", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().All(c => c.ComponentsLoaded));
 
             AddStep("bind on update", () =>
             {
@@ -254,10 +254,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             createNew();
 
             AddUntilStep("wait for hud load", () => hudOverlay.IsLoaded);
-            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().Alpha == 0);
+            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Alpha == 0);
 
-            AddStep("reload components", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().Reload());
-            AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinnableTargetContainer>().Single().ComponentsLoaded);
+            AddStep("reload components", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Reload());
+            AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().ComponentsLoaded);
         }
 
         private void createNew(Action<HUDOverlay>? action = null)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             base.SetUpSteps();
 
-            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableTargetContainer>().All(c => c.ComponentsLoaded));
+            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinComponentsContainer>().All(c => c.ComponentsLoaded));
 
             AddStep("reload skin editor", () =>
             {

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -1,11 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Game.Configuration;
-using osu.Game.Skinning;
 using osuTK;
 
 namespace osu.Game.Extensions
@@ -47,42 +43,5 @@ namespace osu.Game.Extensions
         /// <returns>The delta vector in Parent's coordinates.</returns>
         public static Vector2 ScreenSpaceDeltaToParentSpace(this Drawable drawable, Vector2 delta) =>
             drawable.Parent.ToLocalSpace(drawable.Parent.ToScreenSpace(Vector2.Zero) + delta);
-
-        public static SerialisedDrawableInfo CreateSerialisedInfo(this Drawable component) => new SerialisedDrawableInfo(component);
-
-        public static void ApplySerialisedInfo(this Drawable component, SerialisedDrawableInfo drawableInfo)
-        {
-            // todo: can probably make this better via deserialisation directly using a common interface.
-            component.Position = drawableInfo.Position;
-            component.Rotation = drawableInfo.Rotation;
-            component.Scale = drawableInfo.Scale;
-            component.Anchor = drawableInfo.Anchor;
-            component.Origin = drawableInfo.Origin;
-
-            if (component is ISerialisableDrawable skinnable)
-            {
-                skinnable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
-
-                foreach (var (_, property) in component.GetSettingsSourceProperties())
-                {
-                    var bindable = ((IBindable)property.GetValue(component)!);
-
-                    if (!drawableInfo.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
-                    {
-                        // TODO: We probably want to restore default if not included in serialisation information.
-                        // This is not simple to do as SetDefault() is only found in the typed Bindable<T> interface right now.
-                        continue;
-                    }
-
-                    skinnable.CopyAdjustedSetting(bindable, settingValue);
-                }
-            }
-
-            if (component is Container container)
-            {
-                foreach (var child in drawableInfo.Children)
-                    container.Add(child.CreateInstance());
-            }
-        }
     }
 }

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -48,9 +48,9 @@ namespace osu.Game.Extensions
         public static Vector2 ScreenSpaceDeltaToParentSpace(this Drawable drawable, Vector2 delta) =>
             drawable.Parent.ToLocalSpace(drawable.Parent.ToScreenSpace(Vector2.Zero) + delta);
 
-        public static SkinnableDrawableInfo CreateSkinnableInfo(this Drawable component) => new SkinnableDrawableInfo(component);
+        public static SerialisedDrawableInfo CreateSerialisedInfo(this Drawable component) => new SerialisedDrawableInfo(component);
 
-        public static void ApplySkinnableInfo(this Drawable component, SkinnableDrawableInfo drawableInfo)
+        public static void ApplySerialisedInfo(this Drawable component, SerialisedDrawableInfo drawableInfo)
         {
             // todo: can probably make this better via deserialisation directly using a common interface.
             component.Position = drawableInfo.Position;

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -5,7 +5,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osuTK;
 

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Extensions
             component.Anchor = drawableInfo.Anchor;
             component.Origin = drawableInfo.Origin;
 
-            if (component is ISkinnableDrawable skinnable)
+            if (component is ISerialisableDrawable skinnable)
             {
                 skinnable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
 

--- a/osu.Game/Extensions/DrawableExtensions.cs
+++ b/osu.Game/Extensions/DrawableExtensions.cs
@@ -48,26 +48,26 @@ namespace osu.Game.Extensions
         public static Vector2 ScreenSpaceDeltaToParentSpace(this Drawable drawable, Vector2 delta) =>
             drawable.Parent.ToLocalSpace(drawable.Parent.ToScreenSpace(Vector2.Zero) + delta);
 
-        public static SkinnableInfo CreateSkinnableInfo(this Drawable component) => new SkinnableInfo(component);
+        public static SkinnableDrawableInfo CreateSkinnableInfo(this Drawable component) => new SkinnableDrawableInfo(component);
 
-        public static void ApplySkinnableInfo(this Drawable component, SkinnableInfo info)
+        public static void ApplySkinnableInfo(this Drawable component, SkinnableDrawableInfo drawableInfo)
         {
             // todo: can probably make this better via deserialisation directly using a common interface.
-            component.Position = info.Position;
-            component.Rotation = info.Rotation;
-            component.Scale = info.Scale;
-            component.Anchor = info.Anchor;
-            component.Origin = info.Origin;
+            component.Position = drawableInfo.Position;
+            component.Rotation = drawableInfo.Rotation;
+            component.Scale = drawableInfo.Scale;
+            component.Anchor = drawableInfo.Anchor;
+            component.Origin = drawableInfo.Origin;
 
             if (component is ISkinnableDrawable skinnable)
             {
-                skinnable.UsesFixedAnchor = info.UsesFixedAnchor;
+                skinnable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
 
                 foreach (var (_, property) in component.GetSettingsSourceProperties())
                 {
                     var bindable = ((IBindable)property.GetValue(component)!);
 
-                    if (!info.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
+                    if (!drawableInfo.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
                     {
                         // TODO: We probably want to restore default if not included in serialisation information.
                         // This is not simple to do as SetDefault() is only found in the typed Bindable<T> interface right now.
@@ -80,7 +80,7 @@ namespace osu.Game.Extensions
 
             if (component is Container container)
             {
-                foreach (var child in info.Children)
+                foreach (var child in drawableInfo.Children)
                     container.Add(child.CreateInstance());
             }
         }

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -17,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Overlays.SkinEditor
 {
-    public partial class SkinBlueprint : SelectionBlueprint<ISkinnableDrawable>
+    public partial class SkinBlueprint : SelectionBlueprint<ISerialisableDrawable>
     {
         private Container box = null!;
 
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.SkinEditor
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        public SkinBlueprint(ISkinnableDrawable component)
+        public SkinBlueprint(ISerialisableDrawable component)
             : base(component)
         {
         }

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -24,11 +24,11 @@ using osuTK.Input;
 
 namespace osu.Game.Overlays.SkinEditor
 {
-    public partial class SkinBlueprintContainer : BlueprintContainer<ISkinnableDrawable>
+    public partial class SkinBlueprintContainer : BlueprintContainer<ISerialisableDrawable>
     {
         private readonly Drawable target;
 
-        private readonly List<BindableList<ISkinnableDrawable>> targetComponents = new List<BindableList<ISkinnableDrawable>>();
+        private readonly List<BindableList<ISerialisableDrawable>> targetComponents = new List<BindableList<ISerialisableDrawable>>();
 
         [Resolved]
         private SkinEditor editor { get; set; } = null!;
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             foreach (var targetContainer in targetContainers)
             {
-                var bindableList = new BindableList<ISkinnableDrawable> { BindTarget = targetContainer.Components };
+                var bindableList = new BindableList<ISerialisableDrawable> { BindTarget = targetContainer.Components };
                 bindableList.BindCollectionChanged(componentsChanged, true);
 
                 targetComponents.Add(bindableList);
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays.SkinEditor
                 case NotifyCollectionChangedAction.Add:
                     Debug.Assert(e.NewItems != null);
 
-                    foreach (var item in e.NewItems.Cast<ISkinnableDrawable>())
+                    foreach (var item in e.NewItems.Cast<ISerialisableDrawable>())
                         AddBlueprintFor(item);
                     break;
 
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.SkinEditor
                 case NotifyCollectionChangedAction.Reset:
                     Debug.Assert(e.OldItems != null);
 
-                    foreach (var item in e.OldItems.Cast<ISkinnableDrawable>())
+                    foreach (var item in e.OldItems.Cast<ISerialisableDrawable>())
                         RemoveBlueprintFor(item);
                     break;
 
@@ -85,16 +85,16 @@ namespace osu.Game.Overlays.SkinEditor
                     Debug.Assert(e.NewItems != null);
                     Debug.Assert(e.OldItems != null);
 
-                    foreach (var item in e.OldItems.Cast<ISkinnableDrawable>())
+                    foreach (var item in e.OldItems.Cast<ISerialisableDrawable>())
                         RemoveBlueprintFor(item);
 
-                    foreach (var item in e.NewItems.Cast<ISkinnableDrawable>())
+                    foreach (var item in e.NewItems.Cast<ISerialisableDrawable>())
                         AddBlueprintFor(item);
                     break;
             }
         });
 
-        protected override void AddBlueprintFor(ISkinnableDrawable item)
+        protected override void AddBlueprintFor(ISerialisableDrawable item)
         {
             if (!item.IsEditable)
                 return;
@@ -145,12 +145,12 @@ namespace osu.Game.Overlays.SkinEditor
             // convert to game space coordinates
             delta = firstBlueprint.ToScreenSpace(delta) - firstBlueprint.ToScreenSpace(Vector2.Zero);
 
-            SelectionHandler.HandleMovement(new MoveSelectionEvent<ISkinnableDrawable>(firstBlueprint, delta));
+            SelectionHandler.HandleMovement(new MoveSelectionEvent<ISerialisableDrawable>(firstBlueprint, delta));
         }
 
-        protected override SelectionHandler<ISkinnableDrawable> CreateSelectionHandler() => new SkinSelectionHandler();
+        protected override SelectionHandler<ISerialisableDrawable> CreateSelectionHandler() => new SkinSelectionHandler();
 
-        protected override SelectionBlueprint<ISkinnableDrawable> CreateBlueprintFor(ISkinnableDrawable component)
+        protected override SelectionBlueprint<ISerialisableDrawable> CreateBlueprintFor(ISerialisableDrawable component)
             => new SkinBlueprint(component);
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Overlays.SkinEditor
             SelectedItems.BindTo(editor.SelectedComponents);
 
             // track each target container on the current screen.
-            var targetContainers = target.ChildrenOfType<ISkinnableTarget>().ToArray();
+            var targetContainers = target.ChildrenOfType<ISerialisableDrawableContainer>().ToArray();
 
             if (targetContainers.Length == 0)
             {

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.SkinEditor
         {
             fill.Clear();
 
-            var skinnableTypes = SkinnableInfo.GetAllAvailableDrawables();
+            var skinnableTypes = SkinnableDrawableInfo.GetAllAvailableDrawables(target?.Ruleset);
             foreach (var type in skinnableTypes)
                 attemptAddComponent(type);
         }

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -10,9 +10,7 @@ using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Localisation;
 using osu.Game.Screens.Edit.Components;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osuTK;
 

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -10,6 +10,7 @@ using osu.Framework.Logging;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Skinning;
 using osuTK;
@@ -48,7 +49,7 @@ namespace osu.Game.Overlays.SkinEditor
         {
             fill.Clear();
 
-            var skinnableTypes = SkinnableDrawableInfo.GetAllAvailableDrawables(target?.Ruleset);
+            var skinnableTypes = SerialisedDrawableInfo.GetAllAvailableDrawables();
             foreach (var type in skinnableTypes)
                 attemptAddComponent(type);
         }

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 Drawable instance = (Drawable)Activator.CreateInstance(type)!;
 
-                if (!((ISkinnableDrawable)instance).IsEditable) return;
+                if (!((ISerialisableDrawable)instance).IsEditable) return;
 
                 fill.Add(new ToolboxComponentButton(instance, target)
                 {

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         public const float MENU_HEIGHT = 40;
 
-        public readonly BindableList<ISkinnableDrawable> SelectedComponents = new BindableList<ISkinnableDrawable>();
+        public readonly BindableList<ISerialisableDrawable> SelectedComponents = new BindableList<ISerialisableDrawable>();
 
         protected override bool StartHidden => true;
 
@@ -302,13 +302,13 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void placeComponent(Type type)
         {
-            if (!(Activator.CreateInstance(type) is ISkinnableDrawable component))
-                throw new InvalidOperationException($"Attempted to instantiate a component for placement which was not an {typeof(ISkinnableDrawable)}.");
+            if (!(Activator.CreateInstance(type) is ISerialisableDrawable component))
+                throw new InvalidOperationException($"Attempted to instantiate a component for placement which was not an {typeof(ISerialisableDrawable)}.");
 
             placeComponent(component);
         }
 
-        private void placeComponent(ISkinnableDrawable component, bool applyDefaults = true)
+        private void placeComponent(ISerialisableDrawable component, bool applyDefaults = true)
         {
             var targetContainer = getFirstTarget();
 
@@ -400,7 +400,7 @@ namespace osu.Game.Overlays.SkinEditor
             this.FadeOut(TRANSITION_DURATION, Easing.OutQuint);
         }
 
-        public void DeleteItems(ISkinnableDrawable[] items)
+        public void DeleteItems(ISerialisableDrawable[] items)
         {
             foreach (var item in items)
                 availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -339,7 +339,7 @@ namespace osu.Game.Overlays.SkinEditor
                 settingsSidebar.Add(new SkinSettingsToolbox(component));
         }
 
-        private IEnumerable<ISerialisableDrawableContainer> availableTargets => targetScreen.ChildrenOfType<ISerialisableDrawableContainer>();
+        private IEnumerable<SkinnableTargetContainer> availableTargets => targetScreen.ChildrenOfType<SkinnableTargetContainer>();
 
         private ISerialisableDrawableContainer? getFirstTarget() => availableTargets.FirstOrDefault();
 
@@ -350,7 +350,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void revert()
         {
-            ISerialisableDrawableContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableTargetContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
             {
@@ -370,7 +370,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (!hasBegunMutating)
                 return;
 
-            ISerialisableDrawableContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableTargetContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
                 currentSkin.Value.UpdateDrawableTarget(t);

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -339,25 +339,25 @@ namespace osu.Game.Overlays.SkinEditor
                 settingsSidebar.Add(new SkinSettingsToolbox(component));
         }
 
-        private IEnumerable<SkinnableTargetContainer> availableTargets => targetScreen.ChildrenOfType<SkinnableTargetContainer>();
+        private IEnumerable<SkinComponentsContainer> availableTargets => targetScreen.ChildrenOfType<SkinComponentsContainer>();
 
         private ISerialisableDrawableContainer? getFirstTarget() => availableTargets.FirstOrDefault();
 
-        private ISerialisableDrawableContainer? getTarget(GlobalSkinComponentLookup.LookupType target)
+        private ISerialisableDrawableContainer? getTarget(SkinComponentsContainerLookup.TargetArea target)
         {
-            return availableTargets.FirstOrDefault(c => c.Target == target);
+            return availableTargets.FirstOrDefault(c => c.Lookup.Target == target);
         }
 
         private void revert()
         {
-            SkinnableTargetContainer[] targetContainers = availableTargets.ToArray();
+            SkinComponentsContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
             {
                 currentSkin.Value.ResetDrawableTarget(t);
 
                 // add back default components
-                getTarget(t.Target)?.Reload();
+                getTarget(t.Lookup.Target)?.Reload();
             }
         }
 
@@ -370,7 +370,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (!hasBegunMutating)
                 return;
 
-            SkinnableTargetContainer[] targetContainers = availableTargets.ToArray();
+            SkinComponentsContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
                 currentSkin.Value.UpdateDrawableTarget(t);

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -339,18 +339,18 @@ namespace osu.Game.Overlays.SkinEditor
                 settingsSidebar.Add(new SkinSettingsToolbox(component));
         }
 
-        private IEnumerable<ISkinnableTarget> availableTargets => targetScreen.ChildrenOfType<ISkinnableTarget>();
+        private IEnumerable<ISerialisableDrawableContainer> availableTargets => targetScreen.ChildrenOfType<ISerialisableDrawableContainer>();
 
-        private ISkinnableTarget? getFirstTarget() => availableTargets.FirstOrDefault();
+        private ISerialisableDrawableContainer? getFirstTarget() => availableTargets.FirstOrDefault();
 
-        private ISkinnableTarget? getTarget(GlobalSkinComponentLookup.LookupType target)
+        private ISerialisableDrawableContainer? getTarget(GlobalSkinComponentLookup.LookupType target)
         {
             return availableTargets.FirstOrDefault(c => c.Target == target);
         }
 
         private void revert()
         {
-            ISkinnableTarget[] targetContainers = availableTargets.ToArray();
+            ISerialisableDrawableContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
             {
@@ -370,7 +370,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (!hasBegunMutating)
                 return;
 
-            ISkinnableTarget[] targetContainers = availableTargets.ToArray();
+            ISerialisableDrawableContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
                 currentSkin.Value.UpdateDrawableTarget(t);

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Overlays.SkinEditor
 {
     public partial class SkinEditorChangeHandler : EditorChangeHandler
     {
-        private readonly ISkinnableTarget? firstTarget;
+        private readonly ISerialisableDrawableContainer? firstTarget;
 
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly BindableList<ISerialisableDrawable>? components;
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.SkinEditor
             // In the future we'll want this to cover all changes, even to skin's `InstantiationInfo`.
             // We'll also need to consider cases where multiple targets are on screen at the same time.
 
-            firstTarget = targetScreen.ChildrenOfType<ISkinnableTarget>().FirstOrDefault();
+            firstTarget = targetScreen.ChildrenOfType<ISerialisableDrawableContainer>().FirstOrDefault();
 
             if (firstTarget == null)
                 return;

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (firstTarget == null)
                 return;
 
-            var skinnableInfos = firstTarget.CreateSkinnableInfo().ToArray();
+            var skinnableInfos = firstTarget.CreateSerialisedInfo().ToArray();
             string json = JsonConvert.SerializeObject(skinnableInfos, new JsonSerializerSettings { Formatting = Formatting.Indented });
             stream.Write(Encoding.UTF8.GetBytes(json));
         }
@@ -52,12 +52,12 @@ namespace osu.Game.Overlays.SkinEditor
             if (firstTarget == null)
                 return;
 
-            var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SkinnableDrawableInfo>>(Encoding.UTF8.GetString(newState));
+            var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(newState));
 
             if (deserializedContent == null)
                 return;
 
-            SkinnableDrawableInfo[] skinnableInfo = deserializedContent.ToArray();
+            SerialisedDrawableInfo[] skinnableInfo = deserializedContent.ToArray();
             Drawable[] targetComponents = firstTarget.Components.OfType<Drawable>().ToArray();
 
             if (!skinnableInfo.Select(s => s.Type).SequenceEqual(targetComponents.Select(d => d.GetType())))
@@ -70,7 +70,7 @@ namespace osu.Game.Overlays.SkinEditor
                 int i = 0;
 
                 foreach (var drawable in targetComponents)
-                    drawable.ApplySkinnableInfo(skinnableInfo[i++]);
+                    drawable.ApplySerialisedInfo(skinnableInfo[i++]);
             }
         }
     }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
-using osu.Game.Extensions;
 using osu.Game.Screens.Edit;
 using osu.Game.Skinning;
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.SkinEditor
         private readonly ISkinnableTarget? firstTarget;
 
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        private readonly BindableList<ISkinnableDrawable>? components;
+        private readonly BindableList<ISerialisableDrawable>? components;
 
         public SkinEditorChangeHandler(Drawable targetScreen)
         {
@@ -33,7 +33,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (firstTarget == null)
                 return;
 
-            components = new BindableList<ISkinnableDrawable> { BindTarget = firstTarget.Components };
+            components = new BindableList<ISerialisableDrawable> { BindTarget = firstTarget.Components };
             components.BindCollectionChanged((_, _) => SaveState());
         }
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Extensions;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 
 namespace osu.Game.Overlays.SkinEditor

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -52,12 +52,12 @@ namespace osu.Game.Overlays.SkinEditor
             if (firstTarget == null)
                 return;
 
-            var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SkinnableInfo>>(Encoding.UTF8.GetString(newState));
+            var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SkinnableDrawableInfo>>(Encoding.UTF8.GetString(newState));
 
             if (deserializedContent == null)
                 return;
 
-            SkinnableInfo[] skinnableInfo = deserializedContent.ToArray();
+            SkinnableDrawableInfo[] skinnableInfo = deserializedContent.ToArray();
             Drawable[] targetComponents = firstTarget.Components.OfType<Drawable>().ToArray();
 
             if (!skinnableInfo.Select(s => s.Type).SequenceEqual(targetComponents.Select(d => d.GetType())))

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -19,7 +19,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.SkinEditor
 {
-    public partial class SkinSelectionHandler : SelectionHandler<ISkinnableDrawable>
+    public partial class SkinSelectionHandler : SelectionHandler<ISerialisableDrawable>
     {
         [Resolved]
         private SkinEditor skinEditor { get; set; } = null!;
@@ -147,7 +147,7 @@ namespace osu.Game.Overlays.SkinEditor
             return true;
         }
 
-        public override bool HandleMovement(MoveSelectionEvent<ISkinnableDrawable> moveEvent)
+        public override bool HandleMovement(MoveSelectionEvent<ISerialisableDrawable> moveEvent)
         {
             foreach (var c in SelectedBlueprints)
             {
@@ -178,10 +178,10 @@ namespace osu.Game.Overlays.SkinEditor
             SelectionBox.CanReverse = false;
         }
 
-        protected override void DeleteItems(IEnumerable<ISkinnableDrawable> items) =>
+        protected override void DeleteItems(IEnumerable<ISerialisableDrawable> items) =>
             skinEditor.DeleteItems(items.ToArray());
 
-        protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<ISkinnableDrawable>> selection)
+        protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<ISerialisableDrawable>> selection)
         {
             var closestItem = new TernaryStateRadioMenuItem("Closest", MenuItemType.Standard, _ => applyClosestAnchors())
             {
@@ -209,7 +209,7 @@ namespace osu.Game.Overlays.SkinEditor
             foreach (var item in base.GetContextMenuItemsForSelection(selection))
                 yield return item;
 
-            IEnumerable<TernaryStateMenuItem> createAnchorItems(Func<ISkinnableDrawable, Anchor, bool> checkFunction, Action<Anchor> applyFunction)
+            IEnumerable<TernaryStateMenuItem> createAnchorItems(Func<ISerialisableDrawable, Anchor, bool> checkFunction, Action<Anchor> applyFunction)
             {
                 var displayableAnchors = new[]
                 {

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -16,7 +16,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class BPMCounter : RollingCounter<double>, ISkinnableDrawable
+    public partial class BPMCounter : RollingCounter<double>, ISerialisableDrawable
     {
         protected override double RollingDuration => 750;
 

--- a/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
@@ -14,7 +14,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
 {
-    public partial class ClicksPerSecondCounter : RollingCounter<int>, ISkinnableDrawable
+    public partial class ClicksPerSecondCounter : RollingCounter<int>, ISerialisableDrawable
     {
         [Resolved]
         private ClicksPerSecondCalculator calculator { get; set; } = null!;

--- a/osu.Game/Screens/Play/HUD/ComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ComboCounter.cs
@@ -7,7 +7,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public abstract partial class ComboCounter : RollingCounter<int>, ISkinnableDrawable
+    public abstract partial class ComboCounter : RollingCounter<int>, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUD/DefaultAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultAccuracyCounter.cs
@@ -9,7 +9,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class DefaultAccuracyCounter : GameplayAccuracyCounter, ISkinnableDrawable
+    public partial class DefaultAccuracyCounter : GameplayAccuracyCounter, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
@@ -19,7 +19,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class DefaultHealthDisplay : HealthDisplay, IHasAccentColour, ISkinnableDrawable
+    public partial class DefaultHealthDisplay : HealthDisplay, IHasAccentColour, ISerialisableDrawable
     {
         /// <summary>
         /// The base opacity of the glow.

--- a/osu.Game/Screens/Play/HUD/DefaultScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultScoreCounter.cs
@@ -10,7 +10,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class DefaultScoreCounter : GameplayScoreCounter, ISkinnableDrawable
+    public partial class DefaultScoreCounter : GameplayScoreCounter, ISerialisableDrawable
     {
         public DefaultScoreCounter()
         {

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/HitErrorMeter.cs
@@ -14,7 +14,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 {
-    public abstract partial class HitErrorMeter : CompositeDrawable, ISkinnableDrawable
+    public abstract partial class HitErrorMeter : CompositeDrawable, ISerialisableDrawable
     {
         protected HitWindows HitWindows { get; private set; }
 

--- a/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.HUD.JudgementCounter
 {
-    public partial class JudgementCounterDisplay : CompositeDrawable, ISkinnableDrawable
+    public partial class JudgementCounterDisplay : CompositeDrawable, ISerialisableDrawable
     {
         public const int TRANSFORM_DURATION = 250;
 

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -35,7 +35,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class PerformancePointsCounter : RollingCounter<int>, ISkinnableDrawable
+    public partial class PerformancePointsCounter : RollingCounter<int>, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUD/SongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgress.cs
@@ -14,7 +14,7 @@ using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public abstract partial class SongProgress : OverlayContainer, ISkinnableDrawable
+    public abstract partial class SongProgress : OverlayContainer, ISerialisableDrawable
     {
         // Some implementations of this element allow seeking during gameplay playback.
         // Set a sane default of never handling input to override the behaviour provided by OverlayContainer.

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -20,7 +20,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.HUD
 {
-    public partial class UnstableRateCounter : RollingCounter<int>, ISkinnableDrawable
+    public partial class UnstableRateCounter : RollingCounter<int>, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Play
 
         private readonly BindableBool holdingForHUD = new BindableBool();
 
-        private readonly SkinnableTargetContainer mainComponents;
+        private readonly SkinComponentsContainer mainComponents;
 
         /// <summary>
         /// A flow which sits at the left side of the screen to house leaderboard (and related) components.
@@ -390,7 +390,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private partial class MainComponentsContainer : SkinnableTargetContainer
+        private partial class MainComponentsContainer : SkinComponentsContainer
         {
             private Bindable<ScoringMode> scoringMode;
 
@@ -398,7 +398,7 @@ namespace osu.Game.Screens.Play
             private OsuConfigManager config { get; set; }
 
             public MainComponentsContainer()
-                : base(GlobalSkinComponentLookup.LookupType.MainHUDComponents)
+                : base(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.MainHUDComponents))
             {
                 RelativeSizeAxes = Axes.Both;
             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -273,7 +273,7 @@ namespace osu.Game.Screens.Select
                         }
                     }
                 },
-                new SkinnableTargetContainer(GlobalSkinComponentLookup.LookupType.SongSelect)
+                new SkinComponentsContainer(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.SongSelect))
                 {
                     RelativeSizeAxes = Axes.Both,
                 },

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -90,8 +90,8 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup componentLookup:
-                    switch (componentLookup.Target)
+                case SkinComponentsContainerLookup containerLookup:
+                    switch (containerLookup.Target)
                     {
                         case SkinComponentsContainerLookup.TargetArea.SongSelect:
                             var songSelectComponents = new DefaultSkinComponentsContainer(_ =>

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -90,10 +90,10 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case GlobalSkinComponentLookup globalLookup:
-                    switch (globalLookup.Lookup)
+                case SkinComponentsContainerLookup componentLookup:
+                    switch (componentLookup.Target)
                     {
-                        case GlobalSkinComponentLookup.LookupType.SongSelect:
+                        case SkinComponentsContainerLookup.TargetArea.SongSelect:
                             var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
                             {
                                 // do stuff when we need to.
@@ -101,7 +101,7 @@ namespace osu.Game.Skinning
 
                             return songSelectComponents;
 
-                        case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
+                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                             var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();

--- a/osu.Game/Skinning/Components/BigBlackBox.cs
+++ b/osu.Game/Skinning/Components/BigBlackBox.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning.Components
     /// Intended to be a test bed for skinning. May be removed at some point in the future.
     /// </summary>
     [UsedImplicitly]
-    public partial class BigBlackBox : CompositeDrawable, ISkinnableDrawable
+    public partial class BigBlackBox : CompositeDrawable, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Skinning/FontAdjustableSkinComponent.cs
+++ b/osu.Game/Skinning/FontAdjustableSkinComponent.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Skinning
     /// <summary>
     /// A skin component that contains text and allows the user to choose its font.
     /// </summary>
-    public abstract partial class FontAdjustableSkinComponent : Container, ISkinnableDrawable
+    public abstract partial class FontAdjustableSkinComponent : Container, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Skinning/GameplaySkinComponentLookup.cs
+++ b/osu.Game/Skinning/GameplaySkinComponentLookup.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Scoring;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A lookup typed intended for use for skinnable gameplay components (not HUD level components).
+    /// A lookup type intended for use for skinnable gameplay components (not HUD level components).
     /// </summary>
     /// <remarks>
     /// The most common usage of this class is for ruleset-specific skinning implementations, but it can also be used directly

--- a/osu.Game/Skinning/GameplaySkinComponentLookup.cs
+++ b/osu.Game/Skinning/GameplaySkinComponentLookup.cs
@@ -1,12 +1,23 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Skinning
 {
+    /// <summary>
+    /// A lookup typed intended for use for skinnable gameplay components (not HUD level components).
+    /// </summary>
+    /// <remarks>
+    /// The most common usage of this class is for ruleset-specific skinning implementations, but it can also be used directly
+    /// (see <see cref="DrawableJudgement"/>'s usage for <see cref="HitResult"/>) where ruleset-agnostic elements are required.
+    /// </remarks>
+    /// <typeparam name="T">An enum lookup type.</typeparam>
     public class GameplaySkinComponentLookup<T> : ISkinComponentLookup
-        where T : notnull
+        where T : Enum
     {
         public readonly T Component;
 
@@ -16,7 +27,7 @@ namespace osu.Game.Skinning
         }
 
         protected virtual string RulesetPrefix => string.Empty;
-        protected virtual string ComponentName => Component.ToString() ?? string.Empty;
+        protected virtual string ComponentName => Component.ToString();
 
         public string LookupName =>
             string.Join('/', new[] { "Gameplay", RulesetPrefix, ComponentName }.Where(s => !string.IsNullOrEmpty(s)));

--- a/osu.Game/Skinning/ISerialisableDrawable.cs
+++ b/osu.Game/Skinning/ISerialisableDrawable.cs
@@ -10,13 +10,14 @@ using osu.Game.Configuration;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A drawable which can be serialised to a skin, placed and customised via the skin layout editor.
+    /// A drawable which is intended to be serialised to <see cref="SerialisedDrawableInfo"/>.
     /// </summary>
     /// <remarks>
-    /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable to user skins (see <see cref="SkinImporter.Save"/>).
-    /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also allow serialising settings automatically.
+    /// This is currently used exclusively for serialisation to a skin, and leaned on heavily to allow placement and customisation in the skin layout editor.
+    /// That said, it is intended to be flexible enough to potentially be used in other places we want to serialise drawables in the future.
     ///
-    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="SerialisableDrawableExtensions.CreateSerialisedInfo"/>.
+    /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable via <see cref="SerialisableDrawableExtensions.CreateSerialisedInfo"/>.
+    /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also allow serialising settings automatically.
     /// </remarks>
     public interface ISerialisableDrawable : IDrawable
     {

--- a/osu.Game/Skinning/ISerialisableDrawable.cs
+++ b/osu.Game/Skinning/ISerialisableDrawable.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Skinning
     /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable to user skins (see <see cref="SkinImporter.Save"/>).
     /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also allow serialising settings automatically.
     ///
-    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="osu.Game.Extensions.DrawableExtensions.CreateSerialisedInfo"/>.
+    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="SerialisableDrawableExtensions.CreateSerialisedInfo"/>.
     /// </remarks>
     public interface ISerialisableDrawable : IDrawable
     {

--- a/osu.Game/Skinning/ISerialisableDrawable.cs
+++ b/osu.Game/Skinning/ISerialisableDrawable.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Skinning
     ///
     /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="osu.Game.Extensions.DrawableExtensions.CreateSerialisedInfo"/>.
     /// </remarks>
-    public interface ISkinnableDrawable : IDrawable
+    public interface ISerialisableDrawable : IDrawable
     {
         /// <summary>
         /// Whether this component should be editable by an end user.
@@ -26,8 +26,8 @@ namespace osu.Game.Skinning
         bool IsEditable => true;
 
         /// <summary>
-        /// In the context of the skin layout editor, whether this <see cref="ISkinnableDrawable"/> has a permanent anchor defined.
-        /// If <see langword="false"/>, this <see cref="ISkinnableDrawable"/>'s <see cref="Drawable.Anchor"/> is automatically determined by proximity,
+        /// In the context of the skin layout editor, whether this <see cref="ISerialisableDrawable"/> has a permanent anchor defined.
+        /// If <see langword="false"/>, this <see cref="ISerialisableDrawable"/>'s <see cref="Drawable.Anchor"/> is automatically determined by proximity,
         /// If <see langword="true"/>, a fixed anchor point has been defined.
         /// </summary>
         bool UsesFixedAnchor { get; set; }

--- a/osu.Game/Skinning/ISerialisableDrawableContainer.cs
+++ b/osu.Game/Skinning/ISerialisableDrawableContainer.cs
@@ -16,11 +16,6 @@ namespace osu.Game.Skinning
     public interface ISerialisableDrawableContainer : IDrawable
     {
         /// <summary>
-        /// The definition of this target.
-        /// </summary>
-        GlobalSkinComponentLookup.LookupType Target { get; }
-
-        /// <summary>
         /// A bindable list of components which are being tracked by this skinnable target.
         /// </summary>
         IBindableList<ISerialisableDrawable> Components { get; }

--- a/osu.Game/Skinning/ISerialisableDrawableContainer.cs
+++ b/osu.Game/Skinning/ISerialisableDrawableContainer.cs
@@ -10,9 +10,10 @@ using osu.Game.Extensions;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Denotes a container which can house <see cref="ISerialisableDrawable"/>s.
+    /// A container which can house <see cref="ISerialisableDrawable"/>s.
+    /// Contains functionality for new drawables to be added, removed, and reloaded from provided <see cref="SerialisedDrawableInfo"/>.
     /// </summary>
-    public interface ISkinnableTarget : IDrawable
+    public interface ISerialisableDrawableContainer : IDrawable
     {
         /// <summary>
         /// The definition of this target.

--- a/osu.Game/Skinning/ISerialisableDrawableContainer.cs
+++ b/osu.Game/Skinning/ISerialisableDrawableContainer.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Extensions;
 
 namespace osu.Game.Skinning
 {

--- a/osu.Game/Skinning/ISkin.cs
+++ b/osu.Game/Skinning/ISkin.cs
@@ -10,7 +10,7 @@ using osu.Game.Audio;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Provides access to skinnable elements.
+    /// Provides access to various elements contained by a skin.
     /// </summary>
     public interface ISkin
     {

--- a/osu.Game/Skinning/ISkinComponentLookup.cs
+++ b/osu.Game/Skinning/ISkinComponentLookup.cs
@@ -4,7 +4,8 @@
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A lookup type which can be used with <see cref="ISkin.GetDrawableComponent"/>.
+    /// The base lookup type to be used with <see cref="ISkin.GetDrawableComponent"/>.
+    /// Should be implemented as necessary to add further criteria to lookups, which are usually consumed by ruleset transformers or legacy lookup cases.
     /// </summary>
     /// <remarks>
     /// Implementations of <see cref="ISkin.GetDrawableComponent"/> should match on types implementing this interface

--- a/osu.Game/Skinning/ISkinSource.cs
+++ b/osu.Game/Skinning/ISkinSource.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// An abstract skin implementation which generally provides access to more than one skins (with fallback logic).
+    /// An abstract skin implementation, whose primary purpose is to properly handle component fallback across multiple layers of skins (e.g.: beatmap skin, user skin, default skin).
     /// </summary>
     /// <remarks>
     /// Common usage is to do an initial lookup via <see cref="FindProvider"/>, and use the returned <see cref="ISkin"/>

--- a/osu.Game/Skinning/ISkinSource.cs
+++ b/osu.Game/Skinning/ISkinSource.cs
@@ -7,8 +7,16 @@ using System.Collections.Generic;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Provides access to skinnable elements.
+    /// An abstract skin implementation which generally provides access to more than one skins (with fallback logic).
     /// </summary>
+    /// <remarks>
+    /// Common usage is to do an initial lookup via <see cref="FindProvider"/>, and use the returned <see cref="ISkin"/>
+    /// to do further lookups for related components.
+    ///
+    /// The initial lookup is used to lock consecutive lookups to the same underlying skin source (as to not get some elements
+    /// from one skin and others from another, which would be the case if using <see cref="ISkin"/> methods like
+    /// <see cref="ISkin.GetSample"/> directly).
+    /// </remarks>
     public interface ISkinSource : ISkin
     {
         /// <summary>

--- a/osu.Game/Skinning/ISkinnableDrawable.cs
+++ b/osu.Game/Skinning/ISkinnableDrawable.cs
@@ -10,13 +10,13 @@ using osu.Game.Configuration;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Denotes a drawable which, as a drawable, can be adjusted via skinning specifications.
+    /// A drawable which can be serialised to a skin, placed and customised via the skin layout editor.
     /// </summary>
     /// <remarks>
     /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable to user skins (see <see cref="SkinImporter.Save"/>).
     /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also allow serialising settings automatically.
     ///
-    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="Extensions.DrawableExtensions.CreateSerialisedInfo"/>.
+    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="osu.Game.Extensions.DrawableExtensions.CreateSerialisedInfo"/>.
     /// </remarks>
     public interface ISkinnableDrawable : IDrawable
     {

--- a/osu.Game/Skinning/ISkinnableDrawable.cs
+++ b/osu.Game/Skinning/ISkinnableDrawable.cs
@@ -13,8 +13,10 @@ namespace osu.Game.Skinning
     /// Denotes a drawable which, as a drawable, can be adjusted via skinning specifications.
     /// </summary>
     /// <remarks>
-    /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable to skin settings.
-    /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also serialise these settings alongside each instance.
+    /// Attaching this interface to any <see cref="IDrawable"/> will make it serialisable to user skins (see <see cref="SkinImporter.Save"/>).
+    /// Adding <see cref="SettingSourceAttribute"/> annotated bindables will also allow serialising settings automatically.
+    ///
+    /// Serialisation is done via <see cref="SerialisedDrawableInfo"/> using <see cref="Extensions.DrawableExtensions.CreateSerialisedInfo"/>.
     /// </remarks>
     public interface ISkinnableDrawable : IDrawable
     {

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Skinning
         /// Serialise all children as <see cref="SkinnableInfo"/>.
         /// </summary>
         /// <returns>The serialised content.</returns>
-        IEnumerable<SkinnableInfo> CreateSkinnableInfo() => Components.Select(d => ((Drawable)d).CreateSkinnableInfo());
+        IEnumerable<SkinnableDrawableInfo> CreateSkinnableInfo() => Components.Select(d => ((Drawable)d).CreateSkinnableInfo());
 
         /// <summary>
         /// Reload this target from the current skin.
@@ -39,7 +39,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Reload this target from the provided skinnable information.
         /// </summary>
-        void Reload(SkinnableInfo[] skinnableInfo);
+        void Reload(SkinnableDrawableInfo[] skinnableInfo);
 
         /// <summary>
         /// Add a new skinnable component to this target.

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Extensions;
-using osu.Game.Rulesets;
 
 namespace osu.Game.Skinning
 {
@@ -26,10 +25,10 @@ namespace osu.Game.Skinning
         IBindableList<ISkinnableDrawable> Components { get; }
 
         /// <summary>
-        /// Serialise all children as <see cref="SkinnableInfo"/>.
+        /// Serialise all children as <see cref="SerialisedDrawableInfo"/>.
         /// </summary>
         /// <returns>The serialised content.</returns>
-        IEnumerable<SkinnableDrawableInfo> CreateSkinnableInfo() => Components.Select(d => ((Drawable)d).CreateSkinnableInfo());
+        IEnumerable<SerialisedDrawableInfo> CreateSerialisedInfo() => Components.Select(d => ((Drawable)d).CreateSerialisedInfo());
 
         /// <summary>
         /// Reload this target from the current skin.
@@ -39,7 +38,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// Reload this target from the provided skinnable information.
         /// </summary>
-        void Reload(SkinnableDrawableInfo[] skinnableInfo);
+        void Reload(SerialisedDrawableInfo[] skinnableInfo);
 
         /// <summary>
         /// Add a new skinnable component to this target.

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Extensions;
-using osu.Game.Screens.Play.HUD;
+using osu.Game.Rulesets;
 
 namespace osu.Game.Skinning
 {

--- a/osu.Game/Skinning/ISkinnableTarget.cs
+++ b/osu.Game/Skinning/ISkinnableTarget.cs
@@ -10,7 +10,7 @@ using osu.Game.Extensions;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Denotes a container which can house <see cref="ISkinnableDrawable"/>s.
+    /// Denotes a container which can house <see cref="ISerialisableDrawable"/>s.
     /// </summary>
     public interface ISkinnableTarget : IDrawable
     {
@@ -22,7 +22,7 @@ namespace osu.Game.Skinning
         /// <summary>
         /// A bindable list of components which are being tracked by this skinnable target.
         /// </summary>
-        IBindableList<ISkinnableDrawable> Components { get; }
+        IBindableList<ISerialisableDrawable> Components { get; }
 
         /// <summary>
         /// Serialise all children as <see cref="SerialisedDrawableInfo"/>.
@@ -44,12 +44,12 @@ namespace osu.Game.Skinning
         /// Add a new skinnable component to this target.
         /// </summary>
         /// <param name="drawable">The component to add.</param>
-        void Add(ISkinnableDrawable drawable);
+        void Add(ISerialisableDrawable drawable);
 
         /// <summary>
         /// Remove an existing skinnable component from this target.
         /// </summary>
         /// <param name="component">The component to remove.</param>
-        void Remove(ISkinnableDrawable component);
+        void Remove(ISerialisableDrawable component);
     }
 }

--- a/osu.Game/Skinning/LegacyAccuracyCounter.cs
+++ b/osu.Game/Skinning/LegacyAccuracyCounter.cs
@@ -8,7 +8,7 @@ using osuTK;
 
 namespace osu.Game.Skinning
 {
-    public partial class LegacyAccuracyCounter : GameplayAccuracyCounter, ISkinnableDrawable
+    public partial class LegacyAccuracyCounter : GameplayAccuracyCounter, ISerialisableDrawable
     {
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Skinning
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is SkinComponentsContainerLookup targetComponent)
+            if (lookup is SkinComponentsContainerLookup containerLookup)
             {
-                switch (targetComponent.Target)
+                switch (containerLookup.Target)
                 {
                     case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                         // this should exist in LegacySkin instead, but there isn't a fallback skin for LegacySkins yet.

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -45,11 +45,11 @@ namespace osu.Game.Skinning
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is GlobalSkinComponentLookup targetComponent)
+            if (lookup is SkinComponentsContainerLookup targetComponent)
             {
-                switch (targetComponent.Lookup)
+                switch (targetComponent.Target)
                 {
-                    case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
+                    case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                         // this should exist in LegacySkin instead, but there isn't a fallback skin for LegacySkins yet.
                         // therefore keep the check here until fallback default legacy skin is supported.
                         if (!this.HasFont(LegacyFont.Score))

--- a/osu.Game/Skinning/LegacyComboCounter.cs
+++ b/osu.Game/Skinning/LegacyComboCounter.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Skinning
     /// <summary>
     /// Uses the 'x' symbol and has a pop-out effect while rolling over.
     /// </summary>
-    public partial class LegacyComboCounter : CompositeDrawable, ISkinnableDrawable
+    public partial class LegacyComboCounter : CompositeDrawable, ISerialisableDrawable
     {
         public Bindable<int> Current { get; } = new BindableInt { MinValue = 0 };
 

--- a/osu.Game/Skinning/LegacyComboCounter.cs
+++ b/osu.Game/Skinning/LegacyComboCounter.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Skinning
         private readonly Container counterContainer;
 
         /// <summary>
-        /// Hides the combo counter internally without affecting its <see cref="SkinnableDrawableInfo"/>.
+        /// Hides the combo counter internally without affecting its <see cref="SerialisedDrawableInfo"/>.
         /// </summary>
         /// <remarks>
         /// This is used for rulesets that provide their own combo counter and don't want this HUD one to be visible,

--- a/osu.Game/Skinning/LegacyComboCounter.cs
+++ b/osu.Game/Skinning/LegacyComboCounter.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Screens.Play.HUD;
 using osuTK;
 
 namespace osu.Game.Skinning

--- a/osu.Game/Skinning/LegacyComboCounter.cs
+++ b/osu.Game/Skinning/LegacyComboCounter.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Skinning
         private readonly Container counterContainer;
 
         /// <summary>
-        /// Hides the combo counter internally without affecting its <see cref="SkinnableInfo"/>.
+        /// Hides the combo counter internally without affecting its <see cref="SkinnableDrawableInfo"/>.
         /// </summary>
         /// <remarks>
         /// This is used for rulesets that provide their own combo counter and don't want this HUD one to be visible,

--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -19,7 +19,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Skinning
 {
-    public partial class LegacyHealthDisplay : HealthDisplay, ISkinnableDrawable
+    public partial class LegacyHealthDisplay : HealthDisplay, ISerialisableDrawable
     {
         private const double epic_cutoff = 0.5;
 

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -8,7 +8,7 @@ using osuTK;
 
 namespace osu.Game.Skinning
 {
-    public partial class LegacyScoreCounter : GameplayScoreCounter, ISkinnableDrawable
+    public partial class LegacyScoreCounter : GameplayScoreCounter, ISerialisableDrawable
     {
         protected override double RollingDuration => 1000;
         protected override Easing RollingEasing => Easing.Out;

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -343,8 +343,8 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup componentLookup:
-                    switch (componentLookup.Target)
+                case SkinComponentsContainerLookup containerLookup:
+                    switch (containerLookup.Target)
                     {
                         case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                             var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -343,10 +343,10 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case GlobalSkinComponentLookup target:
-                    switch (target.Lookup)
+                case SkinComponentsContainerLookup componentLookup:
+                    switch (componentLookup.Target)
                     {
-                        case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
+                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                             var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<LegacyScoreCounter>().FirstOrDefault();

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Skinning
             component.Anchor = drawableInfo.Anchor;
             component.Origin = drawableInfo.Origin;
 
-            if (component is ISerialisableDrawable skinnable)
+            if (component is ISerialisableDrawable serialisableDrawable)
             {
-                skinnable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
+                serialisableDrawable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
 
                 foreach (var (_, property) in component.GetSettingsSourceProperties())
                 {
@@ -37,7 +37,7 @@ namespace osu.Game.Skinning
                         continue;
                     }
 
-                    skinnable.CopyAdjustedSetting(bindable, settingValue);
+                    serialisableDrawable.CopyAdjustedSetting(bindable, settingValue);
                 }
             }
 

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Configuration;
+using osu.Game.Extensions;
+
+namespace osu.Game.Skinning
+{
+    public static class SerialisableDrawableExtensions
+    {
+        public static SerialisedDrawableInfo CreateSerialisedInfo(this Drawable component) => new SerialisedDrawableInfo(component);
+
+        public static void ApplySerialisedInfo(this Drawable component, SerialisedDrawableInfo drawableInfo)
+        {
+            // todo: can probably make this better via deserialisation directly using a common interface.
+            component.Position = drawableInfo.Position;
+            component.Rotation = drawableInfo.Rotation;
+            component.Scale = drawableInfo.Scale;
+            component.Anchor = drawableInfo.Anchor;
+            component.Origin = drawableInfo.Origin;
+
+            if (component is ISerialisableDrawable skinnable)
+            {
+                skinnable.UsesFixedAnchor = drawableInfo.UsesFixedAnchor;
+
+                foreach (var (_, property) in component.GetSettingsSourceProperties())
+                {
+                    var bindable = ((IBindable)property.GetValue(component)!);
+
+                    if (!drawableInfo.Settings.TryGetValue(property.Name.ToSnakeCase(), out object? settingValue))
+                    {
+                        // TODO: We probably want to restore default if not included in serialisation information.
+                        // This is not simple to do as SetDefault() is only found in the typed Bindable<T> interface right now.
+                        continue;
+                    }
+
+                    skinnable.CopyAdjustedSetting(bindable, settingValue);
+                }
+            }
+
+            if (component is Container container)
+            {
+                foreach (var child in drawableInfo.Children)
+                    container.Add(child.CreateInstance());
+            }
+        }
+    }
+}

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -64,8 +64,8 @@ namespace osu.Game.Skinning
             Anchor = component.Anchor;
             Origin = component.Origin;
 
-            if (component is ISerialisableDrawable skinnable)
-                UsesFixedAnchor = skinnable.UsesFixedAnchor;
+            if (component is ISerialisableDrawable serialisableDrawable)
+                UsesFixedAnchor = serialisableDrawable.UsesFixedAnchor;
 
             foreach (var (_, property) in component.GetSettingsSourceProperties())
             {

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +26,7 @@ namespace osu.Game.Skinning
     [Serializable]
     public sealed class SerialisedDrawableInfo
     {
-        public Type Type { get; set; }
+        public Type Type { get; set; } = null!;
 
         public Vector2 Position { get; set; }
 

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
-using osu.Game.Rulesets;
 using osuTK;
 
 namespace osu.Game.Skinning
@@ -22,7 +21,7 @@ namespace osu.Game.Skinning
     /// Serialised information governing custom changes to an <see cref="ISkinnableDrawable"/>.
     /// </summary>
     [Serializable]
-    public sealed class SkinnableDrawableInfo
+    public sealed class SerialisedDrawableInfo
     {
         public Type Type { get; set; }
 
@@ -41,10 +40,10 @@ namespace osu.Game.Skinning
 
         public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
 
-        public List<SkinnableDrawableInfo> Children { get; } = new List<SkinnableDrawableInfo>();
+        public List<SerialisedDrawableInfo> Children { get; } = new List<SerialisedDrawableInfo>();
 
         [JsonConstructor]
-        public SkinnableDrawableInfo()
+        public SerialisedDrawableInfo()
         {
         }
 
@@ -52,7 +51,7 @@ namespace osu.Game.Skinning
         /// Construct a new instance populating all attributes from the provided drawable.
         /// </summary>
         /// <param name="component">The drawable which attributes should be sourced from.</param>
-        public SkinnableDrawableInfo(Drawable component)
+        public SerialisedDrawableInfo(Drawable component)
         {
             Type = component.GetType();
 
@@ -75,7 +74,7 @@ namespace osu.Game.Skinning
             if (component is Container<Drawable> container)
             {
                 foreach (var child in container.OfType<ISkinnableDrawable>().OfType<Drawable>())
-                    Children.Add(child.CreateSkinnableInfo());
+                    Children.Add(child.CreateSerialisedInfo());
             }
         }
 
@@ -88,7 +87,7 @@ namespace osu.Game.Skinning
             try
             {
                 Drawable d = (Drawable)Activator.CreateInstance(Type)!;
-                d.ApplySkinnableInfo(this);
+                d.ApplySerialisedInfo(this);
                 return d;
             }
             catch (Exception e)

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -18,9 +18,13 @@ using osuTK;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Serialised backing data for <see cref="ISkinnableDrawable"/>s.
+    /// Serialised backing data for <see cref="ISerialisableDrawable"/>s.
     /// Used for json serialisation in user skins.
     /// </summary>
+    /// <remarks>
+    /// Can be created using <see cref="SerialisableDrawableExtensions.CreateSerialisedInfo"/>.
+    /// Can also be applied to an existing drawable using <see cref="SerialisableDrawableExtensions.ApplySerialisedInfo"/>.
+    /// </remarks>
     [Serializable]
     public sealed class SerialisedDrawableInfo
     {
@@ -36,7 +40,7 @@ namespace osu.Game.Skinning
 
         public Anchor Origin { get; set; }
 
-        /// <inheritdoc cref="ISkinnableDrawable.UsesFixedAnchor"/>
+        /// <inheritdoc cref="ISerialisableDrawable.UsesFixedAnchor"/>
         public bool UsesFixedAnchor { get; set; }
 
         public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
@@ -62,7 +66,7 @@ namespace osu.Game.Skinning
             Anchor = component.Anchor;
             Origin = component.Origin;
 
-            if (component is ISkinnableDrawable skinnable)
+            if (component is ISerialisableDrawable skinnable)
                 UsesFixedAnchor = skinnable.UsesFixedAnchor;
 
             foreach (var (_, property) in component.GetSettingsSourceProperties())
@@ -74,7 +78,7 @@ namespace osu.Game.Skinning
 
             if (component is Container<Drawable> container)
             {
-                foreach (var child in container.OfType<ISkinnableDrawable>().OfType<Drawable>())
+                foreach (var child in container.OfType<ISerialisableDrawable>().OfType<Drawable>())
                     Children.Add(child.CreateSerialisedInfo());
             }
         }
@@ -102,7 +106,7 @@ namespace osu.Game.Skinning
         {
             return typeof(OsuGame).Assembly.GetTypes()
                                   .Where(t => !t.IsInterface && !t.IsAbstract)
-                                  .Where(t => typeof(ISkinnableDrawable).IsAssignableFrom(t))
+                                  .Where(t => typeof(ISerialisableDrawable).IsAssignableFrom(t))
                                   .OrderBy(t => t.Name)
                                   .ToArray();
         }

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -18,7 +18,8 @@ using osuTK;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// Serialised information governing custom changes to an <see cref="ISkinnableDrawable"/>.
+    /// Serialised backing data for <see cref="ISkinnableDrawable"/>s.
+    /// Used for json serialisation in user skins.
     /// </summary>
     [Serializable]
     public sealed class SerialisedDrawableInfo

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -165,8 +165,8 @@ namespace osu.Game.Skinning
                 case SkinnableSprite.SpriteComponentLookup sprite:
                     return this.GetAnimation(sprite.LookupName, false, false);
 
-                case SkinComponentsContainerLookup componentLookup:
-                    if (!DrawableComponentInfo.TryGetValue(componentLookup.Target, out var skinnableInfo))
+                case SkinComponentsContainerLookup containerLookup:
+                    if (!DrawableComponentInfo.TryGetValue(containerLookup.Target, out var skinnableInfo))
                         return null;
 
                     var components = new List<Drawable>();

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Skinning
         /// Remove all stored customisations for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to reset.</param>
-        public void ResetDrawableTarget(ISkinnableTarget targetContainer)
+        public void ResetDrawableTarget(ISerialisableDrawableContainer targetContainer)
         {
             DrawableComponentInfo.Remove(targetContainer.Target);
         }
@@ -152,7 +152,7 @@ namespace osu.Game.Skinning
         /// Update serialised information for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to serialise to this skin.</param>
-        public void UpdateDrawableTarget(ISkinnableTarget targetContainer)
+        public void UpdateDrawableTarget(ISerialisableDrawableContainer targetContainer)
         {
             DrawableComponentInfo[targetContainer.Target] = targetContainer.CreateSerialisedInfo().ToArray();
         }

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -37,9 +37,9 @@ namespace osu.Game.Skinning
 
         public SkinConfiguration Configuration { get; set; }
 
-        public IDictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]> DrawableComponentInfo => drawableComponentInfo;
+        public IDictionary<SkinComponentsContainerLookup.TargetArea, SerialisedDrawableInfo[]> DrawableComponentInfo => drawableComponentInfo;
 
-        private readonly Dictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]> drawableComponentInfo = new Dictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]>();
+        private readonly Dictionary<SkinComponentsContainerLookup.TargetArea, SerialisedDrawableInfo[]> drawableComponentInfo = new Dictionary<SkinComponentsContainerLookup.TargetArea, SerialisedDrawableInfo[]>();
 
         public abstract ISample? GetSample(ISampleInfo sampleInfo);
 
@@ -100,7 +100,7 @@ namespace osu.Game.Skinning
                 Configuration = new SkinConfiguration();
 
             // skininfo files may be null for default skin.
-            foreach (GlobalSkinComponentLookup.LookupType skinnableTarget in Enum.GetValues<GlobalSkinComponentLookup.LookupType>())
+            foreach (SkinComponentsContainerLookup.TargetArea skinnableTarget in Enum.GetValues<SkinComponentsContainerLookup.TargetArea>())
             {
                 string filename = $"{skinnableTarget}.json";
 
@@ -143,18 +143,18 @@ namespace osu.Game.Skinning
         /// Remove all stored customisations for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to reset.</param>
-        public void ResetDrawableTarget(SkinnableTargetContainer targetContainer)
+        public void ResetDrawableTarget(SkinComponentsContainer targetContainer)
         {
-            DrawableComponentInfo.Remove(targetContainer.Target);
+            DrawableComponentInfo.Remove(targetContainer.Lookup.Target);
         }
 
         /// <summary>
         /// Update serialised information for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to serialise to this skin.</param>
-        public void UpdateDrawableTarget(SkinnableTargetContainer targetContainer)
+        public void UpdateDrawableTarget(SkinComponentsContainer targetContainer)
         {
-            DrawableComponentInfo[targetContainer.Target] = ((ISerialisableDrawableContainer)targetContainer).CreateSerialisedInfo().ToArray();
+            DrawableComponentInfo[targetContainer.Lookup.Target] = ((ISerialisableDrawableContainer)targetContainer).CreateSerialisedInfo().ToArray();
         }
 
         public virtual Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
@@ -165,8 +165,8 @@ namespace osu.Game.Skinning
                 case SkinnableSprite.SpriteComponentLookup sprite:
                     return this.GetAnimation(sprite.LookupName, false, false);
 
-                case GlobalSkinComponentLookup target:
-                    if (!DrawableComponentInfo.TryGetValue(target.Lookup, out var skinnableInfo))
+                case SkinComponentsContainerLookup componentLookup:
+                    if (!DrawableComponentInfo.TryGetValue(componentLookup.Target, out var skinnableInfo))
                         return null;
 
                     var components = new List<Drawable>();

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -18,7 +18,6 @@ using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Database;
 using osu.Game.IO;
-using osu.Game.Screens.Play.HUD;
 
 namespace osu.Game.Skinning
 {
@@ -38,9 +37,9 @@ namespace osu.Game.Skinning
 
         public SkinConfiguration Configuration { get; set; }
 
-        public IDictionary<GlobalSkinComponentLookup.LookupType, SkinnableInfo[]> DrawableComponentInfo => drawableComponentInfo;
+        public IDictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]> DrawableComponentInfo => drawableComponentInfo;
 
-        private readonly Dictionary<GlobalSkinComponentLookup.LookupType, SkinnableInfo[]> drawableComponentInfo = new Dictionary<GlobalSkinComponentLookup.LookupType, SkinnableInfo[]>();
+        private readonly Dictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]> drawableComponentInfo = new Dictionary<GlobalSkinComponentLookup.LookupType, SerialisedDrawableInfo[]>();
 
         public abstract ISample? GetSample(ISampleInfo sampleInfo);
 
@@ -120,7 +119,7 @@ namespace osu.Game.Skinning
                     jsonContent = jsonContent.Replace(@"osu.Game.Screens.Play.SongProgress", @"osu.Game.Screens.Play.HUD.DefaultSongProgress");
                     jsonContent = jsonContent.Replace(@"osu.Game.Screens.Play.HUD.LegacyComboCounter", @"osu.Game.Skinning.LegacyComboCounter");
 
-                    var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SkinnableInfo>>(jsonContent);
+                    var deserializedContent = JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(jsonContent);
 
                     if (deserializedContent == null)
                         continue;
@@ -155,7 +154,7 @@ namespace osu.Game.Skinning
         /// <param name="targetContainer">The target container to serialise to this skin.</param>
         public void UpdateDrawableTarget(ISkinnableTarget targetContainer)
         {
-            DrawableComponentInfo[targetContainer.Target] = targetContainer.CreateSkinnableInfo().ToArray();
+            DrawableComponentInfo[targetContainer.Target] = targetContainer.CreateSerialisedInfo().ToArray();
         }
 
         public virtual Drawable? GetDrawableComponent(ISkinComponentLookup lookup)

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Skinning
         /// Remove all stored customisations for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to reset.</param>
-        public void ResetDrawableTarget(ISerialisableDrawableContainer targetContainer)
+        public void ResetDrawableTarget(SkinnableTargetContainer targetContainer)
         {
             DrawableComponentInfo.Remove(targetContainer.Target);
         }
@@ -152,9 +152,9 @@ namespace osu.Game.Skinning
         /// Update serialised information for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to serialise to this skin.</param>
-        public void UpdateDrawableTarget(ISerialisableDrawableContainer targetContainer)
+        public void UpdateDrawableTarget(SkinnableTargetContainer targetContainer)
         {
-            DrawableComponentInfo[targetContainer.Target] = targetContainer.CreateSerialisedInfo().ToArray();
+            DrawableComponentInfo[targetContainer.Target] = ((ISerialisableDrawableContainer)targetContainer).CreateSerialisedInfo().ToArray();
         }
 
         public virtual Drawable? GetDrawableComponent(ISkinComponentLookup lookup)

--- a/osu.Game/Skinning/SkinComponentsContainer.cs
+++ b/osu.Game/Skinning/SkinComponentsContainer.cs
@@ -24,6 +24,9 @@ namespace osu.Game.Skinning
     {
         private Container? content;
 
+        /// <summary>
+        /// The lookup criteria which will be used to retrieve components from the active skin.
+        /// </summary>
         public SkinComponentsContainerLookup Lookup { get; }
 
         public IBindableList<ISerialisableDrawable> Components => components;

--- a/osu.Game/Skinning/SkinComponentsContainer.cs
+++ b/osu.Game/Skinning/SkinComponentsContainer.cs
@@ -11,11 +11,20 @@ using osu.Framework.Graphics.Containers;
 
 namespace osu.Game.Skinning
 {
-    public partial class SkinnableTargetContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
+    /// <summary>
+    /// A container which holds many skinnable components, with functionality to add, remove and reload layouts.
+    /// Used to allow user customisation of skin layouts.
+    /// </summary>
+    /// <remarks>
+    /// This is currently used as a means of serialising skin layouts to files.
+    /// Currently, one json file in a skin will represent one <see cref="SkinComponentsContainer"/>, containing
+    /// the output of <see cref="ISerialisableDrawableContainer.CreateSerialisedInfo"/>.
+    /// </remarks>
+    public partial class SkinComponentsContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
     {
         private Container? content;
 
-        public GlobalSkinComponentLookup.LookupType Target { get; }
+        public SkinComponentsContainerLookup Lookup { get; }
 
         public IBindableList<ISerialisableDrawable> Components => components;
 
@@ -27,9 +36,9 @@ namespace osu.Game.Skinning
 
         private CancellationTokenSource? cancellationSource;
 
-        public SkinnableTargetContainer(GlobalSkinComponentLookup.LookupType target)
+        public SkinComponentsContainer(SkinComponentsContainerLookup lookup)
         {
-            Target = target;
+            Lookup = lookup;
         }
 
         public void Reload(SerialisedDrawableInfo[] skinnableInfo)
@@ -46,7 +55,7 @@ namespace osu.Game.Skinning
             });
         }
 
-        public void Reload() => Reload(CurrentSkin.GetDrawableComponent(new GlobalSkinComponentLookup(Target)) as Container);
+        public void Reload() => Reload(CurrentSkin.GetDrawableComponent(Lookup) as Container);
 
         public void Reload(Container? componentsContainer)
         {

--- a/osu.Game/Skinning/SkinComponentsContainerLookup.cs
+++ b/osu.Game/Skinning/SkinComponentsContainerLookup.cs
@@ -3,8 +3,14 @@
 
 namespace osu.Game.Skinning
 {
+    /// <summary>
+    /// Represents a lookup of a collection of elements that make up a particular skinnable <see cref="TargetArea"/> of the game.
+    /// </summary>
     public class SkinComponentsContainerLookup : ISkinComponentLookup
     {
+        /// <summary>
+        /// The target area / layer of the game for which skin components will be returned.
+        /// </summary>
         public readonly TargetArea Target;
 
         public SkinComponentsContainerLookup(TargetArea target)
@@ -12,6 +18,9 @@ namespace osu.Game.Skinning
             Target = target;
         }
 
+        /// <summary>
+        /// Represents a particular area or part of a game screen whose layout can be customised using the skin editor.
+        /// </summary>
         public enum TargetArea
         {
             MainHUDComponents,

--- a/osu.Game/Skinning/SkinComponentsContainerLookup.cs
+++ b/osu.Game/Skinning/SkinComponentsContainerLookup.cs
@@ -3,16 +3,16 @@
 
 namespace osu.Game.Skinning
 {
-    public class GlobalSkinComponentLookup : ISkinComponentLookup
+    public class SkinComponentsContainerLookup : ISkinComponentLookup
     {
-        public readonly LookupType Lookup;
+        public readonly TargetArea Target;
 
-        public GlobalSkinComponentLookup(LookupType lookup)
+        public SkinComponentsContainerLookup(TargetArea target)
         {
-            Lookup = lookup;
+            Target = target;
         }
 
-        public enum LookupType
+        public enum TargetArea
         {
             MainHUDComponents,
             SongSelect

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -15,8 +15,13 @@ using osu.Game.Audio;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A container which adds a local <see cref="ISkinSource"/> to the hierarchy.
+    /// A container which adds a provided <see cref="ISkin"/> to the DI skin lookup hierarchy.
     /// </summary>
+    /// <remarks>
+    /// This container will expose an <see cref="ISkinSource"/> to its children.
+    /// The source will first consider the skin provided via the constructor (if any), then fallback
+    /// to any <see cref="ISkinSource"/> providers in the parent DI hierarchy.
+    /// </remarks>
     public partial class SkinProvidingContainer : Container, ISkinSource
     {
         public event Action? SourceChanged;

--- a/osu.Game/Skinning/SkinReloadableDrawable.cs
+++ b/osu.Game/Skinning/SkinReloadableDrawable.cs
@@ -9,7 +9,8 @@ using osu.Framework.Graphics.Pooling;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A drawable which has a callback when the skin changes.
+    /// A poolable drawable implementation which has a pre-wired callback (see <see cref="SkinChanged"/>) that fires
+    /// once on load and again on any subsequent skin change.
     /// </summary>
     public abstract partial class SkinReloadableDrawable : PoolableDrawable
     {

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -10,6 +10,13 @@ using osu.Game.Audio;
 
 namespace osu.Game.Skinning
 {
+    /// <summary>
+    /// A default skin transformer, which falls back to the provided skin by default.
+    /// </summary>
+    /// <remarks>
+    /// Implementations of skin transformers should generally derive this class and override
+    /// individual lookup methods, modifying the lookup flow as required.
+    /// </remarks>
     public abstract class SkinTransformer : ISkinTransformer
     {
         public ISkin Skin { get; }

--- a/osu.Game/Skinning/SkinnableDrawableInfo.cs
+++ b/osu.Game/Skinning/SkinnableDrawableInfo.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Skinning
     /// Serialised information governing custom changes to an <see cref="ISkinnableDrawable"/>.
     /// </summary>
     [Serializable]
-    public class SkinnableInfo
+    public sealed class SkinnableDrawableInfo
     {
         public Type Type { get; set; }
 
@@ -41,10 +41,10 @@ namespace osu.Game.Skinning
 
         public Dictionary<string, object> Settings { get; set; } = new Dictionary<string, object>();
 
-        public List<SkinnableInfo> Children { get; } = new List<SkinnableInfo>();
+        public List<SkinnableDrawableInfo> Children { get; } = new List<SkinnableDrawableInfo>();
 
         [JsonConstructor]
-        public SkinnableInfo()
+        public SkinnableDrawableInfo()
         {
         }
 
@@ -52,7 +52,7 @@ namespace osu.Game.Skinning
         /// Construct a new instance populating all attributes from the provided drawable.
         /// </summary>
         /// <param name="component">The drawable which attributes should be sourced from.</param>
-        public SkinnableInfo(Drawable component)
+        public SkinnableDrawableInfo(Drawable component)
         {
             Type = component.GetType();
 

--- a/osu.Game/Skinning/SkinnableInfo.cs
+++ b/osu.Game/Skinning/SkinnableInfo.cs
@@ -13,10 +13,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
-using osu.Game.Skinning;
+using osu.Game.Rulesets;
 using osuTK;
 
-namespace osu.Game.Screens.Play.HUD
+namespace osu.Game.Skinning
 {
     /// <summary>
     /// Serialised information governing custom changes to an <see cref="ISkinnableDrawable"/>.

--- a/osu.Game/Skinning/SkinnableSprite.cs
+++ b/osu.Game/Skinning/SkinnableSprite.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Skinning
     /// <summary>
     /// A skinnable element which uses a single texture backing.
     /// </summary>
-    public partial class SkinnableSprite : SkinnableDrawable, ISkinnableDrawable
+    public partial class SkinnableSprite : SkinnableDrawable, ISerialisableDrawable
     {
         protected override bool ApplySizeRestrictionsToDefault => true;
 

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Skinning
             Target = target;
         }
 
-        public void Reload(SkinnableDrawableInfo[] skinnableInfo)
+        public void Reload(SerialisedDrawableInfo[] skinnableInfo)
         {
             var drawables = new List<Drawable>();
 

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Skinning.Serialisation;
 
 namespace osu.Game.Skinning
 {

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -12,7 +12,7 @@ using osu.Game.Skinning.Serialisation;
 
 namespace osu.Game.Skinning
 {
-    public partial class SkinnableTargetContainer : SkinReloadableDrawable, ISkinnableTarget
+    public partial class SkinnableTargetContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
     {
         private Container? content;
 
@@ -76,7 +76,7 @@ namespace osu.Game.Skinning
                 ComponentsLoaded = true;
         }
 
-        /// <inheritdoc cref="ISkinnableTarget"/>
+        /// <inheritdoc cref="ISerialisableDrawableContainer"/>
         /// <exception cref="NotSupportedException">Thrown when attempting to add an element to a target which is not supported by the current skin.</exception>
         /// <exception cref="ArgumentException">Thrown if the provided instance is not a <see cref="Drawable"/>.</exception>
         public void Add(ISerialisableDrawable component)
@@ -91,7 +91,7 @@ namespace osu.Game.Skinning
             components.Add(component);
         }
 
-        /// <inheritdoc cref="ISkinnableTarget"/>
+        /// <inheritdoc cref="ISerialisableDrawableContainer"/>
         /// <exception cref="NotSupportedException">Thrown when attempting to add an element to a target which is not supported by the current skin.</exception>
         /// <exception cref="ArgumentException">Thrown if the provided instance is not a <see cref="Drawable"/>.</exception>
         public void Remove(ISerialisableDrawable component)

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Skinning
             Target = target;
         }
 
-        public void Reload(SkinnableInfo[] skinnableInfo)
+        public void Reload(SkinnableDrawableInfo[] skinnableInfo)
         {
             var drawables = new List<Drawable>();
 

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -8,7 +8,7 @@ using System.Threading;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Screens.Play.HUD;
+using osu.Game.Skinning.Serialisation;
 
 namespace osu.Game.Skinning
 {

--- a/osu.Game/Skinning/SkinnableTargetContainer.cs
+++ b/osu.Game/Skinning/SkinnableTargetContainer.cs
@@ -18,9 +18,9 @@ namespace osu.Game.Skinning
 
         public GlobalSkinComponentLookup.LookupType Target { get; }
 
-        public IBindableList<ISkinnableDrawable> Components => components;
+        public IBindableList<ISerialisableDrawable> Components => components;
 
-        private readonly BindableList<ISkinnableDrawable> components = new BindableList<ISkinnableDrawable>();
+        private readonly BindableList<ISerialisableDrawable> components = new BindableList<ISerialisableDrawable>();
 
         public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks; // ensure that components are loaded even if the target container is hidden (ie. due to user toggle).
 
@@ -68,7 +68,7 @@ namespace osu.Game.Skinning
                 LoadComponentAsync(content, wrapper =>
                 {
                     AddInternal(wrapper);
-                    components.AddRange(wrapper.Children.OfType<ISkinnableDrawable>());
+                    components.AddRange(wrapper.Children.OfType<ISerialisableDrawable>());
                     ComponentsLoaded = true;
                 }, (cancellationSource = new CancellationTokenSource()).Token);
             }
@@ -79,7 +79,7 @@ namespace osu.Game.Skinning
         /// <inheritdoc cref="ISkinnableTarget"/>
         /// <exception cref="NotSupportedException">Thrown when attempting to add an element to a target which is not supported by the current skin.</exception>
         /// <exception cref="ArgumentException">Thrown if the provided instance is not a <see cref="Drawable"/>.</exception>
-        public void Add(ISkinnableDrawable component)
+        public void Add(ISerialisableDrawable component)
         {
             if (content == null)
                 throw new NotSupportedException("Attempting to add a new component to a target container which is not supported by the current skin.");
@@ -94,7 +94,7 @@ namespace osu.Game.Skinning
         /// <inheritdoc cref="ISkinnableTarget"/>
         /// <exception cref="NotSupportedException">Thrown when attempting to add an element to a target which is not supported by the current skin.</exception>
         /// <exception cref="ArgumentException">Thrown if the provided instance is not a <see cref="Drawable"/>.</exception>
-        public void Remove(ISkinnableDrawable component)
+        public void Remove(ISerialisableDrawable component)
         {
             if (content == null)
                 throw new NotSupportedException("Attempting to remove a new component from a target container which is not supported by the current skin.");

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -68,8 +68,8 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup componentLookup:
-                    switch (componentLookup.Target)
+                case SkinComponentsContainerLookup containerLookup:
+                    switch (containerLookup.Target)
                     {
                         case SkinComponentsContainerLookup.TargetArea.SongSelect:
                             var songSelectComponents = new DefaultSkinComponentsContainer(_ =>

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -68,10 +68,10 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case GlobalSkinComponentLookup target:
-                    switch (target.Lookup)
+                case SkinComponentsContainerLookup componentLookup:
+                    switch (componentLookup.Target)
                     {
-                        case GlobalSkinComponentLookup.LookupType.SongSelect:
+                        case SkinComponentsContainerLookup.TargetArea.SongSelect:
                             var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
                             {
                                 // do stuff when we need to.
@@ -79,7 +79,7 @@ namespace osu.Game.Skinning
 
                             return songSelectComponents;
 
-                        case GlobalSkinComponentLookup.LookupType.MainHUDComponents:
+                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                             var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();

--- a/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
@@ -45,13 +45,13 @@ namespace osu.Game.Tests.Visual
 
         private void addResetTargetsStep()
         {
-            AddStep("reset targets", () => this.ChildrenOfType<SkinnableTargetContainer>().ForEach(t =>
+            AddStep("reset targets", () => this.ChildrenOfType<SkinComponentsContainer>().ForEach(t =>
             {
                 LegacySkin.ResetDrawableTarget(t);
                 t.Reload();
             }));
 
-            AddUntilStep("wait for components to load", () => this.ChildrenOfType<SkinnableTargetContainer>().All(t => t.ComponentsLoaded));
+            AddUntilStep("wait for components to load", () => this.ChildrenOfType<SkinComponentsContainer>().All(t => t.ComponentsLoaded));
         }
 
         public partial class SkinProvidingPlayer : TestPlayer


### PR DESCRIPTION
This is a full pass on the skin namespace, focused on renaming, documenting and generally knocking some (final?) sense into the structure and understandability before I attempt to make things more complicated.

- [x] Depends on #22647 (conflict avoidance)

Note that I've intentionally avoided changing any naming or namespaces which would break existing usages / serialisation.