### PR TITLE
Fix default progress graph not updating after flip

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
@@ -63,12 +63,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             public int CreationCount { get; private set; }
 
-            protected override void UpdateGraph()
+            protected override void RecreateGraph()
             {
-                base.UpdateGraph();
-
-                if (ColumnCount > 0)
-                    CreationCount++;
+                base.RecreateGraph();
+                CreationCount++;
             }
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 base.UpdateGraph();
 
-                if (base.ColumnCount > 0)
+                if (ColumnCount > 0)
                     CreationCount++;
             }
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDefaultSongProgressGraph.cs
@@ -63,10 +63,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             public int CreationCount { get; private set; }
 
-            protected override void RecreateGraph()
+            protected override void UpdateGraph()
             {
-                base.RecreateGraph();
-                CreationCount++;
+                base.UpdateGraph();
+
+                if (base.ColumnCount > 0)
+                    CreationCount++;
             }
         }
     }

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -51,7 +51,8 @@ namespace osu.Game.Screens.Play
                 if (value == values) return;
 
                 values = value;
-                graphNeedsUpdate = true;
+                scheduledCreate?.Cancel();
+                scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
             }
         }
 
@@ -70,27 +71,6 @@ namespace osu.Game.Screens.Play
         }
 
         private ScheduledDelegate scheduledCreate;
-
-        private bool graphNeedsUpdate;
-
-        private Vector2 previousDrawSize;
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (graphNeedsUpdate || (values != null && DrawSize != previousDrawSize))
-            {
-                columns?.FadeOut(500, Easing.OutQuint).Expire();
-
-                scheduledCreate?.Cancel();
-                scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
-
-                previousDrawSize = DrawSize;
-                graphNeedsUpdate = false;
-            }
-        }
-
         private CancellationTokenSource cts;
 
         /// <summary>
@@ -98,7 +78,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual void RecreateGraph()
         {
-            var newColumns = new BufferedContainer<Column>(cachedFrameBuffer: true)
+            var newColumns = new BufferedContainer<Column>
             {
                 RedrawOnScale = false,
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -75,18 +75,28 @@ namespace osu.Game.Screens.Play
 
         private Vector2 previousDrawSize;
 
+        private Vector2 previousParentScale;
+
         protected override void Update()
         {
             base.Update();
 
-            if (graphNeedsUpdate || (values != null && DrawSize != previousDrawSize))
+            bool hasFlipped = previousParentScale != Parent.Scale;
+            if (graphNeedsUpdate || (values != null && DrawSize != previousDrawSize) || hasFlipped)
             {
-                columns?.FadeOut(500, Easing.OutQuint).Expire();
-
                 scheduledCreate?.Cancel();
-                scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
+
+                if (!hasFlipped)
+                {
+                    scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
+                }
+                else
+                {
+                    RecreateGraph();
+                }
 
                 previousDrawSize = DrawSize;
+                previousParentScale = Parent.Scale;
                 graphNeedsUpdate = false;
             }
         }

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -90,9 +90,6 @@ namespace osu.Game.Screens.Play
             };
         }
 
