### PR TITLE
Rename beatmap-level velocity/tick rate to remove "slider" terminology

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         protected override IBeatmap GetPlayableBeatmap()
         {
             var playable = base.GetPlayableBeatmap();
-            playable.Difficulty.SliderTickRate = 5;
-            playable.Difficulty.BaseSliderVelocity = velocity_factor * 10;
+            playable.Difficulty.TickRate = 5;
+            playable.Difficulty.BaseVelocity = velocity_factor * 10;
             return playable;
         }
 

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         {
             var playable = base.GetPlayableBeatmap();
             playable.Difficulty.SliderTickRate = 5;
-            playable.Difficulty.SliderMultiplier = velocity_factor * 10;
+            playable.Difficulty.BaseSliderVelocity = velocity_factor * 10;
             return playable;
         }
 

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
                 X = x,
                 Path = sliderPath,
             };
-            EditorBeatmap.Difficulty.BaseSliderVelocity = velocity;
+            EditorBeatmap.Difficulty.BaseVelocity = velocity;
             EditorBeatmap.Add(hitObject);
             EditorBeatmap.Update(hitObject);
             Assert.That(hitObject.Velocity, Is.EqualTo(velocity));

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
                 X = x,
                 Path = sliderPath,
             };
-            EditorBeatmap.Difficulty.SliderMultiplier = velocity;
+            EditorBeatmap.Difficulty.BaseSliderVelocity = velocity;
             EditorBeatmap.Add(hitObject);
             EditorBeatmap.Update(hitObject);
             Assert.That(hitObject.Velocity, Is.EqualTo(velocity));

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             {
                 BeatmapInfo = new BeatmapInfo
                 {
-                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseSliderVelocity = 3 },
+                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseVelocity = 3 },
                     Ruleset = ruleset
                 }
             };

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneAutoJuiceStream.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             {
                 BeatmapInfo = new BeatmapInfo
                 {
-                    Difficulty = new BeatmapDifficulty { CircleSize = 6, SliderMultiplier = 3 },
+                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseSliderVelocity = 3 },
                     Ruleset = ruleset
                 }
             };

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             BeatmapInfo = new BeatmapInfo
             {
-                Difficulty = new BeatmapDifficulty { CircleSize = 5, BaseSliderVelocity = 2 },
+                Difficulty = new BeatmapDifficulty { CircleSize = 5, BaseVelocity = 2 },
                 Ruleset = ruleset
             },
             HitObjects = new List<HitObject>

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneJuiceStream.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             BeatmapInfo = new BeatmapInfo
             {
-                Difficulty = new BeatmapDifficulty { CircleSize = 5, SliderMultiplier = 2 },
+                Difficulty = new BeatmapDifficulty { CircleSize = 5, BaseSliderVelocity = 2 },
                 Ruleset = ruleset
             },
             HitObjects = new List<HitObject>

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -64,8 +64,8 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            velocityFactor = base_scoring_distance * difficulty.BaseSliderVelocity / timingPoint.BeatLength;
-            tickDistanceFactor = base_scoring_distance * difficulty.BaseSliderVelocity / difficulty.SliderTickRate;
+            velocityFactor = base_scoring_distance * difficulty.BaseVelocity / timingPoint.BeatLength;
+            tickDistanceFactor = base_scoring_distance * difficulty.BaseVelocity / difficulty.TickRate;
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -64,8 +64,8 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            velocityFactor = base_scoring_distance * difficulty.SliderMultiplier / timingPoint.BeatLength;
-            tickDistanceFactor = base_scoring_distance * difficulty.SliderMultiplier / difficulty.SliderTickRate;
+            velocityFactor = base_scoring_distance * difficulty.BaseSliderVelocity / timingPoint.BeatLength;
+            tickDistanceFactor = base_scoring_distance * difficulty.BaseSliderVelocity / difficulty.SliderTickRate;
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new ManiaRuleset().RulesetInfo
                 },
             };
@@ -310,7 +310,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new ManiaRuleset().RulesetInfo
                 },
             };
@@ -357,7 +357,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new ManiaRuleset().RulesetInfo
                 },
             };
@@ -420,7 +420,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 {
                     Difficulty = new BeatmapDifficulty
                     {
-                        SliderTickRate = 4,
+                        TickRate = 4,
                         OverallDifficulty = 10,
                     },
                     Ruleset = new ManiaRuleset().RulesetInfo
@@ -460,7 +460,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = tick_rate },
+                    Difficulty = new BeatmapDifficulty { TickRate = tick_rate },
                     Ruleset = new ManiaRuleset().RulesetInfo
                 },
             };
@@ -540,7 +540,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                     },
                     BeatmapInfo =
                     {
-                        Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                        Difficulty = new BeatmapDifficulty { TickRate = 4 },
                         Ruleset = new ManiaRuleset().RulesetInfo
                     },
                 };

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
             StartTime = (int)Math.Round(hitObject.StartTime);
 
             // This matches stable's calculation.
-            EndTime = (int)Math.Floor(StartTime + distanceData.Distance * beatLength * SpanCount * 0.01 / beatmap.Difficulty.BaseSliderVelocity);
+            EndTime = (int)Math.Floor(StartTime + distanceData.Distance * beatLength * SpanCount * 0.01 / beatmap.Difficulty.BaseVelocity);
 
             SegmentDuration = (EndTime - StartTime) / SpanCount;
         }

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
             StartTime = (int)Math.Round(hitObject.StartTime);
 
             // This matches stable's calculation.
