### PR TITLE
Fix rapid back button test failure

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -700,7 +700,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("press escape twice rapidly", () =>
             {
                 InputManager.Key(Key.Escape);
-                InputManager.Key(Key.Escape);
+                Schedule(InputManager.Key, Key.Escape);
             });
 
             pushEscape();


### PR DESCRIPTION
Intended to fix https://github.com/ppy/osu/actions/runs/4903177083/jobs/8755467582#step:5:26

Test fails 100% on master when ran in test browser. Failure bisects to https://github.com/ppy/osu/pull/19114/commits/c59784c49f31265d96f53caf04cdfd5794b776fc.

I'll admit this fix is sort of the theoretical kind. I'd really be also okay with yeeting the test to kingdom come personally but I don't like doing that before at least giving it an honest go to fix.

I've also gone and checked that applying the schedule at the point of https://github.com/ppy/osu/commit/bc839be4d85653fc0872c7e9d923129072eeedff (where the test was added) doesn't make the test pass, which means that in theory the test is still testing what it was supposed to be testing.