### PR TITLE
Make NodeSamples bindable

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Newtonsoft.Json;
@@ -161,7 +160,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public double Distance => Path.Distance;
 
-        public IList<IList<HitSampleInfo>> NodeSamples { get; set; } = new List<IList<HitSampleInfo>>();
+        public BindableList<BindableList<HitSampleInfo>> NodeSamples { get; set; } = new BindableList<BindableList<HitSampleInfo>>();
 
         public double? LegacyLastTickOffset { get; set; }
     }

--- a/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaBeatmapSampleConversionTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Mania.Objects;
@@ -40,7 +41,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         private IList<string> getSampleNames(IList<HitSampleInfo> hitSampleInfo)
             => hitSampleInfo.Select(sample => sample.LookupNames.First()).ToList();
 
-        private IList<IList<string>> getNodeSampleNames(IList<IList<HitSampleInfo>> hitSampleInfo)
+        private IList<IList<string>> getNodeSampleNames(IList<BindableList<HitSampleInfo>> hitSampleInfo)
             => hitSampleInfo?.Select(getSampleNames)
                             .ToList();
 

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -8,6 +8,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
@@ -274,11 +275,11 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             /// <remarks>
             /// osu!mania-specific beatmaps in stable only play samples at the start of the hold note.
             /// </remarks>
-            private List<IList<HitSampleInfo>> defaultNodeSamples
-                => new List<IList<HitSampleInfo>>
+            private BindableList<BindableList<HitSampleInfo>> defaultNodeSamples
+                => new BindableList<BindableList<HitSampleInfo>>
                 {
-                    HitObject.Samples,
-                    new List<HitSampleInfo>()
+                    HitObject.SamplesBindable,
+                    new BindableList<HitSampleInfo>()
                 };
         }
     }

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -488,7 +489,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
         /// Retrieves the list of node samples that occur at time greater than or equal to <paramref name="time"/>.
         /// </summary>
         /// <param name="time">The time to retrieve node samples at.</param>
-        private IList<IList<HitSampleInfo>> nodeSamplesAt(int time)
+        private IList<BindableList<HitSampleInfo>> nodeSamplesAt(int time)
         {
             if (!(HitObject is IHasPathWithRepeats curveData))
                 return null;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Audio;
@@ -39,7 +40,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             {
                 var newColumnObjects = new List<ManiaHitObject>();
 
-                var locations = column.OfType<Note>().Select(n => (startTime: n.StartTime, samples: n.Samples))
+                var locations = column.OfType<Note>().Select(n => (startTime: n.StartTime, samples: n.SamplesBindable))
                                       .Concat(column.OfType<HoldNote>().SelectMany(h => new[]
                                       {
                                           (startTime: h.StartTime, samples: h.GetNodeSamples(0)),
@@ -63,7 +64,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                         Column = column.Key,
                         StartTime = locations[i].startTime,
                         Duration = duration,
-                        NodeSamples = new List<IList<HitSampleInfo>> { locations[i].samples, Array.Empty<HitSampleInfo>() }
+                        NodeSamples = new List<BindableList<HitSampleInfo>> { locations[i].samples, new BindableList<HitSampleInfo>() }
                     });
                 }
 

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Threading;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -69,7 +70,7 @@ namespace osu.Game.Rulesets.Mania.Objects
             }
         }
 
-        public IList<IList<HitSampleInfo>> NodeSamples { get; set; }
+        public IList<BindableList<HitSampleInfo>> NodeSamples { get; set; }
 
         /// <summary>
         /// The head note of the hold.
@@ -138,7 +139,7 @@ namespace osu.Game.Rulesets.Mania.Objects
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
-        public IList<HitSampleInfo> GetNodeSamples(int nodeIndex) =>
-            nodeIndex < NodeSamples?.Count ? NodeSamples[nodeIndex] : Samples;
+        public BindableList<HitSampleInfo> GetNodeSamples(int nodeIndex) =>
+            nodeIndex < NodeSamples?.Count ? NodeSamples[nodeIndex] : SamplesBindable;
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -165,7 +164,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 slider = (DrawableSlider)createSlider(repeats: 1);
 
                 for (int i = 0; i < 2; i++)
-                    slider.HitObject.NodeSamples.Add(new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_FINISH) });
+                    slider.HitObject.NodeSamples.Add(new BindableList<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_FINISH) });
 
                 Add(slider);
             });
