### PR TITLE
Redesign timeline sample pieces

### DIFF
--- a/osu.Game/Rulesets/Objects/HitObject.cs
+++ b/osu.Game/Rulesets/Objects/HitObject.cs
@@ -210,10 +210,10 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         /// <param name="sampleName">The name of the sample.</param>
         /// <returns>A populated <see cref="HitSampleInfo"/>.</returns>
-        protected HitSampleInfo GetSampleInfo(string sampleName = HitSampleInfo.HIT_NORMAL)
+        public HitSampleInfo GetSampleInfo(string sampleName = HitSampleInfo.HIT_NORMAL)
         {
             var hitnormalSample = Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL);
-            return hitnormalSample == null ? new HitSampleInfo(sampleName) : hitnormalSample.With(newName: sampleName);
+            return hitnormalSample == null ? new HitSampleInfo(sampleName, SampleControlPoint.DEFAULT_BANK, volume: 100) : hitnormalSample.With(newName: sampleName);
         }
     }
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -206,10 +206,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
             yield return new TernaryButton(NewCombo, "New combo", () => new SpriteIcon { Icon = FontAwesome.Regular.DotCircle });
 
             foreach (var kvp in SelectionHandler.SelectionSampleStates)
-                yield return new TernaryButton(kvp.Value, kvp.Key.Replace("hit", string.Empty).Titleize(), () => getIconForSample(kvp.Key));
+                yield return new TernaryButton(kvp.Value, kvp.Key.Replace("hit", string.Empty).Titleize(), () => GetIconForSample(kvp.Key));
         }
 
-        private Drawable getIconForSample(string sampleName)
+        public static Drawable GetIconForSample(string sampleName)
         {
             switch (sampleName)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -122,7 +122,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (h.Samples.Any(s => s.Name == sampleName))
                     return;
 
-                h.Samples.Add(h.GetSampleInfo(sampleName));
+                var relevantSample = h.Samples.FirstOrDefault(s => s.Name != HitSampleInfo.HIT_NORMAL);
+                h.Samples.Add(relevantSample?.With(sampleName) ?? h.GetSampleInfo(sampleName));
                 EditorBeatmap.Update(h);
             });
         }

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 if (h.Samples.Any(s => s.Name == sampleName))
                     return;
 
-                h.Samples.Add(new HitSampleInfo(sampleName));
+                h.Samples.Add(h.GetSampleInfo(sampleName));
                 EditorBeatmap.Update(h);
             });
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Given a selection target and a function of truth, retrieve the correct ternary state for display.
         /// </summary>
-        protected static TernaryState GetStateFromSelection<TObject>(IEnumerable<TObject> selection, Func<TObject, bool> func)
+        public static TernaryState GetStateFromSelection<TObject>(IEnumerable<TObject> selection, Func<TObject, bool> func)
         {
             if (selection.Any(func))
                 return selection.All(func) ? TernaryState.True : TernaryState.Indeterminate;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             NodeIndex = nodeIndex;
         }
 
