### PR TITLE
Don't filter away results with missing data when using "Date Submitted" or "Date Ranked" sort modes

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -1206,8 +1206,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 get
                 {
-                    foreach (var item in Scroll.Children)
+                    foreach (var item in Scroll.Children.OrderBy(c => c.Y))
                     {
+                        if (item.Item?.Visible != true)
+                            continue;
+
                         yield return item;
 
                         if (item is DrawableCarouselBeatmapSet set)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -532,15 +532,20 @@ namespace osu.Game.Tests.Visual.SongSelect
             loadBeatmaps(sets);
 
             AddStep("Sort by date submitted", () => carousel.Filter(new FilterCriteria { Sort = SortMode.DateSubmitted }, false));
-            checkVisibleItemCount(diff: false, count: 8);
+            checkVisibleItemCount(diff: false, count: 20);
             checkVisibleItemCount(diff: true, count: 5);
+
             AddStep("Sort by date submitted and string", () => carousel.Filter(new FilterCriteria
             {
                 Sort = SortMode.DateSubmitted,
                 SearchText = zzz_string
             }, false));
-            checkVisibleItemCount(diff: false, count: 3);
+            checkVisibleItemCount(diff: false, count: 5);
             checkVisibleItemCount(diff: true, count: 5);
+
+            AddAssert("missing date submitted are at end",
+                () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().TakeLast(2).All(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted == null));
+            AddAssert("rest are at start", () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().Take(3).All(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted != null));
         }
 
         [Test]
@@ -1129,7 +1134,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             // until step required as we are querying against alive items, which are loaded asynchronously inside DrawableCarouselBeatmapSet.
             AddUntilStep($"{count} {(diff ? "diffs" : "sets")} visible", () =>
-                carousel.Items.Count(s => (diff ? s.Item is CarouselBeatmap : s.Item is CarouselBeatmapSet) && s.Item.Visible) == count);
+                carousel.Items.Count(s => (diff ? s.Item is CarouselBeatmap : s.Item is CarouselBeatmapSet) && s.Item.Visible), () => Is.EqualTo(count));
         }
 
         private void checkSelectionIsCentered()

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -516,14 +516,19 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 sets.Clear();
 
-                for (int i = 0; i < 20; i++)
+                for (int i = 0; i < 10; i++)
                 {
                     var set = TestResources.CreateTestBeatmapSetInfo(5);
 
-                    if (i >= 2 && i < 10)
+                    // A total of 6 sets have date submitted (4 don't)
+                    // A total of 5 sets have artist string (3 of which also have date submitted)
+
+                    if (i >= 2 && i < 8) // i = 2, 3, 4, 5, 6, 7 have submitted date
                         set.DateSubmitted = DateTimeOffset.Now.AddMinutes(i);
-                    if (i < 5)
+                    if (i < 5) // i = 0, 1, 2, 3, 4 have matching string
                         set.Beatmaps.ForEach(b => b.Metadata.Artist = zzz_string);
+
+                    set.Beatmaps.ForEach(b => b.Metadata.Title = $"submitted: {set.DateSubmitted}");
 
                     sets.Add(set);
                 }
@@ -532,8 +537,13 @@ namespace osu.Game.Tests.Visual.SongSelect
             loadBeatmaps(sets);
 
             AddStep("Sort by date submitted", () => carousel.Filter(new FilterCriteria { Sort = SortMode.DateSubmitted }, false));
-            checkVisibleItemCount(diff: false, count: 20);
+            checkVisibleItemCount(diff: false, count: 10);
             checkVisibleItemCount(diff: true, count: 5);