-            EndTime = (int)Math.Floor(StartTime + distanceData.Distance * beatLength * SpanCount * 0.01 / beatmap.Difficulty.SliderMultiplier);
+            EndTime = (int)Math.Floor(StartTime + distanceData.Distance * beatLength * SpanCount * 0.01 / beatmap.Difficulty.BaseSliderVelocity);
 
             SegmentDuration = (EndTime - StartTime) / SpanCount;
         }

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Mania.Objects
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
-            tickSpacing = timingPoint.BeatLength / difficulty.SliderTickRate;
+            tickSpacing = timingPoint.BeatLength / difficulty.TickRate;
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Mania.UI
             {
                 // Mania doesn't care about global velocity
                 p.Velocity = 1;
-                p.BaseBeatLength *= Beatmap.Difficulty.BaseSliderVelocity;
+                p.BaseBeatLength *= Beatmap.Difficulty.BaseVelocity;
 
                 // For non-mania beatmap, speed changes should only happen through timing points
                 if (!isForCurrentRuleset)

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Mania.UI
             {
                 // Mania doesn't care about global velocity
                 p.Velocity = 1;
-                p.BaseBeatLength *= Beatmap.Difficulty.SliderMultiplier;
+                p.BaseBeatLength *= Beatmap.Difficulty.BaseSliderVelocity;
 
                 // For non-mania beatmap, speed changes should only happen through timing points
                 if (!isForCurrentRuleset)

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            editorBeatmap.Difficulty.SliderMultiplier = 1;
+            editorBeatmap.Difficulty.BaseSliderVelocity = 1;
             editorBeatmap.ControlPointInfo.Clear();
             editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = beat_length });
             snapProvider.DistanceSpacingMultiplier.Value = 1;

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [SetUp]
         public void Setup() => Schedule(() =>
         {
-            editorBeatmap.Difficulty.BaseSliderVelocity = 1;
+            editorBeatmap.Difficulty.BaseVelocity = 1;
             editorBeatmap.ControlPointInfo.Clear();
             editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = beat_length });
             snapProvider.DistanceSpacingMultiplier.Value = 1;

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddStep("change to these specific circumstances", () =>
             {
-                EditorBeatmap.Difficulty.SliderMultiplier = 1;
+                EditorBeatmap.Difficulty.BaseSliderVelocity = 1;
                 var timingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(slider.StartTime);
                 timingPoint.BeatLength = 352.941176470588;
                 slider.Path.ControlPoints[^1].Position = new Vector2(-110, 16);

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddStep("change to these specific circumstances", () =>
             {
-                EditorBeatmap.Difficulty.BaseSliderVelocity = 1;
+                EditorBeatmap.Difficulty.BaseVelocity = 1;
                 var timingPoint = EditorBeatmap.ControlPointInfo.TimingPointAt(slider.StartTime);
                 timingPoint.BeatLength = 352.941176470588;
                 slider.Path.ControlPoints[^1].Position = new Vector2(-110, 16);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneObjectOrderedHitPolicy.cs
@@ -402,7 +402,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Beatmap.Value = CreateWorkingBeatmap(new Beatmap<OsuHitObject>
                 {
                     HitObjects = hitObjects,
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 3 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 3 },
                     BeatmapInfo =
                     {
                         Ruleset = new OsuRuleset().RulesetInfo

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -363,7 +363,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             slider.ApplyDefaults(cpi, new BeatmapDifficulty
             {
                 CircleSize = circleSize,
-                SliderTickRate = 3
+                TickRate = 3
             });
 
             var drawable = CreateDrawableSlider(slider);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     Difficulty = new BeatmapDifficulty
                     {
                         CircleSize = circleSize,
-                        SliderTickRate = 1
+                        TickRate = 1
                     },
                     Ruleset = new OsuRuleset().RulesetInfo
                 },

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -359,7 +359,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     },
                     BeatmapInfo =
                     {
-                        Difficulty = new BeatmapDifficulty { SliderTickRate = 3 },
+                        Difficulty = new BeatmapDifficulty { TickRate = 3 },
                         Ruleset = new OsuRuleset().RulesetInfo
                     },
                 });

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -366,7 +366,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     HitObjects = hitObjects,
                     BeatmapInfo =
                     {
-                        Difficulty = new BeatmapDifficulty { SliderTickRate = 3 },
+                        Difficulty = new BeatmapDifficulty { TickRate = 3 },
                         Ruleset = new OsuRuleset().RulesetInfo
                     },
                 });

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -167,10 +167,10 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.BaseSliderVelocity * SliderVelocity;
+            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.BaseVelocity * SliderVelocity;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
-            TickDistance = GenerateTicks ? (scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier) : double.PositiveInfinity;
+            TickDistance = GenerateTicks ? (scoringDistance / difficulty.TickRate * TickDistanceMultiplier) : double.PositiveInfinity;
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.BaseSliderVelocity * SliderVelocity;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = GenerateTicks ? (scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier) : double.PositiveInfinity;

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
         [Test]
         public void TestTaikoSliderMultiplier()
         {
-            AddStep("Set slider multiplier", () => EditorBeatmap.Difficulty.SliderMultiplier = 2);
+            AddStep("Set slider multiplier", () => EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
 
             SaveEditor();
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 // therefore, ensure that we have that difficulty type by calling .CopyFrom(), which is a no-op if the type is already correct.
                 var taikoDifficulty = new TaikoBeatmapConverter.TaikoMultiplierAppliedDifficulty();
                 taikoDifficulty.CopyFrom(EditorBeatmap.Difficulty);
-                return Precision.AlmostEquals(taikoDifficulty.SliderMultiplier, 2);
+                return Precision.AlmostEquals(taikoDifficulty.BaseSliderVelocity, 2);
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorSaving.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
         [Test]
         public void TestTaikoSliderMultiplier()
         {
-            AddStep("Set slider multiplier", () => EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
+            AddStep("Set slider multiplier", () => EditorBeatmap.Difficulty.BaseVelocity = 2);
 
             SaveEditor();
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 // therefore, ensure that we have that difficulty type by calling .CopyFrom(), which is a no-op if the type is already correct.
                 var taikoDifficulty = new TaikoBeatmapConverter.TaikoMultiplierAppliedDifficulty();
                 taikoDifficulty.CopyFrom(EditorBeatmap.Difficulty);
-                return Precision.AlmostEquals(taikoDifficulty.BaseSliderVelocity, 2);
+                return Precision.AlmostEquals(taikoDifficulty.BaseVelocity, 2);
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 HitObjects = hitObjects.ToList(),
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },
             };

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },
             };
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },
             };
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 },
                 BeatmapInfo =
                 {
-                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Difficulty = new BeatmapDifficulty { TickRate = 4 },
                     Ruleset = new TaikoRuleset().RulesetInfo
                 },
             };

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             else
                 beatLength = timingPoint.BeatLength;
 