-        protected override Color4 GetRepresentingColour(OsuColour colours) => colours.Purple;
+        protected override Color4 GetRepresentingColour(OsuColour colours) => colours.PinkDarker;
 
         protected override IList<HitSampleInfo> GetSamples()
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Audio;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit.Compose.Components.Timeline
+{
+    public partial class NodeSamplePointPiece : SamplePointPiece
+    {
+        public readonly int NodeIndex;
+
+        public NodeSamplePointPiece(HitObject hitObject, int nodeIndex)
+            : base(hitObject)
+        {
+            if (hitObject is not IHasRepeats)
+                throw new System.ArgumentException($"HitObject must implement {nameof(IHasRepeats)}", nameof(hitObject));
+
+            NodeIndex = nodeIndex;
+        }
+
+        protected override Color4 GetRepresentingColour(OsuColour colours) => colours.Purple;
+
+        protected override IList<HitSampleInfo> GetSamples()
+        {
+            var hasRepeats = (IHasRepeats)HitObject;
+            return NodeIndex < hasRepeats.NodeSamples.Count ? hasRepeats.NodeSamples[NodeIndex] : HitObject.Samples;
+        }
+
+        public override Popover GetPopover() => new NodeSampleEditPopover(HitObject);
+
+        public partial class NodeSampleEditPopover : SampleEditPopover
+        {
+            private readonly int nodeIndex;
+
+            protected override IList<HitSampleInfo> GetSamples(HitObject ho)
+            {
+                var hasRepeats = (IHasRepeats)ho;
+                return nodeIndex < hasRepeats.NodeSamples.Count ? hasRepeats.NodeSamples[nodeIndex] : ho.Samples;
+            }
+
+            public NodeSampleEditPopover(HitObject hitObject, int nodeIndex = 0)
+                : base(hitObject)
+            {
+                this.nodeIndex = nodeIndex;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             return NodeIndex < hasRepeats.NodeSamples.Count ? hasRepeats.NodeSamples[NodeIndex] : HitObject.Samples;
         }
 
-        public override Popover GetPopover() => new NodeSampleEditPopover(HitObject);
+        public override Popover GetPopover() => new NodeSampleEditPopover(HitObject, NodeIndex);
 
         public partial class NodeSampleEditPopover : SampleEditPopover
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 return nodeIndex < hasRepeats.NodeSamples.Count ? hasRepeats.NodeSamples[nodeIndex] : ho.Samples;
             }
 
-            public NodeSampleEditPopover(HitObject hitObject, int nodeIndex = 0)
+            public NodeSampleEditPopover(HitObject hitObject, int nodeIndex)
                 : base(hitObject)
             {
                 this.nodeIndex = nodeIndex;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/NodeSamplePointPiece.cs
@@ -40,7 +40,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             protected override IList<HitSampleInfo> GetSamples(HitObject ho)
             {
-                var hasRepeats = (IHasRepeats)ho;
+                if (ho is not IHasRepeats hasRepeats)
+                    return ho.Samples;
+
                 return nodeIndex < hasRepeats.NodeSamples.Count ? hasRepeats.NodeSamples[nodeIndex] : ho.Samples;
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -26,12 +26,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         public readonly HitObject HitObject;
 
-        private readonly BindableList<HitSampleInfo> samplesBindable;
+        [Resolved(canBeNull: true)]
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
 
         public SamplePointPiece(HitObject hitObject)
         {
             HitObject = hitObject;
-            samplesBindable = hitObject.SamplesBindable.GetBoundCopy();
         }
 
         protected override Color4 GetRepresentingColour(OsuColour colours) => colours.Pink;
@@ -39,7 +39,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [BackgroundDependencyLoader]
         private void load()
         {
-            samplesBindable.BindCollectionChanged((_, _) => updateText(), true);
+            HitObject.DefaultsApplied += _ => updateText();
+            updateText();
         }
 
         protected override bool OnClick(ClickEvent e)
@@ -50,7 +51,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateText()
         {
-            Label.Text = $"{GetBankValue(samplesBindable)} {GetVolumeValue(samplesBindable)}";
+            Label.Text = $"{GetBankValue(HitObject.Samples)} {GetVolumeValue(HitObject.Samples)}";
         }
 
         public static string? GetBankValue(IEnumerable<HitSampleInfo> samples)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -33,8 +33,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         public readonly HitObject HitObject;
 
-        protected Container VolumeBar { get; private set; } = null!;
-        protected OsuSpriteText Label { get; private set; } = null!;
+        private Container volumeBar = null!;
+        private OsuSpriteText label = null!;
+        private Container additionsContainer = null!;
 
         protected virtual Color4 GetRepresentingColour(OsuColour colours) => colours.Pink;
 
@@ -52,7 +53,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             Height = 40;
             InternalChildren = new Drawable[]
             {
-                VolumeBar = new Container
+                volumeBar = new Container
                 {
                     RelativeSizeAxes = Axes.Y,
                     Anchor = Anchor.BottomLeft,
@@ -72,16 +73,38 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         }
                     }
                 },
-                Label = new OsuSpriteText
+                label = new OsuSpriteText
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.CentreLeft,
                     X = 9,
                     Rotation = -90,
+                    Width = 28,
                     Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold),
                     Colour = colours.GrayF,
+                    Truncate = true,
+                },
+                additionsContainer = new Container
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopCentre,
+                    X = 9,
+                    RelativeSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.X,
                 }
             };
