### PR TITLE
Fix some videos with uppercase file extensions not displaying correctly in-game

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -21,6 +21,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Resources;
 using osuTK;
 using osuTK.Graphics;
@@ -157,6 +158,36 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(122474, breakPoint.StartTime);
                 Assert.AreEqual(140135, breakPoint.EndTime);
                 Assert.IsTrue(breakPoint.HasEffect);
+            }
+        }
+
+        [Test]
+        public void TestDecodeVideoWithLowercaseExtension()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("video-with-lowercase-extension.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var beatmap = decoder.Decode(stream);
+                var metadata = beatmap.Metadata;
+
+                Assert.AreEqual("BG.jpg", metadata.BackgroundFile);
+            }
+        }
+
+        [Test]
+        public void TestDecodeVideoWithUppercaseExtension()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("video-with-uppercase-extension.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var beatmap = decoder.Decode(stream);
+                var metadata = beatmap.Metadata;
+
+                Assert.AreEqual("BG.jpg", metadata.BackgroundFile);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -21,7 +21,6 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Skinning;
-using osu.Game.Storyboards;
 using osu.Game.Tests.Resources;
 using osuTK;
 using osuTK.Graphics;

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -170,6 +170,40 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestDecodeVideoWithLowercaseExtension()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("video-with-lowercase-extension.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var storyboard = decoder.Decode(stream);
+
+                StoryboardLayer video = storyboard.Layers.Single(l => l.Name == "Video");
+                Assert.That(video.Elements.Count, Is.EqualTo(1));
+
+                Assert.AreEqual("Video.avi", ((StoryboardVideo)video.Elements[0]).Path);
+            }
+        }
+
+        [Test]
+        public void TestDecodeVideoWithUppercaseExtension()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("video-with-uppercase-extension.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var storyboard = decoder.Decode(stream);
+
+                StoryboardLayer video = storyboard.Layers.Single(l => l.Name == "Video");
+                Assert.That(video.Elements.Count, Is.EqualTo(1));
+
+                Assert.AreEqual("Video.AVI", ((StoryboardVideo)video.Elements[0]).Path);
+            }
+        }
+
+        [Test]
         public void TestDecodeImageSpecifiedAsVideo()
         {
             var decoder = new LegacyStoryboardDecoder();
@@ -179,8 +213,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
                 var storyboard = decoder.Decode(stream);
 
-                StoryboardLayer foreground = storyboard.Layers.Single(l => l.Name == "Video");
-                Assert.That(foreground.Elements.Count, Is.Zero);
+                StoryboardLayer video = storyboard.Layers.Single(l => l.Name == "Video");
+                Assert.That(video.Elements.Count, Is.Zero);
             }
         }
 

--- a/osu.Game.Tests/Resources/video-with-lowercase-extension.osb
+++ b/osu.Game.Tests/Resources/video-with-lowercase-extension.osb
@@ -1,0 +1,5 @@
+osu file format v14
+
+[Events]
+0,0,"BG.jpg",0,0
+Video,0,"Video.avi",0,0

--- a/osu.Game.Tests/Resources/video-with-uppercase-extension.osb
+++ b/osu.Game.Tests/Resources/video-with-uppercase-extension.osb
@@ -1,0 +1,5 @@
+osu file format v14
+
+[Events]
+0,0,"BG.jpg",0,0
+Video,0,"Video.AVI",0,0

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -368,7 +368,7 @@ namespace osu.Game.Beatmaps
                     // user requested abort
                     return;
 
-                var video = b.Files.FirstOrDefault(f => OsuGameBase.VIDEO_EXTENSIONS.Any(ex => f.Filename.EndsWith(ex, StringComparison.Ordinal)));
+                var video = b.Files.FirstOrDefault(f => OsuGameBase.VIDEO_EXTENSIONS.Any(ex => f.Filename.EndsWith(ex, StringComparison.OrdinalIgnoreCase)));
 
                 if (video != null)
                 {

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -369,7 +369,7 @@ namespace osu.Game.Beatmaps.Formats
                     // Some very old beatmaps had incorrect type specifications for their backgrounds (ie. using 1 for VIDEO
                     // instead of 0 for BACKGROUND). To handle this gracefully, check the file extension against known supported
                     // video extensions and handle similar to a background if it doesn't match.
-                    if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(filename).ToUpperInvariant()))
+                    if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(filename).ToLowerInvariant()))
                     {
                         beatmap.BeatmapInfo.Metadata.BackgroundFile = filename;
                     }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -369,7 +369,7 @@ namespace osu.Game.Beatmaps.Formats
                     // Some very old beatmaps had incorrect type specifications for their backgrounds (ie. using 1 for VIDEO
                     // instead of 0 for BACKGROUND). To handle this gracefully, check the file extension against known supported
                     // video extensions and handle similar to a background if it doesn't match.