-            double sliderScoringPointDistance = osu_base_scoring_distance * beatmap.Difficulty.SliderMultiplier / beatmap.Difficulty.SliderTickRate;
+            double sliderScoringPointDistance = osu_base_scoring_distance * beatmap.Difficulty.BaseSliderVelocity / beatmap.Difficulty.SliderTickRate;
 
             // The velocity and duration of the taiko hit object - calculated as the velocity of a drum roll.
             double taikoVelocity = sliderScoringPointDistance * beatmap.Difficulty.SliderTickRate;
@@ -239,14 +239,14 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             {
                 base.CopyTo(other);
                 if (!(other is TaikoMultiplierAppliedDifficulty))
-                    other.SliderMultiplier /= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
+                    other.BaseSliderVelocity /= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
             }
 
             public override void CopyFrom(IBeatmapDifficultyInfo other)
             {
                 base.CopyFrom(other);
                 if (!(other is TaikoMultiplierAppliedDifficulty))
-                    SliderMultiplier *= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
+                    BaseSliderVelocity *= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
             }
 
             #endregion

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             StartTime = obj.StartTime,
                             Samples = obj.Samples,
                             Duration = taikoDuration,
-                            TickRate = beatmap.Difficulty.SliderTickRate == 3 ? 3 : 4,
+                            TickRate = beatmap.Difficulty.TickRate == 3 ? 3 : 4,
                             SliderVelocity = obj is IHasSliderVelocity velocityData ? velocityData.SliderVelocity : 1
                         };
                     }
@@ -189,10 +189,10 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             else
                 beatLength = timingPoint.BeatLength;
 
-            double sliderScoringPointDistance = osu_base_scoring_distance * beatmap.Difficulty.BaseSliderVelocity / beatmap.Difficulty.SliderTickRate;
+            double sliderScoringPointDistance = osu_base_scoring_distance * beatmap.Difficulty.BaseVelocity / beatmap.Difficulty.TickRate;
 
             // The velocity and duration of the taiko hit object - calculated as the velocity of a drum roll.
-            double taikoVelocity = sliderScoringPointDistance * beatmap.Difficulty.SliderTickRate;
+            double taikoVelocity = sliderScoringPointDistance * beatmap.Difficulty.TickRate;
             taikoDuration = (int)(distance / taikoVelocity * beatLength);
 
             if (isForCurrentRuleset)
@@ -208,7 +208,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 beatLength = timingPoint.BeatLength;
 
             // If the drum roll is to be split into hit circles, assume the ticks are 1/8 spaced within the duration of one beat
-            tickSpacing = Math.Min(beatLength / beatmap.Difficulty.SliderTickRate, (double)taikoDuration / spans);
+            tickSpacing = Math.Min(beatLength / beatmap.Difficulty.TickRate, (double)taikoDuration / spans);
 
             return tickSpacing > 0
                    && distance / osuVelocity * 1000 < 2 * beatLength;
@@ -239,14 +239,14 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             {
                 base.CopyTo(other);
                 if (!(other is TaikoMultiplierAppliedDifficulty))
-                    other.BaseSliderVelocity /= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
+                    other.BaseVelocity /= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
             }
 
             public override void CopyFrom(IBeatmapDifficultyInfo other)
             {
                 base.CopyFrom(other);
                 if (!(other is TaikoMultiplierAppliedDifficulty))
-                    BaseSliderVelocity *= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
+                    BaseVelocity *= LegacyBeatmapEncoder.LEGACY_TAIKO_VELOCITY_MULTIPLIER;
             }
 
             #endregion

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             base.ApplySettings(difficulty);
 
-            if (ScrollSpeed.Value != null) difficulty.SliderMultiplier *= ScrollSpeed.Value.Value;
+            if (ScrollSpeed.Value != null) difficulty.BaseSliderVelocity *= ScrollSpeed.Value.Value;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             base.ApplySettings(difficulty);
 
-            if (ScrollSpeed.Value != null) difficulty.BaseSliderVelocity *= ScrollSpeed.Value.Value;
+            if (ScrollSpeed.Value != null) difficulty.BaseVelocity *= ScrollSpeed.Value.Value;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
-            difficulty.SliderMultiplier *= slider_multiplier;
+            difficulty.BaseSliderVelocity *= slider_multiplier;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModEasy.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
-            difficulty.BaseSliderVelocity *= slider_multiplier;
+            difficulty.BaseVelocity *= slider_multiplier;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
-            difficulty.BaseSliderVelocity *= slider_multiplier;
+            difficulty.BaseVelocity *= slider_multiplier;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHardRock.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
             base.ApplyToDifficulty(difficulty);
-            difficulty.SliderMultiplier *= slider_multiplier;
+            difficulty.BaseSliderVelocity *= slider_multiplier;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = base_distance * difficulty.BaseSliderVelocity * SliderVelocity;
+            double scoringDistance = base_distance * difficulty.BaseVelocity * SliderVelocity;
             Velocity = scoringDistance / timingPoint.BeatLength;
 
             tickSpacing = timingPoint.BeatLength / TickRate;

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = base_distance * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = base_distance * difficulty.BaseSliderVelocity * SliderVelocity;
             Velocity = scoringDistance / timingPoint.BeatLength;
 
             tickSpacing = timingPoint.BeatLength / TickRate;

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(4, difficulty.CircleSize);
                 Assert.AreEqual(8, difficulty.OverallDifficulty);
                 Assert.AreEqual(9, difficulty.ApproachRate);
