### PR TITLE
Fix "Return to main page" link not working on wiki after error

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -27,13 +27,13 @@ namespace osu.Game.Tests.Visual.Online
         public void TestMainPage()
         {
             setUpWikiResponse(responseMainPage);
-            AddStep("Show main page", () => wiki.Show());
+            AddStep("Show main page", () => wiki.ShowPage());
         }
 
         [Test]
         public void TestCancellationDoesntShowError()
         {
-            AddStep("Show main page", () => wiki.Show());
+            AddStep("Show main page", () => wiki.ShowPage());
             AddStep("Show another page", () => wiki.ShowPage("Article_styling_criteria/Formatting"));
 
             AddUntilStep("Current path is not error", () => wiki.CurrentPath != "error");

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Net;
@@ -20,7 +18,7 @@ namespace osu.Game.Tests.Visual.Online
     {
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
-        private WikiOverlay wiki;
+        private WikiOverlay wiki = null!;
 
         [SetUp]
         public void SetUp() => Schedule(() => Child = wiki = new WikiOverlay());
@@ -73,7 +71,23 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("Error message correct", () => wiki.ChildrenOfType<SpriteText>().Any(text => text.Text == "\"This_page_will_error_out\"."));
         }
 
-        private void setUpWikiResponse(APIWikiPage r, string redirectionPath = null)
+        [Test]
+        public void TestReturnAfterErrorPage()
+        {
+            setUpWikiResponse(responseArticlePage);
+
+            AddStep("Show article page", () => wiki.ShowPage("Article_styling_criteria/Formatting"));
+            AddUntilStep("Wait for non-error page", () => wiki.CurrentPath == "Article_styling_criteria/Formatting");
+
+            AddStep("Show nonexistent page", () => wiki.ShowPage("This_page_will_error_out"));
+            AddUntilStep("Wait for error page", () => wiki.CurrentPath == "error");
+
+            AddStep("Show article page", () => wiki.ShowPage("Article_styling_criteria/Formatting"));
+            AddUntilStep("Wait for non-error page", () => wiki.CurrentPath == "Article_styling_criteria/Formatting");
+            AddUntilStep("Error message not displayed", () => wiki.ChildrenOfType<SpriteText>().All(text => text.Text != "\"This_page_will_error_out\"."));
+        }
+
+        private void setUpWikiResponse(APIWikiPage r, string? redirectionPath = null)
             => AddStep("set up response", () =>
             {
                 dummyAPI.HandleRequest = request =>

--- a/osu.Game/Overlays/WikiOverlay.cs
+++ b/osu.Game/Overlays/WikiOverlay.cs
@@ -157,7 +157,9 @@ namespace osu.Game.Overlays
 
         private void onFail(string originalPath)
         {
+            wikiData.Value = null;
             path.Value = "error";
+
             LoadDisplay(articlePage = new WikiArticlePage($@"{api.WebsiteRootUrl}/wiki/",
                 $"Something went wrong when trying to fetch page \"{originalPath}\".\n\n[Return to the main page](Main_Page)."));
         }


### PR DESCRIPTION
Test by clicking "Glossary" on dev server (which is 404).

Shown working:

https://user-images.githubusercontent.com/191335/236749331-1f1b003b-1d4a-4f9c-bac0-a3b0d4fd8de5.mp4

Fail case due to data not being nulled:

![JetBrains Rider 2023-05-08 at 06 23 23](https://user-images.githubusercontent.com/191335/236749618-0d54d355-1f4f-44e4-8201-52cfbbb793c0.png)

