### PR TITLE
Imported skin notification now says "Click to apply" instead of "Click to view"

### DIFF
--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -163,7 +163,11 @@ namespace osu.Game.Database
 
                 if (imported.Count > 0 && PresentImport != null)
                 {
-                    notification.CompletionText += " Click to view.";
+                    if (HumanisedModelName == "skin")
+                        notification.CompletionText += " Click to apply.";
+                    else
+                        notification.CompletionText += " Click to view.";
+
                     notification.CompletionClickAction = () =>
                     {
                         PresentImport?.Invoke(imported);


### PR DESCRIPTION
The logic behind this is that clicking on the notification does not allow you to view the skin, and instead applies it.

![image](https://user-images.githubusercontent.com/48618519/235352558-763d43bc-2ba0-4358-b4d0-0fe8efb9160b.png)