### PR TITLE
Add support for flipping colour of reverse arrow on legacy default skin when combo colour is too bright

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
@@ -3,11 +3,13 @@
 
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 {
@@ -18,6 +20,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private Drawable proxy = null!;
 
+        private Bindable<Color4> accentColour = null!;
+
+        private bool textureIsDefaultSkin;
+
+        private Drawable arrow = null!;
+
         [BackgroundDependencyLoader]
         private void load(ISkinSource skinSource)
         {
@@ -26,7 +34,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             string lookupName = new OsuSkinComponentLookup(OsuSkinComponents.ReverseArrow).LookupName;
 
             var skin = skinSource.FindProvider(s => s.GetTexture(lookupName) != null);
-            InternalChild = skin?.GetAnimation(lookupName, true, true) ?? Empty();
+
+            InternalChild = arrow = (skin?.GetAnimation(lookupName, true, true) ?? Empty());
+            textureIsDefaultSkin = skin is ISkinTransformer transformer && transformer.Skin is DefaultLegacySkin;
         }
 
         protected override void LoadComplete()
@@ -39,6 +49,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             {
                 drawableHitObject.HitObjectApplied += onHitObjectApplied;
                 onHitObjectApplied(drawableHitObject);
+
+                accentColour = drawableHitObject.AccentColour.GetBoundCopy();
+                accentColour.BindValueChanged(c =>
+                {
+                    arrow.Colour = textureIsDefaultSkin && c.NewValue.R + c.NewValue.G + c.NewValue.B > (600 / 255f) ? Color4.Black : Color4.White;
+                }, true);
             }
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/discussions/23138.

Tested with https://osu.ppy.sh/beatmapsets/4392#osu/24021 (can adjust combo colour normalisation to see it applied in real-time).