### PR TITLE
Add rotation snapping to editor selection

### DIFF
--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -100,14 +100,14 @@ namespace osu.Game.Localisation
         public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
 
         /// <summary>
-        /// "0.0°"
+        /// "{0:0.0}&#176;"
         /// </summary>
-        public static LocalisableString RotationFormatUnsnapped => new TranslatableString(getKey(@"rotation_format_unsnapped"), @"0.0°");
+        public static LocalisableString RotationUnsnapped(float newRotation) => new TranslatableString(getKey(@"rotation_unsnapped"), @"{0:0.0}°", newRotation);
 
         /// <summary>
-        /// "0.0° (snapped)"
+        /// "{0:0.0}&#176; (snapped)"
         /// </summary>
-        public static LocalisableString RotationFormatSnapped => new TranslatableString(getKey(@"rotation_format_snapped"), @"0.0° (snapped)");
+        public static LocalisableString RotationSnapped(float newRotation) => new TranslatableString(getKey(@"rotation_snapped"), @"{0:0.0}° (snapped)", newRotation);
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -99,6 +99,16 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
 
+        /// <summary>
+        /// "0.0°"
+        /// </summary>
+        public static LocalisableString RotationFormatUnsnapped => new TranslatableString(getKey(@"rotation_format_unsnapped"), @"0.0°");
+
+        /// <summary>
+        /// "0.0° (snapped)"
+        /// </summary>
+        public static LocalisableString RotationFormatSnapped => new TranslatableString(getKey(@"rotation_format_snapped"), @"0.0° (snapped)");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -54,11 +54,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             });
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-        }
-
         protected override void UpdateHoverState()
         {
             base.UpdateHoverState();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -134,10 +134,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 cumulativeRotation.Value = rawCumulativeRotation;
             }
 
-            if (cumulativeRotation.Value < -180)
-                cumulativeRotation.Value += 360;
-            else if (cumulativeRotation.Value > 180)
-                cumulativeRotation.Value -= 360;
+            cumulativeRotation.Value = (cumulativeRotation.Value - 180) % 360 + 180;
 
             HandleRotate?.Invoke((float)cumulativeRotation.Value - oldRotation);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Localisation;
 using osuTK;
 using osuTK.Graphics;
 using Key = osuTK.Input.Key;
@@ -56,7 +57,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            cumulativeRotation.BindValueChanged(_ => updateTooltipText(), true);
         }
 
         protected override void UpdateHoverState()
@@ -130,18 +130,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             newRotation = (newRotation - 180) % 360 + 180;
 
             cumulativeRotation.Value = newRotation;
-            HandleRotate?.Invoke((float)cumulativeRotation.Value - oldRotation);
+
+            HandleRotate?.Invoke(newRotation - oldRotation);
+            string tooltipFormat = shouldSnap ? EditorStrings.RotationFormatSnapped.ToString() : EditorStrings.RotationFormatUnsnapped.ToString();
+            TooltipText = newRotation.ToLocalisableString(tooltipFormat);
         }
 
         private float snap(float value, float step)
         {
             float floor = MathF.Floor(value / step) * step;
             return value - floor < step / 2f ? floor : floor + step;
-        }
-
-        private void updateTooltipText()
-        {
-            TooltipText = cumulativeRotation.Value?.ToLocalisableString("0.0°") ?? default;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -129,10 +129,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             TooltipText = newRotation.ToLocalisableString(tooltipFormat);
         }
 
-        private float snap(float value, float step)
-        {
-            float floor = MathF.Floor(value / step) * step;
-            return value - floor < step / 2f ? floor : floor + step;
-        }
+        private float snap(float value, float step) => MathF.Round(value / step) * step;
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -7,7 +7,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
@@ -125,8 +124,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             cumulativeRotation.Value = newRotation;
 
             HandleRotate?.Invoke(newRotation - oldRotation);
