### PR TITLE
Fix mod select overlay buttons potentially showing wrong state after exiting editor

### DIFF
--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -22,6 +22,11 @@ namespace osu.Game.Overlays.Mods
 
         private readonly ModState modState;
 
+        public ModPanel(Mod mod)
+            : this(new ModState(mod))
+        {
+        }
+
         public ModPanel(ModState modState)
         {
             this.modState = modState;
@@ -37,11 +42,6 @@ namespace osu.Game.Overlays.Mods
                 Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                 Scale = new Vector2(HEIGHT / ModSwitchSmall.DEFAULT_SIZE)
             };
-        }
-
-        public ModPanel(Mod mod)
-            : this(new ModState(mod))
-        {
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -45,7 +45,8 @@ namespace osu.Game.Overlays.Mods
         /// Contrary to <see cref="OsuGameBase.AvailableMods"/> and <see cref="globalAvailableMods"/>, the <see cref="Mod"/> instances
         /// inside the <see cref="ModState"/> objects are owned solely by this <see cref="ModSelectOverlay"/> instance.
         /// </remarks>
-        public Bindable<Dictionary<ModType, IReadOnlyList<ModState>>> AvailableMods { get; } = new Bindable<Dictionary<ModType, IReadOnlyList<ModState>>>(new Dictionary<ModType, IReadOnlyList<ModState>>());
+        public Bindable<Dictionary<ModType, IReadOnlyList<ModState>>> AvailableMods { get; } =
+            new Bindable<Dictionary<ModType, IReadOnlyList<ModState>>>(new Dictionary<ModType, IReadOnlyList<ModState>>());
 
         private Func<Mod, bool> isValidMod = _ => true;
 
@@ -438,7 +439,8 @@ namespace osu.Game.Overlays.Mods
                 }
             }
 
-            SelectedMods.Value = newSelection;
+            if (!SelectedMods.Disabled)
+                SelectedMods.Value = newSelection;
 
             externalSelectionUpdateInProgress = false;
         }


### PR DESCRIPTION
- Select osu! beatmap
- Change ruleset at song select to taiko
- Select "swap" mod (only valid for taiko)
- Enter editor (mod is deselected on entering)
- Exit editor
- Ensure mod is visibly selected in mod select overlay

It was quite a pain to figure this one out. Not sure if fixing like this is good-enough, or whether we should reexamine the `Unbind`/`Rebind` logic in song select's screen transitions. I can understand why it's there (the overlay also mutates `SelectedMods`) so maybe it's fine?

Closes #22816.