### PR TITLE
Normalise horizontal padding on overlays

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Overlays.BeatmapListing
                     Padding = new MarginPadding
                     {
                         Vertical = 20,
-                        Horizontal = 40,
+                        Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
                     },
                     Child = new FillFlowContainer
                     {

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -97,8 +97,8 @@ namespace osu.Game.Overlays.BeatmapSet
                         Padding = new MarginPadding
                         {
                             Vertical = BeatmapSetOverlay.Y_PADDING,
-                            Left = BeatmapSetOverlay.X_PADDING,
-                            Right = BeatmapSetOverlay.X_PADDING + BeatmapSetOverlay.RIGHT_WIDTH,
+                            Left = WaveOverlayContainer.HORIZONTAL_PADDING,
+                            Right = WaveOverlayContainer.HORIZONTAL_PADDING + BeatmapSetOverlay.RIGHT_WIDTH,
                         },
                         Children = new Drawable[]
                         {
@@ -170,7 +170,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         Anchor = Anchor.BottomRight,
                         Origin = Anchor.BottomRight,
                         AutoSizeAxes = Axes.Both,
-                        Margin = new MarginPadding { Top = BeatmapSetOverlay.Y_PADDING, Right = BeatmapSetOverlay.X_PADDING },
+                        Margin = new MarginPadding { Top = BeatmapSetOverlay.Y_PADDING, Right = WaveOverlayContainer.HORIZONTAL_PADDING },
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(10),
                         Children = new Drawable[]

--- a/osu.Game/Overlays/BeatmapSet/Info.cs
+++ b/osu.Game/Overlays/BeatmapSet/Info.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Top = 15, Horizontal = BeatmapSetOverlay.X_PADDING },
+                    Padding = new MarginPadding { Top = 15, Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Children = new Drawable[]
                     {
                         new Container

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoresContainer.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding { Horizontal = 50 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Margin = new MarginPadding { Vertical = 20 },
                     Children = new Drawable[]
                     {

--- a/osu.Game/Overlays/BeatmapSetOverlay.cs
+++ b/osu.Game/Overlays/BeatmapSetOverlay.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Overlays
 {
     public partial class BeatmapSetOverlay : OnlineOverlay<BeatmapSetHeader>
     {
-        public const float X_PADDING = 40;
         public const float Y_PADDING = 25;
         public const float RIGHT_WIDTH = 275;
 

--- a/osu.Game/Overlays/Changelog/ChangelogBuild.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogBuild.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Overlays.Changelog
 {
     public partial class ChangelogBuild : FillFlowContainer
     {
-        public const float HORIZONTAL_PADDING = 70;
-
         public Action<APIChangelogBuild> SelectBuild;
 
         protected readonly APIChangelogBuild Build;
@@ -33,7 +31,7 @@ namespace osu.Game.Overlays.Changelog
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
             Direction = FillDirection.Vertical;
-            Padding = new MarginPadding { Horizontal = HORIZONTAL_PADDING };
+            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING };
 
             Children = new Drawable[]
             {

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays.Changelog
                     AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding
                     {
-                        Horizontal = 65,
+                        Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - ChangelogUpdateStreamItem.PADDING,
                         Vertical = 20
                     },
                     Child = Streams = new ChangelogUpdateStreamControl { Current = currentStream },

--- a/osu.Game/Overlays/Changelog/ChangelogListing.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogListing.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Overlays.Changelog
                     {
                         RelativeSizeAxes = Axes.X,
                         Height = 1,
-                        Padding = new MarginPadding { Horizontal = ChangelogBuild.HORIZONTAL_PADDING },
+                        Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                         Margin = new MarginPadding { Top = 30 },
                         Child = new Box
                         {

--- a/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogSupporterPromo.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Overlays.Changelog
             Padding = new MarginPadding
             {
                 Vertical = 20,
-                Horizontal = 50,
+                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
             };
         }
 
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Changelog
                                     Direction = FillDirection.Vertical,
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Padding = new MarginPadding { Right = 50 + image_container_width },
+                                    Padding = new MarginPadding { Right = WaveOverlayContainer.HORIZONTAL_PADDING + image_container_width },
                                     Children = new Drawable[]
                                     {
                                         new OsuSpriteText

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Overlays.Comments
                                             ShowDeleted = { BindTarget = ShowDeleted },
                                             Margin = new MarginPadding
                                             {
-                                                Horizontal = 70,
+                                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
                                                 Vertical = 10
                                             }
                                         },

--- a/osu.Game/Overlays/Comments/CommentsContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentsContainer.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Comments
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
-                            Padding = new MarginPadding { Horizontal = 50, Vertical = 20 },
+                            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Vertical = 20 },
                             Children = new Drawable[]
                             {
                                 avatar = new UpdateableAvatar(api.LocalUser.Value)
@@ -393,7 +393,7 @@ namespace osu.Game.Overlays.Comments
                     {
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
-                        Margin = new MarginPadding { Left = 50 },
+                        Margin = new MarginPadding { Left = WaveOverlayContainer.HORIZONTAL_PADDING },
                         Text = CommentsStrings.Empty
                     }
                 });

--- a/osu.Game/Overlays/Comments/CommentsHeader.cs
+++ b/osu.Game/Overlays/Comments/CommentsHeader.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays.Comments
                 new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Horizontal = 50 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Children = new Drawable[]
                     {
                         new OverlaySortTabControl<CommentsSortCriteria>

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -537,7 +537,7 @@ namespace osu.Game.Overlays.Comments
             {
                 return new MarginPadding
                 {
-                    Horizontal = 70,
+                    Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING,
                     Vertical = 15
                 };
             }

--- a/osu.Game/Overlays/Comments/TotalCommentsCounter.cs
+++ b/osu.Game/Overlays/Comments/TotalCommentsCounter.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.Comments
                 Origin = Anchor.CentreLeft,
                 AutoSizeAxes = Axes.Both,
                 Direction = FillDirection.Horizontal,
-                Margin = new MarginPadding { Left = 50 },
+                Margin = new MarginPadding { Left = WaveOverlayContainer.HORIZONTAL_PADDING },
                 Spacing = new Vector2(5, 0),
                 Children = new Drawable[]
                 {

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.Dashboard
                 new Container<BasicSearchTextBox>
                 {
                     RelativeSizeAxes = Axes.X,
-                    Padding = new MarginPadding(padding),
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Vertical = padding },
                     Child = searchTextBox = new BasicSearchTextBox
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                 Padding = new MarginPadding
                                 {
                                     Top = 20,
-                                    Horizontal = 45
+                                    Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - FriendsOnlineStatusItem.PADDING
                                 },
                                 Child = onlineStreamControl = new FriendOnlineStreamControl(),
                             }

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                             {
                                                 RelativeSizeAxes = Axes.X,
                                                 AutoSizeAxes = Axes.Y,
-                                                Padding = new MarginPadding { Horizontal = 50 }
+                                                Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING }
                                             },
                                             loading = new LoadingLayer(true)
                                         }

--- a/osu.Game/Overlays/News/Displays/ArticleListing.cs
+++ b/osu.Game/Overlays/News/Displays/ArticleListing.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays.News.Displays
             {
                 Vertical = 20,
                 Left = 30,
-                Right = 50
+                Right = WaveOverlayContainer.HORIZONTAL_PADDING
             };
 
             InternalChild = new FillFlowContainer

--- a/osu.Game/Overlays/OverlayHeader.cs
+++ b/osu.Game/Overlays/OverlayHeader.cs
@@ -89,7 +89,7 @@ namespace osu.Game.Overlays
                 }
             });
 
-            ContentSidePadding = 50;
+            ContentSidePadding = WaveOverlayContainer.HORIZONTAL_PADDING;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/OverlaySidebar.cs
+++ b/osu.Game/Overlays/OverlaySidebar.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays
                                 Padding = new MarginPadding
                                 {
                                     Vertical = 20,
-                                    Left = 50,
+                                    Left = WaveOverlayContainer.HORIZONTAL_PADDING,
                                     Right = 30
                                 },
                                 Child = CreateContent()

--- a/osu.Game/Overlays/OverlayStreamItem.cs
+++ b/osu.Game/Overlays/OverlayStreamItem.cs
@@ -39,12 +39,14 @@ namespace osu.Game.Overlays
         private FillFlowContainer<SpriteText> text;
         private ExpandingBar expandingBar;
 
+        public const float PADDING = 5;
+
         protected OverlayStreamItem(T value)
             : base(value)
         {
             Height = 50;
             Width = 90;
-            Margin = new MarginPadding(5);
+            Margin = new MarginPadding(PADDING);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Profile/Header/BadgeHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BadgeHeaderContainer.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Profile.Header
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Spacing = new Vector2(10, 10),
-                    Padding = new MarginPadding { Horizontal = UserProfileOverlay.CONTENT_X_MARGIN, Top = 10 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Top = 10 },
                 }
             };
         }

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Overlays.Profile.Header
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding { Horizontal = UserProfileOverlay.CONTENT_X_MARGIN, Vertical = 10 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Vertical = 10 },
                     Spacing = new Vector2(0, 10),
                     Children = new Drawable[]
                     {

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.Profile.Header
                             Origin = Anchor.CentreRight,
                             Width = 200,
                             Height = 6,
-                            Margin = new MarginPadding { Right = 50 },
+                            Margin = new MarginPadding { Right = WaveOverlayContainer.HORIZONTAL_PADDING },
                             Child = new LevelProgressBar
                             {
                                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/CentreHeaderContainer.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Profile.Header
                     RelativeSizeAxes = Axes.Y,
                     Direction = FillDirection.Horizontal,
                     Padding = new MarginPadding { Vertical = 10 },
-                    Margin = new MarginPadding { Left = UserProfileOverlay.CONTENT_X_MARGIN },
+                    Margin = new MarginPadding { Left = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Spacing = new Vector2(10, 0),
                     Children = new Drawable[]
                     {
@@ -62,7 +62,7 @@ namespace osu.Game.Overlays.Profile.Header
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
                     AutoSizeAxes = Axes.Both,
-                    Margin = new MarginPadding { Right = UserProfileOverlay.CONTENT_X_MARGIN },
+                    Margin = new MarginPadding { Right = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Children = new Drawable[]
                     {
                         levelBadge = new LevelBadge

--- a/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/DetailHeaderContainer.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays.Profile.Header
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = UserProfileOverlay.CONTENT_X_MARGIN, Vertical = 10 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Vertical = 10 },
                     Child = new GridContainer
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Overlays.Profile.Header
                                     Direction = FillDirection.Horizontal,
                                     Padding = new MarginPadding
                                     {
-                                        Left = UserProfileOverlay.CONTENT_X_MARGIN,
+                                        Left = WaveOverlayContainer.HORIZONTAL_PADDING,
                                         Vertical = vertical_padding
                                     },
                                     Height = content_height + 2 * vertical_padding,

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.Profile
 
         public ProfileHeader()
         {
-            ContentSidePadding = UserProfileOverlay.CONTENT_X_MARGIN;
+            ContentSidePadding = WaveOverlayContainer.HORIZONTAL_PADDING;
 
             TabControl.AddItem(LayoutStrings.HeaderUsersShow);
 

--- a/osu.Game/Overlays/Profile/ProfileSection.cs
+++ b/osu.Game/Overlays/Profile/ProfileSection.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays.Profile
                             AutoSizeAxes = Axes.Both,
                             Margin = new MarginPadding
                             {
-                                Horizontal = UserProfileOverlay.CONTENT_X_MARGIN - outer_gutter_width,
+                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - outer_gutter_width,
                                 Top = 20,
                                 Bottom = 20,
                             },
@@ -97,7 +97,7 @@ namespace osu.Game.Overlays.Profile
                             RelativeSizeAxes = Axes.X,
                             Padding = new MarginPadding
                             {
-                                Horizontal = UserProfileOverlay.CONTENT_X_MARGIN - outer_gutter_width,
+                                Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING - outer_gutter_width,
                                 Bottom = 20
                             }
                         },

--- a/osu.Game/Overlays/Rankings/CountryFilter.cs
+++ b/osu.Game/Overlays/Rankings/CountryFilter.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Overlays.Rankings
                         Origin = Anchor.CentreLeft,
                         Direction = FillDirection.Horizontal,
                         Spacing = new Vector2(10, 0),
-                        Margin = new MarginPadding { Left = UserProfileOverlay.CONTENT_X_MARGIN },
+                        Margin = new MarginPadding { Left = WaveOverlayContainer.HORIZONTAL_PADDING },
                         Children = new Drawable[]
                         {
                             new OsuSpriteText

--- a/osu.Game/Overlays/Rankings/SpotlightSelector.cs
+++ b/osu.Game/Overlays/Rankings/SpotlightSelector.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays.Rankings
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = UserProfileOverlay.CONTENT_X_MARGIN },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING },
                     Child = new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
+++ b/osu.Game/Overlays/Rankings/Tables/RankingsTable.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Overlays.Rankings.Tables
     public abstract partial class RankingsTable<TModel> : TableContainer
     {
         protected const int TEXT_SIZE = 12;
-        private const float horizontal_inset = 20;
         private const float row_height = 32;
         private const float row_spacing = 3;
         private const int items_per_page = 50;
@@ -39,7 +38,7 @@ namespace osu.Game.Overlays.Rankings.Tables
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            Padding = new MarginPadding { Horizontal = horizontal_inset };
+            Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING };
             RowSize = new Dimension(GridSizeMode.Absolute, row_height + row_spacing);
         }
 

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Overlays
         [Resolved]
         private RulesetStore rulesets { get; set; } = null!;
 
-        public const float CONTENT_X_MARGIN = 50;
-
         public UserProfileOverlay()
             : base(OverlayColourScheme.Pink)
         {
@@ -184,7 +182,7 @@ namespace osu.Game.Overlays
             public ProfileSectionTabControl()
             {
                 Height = 40;
-                Padding = new MarginPadding { Horizontal = CONTENT_X_MARGIN };
+                Padding = new MarginPadding { Horizontal = HORIZONTAL_PADDING };
                 TabContainer.Spacing = new Vector2(20);
             }
 

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Overlays
 
         protected override string PopInSampleName => "UI/wave-pop-in";
 
+        public const float HORIZONTAL_PADDING = 50;
+
         protected WaveOverlayContainer()
         {
             AddInternal(Waves = new WaveContainer

--- a/osu.Game/Overlays/Wiki/WikiArticlePage.cs
+++ b/osu.Game/Overlays/Wiki/WikiArticlePage.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Wiki
                             {
                                 Vertical = 20,
                                 Left = 30,
-                                Right = 50,
+                                Right = WaveOverlayContainer.HORIZONTAL_PADDING,
                             },
                             OnAddHeading = sidebar.AddEntry,
                         }

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Overlays
                     Padding = new MarginPadding
                     {
                         Vertical = 20,
-                        Horizontal = 50,
+                        Horizontal = HORIZONTAL_PADDING,
                     },
                 });
             }


### PR DESCRIPTION
All overlays should have 50 horizontal padding. The changes mostly match web, with a difference:
- web subtracts 10 horizontal padding from beatmap listing (search text box) and info (everything) for some reason. I didn't do this for consistency and the new designs also don't do that.