+
+            for (int i = 0; i < 3; i++)
+            {
+                additionsContainer.Add(new Circle
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Size = new Vector2(4),
+                    Colour = colour,
+                    Y = i * 5,
+                });
+            }
 
             HitObject.DefaultsApplied += _ => updateVisual();
             updateVisual();
@@ -95,8 +118,23 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateVisual()
         {
-            Label.Text = $"{GetBankValue(GetSamples())}";
-            VolumeBar.ResizeHeightTo(GetVolumeValue(GetSamples()) / 100f, 200, Easing.OutQuint);
+            var samples = GetSamples();
+            int i = 0;
+
+            label.Text = $"{GetBankValue(samples)}";
+            volumeBar.ResizeHeightTo(GetVolumeValue(samples) / 100f, 200, Easing.OutQuint);
+
+            foreach (string sampleName in HitSampleInfo.AllAdditions)
+            {
+                if (samples.Any(s => s.Name == sampleName))
+                {
+                    additionsContainer.Children[i++].Show();
+                }
+                else
+                {
+                    additionsContainer.Children[i++].Hide();
+                }
+            }
         }
 
         private static string? abbreviateBank(string? bank)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -158,9 +158,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 foreach (var h in objects)
                 {
-                    for (int i = 0; i < h.Samples.Count; i++)
+                    var samples = GetSamples(h);
+
+                    for (int i = 0; i < samples.Count; i++)
                     {
-                        h.Samples[i] = h.Samples[i].With(newBank: newBank);
+                        samples[i] = samples[i].With(newBank: newBank);
                     }
 
                     beatmap.Update(h);
@@ -171,7 +173,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             private void updateBankPlaceholderText(IEnumerable<HitObject> objects)
             {
-                string? commonBank = getCommonBank(objects.Select(h => h.Samples).ToArray());
+                string? commonBank = getCommonBank(objects.Select(GetSamples).ToArray());
                 bank.PlaceholderText = string.IsNullOrEmpty(commonBank) ? "(multiple)" : string.Empty;
             }
 
@@ -184,9 +186,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 foreach (var h in objects)
                 {
-                    for (int i = 0; i < h.Samples.Count; i++)
+                    var samples = GetSamples(h);
+
+                    for (int i = 0; i < samples.Count; i++)
                     {
-                        h.Samples[i] = h.Samples[i].With(newVolume: newVolume.Value);
+                        samples[i] = samples[i].With(newVolume: newVolume.Value);
                     }
 
                     beatmap.Update(h);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -48,7 +48,18 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateText()
         {
-            Label.Text = $"{GetBankValue(GetSamples())} {GetVolumeValue(GetSamples())}";
+            Label.Text = $"{abbreviateBank(GetBankValue(GetSamples()))} {GetVolumeValue(GetSamples())}";
+        }
+
+        private static string? abbreviateBank(string? bank)
+        {
+            return bank switch
+            {
+                "normal" => "N",
+                "soft" => "S",
+                "drum" => "D",
+                _ => bank
+            };
         }
 
         public static string? GetBankValue(IEnumerable<HitSampleInfo> samples)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private void updateText()
         {
-            Label.Text = $"{GetBankValue(HitObject.Samples)} {GetVolumeValue(HitObject.Samples)}";
+            Label.Text = $"{GetBankValue(GetSamples())} {GetVolumeValue(GetSamples())}";
         }
 
         public static string? GetBankValue(IEnumerable<HitSampleInfo> samples)
@@ -61,7 +61,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             return samples.Count == 0 ? 0 : samples.Max(o => o.Volume);
         }
 
-        public Popover GetPopover() => new SampleEditPopover(HitObject);
+        protected virtual IList<HitSampleInfo> GetSamples() => HitObject.Samples;
+
+        public virtual Popover GetPopover() => new SampleEditPopover(HitObject);
 
         public partial class SampleEditPopover : OsuPopover
         {
@@ -69,6 +71,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             private LabelledTextBox bank = null!;
             private IndeterminateSliderWithTextBoxInput<int> volume = null!;
+
+            protected virtual IList<HitSampleInfo> GetSamples(HitObject ho) => ho.Samples;
 
             [Resolved(canBeNull: true)]
             private EditorBeatmap beatmap { get; set; } = null!;
@@ -112,7 +116,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
                 var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).ToArray();
-                var relevantSamples = relevantObjects.Select(h => h.Samples).ToArray();
+                var relevantSamples = relevantObjects.Select(GetSamples).ToArray();
 
                 // even if there are multiple objects selected, we can still display sample volume or bank if they all have the same value.
                 string? commonBank = getCommonBank(relevantSamples);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -48,6 +48,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private void load(OsuColour colours)
         {
             Color4 colour = GetRepresentingColour(colours);
+            var additionColours = new[]
+            {
+                colours.Yellow,
+                colours.Blue,
+                colours.Purple,
+            };
 
             AutoSizeAxes = Axes.X;
             Height = 40;
@@ -101,7 +107,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Size = new Vector2(4),
-                    Colour = colour,
+                    Colour = additionColours[i],
                     Y = i * 5,
                 });
             }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         public readonly HitObject HitObject;
 
