### PR TITLE
Option to restrict dragging of the tablet area within the full usable area

### DIFF
--- a/osu.Game/Localisation/TabletSettingsStrings.cs
+++ b/osu.Game/Localisation/TabletSettingsStrings.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Localisation
         public static LocalisableString YOffset => new TranslatableString(getKey(@"y_offset"), @"Y Offset");
 
         /// <summary>
-        /// "Confine dragging within full area"
+        /// "Allow dragging outside of full area"
         /// </summary>
-        public static LocalisableString ConfineDraggingWithinArea => new TranslatableString(getKey(@"confine_dragging_within_full_area"), @"Confine dragging within full area");
+        public static LocalisableString AllowDraggingOutsideArea => new TranslatableString(getKey(@"allow_dragging_outside_of_full_area"), @"Allow dragging outside of full area");
 
         /// <summary>
         /// "Rotation"

--- a/osu.Game/Localisation/TabletSettingsStrings.cs
+++ b/osu.Game/Localisation/TabletSettingsStrings.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Localisation
         public static LocalisableString YOffset => new TranslatableString(getKey(@"y_offset"), @"Y Offset");
 
         /// <summary>
+        /// "Confine dragging within full area"
+        /// </summary>
+        public static LocalisableString ConfineDraggingWithinArea => new TranslatableString(getKey(@"confine_dragging_within_full_area"), @"Confine dragging within full area");
+
+        /// <summary>
         /// "Rotation"
         /// </summary>
         public static LocalisableString Rotation => new TranslatableString(getKey(@"rotation"), @"Rotation");

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 Vector2 halfSize = Size / 2;
 
-                if (Parent.Rotation < -45 && Parent.Rotation > -135 || Parent.Rotation < -225 && Parent.Rotation > -315)
+                if ((Parent.Rotation < -45 && Parent.Rotation > -135) || (Parent.Rotation < -225 && Parent.Rotation > -315))
                 {
                     halfSize = new Vector2(halfSize.Y, halfSize.X);
                 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -201,10 +201,26 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             usableAreaQuad *= matrix;
 
             IsWithinBounds =
-                tabletArea.Contains(usableAreaQuad.TopLeft) &&
-                tabletArea.Contains(usableAreaQuad.TopRight) &&
-                tabletArea.Contains(usableAreaQuad.BottomLeft) &&
-                tabletArea.Contains(usableAreaQuad.BottomRight);
+                tabletArea.TopLeft.X < usableAreaQuad.TopLeft.X &&
+                tabletArea.TopLeft.Y < usableAreaQuad.TopLeft.Y &&
+                tabletArea.BottomLeft.X < usableAreaQuad.BottomLeft.X &&
+                tabletArea.BottomLeft.Y > usableAreaQuad.BottomLeft.Y &&
+                tabletArea.TopRight.X > usableAreaQuad.TopRight.X &&
+                tabletArea.TopRight.Y < usableAreaQuad.TopRight.Y &&
+                tabletArea.BottomRight.X > usableAreaQuad.BottomRight.X &&
+                tabletArea.BottomRight.Y > usableAreaQuad.BottomRight.Y;
+
+            //flag is a hypothetical settings checkbox
+            bool flag = true;
+            if(!IsWithinBounds && flag){
+                //Snap to top left
+                Vector2 newLocation = new Vector2(tabletArea.TopLeft.X + halfUsableArea.X, tabletArea.TopLeft.Y + halfUsableArea.Y);
+                usableAreaContainer.MoveTo(newLocation, 100, Easing.OutQuint);
+                areaOffset.Value = newLocation;
+                IsWithinBounds = tabletArea.Contains(newLocation);
+                Console.WriteLine("kok");
+            }
+            
 
             usableFill.FadeColour(IsWithinBounds ? colour.Blue : colour.RedLight, 100);
         }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private Container usableAreaContainer;
 
         private readonly Bindable<Vector2> areaOffset = new Bindable<Vector2>();
-        private readonly Bindable<bool> dragConfine;
+        private readonly Bindable<bool> dragOutOfBounds;
         private readonly Bindable<Vector2> areaSize = new Bindable<Vector2>();
 
         private readonly BindableNumber<float> rotation = new BindableNumber<float>();
@@ -43,10 +43,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private Box usableFill;
         private OsuSpriteText usableAreaText;
 
