### PR TITLE
Fix import of skins with non-ASCII names that have been previously exported by lazer

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -134,6 +134,25 @@ namespace osu.Game.Tests.Skins.IO
         });
 
         [Test]
+        public Task TestImportExportedNonAsciiSkinFilename() => runSkinTest(async osu =>
+        {
+            MemoryStream exportStream = new MemoryStream();
+
+            var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 『1』", "author 1"), "custom.osk"));
+            assertCorrectMetadata(import1, "name 『1』 [custom]", "author 1", osu);
+
+            import1.PerformRead(s =>
+            {
+                new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportModelTo(s, exportStream);
+            });
+
+            string exportFilename = import1.GetDisplayString().GetValidFilename();
+
+            var import2 = await loadSkinIntoOsu(osu, new ImportTask(exportStream, $"{exportFilename}.osk"));
+            assertCorrectMetadata(import2, "name 『1』 [custom]", "author 1", osu);
+        });
+
+        [Test]
         public Task TestSameMetadataNameSameFolderName([Values] bool batchImport) => runSkinTest(async osu =>
         {
             var import1 = await loadSkinIntoOsu(osu, new ImportTask(createOskWithIni("name 1", "author 1"), "my custom skin 1"), batchImport);

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -101,7 +101,8 @@ namespace osu.Game.Skinning
                 // In both of these cases, the expectation from the user is that the filename or folder name is displayed somewhere to identify the skin.
                 if (archiveName != item.Name
                     // lazer exports use this format
-                    && archiveName != item.GetDisplayString())
+                    // GetValidFilename accounts for skins with non-ASCII characters in the name that have been exported by lazer.
+                    && archiveName != item.GetDisplayString().GetValidFilename())
                     item.Name = @$"{item.Name} [{archiveName}]";
             }
 


### PR DESCRIPTION
Fixes #22681 

This prevents skins with non-ASCII names being imported incorrectly after being previously exported, since upon export a "valid" version of the skin name is used for the directory, and that was not being accounted for in the import. 

Apologies for the previous naive PR for this issue (I wasn't able to reopen for whatever reason), this version passes all skin import tests.