### PR TITLE
Fix settings jump buttons not always seeking to correct location the first time

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -212,13 +212,19 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     }
                 },
             };
+
+            // Early binds and initial visibility update are important to ensure this section has its autosized height before becoming present.
+            // This aids in the settings panel being able to correctly scroll to sections using the jump-buttons on the left.
+            enabled.BindTo(tabletHandler.Enabled);
+            tablet.BindTo(tabletHandler.Tablet);
+
+            updateVisibility();
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            enabled.BindTo(tabletHandler.Enabled);
             enabled.BindValueChanged(_ => Scheduler.AddOnce(updateVisibility));
 
             rotation.BindTo(tabletHandler.Rotation);
@@ -263,7 +269,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 aspectRatioApplication = Schedule(() => forceAspectRatio(aspect.NewValue));
             });
 
-            tablet.BindTo(tabletHandler.Tablet);
             tablet.BindValueChanged(val => Schedule(() =>
             {
                 Scheduler.AddOnce(updateVisibility);


### PR DESCRIPTION
Having a tablet connected would cause the first jump to be too short if the tablet settings have not come into view yet.

I don't know a better way to handle this. I'm also not sure how to best guard against this happening in the future (without forcing `IsPresent` for a frame or something, for all `SettingsSubsection`s) as it's a pretty case-by-case implementation.

Closes https://github.com/ppy/osu/issues/23123.