### PR TITLE
Add the abbilty to place spinners and sliders in lazer on mobile devices, as well as submit maps for ranking

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -770,7 +770,7 @@ namespace osu.Game.Screens.Select
             {
                 updateItem(item);
 
-                if (!item.Item.Filtered.Value)
+                if (item.Item.Visible)
                 {
                     bool isSelected = item.Item.State.Value == CarouselItemState.Selected;
 


### PR DESCRIPTION
When I try and place sliders or spinners in osu! lazer on a Samsung Galaxy TAB A8 X-200 it won't work, dragging works fine, but placing them doesn't work, as well as that, allow submissions of maps in lazer on mobile