### PR TITLE
Fix window mode dropdown not showing

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
         private FillFlowContainer<SettingsSlider<float>> scalingSettings = null!;
 
         private readonly Bindable<Display> currentDisplay = new Bindable<Display>();
-        private readonly IBindableList<WindowMode> windowModes = new BindableList<WindowMode>();
 
         private Bindable<ScalingMode> scalingMode = null!;
         private Bindable<Size> sizeFullscreen = null!;
@@ -87,6 +86,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 {
                     LabelText = GraphicsSettingsStrings.ScreenMode,
                     Items = window?.SupportedWindowModes,
+                    CanBeShown = { Value = window?.SupportedWindowModes.Count() > 1 },
                     Current = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode),
                 },
                 displayDropdown = new DisplaySettingsDropdown
@@ -180,8 +180,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 updateScreenModeWarning();
             }, true);
 
-            windowModes.BindCollectionChanged((_, _) => updateDisplaySettingsVisibility());
-
             currentDisplay.BindValueChanged(display => Schedule(() =>
             {
                 resolutions.RemoveRange(1, resolutions.Count - 1);
@@ -235,7 +233,6 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
         private void updateDisplaySettingsVisibility()
         {
-            windowModeDropdown.CanBeShown.Value = windowModes.Count > 1;
             resolutionDropdown.CanBeShown.Value = resolutions.Count > 1 && windowModeDropdown.Current.Value == WindowMode.Fullscreen;
             displayDropdown.CanBeShown.Value = displayDropdown.Items.Count() > 1;
             safeAreaConsiderationsCheckbox.CanBeShown.Value = host.Window?.SafeAreaPadding.Value.Total != Vector2.Zero;


### PR DESCRIPTION
Bug introduced with https://github.com/ppy/osu/commit/cf5acbf66eb5b0ff872eef50ff78f5409d4111a8: `windowModes` is neved bound and is always empty, so the dropdown would never show.