### PR TITLE
Copy slider velocities to strict tracking sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -98,6 +98,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 ComboOffset = original.ComboOffset;
                 LegacyLastTickOffset = original.LegacyLastTickOffset;
                 TickDistanceMultiplier = original.TickDistanceMultiplier;
+                SliderVelocity = original.SliderVelocity;
             }
 
             protected override void CreateNestedHitObjects(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/23471

The `SliderVelocity` property was introduced to `Slider` in https://github.com/ppy/osu/pull/23308, changing the way slider velocities are applied to sliders. To keep things working as expected, this property needs to be also copied over when creating `StrictTrackingSlider`s.

If you want to test this, you can try the [Stalagmite] difficulty on https://osu.ppy.sh/beatmapsets/1006950#osu/2384193 which is currently broken on master.