### PR TITLE
Fix break overlay grade changing to 'F' when exiting play

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakOverlay.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Screens;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneBreakOverlay : OsuPlayerTestScene
+    {
+        [Test]
+        public void TestGradeNotUpdatedOnExit()
+        {
+            bool gradeDisplayUpdated = false;
+
+            AddStep("exit player", () =>
+            {
+                gradeDisplayUpdated = false;
+                Player.BreakOverlay.Info.GradeDisplay.Current.ValueChanged += _ => { gradeDisplayUpdated = true; };
+                Player.Exit();
+            });
+            AddAssert("grade display didn't update", () => !gradeDisplayUpdated);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -47,11 +47,11 @@ namespace osu.Game.Screens.Play
         private readonly RemainingTimeCounter remainingTimeCounter;
         private readonly BreakArrows breakArrows;
 
+        public readonly BreakInfo Info;
+
         public BreakOverlay(bool letterboxing, ScoreProcessor scoreProcessor)
         {
             RelativeSizeAxes = Axes.Both;
-
-            BreakInfo info;
 
             Child = fadeContainer = new Container
             {
@@ -89,7 +89,7 @@ namespace osu.Game.Screens.Play
                         Origin = Anchor.BottomCentre,
                         Margin = new MarginPadding { Bottom = vertical_margin },
                     },
-                    info = new BreakInfo
+                    Info = new BreakInfo
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.TopCentre,
@@ -105,8 +105,8 @@ namespace osu.Game.Screens.Play
 
             if (scoreProcessor != null)
             {
-                info.AccuracyDisplay.Current.BindTo(scoreProcessor.Accuracy);
-                info.GradeDisplay.Current.BindTo(scoreProcessor.Rank);
+                Info.AccuracyDisplay.Current.BindTo(scoreProcessor.Accuracy);
+                Info.GradeDisplay.Current.BindTo(scoreProcessor.Rank);
             }
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1085,7 +1085,10 @@ namespace osu.Game.Screens.Play
 
                 // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
                 if (prepareScoreForDisplayTask == null)
+                {
+                    BreakOverlay.Info.GradeDisplay.Current.UnbindFrom(ScoreProcessor.Rank);
                     ScoreProcessor.FailScore(Score.ScoreInfo);
+                }
             }
 
             // GameplayClockContainer performs seeks / start / stop operations on the beatmap's track.


### PR DESCRIPTION
Closes #22718

Before:

https://user-images.githubusercontent.com/42323315/221180444-3a462e4f-473a-40ab-badd-48cea97b7ee1.mp4

After:

https://user-images.githubusercontent.com/42323315/221180453-685107b7-8ba9-44e1-99ba-012f08415595.mp4