-        [Resolved(canBeNull: true)]
-        private EditorBeatmap editorBeatmap { get; set; } = null!;
-
         public SamplePointPiece(HitObject hitObject)
         {
             HitObject = hitObject;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private Container volumeBar = null!;
         private OsuSpriteText label = null!;
+        private OsuSpriteText additionLabel = null!;
         private Container additionsContainer = null!;
 
         protected virtual Color4 GetRepresentingColour(OsuColour colours) => colours.Pink;
@@ -78,6 +79,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             RelativeSizeAxes = Axes.Both
                         }
                     }
+                },
+                additionLabel = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Position = new Vector2(6, -12),
+                    Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold),
+                    Colour = colours.GrayF,
+                    Truncate = true,
                 },
                 label = new OsuSpriteText
                 {
@@ -124,8 +134,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             var samples = GetSamples();
             int i = 0;
+            string? bank = abbreviateBank(GetBankValue(samples));
+            string? additionBank = abbreviateBank(GetAdditionBankValue(samples));
 
-            label.Text = $"{abbreviateBank(GetBankValue(samples))}";
+            label.Text = bank ?? string.Empty;
+            additionLabel.Text = additionBank != bank && additionBank is not null ? additionBank : string.Empty;
             volumeBar.ResizeHeightTo(GetVolumeValue(samples) / 100f, 200, Easing.OutQuint);
 
             foreach (string sampleName in HitSampleInfo.AllAdditions)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -82,10 +82,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 label = new OsuSpriteText
                 {
                     Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.CentreLeft,
-                    X = 9,
-                    Rotation = -90,
-                    Width = 28,
+                    Origin = Anchor.BottomLeft,
+                    X = 6,
                     Font = OsuFont.Default.With(size: 12, weight: FontWeight.SemiBold),
                     Colour = colours.GrayF,
                     Truncate = true,
@@ -127,7 +125,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             var samples = GetSamples();
             int i = 0;
 
-            label.Text = $"{GetBankValue(samples)}";
+            label.Text = $"{abbreviateBank(GetBankValue(samples))}";
             volumeBar.ResizeHeightTo(GetVolumeValue(samples) / 100f, 200, Easing.OutQuint);
 
             foreach (string sampleName in HitSampleInfo.AllAdditions)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     {
         private const float timeline_height = 72;
         private const float timeline_expanded_height = 94;
+        private const float timeline_samples_height = 42;
 
         private readonly Drawable userContent;
 
@@ -72,7 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             this.userContent = userContent;
 
             RelativeSizeAxes = Axes.X;
-            Height = timeline_height;
+            Height = timeline_height + timeline_samples_height;
 
             ZoomDuration = 200;
             ZoomEasing = Easing.OutQuint;
@@ -112,6 +113,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = timeline_height,
+                    Margin = new MarginPadding { Bottom = timeline_samples_height },
                     Depth = float.MaxValue,
                     Children = new[]
                     {
@@ -136,6 +138,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         userContent,
                     }
                 },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = timeline_expanded_height + timeline_samples_height,
+                }
             });
 
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
@@ -159,7 +166,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 if (visible.NewValue)
                 {
-                    this.ResizeHeightTo(timeline_expanded_height, 200, Easing.OutQuint);
+                    this.ResizeHeightTo(timeline_expanded_height + timeline_samples_height, 200, Easing.OutQuint);
                     mainContent.MoveToY(20, 200, Easing.OutQuint);
 
                     // delay the fade in else masking looks weird.
@@ -170,7 +177,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     controlPoints.FadeOut(200, Easing.OutQuint);
 
                     // likewise, delay the resize until the fade is complete.
-                    this.Delay(180).ResizeHeightTo(timeline_height, 200, Easing.OutQuint);
+                    this.Delay(180).ResizeHeightTo(timeline_height + timeline_samples_height, 200, Easing.OutQuint);
                     mainContent.Delay(180).MoveToY(0, 200, Easing.OutQuint);
                 }
             }, true);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private const float circle_size = 38;
 
         private Container? repeatsContainer;
