### PR TITLE
Fix runaway memory usage at song select when opening many beatmaps many times

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -250,9 +250,6 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Dispose(isDisposing);
             starDifficultyCancellationSource?.Cancel();
-
-            // This is important to clean up event subscriptions.
-            Item = null;
         }
     }
 }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -250,6 +250,9 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Dispose(isDisposing);
             starDifficultyCancellationSource?.Cancel();
+
+            // This is important to clean up event subscriptions.
+            Item = null;
         }
     }
 }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Select.Carousel
 
                 item = value;
 
-                if (IsLoaded)
+                if (IsLoaded && !IsDisposed)
                     UpdateItem();
             }
         }
@@ -164,6 +164,14 @@ namespace osu.Game.Screens.Select.Carousel
 
             Item.State.Value = CarouselItemState.Selected;
             return true;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            // This is important to clean up event subscriptions.
+            Item = null;
         }
     }
 }


### PR DESCRIPTION
The handling of cleanup is performed only the `Item_Set` method. This was already correctly called for `DrawableCarouselBeatmapSet`, but not for the class in question here.

This would cause runaway memory usage at song select when opening many beatmaps to show their difficulties. For simplicity, we don't yet pool these (and generate the drawables each time a set is opened) which isn't great but likely will be improved upon when we update the visual / filtering of the carousel. But this simplicity caused the memory usage to blow out until exiting back to the main menu when cleanup would finally occur.

![Parallels Desktop 2023-05-03 at 09 44 19](https://user-images.githubusercontent.com/191335/235883454-f26f3756-a4a0-455f-9cb5-0266124c80f5.png)

Closes #23121.