### PR TITLE
Fix some tablet settings being hidden when searching using "area" keyword

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -23,6 +25,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public partial class TabletSettings : SettingsSubsection
     {
+        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { "area" });
+
         public TabletAreaSelection AreaSelection { get; private set; }
 
         private readonly ITabletHandler tabletHandler;


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/discussions/23504.