### PR TITLE
Osu! audio device notification had extra newlines

### DIFF
--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -54,9 +54,7 @@ namespace osu.Game.Localisation
         ///
         /// Please try changing your audio device to a working setting."
         /// </summary>
-        public static LocalisableString AudioPlaybackIssue => new TranslatableString(getKey(@"audio_playback_issue"), @"osu! doesn't seem to be able to play audio correctly.
-
-Please try changing your audio device to a working setting.");
+        public static LocalisableString AudioPlaybackIssue => new TranslatableString(getKey(@"audio_playback_issue"), @"osu! doesn't seem to be able to play audio correctly. Please try changing your audio device to a working setting.");
 
         /// <summary>
         /// "The score overlay is currently disabled. You can toggle this by pressing {0}."


### PR DESCRIPTION
This notification had extra newlines added to it
![image](https://user-images.githubusercontent.com/64970593/229306883-46a38a8b-cd6d-436e-8ba4-6384eef5ef7b.png)

This has been fixed in the fork