### PR TITLE
Fix whole game potentially breaking when entering editor too early from song select

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Tests.Visual.Background
         public void TestPlayerLoaderSettingsHover()
         {
             setupUserSettings();
-            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new LoadBlockingTestPlayer { BlockLoad = true })));
+            AddStep("Start player loader", () => songSelect.FinaliseSelection(customStartAction: () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new LoadBlockingTestPlayer { BlockLoad = true }))));
             AddUntilStep("Wait for Player Loader to load", () => playerLoader?.IsLoaded ?? false);
             AddAssert("Background retained from song select", () => songSelect.IsBackgroundCurrent());
             AddStep("Trigger background preview", () =>
@@ -274,7 +274,7 @@ namespace osu.Game.Tests.Visual.Background
         {
             setupUserSettings();
 
-            AddStep("Start player loader", () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new LoadBlockingTestPlayer(allowPause))));
+            AddStep("Start player loader", () => songSelect.FinaliseSelection(customStartAction: () => songSelect.Push(playerLoader = new TestPlayerLoader(player = new LoadBlockingTestPlayer(allowPause)))));
 
             AddUntilStep("Wait for Player Loader to load", () => playerLoader.IsLoaded);
             AddStep("Move mouse to center of screen", () => InputManager.MoveMouseTo(playerLoader.ScreenPos));

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            AddStep("push child screen", () => songSelect!.FinaliseSelection(customStartAction: () => songSelect.Push(new TestSceneOsuScreenStack.TestScreen("test child"))));
             AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
 
             AddStep("return", () => songSelect!.MakeCurrent());
@@ -274,7 +274,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            AddStep("push child screen", () => songSelect!.FinaliseSelection(customStartAction: () => songSelect.Push(new TestSceneOsuScreenStack.TestScreen("test child"))));
             AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
 
             AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
@@ -291,7 +291,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
+            AddStep("push child screen", () => songSelect!.FinaliseSelection(customStartAction: () => songSelect.Push(new TestSceneOsuScreenStack.TestScreen("test child"))));
             AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
 
             AddStep("update beatmap", () =>
@@ -546,6 +546,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             addRulesetImportStep(0);
 
             changeMods(new OsuModHardRock());
+
+            AddStep("exit first song select", () => songSelect!.Exit());
 
             createSongSelect();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -655,15 +655,23 @@ namespace osu.Game
                 Ruleset.Value = databasedScore.ScoreInfo.Ruleset;
                 Beatmap.Value = BeatmapManager.GetWorkingBeatmap(databasedBeatmap);
 
-                switch (presentType)
-                {
-                    case ScorePresentType.Gameplay:
-                        screen.Push(new ReplayPlayerLoader(databasedScore));
-                        break;
+                if (screen is SongSelect songSelect)
+                    songSelect.FinaliseSelection(databasedBeatmap, databasedScore.ScoreInfo.Ruleset, customStartAction: push);
+                else
+                    push();
 
-                    case ScorePresentType.Results:
-                        screen.Push(new SoloResultsScreen(databasedScore.ScoreInfo, false));
-                        break;
+                void push()
+                {
+                    switch (presentType)
+                    {
+                        case ScorePresentType.Gameplay:
+                            screen.Push(new ReplayPlayerLoader(databasedScore));
+                            break;
+
+                        case ScorePresentType.Results:
+                            screen.Push(new SoloResultsScreen(databasedScore.ScoreInfo, false));
+                            break;
+                    }
                 }
             }, validScreens: validScreens);
         }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
@@ -111,8 +111,15 @@ namespace osu.Game.Overlays.SkinEditor
                                         if (!ModUtils.CheckCompatibleSet(usableMods, out var invalid))
                                             mods.Value = mods.Value.Except(invalid).ToArray();
 
-                                        if (replayGeneratingMod != null)
-                                            screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))));
+                                        if (replayGeneratingMod == null)
+                                            return;
+
+                                        if (screen is SongSelect songSelect)
+                                            songSelect.FinaliseSelection(customStartAction: loadPlayer);
+                                        else
+                                            loadPlayer();
+
+                                        void loadPlayer() => screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))));
                                     }, new[] { typeof(Player), typeof(SongSelect) })
                                 },
                             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -387,7 +387,7 @@ namespace osu.Game.Screens.Select
                 throw new InvalidOperationException($"Attempted to edit when {nameof(AllowEditing)} is disabled");
 
             Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo ?? beatmapInfoNoDebounce);
-            this.Push(new EditorLoader());
+            FinaliseSelection(beatmapInfo ?? beatmapInfoNoDebounce, customStartAction: () => this.Push(new EditorLoader()));
         }
 
         /// <summary>
@@ -428,13 +428,16 @@ namespace osu.Game.Screens.Select
                 selectionChangedDebounce = null;
             }
 
+            Carousel.AllowSelection = false;
+
             if (customStartAction != null)
-            {
                 customStartAction();
-                Carousel.AllowSelection = false;
+            else
+            {
+                if (!OnStart())
+                    // start operation failed; allow selection again.
+                    Carousel.AllowSelection = true;
             }
-            else if (OnStart())
-                Carousel.AllowSelection = false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -664,6 +664,9 @@ namespace osu.Game.Screens.Select
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
+            // This is very important as we have not yet bound to screen-level bindables before the carousel load is completed.
+            Debug.Assert(Carousel.BeatmapSetsLoaded);
+
             // Handle the case where FinaliseSelection is never called (ie. when a screen is pushed externally).
             // Without this, it's possible for a transfer to happen while we are not the current screen.
             transferRulesetValue();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -666,6 +666,7 @@ namespace osu.Game.Screens.Select
         {
             // This is very important as we have not yet bound to screen-level bindables before the carousel load is completed.
             Debug.Assert(Carousel.BeatmapSetsLoaded);
+            Debug.Assert(!Carousel.AllowSelection, $"Carousel selection is still allowed on suspension. Make sure to call {nameof(FinaliseSelection)} when pushing a new screen.");
 
             // Handle the case where FinaliseSelection is never called (ie. when a screen is pushed externally).
             // Without this, it's possible for a transfer to happen while we are not the current screen.


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/22927.

TL;DR the editor could get loaded while `DummyRuleset` is active, and then restore that ruleset `OnExiting`, causing a cascading failure which means no beatmap can be diffcalc'd or even played until the game-wide ruleset is switched at least once.

To prevent similar scenarios from happening elsewhere, I've forbidden the usage of `Push` on `SongSelect`. It makes handling pushing when song select is involved a bit more arduous, but I think it's for the best (short of `Push` being `virtual` so we could add protection there).

Of note, this means that operations which would previous leave the game in an unknown state will now *not fire* instead. `FinaliseSelection` has early-abort when state is incorrect. In the future we may want to queue the action and run it when the load completes, but I think that's for a separate day.