### PR TITLE
Show count of visible beatmaps at song select

### DIFF
--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -19,11 +19,6 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString LocallyModifiedTooltip => new TranslatableString(getKey(@"locally_modified_tooltip"), @"Has been locally modified");
 
-        /// <summary>
-        /// "{0} beatmaps displayed"
-        /// </summary>
-        public static LocalisableString BeatmapsDisplayed(int arg0) => new TranslatableString(getKey(@"beatmaps_displayed"), @"{0:#,0} beatmaps displayed", arg0);
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
@@ -18,6 +18,11 @@ namespace osu.Game.Localisation
         /// "Has been locally modified"
         /// </summary>
         public static LocalisableString LocallyModifiedTooltip => new TranslatableString(getKey(@"locally_modified_tooltip"), @"Has been locally modified");
+
+        /// <summary>
+        /// "{0} beatmaps displayed"
+        /// </summary>
+        public static LocalisableString BeatmapsDisplayed(int arg0) => new TranslatableString(getKey(@"beatmaps_displayed"), @"{0:#,0} beatmaps displayed", arg0);
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -50,11 +50,21 @@ namespace osu.Game.Screens.Select
         public Action? BeatmapSetsChanged;
 
         /// <summary>
+        /// Triggered after filter conditions have finished being applied to the model hierarchy.
+        /// </summary>
+        public Action? FilterApplied;
+
+        /// <summary>
         /// The currently selected beatmap.
         /// </summary>
         public BeatmapInfo? SelectedBeatmapInfo => selectedBeatmap?.BeatmapInfo;
 
         private CarouselBeatmap? selectedBeatmap => selectedBeatmapSet?.Beatmaps.FirstOrDefault(s => s.State.Value == CarouselItemState.Selected);
+
+        /// <summary>
+        /// The total count of non-filtered beatmaps displayed.
+        /// </summary>
+        public int CountDisplayed => beatmapSets.Where(s => !s.Filtered.Value).Sum(s => s.Beatmaps.Count(b => !b.Filtered.Value));
 
         /// <summary>
         /// The currently selected beatmap set.
@@ -639,6 +649,8 @@ namespace osu.Game.Screens.Select
 
                 if (alwaysResetScrollPosition || !Scroll.UserScrolling)
                     ScrollToSelected(true);
+
+                FilterApplied?.Invoke();
             }
         }
 

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -38,8 +38,8 @@ namespace osu.Game.Screens.Select
 
         public LocalisableString InformationalText
         {
-            get => filterText.Text;
-            set => filterText.Text = value;
+            get => searchTextBox.FilterText.Text;
+            set => searchTextBox.FilterText.Text = value;
         }
 
         private OsuTabControl<SortMode> sortTabs;
@@ -48,11 +48,9 @@ namespace osu.Game.Screens.Select
 
         private Bindable<GroupMode> groupMode;
 
-        private SeekLimitedSearchTextBox searchTextBox;
+        private FilterControlTextBox searchTextBox;
 
         private CollectionDropdown collectionDropdown;