-                Assert.AreEqual(1.8, difficulty.SliderMultiplier);
+                Assert.AreEqual(1.8, difficulty.BaseSliderVelocity);
                 Assert.AreEqual(2, difficulty.SliderTickRate);
             }
         }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -136,8 +136,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.AreEqual(4, difficulty.CircleSize);
                 Assert.AreEqual(8, difficulty.OverallDifficulty);
                 Assert.AreEqual(9, difficulty.ApproachRate);
-                Assert.AreEqual(1.8, difficulty.BaseSliderVelocity);
-                Assert.AreEqual(2, difficulty.SliderTickRate);
+                Assert.AreEqual(1.8, difficulty.BaseVelocity);
+                Assert.AreEqual(2, difficulty.TickRate);
             }
         }
 

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -91,8 +91,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
             Assert.AreEqual(4, difficulty.CircleSize);
             Assert.AreEqual(8, difficulty.OverallDifficulty);
             Assert.AreEqual(9, difficulty.ApproachRate);
-            Assert.AreEqual(1.8, difficulty.BaseSliderVelocity);
-            Assert.AreEqual(2, difficulty.SliderTickRate);
+            Assert.AreEqual(1.8, difficulty.BaseVelocity);
+            Assert.AreEqual(2, difficulty.TickRate);
         }
 
         [Test]

--- a/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/OsuJsonDecoderTest.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             Assert.AreEqual(4, difficulty.CircleSize);
             Assert.AreEqual(8, difficulty.OverallDifficulty);
             Assert.AreEqual(9, difficulty.ApproachRate);
-            Assert.AreEqual(1.8, difficulty.SliderMultiplier);
+            Assert.AreEqual(1.8, difficulty.BaseSliderVelocity);
             Assert.AreEqual(2, difficulty.SliderTickRate);
         }
 

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Editing
 
             BeatDivisor.Value = 1;
 
-            composer.EditorBeatmap.Difficulty.SliderMultiplier = 1;
+            composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 1;
             composer.EditorBeatmap.ControlPointInfo.Clear();
             composer.EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 });
         });
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Editing
         [TestCase(2)]
         public void TestSliderMultiplier(float multiplier)
         {
-            AddStep($"set slider multiplier = {multiplier}", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = multiplier);
+            AddStep($"set slider multiplier = {multiplier}", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = multiplier);
 
             assertSnapDistance(100 * multiplier, null, true);
         }
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Editing
             assertDurationToDistance(500, 50);
             assertDurationToDistance(1000, 100);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
 
             assertDurationToDistance(500, 100);
             assertDurationToDistance(1000, 200);
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Editing
             assertDistanceToDuration(50, 500);
             assertDistanceToDuration(100, 1000);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
 
             assertDistanceToDuration(100, 500);
             assertDistanceToDuration(200, 1000);
@@ -174,7 +174,7 @@ namespace osu.Game.Tests.Editing
             assertSnappedDuration(200, 2000);
             assertSnappedDuration(250, 3000);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
 
             assertSnappedDuration(0, 0);
             assertSnappedDuration(50, 0);
@@ -206,7 +206,7 @@ namespace osu.Game.Tests.Editing
             assertSnappedDistance(200, 200);
             assertSnappedDistance(250, 200);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.SliderMultiplier = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
 
             assertSnappedDistance(50, 0);
             assertSnappedDistance(100, 0);

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Editing
 
             BeatDivisor.Value = 1;
 
-            composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 1;
+            composer.EditorBeatmap.Difficulty.BaseVelocity = 1;
             composer.EditorBeatmap.ControlPointInfo.Clear();
             composer.EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 });
         });
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Editing
         [TestCase(2)]
         public void TestSliderMultiplier(float multiplier)
         {
-            AddStep($"set slider multiplier = {multiplier}", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = multiplier);
+            AddStep($"set slider multiplier = {multiplier}", () => composer.EditorBeatmap.Difficulty.BaseVelocity = multiplier);
 
             assertSnapDistance(100 * multiplier, null, true);
         }
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Editing
             assertDurationToDistance(500, 50);
             assertDurationToDistance(1000, 100);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseVelocity = 2);
 
             assertDurationToDistance(500, 100);
             assertDurationToDistance(1000, 200);
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Editing
             assertDistanceToDuration(50, 500);
             assertDistanceToDuration(100, 1000);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseVelocity = 2);
 
             assertDistanceToDuration(100, 500);
             assertDistanceToDuration(200, 1000);
@@ -174,7 +174,7 @@ namespace osu.Game.Tests.Editing
             assertSnappedDuration(200, 2000);
             assertSnappedDuration(250, 3000);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseVelocity = 2);
 
             assertSnappedDuration(0, 0);
             assertSnappedDuration(50, 0);
@@ -206,7 +206,7 @@ namespace osu.Game.Tests.Editing
             assertSnappedDistance(200, 200);
             assertSnappedDistance(250, 200);
 
-            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseSliderVelocity = 2);
+            AddStep("set slider multiplier = 2", () => composer.EditorBeatmap.Difficulty.BaseVelocity = 2);
 
             assertSnappedDistance(50, 0);
             assertSnappedDistance(100, 0);

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.Editing
                 }
             });
             editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = beat_length });
-            editorBeatmap.Difficulty.SliderMultiplier = 1;
+            editorBeatmap.Difficulty.BaseSliderVelocity = 1;
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.Editing
                 }
             });
             editorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = beat_length });
