### PR TITLE
Fix ruleset shaders not being able to reference framework parts

### DIFF
--- a/osu.Game.Tests/Resources/Shaders/sh_TestFragment.fs
+++ b/osu.Game.Tests/Resources/Shaders/sh_TestFragment.fs
@@ -1,11 +1,14 @@
-#include "sh_Utils.h"
+#define HIGH_PRECISION_VERTEX
 
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+
+layout(location = 2) in highp vec2 v_TexCoord;
+
+layout(location = 0) out vec4 o_Colour;
 
 void main(void)
 {
-    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
-    gl_FragColor = hsv2rgb(vec4(hueValue, 1, 1, 1));
+    highp float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    o_Colour = getRoundedColor(hsv2rgb(vec4(hueValue, 1, 1, 1)), v_TexCoord);
 }
-

--- a/osu.Game.Tests/Resources/Shaders/sh_TestVertex.vs
+++ b/osu.Game.Tests/Resources/Shaders/sh_TestVertex.vs
@@ -1,31 +1,25 @@
-#include "sh_Utils.h"
+layout(location = 0) in highp vec2 m_Position;
+layout(location = 1) in lowp vec4 m_Colour;
+layout(location = 2) in highp vec2 m_TexCoord;
+layout(location = 3) in highp vec4 m_TexRect;
+layout(location = 4) in mediump vec2 m_BlendRange;
 
-attribute highp vec2 m_Position;
-attribute lowp vec4 m_Colour;
-attribute mediump vec2 m_TexCoord;
-attribute mediump vec4 m_TexRect;
-attribute mediump vec2 m_BlendRange;
-
-varying highp vec2 v_MaskingPosition;
-varying lowp vec4 v_Colour;
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
-varying mediump vec2 v_BlendRange;
-
-uniform highp mat4 g_ProjMatrix;
-uniform highp mat3 g_ToMaskingSpace;
+layout(location = 0) out highp vec2 v_MaskingPosition;
+layout(location = 1) out lowp vec4 v_Colour;
+layout(location = 2) out highp vec2 v_TexCoord;
+layout(location = 3) out highp vec4 v_TexRect;
+layout(location = 4) out mediump vec2 v_BlendRange;
 
 void main(void)
 {
-    // Transform from screen space to masking space.
-    highp vec3 maskingPos = g_ToMaskingSpace * vec3(m_Position, 1.0);
-    v_MaskingPosition = maskingPos.xy / maskingPos.z;
+	// Transform from screen space to masking space.
+	highp vec3 maskingPos = g_ToMaskingSpace * vec3(m_Position, 1.0);
+	v_MaskingPosition = maskingPos.xy / maskingPos.z;
 
-    v_Colour = m_Colour;
-    v_TexCoord = m_TexCoord;
-    v_TexRect = m_TexRect;
-    v_BlendRange = m_BlendRange;
+	v_Colour = m_Colour;
+	v_TexCoord = m_TexCoord;
+	v_TexRect = m_TexRect;
+	v_BlendRange = m_BlendRange;
 
-    gl_Position = gProjMatrix * vec4(m_Position, 1.0, 1.0);
+	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0, 1.0);
 }
-

--- a/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
+++ b/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
@@ -53,6 +53,7 @@ namespace osu.Game.Tests.Testing
             {
                 Dependencies.Get<ShaderManager>().LoadRaw(@"sh_TestVertex.vs");
                 Dependencies.Get<ShaderManager>().LoadRaw(@"sh_TestFragment.fs");
+                Dependencies.Get<ShaderManager>().Load(@"TestVertex", @"TestFragment");
             });
         }
 

--- a/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
+++ b/osu.Game.Tests/Testing/TestSceneRulesetDependencies.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Tests.Testing
                 Dependencies.Get<ShaderManager>().LoadRaw(@"sh_TestVertex.vs");
                 Dependencies.Get<ShaderManager>().LoadRaw(@"sh_TestFragment.fs");
                 Dependencies.Get<ShaderManager>().Load(@"TestVertex", @"TestFragment");
+                Dependencies.Get<ShaderManager>().Load(VertexShaderDescriptor.TEXTURE_2, @"TestFragment");
             });
         }
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/ppy/osu-framework/pull/5739
- [ ] Framework bump

Closes https://github.com/ppy/osu/issues/23116

Additional perk: ruleset-specific shaders are being cached in the game's `ShaderManager`, which fixes their recompilation on each gameplay enter.