### PR TITLE
Fix spinners being selectable for too long after they fade in the editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/OsuSelectionBlueprint.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints
         protected override bool AlwaysShowWhenSelected => true;
 
         protected override bool ShouldBeAlive => base.ShouldBeAlive
-                                                 || (ShowHitMarkers.Value && editorClock.CurrentTime >= Item.StartTime && editorClock.CurrentTime - Item.GetEndTime() < HitCircleOverlapMarker.FADE_OUT_EXTENSION);
+                                                 || (DrawableObject is not DrawableSpinner && ShowHitMarkers.Value && editorClock.CurrentTime >= Item.StartTime && editorClock.CurrentTime - Item.GetEndTime() < HitCircleOverlapMarker.FADE_OUT_EXTENSION);
 
         protected OsuSelectionBlueprint(T hitObject)
             : base(hitObject)


### PR DESCRIPTION
The actual visual extension is only applied to `HitCircle`s (which does include slider start / end), and should not be applied to spinners in the first place.

Addresses https://github.com/ppy/osu/discussions/22949.