### PR TITLE
Fix overlay scroll back button not absorbing hover from behind

### DIFF
--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -185,6 +185,8 @@ namespace osu.Game.Overlays
                 content.ScaleTo(1, 1000, Easing.OutElastic);
                 base.OnMouseUp(e);
             }
+
+            protected override bool OnHover(HoverEvent e) => true;
         }
     }
 }

--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -186,7 +186,11 @@ namespace osu.Game.Overlays
                 base.OnMouseUp(e);
             }
 
-            protected override bool OnHover(HoverEvent e) => true;
+            protected override bool OnHover(HoverEvent e)
+            {
+                base.OnHover(e);
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
Kind of a rare case as you need ui scaling to let the content overlap with this button.

| Before | After | Web |
| --- | --- | --- |
| ![osu!_uZYF8HdbRL](https://user-images.githubusercontent.com/35318437/235839171-711561fa-1230-411e-9e40-67e299ef663e.gif) | ![osu!_RANYcpaVFE](https://user-images.githubusercontent.com/35318437/235841567-9124aba9-b1dc-44f0-8c70-35377673a9f3.gif) | ![firefox_kkajKbCeXV](https://user-images.githubusercontent.com/35318437/235839424-402cbb34-c8c9-4db8-9139-07bba269380e.gif) |