-            string tooltipFormat = shouldSnap ? EditorStrings.RotationFormatSnapped.ToString() : EditorStrings.RotationFormatUnsnapped.ToString();
-            TooltipText = newRotation.ToLocalisableString(tooltipFormat);
+            TooltipText = shouldSnap ? EditorStrings.RotationSnapped(newRotation) : EditorStrings.RotationUnsnapped(newRotation);
         }
 
         private float snap(float value, float step) => MathF.Round(value / step) * step;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -81,24 +81,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            base.OnKeyDown(e);
-
-            if (cumulativeRotation.Value != null && (e.Key == Key.ShiftLeft || e.Key == Key.ShiftRight))
+            if (IsDragged && (e.Key == Key.ShiftLeft || e.Key == Key.ShiftRight))
             {
                 applyRotation(shouldSnap: true);
+                return true;
             }
 
-            return true;
+            return base.OnKeyDown(e);
         }
 
         protected override void OnKeyUp(KeyUpEvent e)
         {
             base.OnKeyUp(e);
 
-            if (cumulativeRotation.Value != null && (e.Key == Key.ShiftLeft || e.Key == Key.ShiftRight))
-            {
+            if (IsDragged && (e.Key == Key.ShiftLeft || e.Key == Key.ShiftRight))
                 applyRotation(shouldSnap: false);
-            }
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -111,6 +111,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.OnDragEnd(e);
             cumulativeRotation.Value = null;
             rawCumulativeRotation = 0;
+            TooltipText = default;
         }
 
         private float convertDragEventToAngleOfRotation(DragEvent e)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -15,7 +15,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
-
 using Key = osuTK.Input.Key;
 
 namespace osu.Game.Screens.Edit.Compose.Components
@@ -28,8 +27,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private SpriteIcon icon;
 
-        private const float snapStep = 15;
-        private float rawCumulativeRotation = 0;
+        private const float snap_step = 15;
+
         private readonly Bindable<float?> cumulativeRotation = new Bindable<float?>();
 
         [Resolved]
@@ -65,6 +64,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.UpdateHoverState();
             icon.FadeColour(!IsHeld && IsHovered ? Color4.White : Color4.Black, TRANSFORM_DURATION, Easing.OutQuint);
         }
+
+        private float rawCumulativeRotation;
 
         protected override bool OnDragStart(DragStartEvent e)
         {
@@ -125,17 +126,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             float oldRotation = cumulativeRotation.Value ?? 0;
 
-            if (shouldSnap)
-            {
-                cumulativeRotation.Value = snap(rawCumulativeRotation, snapStep);
-            }
-            else
-            {
-                cumulativeRotation.Value = rawCumulativeRotation;
-            }
+            float newRotation = shouldSnap ? snap(rawCumulativeRotation, snap_step) : rawCumulativeRotation;
+            newRotation = (newRotation - 180) % 360 + 180;
 
-            cumulativeRotation.Value = (cumulativeRotation.Value - 180) % 360 + 180;
-
+            cumulativeRotation.Value = newRotation;
             HandleRotate?.Invoke((float)cumulativeRotation.Value - oldRotation);
         }
 


### PR DESCRIPTION
This PR adds 15° snapping to the rotation of the editor selection while holding shift.

Why shift? It was used for snapping in other places too (e.g. `osu.Framework.Graphics.UserInterface.SliderBar` snaps to its `KeyboardStep` when dragging while holding shift).

Why 15°? Completely arbitrary but it felt right I guess..?

It also fixes two small issues with the previous wrapping algorithm used:
1.  A half-turn rotation used to show up as -180° instead of 180°.
    This was not noticeable until now, because it wasn't possible to rotate by exact amounts.
2.  Rotating more than 180° in one drag event would overwhelm the algorithm and cause the value to go outside its desired range.
    This happened to me a couple of times during testing when spinning the selection really fast.

These fixes come at a small cost: The wrapping now unconditionally performs a division (modulo), which may be marginally slower than before (immeasurable, I would imagine).
I wouldn't be surprised if the removal of the if-statements increased the performance by more than the modulo decreases it.