### PR TITLE
Fix "talking with" text overflowing when usernames are too long

### DIFF
--- a/osu.Game/Overlays/Chat/ChatTextBar.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBar.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Overlays.Chat
 
         private const float chatting_text_width = 220;
         private const float search_icon_width = 40;
+        private const float padding = 5;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -71,9 +72,10 @@ namespace osu.Game.Overlays.Chat
                                 RelativeSizeAxes = Axes.Y,
                                 Width = chatting_text_width,
                                 Masking = true,
-                                Padding = new MarginPadding { Right = 5 },
+                                Padding = new MarginPadding { Horizontal = padding },
                                 Child = chattingText = new OsuSpriteText
                                 {
+                                    MaxWidth = chatting_text_width - padding * 2,
                                     Font = OsuFont.Torus.With(size: 20),
                                     Colour = colourProvider.Background1,
                                     Anchor = Anchor.CentreRight,
@@ -97,7 +99,7 @@ namespace osu.Game.Overlays.Chat
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Right = 5 },
+                                Padding = new MarginPadding { Right = padding },
                                 Child = chatTextBox = new ChatTextBox
                                 {
                                     Anchor = Anchor.CentreLeft,


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/18430

There seems to be a `Truncate` set already, but the autosizing is required for right anchor so I used `MaxWidth` (may be a workaround but all other usages are workarounds for the anchor case).

![osu!_SLFFlQaeNt](https://user-images.githubusercontent.com/35318437/222345686-af83b102-c3b5-4abf-a517-a869f7e446e3.png)