+        private Container? nodeSamplesContainer;
 
         public Action<DragEvent?>? OnDragHandled = null!;
 
@@ -49,6 +50,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private readonly Border border;
 
         private readonly Container colouredComponents;
+        private readonly Container sampleComponents;
         private readonly OsuSpriteText comboIndexText;
 
         [Resolved]
@@ -101,10 +103,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         },
                     }
                 },
+                sampleComponents = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
                 new SamplePointPiece(Item)
                 {
                     Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.TopCentre
+                    Origin = Anchor.TopCentre,
+                    X = Item is IHasRepeats ? -10 : 0
                 },
             });
 
@@ -231,6 +238,25 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 repeatsContainer.Add(new Tick
                 {
                     X = (float)(i + 1) / (repeats.RepeatCount + 1)
+                });
+            }
+
+            // Add node sample pieces
+            nodeSamplesContainer?.Expire();
+
+            sampleComponents.Add(nodeSamplesContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+
+            for (int i = 0; i < repeats.RepeatCount + 2; i++)
+            {
+                nodeSamplesContainer.Add(new NodeSamplePointPiece(Item, i)
+                {
+                    X = (float)i / (repeats.RepeatCount + 1),
+                    RelativePositionAxes = Axes.X,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.TopCentre,
                 });
             }
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 new SamplePointPiece(Item)
                 {
                     Anchor = Anchor.BottomLeft,
-                    OriginPosition = Item is IHasRepeats ? new Vector2(11, 0) : new Vector2(2, 0),
+                    OriginPosition = Item is IHasRepeats ? new Vector2(10, 0) : new Vector2(2, 0),
                     Y = 17
                 },
             });
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     Anchor = Anchor.BottomLeft,
                     RelativePositionAxes = Axes.X,
-                    OriginPosition = i == 0 ? new Vector2(-7, 0) : new Vector2(2, 0),
+                    OriginPosition = i == 0 ? new Vector2(-6, 0) : new Vector2(2, 0),
                     X = (float)i / (repeats.RepeatCount + 1),
                     Y = 17,
                 });

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -110,8 +110,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 new SamplePointPiece(Item)
                 {
                     Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.TopCentre,
-                    X = Item is IHasRepeats ? -10 : 0
+                    OriginPosition = Item is IHasRepeats ? new Vector2(11, 0) : new Vector2(2, 0),
+                    Y = 17
                 },
             });
 
@@ -253,10 +253,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 nodeSamplesContainer.Add(new NodeSamplePointPiece(Item, i)
                 {
-                    X = (float)i / (repeats.RepeatCount + 1),
-                    RelativePositionAxes = Axes.X,
                     Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.TopCentre,
+                    RelativePositionAxes = Axes.X,
+                    OriginPosition = i == 0 ? new Vector2(-7, 0) : new Vector2(2, 0),
+                    X = (float)i / (repeats.RepeatCount + 1),
+                    Y = 17,
                 });
             }
         }


### PR DESCRIPTION
Changed `SamplePointPiece` to show more hitsounding information on the timeline in a concise manner. You can now also see which additions are enabled and if there is a different additions bank name.

I'm not certain about my choice of colors, but I at least know that the circles indicating which additions are enabled should have different colors to make it more readable.

Also the timeline is now significantly higher so it might be good to add a toggle for hitsound info visibility on the timeline in the future. I know only about 50% of mappers apply hitsound while mapping.

It's also possible to later add the ability to edit the volume sliders on these right from the timeline, so a mapper could make volume gradients in a single gesture.

Depends on 
- [x] https://github.com/ppy/osu/pull/23443

![image](https://user-images.githubusercontent.com/17460441/236953054-17bf725e-bc6c-4448-b3c7-ef952f7e29a7.png)

