### PR TITLE
Don't show epilepsy warning when storyboards are disabled

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -338,6 +338,23 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestEpilepsyWarningWithDisabledStoryboard()
+        {
+            saveVolumes();
+            setFullVolume();
+
+            AddStep("disable storyboards", () => config.SetValue(OsuSetting.ShowStoryboard, false));
+            AddStep("change epilepsy warning", () => epilepsyWarning = true);
+            AddStep("load dummy beatmap", () => resetPlayer(false));
+
+            AddUntilStep("wait for current", () => loader.IsCurrentScreen());
+
+            AddUntilStep("epilepsy warning absent", () => getWarning() == null);
+
+            restoreVolumes();
+        }
+
+        [Test]
         public void TestEpilepsyWarningEarlyExit()
         {
             saveVolumes();
@@ -454,7 +471,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("click notification", () => notification.TriggerClick());
         }
 
-        private EpilepsyWarning getWarning() => loader.ChildrenOfType<EpilepsyWarning>().SingleOrDefault();
+        private EpilepsyWarning getWarning() => loader.ChildrenOfType<EpilepsyWarning>().SingleOrDefault(w => w.IsAlive);
 
         private partial class TestPlayerLoader : PlayerLoader
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -45,6 +45,9 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Resolved]
         private SessionStatics sessionStatics { get; set; }
 
+        [Resolved]
+        private OsuConfigManager config { get; set; }
+
         [Cached(typeof(INotificationOverlay))]
         private readonly NotificationOverlay notificationOverlay;
 
@@ -317,6 +320,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             saveVolumes();
             setFullVolume();
 
+            AddStep("enable storyboards", () => config.SetValue(OsuSetting.ShowStoryboard, true));
             AddStep("change epilepsy warning", () => epilepsyWarning = warning);
             AddStep("load dummy beatmap", () => resetPlayer(false));
 
@@ -339,6 +343,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             saveVolumes();
             setFullVolume();
 
+            AddStep("enable storyboards", () => config.SetValue(OsuSetting.ShowStoryboard, true));
             AddStep("set epilepsy warning", () => epilepsyWarning = true);
             AddStep("load dummy beatmap", () => resetPlayer(false));
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -489,6 +489,7 @@ namespace osu.Game.Screens.Play
                 {
                     // This goes hand-in-hand with the restoration of low pass filter in contentOut().
                     this.TransformBindableTo(volumeAdjustment, 0, CONTENT_OUT_DURATION, Easing.OutCubic);
+                    epilepsyWarning?.Expire();
                 }
 
                 pushSequence.Schedule(() =>

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -67,6 +67,8 @@ namespace osu.Game.Screens.Play
 
         private OsuScrollContainer settingsScroll = null!;
 
+        private Bindable<bool> showStoryboards = null!;
+
         private bool backgroundBrightnessReduction;
 
         private readonly BindableDouble volumeAdjustment = new BindableDouble(1);
@@ -149,10 +151,11 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader]
-        private void load(SessionStatics sessionStatics, AudioManager audio)
+        private void load(SessionStatics sessionStatics, AudioManager audio, OsuConfigManager config)
         {
             muteWarningShownOnce = sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce);
             batteryWarningShownOnce = sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce);
+            showStoryboards = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
 
             const float padding = 25;
 
@@ -463,7 +466,10 @@ namespace osu.Game.Screens.Play
 
                 // only show if the warning was created (i.e. the beatmap needs it)
                 // and this is not a restart of the map (the warning expires after first load).
-                if (epilepsyWarning?.IsAlive == true)
+                //
+                // note the late check of storyboard enable as the user may have just changed it
+                // from the settings on the loader screen.
+                if (epilepsyWarning?.IsAlive == true && showStoryboards.Value)
                 {
                     const double epilepsy_display_length = 3000;
 


### PR DESCRIPTION
I have more thoughts on this warning in general (which will likely see it removed or moved in the future) but this seems like a quick QOL fix for now.

As mentioned in https://github.com/ppy/osu/discussions/22861.