### PR TITLE
Fix hit object animations not being played back in sync

### DIFF
--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -30,7 +30,7 @@ using osuTK.Graphics;
 namespace osu.Game.Rulesets.Objects.Drawables
 {
     [Cached(typeof(DrawableHitObject))]
-    public abstract partial class DrawableHitObject : PoolableDrawableWithLifetime<HitObjectLifetimeEntry>
+    public abstract partial class DrawableHitObject : PoolableDrawableWithLifetime<HitObjectLifetimeEntry>, IAnimationTimeReference
     {
         /// <summary>
         /// Invoked after this <see cref="DrawableHitObject"/>'s applied <see cref="HitObject"/> has had its defaults applied.
@@ -425,11 +425,13 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
             LifetimeEnd = double.MaxValue;
 
-            double transformTime = HitObject.StartTime - InitialLifetimeOffset;
-
             clearExistingStateTransforms();
 
-            using (BeginAbsoluteSequence(transformTime))
+            double initialTransformsTime = HitObject.StartTime - InitialLifetimeOffset;
+
+            AnimationStartTime.Value = initialTransformsTime;
+
+            using (BeginAbsoluteSequence(initialTransformsTime))
                 UpdateInitialTransforms();
 
             using (BeginAbsoluteSequence(StateUpdateTime))
@@ -721,6 +723,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
             if (CurrentSkin != null)
                 CurrentSkin.SourceChanged -= skinSourceChanged;
         }
+
+        public Bindable<double> AnimationStartTime { get; } = new BindableDouble();
     }
 
     public abstract partial class DrawableHitObject<TObject> : DrawableHitObject


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23187.

Have not compared timing offset with stable, but at least this brings animations into a stable state, relative to their hitobjects.