### PR TITLE
Fix hit lighting misalignment on argon skin with upscroll

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaPlayer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaPlayer.cs
@@ -3,6 +3,9 @@
 
 #nullable disable
 
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Game.Rulesets.Mania.Configuration;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests
@@ -10,5 +13,19 @@ namespace osu.Game.Rulesets.Mania.Tests
     public partial class TestSceneManiaPlayer : PlayerTestScene
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("change direction to down", () => changeDirectionTo(ManiaScrollingDirection.Down));
+            AddStep("change direction to up", () => changeDirectionTo(ManiaScrollingDirection.Up));
+        }
+
+        private void changeDirectionTo(ManiaScrollingDirection direction)
+        {
+            var rulesetConfig = (ManiaRulesetConfigManager)RulesetConfigs.GetConfigFor(new ManiaRuleset()).AsNonNull();
+            rulesetConfig.SetValue(ManiaRulesetSetting.ScrollDirection, direction);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
@@ -43,8 +43,6 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
             {
                 largeFaint = new Container
                 {
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.BottomCentre,
                     RelativeSizeAxes = Axes.Both,
                     Height = ArgonNotePiece.NOTE_ACCENT_RATIO,
                     Masking = true,
@@ -78,16 +76,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
         private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
         {
-            if (direction.NewValue == ScrollingDirection.Up)
-            {
-                Anchor = Anchor.TopCentre;
-                Y = ArgonNotePiece.NOTE_HEIGHT / 2;
-            }
-            else
-            {
-                Anchor = Anchor.BottomCentre;
-                Y = -ArgonNotePiece.NOTE_HEIGHT / 2;
-            }
+            Anchor = largeFaint.Anchor = largeFaint.Origin = direction.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
+            Y = direction.NewValue == ScrollingDirection.Up ? ArgonNotePiece.NOTE_HEIGHT / 2 : -ArgonNotePiece.NOTE_HEIGHT / 2;
         }
 
         public void Animate(JudgementResult result)

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonHitExplosion.cs
@@ -76,8 +76,20 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
         private void onDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
         {
-            Anchor = largeFaint.Anchor = largeFaint.Origin = direction.NewValue == ScrollingDirection.Up ? Anchor.TopCentre : Anchor.BottomCentre;
-            Y = direction.NewValue == ScrollingDirection.Up ? ArgonNotePiece.NOTE_HEIGHT / 2 : -ArgonNotePiece.NOTE_HEIGHT / 2;
+            if (direction.NewValue == ScrollingDirection.Up)
+            {
+                Anchor = Anchor.TopCentre;
+                largeFaint.Anchor = Anchor.TopCentre;
+                largeFaint.Origin = Anchor.TopCentre;
+                Y = ArgonNotePiece.NOTE_HEIGHT / 2;
+            }
+            else
+            {
+                Anchor = Anchor.BottomCentre;
+                largeFaint.Anchor = Anchor.BottomCentre;
+                largeFaint.Origin = Anchor.BottomCentre;
+                Y = -ArgonNotePiece.NOTE_HEIGHT / 2;
+            }
         }
 
         public void Animate(JudgementResult result)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22979

Before:

https://user-images.githubusercontent.com/20418176/228014687-b8cb5794-b8d1-47ab-a69f-56317387cace.mp4

After:

https://user-images.githubusercontent.com/20418176/228014747-bec79ef5-45e1-4822-bc5d-4f9a7fd16463.mp4

Also includes a few extra test steps in `TestSceneManiaPlayer` to cover downscroll/upscroll, because none of the skinning test scenes were really any help in spotting this. Maybe this way I'll remember to check upscroll next time...