### PR TITLE
Refactor `GameplaySampleTriggerSource` test to not be realtime dependent

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Audio;
@@ -20,10 +18,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public partial class TestSceneGameplaySampleTriggerSource : PlayerTestScene
     {
-        private TestGameplaySampleTriggerSource sampleTriggerSource;
+        private TestGameplaySampleTriggerSource sampleTriggerSource = null!;
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
 
-        private Beatmap beatmap;
+        private Beatmap beatmap = null!;
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {
@@ -80,7 +78,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestCorrectHitObject()
         {
-            HitObjectLifetimeEntry nextObjectEntry = null;
+            HitObjectLifetimeEntry? nextObjectEntry = null;
 
             AddAssert("no alive objects", () => getNextAliveObject() == null);
 
@@ -103,7 +101,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("hit first hitobject", () =>
             {
                 InputManager.Click(MouseButton.Left);
-                return nextObjectEntry.Result?.HasResult == true;
+                return nextObjectEntry?.Result?.HasResult == true;
             });
 
             AddAssert("check correct object after hit", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[1]);
@@ -115,7 +113,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("check correct object after none alive", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[3]);
         }
 
-        private DrawableHitObject getNextAliveObject() =>
+        private DrawableHitObject? getNextAliveObject() =>
             Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.FirstOrDefault();
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -1,8 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Timing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -12,6 +16,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.UI;
+using osu.Game.Storyboards;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -22,6 +27,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
 
         private Beatmap beatmap = null!;
+
+        [Resolved]
+        private AudioManager audio { get; set; } = null!;
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
+            => new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audio);
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
         {
@@ -37,12 +48,13 @@ namespace osu.Game.Tests.Visual.Gameplay
             const double start_offset = 8000;
             const double spacing = 2000;
 
+            // intentionally start objects a bit late so we can test the case of no alive objects.
             double t = start_offset;
+
             beatmap.HitObjects.AddRange(new[]
             {
                 new HitCircle
                 {
-                    // intentionally start objects a bit late so we can test the case of no alive objects.
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
                 },
@@ -78,40 +90,63 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestCorrectHitObject()
         {
-            HitObjectLifetimeEntry? nextObjectEntry = null;
+            waitForAliveObjectIndex(null);
 
-            AddAssert("no alive objects", () => getNextAliveObject() == null);
+            seekBeforeIndex(0);
+            waitForAliveObjectIndex(0);
+            checkValidObjectIndex(0);
 
-            AddAssert("check initially correct object", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[0]);
+            AddAssert("first object not hit", () => getNextAliveObject()?.Entry?.Result?.HasResult != true);
 
-            AddUntilStep("get next object", () =>
+            AddStep("hit first object", () =>
             {
-                var nextDrawableObject = getNextAliveObject();
+                var next = getNextAliveObject();
 
-                if (nextDrawableObject != null)
+                if (next != null)
                 {
-                    nextObjectEntry = nextDrawableObject.Entry;
-                    InputManager.MoveMouseTo(nextDrawableObject.ScreenSpaceDrawQuad.Centre);
-                    return true;
+                    Debug.Assert(next.Entry?.Result?.HasResult != true);
+
+                    InputManager.MoveMouseTo(next.ScreenSpaceDrawQuad.Centre);
+                    InputManager.Click(MouseButton.Left);
                 }
-
-                return false;
             });
 
-            AddUntilStep("hit first hitobject", () =>
-            {
-                InputManager.Click(MouseButton.Left);
-                return nextObjectEntry?.Result?.HasResult == true;
-            });
+            AddAssert("first object hit", () => getNextAliveObject()?.Entry?.Result?.HasResult == true);
 
-            AddAssert("check correct object after hit", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[1]);
+            checkValidObjectIndex(1);
 
-            AddUntilStep("check correct object after miss", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[2]);
-            AddUntilStep("check correct object after miss", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[3]);
+            // Still object 1 as it's not hit yet.
+            seekBeforeIndex(1);
+            waitForAliveObjectIndex(1);
+            checkValidObjectIndex(1);
 
-            AddUntilStep("no alive objects", () => getNextAliveObject() == null);
-            AddAssert("check correct object after none alive", () => sampleTriggerSource.GetMostValidObject() == beatmap.HitObjects[3]);
+            seekBeforeIndex(2);
+            waitForAliveObjectIndex(2);
+            checkValidObjectIndex(2);
+
+            seekBeforeIndex(3);
+            waitForAliveObjectIndex(3);
+            checkValidObjectIndex(3);
+
+            AddStep("Seek into future", () => Beatmap.Value.Track.Seek(beatmap.HitObjects.Last().GetEndTime() + 10000));
+
+            waitForAliveObjectIndex(null);
+            checkValidObjectIndex(3);
         }
+
+        private void seekBeforeIndex(int index) =>
+            AddStep($"seek to just before object {index}", () => Beatmap.Value.Track.Seek(beatmap.HitObjects[index].StartTime - 100));
+
+        private void waitForAliveObjectIndex(int? index)
+        {
+            if (index == null)
+                AddUntilStep("wait for no alive objects", getNextAliveObject, () => Is.Null);
+            else
+                AddUntilStep($"wait for next alive to be {index}", () => getNextAliveObject()?.HitObject, () => Is.EqualTo(beatmap.HitObjects[index.Value]));
+        }
+
+        private void checkValidObjectIndex(int index) =>
+            AddAssert($"check valid object is {index}", () => sampleTriggerSource.GetMostValidObject(), () => Is.EqualTo(beatmap.HitObjects[index]));
 
         private DrawableHitObject? getNextAliveObject() =>
             Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.FirstOrDefault();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -91,6 +91,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestCorrectHitObject()
         {
             waitForAliveObjectIndex(null);
+            checkValidObjectIndex(0);
 
             seekBeforeIndex(0);
             waitForAliveObjectIndex(0);


### PR DESCRIPTION
I wanted to add more to this test to fix an issue, but turns out it's a pretty shoddy test in the first place. @frenzibyte also mentioned seeing this as a flaky test in the past, so fixing this while we're here makes sense.