-            editorBeatmap.Difficulty.BaseSliderVelocity = 1;
+            editorBeatmap.Difficulty.BaseVelocity = 1;
         }
 
         [SetUp]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = createBeatmap();
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
-            beatmap.Difficulty.BaseSliderVelocity = 2;
+            beatmap.Difficulty.BaseVelocity = 2;
 
             createTest(beatmap, d => d.RelativeScaleBeatLengthsOverride = true);
             AddStep("adjust time range", () => drawableRuleset.TimeRange.Value = 5000);
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = createBeatmap();
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
-            beatmap.Difficulty.BaseSliderVelocity = 2;
+            beatmap.Difficulty.BaseVelocity = 2;
 
             createTest(beatmap);
             AddStep("adjust time range", () => drawableRuleset.TimeRange.Value = 2000);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -184,7 +184,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = createBeatmap();
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
-            beatmap.Difficulty.SliderMultiplier = 2;
+            beatmap.Difficulty.BaseSliderVelocity = 2;
 
             createTest(beatmap, d => d.RelativeScaleBeatLengthsOverride = true);
             AddStep("adjust time range", () => drawableRuleset.TimeRange.Value = 5000);
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = createBeatmap();
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
-            beatmap.Difficulty.SliderMultiplier = 2;
+            beatmap.Difficulty.BaseSliderVelocity = 2;
 
             createTest(beatmap);
             AddStep("adjust time range", () => drawableRuleset.TimeRange.Value = 2000);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 BeatmapInfo = new BeatmapInfo
                 {
-                    Difficulty = new BeatmapDifficulty { CircleSize = 6, SliderMultiplier = 3 },
+                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseSliderVelocity = 3 },
                     Ruleset = ruleset
                 },
                 ControlPointInfo = controlPointInfo

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 BeatmapInfo = new BeatmapInfo
                 {
-                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseSliderVelocity = 3 },
+                    Difficulty = new BeatmapDifficulty { CircleSize = 6, BaseVelocity = 3 },
                     Ruleset = ruleset
                 },
                 ControlPointInfo = controlPointInfo

--- a/osu.Game/Beatmaps/BeatmapDifficulty.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficulty.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Beatmaps
     public class BeatmapDifficulty : EmbeddedObject, IBeatmapDifficultyInfo
     {
         /// <summary>
-        /// The default value used for all difficulty settings except <see cref="BaseSliderVelocity"/> and <see cref="SliderTickRate"/>.
+        /// The default value used for all difficulty settings except <see cref="BaseVelocity"/> and <see cref="TickRate"/>.
         /// </summary>
         public const float DEFAULT_DIFFICULTY = 5;
 
@@ -20,8 +20,8 @@ namespace osu.Game.Beatmaps
         public float OverallDifficulty { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
         public float ApproachRate { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
 
-        public double BaseSliderVelocity { get; set; } = 1;
-        public double SliderTickRate { get; set; } = 1;
+        public double BaseVelocity { get; set; } = 1;
+        public double TickRate { get; set; } = 1;
 
         public BeatmapDifficulty()
         {
@@ -44,8 +44,8 @@ namespace osu.Game.Beatmaps
             difficulty.CircleSize = CircleSize;
             difficulty.OverallDifficulty = OverallDifficulty;
 
-            difficulty.BaseSliderVelocity = BaseSliderVelocity;
-            difficulty.SliderTickRate = SliderTickRate;
+            difficulty.BaseVelocity = BaseVelocity;
+            difficulty.TickRate = TickRate;
         }
 
         public virtual void CopyFrom(IBeatmapDifficultyInfo other)
@@ -55,8 +55,8 @@ namespace osu.Game.Beatmaps
             CircleSize = other.CircleSize;
             OverallDifficulty = other.OverallDifficulty;
 
-            BaseSliderVelocity = other.BaseSliderVelocity;
-            SliderTickRate = other.SliderTickRate;
+            BaseVelocity = other.BaseVelocity;
+            TickRate = other.TickRate;
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapDifficulty.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficulty.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Beatmaps
     public class BeatmapDifficulty : EmbeddedObject, IBeatmapDifficultyInfo
     {
         /// <summary>
-        /// The default value used for all difficulty settings except <see cref="SliderMultiplier"/> and <see cref="SliderTickRate"/>.
+        /// The default value used for all difficulty settings except <see cref="BaseSliderVelocity"/> and <see cref="SliderTickRate"/>.
         /// </summary>
         public const float DEFAULT_DIFFICULTY = 5;
 
@@ -20,7 +20,7 @@ namespace osu.Game.Beatmaps
         public float OverallDifficulty { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
         public float ApproachRate { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
 
-        public double SliderMultiplier { get; set; } = 1;
+        public double BaseSliderVelocity { get; set; } = 1;
         public double SliderTickRate { get; set; } = 1;
 
         public BeatmapDifficulty()
@@ -44,7 +44,7 @@ namespace osu.Game.Beatmaps
             difficulty.CircleSize = CircleSize;
             difficulty.OverallDifficulty = OverallDifficulty;
 
-            difficulty.SliderMultiplier = SliderMultiplier;
+            difficulty.BaseSliderVelocity = BaseSliderVelocity;
             difficulty.SliderTickRate = SliderTickRate;
         }
 
@@ -55,7 +55,7 @@ namespace osu.Game.Beatmaps
             CircleSize = other.CircleSize;
             OverallDifficulty = other.OverallDifficulty;
 
-            SliderMultiplier = other.SliderMultiplier;
+            BaseSliderVelocity = other.BaseSliderVelocity;
             SliderTickRate = other.SliderTickRate;
         }
     }

--- a/osu.Game/Beatmaps/BeatmapDifficulty.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficulty.cs
@@ -20,7 +20,10 @@ namespace osu.Game.Beatmaps
         public float OverallDifficulty { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
         public float ApproachRate { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
 
+        [Ignored]
         public double BaseVelocity { get; set; } = 1;
+
+        [Ignored]
         public double TickRate { get; set; } = 1;
 
         public BeatmapDifficulty()

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -353,8 +353,8 @@ namespace osu.Game.Beatmaps
                         CircleSize = decodedDifficulty.CircleSize,
                         OverallDifficulty = decodedDifficulty.OverallDifficulty,
                         ApproachRate = decodedDifficulty.ApproachRate,
-                        BaseSliderVelocity = decodedDifficulty.BaseSliderVelocity,
-                        SliderTickRate = decodedDifficulty.SliderTickRate,
+                        BaseVelocity = decodedDifficulty.BaseVelocity,
+                        TickRate = decodedDifficulty.TickRate,
                     };
 
                     var metadata = new BeatmapMetadata

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -353,7 +353,7 @@ namespace osu.Game.Beatmaps
                         CircleSize = decodedDifficulty.CircleSize,
                         OverallDifficulty = decodedDifficulty.OverallDifficulty,
                         ApproachRate = decodedDifficulty.ApproachRate,
-                        SliderMultiplier = decodedDifficulty.SliderMultiplier,
+                        BaseSliderVelocity = decodedDifficulty.BaseSliderVelocity,
                         SliderTickRate = decodedDifficulty.SliderTickRate,
                     };
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -384,11 +384,11 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"SliderMultiplier":
-                    difficulty.BaseSliderVelocity = Parsing.ParseDouble(pair.Value);
+                    difficulty.BaseVelocity = Parsing.ParseDouble(pair.Value);
                     break;
 
                 case @"SliderTickRate":
-                    difficulty.SliderTickRate = Parsing.ParseDouble(pair.Value);
+                    difficulty.TickRate = Parsing.ParseDouble(pair.Value);
                     break;
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -384,7 +384,7 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"SliderMultiplier":
-                    difficulty.SliderMultiplier = Parsing.ParseDouble(pair.Value);
+                    difficulty.BaseSliderVelocity = Parsing.ParseDouble(pair.Value);
                     break;
 
                 case @"SliderTickRate":

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -155,10 +155,10 @@ namespace osu.Game.Beatmaps.Formats
 
             // Taiko adjusts the slider multiplier (see: LEGACY_TAIKO_VELOCITY_MULTIPLIER)
             writer.WriteLine(onlineRulesetID == 1
-                ? FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseSliderVelocity / LEGACY_TAIKO_VELOCITY_MULTIPLIER}")
-                : FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseSliderVelocity}"));
+                ? FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseVelocity / LEGACY_TAIKO_VELOCITY_MULTIPLIER}")
+                : FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseVelocity}"));
 
