### PR TITLE
Fix beatmap listing sort direction not resetting when changing criteria

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSortTabControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSortTabControl.cs
@@ -14,10 +14,11 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapListing;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public partial class TestSceneBeatmapListingSortTabControl : OsuTestScene
+    public partial class TestSceneBeatmapListingSortTabControl : OsuManualInputManagerTestScene
     {
         private readonly BeatmapListingSortTabControl control;
 
@@ -109,6 +110,29 @@ namespace osu.Game.Tests.Visual.UserInterface
             resetUsesCriteriaOnCategory(SortCriteria.Updated, SearchCategory.Wip);
             resetUsesCriteriaOnCategory(SortCriteria.Updated, SearchCategory.Graveyard);
             resetUsesCriteriaOnCategory(SortCriteria.Updated, SearchCategory.Mine);
+        }
+
+        [Test]
+        public void TestSortDirectionOnCriteriaChange()
+        {
+            AddStep("set category to leaderboard", () => control.Reset(SearchCategory.Leaderboard, false));
+            AddAssert("sort direction is descending", () => control.SortDirection.Value == SortDirection.Descending);
+
+            AddStep("click ranked sort button", () =>
+            {
+                InputManager.MoveMouseTo(control.TabControl.ChildrenOfType<BeatmapListingSortTabControl.BeatmapTabButton>().Single(s => s.Active.Value));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("sort direction is ascending", () => control.SortDirection.Value == SortDirection.Ascending);
+
+            AddStep("click first inactive sort button", () =>
+            {
+                InputManager.MoveMouseTo(control.TabControl.ChildrenOfType<BeatmapListingSortTabControl.BeatmapTabButton>().First(s => !s.Active.Value));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("sort direction is descending", () => control.SortDirection.Value == SortDirection.Descending);
         }
 
         private void criteriaShowsOnCategory(bool expected, SortCriteria criteria, SearchCategory category)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
                 SortDirection.BindValueChanged(direction =>
                 {
-                    icon.Icon = direction.NewValue == Overlays.SortDirection.Ascending ? FontAwesome.Solid.CaretUp : FontAwesome.Solid.CaretDown;
+                    icon.Icon = direction.NewValue == Overlays.SortDirection.Ascending && Active.Value ? FontAwesome.Solid.CaretUp : FontAwesome.Solid.CaretDown;
                 }, true);
             }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
             if (currentParameters == null)
                 Reset(SearchCategory.Leaderboard, false);
+
+            Current.BindValueChanged(_ => SortDirection.Value = Overlays.SortDirection.Descending);
         }
 
         public void Reset(SearchCategory category, bool hasQuery)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSortTabControl.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.BeatmapListing
             };
         }
 
-        private partial class BeatmapTabButton : TabButton
+        public partial class BeatmapTabButton : TabButton
         {
             public readonly Bindable<SortDirection> SortDirection = new Bindable<SortDirection>();
 

--- a/osu.Game/Overlays/OverlaySortTabControl.cs
+++ b/osu.Game/Overlays/OverlaySortTabControl.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Overlays
             }
         }
 
-        protected partial class TabButton : HeaderButton
+        public partial class TabButton : HeaderButton
         {
             public readonly BindableBool Active = new BindableBool();
 


### PR DESCRIPTION
To be in line with web behavior.

Before:
![osu!_Di9FddkDsd](https://user-images.githubusercontent.com/35318437/226748344-555ad20a-4714-4182-b1d6-a22147af03d1.gif)

After:
![osu!_hzTEeBoIji](https://user-images.githubusercontent.com/35318437/226748108-8b2427e6-69a1-4d54-b471-9c9844988a8a.gif)

Web:
![firefox_7VdvYydzI7](https://user-images.githubusercontent.com/35318437/226748205-3c0b2c78-6e94-4497-8cac-14f33624b0b1.gif)