@@ -333,9 +332,9 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private Drawable createCatmull(int repeats = 0)
         {
-            var repeatSamples = new List<IList<HitSampleInfo>>();
+            var repeatSamples = new BindableList<BindableList<HitSampleInfo>>();
             for (int i = 0; i < repeats; i++)
-                repeatSamples.Add(new List<HitSampleInfo>());
+                repeatSamples.Add(new BindableList<HitSampleInfo>());
 
             var slider = new Slider
             {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -318,7 +318,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     LegacyLastTickOffset = HitObject.LegacyLastTickOffset,
                     Samples = HitObject.Samples.Select(s => s.With()).ToList(),
                     RepeatCount = HitObject.RepeatCount,
-                    NodeSamples = HitObject.NodeSamples.Select(n => (IList<HitSampleInfo>)n.Select(s => s.With()).ToList()).ToList(),
+                    NodeSamples = new BindableList<BindableList<HitSampleInfo>>(HitObject.NodeSamples.Select(n => new BindableList<HitSampleInfo>(n.Select(s => s.With())))),
                     Path = new SliderPath(splitControlPoints.Select(o => new PathControlPoint(o.Position - splitControlPoints[0].Position, o == splitControlPoints[^1] ? null : o.Type)).ToArray())
                 };
 

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             SamplesBindable.CollectionChanged += (_, _) => updateNestedTickSamples();
             Path.Version.ValueChanged += _ => updateNestedPositions();
-            nodeSamples.CollectionChanged += NodeSamplesOnCollectionChanged;
+            nodeSamples.CollectionChanged += nodeSamplesOnCollectionChanged;
         }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
@@ -283,7 +283,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                 tick.Samples = sampleList;
         }
 
-        private void NodeSamplesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void nodeSamplesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             foreach (var repeat in NestedHitObjects.OfType<SliderRepeat>())
             {

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -291,8 +291,8 @@ namespace osu.Game.Rulesets.Osu.Objects
                 bindNew(repeat.SamplesBindable, repeat.RepeatIndex + 1);
             }
 
-            unbindOld(HeadCircle.SamplesBindable, 0);
-            bindNew(HeadCircle.SamplesBindable, 0);
+            unbindOld(HeadCircle?.SamplesBindable, 0);
+            bindNew(HeadCircle?.SamplesBindable, 0);
             unbindOld(TailSamples, repeatCount + 1);
             bindNew(TailSamples, repeatCount + 1);
 

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using osu.Framework.Utils;
 using System.Threading;
 using JetBrains.Annotations;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -98,7 +99,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
         protected override IEnumerable<TaikoHitObject> ConvertHitObject(HitObject obj, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             // Old osu! used hit sounding to determine various hit type information
-            IList<HitSampleInfo> samples = obj.Samples;
+            BindableList<HitSampleInfo> samples = obj.SamplesBindable;
 
             switch (obj)
             {
@@ -106,7 +107,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 {
                     if (shouldConvertSliderToHits(obj, beatmap, distanceData, out int taikoDuration, out double tickSpacing))
                     {
-                        IList<IList<HitSampleInfo>> allSamples = obj is IHasPathWithRepeats curveData ? curveData.NodeSamples : new List<IList<HitSampleInfo>>(new[] { samples });
+                        IList<BindableList<HitSampleInfo>> allSamples = obj is IHasPathWithRepeats curveData ? curveData.NodeSamples : new List<BindableList<HitSampleInfo>>(new[] { samples });
 
                         int i = 0;
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -9,9 +9,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Logging;
+using osu.Game.Audio;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Beatmaps.Timing;
@@ -130,7 +132,7 @@ namespace osu.Game.Beatmaps.Formats
                     double time = hitObject.StartTime + i * hasRepeats.Duration / hasRepeats.SpanCount() + control_point_leniency;
                     var nodeSamplePoint = (beatmap.ControlPointInfo as LegacyControlPointInfo)?.SamplePointAt(time) ?? SampleControlPoint.DEFAULT;
 
-                    hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Select(o => nodeSamplePoint.ApplyTo(o)).ToList();
+                    hasRepeats.NodeSamples[i] = new BindableList<HitSampleInfo>(hasRepeats.NodeSamples[i].Select(o => nodeSamplePoint.ApplyTo(o)));
                 }
             }
         }

--- a/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertHitObjectParser.cs
@@ -5,7 +5,7 @@
 
 using osuTK;
 using osu.Game.Audio;
-using System.Collections.Generic;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Catch
 {
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Catch
         }
 
         protected override HitObject CreateSlider(Vector2 position, bool newCombo, int comboOffset, PathControlPoint[] controlPoints, double? length, int repeatCount,
-                                                  IList<IList<HitSampleInfo>> nodeSamples)
+                                                  BindableList<BindableList<HitSampleInfo>> nodeSamples)
         {
             newCombo |= forceNewCombo;
             comboOffset += extraComboOffset;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps.Formats;
 using osu.Game.Audio;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.Legacy;
@@ -138,7 +139,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 }
 
                 // Generate the final per-node samples
-                var nodeSamples = new List<IList<HitSampleInfo>>(nodes);
+                var nodeSamples = new BindableList<BindableList<HitSampleInfo>>();
                 for (int i = 0; i < nodes; i++)
                     nodeSamples.Add(convertSoundType(nodeSoundTypes[i], nodeBankInfos[i]));
 
