### PR TITLE
Update resources and framework

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -11,7 +11,7 @@
     <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.506.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.510.0" />
   </ItemGroup>
   <ItemGroup>
     <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)osu.Android\Properties\AndroidManifestOverlay.xml" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.506.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.510.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.417.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.510.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.417.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.510.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -16,6 +16,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.506.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.510.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- New localisations
- Fix for running on older macOS versions

Intended to go out in release (instead of previously tagged `2023.510.0`).