-            writer.WriteLine(FormattableString.Invariant($"SliderTickRate: {beatmap.Difficulty.SliderTickRate}"));
+            writer.WriteLine(FormattableString.Invariant($"SliderTickRate: {beatmap.Difficulty.TickRate}"));
         }
 
         private void handleEvents(TextWriter writer)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -155,8 +155,8 @@ namespace osu.Game.Beatmaps.Formats
 
             // Taiko adjusts the slider multiplier (see: LEGACY_TAIKO_VELOCITY_MULTIPLIER)
             writer.WriteLine(onlineRulesetID == 1
-                ? FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.SliderMultiplier / LEGACY_TAIKO_VELOCITY_MULTIPLIER}")
-                : FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.SliderMultiplier}"));
+                ? FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseSliderVelocity / LEGACY_TAIKO_VELOCITY_MULTIPLIER}")
+                : FormattableString.Invariant($"SliderMultiplier: {beatmap.Difficulty.BaseSliderVelocity}"));
 
             writer.WriteLine(FormattableString.Invariant($"SliderTickRate: {beatmap.Difficulty.SliderTickRate}"));
         }

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Beatmaps
     public interface IBeatmapDifficultyInfo
     {
         /// <summary>
-        /// The default value used for all difficulty settings except <see cref="BaseSliderVelocity"/> and <see cref="SliderTickRate"/>.
+        /// The default value used for all difficulty settings except <see cref="BaseVelocity"/> and <see cref="TickRate"/>.
         /// </summary>
         const float DEFAULT_DIFFICULTY = 5;
 
@@ -37,12 +37,15 @@ namespace osu.Game.Beatmaps
         /// The base slider velocity of the associated beatmap.
         /// This was known as "SliderMultiplier" in the .osu format and stable editor.
         /// </summary>
-        double BaseSliderVelocity { get; }
+        double BaseVelocity { get; }
 
         /// <summary>
-        /// The slider tick rate of the associated beatmap.
+        /// The tick rate of the associated beatmap.
         /// </summary>
-        double SliderTickRate { get; }
+        /// <remarks>
+        /// This is used by objects with "ticks" to decide how often the ticks are spawned.
+        /// </remarks>
+        double TickRate { get; }
 
         /// <summary>
         /// Maps a difficulty value [0, 10] to a two-piece linear range of values.

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Beatmaps
     public interface IBeatmapDifficultyInfo
     {
         /// <summary>
-        /// The default value used for all difficulty settings except <see cref="SliderMultiplier"/> and <see cref="SliderTickRate"/>.
+        /// The default value used for all difficulty settings except <see cref="BaseSliderVelocity"/> and <see cref="SliderTickRate"/>.
         /// </summary>
         const float DEFAULT_DIFFICULTY = 5;
 
@@ -34,9 +34,10 @@ namespace osu.Game.Beatmaps
         float ApproachRate { get; }
 
         /// <summary>
-        /// The slider multiplier of the associated beatmap.
+        /// The base slider velocity of the associated beatmap.
+        /// This was known as "SliderMultiplier" in the .osu format and stable editor.
         /// </summary>
-        double SliderMultiplier { get; }
+        double BaseSliderVelocity { get; }
 
         /// <summary>
         /// The slider tick rate of the associated beatmap.

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -34,9 +34,12 @@ namespace osu.Game.Beatmaps
         float ApproachRate { get; }
 
         /// <summary>
-        /// The base slider velocity of the associated beatmap.
-        /// This was known as "SliderMultiplier" in the .osu format and stable editor.
+        /// The base velocity of the associated beatmap.
         /// </summary>
+        /// <remarks>
+        /// This was known as "SliderMultiplier" in the .osu format and stable editor.
+        /// It is used for things like velocity of objects with paths and scrolling speed in some rulesets.
+        /// </remarks>
         double BaseVelocity { get; }
 
         /// <summary>
@@ -44,6 +47,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <remarks>
         /// This is used by objects with "ticks" to decide how often the ticks are spawned.
+        /// A tick rate of 1 will spawn ticks on each beat, 2 would be twice per beat, etc.
         /// </remarks>
         double TickRate { get; }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -71,8 +71,9 @@ namespace osu.Game.Database
         /// 24   2022-08-22    Added MaximumStatistics to ScoreInfo.
         /// 25   2022-09-18    Remove skins to add with new naming.
         /// 26   2023-02-05    Added BeatmapHash to ScoreInfo.
+        /// 27   2023-05-08    Remove SliderMultiplier and SliderTickRate from BeatmapInfo.
         /// </summary>
-        private const int schema_version = 26;
+        private const int schema_version = 27;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Localisation/EditorSetupStrings.cs
+++ b/osu.Game/Localisation/EditorSetupStrings.cs
@@ -127,6 +127,16 @@ namespace osu.Game.Localisation
             new TranslatableString(getKey(@"overall_difficulty_description"), @"The harshness of hit windows and difficulty of special objects (ie. spinners)");
 
         /// <summary>
+        /// "Base Velocity"
+        /// </summary>
+        public static LocalisableString BaseVelocity => new TranslatableString(getKey(@"base_velocity"), @"Base Velocity");
+
+        /// <summary>
+        /// "The base velocity of the beatmap, affecting things like slider velocity and scroll speed in some rulesets."
+        /// </summary>
+        public static LocalisableString BaseVelocityDescription => new TranslatableString(getKey(@"base_velocity_description"), @"The base velocity of the beatmap, affecting things like slider velocity and scroll speed in some rulesets.");
+
+        /// <summary>
         /// "Metadata"
         /// </summary>
         public static LocalisableString MetadataHeader => new TranslatableString(getKey(@"metadata_header"), @"Metadata");

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Edit
 
         public virtual float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true)
         {
-            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocity : 1) * EditorBeatmap.Difficulty.BaseSliderVelocity * 1
+            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocity : 1) * EditorBeatmap.Difficulty.BaseVelocity * 1
                            / BeatSnapProvider.BeatDivisor);
         }
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Edit
 
         public virtual float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true)
         {
-            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocity : 1) * EditorBeatmap.Difficulty.SliderMultiplier * 1
+            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocity : 1) * EditorBeatmap.Difficulty.BaseSliderVelocity * 1
                            / BeatSnapProvider.BeatDivisor);
         }
 

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = base_scoring_distance * difficulty.BaseSliderVelocity * SliderVelocity;
+            double scoringDistance = base_scoring_distance * difficulty.BaseVelocity * SliderVelocity;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
         }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = base_scoring_distance * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = base_scoring_distance * difficulty.BaseSliderVelocity * SliderVelocity;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
         }

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
                 // The slider multiplier is post-multiplied to determine the final velocity, but for relative scale beat lengths
                 // the multiplier should not affect the effective timing point (the longest in the beatmap), so it is factored out here
