### PR TITLE
Fix tournament interface save button not usable after changing match progression/round

### DIFF
--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -332,13 +332,6 @@ namespace osu.Game.Tournament
 
         private void saveChanges()
         {
-            foreach (var r in ladder.Rounds)
-                r.Matches = ladder.Matches.Where(p => p.Round.Value == r).Select(p => p.ID).ToList();
-
-            ladder.Progressions = ladder.Matches.Where(p => p.Progression.Value != null).Select(p => new TournamentProgression(p.ID, p.Progression.Value.ID)).Concat(
-                                            ladder.Matches.Where(p => p.LosersProgression.Value != null).Select(p => new TournamentProgression(p.ID, p.LosersProgression.Value.ID, true)))
-                                        .ToList();
-
             // Serialise before opening stream for writing, so if there's a failure it will leave the file in the previous state.
             string serialisedLadder = GetSerialisedLadder();
 
@@ -349,6 +342,13 @@ namespace osu.Game.Tournament
 
         public string GetSerialisedLadder()
         {
+            foreach (var r in ladder.Rounds)
+                r.Matches = ladder.Matches.Where(p => p.Round.Value == r).Select(p => p.ID).ToList();
+
+            ladder.Progressions = ladder.Matches.Where(p => p.Progression.Value != null).Select(p => new TournamentProgression(p.ID, p.Progression.Value.ID)).Concat(
+                                            ladder.Matches.Where(p => p.LosersProgression.Value != null).Select(p => new TournamentProgression(p.ID, p.LosersProgression.Value.ID, true)))
+                                        .ToList();
+
             return JsonConvert.SerializeObject(ladder,
                 new JsonSerializerSettings
                 {


### PR DESCRIPTION
We need to make sure that the fields present purely for serialisation are always updated before serialising as an equality check.

Closes #22937.