### PR TITLE
Beatmap Editor `ControlPointTable` lock and "use current time" issue with `EffectControlPoint`

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -266,6 +266,9 @@ namespace osu.Game.Beatmaps.ControlPoints
 
                 case EffectControlPoint:
                     existing = EffectPointAt(time);
+                    // EffectPointAt() still returns even if no point is at time so a check is needed
+                    if (existing.Time != time)
+                        existing = null;
                     break;
             }
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Edit
             public RowBackground(object item)
             {
                 Item = item;
-                locked_item = false; 
+                locked_item = false;
 
                 RelativeSizeAxes = Axes.X;
                 Height = 25;
@@ -163,12 +163,12 @@ namespace osu.Game.Screens.Edit
                 else if (!locked_table)
                 {
                     locked_item = true;
-                    locked_table = true; 
+                    locked_table = true;
                 }
                 updateState();
                 return true;
             }
-            
+
             private void updateState()
             {
                 if (locked_table)

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.Edit
 
         public const int TEXT_SIZE = 14;
 
+        public static bool locked_table = false;
+
         protected readonly FillFlowContainer<RowBackground> BackgroundFlow;
 
         protected EditorTable()
@@ -48,6 +50,9 @@ namespace osu.Game.Screens.Edit
 
         protected void SetSelectedRow(object? item)
         {
+            if (locked_table)
+                return;
+
             foreach (var b in BackgroundFlow)
             {
                 b.Selected = ReferenceEquals(b.Item, item);
@@ -74,11 +79,14 @@ namespace osu.Game.Screens.Edit
 
             private const int fade_duration = 100;
 
+            private bool locked_item = false;
+
             private readonly Box hoveredBackground;
 
             public RowBackground(object item)
             {
                 Item = item;
+                locked_item = false; 
 
                 RelativeSizeAxes = Axes.X;
                 Height = 25;
@@ -100,12 +108,14 @@ namespace osu.Game.Screens.Edit
 
             private Color4 colourHover;
             private Color4 colourSelected;
+            private Color4 colourLocked;
 
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colours)
             {
                 colourHover = colours.Background1;
                 colourSelected = colours.Colour3;
+                colourLocked = colours.Colour2;
             }
 
             protected override void LoadComplete()
@@ -143,9 +153,28 @@ namespace osu.Game.Screens.Edit
                 base.OnHoverLost(e);
             }
 
+            protected override bool OnDoubleClick(DoubleClickEvent e)
+            {
+                if (locked_table && locked_item)
+                {
+                    locked_item = false;
+                    locked_table = false;
+                }
+                else if (!locked_table)
+                {
+                    locked_item = true;
+                    locked_table = true; 
+                }
+                updateState();
+                return true;
+            }
+            
             private void updateState()
             {
-                hoveredBackground.FadeColour(selected ? colourSelected : colourHover, 450, Easing.OutQuint);
+                if (locked_table)
+                    hoveredBackground.FadeColour(selected ? colourLocked : colourHover, 450, Easing.OutQuint);
+                else
+                    hoveredBackground.FadeColour(selected ? colourSelected : colourHover, 450, Easing.OutQuint);
 
                 if (selected || IsHovered)
                     hoveredBackground.FadeIn(fade_duration, Easing.OutQuint);

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -118,7 +118,8 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override bool OnClick(ClickEvent e)
         {
-            selectedGroup.Value = null;
+            if (!ControlPointTable.locked_table)
+                selectedGroup.Value = null;
             return true;
         }
 
@@ -156,7 +157,7 @@ namespace osu.Game.Screens.Edit.Timing
                     trackedType = selectedGroup.Value?.ControlPoints.FirstOrDefault()?.GetType();
             }
 
-            if (trackedType != null)
+            if (trackedType != null && !ControlPointTable.locked_table)
             {
                 // We don't have an efficient way of looking up groups currently, only individual point types.
                 // To improve the efficiency of this in the future, we should reconsider the overall structure of ControlPointInfo.
@@ -177,6 +178,8 @@ namespace osu.Game.Screens.Edit.Timing
                 return;
 
             Beatmap.ControlPointInfo.RemoveGroup(selectedGroup.Value);
+
+            ControlPointTable.locked_table = false;
 
             selectedGroup.Value = Beatmap.ControlPointInfo.Groups.FirstOrDefault(g => g.Time >= clock.CurrentTime);
         }
@@ -202,6 +205,8 @@ namespace osu.Game.Screens.Edit.Timing
                     }
                 }
             }
+
+            ControlPointTable.locked_table = false;
 
             selectedGroup.Value = group;
         }

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         Action = () =>
                         {
-                            selectedGroup.Value = group;
+                            if (!ControlPointTable.locked_table)
+                                selectedGroup.Value = group;
                             clock.SeekSmoothlyTo(group.Time);
                         }
                     });

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -104,6 +104,8 @@ namespace osu.Game.Screens.Edit.Timing
 
             changeHandler?.BeginChange();
 
+            ControlPointTable.locked_table = false;
+
             var currentGroupItems = SelectedGroup.Value.ControlPoints.ToArray();
 
             Beatmap.ControlPointInfo.RemoveGroup(SelectedGroup.Value);


### PR DESCRIPTION
Addresses #23147 and #23196,
For the first issue I added a double click event to `RowBackground` which updates the state between locked and unlocked, highlighting the locked row.  With checks added to prevent the `selectedGroup` from being updated as well as the row's background color.

For the other issue it seems to be related to how `ControlPointInfo` handles `EffectControlPoint` objects. When `changeSelectedGroupTime` gets triggered it deletes the old point but when it reaches the `Add`, in the snippet below.

https://github.com/ppy/osu/blob/a6e7efa62caaf03ddcc258e56768645be4998843/osu.Game/Screens/Edit/Timing/GroupSection.cs#L109-L115

It then calls `CheckAlreadyExisting` for an `EffectControlPoint` but when the binary search is performed if the new time is greater than or doesn't exist in the list (lines 229 and 247 below) it returns a valid `EffectControlPoint`. Resulting in the `IsRedundant` check to come out as true and it not being added. Leaving the `GroupAt`, in the above snippet, to populate the table with an empty point as no point exists at that time. To address the issue I just added another check to see if the time is equal otherwise set it to null which would fail the redundancy check.
https://github.com/ppy/osu/blob/7aeab174eb0ec8711091ea4d99906d858212538d/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs#L217-L248


Video:

https://user-images.githubusercontent.com/70667577/231600087-66a89604-4ec6-4bb7-b2d6-63dcb487c78f.mp4


