### PR TITLE
Fix select beatmap button not highlighting when creating a multiplayer room using keyboard

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -73,11 +73,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             private OsuSpriteText typeLabel = null!;
             private LoadingLayer loadingLayer = null!;
 
-            public void SelectBeatmap()
-            {
-                if (matchSubScreen.IsCurrentScreen())
-                    matchSubScreen.Push(new MultiplayerMatchSongSelect(matchSubScreen.Room));
-            }
+            public void SelectBeatmap() => selectBeatmapButton.TriggerClick();
 
             [Resolved]
             private MultiplayerMatchSubScreen matchSubScreen { get; set; } = null!;
@@ -97,6 +93,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             private IDisposable? applyingSettingsOperation;
             private Drawable playlistContainer = null!;
             private DrawableRoomPlaylist drawablePlaylist = null!;
+            private RoundedButton selectBeatmapButton = null!;
 
             public MatchSettings(Room room)
             {
@@ -275,12 +272,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             RelativeSizeAxes = Axes.X,
                                                             Height = DrawableRoomPlaylistItem.HEIGHT
                                                         },
-                                                        new RoundedButton
+                                                        selectBeatmapButton = new RoundedButton
                                                         {
                                                             RelativeSizeAxes = Axes.X,
                                                             Height = 40,
                                                             Text = "Select beatmap",
-                                                            Action = SelectBeatmap
+                                                            Action = () =>
+                                                            {
+                                                                if (matchSubScreen.IsCurrentScreen())
+                                                                    matchSubScreen.Push(new MultiplayerMatchSongSelect(matchSubScreen.Room));
+                                                            }
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
This was done playlists-side in https://github.com/ppy/osu/commit/2b973b9831daca95b12de46381fb4bb1b451f62e but was missed here.

Before:
![osu!_hbtv6IvZI6](https://user-images.githubusercontent.com/35318437/227810703-2ac69eda-2486-4edb-9661-e7fd9a8c73f0.gif)

After:
![osu!_YMx8iFaEEr](https://user-images.githubusercontent.com/35318437/227810559-363c1151-f26b-41a8-a62d-b89b775706d7.gif)