### PR TITLE
Add ability to send selected skin components to front or back

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
@@ -21,7 +22,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public partial class TestSceneSkinEditor : PlayerTestScene
     {
-        private SkinEditor? skinEditor;
+        private SkinEditor skinEditor = null!;
 
         protected override bool Autoplay => true;
 
@@ -40,17 +41,18 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("reload skin editor", () =>
             {
-                skinEditor?.Expire();
+                if (skinEditor.IsNotNull())
+                    skinEditor.Expire();
                 Player.ScaleTo(0.4f);
                 LoadComponentAsync(skinEditor = new SkinEditor(Player), Add);
             });
-            AddUntilStep("wait for loaded", () => skinEditor!.IsLoaded);
+            AddUntilStep("wait for loaded", () => skinEditor.IsLoaded);
         }
 
         [Test]
         public void TestToggleEditor()
         {
-            AddToggleStep("toggle editor visibility", _ => skinEditor!.ToggleVisibility());
+            AddToggleStep("toggle editor visibility", _ => skinEditor.ToggleVisibility());
         }
 
         [Test]
@@ -63,7 +65,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 var blueprint = skinEditor.ChildrenOfType<SkinBlueprint>().First(b => b.Item is BarHitErrorMeter);
 
                 hitErrorMeter = (BarHitErrorMeter)blueprint.Item;
-                skinEditor!.SelectedComponents.Clear();
+                skinEditor.SelectedComponents.Clear();
                 skinEditor.SelectedComponents.Add(blueprint.Item);
             });
 

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Overlays.SkinEditor
                         {
                             Text = Item.GetType().Name,
                             Font = OsuFont.Default.With(size: 10, weight: FontWeight.Bold),
+                            Alpha = 0,
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.TopRight,
                         },
@@ -99,7 +100,6 @@ namespace osu.Game.Overlays.SkinEditor
             base.LoadComplete();
 
             updateSelectedState();
-            this.FadeInFromZero(200, Easing.OutQuint);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -566,6 +566,8 @@ namespace osu.Game.Overlays.SkinEditor
             if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
                 return;
 
+            changeHandler?.BeginChange();
+
             // Iterating by target components order ensures we maintain the same order across selected components, regardless
             // of the order they were selected in.
             foreach (var d in target.Components.ToArray())
@@ -579,12 +581,16 @@ namespace osu.Game.Overlays.SkinEditor
                 SelectedComponents.Add(d);
                 target.Add(d);
             }
+
+            changeHandler?.EndChange();
         }
 
         public void SendSelectionToBack()
         {
             if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
                 return;
+
+            changeHandler?.BeginChange();
 
             foreach (var d in target.Components.ToArray())
             {
@@ -594,6 +600,8 @@ namespace osu.Game.Overlays.SkinEditor
                 target.Remove(d, false);
                 target.Add(d);
             }
+
+            changeHandler?.EndChange();
         }
 
         #region Drag & drop import handling

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -556,9 +556,44 @@ namespace osu.Game.Overlays.SkinEditor
             changeHandler?.BeginChange();
 
             foreach (var item in items)
-                availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item);
+                availableTargets.FirstOrDefault(t => t.Components.Contains(item))?.Remove(item, true);
 
             changeHandler?.EndChange();
+        }
+
+        public void BringSelectionToFront()
+        {
+            if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
+                return;
+
+            // Iterating by target components order ensures we maintain the same order across selected components, regardless
+            // of the order they were selected in.
+            foreach (var d in target.Components.ToArray())
+            {
+                if (!SelectedComponents.Contains(d))
+                    continue;
+
+                target.Remove(d, false);
+
+                // Selection would be reset by the remove.
+                SelectedComponents.Add(d);
+                target.Add(d);
+            }
+        }
+
+        public void SendSelectionToBack()
+        {
+            if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
+                return;
+
+            foreach (var d in target.Components.ToArray())
+            {
+                if (SelectedComponents.Contains(d))
+                    continue;
+
+                target.Remove(d, false);
+                target.Add(d);
+            }
         }
 
         #region Drag & drop import handling

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -13,6 +13,7 @@ using osu.Framework.Utils;
 using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Skinning;
 using osuTK;
@@ -205,6 +206,14 @@ namespace osu.Game.Overlays.SkinEditor
                 foreach (var blueprint in SelectedBlueprints)
                     ((Drawable)blueprint.Item).Position = Vector2.Zero;
             });
+
+            yield return new EditorMenuItemSpacer();
+
+            yield return new OsuMenuItem("Bring to front", MenuItemType.Standard, () => skinEditor.BringSelectionToFront());
+
+            yield return new OsuMenuItem("Send to back", MenuItemType.Standard, () => skinEditor.SendSelectionToBack());
+
+            yield return new EditorMenuItemSpacer();
 
             foreach (var item in base.GetContextMenuItemsForSelection(selection))
                 yield return item;

--- a/osu.Game/Skinning/ISerialisableDrawableContainer.cs
+++ b/osu.Game/Skinning/ISerialisableDrawableContainer.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Skinning
         /// Remove an existing skinnable component from this target.
         /// </summary>
         /// <param name="component">The component to remove.</param>
-        void Remove(ISerialisableDrawable component);
+        /// <param name="disposeImmediately">Whether removed items should be immediately disposed.</param>
+        void Remove(ISerialisableDrawable component, bool disposeImmediately);
     }
 }

--- a/osu.Game/Skinning/SkinComponentsContainer.cs
+++ b/osu.Game/Skinning/SkinComponentsContainer.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Skinning
         /// <inheritdoc cref="ISerialisableDrawableContainer"/>
         /// <exception cref="NotSupportedException">Thrown when attempting to add an element to a target which is not supported by the current skin.</exception>
         /// <exception cref="ArgumentException">Thrown if the provided instance is not a <see cref="Drawable"/>.</exception>
-        public void Remove(ISerialisableDrawable component)
+        public void Remove(ISerialisableDrawable component, bool disposeImmediately)
         {
             if (content == null)
                 throw new NotSupportedException("Attempting to remove a new component from a target container which is not supported by the current skin.");
@@ -108,7 +108,7 @@ namespace osu.Game.Skinning
             if (!(component is Drawable drawable))
                 throw new ArgumentException($"Provided argument must be of type {nameof(Drawable)}.", nameof(component));
 
-            content.Remove(drawable, true);
+            content.Remove(drawable, disposeImmediately);
             components.Remove(component);
         }
 


### PR DESCRIPTION
An easy way of allowing the user to manage depth without creating a rearrangeable list display.


https://user-images.githubusercontent.com/191335/220578383-94699392-797a-41b1-b71d-00a2b408d046.mp4

