### PR TITLE
Update osu!mania argon design in line with proposal

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -236,6 +236,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             };
 
             // Position and resize the body to lie half-way under the head and the tail notes.
+            // The rationale for this is account for heads/tails with corner radius.
             bodyPiece.Y = (Direction.Value == ScrollingDirection.Up ? 1 : -1) * Head.Height / 2;
             bodyPiece.Height = DrawHeight - Head.Height / 2 + Tail.Height / 2;
 

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     {
         protected override ManiaSkinComponents Component => ManiaSkinComponents.HoldNoteTail;
 
-        protected DrawableHoldNote HoldNote => (DrawableHoldNote)ParentHitObject;
+        protected internal DrawableHoldNote HoldNote => (DrawableHoldNote)ParentHitObject;
 
         public DrawableHoldNoteTail()
             : this(null)

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
@@ -43,9 +43,10 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             {
                 largeFaint = new Container
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
                     RelativeSizeAxes = Axes.Both,
+                    Height = ArgonNotePiece.NOTE_ACCENT_RATIO,
                     Masking = true,
                     CornerRadius = ArgonNotePiece.CORNER_RADIUS,
                     Blending = BlendingParameters.Additive,

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitTarget.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private void load(IScrollingInfo scrollingInfo)
         {
             RelativeSizeAxes = Axes.X;
-            Height = ArgonNotePiece.NOTE_HEIGHT;
+            Height = ArgonNotePiece.NOTE_HEIGHT * ArgonNotePiece.NOTE_ACCENT_RATIO;
 
             Masking = true;
             CornerRadius = ArgonNotePiece.CORNER_RADIUS;

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             // Without this, the width of the body will be slightly larger than the head/tail.
             Masking = true;
             CornerRadius = ArgonNotePiece.CORNER_RADIUS;
-            Blending = BlendingParameters.Additive;
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
@@ -20,10 +20,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
     public partial class ArgonHoldBodyPiece : CompositeDrawable, IHoldNoteBody
     {
         protected readonly Bindable<Color4> AccentColour = new Bindable<Color4>();
-        protected readonly IBindable<bool> IsHitting = new Bindable<bool>();
 
         private Drawable background = null!;
-        private Box foreground = null!;
+        private ArgonHoldNoteHittingLayer hittingLayer = null!;
 
         public ArgonHoldBodyPiece()
         {
@@ -40,12 +39,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             InternalChildren = new[]
             {
                 background = new Box { RelativeSizeAxes = Axes.Both },
-                foreground = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Blending = BlendingParameters.Additive,
-                    Alpha = 0,
-                },
+                hittingLayer = new ArgonHoldNoteHittingLayer()
             };
 
             if (drawableObject != null)
@@ -53,44 +47,19 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 var holdNote = (DrawableHoldNote)drawableObject;
 
                 AccentColour.BindTo(holdNote.AccentColour);
-                IsHitting.BindTo(holdNote.IsHitting);
+                hittingLayer.AccentColour.BindTo(holdNote.AccentColour);
+                ((IBindable<bool>)hittingLayer.IsHitting).BindTo(holdNote.IsHitting);
             }
 
             AccentColour.BindValueChanged(colour =>
             {
                 background.Colour = colour.NewValue.Darken(0.6f);
-                foreground.Colour = colour.NewValue.Opacity(0.2f);
             }, true);
-
-            IsHitting.BindValueChanged(hitting =>
-            {
-                const float animation_length = 50;
-
-                foreground.ClearTransforms();
-
-                if (hitting.NewValue)
-                {
-                    // wait for the next sync point
-                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
-
-                    using (foreground.BeginDelayedSequence(synchronisedOffset))
-                    {
-                        foreground.FadeTo(1, animation_length).Then()
-                                  .FadeTo(0.5f, animation_length)
-                                  .Loop();
-                    }
-                }
-                else
-                {
-                    foreground.FadeOut(animation_length);
-                }
-            });
         }
 
         public void Recycle()
         {
-            foreground.ClearTransforms();
-            foreground.Alpha = 0;
+            hittingLayer.Recycle();
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldBodyPiece.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
             AccentColour.BindValueChanged(colour =>
             {
-                background.Colour = colour.NewValue.Darken(1.2f);
+                background.Colour = colour.NewValue.Darken(0.6f);
                 foreground.Colour = colour.NewValue.Opacity(0.2f);
             }, true);
 

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHeadPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHeadPiece.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
+            Y = 2,
             Size = new Vector2(20, 5),
         };
     }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHeadPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHeadPiece.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Argon
+{
+    internal partial class ArgonHoldNoteHeadPiece : ArgonNotePiece
+    {
+        protected override Drawable CreateIcon() => new Circle
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Size = new Vector2(20, 5),
+        };
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHittingLayer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHittingLayer.cs
@@ -27,12 +27,12 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
             AccentColour.BindValueChanged(colour =>
             {
-                Colour = colour.NewValue.Opacity(0.2f);
+                Colour = colour.NewValue.Lighten(0.2f).Opacity(0.3f);
             }, true);
 
             IsHitting.BindValueChanged(hitting =>
             {
-                const float animation_length = 50;
+                const float animation_length = 80;
 
                 ClearTransforms();
 
@@ -43,8 +43,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                     using (BeginDelayedSequence(synchronisedOffset))
                     {
-                        this.FadeTo(1, animation_length).Then()
-                            .FadeTo(0.5f, animation_length)
+                        this.FadeTo(1, animation_length, Easing.OutSine).Then()
+                            .FadeTo(0.5f, animation_length, Easing.InSine)
                             .Loop();
                     }
                 }
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 {
                     this.FadeOut(animation_length);
                 }
-            });
+            }, true);
         }
 
         public void Recycle()

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHittingLayer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteHittingLayer.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+using Box = osu.Framework.Graphics.Shapes.Box;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Argon
+{
+    public partial class ArgonHoldNoteHittingLayer : Box
+    {
+        public readonly Bindable<Color4> AccentColour = new Bindable<Color4>();
+        public readonly Bindable<bool> IsHitting = new Bindable<bool>();
+
+        public ArgonHoldNoteHittingLayer()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Blending = BlendingParameters.Additive;
+            Alpha = 0;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AccentColour.BindValueChanged(colour =>
+            {
+                Colour = colour.NewValue.Opacity(0.2f);
+            }, true);
+
+            IsHitting.BindValueChanged(hitting =>
+            {
+                const float animation_length = 50;
+
+                ClearTransforms();
+
+                if (hitting.NewValue)
+                {
+                    // wait for the next sync point
+                    double synchronisedOffset = animation_length * 2 - Time.Current % (animation_length * 2);
+
+                    using (BeginDelayedSequence(synchronisedOffset))
+                    {
+                        this.FadeTo(1, animation_length).Then()
+                            .FadeTo(0.5f, animation_length)
+                            .Loop();
+                    }
+                }
+                else
+                {
+                    this.FadeOut(animation_length);
+                }
+            });
+        }
+
+        public void Recycle()
+        {
+            ClearTransforms();
+            Alpha = 0;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
@@ -21,7 +21,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
         private readonly Box shadow;
-        private readonly Box shadeForeground;
+        private readonly Box foreground;
+        private readonly Box foregroundAdditive;
 
         public ArgonHoldNoteTailPiece()
         {
@@ -55,9 +56,15 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                             Masking = true,
                             Children = new Drawable[]
                             {
-                                shadeForeground = new Box
+                                foreground = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
+                                },
+                                foregroundAdditive = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Blending = BlendingParameters.Additive,
+                                    Height = 0.5f,
                                 },
                             },
                         },
