### PR TITLE
Fix song select beatmap difficulty count not updating when deleting

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1068,6 +1068,21 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("options disabled", () => !songSelect.ChildrenOfType<FooterButtonOptions>().Single().Enabled.Value);
         }
 
+        [Test]
+        public void TestTextBoxBeatmapDifficultyCount()
+        {
+            createSongSelect();
+
+            AddAssert("0 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "0 matching beatmaps");
+
+            addRulesetImportStep(0);
+
+            AddAssert("3 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "3 matching beatmaps");
+            AddStep("delete all beatmaps", () => manager.Delete());
+            AddUntilStep("wait for no beatmap", () => Beatmap.IsDefault);
+            AddAssert("0 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "0 matching beatmaps");
+        }
+
         private void waitForInitialSelection()
         {
             AddUntilStep("wait for initial selection", () => !Beatmap.IsDefault);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -50,11 +50,6 @@ namespace osu.Game.Screens.Select
         public Action? BeatmapSetsChanged;
 
         /// <summary>
-        /// Triggered when the deleted <see cref="BeatmapSets"/> change.
-        /// </summary>
-        public Action? DeletedBeatmapSetsChanged;
-
-        /// <summary>
         /// Triggered after filter conditions have finished being applied to the model hierarchy.
         /// </summary>
         public Action? FilterApplied;
@@ -359,7 +354,7 @@ namespace osu.Game.Screens.Select
             if (!Scroll.UserScrolling)
                 ScrollToSelected(true);
 
-            DeletedBeatmapSetsChanged?.Invoke();
+            BeatmapSetsChanged?.Invoke();
         });
 
         public void UpdateBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Select
         public float BleedBottom { get; set; }
 
         /// <summary>
-        /// Triggered when the <see cref="BeatmapSets"/> loaded change and are completely loaded.
+        /// Triggered when <see cref="BeatmapSets"/> finish loading, or are subsequently changed.
         /// </summary>
         public Action? BeatmapSetsChanged;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -50,6 +50,11 @@ namespace osu.Game.Screens.Select
         public Action? BeatmapSetsChanged;
 
         /// <summary>
+        /// Triggered when the deleted <see cref="BeatmapSets"/> change.
+        /// </summary>
+        public Action? DeletedBeatmapSetsChanged;
+
+        /// <summary>
         /// Triggered after filter conditions have finished being applied to the model hierarchy.
         /// </summary>
         public Action? FilterApplied;
@@ -353,6 +358,8 @@ namespace osu.Game.Screens.Select
 
             if (!Scroll.UserScrolling)
                 ScrollToSelected(true);
+
+            DeletedBeatmapSetsChanged?.Invoke();
         });
 
         public void UpdateBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,6 +162,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
+                DeletedBeatmapSetsChanged = updateVisibleBeatmapCount,
                 FilterApplied = updateVisibleBeatmapCount,
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,7 +162,6 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                DeletedBeatmapSetsChanged = updateVisibleBeatmapCount,
                 FilterApplied = updateVisibleBeatmapCount,
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);


### PR DESCRIPTION
~Not sure about using the existing `BeatmapSetsChanged` action in `removeBeatmapSet()` as it invokes `carouselBeatmapsLoaded()` which may cause unintended behavior, so I just made another action specifically for deleted change.~

Before:
![osu!_RJ3xkCOJKj](https://user-images.githubusercontent.com/35318437/230831795-49bfbe4f-3818-4bc9-a1c9-46055bd8ff91.gif)

After:
![osu!_8qlOL0CpkD](https://user-images.githubusercontent.com/35318437/230831625-4bb525b9-ec89-43ba-bcc7-75bf5cfcf3b0.gif)
