### PR TITLE
Show beatmap slider velocity statistics when adjusting velocity

### DIFF
--- a/osu.Game/Rulesets/Edit/EditorInspector.cs
+++ b/osu.Game/Rulesets/Edit/EditorInspector.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Rulesets.Edit
+{
+    internal partial class EditorInspector : CompositeDrawable
+    {
+        protected OsuTextFlowContainer InspectorText = null!;
+
+        [Resolved]
+        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+
+            InternalChild = InspectorText = new OsuTextFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+            };
+        }
+
+        protected void AddHeader(string header) => InspectorText.AddParagraph($"{header}: ", s =>
+        {
+            s.Padding = new MarginPadding { Top = 2 };
+            s.Font = s.Font.With(size: 12);
+            s.Colour = colourProvider.Content2;
+        });
+
+        protected void AddValue(string value) => InspectorText.AddParagraph(value, s =>
+        {
+            s.Font = s.Font.With(weight: FontWeight.SemiBold);
+            s.Colour = colourProvider.Content1;
+        });
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectInspector.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectInspector.cs
@@ -2,43 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Edit
 {
-    internal partial class HitObjectInspector : CompositeDrawable
+    internal partial class HitObjectInspector : EditorInspector
     {
-        private OsuTextFlowContainer inspectorText = null!;
-
-        [Resolved]
-        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
-
-        [Resolved]
-        private OverlayColourProvider colourProvider { get; set; } = null!;
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            AutoSizeAxes = Axes.Y;
-            RelativeSizeAxes = Axes.X;
-
-            InternalChild = inspectorText = new OsuTextFlowContainer
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-            };
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -53,69 +25,69 @@ namespace osu.Game.Rulesets.Edit
 
         private void updateInspectorText()
         {
-            inspectorText.Clear();
+            InspectorText.Clear();
             rollingTextUpdate?.Cancel();
             rollingTextUpdate = null;
 
             switch (EditorBeatmap.SelectedHitObjects.Count)
             {
                 case 0:
-                    addValue("No selection");
+                    AddValue("No selection");
                     break;
 
                 case 1:
                     var selected = EditorBeatmap.SelectedHitObjects.Single();
 
-                    addHeader("Type");
-                    addValue($"{selected.GetType().ReadableName()}");
+                    AddHeader("Type");
+                    AddValue($"{selected.GetType().ReadableName()}");
 
-                    addHeader("Time");
-                    addValue($"{selected.StartTime:#,0.##}ms");
+                    AddHeader("Time");
+                    AddValue($"{selected.StartTime:#,0.##}ms");
 
                     switch (selected)
                     {
                         case IHasPosition pos:
-                            addHeader("Position");
-                            addValue($"x:{pos.X:#,0.##} y:{pos.Y:#,0.##}");
+                            AddHeader("Position");
+                            AddValue($"x:{pos.X:#,0.##} y:{pos.Y:#,0.##}");
                             break;
 
                         case IHasXPosition x:
-                            addHeader("Position");
+                            AddHeader("Position");
 
-                            addValue($"x:{x.X:#,0.##} ");
+                            AddValue($"x:{x.X:#,0.##} ");
                             break;
 
                         case IHasYPosition y:
-                            addHeader("Position");
+                            AddHeader("Position");
 
-                            addValue($"y:{y.Y:#,0.##}");
+                            AddValue($"y:{y.Y:#,0.##}");
                             break;
                     }
 
                     if (selected is IHasDistance distance)
                     {
-                        addHeader("Distance");
-                        addValue($"{distance.Distance:#,0.##}px");
+                        AddHeader("Distance");
+                        AddValue($"{distance.Distance:#,0.##}px");
                     }
 
                     if (selected is IHasSliderVelocity sliderVelocity)
                     {
-                        addHeader("Slider Velocity");
-                        addValue($"{sliderVelocity.SliderVelocity:#,0.00}x");
+                        AddHeader("Slider Velocity");
+                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x");
                     }
 
                     if (selected is IHasRepeats repeats)
                     {
-                        addHeader("Repeats");
-                        addValue($"{repeats.RepeatCount:#,0.##}");
+                        AddHeader("Repeats");
+                        AddValue($"{repeats.RepeatCount:#,0.##}");
                     }
 
                     if (selected is IHasDuration duration)
                     {
-                        addHeader("End Time");
-                        addValue($"{duration.EndTime:#,0.##}ms");
-                        addHeader("Duration");
-                        addValue($"{duration.Duration:#,0.##}ms");
+                        AddHeader("End Time");
+                        AddValue($"{duration.EndTime:#,0.##}ms");
+                        AddHeader("Duration");
+                        AddValue($"{duration.Duration:#,0.##}ms");
                     }
 
                     // I'd hope there's a better way to do this, but I don't want to bind to each and every property above to watch for changes.
@@ -124,29 +96,16 @@ namespace osu.Game.Rulesets.Edit
                     break;
 
                 default:
-                    addHeader("Selected Objects");
-                    addValue($"{EditorBeatmap.SelectedHitObjects.Count:#,0.##}");
+                    AddHeader("Selected Objects");
+                    AddValue($"{EditorBeatmap.SelectedHitObjects.Count:#,0.##}");
 
-                    addHeader("Start Time");
-                    addValue($"{EditorBeatmap.SelectedHitObjects.Min(o => o.StartTime):#,0.##}ms");
+                    AddHeader("Start Time");
+                    AddValue($"{EditorBeatmap.SelectedHitObjects.Min(o => o.StartTime):#,0.##}ms");
 
-                    addHeader("End Time");
-                    addValue($"{EditorBeatmap.SelectedHitObjects.Max(o => o.GetEndTime()):#,0.##}ms");
+                    AddHeader("End Time");
+                    AddValue($"{EditorBeatmap.SelectedHitObjects.Max(o => o.GetEndTime()):#,0.##}ms");
                     break;
             }
-
-            void addHeader(string header) => inspectorText.AddParagraph($"{header}: ", s =>
-            {
-                s.Padding = new MarginPadding { Top = 2 };
-                s.Font = s.Font.With(size: 12);
-                s.Colour = colourProvider.Content2;
-            });
-
-            void addValue(string value) => inspectorText.AddParagraph(value, s =>
-            {
-                s.Font = s.Font.With(weight: FontWeight.SemiBold);
-                s.Colour = colourProvider.Content1;
-            });
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -7,9 +7,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
-using osu.Game.Screens.Edit;
 
-namespace osu.Game.Rulesets.Edit
+namespace osu.Game.Screens.Edit.Compose.Components
 {
     internal partial class EditorInspector : CompositeDrawable
     {

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -7,7 +7,7 @@ using osu.Framework.Threading;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 
-namespace osu.Game.Rulesets.Edit
+namespace osu.Game.Screens.Edit.Compose.Components
 {
     internal partial class HitObjectInspector : EditorInspector
     {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -174,5 +174,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             AddHeader("Velocity range");
             AddValue($"{sliderVelocities.First():#,0.00}x - {sliderVelocities.Last():#,0.00}x");
         }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            EditorBeatmap.TransactionBegan -= updateInspectorText;
+            EditorBeatmap.TransactionEnded -= updateInspectorText;
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             double? modeSliderVelocity = sliderVelocities.GroupBy(v => v).MaxBy(v => v.Count())?.Key;
             double? medianSliderVelocity = sliderVelocities[sliderVelocities.Length / 2];
 
-            AddHeader("Beatmap average velocity");
+            AddHeader("Average velocity");
             AddValue($"{medianSliderVelocity:#,0.00}x");
 
             AddHeader("Most used velocity");


### PR DESCRIPTION
In response to discussion at https://github.com/ppy/osu/discussions/23391.

Gives a mapper / reviewer a better sense of the larger picture of the beatmap when viewing slider velocity.

I've implemented this in a way which can be transplanted elsewhere. For instance, I could see this potentially displaying on the right hand side of the editor when no selection is made. But let's put it here for now.

![osu! 2023-05-05 at 06 56 16](https://user-images.githubusercontent.com/191335/236394489-e49d82f4-6edf-47f0-ab7c-937366f53123.png)

- [x] Depends on https://github.com/ppy/osu/pull/23404 to ease merging.