### PR TITLE
Fix beatmap listing filter control being blocked by loading layer

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using osu.Framework.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -10,7 +11,11 @@ namespace osu.Game.Overlays.BeatmapListing
 {
     public partial class BeatmapListingHeader : OverlayHeader
     {
+        public BeatmapListingFilterControl FilterControl { get; private set; }
+
         protected override OverlayTitle CreateTitle() => new BeatmapListingTitle();
+
+        protected override Drawable CreateContent() => FilterControl = new BeatmapListingFilterControl();
 
         private partial class BeatmapListingTitle : OverlayTitle
         {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -43,7 +43,13 @@ namespace osu.Game.Overlays
 
         private Container panelTarget;
         private FillFlowContainer<BeatmapCard> foundContent;
-        private BeatmapListingFilterControl filterControl;
+
+        private BeatmapListingFilterControl filterControl => Header.FilterControl.With(f =>
+        {
+            f.TypingStarted = onTypingStarted;
+            f.SearchStarted = onSearchStarted;
+            f.SearchFinished = onSearchFinished;
+        });
 
         public BeatmapListingOverlay()
             : base(OverlayColourScheme.Blue)
@@ -60,12 +66,6 @@ namespace osu.Game.Overlays
                 Direction = FillDirection.Vertical,
                 Children = new Drawable[]
                 {
-                    filterControl = new BeatmapListingFilterControl
-                    {
-                        TypingStarted = onTypingStarted,
-                        SearchStarted = onSearchStarted,
-                        SearchFinished = onSearchFinished,
-                    },
                     new Container
                     {
                         AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -44,12 +44,7 @@ namespace osu.Game.Overlays
         private Container panelTarget;
         private FillFlowContainer<BeatmapCard> foundContent;
 
-        private BeatmapListingFilterControl filterControl => Header.FilterControl.With(f =>
-        {
-            f.TypingStarted = onTypingStarted;
-            f.SearchStarted = onSearchStarted;
-            f.SearchFinished = onSearchFinished;
-        });
+        private BeatmapListingFilterControl filterControl => Header.FilterControl;
 
         public BeatmapListingOverlay()
             : base(OverlayColourScheme.Blue)
@@ -88,6 +83,10 @@ namespace osu.Game.Overlays
                     },
                 }
             };
+
+            filterControl.TypingStarted = onTypingStarted;
+            filterControl.SearchStarted = onSearchStarted;
+            filterControl.SearchFinished = onSearchFinished;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -81,6 +81,7 @@ namespace osu.Game.Overlays
         {
             base.UpdateAfterChildren();
 
+            // don't block header by applying padding equal to the visible header height
             loadingContainer.Padding = new MarginPadding { Top = Math.Max(0, Header.Height - ScrollFlow.Current) };
         }
     }

--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -22,6 +23,7 @@ namespace osu.Game.Overlays
         protected readonly OverlayScrollContainer ScrollFlow;
 
         protected readonly LoadingLayer Loading;
+        private readonly Container loadingContainer;
         private readonly Container content;
 
         protected OnlineOverlay(OverlayColourScheme colourScheme, bool requiresSignIn = true)
@@ -65,10 +67,21 @@ namespace osu.Game.Overlays
                         },
                     }
                 },
-                Loading = new LoadingLayer(true)
+                loadingContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = Loading = new LoadingLayer(true),
+                }
             });
 
             base.Content.Add(mainContent);
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            loadingContainer.Padding = new MarginPadding { Top = Math.Max(0, Header.Height - ScrollFlow.Current) };
         }
     }
 }


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/11471

Written with beatmap listing as a focus since that is where the change is most significant.

Before:
![osu!_am318KgCyl](https://user-images.githubusercontent.com/35318437/226796770-94ddcd8b-e399-4c60-9661-82f7908c688d.gif)

After:
![osu!_69Idn9KZT9](https://user-images.githubusercontent.com/35318437/226796636-7bbeaec4-5fbc-4a48-9b32-9ced76cfcb82.gif)