-                baseBeatLength /= Beatmap.Difficulty.BaseSliderVelocity;
+                baseBeatLength /= Beatmap.Difficulty.BaseVelocity;
             }
 
             // Merge sequences of timing and difficulty control points to create the aggregate "multiplier" control point
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
                 return new MultiplierControlPoint(c.Time)
                 {
-                    Velocity = Beatmap.Difficulty.BaseSliderVelocity,
+                    Velocity = Beatmap.Difficulty.BaseVelocity,
                     BaseBeatLength = baseBeatLength,
                     TimingPoint = lastTimingPoint,
                     EffectPoint = lastEffectPoint
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
             ControlPoints.AddRange(timingChanges);
 
             if (ControlPoints.Count == 0)
-                ControlPoints.Add(new MultiplierControlPoint { Velocity = Beatmap.Difficulty.BaseSliderVelocity });
+                ControlPoints.Add(new MultiplierControlPoint { Velocity = Beatmap.Difficulty.BaseVelocity });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/DrawableScrollingRuleset.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
                 // The slider multiplier is post-multiplied to determine the final velocity, but for relative scale beat lengths
                 // the multiplier should not affect the effective timing point (the longest in the beatmap), so it is factored out here
-                baseBeatLength /= Beatmap.Difficulty.SliderMultiplier;
+                baseBeatLength /= Beatmap.Difficulty.BaseSliderVelocity;
             }
 
             // Merge sequences of timing and difficulty control points to create the aggregate "multiplier" control point
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
                 return new MultiplierControlPoint(c.Time)
                 {
-                    Velocity = Beatmap.Difficulty.SliderMultiplier,
+                    Velocity = Beatmap.Difficulty.BaseSliderVelocity,
                     BaseBeatLength = baseBeatLength,
                     TimingPoint = lastTimingPoint,
                     EffectPoint = lastEffectPoint
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
             ControlPoints.AddRange(timingChanges);
 
             if (ControlPoints.Count == 0)
-                ControlPoints.Add(new MultiplierControlPoint { Velocity = Beatmap.Difficulty.SliderMultiplier });
+                ControlPoints.Add(new MultiplierControlPoint { Velocity = Beatmap.Difficulty.BaseSliderVelocity });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     if (selected is IHasSliderVelocity sliderVelocity)
                     {
                         AddHeader("Slider Velocity");
-                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x");
+                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x ({sliderVelocity.SliderVelocity * EditorBeatmap.Difficulty.BaseSliderVelocity:#,0.00}x)");
                     }
 
                     if (selected is IHasRepeats repeats)

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     if (selected is IHasSliderVelocity sliderVelocity)
                     {
                         AddHeader("Slider Velocity");
-                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x ({sliderVelocity.SliderVelocity * EditorBeatmap.Difficulty.BaseSliderVelocity:#,0.00}x)");
+                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x ({sliderVelocity.SliderVelocity * EditorBeatmap.Difficulty.BaseVelocity:#,0.00}x)");
                     }
 
                     if (selected is IHasRepeats repeats)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateInspectorText()
         {
-            double beatmapVelocity = EditorBeatmap.Difficulty.BaseSliderVelocity;
+            double beatmapVelocity = EditorBeatmap.Difficulty.BaseVelocity;
 
             InspectorText.Clear();
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -159,20 +159,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             double[] sliderVelocities = EditorBeatmap.HitObjects.OfType<IHasSliderVelocity>().Select(sv => sv.SliderVelocity).OrderBy(v => v).ToArray();
 
-            if (sliderVelocities.Length < 2)
-                return;
+            if (sliderVelocities.First() != sliderVelocities.Last())
+            {
+                AddHeader("Used velocity range");
+                AddValue($"{sliderVelocities.First():#,0.00}x - {sliderVelocities.Last():#,0.00}x");
+            }
 
-            double? modeSliderVelocity = sliderVelocities.GroupBy(v => v).MaxBy(v => v.Count())?.Key;
-            double? medianSliderVelocity = sliderVelocities[sliderVelocities.Length / 2];
-
-            AddHeader("Average velocity");
-            AddValue($"{medianSliderVelocity:#,0.00}x");
-
-            AddHeader("Most used velocity");
-            AddValue($"{modeSliderVelocity:#,0.00}x");
-
-            AddHeader("Velocity range");
-            AddValue($"{sliderVelocities.First():#,0.00}x - {sliderVelocities.Last():#,0.00}x");
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -165,6 +165,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 AddValue($"{sliderVelocities.First():#,0.00}x - {sliderVelocities.Last():#,0.00}x");
             }
 
+            AddHeader("Beatmap base velocity");
+            AddValue($"{EditorBeatmap.Difficulty.BaseSliderVelocity:#,0.00}x");
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -96,10 +96,13 @@ namespace osu.Game.Screens.Edit.Setup
             };
 
             foreach (var item in Children.OfType<LabelledSliderBar<float>>())
-                item.Current.ValueChanged += onValueChanged;
+                item.Current.ValueChanged += _ => updateValues();
+
+            foreach (var item in Children.OfType<LabelledSliderBar<double>>())
+                item.Current.ValueChanged += _ => updateValues();
         }
 
-        private void onValueChanged(ValueChangedEvent<float> args)
+        private void updateValues()
         {
             // for now, update these on commit rather than making BeatmapMetadata bindables.
             // after switching database engines we can reconsider if switching to bindables is a good direction.

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -88,9 +88,9 @@ namespace osu.Game.Screens.Edit.Setup
                     Current = new BindableDouble(Beatmap.Difficulty.BaseSliderVelocity)
                     {
                         Default = 1,
-                        MinValue = 0.01,
-                        MaxValue = 10,
-                        Precision = 0.1f,
+                        MinValue = 0.4,
+                        MaxValue = 3.6,
+                        Precision = 0.01f,
                     }
                 },
             };

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Edit.Setup
                     Label = EditorSetupStrings.BaseVelocity,
                     FixedLabelWidth = LABEL_WIDTH,
                     Description = EditorSetupStrings.BaseVelocityDescription,
-                    Current = new BindableDouble(Beatmap.Difficulty.BaseSliderVelocity)
+                    Current = new BindableDouble(Beatmap.Difficulty.BaseVelocity)
                     {
                         Default = 1,
                         MinValue = 0.4,
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Difficulty.DrainRate = healthDrainSlider.Current.Value;
             Beatmap.Difficulty.ApproachRate = approachRateSlider.Current.Value;
             Beatmap.Difficulty.OverallDifficulty = overallDifficultySlider.Current.Value;
-            Beatmap.Difficulty.BaseSliderVelocity = baseVelocitySlider.Current.Value;
+            Beatmap.Difficulty.BaseVelocity = baseVelocitySlider.Current.Value;
 
             Beatmap.UpdateAllHitObjects();
             Beatmap.SaveState();

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Screens.Edit.Setup
         private LabelledSliderBar<float> healthDrainSlider = null!;
         private LabelledSliderBar<float> approachRateSlider = null!;
         private LabelledSliderBar<float> overallDifficultySlider = null!;
+        private LabelledSliderBar<double> baseVelocitySlider = null!;
 
         public override LocalisableString Title => EditorSetupStrings.DifficultyHeader;
 
@@ -79,6 +80,19 @@ namespace osu.Game.Screens.Edit.Setup
                         Precision = 0.1f,
                     }
                 },
+                baseVelocitySlider = new LabelledSliderBar<double>
+                {
+                    Label = EditorSetupStrings.BaseVelocity,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = EditorSetupStrings.BaseVelocityDescription,
+                    Current = new BindableDouble(Beatmap.Difficulty.BaseSliderVelocity)
+                    {
+                        Default = 1,
+                        MinValue = 0.01,
+                        MaxValue = 10,
+                        Precision = 0.1f,
+                    }
+                },
             };
 
             foreach (var item in Children.OfType<LabelledSliderBar<float>>())
@@ -93,6 +107,7 @@ namespace osu.Game.Screens.Edit.Setup
             Beatmap.Difficulty.DrainRate = healthDrainSlider.Current.Value;
             Beatmap.Difficulty.ApproachRate = approachRateSlider.Current.Value;
             Beatmap.Difficulty.OverallDifficulty = overallDifficultySlider.Current.Value;
+            Beatmap.Difficulty.BaseSliderVelocity = baseVelocitySlider.Current.Value;
 
             Beatmap.UpdateAllHitObjects();
             Beatmap.SaveState();


### PR DESCRIPTION
These values are used for more than just sliders across all rulesets, so it makes sense to rename them as such.

Also removes these values from realm, as they probably shouldn't have been in there in the first place.

- [x] Depends on https://github.com/ppy/osu/pull/23431