### PR TITLE
Adds Rate Changer mod to the Conversion tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,6 @@ FodyWeavers.xsd
 **/FodyWeavers.xml
 
 .idea/.idea.osu.Desktop/.idea/misc.xml
+Osu Trainer.bat
+osu.Game/Rulesets/Mods/ModRateChanger VER2.txt
+osu.Game/Rulesets/Mods/ModRateChanger VER2.5.txt

--- a/.gitignore
+++ b/.gitignore
@@ -342,6 +342,3 @@ FodyWeavers.xsd
 **/FodyWeavers.xml
 
 .idea/.idea.osu.Desktop/.idea/misc.xml
-Osu Trainer.bat
-osu.Game/Rulesets/Mods/ModRateChanger VER2.txt
-osu.Game/Rulesets/Mods/ModRateChanger VER2.5.txt

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModRateChanger : ModRateChanger
+    {
+        public override double ScoreMultiplier => 0;
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
@@ -7,6 +7,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModRateChanger : ModRateChanger
     {
-        public override double ScoreMultiplier => 0;
+        public override double ScoreMultiplier => SpeedChange.Value;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRateChanger.cs
@@ -7,6 +7,6 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModRateChanger : ModRateChanger
     {
-        public override double ScoreMultiplier => SpeedChange.Value;
+        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -172,6 +172,7 @@ namespace osu.Game.Rulesets.Osu
                     return new Mod[]
                     {
                         new OsuModTargetPractice(),
+                        new OsuModRateChanger(),
                         new OsuModDifficultyAdjust(),
                         new OsuModClassic(),
                         new OsuModRandom(),

--- a/osu.Game/Rulesets/Mods/ModRateChanger.cs
+++ b/osu.Game/Rulesets/Mods/ModRateChanger.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Framework.Logging;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract class ModRateChanger : ModRateAdjust
+    {
+        public override string Name => "Rate Changer";
+        public override string Acronym => "RC";
+        public override IconUsage? Icon => OsuIcon.ModHalftime;
+        public override ModType Type => ModType.Conversion;
+        public override LocalisableString Description => "Change speed and pitch separately for any song";
+
+        private readonly BindableNumber<double> tempoAdjust = new BindableDouble(1);
+
+        private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
+
+        public double speedMultiplier = 1;
+
+        bool allowLog = true;
+        
+        [SettingSource("Speed edit", "The song speed multiplier")]
+        public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1)
+        {
+            MinValue = 0.1,
+            MaxValue = 2,
+            Precision = 0.01,
+        };
+
+        [SettingSource("Pitch edit", "The song pitch multiplier")]
+        public BindableNumber<double> PitchChange { get; } = new BindableDouble(1)
+        {
+            MinValue = 0.1,
+            MaxValue = 2,
+            Precision = 0.01,
+        };
+
+        protected ModRateChanger()
+        {
+            // Muda a velocidade sem mudar o pitch.
+            SpeedChange.BindValueChanged(val =>
+            {
+                speedMultiplier = val.NewValue;
+
+                ValTempoReal();
+            }, true);
+
+            // Muda a velocidade e o pitch
+            PitchChange.BindValueChanged(val =>
+            {
+                freqAdjust.Value = val.NewValue;
+
+                ValTempoReal();
+            }, true);
+        }
+
+        public override void ApplyToTrack(IAdjustableAudioComponent track)
+        {
+            // base.ApplyToTrack() intentionally not called (different tempo adjustment is applied)
+            track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
+            track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
+        }
+
+        
+        // Implementa a função 1/x pra definir o valor do tempoAdjust.
+        void ValTempoReal() {
+            if ((speedMultiplier * (1/freqAdjust.Value)) > 0.05)
+            {
+                tempoAdjust.Value = speedMultiplier * (1/freqAdjust.Value);
+                allowLog = true;
+            }
+            else if (allowLog)
+            {
+                Logger.Log("Resulting internal tempo would be smaller than 0,05.", LoggingTarget.Information, LogLevel.Important);
+                allowLog = false;
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModRateChanger.cs
+++ b/osu.Game/Rulesets/Mods/ModRateChanger.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Rulesets.Mods
 
         protected ModRateChanger()
         {
-            // Muda a velocidade sem mudar o pitch.
             SpeedChange.BindValueChanged(val =>
             {
                 speedMultiplier = val.NewValue;
@@ -53,7 +52,6 @@ namespace osu.Game.Rulesets.Mods
                 ValTempoReal();
             }, true);
 
-            // Muda a velocidade e o pitch
             PitchChange.BindValueChanged(val =>
             {
                 freqAdjust.Value = val.NewValue;
@@ -68,9 +66,8 @@ namespace osu.Game.Rulesets.Mods
             track.AddAdjustment(AdjustableProperty.Frequency, freqAdjust);
             track.AddAdjustment(AdjustableProperty.Tempo, tempoAdjust);
         }
-
         
-        // Implementa a função 1/x pra definir o valor do tempoAdjust.
+        // Implements 1/x to define the value of tempoAdjust.
         void ValTempoReal() {
             if ((speedMultiplier * (1/freqAdjust.Value)) > 0.05)
             {


### PR DESCRIPTION
> **Because a significant amount of people have asked for a in-game way to modify pitch or song tempo more freely.**

![rate changer 1](https://user-images.githubusercontent.com/60430641/221421543-e548e92b-1c89-474c-8832-12ebd769f3c6.png)
![rate changer 2](https://user-images.githubusercontent.com/60430641/221421551-c279f4ea-0844-4292-bc64-c2924cd61b75.png)

With this PR I have managed to counterbalance the track pitch/rate adjustment speed change and provide a more reliable tempo multiplier method (unlike daycore's 0.75x speed adjustment, that is actually slower because of the 0.75x pitch/rate change).

I'm not actually sure if this should be a separate mod or be included inside the difficulty adjustment one, as it is fundamentally made to substitute external trainers used to adjust the beatmap difficulty and song speed like this.

Ps: due to audio limitations I had to include a fail-safe in case the user tries to set the track tempo property to less than 0.05, now it doesn't crash the game anymore.
