### PR TITLE
Make osu! touch input aware of the distance travelled of a non-direct touch

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             beginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
-            checkPressed(OsuAction.LeftButton);
+            checkNotPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             // in this case, touch 2 should not become the positional tracking touch.
             checkPosition(TouchSource.Touch1);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -176,6 +176,14 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPressed(OsuAction.RightButton);
             // in this case, touch 2 should not become the positional tracking touch.
             checkPosition(TouchSource.Touch1);
+
+            // even if the second touch moves on the screen, the original tracking touch is retained.
+            beginTouch(TouchSource.Touch2, new Vector2(0));
+            beginTouch(TouchSource.Touch2, new Vector2(9999));
+            beginTouch(TouchSource.Touch2, new Vector2(0));
+            beginTouch(TouchSource.Touch2, new Vector2(9999));
+
+            checkPosition(TouchSource.Touch1);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -151,6 +151,34 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
+        public void TestPositionalTrackingAfterLongDistanceTravelled()
+        {
+            // When a single touch has already travelled enough distance on screen, it should remain as the positional
+            // tracking touch until released (unless a direct touch occurs).
+
+            beginTouch(TouchSource.Touch1);
+
+            assertKeyCounter(1, 0);
+            checkPressed(OsuAction.LeftButton);
+            checkPosition(TouchSource.Touch1);
+
+            // cover some distance
+            beginTouch(TouchSource.Touch1, new Vector2(0));
+            beginTouch(TouchSource.Touch1, new Vector2(9999));
+            beginTouch(TouchSource.Touch1, new Vector2(0));
+            beginTouch(TouchSource.Touch1, new Vector2(9999));
+            beginTouch(TouchSource.Touch1);
+
+            beginTouch(TouchSource.Touch2);
+
+            assertKeyCounter(1, 1);
+            checkPressed(OsuAction.LeftButton);
+            checkPressed(OsuAction.RightButton);
+            // in this case, touch 2 should not become the positional tracking touch.
+            checkPosition(TouchSource.Touch1);
+        }
+
+        [Test]
         public void TestPositionalInputUpdatesOnlyFromMostRecentTouch()
         {
             beginTouch(TouchSource.Touch1);

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.UI
         /// After this distance is covered, any extra touches on the screen will be considered as button inputs, unless
         /// a new touch directly interacts with a hit circle.
         /// </summary>
-        private const float distance_before_position_tracking_lock_in = 200;
+        private const float distance_before_position_tracking_lock_in = 100;
 
         private TrackedTouch? positionTrackingTouch;
 

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -97,8 +97,8 @@ namespace osu.Game.Rulesets.Osu.UI
                 return;
             }
 
-            // ..or if the current position tracking touch was not a direct touch (this one is debatable and may be change in the future, but it's the simplest way to handle)
-            if (!positionTrackingTouch.DirectTouch)
+            // ..or if the current position tracking touch was not a direct touch (and didn't travel across the screen too far).
+            if (!positionTrackingTouch.DirectTouch && positionTrackingTouch.DistanceTravelled < 200)
             {
                 positionTrackingTouch = newTouch;
                 return;
@@ -117,6 +117,12 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private void handleTouchMovement(TouchEvent touchEvent)
         {
+            if (touchEvent is TouchMoveEvent moveEvent)
+            {
+                var trackedTouch = trackedTouches.Single(t => t.Source == touchEvent.Touch.Source);
+                trackedTouch.DistanceTravelled += moveEvent.Delta.Length;
+            }
+
             // Movement should only be tracked for the most recent touch.
             if (touchEvent.Touch.Source != positionTrackingTouch?.Source)
                 return;
@@ -148,7 +154,15 @@ namespace osu.Game.Rulesets.Osu.UI
 
             public OsuAction? Action;
 
+            /// <summary>
+            /// Whether the touch was on a hit circle receptor.
+            /// </summary>
             public readonly bool DirectTouch;
+
+            /// <summary>
+            /// The total distance on screen travelled by this touch.
+            /// </summary>
+            public double DistanceTravelled;
 
             public TrackedTouch(TouchSource source, OsuAction? action, bool directTouch)
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -22,6 +22,13 @@ namespace osu.Game.Rulesets.Osu.UI
         /// </summary>
         private readonly List<TrackedTouch> trackedTouches = new List<TrackedTouch>();
 
+        /// <summary>
+        /// The distance (in local pixels) that a touch must move before being considered a permanent tracking touch.
+        /// After this distance is covered, any extra touches on the screen will be considered as button inputs, unless
+        /// a new touch directly interacts with a hit circle.
+        /// </summary>
+        private const float distance_before_position_tracking_lock_in = 200;
+
         private TrackedTouch? positionTrackingTouch;
 
         private readonly OsuInputManager osuInputManager;
@@ -98,7 +105,7 @@ namespace osu.Game.Rulesets.Osu.UI
             }
 
             // ..or if the current position tracking touch was not a direct touch (and didn't travel across the screen too far).
-            if (!positionTrackingTouch.DirectTouch && positionTrackingTouch.DistanceTravelled < 200)
+            if (!positionTrackingTouch.DirectTouch && positionTrackingTouch.DistanceTravelled < distance_before_position_tracking_lock_in)
             {
                 positionTrackingTouch = newTouch;
                 return;
@@ -160,9 +167,9 @@ namespace osu.Game.Rulesets.Osu.UI
             public readonly bool DirectTouch;
 
             /// <summary>
-            /// The total distance on screen travelled by this touch.
+            /// The total distance on screen travelled by this touch (in local pixels).
             /// </summary>
-            public double DistanceTravelled;
+            public float DistanceTravelled;
 
             public TrackedTouch(TouchSource source, OsuAction? action, bool directTouch)
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -105,12 +105,12 @@ namespace osu.Game.Rulesets.Osu.UI
             }
 
             // In the case the new touch was not used for position tracking, we should also check the previous position tracking touch.
-            // If it was a direct touch and still has its action pressed, that action should be released.
+            // If it still has its action pressed, that action should be released.
             //
             // This is done to allow tracking with the initial touch while still having both Left/Right actions available for alternating with two more touches.
-            if (positionTrackingTouch.DirectTouch && positionTrackingTouch.Action is OsuAction directTouchAction)
+            if (positionTrackingTouch.Action is OsuAction touchAction)
             {
-                osuInputManager.KeyBindingContainer.TriggerReleased(directTouchAction);
+                osuInputManager.KeyBindingContainer.TriggerReleased(touchAction);
                 positionTrackingTouch.Action = null;
             }
         }


### PR DESCRIPTION
Aims to address at least part of https://github.com/ppy/osu/issues/22556 – specifically the case where it is clear that the user's intention is to use a touch for positional tracking, but the game switches away to a tapping touch.

The most common scenario:
- Beatmap finishes loading / break finishes
- User starts dragging finger on screen (but doesn't hit a circle)
- User taps off to the side of the screen in hope of being recognised as a non-positional touch

On `master`, the last step here would fail. On this branch it will succeed.

This is done by introducing the concept of "distance travelled" to a touch. If a touch covers a certain distance, it becomes the preferred positional tracking touch (only to be overridden by a direct touch, as previously).

This is one of the ideas I had to improve the touch system, but I wanted to keep any added complexity out of the initial implementation. There are other additions I can imagine helping with the edge cases pointed out (for instance, considering the playfield bounds as proposed in that thread) but I want to apply these one-per-build and get confirmation from users that we're going in the correct direction.