### PR TITLE
Rename `SettingSource` tests to match attribute name

### DIFF
--- a/osu.Game.Tests/Mods/SettingSourceAttributeTest.cs
+++ b/osu.Game.Tests/Mods/SettingSourceAttributeTest.cs
@@ -12,7 +12,7 @@ using osu.Game.Overlays.Settings;
 namespace osu.Game.Tests.Mods
 {
     [TestFixture]
-    public partial class SettingsSourceAttributeTest
+    public partial class SettingSourceAttributeTest
     {
         [Test]
         public void TestOrdering()


### PR DESCRIPTION
I always struggle remembering which one is correct, but let's prefer the one from the attribute.