### PR TITLE
Fix exclusive fullscreen notice showing false positives for new renderers

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
                 return;
             }
 
-            if (host.Window is WindowsWindow)
+            if (host.Renderer is IWindowsRenderer)
             {
                 switch (fullscreenCapability.Value)
                 {


### PR DESCRIPTION
This avoids the notice showing when running on windows, but using the newer renderers (where the underlying logic hasn't been tested properly and can result in false-positives).

Supersedes https://github.com/ppy/osu-framework/pull/5759 as a more correct implementation.