### PR TITLE
Add workflow for automated osu-web mod definition updates

### DIFF
--- a/.github/workflows/update-web-mod-definitions.yml
+++ b/.github/workflows/update-web-mod-definitions.yml
@@ -1,0 +1,53 @@
+name: Update osu-web mod definitions
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  update-mod-definitions:
+    name: Update osu-web mod definitions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install .NET 6.0.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: "6.0.x"
+
+    - name: Checkout ppy/osu
+      uses: actions/checkout@v3
+      with:
+        path: osu
+
+    - name: Checkout ppy/osu-tools
+      uses: actions/checkout@v3
+      with:
+        repository: ppy/osu-tools
+        path: osu-tools
+
+    - name: Checkout ppy/osu-web
+      uses: actions/checkout@v3
+      with:
+        repository: ppy/osu-web
+        path: osu-web
+
+    - name: Setup local game checkout for tools
+      run: ./UseLocalOsu.sh
+      working-directory: ./osu-tools
+
+    - name: Regenerate mod definitions
+      run: dotnet run --project PerformanceCalculator -- mods > ../osu-web/database/mods.json
+      working-directory: ./osu-tools
+
+    - name: Create pull request with changes
+      uses: peter-evans/create-pull-request@v5
+      with:
+        title: Update mod definitions
+        body: "This PR has been auto-generated to update the mod definitions to match ppy/osu@${{ github.ref_name }}."
+        branch: update-mod-definitions
+        commit-message: Update mod definitions
+        path: osu-web
+        token: ${{ secrets.OSU_WEB_PULL_REQUEST_PAT }}


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-web/issues/9942
- Continued from https://github.com/ppy/osu-web/pull/10156

This PR adds a new GitHub Actions workflow whose goal is to automatically open a PR with mod definition updates on `osu-web` whenever a new tag is pushed. Contrary to the first version linked above, this version of the PR requires no coordination across repositories and is much simplified due to that.

## Setup

For this workflow to work, a new `OSU_WEB_PULL_REQUEST_PAT` (naming negotiable) secret must be added to the `osu` repository. This secret is a GitHub personal access token required to be able to push branches to and open pulls in `osu-web`.

From my testing, the minimal solution permissions-wise seems to be a [fine-grained personal access token](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/). It requires to be scoped to the `osu-web` target repository:

![1683366429](https://user-images.githubusercontent.com/20418176/236620128-30a9e95c-8dae-4d03-8310-6dedb958d76d.png)

and requires the following permissions to work:

![1683366409](https://user-images.githubusercontent.com/20418176/236620134-2ce1091a-1607-4840-b406-77338584e996.png)

These permissions are required by the `peter-evans/create-pull-request` action used in this workflow ([see docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens)). The metadata permission is automatically requested when requesting either of the other remaining two permissions.

The "contents" permissions are the most contentious, but it doesn't look like they can be dropped. If this is considered unacceptable then I'm willing to consider other solutions, although if we want full automation, there aren't many available, and they're generally not pretty. One ugly solution would be to use a github sockpuppet account which uses [a fork isolated from the upstream repo](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork), which fixes the permissions problem, but creates a "how to trigger this automatically on tag" problem again. Another would be to go back to the semi-automated `osu-web` version (it would require someone to go and trigger the workflow, but the rest would happen automatically).

## Testing

This was tested to work by [pushing a tag to my fork](https://github.com/bdach/osu/releases/tag/automated-mod-updates-test). The test run of the workflow can be seen [here](https://github.com/bdach/osu/actions/runs/4901191404), and the resulting opened PR is [here](https://github.com/bdach/osu-web/pull/3).