### PR TITLE
Change default beat divisor to 1/4 snap

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Beatmaps
         /// </remarks>
         public double DistanceSpacing { get; set; } = 1.0;
 
-        public int BeatDivisor { get; set; }
+        public int BeatDivisor { get; set; } = 4;
 
         public int GridSize { get; set; }
 


### PR DESCRIPTION
This matches stable, and is a much saner default value.

Will apply to new beatmaps and also beatmaps which don't specify a snap value in the `.osu` file.