-                    if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(filename)))
+                    if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(filename).ToUpperInvariant()))
                     {
                         beatmap.BeatmapInfo.Metadata.BackgroundFile = filename;
                     }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Beatmaps.Formats
                         //
                         // This avoids potential weird crashes when ffmpeg attempts to parse an image file as a video
                         // (see https://github.com/ppy/osu/issues/22829#issuecomment-1465552451).
-                        if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path)))
+                        if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path).ToUpperInvariant()))
                             break;
 
                         storyboard.GetLayer("Video").Add(new StoryboardVideo(path, offset));

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Beatmaps.Formats
                         //
                         // This avoids potential weird crashes when ffmpeg attempts to parse an image file as a video
                         // (see https://github.com/ppy/osu/issues/22829#issuecomment-1465552451).
-                        if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path).ToUpperInvariant()))
+                        if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path).ToLowerInvariant()))
                             break;
 
                         storyboard.GetLayer("Video").Add(new StoryboardVideo(path, offset));

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 get
                 {
-                    if (OsuGameBase.VIDEO_EXTENSIONS.Contains(File.Extension.ToUpperInvariant()))
+                    if (OsuGameBase.VIDEO_EXTENSIONS.Contains(File.Extension.ToLowerInvariant()))
                         return FontAwesome.Regular.FileVideo;
 
                     switch (File.Extension)

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 get
                 {
-                    if (OsuGameBase.VIDEO_EXTENSIONS.Contains(File.Extension))
+                    if (OsuGameBase.VIDEO_EXTENSIONS.Contains(File.Extension.ToUpperInvariant()))
                         return FontAwesome.Regular.FileVideo;
 
                     switch (File.Extension)

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -71,7 +71,7 @@ namespace osu.Game
     [Cached(typeof(OsuGameBase))]
     public partial class OsuGameBase : Framework.Game, ICanAcceptFiles, IBeatSyncProvider
     {
-        public static readonly string[] VIDEO_EXTENSIONS = { ".mp4", ".mov", ".avi", ".flv", ".mpg", ".wmv", ".m4v" };
+        public static readonly string[] VIDEO_EXTENSIONS = { ".MP4", ".MOV", ".AVI", ".FLV", ".MPG", ".WMV", ".M4V" };
 
         public const string OSU_PROTOCOL = "osu://";
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -71,7 +71,7 @@ namespace osu.Game
     [Cached(typeof(OsuGameBase))]
     public partial class OsuGameBase : Framework.Game, ICanAcceptFiles, IBeatSyncProvider
     {
-        public static readonly string[] VIDEO_EXTENSIONS = { ".MP4", ".MOV", ".AVI", ".FLV", ".MPG", ".WMV", ".M4V" };
+        public static readonly string[] VIDEO_EXTENSIONS = { ".mp4", ".mov", ".avi", ".flv", ".mpg", ".wmv", ".m4v" };
 
         public const string OSU_PROTOCOL = "osu://";
 


### PR DESCRIPTION
This PR fixes #23259.

The reason for this bug is that the file extension of the video is checked against a list of accepted video file extensions. However, this comparison is case-sensitive, and the list of accepted extensions is all-lowercase. So if a beatmap has a background video with an uppercase file extension, like the beatmap mentioned in the original bug report (https://osu.ppy.sh/beatmapsets/15639: `Video.AVI`), it is interpreted as an image file incorrectly specified as a video (see da947d86613ffe99f19f4d49a6535810ba752c59 for details about that), which causes both the video and original background image to break.

This PR fixes this bug by changing the list to all-uppercase, and converting all extensions to uppercase (using `ToUpperInvariant`) before checking them against the list. I used uppercase instead of lowercase because of https://learn.microsoft.com/de-de/previous-versions/visualstudio/visual-studio-2015/code-quality/ca1308-normalize-strings-to-uppercase?view=vs-2015&redirectedfrom=MSDN (this is further explaind in https://stackoverflow.com/questions/2801508/what-is-wrong-with-tolowerinvariant and https://stackoverflow.com/questions/6225808/string-tolower-and-string-tolowerinvariant).