### PR TITLE
Display stub notice in marked wiki articles

### DIFF
--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Resources.Localisation.Web;
+using osuTK;
 
 namespace osu.Game.Overlays.Wiki.Markdown
 {
@@ -26,6 +27,7 @@ namespace osu.Game.Overlays.Wiki.Markdown
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
             Direction = FillDirection.Vertical;
+            Spacing = new Vector2(10);
 
             foreach (object line in yamlFrontMatterBlock.Lines)
             {

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -30,11 +30,11 @@ namespace osu.Game.Overlays.Wiki.Markdown
             {
                 switch (line.ToString())
                 {
-                    case "outdated: true":
+                    case @"outdated: true":
                         isOutdated = true;
                         break;
 
-                    case "needs_cleanup: true":
+                    case @"needs_cleanup: true":
                         needsCleanup = true;
                         break;
                 }

--- a/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiNoticeContainer.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Overlays.Wiki.Markdown
     {
         private readonly bool isOutdated;
         private readonly bool needsCleanup;
+        private readonly bool isStub;
 
         public WikiNoticeContainer(YamlFrontMatterBlock yamlFrontMatterBlock)
         {
@@ -36,6 +37,10 @@ namespace osu.Game.Overlays.Wiki.Markdown
 
                     case @"needs_cleanup: true":
                         needsCleanup = true;
+                        break;
+
+                    case @"stub: true":
+                        isStub = true;
                         break;
                 }
             }
@@ -58,6 +63,14 @@ namespace osu.Game.Overlays.Wiki.Markdown
                 Add(new NoticeBox
                 {
                     Text = WikiStrings.ShowNeedsCleanupOrRewrite,
+                });
+            }
+
+            if (isStub)
+            {
+                Add(new NoticeBox
+                {
+                    Text = WikiStrings.ShowStub,
                 });
             }
         }


### PR DESCRIPTION
First web reference is already in code but linking the specific lines here:
https://github.com/ppy/osu-web/blob/76e9b9cb71fef7177a2f63ab83c0b9cd5ac6f01f/resources/views/wiki/_notice.blade.php#L37-L41
https://github.com/ppy/osu-web/blob/76e9b9cb71fef7177a2f63ab83c0b9cd5ac6f01f/resources/css/bem/wiki-notice.less#L9

Example: https://dev.ppy.sh/wiki/en/Gameplay/Game_modifier/Score_multiplier

| Before | After | Web |
| --- | --- | --- |
| ![osu!_lRpWMdqjO2](https://user-images.githubusercontent.com/35318437/224525988-16443e15-5989-4f15-a774-40641f06e86d.png) | ![osu!_cRF1AouFqD](https://user-images.githubusercontent.com/35318437/224525945-5e944008-0e03-40da-9bfd-95be1725cdf6.png) | ![firefox_vBgxM9ZFIB](https://user-images.githubusercontent.com/35318437/224526008-dba78f8a-57a8-4881-aac5-91971cf6e84b.png) |

Note: When reading the multiple notice boxes above, the "outdated" and "stub" notices seem redundant as both say "incomplete". This PR just aims for consistency, so that should be a web/wiki issue.