### PR TITLE
Remove arbitrary extension limitation from drag and drop imports

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -151,10 +151,6 @@ namespace osu.Desktop
         {
             lock (importableFiles)
             {
-                string firstExtension = Path.GetExtension(filePaths.First());
-
-                if (filePaths.Any(f => Path.GetExtension(f) != firstExtension)) return;
-
                 importableFiles.AddRange(filePaths);
 
                 Logger.Log($"Adding {filePaths.Length} files for import");

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;


### PR DESCRIPTION
Noticed while investigating https://github.com/ppy/osu/issues/22841.

`OsuGameBase` already [properly handles](https://github.com/ppy/osu/blob/b8904fe7474e17bf48a7dbbbd60ae338dd77529c/osu.Game/OsuGameBase_Importing.cs#L35) multiple extensions in the same import.
Also this limitation doesn't work, as the files are added one-by-one.