### PR TITLE
Reduce the minimum size of approach circles in the 'Approach Different' mod to 0

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModApproachDifferent.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public BindableFloat Scale { get; } = new BindableFloat(4)
         {
             Precision = 0.1f,
-            MinValue = 1.5f,
+            MinValue = 0f,
             MaxValue = 10,
         };
 


### PR DESCRIPTION
By allowing an approach circle size below 1, you can achieve approach circles that start in the center of the hit circle and expand outwards. While this is admittedly rather hard to see using the default skins, it works quite nicely when played using a skin with a transparent center. I've attached a short clip of how it would look like below:

https://user-images.githubusercontent.com/56395201/226106142-c8ae69ce-e5f9-4b8f-873b-f0a5ce214950.mp4

