### PR TITLE
Prevent LoadingLayer from blocking loading

### DIFF
--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -69,6 +69,10 @@ namespace osu.Game.Graphics.UserInterface
                 // note that this will not work well if touch handling elements are beneath this loading layer (something to consider for the future).
                 case TouchEvent:
                     return false;
+
+                // blocking drag events to prevent unintended ui pausing while loading a beat map (see https://github.com/ppy/osu/issues/22657)
+                case DragEvent:
+                    return false;
             }
 
             return true;

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -69,10 +69,6 @@ namespace osu.Game.Graphics.UserInterface
                 // note that this will not work well if touch handling elements are beneath this loading layer (something to consider for the future).
                 case TouchEvent:
                     return false;
-
-                // blocking drag events to prevent unintended ui pausing while loading a beat map (see https://github.com/ppy/osu/issues/22657)
-                case DragStartEvent:
-                    return false;
             }
 
             return true;

--- a/osu.Game/Graphics/UserInterface/LoadingLayer.cs
+++ b/osu.Game/Graphics/UserInterface/LoadingLayer.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Graphics.UserInterface
                     return false;
 
                 // blocking drag events to prevent unintended ui pausing while loading a beat map (see https://github.com/ppy/osu/issues/22657)
-                case DragEvent:
+                case DragStartEvent:
                     return false;
             }
 

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Play
                                     Anchor = Anchor.Centre,
                                     FillMode = FillMode.Fill,
                                 },
-                                loading = new LoadingLayer(true)
+                                loading = new LoadingLayer(dimBackground: true, blockInput: false)
                             }
                         },
                         versionFlow = new FillFlowContainer


### PR DESCRIPTION
Solution for issue https://github.com/ppy/osu/issues/22657

If you hold the mouse down after the song has been selected / after you retry but before it loads, it will block due to the DraggedDrawable check in the PlayerLoader. 

To resolve this, I have added a condition for the LoadingLayer's UIEvent handler to filter out DragEvents.