### PR TITLE
Force placement of in-progress object when changing tools in the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -79,5 +79,28 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("no active placement", () => this.ChildrenOfType<ComposeBlueprintContainer>().Single().CurrentPlacement.PlacementActive,
                 () => Is.EqualTo(PlacementBlueprint.PlacementState.Waiting));
         }
+
+        [Test]
+        public void TestCommitPlacementViaToolChange()
+        {
+            Playfield playfield = null!;
+
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddStep("move mouse to top left of playfield", () =>
+            {
+                playfield = this.ChildrenOfType<Playfield>().Single();
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("begin placement", () => InputManager.Click(MouseButton.Left));
+            AddStep("move mouse to bottom right of playfield", () =>
+            {
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+
+            AddStep("change tool to circle", () => InputManager.Key(Key.Number2));
+            AddAssert("slider placed", () => EditorBeatmap.HitObjects.Count, () => Is.EqualTo(1));
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -317,12 +317,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
+        private void commitIfPlacementActive()
+        {
+            CurrentPlacement?.EndPlacement(CurrentPlacement.PlacementActive == PlacementBlueprint.PlacementState.Active);
+            removePlacement();
+        }
+
         private void removePlacement()
         {
-            if (CurrentPlacement == null) return;
-
-            CurrentPlacement.EndPlacement(false);
-            CurrentPlacement.Expire();
+            CurrentPlacement?.EndPlacement(false);
+            CurrentPlacement?.Expire();
             CurrentPlacement = null;
         }
 
@@ -342,7 +346,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 currentTool = value;
 
-                refreshTool();
+                // As per stable editor, when changing tools, we should forcefully commit any pending placement.
+                commitIfPlacementActive();
             }
         }
     }


### PR DESCRIPTION
- [x] Depends on #23507


As mentioned in https://github.com/ppy/osu/discussions/23461#discussion-5184310 (tool change behaviour)