### PR TITLE
Add setting to keep leaderboard expanded

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.FadePlayfieldWhenHealthLow, true);
             SetDefault(OsuSetting.KeyOverlay, false);
             SetDefault(OsuSetting.GameplayLeaderboard, true);
+            SetDefault(OsuSetting.KeepGameplayLeaderboardExpanded, false);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
             SetDefault(OsuSetting.FloatingComments, false);
@@ -305,6 +306,7 @@ namespace osu.Game.Configuration
         ShowStoryboard,
         KeyOverlay,
         GameplayLeaderboard,
+        KeepGameplayLeaderboardExpanded,
         PositionalHitsoundsLevel,
         AlwaysPlayFirstComboBreak,
         FloatingComments,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -85,6 +85,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysShowGameplayLeaderboard => new TranslatableString(getKey(@"gameplay_leaderboard"), @"Always show gameplay leaderboard");
 
         /// <summary>
+        /// "Keep gameplay leaderboard expanded"
+        /// </summary>
+        public static LocalisableString KeepGameplayLeaderboardExpanded = new TranslatableString(getKey(@"gameplay_leaderboard_keep_expanded"), @"Keep gameplay leaderboard expanded");
+
+        /// <summary>
         /// "Always play first combo break sound"
         /// </summary>
         public static LocalisableString AlwaysPlayFirstComboBreak => new TranslatableString(getKey(@"always_play_first_combo_break"), @"Always play first combo break sound");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -43,6 +43,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = GameplaySettingsStrings.AlwaysShowGameplayLeaderboard,
                     Current = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard),
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = GameplaySettingsStrings.KeepGameplayLeaderboardExpanded,
+                    Current = config.GetBindable<bool>(OsuSetting.KeepGameplayLeaderboardExpanded),
+                },
             };
         }
     }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -77,6 +77,8 @@ namespace osu.Game.Screens.Play
 
         private readonly Bindable<bool> samplePlaybackDisabled = new Bindable<bool>();
 
+        private readonly Bindable<bool> keepLeaderboardExpanded = new Bindable<bool>();
+
         /// <summary>
         /// Whether gameplay should pause when the game window focus is lost.
         /// </summary>
@@ -216,6 +218,8 @@ namespace osu.Game.Screens.Play
             sampleRestart = audio.Samples.Get(@"Gameplay/restart");
 
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
+
+            config.BindWith(OsuSetting.KeepGameplayLeaderboardExpanded, keepLeaderboardExpanded);
 
             if (game != null)
                 gameActive.BindTo(game.IsActive);
@@ -887,7 +891,7 @@ namespace osu.Game.Screens.Play
         protected virtual void AddLeaderboardToHUD(GameplayLeaderboard leaderboard) => HUDOverlay.LeaderboardFlow.Add(leaderboard);
 
         private void updateLeaderboardExpandedState() =>
-            LeaderboardExpandedState.Value = !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value;
+            LeaderboardExpandedState.Value = keepLeaderboardExpanded.Value || !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value;
 
         #endregion
 


### PR DESCRIPTION
Adds a setting to force gameplay leaderboards to stay expanded, because I prefer to be distracted.

Not sure if this is the right place to implement this though, would it be better to split up Expanded into configExpanded and AlwaysExpanded like it is for visibility?