### PR TITLE
Fix iOS build workflow failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,23 @@ jobs:
 
   build-only-ios:
     name: Build only (iOS)
-    runs-on: macos-latest
+    # `macos-13` is required, because Xcode 14.3 is required (see below).
+    # TODO: can be changed to `macos-latest` once `macos-13` becomes latest (currently in beta)
+    runs-on: macos-13
     timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      # newest Microsoft.iOS.Sdk versions require Xcode 14.3.
+      # 14.3 is currently not the default Xcode version (https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode),
+      # so set it manually.
+      # TODO: remove when 14.3 becomes the default Xcode version.
+      - name: Set Xcode version
+        shell: bash
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_14.3.app"
+          echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.3.app" >> $GITHUB_ENV
 
       - name: Install .NET 6.0.x
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
A [new version of `Microsoft.iOS.Sdk`](https://www.nuget.org/packages/Microsoft.iOS.Sdk/16.4.7054) was released on 2023-05-09T17:28:41.7300000. This version [requires Xcode 14.3](https://github.com/ppy/osu/actions/runs/4929669561/jobs/8809586651?pr=23434#step:5:36), which is [not currently available](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) on `macos-latest` runners (which currently [alias to `macos-12`](https://github.com/actions/runner-images#available-images)).

To fix, migrate to `macos-13`, which is currently in beta, and explicitly use Xcode 14.3 (because even on the `macos-13` image, [Xcode 14.3 is not yet the default](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode)).

Proof that this helps [here](https://github.com/bdach/osu/actions/runs/4929943430/jobs/8810240626).