### PR TITLE
Prevent elements that are anchored in the center from blocking loading

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -101,7 +101,8 @@ namespace osu.Game.Screens.Play
             // not ready if the user is hovering one of the panes, unless they are idle.
             (IsHovered || idleTracker.IsIdle.Value)
             // not ready if the user is dragging a slider or otherwise.
-            && inputManager.DraggedDrawable == null
+            // Filter out the center panel when loading a beat map (see https://github.com/ppy/osu/issues/22657)
+            && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable.Anchor == Anchor.Centre)
             // not ready if a focused overlay is visible, like settings.
             && inputManager.FocusedDrawable == null;
 


### PR DESCRIPTION
Solution for issue https://github.com/ppy/osu/issues/22657

Through testing, I have determined that if you hold the mouse down after the song has been selected / after you retry but before it loads, it will block due to the DraggedDrawable check.

To resolve this, I have added a condition that will filter out the DraggedDrawable if it is anchored in the center. 