### PR TITLE
Fix several issues with skin editor behaviour on screen transitions

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -188,6 +188,30 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("mod overlay closed", () => songSelect.ModSelectOverlay.State.Value == Visibility.Hidden);
         }
 
+        [Test]
+        public void TestChangeToNonSkinnableScreen()
+        {
+            advanceToSongSelect();
+            openSkinEditor();
+            AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
+            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+
+            AddStep("add skinnable component", () =>
+            {
+                skinEditor.ChildrenOfType<SkinComponentToolbox.ToolboxComponentButton>().First().TriggerClick();
+            });
+            AddUntilStep("newly added component selected", () => skinEditor.SelectedComponents, () => Has.Count.EqualTo(1));
+
+            AddStep("exit to main menu", () => Game.ScreenStack.CurrentScreen.Exit());
+            AddAssert("selection cleared", () => skinEditor.SelectedComponents, () => Has.Count.Zero);
+            AddAssert("blueprint container not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.Zero);
+            AddAssert("placeholder present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.EqualTo(1));
+
+            advanceToSongSelect();
+            AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
+            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+        }
+
         private void advanceToSongSelect()
         {
             PushAndConfirm(() => songSelect = new TestPlaySongSelect());

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Tests.Visual.Navigation
             advanceToSongSelect();
             openSkinEditor();
             AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
-            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
 
             AddStep("add skinnable component", () =>
             {
@@ -205,11 +205,11 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("exit to main menu", () => Game.ScreenStack.CurrentScreen.Exit());
             AddAssert("selection cleared", () => skinEditor.SelectedComponents, () => Has.Count.Zero);
             AddAssert("blueprint container not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.Zero);
-            AddAssert("placeholder present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.EqualTo(1));
+            AddAssert("placeholder present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.EqualTo(1));
 
             advanceToSongSelect();
             AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
-            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer.NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+            AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
         }
 
         private void advanceToSongSelect()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -15,6 +15,7 @@ using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
 using osu.Game.Tests.Beatmaps.IO;
@@ -195,6 +196,7 @@ namespace osu.Game.Tests.Visual.Navigation
             openSkinEditor();
             AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
             AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+            AddAssert("editor sidebars not empty", () => skinEditor.ChildrenOfType<EditorSidebar>().SelectMany(sidebar => sidebar.Children).Count(), () => Is.GreaterThan(0));
 
             AddStep("add skinnable component", () =>
             {
@@ -206,10 +208,12 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("selection cleared", () => skinEditor.SelectedComponents, () => Has.Count.Zero);
             AddAssert("blueprint container not present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.Zero);
             AddAssert("placeholder present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.EqualTo(1));
+            AddAssert("editor sidebars empty", () => skinEditor.ChildrenOfType<EditorSidebar>().SelectMany(sidebar => sidebar.Children).Count(), () => Is.Zero);
 
             advanceToSongSelect();
             AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
             AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
+            AddAssert("editor sidebars not empty", () => skinEditor.ChildrenOfType<EditorSidebar>().SelectMany(sidebar => sidebar.Children).Count(), () => Is.GreaterThan(0));
         }
 
         private void advanceToSongSelect()

--- a/osu.Game/Overlays/SkinEditor/NonSkinnableScreenPlaceholder.cs
+++ b/osu.Game/Overlays/SkinEditor/NonSkinnableScreenPlaceholder.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK;
+
+namespace osu.Game.Overlays.SkinEditor
+{
+    public partial class NonSkinnableScreenPlaceholder : CompositeDrawable
+    {
+        [Resolved]
+        private SkinEditorOverlay? skinEditorOverlay { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colourProvider.Dark6,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.95f,
+                },
+                new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(0, 5),
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new SpriteIcon
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Icon = FontAwesome.Solid.ExclamationCircle,
+                            Size = new Vector2(24),
+                            Y = -5,
+                        },
+                        new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold, size: 18))
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            TextAnchor = Anchor.Centre,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Text = "Please navigate to a skinnable screen using the scene library",
+                        },
+                        new RoundedButton
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Width = 200,
+                            Margin = new MarginPadding { Top = 20 },
+                            Action = () => skinEditorOverlay?.Hide(),
+                            Text = "Return to game"
+                        }
+                    }
+                },
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -8,14 +8,8 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Skinning;
@@ -159,66 +153,6 @@ namespace osu.Game.Overlays.SkinEditor
 
             foreach (var list in targetComponents)
                 list.UnbindAll();
-        }
-
-        public partial class NonSkinnableScreenPlaceholder : CompositeDrawable
-        {
-            [Resolved]
-            private SkinEditorOverlay? skinEditorOverlay { get; set; }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                RelativeSizeAxes = Axes.Both;
-
-                InternalChildren = new Drawable[]
-                {
-                    new Box
-                    {
-                        Colour = colourProvider.Dark6,
-                        RelativeSizeAxes = Axes.Both,
-                        Alpha = 0.95f,
-                    },
-                    new FillFlowContainer
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Spacing = new Vector2(0, 5),
-                        Direction = FillDirection.Vertical,
-                        Children = new Drawable[]
-                        {
-                            new SpriteIcon
-                            {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                Icon = FontAwesome.Solid.ExclamationCircle,
-                                Size = new Vector2(24),
-                                Y = -5,
-                            },
-                            new OsuTextFlowContainer(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold, size: 18))
-                            {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                TextAnchor = Anchor.Centre,
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                Text = "Please navigate to a skinnable screen using the scene library",
-                            },
-                            new RoundedButton
-                            {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                Width = 200,
-                                Margin = new MarginPadding { Top = 20 },
-                                Action = () => skinEditorOverlay?.Hide(),
-                                Text = "Return to game"
-                            }
-                        }
-                    },
-                };
-            }
         }
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -7,9 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Skinning;
@@ -20,16 +18,16 @@ namespace osu.Game.Overlays.SkinEditor
 {
     public partial class SkinBlueprintContainer : BlueprintContainer<ISerialisableDrawable>
     {
-        private readonly Drawable target;
+        private readonly ISerialisableDrawableContainer targetContainer;
 
         private readonly List<BindableList<ISerialisableDrawable>> targetComponents = new List<BindableList<ISerialisableDrawable>>();
 
         [Resolved]
         private SkinEditor editor { get; set; } = null!;
 
-        public SkinBlueprintContainer(Drawable target)
+        public SkinBlueprintContainer(ISerialisableDrawableContainer targetContainer)
         {
-            this.target = target;
+            this.targetContainer = targetContainer;
         }
 
         protected override void LoadComplete()
@@ -38,22 +36,10 @@ namespace osu.Game.Overlays.SkinEditor
 
             SelectedItems.BindTo(editor.SelectedComponents);
 
-            // track each target container on the current screen.
-            var targetContainers = target.ChildrenOfType<ISerialisableDrawableContainer>().ToArray();
+            var bindableList = new BindableList<ISerialisableDrawable> { BindTarget = targetContainer.Components };
+            bindableList.BindCollectionChanged(componentsChanged, true);
 
-            if (targetContainers.Length == 0)
-            {
-                AddInternal(new NonSkinnableScreenPlaceholder());
-                return;
-            }
-
-            foreach (var targetContainer in targetContainers)
-            {
-                var bindableList = new BindableList<ISerialisableDrawable> { BindTarget = targetContainer.Components };
-                bindableList.BindCollectionChanged(componentsChanged, true);
-
-                targetComponents.Add(bindableList);
-            }
+            targetComponents.Add(bindableList);
         }
 
         private void componentsChanged(object? sender, NotifyCollectionChangedEventArgs e) => Schedule(() =>

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -323,12 +323,12 @@ namespace osu.Game.Overlays.SkinEditor
             foreach (var toolbox in componentsSidebar.OfType<SkinComponentToolbox>())
                 toolbox.Expire();
 
+            SelectedComponents.Clear();
+
             if (target.NewValue == null)
                 return;
 
             Debug.Assert(content != null);
-
-            SelectedComponents.Clear();
 
             var skinComponentsContainer = getTarget(target.NewValue);
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -304,7 +304,8 @@ namespace osu.Game.Overlays.SkinEditor
             changeHandler?.Dispose();
 
             // Immediately clear the previous blueprint container to ensure it doesn't try to interact with the old target.
-            content?.Clear();
+            if (content?.Child is SkinBlueprintContainer)
+                content.Clear();
 
             Scheduler.AddOnce(loadBlueprintContainer);
             Scheduler.AddOnce(populateSettings);
@@ -325,15 +326,15 @@ namespace osu.Game.Overlays.SkinEditor
 
             SelectedComponents.Clear();
 
-            if (target.NewValue == null)
-                return;
-
             Debug.Assert(content != null);
 
             var skinComponentsContainer = getTarget(target.NewValue);
 
-            if (skinComponentsContainer == null)
+            if (target.NewValue == null || skinComponentsContainer == null)
+            {
+                content.Child = new NonSkinnableScreenPlaceholder();
                 return;
+            }
 
             changeHandler = new SkinEditorChangeHandler(skinComponentsContainer);
             changeHandler.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -324,6 +324,7 @@ namespace osu.Game.Overlays.SkinEditor
             foreach (var toolbox in componentsSidebar.OfType<SkinComponentToolbox>())
                 toolbox.Expire();
 
+            componentsSidebar.Clear();
             SelectedComponents.Clear();
 
             Debug.Assert(content != null);


### PR DESCRIPTION
This is an assorted grab-bag of various fixes of issues that arose in the skin editor after https://github.com/ppy/osu/pull/22674, all associated with screen switches. It must not have been a good day in the office when I was reviewing that one.

## 15409b9c15fc827581ff97b809707fb506548b13: Fix skin selection not clearing on exit to non-skinnable screen

If the new screen being navigated to was not skinnable, then the selected components from the previous screen would remain "selected" as far as the editor was concerned, which in the worst case leads to the right skin editor sidebar still having settings items visible for the "selection".

## 49e298e3049760572133355a1518416b551dfe53: Accept `ISerialisableDrawableContainer` directly in `SkinBlueprintContainer`

This is more of a refactoring than an actual fix, but I think it makes sense to include it here when combined with everything else.

An end result of https://github.com/ppy/osu/pull/22674 is that `SkinBlueprintContainer`s are only ever created by supplying a `SkinComponentsContainer` to them. However, `SkinBlueprintContainer` still contained remnants of code that suggested it was designed to handle cases where the drawable supplied to it contained more than one `ISerialisableDrawableContainer`, or even zero.

The zero path is totally dead right now (because every `SkinComponentsContainer` is *by necessity* an `ISerialisableDrawableContainer`), and the more-than-one path is dead *for now* (and potentially forever?). Therefore, just hard-couple `SkinBlueprintContainer` to receive a single target container.

## d233f3a3ab5f606c308d7682b6b3a121e2e0af6f: Show non-skinnable screen placeholder at higher level

This extracts the placeholder-showing logic out of `SkinBlueprintContainer` to the skin editor level next to the rest of the screen transition logic, and fixes #22784 as a result.

## 60cdd3c0706a7be59eeef64eb6cb3b362d842aaa: Clear components sidebar unconditionally on every target change

Fixes the working layer dropdown lingering after exiting from a skinnable screen to a non-skinnable one.