### PR TITLE
Reset online ID on locally modifying beatmap

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
@@ -2,20 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using System.Net;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Game.Database;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Editing
 {
     public partial class TestSceneLocallyModifyingOnlineBeatmaps : EditorSavingTestScene
     {
-        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
-
         public override void SetUpSteps()
         {
             CreateInitialBeatmap = () =>
@@ -33,20 +28,6 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("editor beatmap has online ID", () => EditorBeatmap.BeatmapInfo.OnlineID, () => Is.GreaterThan(0));
 
             AddStep("delete first hitobject", () => EditorBeatmap.RemoveAt(0));
-
-            AddStep("mock online lookup failure", () =>
-            {
-                dummyAPI.HandleRequest = req =>
-                {
-                    if (req is GetBeatmapRequest)
-                    {
-                        req.TriggerFailure(new APIException("Beatmap not found", new WebException("NotFound")));
-                        return true;
-                    }
-
-                    return false;
-                };
-            });
             SaveEditor();
 
             ReloadEditorToSameBeatmap();

--- a/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneLocallyModifyingOnlineBeatmaps.cs
@@ -1,0 +1,56 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Net;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Game.Database;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public partial class TestSceneLocallyModifyingOnlineBeatmaps : EditorSavingTestScene
+    {
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        public override void SetUpSteps()
+        {
+            CreateInitialBeatmap = () =>
+            {
+                var importedSet = Game.BeatmapManager.Import(new ImportTask(TestResources.GetTestBeatmapForImport())).GetResultSafely();
+                return Game.BeatmapManager.GetWorkingBeatmap(importedSet!.Value.Beatmaps.First());
+            };
+
+            base.SetUpSteps();
+        }
+
+        [Test]
+        public void TestLocallyModifyingOnlineBeatmap()
+        {
+            AddAssert("editor beatmap has online ID", () => EditorBeatmap.BeatmapInfo.OnlineID, () => Is.GreaterThan(0));
+
+            AddStep("delete first hitobject", () => EditorBeatmap.RemoveAt(0));
+
+            AddStep("mock online lookup failure", () =>
+            {
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetBeatmapRequest)
+                    {
+                        req.TriggerFailure(new APIException("Beatmap not found", new WebException("NotFound")));
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            SaveEditor();
+
+            ReloadEditorToSameBeatmap();
+            AddAssert("editor beatmap online ID reset", () => EditorBeatmap.BeatmapInfo.OnlineID, () => Is.EqualTo(-1));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -415,6 +415,13 @@ namespace osu.Game.Beatmaps
             // All changes to metadata are made in the provided beatmapInfo, so this should be copied to the `IBeatmap` before encoding.
             beatmapContent.BeatmapInfo = beatmapInfo;
 
+            // Since now this is a locally-modified beatmap, we also set all relevant flags to indicate this.
+            // Importantly, the `ResetOnlineInfo()` call must happen before encoding, as online ID is encoded into the `.osu` file,
+            // which influences the beatmap checksums.
+            beatmapInfo.LastLocalUpdate = DateTimeOffset.Now;
+            beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
+            beatmapInfo.ResetOnlineInfo();
+
             using (var stream = new MemoryStream())
             {
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
@@ -437,10 +444,6 @@ namespace osu.Game.Beatmaps
 
                 beatmapInfo.MD5Hash = stream.ComputeMD5Hash();
                 beatmapInfo.Hash = stream.ComputeSHA2Hash();
-
-                beatmapInfo.LastLocalUpdate = DateTimeOffset.Now;
-                beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
-                beatmapInfo.ResetOnlineInfo();
 
                 AddFile(setInfo, stream, createBeatmapFilenameFromMetadata(beatmapInfo));
 

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -440,6 +440,7 @@ namespace osu.Game.Beatmaps
 
                 beatmapInfo.LastLocalUpdate = DateTimeOffset.Now;
                 beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
+                beatmapInfo.ResetOnlineInfo();
 
                 AddFile(setInfo, stream, createBeatmapFilenameFromMetadata(beatmapInfo));
 


### PR DESCRIPTION
This PR is intended to be the immediate fix for #23264. It doesn't address all holes I've found along the way, and I intend to work through those in subsequent PRs if the approach I will outline below is accepted. Let's start with the description of the failure case.

---

The cause of the original bug can be summarised as follows: The specific beatmap that the issue reporter used is old enough that it does not have `OnlineID` populated in the `.osu` file. Locally modifying it correctly updated the beatmap hash, but left the beatmap online ID intact. I am hesitant to call this a regression from #23189 for reasons I want to confirm first[^1], but that pull definitely makes it easier for the issue to surface.

When the user navigates to playlists, the online availability tracker [correctly checks both the online ID and the beatmap hash](https://github.com/ppy/osu/blob/5c066c40b1c5bad0dd106fde65739bd9209b99fa/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs#L151-L153), and determines that the beatmap was locally modified and forces the user to redownload the map.

Normally, on beatmaps that have `OnlineID` populated in the `.osu` file, the redownload results in [removing the old locally modified set and importing it afresh](https://github.com/ppy/osu/blob/5c066c40b1c5bad0dd106fde65739bd9209b99fa/osu.Game/Beatmaps/BeatmapImporter.cs#L212C26-L245). However, this is only possible because the online IDs are in the `.osu` files - as the online metadata lookup flow [is no longer part of the import process](https://github.com/ppy/osu/blob/5c066c40b1c5bad0dd106fde65739bd9209b99fa/osu.Game/Beatmaps/BeatmapImporter.cs#L171), but instead happens post-import, the deduplication logic in `BeatmapImporter` can run correctly only for beatmaps with `OnlineID` in `.osu` files present. In cases where the `OnlineID` is missing, however, this leads to a situation where two beatmaps with the same online ID are now present: one is the locally modified instance, and the other is the redownloaded one.

This in turn causes a failure at another point - `RoomSubScreen` [does not have the target md5 of the playlist item it intends to select, and in turn relies on the online ID only](https://github.com/ppy/osu/blob/5c066c40b1c5bad0dd106fde65739bd9209b99fa/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs#L441-L442). `QueryBeatmap()` returns the first item available, which turns out to be the locally available one, completing the failure.

---

For the immediate fix, the invariant I want to enforce here is that if an online beatmap is locally modified and saved, it ceases to be an online beatmap, and as such it gets its online ID reset[^2]. This fixes the most flagrant issue of being able to play a locally-modified beatmap in playlists, because with the online ID reset, there aren't two beatmaps with the same online ID at the end of the scenario anymore.

That said, as I said at the start, I consider this failure to be a general failure in component coordination and this PR is not intended to be the end of the topic, inasmuch as a quick fix for a serious issue. The steps I want to take forward on top of this are:

1. Fix the deduplication logic so that it can work again with beatmap sets that do not have `OnlineID` in their `.osu` files
2. Explore the possibility of adding the md5 of beatmaps to `PlaylistItem`s so that `RoomSubScreen` doesn't have to only rely on the online ID anymore
3. Check whether the online metadata lookup is using the relevant API endpoint correctly[^1].

[^1]: When I checked out e58e1151f3c610d8019e1f1e408a1cb55d204c24 (last commit pre-merge of #23189) and attempted to repeat the scenario in the issue thread, I still managed to get into a broken state in playlists wherein I could set a score on my locally modified copy of the beatmap. I haven't looked into this much yet, but this appears to be a separate bug in the online metadata lookup flow, caused by a misunderstanding of how the `GET /beatmaps/lookup` API endpoint works. It appears that if the endpoint is supplied the online ID, the md5 hash *and* the beatmap filename, it will *not* attempt to match all three at once, but [will try them in sequence one by one](https://github.com/ppy/osu-web/blob/0a41b13acf5f47bb0d2b08bab42a9646b7ab5821/app/Http/Controllers/BeatmapsController.php#L174-L188), in the sequence: md5, filename, online ID. Therefore, the endpoint does *not* 404, but instead returns information for the correct beatmap but with a *different* md5 to the one that client sent, and thus the client [wrongly unconditionally applies the online ID again](https://github.com/ppy/osu/blob/5c066c40b1c5bad0dd106fde65739bd9209b99fa/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs#L108-L110). I have not 100% confirmed this experimentally yet with osu-web, but it is what I saw in debug combined with my reading of the raw php source.
[^2]: At least for now. I imagine this will be revisited when the beatmap submission flow is implemented into lazer; a successful map submission will force an online metadata fetch and assign an online ID to the beatmap.