@@ -86,9 +93,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
         private void onAccentChanged(ValueChangedEvent<Color4> accent)
         {
-            shadeForeground.Colour = ColourInfo.GradientVertical(
-                accent.NewValue.Darken(0.2f),
-                accent.NewValue.Darken(1.2f) // matches body
+            foreground.Colour = accent.NewValue.Darken(0.6f); // matches body
+
+            foregroundAdditive.Colour = ColourInfo.GradientVertical(
+                accent.NewValue.Opacity(0.4f),
+                accent.NewValue.Opacity(0)
             );
         }
     }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
-        private readonly Box shadow;
         private readonly Box foreground;
         private readonly Box foregroundAdditive;
 
@@ -39,7 +38,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        shadow = new Box
+                        new Box
                         {
                             RelativeSizeAxes = Axes.Both,
                             Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Colour4.Black),

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHoldNoteTailPiece.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private readonly IBindable<ScrollingDirection> direction = new Bindable<ScrollingDirection>();
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
-        private readonly Box shadeBackground;
+        private readonly Box shadow;
         private readonly Box shadeForeground;
 
         public ArgonHoldNoteTailPiece()
@@ -27,30 +28,40 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             RelativeSizeAxes = Axes.X;
             Height = ArgonNotePiece.NOTE_HEIGHT;
 
