### PR TITLE
Fix huge lag spike on new combo in osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -422,7 +422,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             caughtObjectContainer.Clear(false);
 
-            //use the already returned PoolableDrawables for new objects
+            // Use the already returned PoolableDrawables for new objects
             var droppedObjects = caughtObjects.Select(getDroppedObject).ToArray();
 
             droppedObjectTarget.AddRange(droppedObjects);
@@ -435,9 +435,11 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             caughtObjectContainer.Remove(caughtObject, false);
 
-            droppedObjectTarget.Add(getDroppedObject(caughtObject));
+            var droppedObject = getDroppedObject(caughtObject);
 
-            applyDropAnimation(caughtObject, animation);
+            droppedObjectTarget.Add(droppedObject);
+
+            applyDropAnimation(droppedObject, animation);
         }
 
         private void applyDropAnimation(Drawable d, DroppedObjectAnimation animation)
@@ -457,7 +459,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     break;
             }
 
-            //define lifetime start for dropped objects to be disposed correctly when rewinding replay
+            // Define lifetime start for dropped objects to be disposed correctly when rewinding replay
             d.LifetimeStart = Clock.CurrentTime;
             d.Expire();
         }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -418,9 +418,12 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private void clearPlate(DroppedObjectAnimation animation)
         {
-            var droppedObjects = caughtObjectContainer.Children.Select(getDroppedObject).ToArray();
+            var caughtObjects = caughtObjectContainer.Children.ToArray();
 
             caughtObjectContainer.Clear(false);
+
+            //use the already returned PoolableDrawables for new objects
+            var droppedObjects = caughtObjects.Select(getDroppedObject).ToArray();
 
             droppedObjectTarget.AddRange(droppedObjects);
 
@@ -430,13 +433,11 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private void removeFromPlate(CaughtObject caughtObject, DroppedObjectAnimation animation)
         {
-            var droppedObject = getDroppedObject(caughtObject);
-
             caughtObjectContainer.Remove(caughtObject, false);
 
-            droppedObjectTarget.Add(droppedObject);
+            droppedObjectTarget.Add(getDroppedObject(caughtObject));
 
-            applyDropAnimation(droppedObject, animation);
+            applyDropAnimation(caughtObject, animation);
         }
 
         private void applyDropAnimation(Drawable d, DroppedObjectAnimation animation)
@@ -456,6 +457,8 @@ namespace osu.Game.Rulesets.Catch.UI
                     break;
             }
 
+            //define lifetime start for dropped objects to be disposed correctly when rewinding replay
+            d.LifetimeStart = Clock.CurrentTime;
             d.Expire();
         }
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/issues/23220

Makes use of already allocated `PoolableDrawable`s instead of allocating new ones.
I could probably imagine some issues with this approach, but not sure.

Also fixes dropped objects not being removed when rewinding (at the end of the video).

https://user-images.githubusercontent.com/100224757/233731777-5d373522-cc89-416b-85ec-897b95fcfe66.mp4

https://user-images.githubusercontent.com/100224757/233731757-5816f69d-a0ee-4cf8-a04d-bb82b1cdec7f.mp4