+
+            AddAssert("missing date are at end",
+                () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().Reverse().TakeWhile(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted == null).Count(), () => Is.EqualTo(4));
+            AddAssert("rest are at start", () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().TakeWhile(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted != null).Count(),
+                () => Is.EqualTo(6));
 
             AddStep("Sort by date submitted and string", () => carousel.Filter(new FilterCriteria
             {
@@ -543,9 +553,10 @@ namespace osu.Game.Tests.Visual.SongSelect
             checkVisibleItemCount(diff: false, count: 5);
             checkVisibleItemCount(diff: true, count: 5);
 
-            AddAssert("missing date submitted are at end",
-                () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().TakeLast(2).All(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted == null));
-            AddAssert("rest are at start", () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().Take(3).All(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted != null));
+            AddAssert("missing date are at end",
+                () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().Reverse().TakeWhile(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted == null).Count(), () => Is.EqualTo(2));
+            AddAssert("rest are at start", () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().TakeWhile(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted != null).Count(),
+                () => Is.EqualTo(3));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (!(other is CarouselBeatmapSet otherSet))
                 return base.CompareTo(criteria, other);
 
-            int comparison = 0;
+            int comparison;
 
             switch (criteria.Sort)
             {
@@ -87,11 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case SortMode.DateRanked:
-                    // Beatmaps which have no ranked date should already be filtered away in this mode.
-                    if (BeatmapSet.DateRanked == null || otherSet.BeatmapSet.DateRanked == null)
-                        break;
-
-                    comparison = otherSet.BeatmapSet.DateRanked.Value.CompareTo(BeatmapSet.DateRanked.Value);
+                    comparison = compareNullableDateTimeOffset(BeatmapSet.DateRanked, otherSet.BeatmapSet.DateRanked);
                     break;
 
                 case SortMode.LastPlayed:
@@ -111,11 +107,7 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case SortMode.DateSubmitted:
-                    // Beatmaps which have no submitted date should already be filtered away in this mode.
-                    if (BeatmapSet.DateSubmitted == null || otherSet.BeatmapSet.DateSubmitted == null)
-                        break;
-
-                    comparison = otherSet.BeatmapSet.DateSubmitted.Value.CompareTo(BeatmapSet.DateSubmitted.Value);
+                    comparison = compareNullableDateTimeOffset(BeatmapSet.DateSubmitted, otherSet.BeatmapSet.DateSubmitted);
                     break;
             }
 
@@ -130,6 +122,14 @@ namespace osu.Game.Screens.Select.Carousel
             // If DateAdded fails to break the tie, fallback to our internal GUID for stability.
             // This basically means it's a stable random sort.
             return otherSet.BeatmapSet.ID.CompareTo(BeatmapSet.ID);
+        }
+
+        private static int compareNullableDateTimeOffset(DateTimeOffset? x, DateTimeOffset? y)
+        {
+            if (x == null) return 1;
+            if (y == null) return -1;
+
+            return y.Value.CompareTo(x.Value);
         }
 
         /// <summary>
@@ -153,12 +153,7 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            bool filtered = Items.All(i => i.Filtered.Value);
-
-            filtered |= criteria.Sort == SortMode.DateRanked && BeatmapSet.DateRanked == null;
-            filtered |= criteria.Sort == SortMode.DateSubmitted && BeatmapSet.DateSubmitted == null;
-
-            Filtered.Value = filtered;
+            Filtered.Value = Items.All(i => i.Filtered.Value);
         }
 
         public override string ToString() => BeatmapSet.ToString();

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case SortMode.DateRanked:
-                    comparison = compareNullableDateTimeOffset(BeatmapSet.DateRanked, otherSet.BeatmapSet.DateRanked);
+                    comparison = Nullable.Compare(otherSet.BeatmapSet.DateRanked, BeatmapSet.DateRanked);
                     break;
 
                 case SortMode.LastPlayed:
@@ -107,7 +107,7 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case SortMode.DateSubmitted:
-                    comparison = compareNullableDateTimeOffset(BeatmapSet.DateSubmitted, otherSet.BeatmapSet.DateSubmitted);
+                    comparison = Nullable.Compare(otherSet.BeatmapSet.DateSubmitted, BeatmapSet.DateSubmitted);
                     break;
             }
 
@@ -122,14 +122,6 @@ namespace osu.Game.Screens.Select.Carousel
             // If DateAdded fails to break the tie, fallback to our internal GUID for stability.
             // This basically means it's a stable random sort.
             return otherSet.BeatmapSet.ID.CompareTo(BeatmapSet.ID);
-        }
-
-        private static int compareNullableDateTimeOffset(DateTimeOffset? x, DateTimeOffset? y)
-        {
-            if (x == null) return 1;
-            if (y == null) return -1;
-
-            return y.Value.CompareTo(x.Value);
         }
 
         /// <summary>


### PR DESCRIPTION
From a user's perspective, changing a sort / order mode shouldn't filter away results, but we were doing this.

In terms of UX expectations, in stable this kind of scenario would results in a group being added to the end of son select with "Not ranked" or "Unknown". I think we should aim to match this eventually.

Addresses the more immediate usability portion of https://github.com/ppy/osu/issues/22416 (triggered by another user hitting the same problem at https://github.com/ppy/osu/discussions/22752).