-
-        private OsuSpriteText filterText;
 
         public FilterCriteria CreateCriteria()
         {
@@ -111,22 +109,9 @@ namespace osu.Game.Screens.Select
                         Spacing = new Vector2(0, 5),
                         Children = new Drawable[]
                         {
-                            searchTextBox = new SeekLimitedSearchTextBox { RelativeSizeAxes = Axes.X },
-                            new Container
+                            searchTextBox = new FilterControlTextBox
                             {
                                 RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                AutoSizeDuration = 200,
-                                AutoSizeEasing = Easing.OutQuint,
-                                Children = new Drawable[]
-                                {
-                                    filterText = new OsuSpriteText
-                                    {
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
-                                        Font = OsuFont.Default.With(size: 12),
-                                    },
-                                }
                             },
                             new Box
                             {
@@ -262,5 +247,32 @@ namespace osu.Game.Screens.Select
         protected override bool OnClick(ClickEvent e) => true;
 
         protected override bool OnHover(HoverEvent e) => true;
+
+        private partial class FilterControlTextBox : SeekLimitedSearchTextBox
+        {
+            private const float filter_text_size = 12;
+
+            public OsuSpriteText FilterText;
+
+            public FilterControlTextBox()
+            {
+                Height += filter_text_size;
+                TextContainer.Margin = new MarginPadding { Bottom = filter_text_size };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                TextContainer.Add(FilterText = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.TopLeft,
+                    Depth = float.MinValue,
+                    Font = OsuFont.Default.With(size: filter_text_size, weight: FontWeight.SemiBold),
+                    Margin = new MarginPadding { Top = 2, Left = 2 },
+                    Colour = colours.Yellow
+                });
+            }
+        }
     }
 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -27,12 +28,19 @@ namespace osu.Game.Screens.Select
 {
     public partial class FilterControl : Container
     {
-        public const float HEIGHT = 2 * side_margin + 85;
-        private const float side_margin = 20;
+        public const float HEIGHT = 2 * side_margin + 120;
+
+        private const float side_margin = 10;
 
         public Action<FilterCriteria> FilterChanged;
 
         public Bindable<string> CurrentTextSearch => searchTextBox.Current;
+
+        public LocalisableString InformationalText
+        {
+            get => filterText.Text;
+            set => filterText.Text = value;
+        }
 
         private OsuTabControl<SortMode> sortTabs;
 
@@ -43,6 +51,8 @@ namespace osu.Game.Screens.Select
         private SeekLimitedSearchTextBox searchTextBox;
 
         private CollectionDropdown collectionDropdown;
+
+        private OsuSpriteText filterText;
 
         public FilterCriteria CreateCriteria()
         {
@@ -99,72 +109,76 @@ namespace osu.Game.Screens.Select
                     {
                         RelativeSizeAxes = Axes.Both,
                         Spacing = new Vector2(0, 5),
-                        Children = new[]
+                        Children = new Drawable[]
                         {
+                            searchTextBox = new SeekLimitedSearchTextBox { RelativeSizeAxes = Axes.X },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
-                                Height = 60,
+                                AutoSizeAxes = Axes.Y,
+                                AutoSizeDuration = 200,
+                                AutoSizeEasing = Easing.OutQuint,
                                 Children = new Drawable[]
                                 {
-                                    searchTextBox = new SeekLimitedSearchTextBox { RelativeSizeAxes = Axes.X },
-                                    new Box
+                                    filterText = new OsuSpriteText
                                     {
-                                        RelativeSizeAxes = Axes.X,
-                                        Height = 1,
-                                        Colour = OsuColour.Gray(80),
-                                        Origin = Anchor.BottomLeft,
-                                        Anchor = Anchor.BottomLeft,
+                                        Anchor = Anchor.TopRight,
+                                        Origin = Anchor.TopRight,
+                                        Font = OsuFont.Default.With(size: 12),
                                     },
-                                    new GridContainer
+                                }
+                            },
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 1,
+                                Colour = OsuColour.Gray(80),
+                            },
+                            new GridContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                ColumnDimensions = new[]
+                                {
+                                    new Dimension(GridSizeMode.AutoSize),
+                                    new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
+                                    new Dimension(),
+                                    new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
+                                    new Dimension(GridSizeMode.AutoSize),
+                                },
+                                RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                Content = new[]
+                                {
+                                    new[]
                                     {
-                                        Anchor = Anchor.BottomRight,
-                                        Origin = Anchor.BottomRight,
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        ColumnDimensions = new[]
+                                        new OsuSpriteText
                                         {
-                                            new Dimension(GridSizeMode.AutoSize),
-                                            new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
-                                            new Dimension(),
-                                            new Dimension(GridSizeMode.Absolute, OsuTabControl<SortMode>.HORIZONTAL_SPACING),
-                                            new Dimension(GridSizeMode.AutoSize),
+                                            Text = SortStrings.Default,
+                                            Font = OsuFont.GetFont(size: 14),
+                                            Margin = new MarginPadding(5),
+                                            Anchor = Anchor.BottomRight,
+                                            Origin = Anchor.BottomRight,
                                         },
-                                        RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                                        Content = new[]
+                                        Empty(),
+                                        sortTabs = new OsuTabControl<SortMode>
                                         {
-                                            new[]
-                                            {
-                                                new OsuSpriteText
-                                                {
-                                                    Text = SortStrings.Default,
-                                                    Font = OsuFont.GetFont(size: 14),
-                                                    Margin = new MarginPadding(5),
-                                                    Anchor = Anchor.BottomRight,
-                                                    Origin = Anchor.BottomRight,
-                                                },
-                                                Empty(),
-                                                sortTabs = new OsuTabControl<SortMode>
-                                                {
-                                                    RelativeSizeAxes = Axes.X,
-                                                    Height = 24,
-                                                    AutoSort = true,
-                                                    Anchor = Anchor.BottomRight,
-                                                    Origin = Anchor.BottomRight,
-                                                    AccentColour = colours.GreenLight,
-                                                    Current = { BindTarget = sortMode }
-                                                },
-                                                Empty(),
-                                                new OsuTabControlCheckbox
-                                                {
-                                                    Text = "Show converted",
-                                                    Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
-                                                    Anchor = Anchor.BottomRight,
-                                                    Origin = Anchor.BottomRight,
-                                                },
-                                            }
-                                        }
-                                    },
+                                            RelativeSizeAxes = Axes.X,
+                                            Height = 24,
+                                            AutoSort = true,
+                                            Anchor = Anchor.BottomRight,
+                                            Origin = Anchor.BottomRight,
+                                            AccentColour = colours.GreenLight,
+                                            Current = { BindTarget = sortMode }
+                                        },
+                                        Empty(),
+                                        new OsuTabControlCheckbox
+                                        {
+                                            Text = "Show converted",
+                                            Current = config.GetBindable<bool>(OsuSetting.ShowConvertedBeatmaps),
+                                            Anchor = Anchor.BottomRight,
+                                            Origin = Anchor.BottomRight,
+                                        },
+                                    }
                                 }
                             },
                             new Container

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Screens.Select
         {
             private const float filter_text_size = 12;
 
-            public OsuSpriteText FilterText;
+            public OsuSpriteText FilterText { get; private set; }
 
             public FilterControlTextBox()
             {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -40,6 +40,7 @@ using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Select
 {
@@ -162,6 +163,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
+                FilterApplied = () => FilterControl.InformationalText = SongSelectStrings.BeatmapsDisplayed(Carousel.CountDisplayed),
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -40,7 +40,6 @@ using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
-using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Select
 {
@@ -163,7 +162,15 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                FilterApplied = () => FilterControl.InformationalText = SongSelectStrings.BeatmapsDisplayed(Carousel.CountDisplayed),
+                FilterApplied = () =>
+                {
+                    FilterControl.InformationalText =
+                        Carousel.CountDisplayed == 1
+                            // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
+                            // but also in this case we want support for formatting a number within a string).
+                            ? $"{Carousel.CountDisplayed:#,0} beatmap displayed"
+                            : $"{Carousel.CountDisplayed:#,0} beatmaps displayed";
+                },
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,15 +162,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                FilterApplied = () =>
-                {
-                    FilterControl.InformationalText =
-                        Carousel.CountDisplayed == 1
-                            // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
-                            // but also in this case we want support for formatting a number within a string).
-                            ? $"{Carousel.CountDisplayed:#,0} matching beatmap"
-                            : $"{Carousel.CountDisplayed:#,0} matching beatmaps";
-                },
+                FilterApplied = updateVisibleBeatmapCount,
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 
@@ -837,6 +829,7 @@ namespace osu.Game.Screens.Select
         private void carouselBeatmapsLoaded()
         {
             bindBindables();
+            updateVisibleBeatmapCount();
 
             Carousel.AllowSelection = true;
 
@@ -864,6 +857,15 @@ namespace osu.Game.Screens.Select
                 // to show the dummy beatmap (we have nothing else to display).
                 performUpdateSelected();
             }
+        }
+
+        private void updateVisibleBeatmapCount()
+        {
+            FilterControl.InformationalText = Carousel.CountDisplayed == 1
+                // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
+                // but also in this case we want support for formatting a number within a string).
+                ? $"{Carousel.CountDisplayed:#,0} matching beatmap"
+                : $"{Carousel.CountDisplayed:#,0} matching beatmaps";
         }
 
         private bool boundLocalBindables;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -168,8 +168,8 @@ namespace osu.Game.Screens.Select
                         Carousel.CountDisplayed == 1
                             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
                             // but also in this case we want support for formatting a number within a string).
-                            ? $"{Carousel.CountDisplayed:#,0} beatmap displayed"
-                            : $"{Carousel.CountDisplayed:#,0} beatmaps displayed";
+                            ? $"{Carousel.CountDisplayed:#,0} matching beatmap"
+                            : $"{Carousel.CountDisplayed:#,0} matching beatmaps";
                 },
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/13837

Brought across from stable. I was going to make this show more relevant information on why things are filtered, but it turns out to be a bit of a PITA. Having the count along is still beneficial I believe.

https://user-images.githubusercontent.com/191335/222648607-b22bffcd-4449-41ae-ab4e-53137dd2a64d.mp4

