### PR TITLE
Fix storyboard videos not fading out on completion

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -58,7 +58,11 @@ namespace osu.Game.Storyboards.Drawables
             using (drawableVideo.BeginAbsoluteSequence(Video.StartTime))
             {
                 Schedule(() => drawableVideo.PlaybackPosition = Time.Current - Video.StartTime);
+
                 drawableVideo.FadeIn(500);
+
+                using (drawableVideo.BeginDelayedSequence(drawableVideo.Duration - 500))
+                    drawableVideo.FadeOut(500);
             }
         }
     }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22802.

Stable uses a 1,000 ms fade-in / out. Rather than matching that, I've stuck with 500ms (what lazer was already using for the fade-in) because I think it feels better.

Tested using the beatmap linked in the issue thread.