### PR TITLE
Fix argon progress bar fill being oversized

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -242,7 +242,6 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     length = value;
                     mask.Width = value * DrawWidth;
-                    fill.Width = value * DrawWidth;
                 }
             }
 


### PR DESCRIPTION
Noticed this in passing while doing some unrelated stuff.

The fill Box was already affected by `RelativeSizeAxes`, so resizing it was redundant, and caused the pixel statistic to skyrocket in the fps counter as playback progresses.