### PR TITLE
Fix `osu://` URL handling on macOS

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -139,7 +139,17 @@ namespace osu.Desktop
 
             desktopWindow.CursorState |= CursorState.Hidden;
             desktopWindow.Title = Name;
-            desktopWindow.DragDrop += f => fileDrop(new[] { f });
+            desktopWindow.DragDrop += f =>
+            {
+                // on macOS, URL associations are handled via SDL_DROPFILE events.
+                if (f.StartsWith(OSU_PROTOCOL, StringComparison.Ordinal))
+                {
+                    HandleLink(f);
+                    return;
+                }
+
+                fileDrop(new[] { f });
+            };
         }
 
         protected override BatteryInfo CreateBatteryInfo() => new SDL2BatteryInfo();


### PR DESCRIPTION
- Closes #22841 

This fixes `osu://` URL handling defined by the [`CFBundleURLTypes`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleurltypes) association in [`Info.plist` (osu-deploy)](https://github.com/ppy/osu-deploy/blob/7117512b082e09e38097e31538baf22e600d8fd6/osu!.app-template.zip).

This fix is not tested!