### PR TITLE
Add an option to not scale the slider body for Grow/Deflate mods

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -45,12 +45,20 @@ namespace osu.Game.Rulesets.Osu.Mods
             var h = (OsuHitObject)drawable.HitObject;
 
             // apply grow effect
-            if ((drawable is DrawableSlider && ScaleSliders.Value)
-                || (drawable is DrawableSliderHead && !ScaleSliders.Value)
-                || drawable is DrawableHitCircle)
+            switch (drawable)
             {
-                using (drawable.BeginAbsoluteSequence(h.StartTime - h.TimePreempt))
-                    drawable.ScaleTo(StartScale.Value).Then().ScaleTo(EndScale, h.TimePreempt, Easing.OutSine);
+                case DrawableSliderTail:
+                    // special case we should *not* be scaling.
+                    break;
+
+                case DrawableSlider when ScaleSliders.Value:
+                case DrawableSliderHead when !ScaleSliders.Value:
+                case DrawableHitCircle:
+                {
+                    using (drawable.BeginAbsoluteSequence(h.StartTime - h.TimePreempt))
+                        drawable.ScaleTo(StartScale.Value).Then().ScaleTo(EndScale, h.TimePreempt, Easing.OutSine);
+                    break;
+                }
             }
 
             // remove approach circles

--- a/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModObjectScaleTween.cs
@@ -24,6 +24,9 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Starting Size", "The initial size multiplier applied to all objects.")]
         public abstract BindableNumber<float> StartScale { get; }
 
+        [SettingSource("Scale Sliders", "Scale the slider bodies as well.")]
+        public BindableBool ScaleSliders { get; } = new BindableBool(true);
+
         protected virtual float EndScale => 1;
 
         public override Type[] IncompatibleMods => new[] { typeof(IRequiresApproachCircles), typeof(OsuModSpinIn), typeof(OsuModObjectScaleTween) };
@@ -42,20 +45,12 @@ namespace osu.Game.Rulesets.Osu.Mods
             var h = (OsuHitObject)drawable.HitObject;
 
             // apply grow effect
-            switch (drawable)
+            if ((drawable is DrawableSlider && ScaleSliders.Value)
+                || (drawable is DrawableSliderHead && !ScaleSliders.Value)
+                || drawable is DrawableHitCircle)
             {
-                case DrawableSliderHead:
-                case DrawableSliderTail:
-                    // special cases we should *not* be scaling.
-                    break;
-
-                case DrawableSlider:
-                case DrawableHitCircle:
-                {
-                    using (drawable.BeginAbsoluteSequence(h.StartTime - h.TimePreempt))
-                        drawable.ScaleTo(StartScale.Value).Then().ScaleTo(EndScale, h.TimePreempt, Easing.OutSine);
-                    break;
-                }
+                using (drawable.BeginAbsoluteSequence(h.StartTime - h.TimePreempt))
+                    drawable.ScaleTo(StartScale.Value).Then().ScaleTo(EndScale, h.TimePreempt, Easing.OutSine);
             }
 
             // remove approach circles


### PR DESCRIPTION
This adds a mod customization option to the 'Grow' and 'Deflate' mods to prevent the slider bodies from scaling. This means that only hit circles and slider heads will scale. I am proposing this addition, as I personally found the scaling of the entire slider to be a rather jarring gameplay experience. As I am sure there are players who prefer the current behavior, I have added it as a mod customization option. The default behavior remains the same.

~~PS: If there is a more elegant way to express that big `if` condition I couldn't think of it.~~