### PR TITLE
Fix editor potentially leaving a dangling beatmap if exiting during load too fast

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditor.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditor.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DeepEqual.Syntax;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Tests.Visual.Navigation
+{
+    public partial class TestSceneBeatmapEditor : OsuGameTestScene
+    {
+        [Test]
+        public void TestCancelNavigationToEditor()
+        {
+            BeatmapSetInfo[] beatmapSets = Array.Empty<BeatmapSetInfo>();
+
+            AddStep("Timestamp current beatmapsets", () =>
+            {
+                Game.Realm.Run(realm =>
+                {
+                    beatmapSets = realm.All<BeatmapSetInfo>().Where(x => !x.DeletePending).ToArray();
+                });
+            });
+
+            AddStep("Open editor and close it while loading", () =>
+            {
+                var task = Task.Run(async () =>
+                {
+                    await Task.Delay(100);
+                    Game.ScreenStack.CurrentScreen.Exit();
+                });
+
+                Game.ScreenStack.Push(new EditorLoader());
+            });
+
+            AddUntilStep("wait for editor", () => Game.ScreenStack.CurrentScreen is MainMenu);
+
+            BeatmapSetInfo[] currentSetInfos = Array.Empty<BeatmapSetInfo>();
+
+            AddStep("Get current beatmaps", () =>
+            {
+                Game.Realm.Run(realm =>
+                {
+                    currentSetInfos = realm.All<BeatmapSetInfo>().Where(x => !x.DeletePending).ToArray();
+                });
+            });
+
+            AddAssert("dummy beatmap didn't appear", () => currentSetInfos.IsDeepEqual(beatmapSets));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditor.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditor.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
-using System.Threading.Tasks;
 using DeepEqual.Syntax;
 using NUnit.Framework;
 using osu.Framework.Screens;
@@ -18,7 +16,7 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestCancelNavigationToEditor()
         {
-            BeatmapSetInfo[] beatmapSets = Array.Empty<BeatmapSetInfo>();
+            BeatmapSetInfo[]? beatmapSets = null;
 
             AddStep("Timestamp current beatmapsets", () =>
             {
@@ -28,20 +26,26 @@ namespace osu.Game.Tests.Visual.Navigation
                 });
             });
 
-            AddStep("Open editor and close it while loading", () =>
+            AddStep("Set current beatmap to default", () =>
             {
-                var task = Task.Run(async () =>
-                {
-                    await Task.Delay(100);
-                    Game.ScreenStack.CurrentScreen.Exit();
-                });
+                Game.Beatmap.SetDefault();
+            });
 
+            AddStep("Open editor loader", () =>
+            {
                 Game.ScreenStack.Push(new EditorLoader());
+            });
+
+            AddUntilStep("wait for editor", () => Game.ScreenStack.CurrentScreen is EditorLoader);
+
+            AddStep("close editor while loading", () =>
+            {
+                Game.ScreenStack.CurrentScreen.Exit();
             });
 
             AddUntilStep("wait for editor", () => Game.ScreenStack.CurrentScreen is MainMenu);
 
-            BeatmapSetInfo[] currentSetInfos = Array.Empty<BeatmapSetInfo>();
+            BeatmapSetInfo[]? currentSetInfos = null;
 
             AddStep("Get current beatmaps", () =>
             {
@@ -51,7 +55,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 });
             });
 
-            AddAssert("dummy beatmap didn't appear", () => currentSetInfos.IsDeepEqual(beatmapSets));
+            AddAssert("dummy beatmap didn't appear", () => currentSetInfos.IsDeepEqual(beatmapSets) && currentSetInfos is not null);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using DeepEqual.Syntax;
 using NUnit.Framework;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
@@ -18,10 +17,7 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             BeatmapSetInfo[] beatmapSets = null!;
 
-            AddStep("Fetch initial beatmaps", () =>
-            {
-                beatmapSets = Game.Realm.Run(realm => realm.All<BeatmapSetInfo>().Where(x => !x.DeletePending).ToArray());
-            });
+            AddStep("Fetch initial beatmaps", () => beatmapSets = allBeatmapSets());
 
             AddStep("Set current beatmap to default", () => Game.Beatmap.SetDefault());
 
@@ -30,12 +26,9 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("Close editor while loading", () => Game.ScreenStack.CurrentScreen.Exit());
 
             AddUntilStep("Wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
+            AddAssert("Check no new beatmaps were made", () => allBeatmapSets().SequenceEqual(beatmapSets));
 
-            AddAssert("Check no new beatmaps were made", () =>
-            {
-                var beatmapSetsAfter = Game.Realm.Run(realm => realm.All<BeatmapSetInfo>().Where(x => !x.DeletePending).ToArray());
-                return beatmapSetsAfter.SequenceEqual(beatmapSets);
-            });
+            BeatmapSetInfo[] allBeatmapSets() => Game.Realm.Run(realm => realm.All<BeatmapSetInfo>().Where(x => !x.DeletePending).ToArray());
         }
     }
 }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -11,7 +11,7 @@ using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
-    public partial class TestSceneBeatmapEditor : OsuGameTestScene
+    public partial class TestSceneBeatmapEditorNavigation : OsuGameTestScene
     {
         [Test]
         public void TestCancelNavigationToEditor()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -12,6 +12,14 @@ namespace osu.Game.Tests.Visual.Navigation
 {
     public partial class TestSceneBeatmapEditorNavigation : OsuGameTestScene
     {
+        /// <summary>
+        /// When entering the editor, a new beatmap is created as part of the asynchronous load process.
+        /// This test ensures that in the case of an early exit from the editor (ie. while it's still loading)
+        /// doesn't leave a dangling beatmap behind.
+        ///
+        /// This may not fail 100% due to timing, but has a pretty high chance of hitting a failure so works well enough
+        /// as a test.
+        /// </summary>
         [Test]
         public void TestCancelNavigationToEditor()
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -210,7 +210,10 @@ namespace osu.Game.Screens.Edit
                 // this is a bit haphazard, but guards against setting the lease Beatmap bindable if
                 // the editor has already been exited.
                 if (!ValidForPush)
+                {
+                    beatmapManager.Delete(loadableBeatmap.BeatmapSetInfo);
                     return;
+                }
             }
 
             try


### PR DESCRIPTION
Reduce amount of dummy beatmaps generated by editor.

| branch | video |
| ---- | ---- |
| Main | <video src="https://user-images.githubusercontent.com/50776304/235228985-d774b76a-cd61-4c78-adde-9dd2dfd346e0.mp4"> |
| This PR | <video src="https://user-images.githubusercontent.com/50776304/235229287-a24403b1-4e97-4a40-a51e-7d3f972fdff7.mp4"> |





Fixes #14878 