### PR TITLE
Enable 'Use current' distance snap when exactly on a hit object

### DIFF
--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Edit
 
         private (HitObject before, HitObject after)? getObjectsOnEitherSideOfCurrentTime()
         {
-            HitObject lastBefore = Playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.HitObject.StartTime <= EditorClock.CurrentTime)?.HitObject;
+            HitObject lastBefore = Playfield.HitObjectContainer.AliveObjects.LastOrDefault(h => h.HitObject.StartTime < EditorClock.CurrentTime)?.HitObject;
 
             if (lastBefore == null)
                 return null;


### PR DESCRIPTION
When exactly on the start time of a hit object, the 'Use current' option becomes unavailable because the first object before and after the current time is the same object. I changed this so it would get the previous hit object and the current hit object in this situation. That way you can easily get the distance snap to copy the same distance as used before.