### PR TITLE
Fix angle sharpness slider value not always scaling by 0.5

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -164,9 +164,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public partial class AngleSharpnessSlider : SettingsSlider<float>
         {
-        public AngleSharpnessSlider()
+            public AngleSharpnessSlider()
             {
-            KeyboardStep = 0.5f;
+                KeyboardStep = 0.5f;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -22,15 +22,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     /// <summary>
     /// Mod that randomises the positions of the <see cref="HitObject"/>s
     /// </summary>
-
-    public partial class AngleSharpnessSlider : SettingsSlider<float>
-    {
-        public AngleSharpnessSlider()
-        {
-            KeyboardStep = 0.5f;
-        }
-    }
-
     public class OsuModRandom : ModRandom, IApplicableToBeatmap
     {
         public override LocalisableString Description => "It never gets boring!";
@@ -169,6 +160,14 @@ namespace osu.Game.Rulesets.Osu.Mods
                                               positionInfos[i - 1].HitObject.NewCombo;
 
             return previousObjectStartedCombo && random.NextDouble() < 0.6f;
+        }
+
+        public partial class AngleSharpnessSlider : SettingsSlider<float>
+        {
+        public AngleSharpnessSlider()
+            {
+            KeyboardStep = 0.5f;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -161,13 +161,13 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             return previousObjectStartedCombo && random.NextDouble() < 0.6f;
         }
+    }
 
-        public partial class AngleSharpnessSlider : SettingsSlider<float>
+    public partial class AngleSharpnessSlider : SettingsSlider<float>
+    {
+        public AngleSharpnessSlider()
         {
-            public AngleSharpnessSlider()
-            {
-                KeyboardStep = 0.5f;
-            }
+            KeyboardStep = 0.5f;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             MinValue = 1,
             MaxValue = 10,
-            Precision = 0.1f
+            Precision = 0.5f
         };
 
         private static readonly float playfield_diagonal = OsuPlayfield.BASE_SIZE.LengthFast;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -9,7 +9,6 @@ using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Beatmaps;
@@ -28,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModTargetPractice)).ToArray();
 
-        [SettingSource("Angle sharpness", "How sharp angles should be", SettingControlType = typeof(AngleSharpnessSlider))]
+        [SettingSource("Angle sharpness", "How sharp angles should be")]
         public BindableFloat AngleSharpness { get; } = new BindableFloat(7)
         {
             MinValue = 1,
@@ -160,14 +159,6 @@ namespace osu.Game.Rulesets.Osu.Mods
                                               positionInfos[i - 1].HitObject.NewCombo;
 
             return previousObjectStartedCombo && random.NextDouble() < 0.6f;
-        }
-    }
-
-    public partial class AngleSharpnessSlider : SettingsSlider<float>
-    {
-        public AngleSharpnessSlider()
-        {
-            KeyboardStep = 0.5f;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRandom.cs
@@ -22,18 +22,27 @@ namespace osu.Game.Rulesets.Osu.Mods
     /// <summary>
     /// Mod that randomises the positions of the <see cref="HitObject"/>s
     /// </summary>
+
+    public partial class AngleSharpnessSlider : SettingsSlider<float>
+    {
+        public AngleSharpnessSlider()
+        {
+            KeyboardStep = 0.5f;
+        }
+    }
+
     public class OsuModRandom : ModRandom, IApplicableToBeatmap
     {
         public override LocalisableString Description => "It never gets boring!";
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModTargetPractice)).ToArray();
 
-        [SettingSource("Angle sharpness", "How sharp angles should be", SettingControlType = typeof(SettingsSlider<float>))]
+        [SettingSource("Angle sharpness", "How sharp angles should be", SettingControlType = typeof(AngleSharpnessSlider))]
         public BindableFloat AngleSharpness { get; } = new BindableFloat(7)
         {
             MinValue = 1,
             MaxValue = 10,
-            Precision = 0.5f
+            Precision = 0.1f
         };
 
         private static readonly float playfield_diagonal = OsuPlayfield.BASE_SIZE.LengthFast;


### PR DESCRIPTION
Closes [#23202](https://github.com/ppy/osu/issues/23202).


Precision at `0.1f` (before change)

https://github.com/ppy/osu/assets/58949994/c9814a4a-8f7b-49b5-81c7-9ded0f347859

Precision at `0.5f` (after change)

https://github.com/ppy/osu/assets/58949994/92239413-08b9-441b-8b35-4fd9c98dd36d


