### PR TITLE
Always round editor rotation to integer values

### DIFF
--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -100,14 +100,14 @@ namespace osu.Game.Localisation
         public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
 
         /// <summary>
-        /// "{0:0.0}&#176;"
+        /// "{0:0}&#176;"
         /// </summary>
-        public static LocalisableString RotationUnsnapped(float newRotation) => new TranslatableString(getKey(@"rotation_unsnapped"), @"{0:0.0}°", newRotation);
+        public static LocalisableString RotationUnsnapped(float newRotation) => new TranslatableString(getKey(@"rotation_unsnapped"), @"{0:0}°", newRotation);
 
         /// <summary>
-        /// "{0:0.0}&#176; (snapped)"
+        /// "{0:0}&#176; (snapped)"
         /// </summary>
-        public static LocalisableString RotationSnapped(float newRotation) => new TranslatableString(getKey(@"rotation_snapped"), @"{0:0.0}° (snapped)", newRotation);
+        public static LocalisableString RotationSnapped(float newRotation) => new TranslatableString(getKey(@"rotation_snapped"), @"{0:0}° (snapped)", newRotation);
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             float oldRotation = cumulativeRotation.Value ?? 0;
 
-            float newRotation = shouldSnap ? snap(rawCumulativeRotation, snap_step) : rawCumulativeRotation;
+            float newRotation = shouldSnap ? snap(rawCumulativeRotation, snap_step) : MathF.Round(rawCumulativeRotation);
             newRotation = (newRotation - 180) % 360 + 180;
 
             cumulativeRotation.Value = newRotation;


### PR DESCRIPTION
As mentioned in youtube comments, there are next to no use cases for having floating-point rotation in the editor, so let's round it for now.

![2023-04-20 14 33 21@2x](https://user-images.githubusercontent.com/191335/233267463-cfa225a5-feeb-4932-8a4f-0e1b6fa9a9d0.png)
