### PR TITLE
Always use `LocalisableString` fallbacks when deploying debug and viewing english

### DIFF
--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Localisation
 
                 // When running a debug build and in viewing english culture, use the fallbacks rather than osu-resources baked strings.
                 // This is what a developer expects to see when making changes to `xxxStrings.cs` files.
-                if (DebugUtils.IsDebugBuild && EffectiveCulture.Name == @"en")
+                if (EffectiveCulture.Name == @"en")
                     return null;
 
                 try

--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Development;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Localisation
@@ -63,6 +64,11 @@ namespace osu.Game.Localisation
                 }
 
                 if (manager == null)
+                    return null;
+
+                // When running a debug build and in viewing english culture, use the fallbacks rather than osu-resources baked strings.
+                // This is what a developer expects to see when making changes to `xxxStrings.cs` files.
+                if (DebugUtils.IsDebugBuild && EffectiveCulture.Name == @"en")
                     return null;
 
                 try

--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
-using osu.Framework.Development;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Localisation

--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -66,8 +66,8 @@ namespace osu.Game.Localisation
                 if (manager == null)
                     return null;
 
-                // When running a debug build and in viewing english culture, use the fallbacks rather than osu-resources baked strings.
-                // This is what a developer expects to see when making changes to `xxxStrings.cs` files.
+                // When using the English culture, prefer the fallbacks rather than osu-resources baked strings.
+                // They are guaranteed to be up-to-date, and is also what a developer expects to see when making changes to `xxxStrings.cs` files.
                 if (EffectiveCulture.Name == @"en")
                     return null;
 


### PR DESCRIPTION
This allows changes to `xxxStrings.cs` files to immediately reflect in the UI, which is (at least for me) an expectation.