### PR TITLE
Fix circle-size based scale being applied twice to caught fruit

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -136,6 +136,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Origin = Anchor.TopCentre;
 
             Size = new Vector2(BASE_SIZE);
+
             if (difficulty != null)
                 Scale = calculateScale(difficulty);
 
@@ -333,8 +334,11 @@ namespace osu.Game.Rulesets.Catch.UI
             base.Update();
 
             var scaleFromDirection = new Vector2((int)VisualDirection, 1);
+
             body.Scale = scaleFromDirection;
-            caughtObjectContainer.Scale = hitExplosionContainer.Scale = flipCatcherPlate ? scaleFromDirection : Vector2.One;
+            // Inverse of catcher scale is applied here, as catcher gets scaled by circle size and so do the incoming fruit.
+            caughtObjectContainer.Scale = (1 / Scale.X) * (flipCatcherPlate ? scaleFromDirection : Vector2.One);
+            hitExplosionContainer.Scale = flipCatcherPlate ? scaleFromDirection : Vector2.One;
 
             // Correct overshooting.
             if ((hyperDashDirection > 0 && hyperDashTargetPosition < X) ||


### PR DESCRIPTION
Closes #22968.

Applied to the container rather than at the `CaughtObject` level as there's logic there which is reading and writing to `Size` and `Scale` to transfer between states, and I didn't want to touch it.