-            CornerRadius = ArgonNotePiece.CORNER_RADIUS;
-            Masking = true;
-
             InternalChildren = new Drawable[]
             {
-                shadeBackground = new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Height = ArgonNotePiece.NOTE_ACCENT_RATIO,
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
+                    RelativeSizeAxes = Axes.X,
+                    Height = ArgonNotePiece.NOTE_HEIGHT,
                     CornerRadius = ArgonNotePiece.CORNER_RADIUS,
                     Masking = true,
                     Children = new Drawable[]
                     {
-                        shadeForeground = new Box
+                        shadow = new Box
                         {
                             RelativeSizeAxes = Axes.Both,
+                            Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Colour4.Black),
+                            // Avoid ugly single pixel overlap.
+                            Height = 0.9f,
                         },
-                    },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            Height = ArgonNotePiece.NOTE_ACCENT_RATIO,
+                            CornerRadius = ArgonNotePiece.CORNER_RADIUS,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                shadeForeground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                            },
+                        },
+                    }
                 },
             };
         }
@@ -75,8 +86,10 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
         private void onAccentChanged(ValueChangedEvent<Color4> accent)
         {
-            shadeBackground.Colour = accent.NewValue.Darken(1.7f);
-            shadeForeground.Colour = accent.NewValue.Darken(1.1f);
+            shadeForeground.Colour = ColourInfo.GradientVertical(
+                accent.NewValue.Darken(0.2f),
+                accent.NewValue.Darken(1.2f) // matches body
+            );
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
         private readonly Box colouredBox;
-        private readonly Box shadow;
 
         public ArgonNotePiece()
         {
@@ -38,7 +37,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
             InternalChildren = new[]
             {
-                shadow = new Box
+                new Box
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Colour4.Black)

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 shadow = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0), Colour4.Black)
                 },
                 new Container
                 {
@@ -109,8 +110,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                 accent.NewValue.Lighten(0.1f),
                 accent.NewValue
             );
-
-            shadow.Colour = accent.NewValue.Darken(0.5f);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonNotePiece.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             CornerRadius = CORNER_RADIUS;
             Masking = true;
 
-            InternalChildren = new Drawable[]
+            InternalChildren = new[]
             {
                 shadow = new Box
                 {
@@ -65,17 +65,21 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                     RelativeSizeAxes = Axes.X,
                     Height = CORNER_RADIUS * 2,
                 },
-                new SpriteIcon
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Y = 4,
-                    Icon = FontAwesome.Solid.AngleDown,
-                    Size = new Vector2(20),
-                    Scale = new Vector2(1, 0.7f)
-                }
+                CreateIcon(),
             };
         }
+
+        protected virtual Drawable CreateIcon() => new SpriteIcon
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Y = 4,
+            // TODO: replace with a non-squashed version.
+            // The 0.7f height scale should be removed.
+            Icon = FontAwesome.Solid.AngleDown,
+            Size = new Vector2(20),
+            Scale = new Vector2(1, 0.7f)
+        };
 
         [BackgroundDependencyLoader(true)]
         private void load(IScrollingInfo scrollingInfo, DrawableHitObject? drawableObject)

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                             return new ArgonHoldNoteTailPiece();
 
                         case ManiaSkinComponents.HoldNoteHead:
+                            return new ArgonHoldNoteHeadPiece();
+
                         case ManiaSkinComponents.Note:
                             return new ArgonNotePiece();
 


### PR DESCRIPTION
As per https://github.com/ppy/osu/discussions/21996 / 
https://user-images.githubusercontent.com/50823728/218038463-b450f46c-ef21-4551-b133-f866be59970c.png

I've tried to match things up, but it's not a 1:1 recreation. There are a few limiting factors so I've done the best I can with what is available without getting too hacky and without making changes to osu!mania which would affect other skin implementations.

A few things to note:

- When a hold note is being hit, the tail doesn't light up with the rest of the track. This is due to the way sizing works on hold notes (basically I can't use additive lighting here because the body underneath the tail note only covers half the tail).
- For similar reasons, it's hard to add the border as proposed in the design. But I think it's not too bad even without it (I'm not sold on the look of the border yet).
- The note height still includes the shadow, even though the shadow isn't really (shouldn't really) be part of the note height. This is because of the way masking is applied in mania at a higher level, meaning there's no way to draw outside of the note area because of the masking applied in `DrawableHoldNote` (see `maskingContainer`). Not great, but also didn't turn out too unreadable.

Colours etc. are ballparked.

![osu! 2023-03-09 at 11 42 22](https://user-images.githubusercontent.com/191335/224012994-2e01f7f9-18b2-449e-b2ef-af1ae2a68d20.png)

https://user-images.githubusercontent.com/191335/224012753-160555b3-11e5-4e4d-b049-5497b9d23876.mp4

