### PR TITLE
Add progressive DT/HT mod multipliers

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModDaycore.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDaycore.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModDaycore : ModDaycore
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModDoubleTime.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDoubleTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModDoubleTime : ModDoubleTime
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModHalfTime.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModHalfTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModHalfTime : ModHalfTime
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Catch/Mods/CatchModNightcore.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModNightcore.cs
@@ -8,6 +8,5 @@ namespace osu.Game.Rulesets.Catch.Mods
 {
     public class CatchModNightcore : ModNightcore<CatchHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDaycore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDaycore.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDaycore : ModDaycore
     {
-        public override double ScoreMultiplier => 0.5;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModDoubleTime : ModDoubleTime
     {
-        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHalfTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHalfTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModHalfTime : ModHalfTime
     {
-        public override double ScoreMultiplier => 0.5;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
@@ -8,6 +8,5 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModNightcore : ModNightcore<ManiaHitObject>
     {
-        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDaycore.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDaycore.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModDaycore : ModDaycore
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDoubleTime.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDoubleTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModDoubleTime : ModDoubleTime
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHalfTime.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHalfTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModHalfTime : ModHalfTime
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNightcore.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNightcore.cs
@@ -8,6 +8,5 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModNightcore : ModNightcore<OsuHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDaycore.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDaycore.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModDaycore : ModDaycore
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDoubleTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModDoubleTime : ModDoubleTime
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHalfTime.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHalfTime.cs
@@ -7,6 +7,5 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModHalfTime : ModHalfTime
     {
-        public override double ScoreMultiplier => 0.3;
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModNightcore.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModNightcore.cs
@@ -8,6 +8,5 @@ namespace osu.Game.Rulesets.Taiko.Mods
 {
     public class TaikoModNightcore : ModNightcore<TaikoHitObject>
     {
-        public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -24,5 +24,22 @@ namespace osu.Game.Rulesets.Mods
             MaxValue = 2,
             Precision = 0.01,
         };
+
+        public override double ScoreMultiplier
+        {
+            get
+            {
+                // Round to the nearest multiple of 0.1.
+                double value = (int)(SpeedChange.Value * 10) / 10.0;
+
+                // Offset back to 0.
+                value -= 1;
+
+                // Each 0.1 multiple changes score multiplier by 0.02.
+                value /= 5;
+
+                return 1 + value;
+            }
+        }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -24,5 +24,19 @@ namespace osu.Game.Rulesets.Mods
             MaxValue = 0.99,
             Precision = 0.01,
         };
+
+        public override double ScoreMultiplier
+        {
+            get
+            {
+                // Round to the nearest multiple of 0.1.
+                double value = (int)(SpeedChange.Value * 10) / 10.0;
+
+                // Offset back to 0.
+                value -= 1;
+
+                return 1 + value;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/22699

For DT, the multiplier is in the range [1.0, 1.2].
For HT, the multiplier is in the range [0.5, 0.9].

- For DT, I intended to make the multiplier for 1.5x speed as close to 1.12 as possible, and it now sits at 1.1x.
- For HT, I took a bit of a liberty since the original 0.3 multiplier doesn't really correspond to anything. In this case, I made it scale in increments of 0.1, which is still harsher than DT's scaling but not as harsh as the original multiplier. Something similar to the original multiplier can be achieved with 2x scaling, however it would result in 0.5x having a multiplier of 0 which doesn't feel right.