-
-        // private Vector2 parentScale;
-
         protected override void Update()
         {
             base.Update();

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -190,27 +190,24 @@ namespace osu.Game.Screens.Play
         /// </summary>
         private void recalculateValues()
         {
-            var newValues = new List<float>();
-
-            if (values == null)
+            int columnCount = ColumnCount;
+            if (values == null || values.Length == 0 || columnCount == 0)
             {
-                for (float i = 0; i < ColumnCount; i++)
-                {
-                    newValues.Add(0);
-                }
-            }
-            else
-            {
-                int max = values.Max();
-                float step = values.Length / (float)ColumnCount;
-
-                for (float i = 0; i < values.Length; i += step)
-                {
-                    newValues.Add((float)values[(int)i] / max);
-                }
+                calculatedValues = new float[0];
+                return;
             }
 
-            calculatedValues = newValues.ToArray();
+            float ratio = values.Length / (float)columnCount;
+
+            if (calculatedValues.Length != columnCount)
+                calculatedValues = new float[columnCount];
+
+            float max = (float)values.Max();
+
+            for (int i = 0; i < calculatedValues.Length; i++)
+            {
+                calculatedValues[i] = values[(int)(i * ratio)] / max;
+            }
         }
 
         public partial class Column : Container, IStateful<ColumnState>

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -140,9 +140,10 @@ namespace osu.Game.Screens.Play
 
             // add missing columns
             float x = ColumnCount * Column.WIDTH;
+
             while (targetColumnCount > ColumnCount)
             {
-                var column = new Column()
+                var column = new Column
                 {
                     Height = DrawHeight,
                     LitColour = fillColour,

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Play
 
         private ScheduledDelegate scheduledCreate;
 
-        private LayoutValue layout = new LayoutValue(Invalidation.DrawSize | Invalidation.DrawInfo);
+        private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize | Invalidation.DrawInfo);
 
         public SquareGraph()
         {

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Screens.Play
             // early exit the most frequent case
             if (!haveValuesChanged && targetColumnCount == ColumnCount)
             {
+                updateColumnHeight();
                 columns.ForceRedraw();
                 return;
             }
@@ -124,6 +125,14 @@ namespace osu.Game.Screens.Play
             haveValuesChanged = false;
         }
 
+        private void updateColumnHeight()
+        {
+            foreach (var column in columns)
+            {
+                column.Height = DrawHeight;
+            }
+        }
+
         private void ensureColumnCount(int targetColumnCount)
         {
             // remove excess columns
@@ -132,11 +141,7 @@ namespace osu.Game.Screens.Play
                 columns.Remove(columns.Children[ColumnCount - 1], true);
             }
 
-            // update height of existing columns
-            foreach (var column in columns)
-            {
-                column.Height = DrawHeight;
-            }
+            updateColumnHeight();
 
             // add missing columns
             float x = ColumnCount * Column.WIDTH;

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using osu.Framework;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -15,7 +14,6 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Allocation;
-using osu.Framework.Threading;
 using osu.Framework.Layout;
 
 namespace osu.Game.Screens.Play
@@ -59,7 +57,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        bool haveValuesChanged;
+        private bool haveValuesChanged;
 
         private Color4 fillColour;
 
@@ -93,7 +91,7 @@ namespace osu.Game.Screens.Play
         protected override void Update()
         {
             base.Update();
-            
+
             if (!layout.IsValid)
             {
                 UpdateGraph();

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -139,18 +139,19 @@ namespace osu.Game.Screens.Play
             if (values == null)
             {
                 for (float i = 0; i < ColumnCount; i++)
+                {
                     newValues.Add(0);
-
-                return;
             }
-
+            }
+            else
+            {
             int max = values.Max();
-
             float step = values.Length / (float)ColumnCount;
 
             for (float i = 0; i < values.Length; i += step)
             {
                 newValues.Add((float)values[(int)i] / max);
+                }
             }
 
             calculatedValues = newValues.ToArray();

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -81,19 +81,30 @@ namespace osu.Game.Screens.Play
         {
             base.Update();
 
-            bool hasFlipped = previousParentScale != Parent.Scale;
-            if (graphNeedsUpdate || (values != null && DrawSize != previousDrawSize) || hasFlipped)
+            bool extraUpdateConditions =
+                DrawSize != previousDrawSize ||
+                previousParentScale != Parent.Scale;
+
+            if (graphNeedsUpdate || (values != null && extraUpdateConditions))
             {
-                scheduledCreate?.Cancel();
+                bool hasFlipped =
+                    previousParentScale.X == -Parent.Scale.X ||
+                    previousParentScale.Y == -Parent.Scale.Y;
 
                 if (!hasFlipped)
                 {
-                    scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
+                    columns?.FadeOut(500, Easing.OutQuint).Expire();
                 }
                 else
                 {
-                    RecreateGraph();
+                    if (columns != null)
+                    {
+                        columns.Alpha = 0.0f;
+                    }
                 }
+
+                scheduledCreate?.Cancel();
+                scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
 
                 previousDrawSize = DrawSize;
                 previousParentScale = Parent.Scale;


### PR DESCRIPTION
Closes #23375 

This is just a dirty hack to make progress update at the right time by checking if parent scale has changed. When flip happens, graph hides immediately in order to not show it positioned incorrectly.

There is just 1 bug where player flips the graph while FadeIn TransformSequence is in progress. If that happens alpha should go back to 0, but i am not sure how TransformSequence can be aborted.

Let me know if this should instead be fixed in some other way.