@@ -418,7 +419,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// <param name="nodeSamples">The samples to be played when the slider nodes are hit. This includes the head and tail of the slider.</param>
         /// <returns>The hit object.</returns>
         protected abstract HitObject CreateSlider(Vector2 position, bool newCombo, int comboOffset, PathControlPoint[] controlPoints, double? length, int repeatCount,
-                                                  IList<IList<HitSampleInfo>> nodeSamples);
+                                                  BindableList<BindableList<HitSampleInfo>> nodeSamples);
 
         /// <summary>
         /// Creates a legacy Spinner-type hit object.
@@ -439,9 +440,9 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// <param name="duration">The hold duration.</param>
         protected abstract HitObject CreateHold(Vector2 position, bool newCombo, int comboOffset, double duration);
 
-        private List<HitSampleInfo> convertSoundType(LegacyHitSoundType type, SampleBankInfo bankInfo)
+        private BindableList<HitSampleInfo> convertSoundType(LegacyHitSoundType type, SampleBankInfo bankInfo)
         {
-            var soundTypes = new List<HitSampleInfo>();
+            var soundTypes = new BindableList<HitSampleInfo>();
 
             if (string.IsNullOrEmpty(bankInfo.Filename))
             {

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using osu.Game.Rulesets.Objects.Types;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 using osu.Game.Audio;
@@ -27,7 +26,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
         public double Distance => Path.Distance;
 
-        public IList<IList<HitSampleInfo>> NodeSamples { get; set; }
+        public BindableList<BindableList<HitSampleInfo>> NodeSamples { get; set; }
         public int RepeatCount { get; set; }
 
         [JsonIgnore]

--- a/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Mania/ConvertHitObjectParser.cs
@@ -5,7 +5,7 @@
 
 using osuTK;
 using osu.Game.Audio;
-using System.Collections.Generic;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Mania
 {
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Mania
         }
 
         protected override HitObject CreateSlider(Vector2 position, bool newCombo, int comboOffset, PathControlPoint[] controlPoints, double? length, int repeatCount,
-                                                  IList<IList<HitSampleInfo>> nodeSamples)
+                                                  BindableList<BindableList<HitSampleInfo>> nodeSamples)
         {
             return new ConvertSlider
             {

--- a/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Osu/ConvertHitObjectParser.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using osuTK;
-using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Osu
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Osu
         }
 
         protected override HitObject CreateSlider(Vector2 position, bool newCombo, int comboOffset, PathControlPoint[] controlPoints, double? length, int repeatCount,
-                                                  IList<IList<HitSampleInfo>> nodeSamples)
+                                                  BindableList<BindableList<HitSampleInfo>> nodeSamples)
         {
             newCombo |= forceNewCombo;
             comboOffset += extraComboOffset;

--- a/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/Taiko/ConvertHitObjectParser.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using osuTK;
-using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Audio;
 
 namespace osu.Game.Rulesets.Objects.Legacy.Taiko
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Objects.Legacy.Taiko
         }
 
         protected override HitObject CreateSlider(Vector2 position, bool newCombo, int comboOffset, PathControlPoint[] controlPoints, double? length, int repeatCount,
-                                                  IList<IList<HitSampleInfo>> nodeSamples)
+                                                  BindableList<BindableList<HitSampleInfo>> nodeSamples)
         {
             return new ConvertSlider
             {

--- a/osu.Game/Rulesets/Objects/Types/IHasRepeats.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasRepeats.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using osu.Game.Audio;
-using System.Collections.Generic;
+using osu.Framework.Bindables;
 
 namespace osu.Game.Rulesets.Objects.Types
 {
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Objects.Types
         /// n-1: The last repeat.<br />
         /// n: The last node.
         /// </summary>
-        IList<IList<HitSampleInfo>> NodeSamples { get; }
+        BindableList<BindableList<HitSampleInfo>> NodeSamples { get; }
     }
 
     public static class HasRepeatsExtensions
@@ -44,8 +44,8 @@ namespace osu.Game.Rulesets.Objects.Types
         /// <param name="obj">The <see cref="HitObject"/>.</param>
         /// <param name="nodeIndex">The node to attempt to retrieve the samples at.</param>
         /// <returns>The samples at the given node index, or <paramref name="obj"/>'s default samples if the given node doesn't exist.</returns>
-        public static IList<HitSampleInfo> GetNodeSamples<T>(this T obj, int nodeIndex)
+        public static BindableList<HitSampleInfo> GetNodeSamples<T>(this T obj, int nodeIndex)
             where T : HitObject, IHasRepeats
-            => nodeIndex < obj.NodeSamples.Count ? obj.NodeSamples[nodeIndex] : obj.Samples;
+            => nodeIndex < obj.NodeSamples.Count ? obj.NodeSamples[nodeIndex] : obj.SamplesBindable;
     }
 }


### PR DESCRIPTION
I changed the type of `IHasRepeats.NodeSamples` to `BindableList<BindableList<HitSampleInfo>>`.
The interface still works the same but now it's possible to listen to changes to the node samples. This will help us create future editor features for editing node samples.

Also changes done to the `Slider.NodeSamples` now get automatically propagated to the nested hit objects.