### PR TITLE
Improvements to saving states of `SkinEditor`s `EditorChangeHandler`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -221,12 +221,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
             revertAndCheckUnchanged();
 
-            AddStep("Move components", () =>
-            {
-                changeHandler.BeginChange();
-                testComponents.ForEach(c => ((Drawable)c).Position += Vector2.One);
-                changeHandler.EndChange();
-            });
+            AddStep("Move components", () => testComponents.ForEach(c => ((Drawable)c).Position += Vector2.One));
             revertAndCheckUnchanged();
 
             AddStep("Select components", () => skinEditor.SelectedComponents.AddRange(testComponents));
@@ -238,7 +233,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             void revertAndCheckUnchanged()
             {
-                AddStep("Revert changes", () => changeHandler.RestoreState(int.MinValue));
+                AddStep("Revert changes", () =>
+                {
+                    changeHandler.SaveState();
+                    changeHandler.RestoreState(int.MinValue);
+                });
                 AddAssert("Current state is same as default", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
             }
         }

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -22,6 +23,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         private readonly List<BindableList<ISerialisableDrawable>> targetComponents = new List<BindableList<ISerialisableDrawable>>();
 
+        public event Action? OnComponentsChanged;
+
         [Resolved]
         private SkinEditor editor { get; set; } = null!;
 
@@ -39,7 +42,7 @@ namespace osu.Game.Overlays.SkinEditor
             SelectedItems.BindTo(editor.SelectedComponents);
 
             var bindableList = new BindableList<ISerialisableDrawable> { BindTarget = targetContainer.Components };
-            bindableList.BindCollectionChanged(componentsChanged, true);
+            bindableList.BindCollectionChanged(componentsChanged, bindableList.Count != 0);
 
             targetComponents.Add(bindableList);
         }
@@ -74,6 +77,8 @@ namespace osu.Game.Overlays.SkinEditor
                         AddBlueprintFor(item);
                     break;
             }
+
+            OnComponentsChanged?.Invoke();
         });
 
         protected override void AddBlueprintFor(ISerialisableDrawable item)
@@ -138,6 +143,8 @@ namespace osu.Game.Overlays.SkinEditor
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
+            OnComponentsChanged = null;
 
             foreach (var list in targetComponents)
                 list.UnbindAll();

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -416,6 +416,8 @@ namespace osu.Game.Overlays.SkinEditor
 
             skins.EnsureMutableSkin();
             hasBegunMutating = true;
+
+            waitForComponentsLoad(() => changeHandler?.ClearHistory(), 0);
         }
 
         /// <summary>

--- a/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorChangeHandler.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Screens.Edit;
@@ -19,9 +18,6 @@ namespace osu.Game.Overlays.SkinEditor
     {
         private readonly ISerialisableDrawableContainer? firstTarget;
 
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        private readonly BindableList<ISerialisableDrawable>? components;
-
         public SkinEditorChangeHandler(Drawable targetScreen)
         {
             // To keep things simple, we are currently only handling the current target screen for undo / redo.
@@ -29,12 +25,6 @@ namespace osu.Game.Overlays.SkinEditor
             // We'll also need to consider cases where multiple targets are on screen at the same time.
 
             firstTarget = targetScreen.ChildrenOfType<ISerialisableDrawableContainer>().FirstOrDefault();
-
-            if (firstTarget == null)
-                return;
-
-            components = new BindableList<ISerialisableDrawable> { BindTarget = firstTarget.Components };
-            components.BindCollectionChanged((_, _) => SaveState());
         }
 
         protected override void WriteCurrentStateToStream(MemoryStream stream)

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -111,6 +111,14 @@ namespace osu.Game.Screens.Edit
             updateBindables();
         }
 
+        public void ClearHistory()
+        {
+            savedStates.Clear();
+            currentState = -1;
+
+            updateBindables();
+        }
+
         /// <summary>
         /// Write a serialised copy of the currently tracked state to the provided stream.
         /// This will be stored as a state which can be restored in the future.


### PR DESCRIPTION
Issues tracking this: https://github.com/ppy/osu/issues/22562

Affected behaviors:
- Fixes issue with skin editor not saving the initial state on opening
- Fixes reverting skin to default potentially adding unwanted change states
- Clears change history when changing skin while skin editor is open