### PR TITLE
Fix issue where multiplier show wrong value when adjusting speed on preset

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Overlays.Mods
             if (AllowCustomisation)
                 ((IBindable<IReadOnlyList<Mod>>)modSettingsArea.SelectedMods).BindTo(SelectedMods);
 
-            SelectedMods.BindValueChanged(val =>
+            SelectedMods.BindValueChanged(_ =>
             {
                 updateMultiplier();
                 updateFromExternalSelection();
@@ -252,6 +252,10 @@ namespace osu.Game.Overlays.Mods
 
                 if (AllowCustomisation)
                 {
+                    // Importantly, use SelectedMods.Value here (and not the ValueChanged NewValue) as the latter can
+                    // potentially be stale, due to complexities in the way change trackers work.
+                    //
+                    // See https://github.com/ppy/osu/pull/23284#issuecomment-1529056988
                     modSettingChangeTracker = new ModSettingChangeTracker(SelectedMods.Value);
                     modSettingChangeTracker.SettingChanged += _ => updateMultiplier();
                 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Overlays.Mods
 
                 if (AllowCustomisation)
                 {
-                    modSettingChangeTracker = new ModSettingChangeTracker(val.NewValue);
+                    modSettingChangeTracker = new ModSettingChangeTracker(SelectedMods.Value);
                     modSettingChangeTracker.SettingChanged += _ => updateMultiplier();
                 }
             }, true);

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -244,11 +244,11 @@ namespace osu.Game.Overlays.Mods
 
             SelectedMods.BindValueChanged(val =>
             {
-                modSettingChangeTracker?.Dispose();
-
                 updateMultiplier();
                 updateFromExternalSelection();
                 updateCustomisation();
+
+                modSettingChangeTracker?.Dispose();
 
                 if (AllowCustomisation)
                 {


### PR DESCRIPTION
This PR reference issue [#23234](https://github.com/ppy/osu/issues/23234)

The fix was already found by [cdwcgt](https://github.com/cdwcgt) in the discussion, I did a little investigation and found that when setting `modSettingChangeTracker` to `val.NewValue` , it didn't trigger [`updateMultipler()`](https://github.com/ppy/osu/blob/master/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L346) when changing the speed slider (with preset mod selected). After changing `val.NewValue` to `SelectedMods.Value`, [`updateMultipler()`](https://github.com/ppy/osu/blob/master/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L346) did get called when changing the speed slider.