-        public TabletAreaSelection(ITabletHandler handler, Bindable<bool> dragConfine)
+        public TabletAreaSelection(ITabletHandler handler, Bindable<bool> dragOutOfBounds)
         {
             this.handler = handler;
-            this.dragConfine = dragConfine.GetBoundCopy();
+            this.dragOutOfBounds = dragOutOfBounds.GetBoundCopy();
 
             Padding = new MarginPadding { Horizontal = SettingsPanel.CONTENT_MARGINS };
         }
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         RelativeSizeAxes = Axes.Both,
                         Colour = colour.Gray1,
                     },
-                    usableAreaContainer = new UsableAreaContainer(handler, dragConfine)
+                    usableAreaContainer = new UsableAreaContainer(handler, dragOutOfBounds)
                     {
                         Origin = Anchor.Centre,
                         Children = new Drawable[]
@@ -232,12 +232,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     public partial class UsableAreaContainer : Container
     {
         private readonly Bindable<Vector2> areaOffset;
-        private readonly Bindable<bool> dragConfine;
+        private readonly Bindable<bool> dragOutOfBounds;
 
-        public UsableAreaContainer(ITabletHandler tabletHandler, Bindable<bool> dragConfine)
+        public UsableAreaContainer(ITabletHandler tabletHandler, Bindable<bool> dragOutOfBounds)
         {
             areaOffset = tabletHandler.AreaOffset.GetBoundCopy();
-            this.dragConfine = dragConfine.GetBoundCopy();
+            this.dragOutOfBounds = dragOutOfBounds.GetBoundCopy();
         }
 
         protected override bool OnDragStart(DragStartEvent e) => true;
@@ -246,15 +246,16 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             var newPos = Position + e.Delta;
 
-            if (dragConfine.Value)
+            if (!dragOutOfBounds.Value)
             {
                 Vector2 halfSize = Size / 2;
 
                 if ((Parent.Rotation < -45 && Parent.Rotation > -135) || (Parent.Rotation < -225 && Parent.Rotation > -315))
                 {
-                    halfSize = new Vector2(halfSize.Y, halfSize.X);
+                    halfSize = halfSize.Yx;
                 }
-                this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero + halfSize, Parent.Size - halfSize));
+
+                this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero + halfSize, (Parent.Size - halfSize)));
             }
             else
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0 };
         private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0 };
 
+        private readonly BindableBool dragConfine = new BindableBool();
+
         private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10 };
         private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10 };
 
@@ -128,7 +130,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        AreaSelection = new TabletAreaSelection(tabletHandler)
+                        AreaSelection = new TabletAreaSelection(tabletHandler, dragConfine)
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 300,
@@ -166,6 +168,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             TransferValueOnCommit = true,
                             LabelText = TabletSettingsStrings.YOffset,
                             Current = offsetY,
+                            CanBeShown = { BindTarget = enabled }
+                        },
+                        new SettingsCheckbox
+                        {
+                            LabelText = TabletSettingsStrings.ConfineDraggingWithinArea,
+                            Current = dragConfine,
                             CanBeShown = { BindTarget = enabled }
                         },
                         new SettingsSlider<float>

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0 };
         private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0 };
 
-        private readonly BindableBool dragConfine = new BindableBool();
+        private readonly BindableBool dragOutOfBounds = new BindableBool();
 
         private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10 };
         private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10 };
@@ -130,7 +130,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        AreaSelection = new TabletAreaSelection(tabletHandler, dragConfine)
+                        AreaSelection = new TabletAreaSelection(tabletHandler, dragOutOfBounds)
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 300,
@@ -172,8 +172,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         },
                         new SettingsCheckbox
                         {
-                            LabelText = TabletSettingsStrings.ConfineDraggingWithinArea,
-                            Current = dragConfine,
+                            LabelText = TabletSettingsStrings.AllowDraggingOutsideArea,
+                            Current = dragOutOfBounds,
                             CanBeShown = { BindTarget = enabled }
                         },
                         new SettingsSlider<float>


### PR DESCRIPTION
As a followup to PR https://github.com/ppy/osu/pull/22697 , 
I decided to work on something that bugged me when i first launched Lazer three days ago and had to micro-adjust my area until it was on the top left. I'd imagine lots of users have similar setups and this option could help making the setup easier.

+Added a checkbox below the offset sliders
+When ticked, the dragging of the area does not allow any part of the area to go out of bounds
+Works with any area size
+Only affects mouse drag behavior; offset sliders can still move it out of bounds

\- Does not work well with angles that aren't 0, 90, 180, 270, 360 degrees

Demo:
https://user-images.githubusercontent.com/35996393/233796042-08627526-fb1a-48bf-937b-02b1528dd512.mp4

Tests:
https://user-images.githubusercontent.com/35996393/233796504-7bf2a97e-ab88-46ef-8b56-99c50fa2c9b7.mp4

Open to discussion and feedback