### PR TITLE
Fix break overlay arrows' glow getting cut off at lower resolutions

### DIFF
--- a/osu.Game/Screens/Play/Break/BlurredIcon.cs
+++ b/osu.Game/Screens/Play/Break/BlurredIcon.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play.Break
             set
             {
                 icon.Size = value;
-                base.Size = value + BlurSigma * 2.5f;
+                base.Size = value + BlurSigma * 5;
                 ForceRedraw();
             }
             get => base.Size;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23210.

Ballparked the fix to work down to the lowest resolution we support. The previous number (`2.5f`) was also likely ballparked so the fix seems in line with expectations.

I don't want to put too much thought into this because the design of this screen is likely going to change in the mean time anyway.