### PR TITLE
Fix extreme aspect ratios in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
-            drawableTaikoRuleset.LockPlayfieldMaxAspect.Value = false;
+            drawableTaikoRuleset.LockPlayfieldAspectRange.Value = false;
 
             var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
             playfield.ClassicHitTargetPosition.Value = true;

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         public new BindableDouble TimeRange => base.TimeRange;
 
-        public readonly BindableBool LockPlayfieldMaxAspect = new BindableBool(true);
+        public readonly BindableBool LockPlayfieldAspectRange = new BindableBool(true);
 
         public new TaikoInputManager KeyBindingInputManager => (TaikoInputManager)base.KeyBindingInputManager;
 
@@ -69,7 +69,9 @@ namespace osu.Game.Rulesets.Taiko.UI
             const float scroll_rate = 10;
 
             // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
-            float ratio = DrawHeight / 480;
+            // Width is used because it defines how many notes fit on the playfield.
+            // We clamp the ratio to the maximum aspect ratio to keep scroll speed consistent on widths lower than the default.
+            float ratio = Math.Max(DrawSize.X / 768f, TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
 
             TimeRange.Value = (Playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate;
         }
@@ -92,7 +94,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer() => new TaikoPlayfieldAdjustmentContainer
         {
-            LockPlayfieldMaxAspect = { BindTarget = LockPlayfieldMaxAspect }
+            LockPlayfieldAspectRange = { BindTarget = LockPlayfieldAspectRange }
         };
 
         protected override PassThroughInputManager CreateInputManager() => new TaikoInputManager(Ruleset.RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -11,9 +11,11 @@ namespace osu.Game.Rulesets.Taiko.UI
     public partial class TaikoPlayfieldAdjustmentContainer : PlayfieldAdjustmentContainer
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
-        private const float default_aspect = 16f / 9f;
 
-        public readonly IBindable<bool> LockPlayfieldMaxAspect = new BindableBool(true);
+        public const float MAXIMUM_ASPECT = 16f / 9f;
+        public const float MINIMUM_ASPECT = 5f / 4f;
+
+        public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
         protected override void Update()
         {
@@ -26,12 +28,22 @@ namespace osu.Game.Rulesets.Taiko.UI
             //
             // As a middle-ground, the aspect ratio can still be adjusted in the downwards direction but has a maximum limit.
             // This is still a bit weird, because readability changes with window size, but it is what it is.
-            if (LockPlayfieldMaxAspect.Value && Parent.ChildSize.X / Parent.ChildSize.Y > default_aspect)
-                height *= Math.Clamp(Parent.ChildSize.X / Parent.ChildSize.Y, 0.4f, 4) / default_aspect;
+            if (LockPlayfieldAspectRange.Value)
+            {
+                float currentAspect = Parent.ChildSize.X / Parent.ChildSize.Y;
 
+                if (currentAspect > MAXIMUM_ASPECT)
+                    height *= currentAspect / MAXIMUM_ASPECT;
+                else if (currentAspect < MINIMUM_ASPECT)
+                    height *= currentAspect / MINIMUM_ASPECT;
+            }
+
+            // Limit the maximum relative height of the playfield to one-third of available area to avoid it masking out on extreme resolutions.
+            height = Math.Min(height, 1f / 3f);
             Height = height;
 
-            // Position the taiko playfield exactly one playfield from the top of the screen.
+            // Position the taiko playfield exactly one playfield from the top of the screen, if there is enough space for it.
+            // Note that the relative height cannot exceed one-third - if that limit is hit, the playfield will be exactly centered.
             RelativePositionAxes = Axes.Y;
             Y = height;
         }


### PR DESCRIPTION
This PR fixes two weird behaviors at extreme aspect ratios.
It incorporates some of the fixes mentioned in #22581.

1) The ratio for the scroll speed calculation now depends on width rather than height. This ensures that on wide aspect ratios the notes become faster to avoid showing more notes. Height ratio didn't always correspond to width ratio.
2) A lower bound for the aspect ratio has been added, that being 5:4, to ensure extreme values don't break the playfield
3) The height of the playfield is now limited to 1/3 of the screen, as per https://github.com/ppy/osu/pull/22581#issuecomment-1428651352

There are some things that could still be done, like avoiding that the playfield moves up on small ratios, and maybe even fixing the wide aspect ratio issue in a graphical way instead of speeding up the notes, but this is a good start.

Master:

https://user-images.githubusercontent.com/54949148/234802514-7df0513b-01cb-4788-bae7-1ee2bc74260d.mp4

This PR:

https://user-images.githubusercontent.com/54949148/234802674-fd0697a8-6579-4e32-a93d-a368e6e33ca9.mp4

Closes #22581 
Closes #22853 