### PR TITLE
Add `VisualSettings` in `GameplayMenuOverlay`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     public partial class TestSceneGameplayMenuOverlay : OsuManualInputManagerTestScene
     {
         private FailOverlay failOverlay;
-        private PauseOverlay pauseOverlay;
+        private TestPauseOverlay pauseOverlay;
 
         private GlobalActionContainer globalActionContainer;
 
@@ -37,7 +37,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             globalActionContainer.Children = new Drawable[]
             {
-                pauseOverlay = new PauseOverlay
+                pauseOverlay = new TestPauseOverlay
                 {
                     OnResume = () => Logger.Log(@"Resume"),
                     OnRetry = () => Logger.Log(@"Retry"),
@@ -287,6 +287,14 @@ namespace osu.Game.Tests.Visual.Gameplay
                 () => pauseOverlay.Buttons.All(button => button.State == SelectionState.NotSelected));
         }
 
+        [Test]
+        public void TestContentFadeoutWhenVisualSettingsHoverd()
+        {
+            showOverlay();
+            AddStep("hover visual settings", () => InputManager.MoveMouseTo(pauseOverlay.VisualSettings));
+            AddUntilStep("content fadeout", () => pauseOverlay.MainContent.IsPresent == false);
+        }
+
         private void showOverlay() => AddStep("Show overlay", () => pauseOverlay.Show());
         private void hideOverlay() => AddStep("Hide overlay", () => pauseOverlay.Hide());
 
@@ -296,6 +304,11 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             globalActionContainer.TriggerPressed(action);
             globalActionContainer.TriggerReleased(action);
+        }
+
+        private partial class TestPauseOverlay : PauseOverlay
+        {
+            public new Container MainContent => base.MainContent;
         }
     }
 }

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -20,6 +20,8 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Overlays;
+using osu.Game.Screens.Play.PlayerSettings;
 using osuTK;
 using osuTK.Graphics;
 
@@ -140,6 +142,18 @@ namespace osu.Game.Screens.Play
                         }
                     }
                 },
+                new Container
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = SettingsToolboxGroup.CONTAINER_WIDTH + 25 * 2,
+                    Padding = new MarginPadding { Vertical = 25, Horizontal = 25 },
+                    Child = new VisualSettings
+                    {
+                        Expanded = { Value = true }
+                    }
+                }
             };
 
             State.ValueChanged += _ => InternalButtons.Deselect();

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Screens.Play
                     Padding = new MarginPadding { Vertical = 25, Horizontal = 25 },
                     Child = VisualSettings = new VisualSettings
                     {
-                        Expanded = { Value = true }
+                        Expanded = { Value = false }
                     }
                 }
             };

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
@@ -62,6 +63,10 @@ namespace osu.Game.Screens.Play
 
         private FillFlowContainer retryCounterContainer;
 
+        private InputManager inputManager = null!;
+        public VisualSettings VisualSettings = null!;
+        protected Container MainContent = null!;
+
         protected GameplayMenuOverlay()
         {
             RelativeSizeAxes = Axes.Both;
@@ -72,74 +77,81 @@ namespace osu.Game.Screens.Play
         {
             Children = new Drawable[]
             {
-                new Box
+                MainContent = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black,
-                    Alpha = background_alpha,
-                },
-                new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 50),
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
                     Children = new Drawable[]
                     {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Black,
+                            Alpha = background_alpha,
+                        },
                         new FillFlowContainer
                         {
-                            Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
                             Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(0, 20),
+                            Spacing = new Vector2(0, 50),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
                             Children = new Drawable[]
                             {
-                                new OsuSpriteText
+                                new FillFlowContainer
                                 {
-                                    Text = Header,
-                                    Font = OsuFont.GetFont(size: 30),
-                                    Spacing = new Vector2(5, 0),
                                     Origin = Anchor.TopCentre,
                                     Anchor = Anchor.TopCentre,
-                                    Colour = colours.Yellow,
-                                    Shadow = true,
-                                    ShadowColour = new Color4(0, 0, 0, 0.25f)
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 20),
+                                    Children = new Drawable[]
+                                    {
+                                        new OsuSpriteText
+                                        {
+                                            Text = Header,
+                                            Font = OsuFont.GetFont(size: 30),
+                                            Spacing = new Vector2(5, 0),
+                                            Origin = Anchor.TopCentre,
+                                            Anchor = Anchor.TopCentre,
+                                            Colour = colours.Yellow,
+                                            Shadow = true,
+                                            ShadowColour = new Color4(0, 0, 0, 0.25f)
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Text = Description,
+                                            Origin = Anchor.TopCentre,
+                                            Anchor = Anchor.TopCentre,
+                                            Shadow = true,
+                                            ShadowColour = new Color4(0, 0, 0, 0.25f)
+                                        }
+                                    }
                                 },
-                                new OsuSpriteText
+                                InternalButtons = new SelectionCycleFillFlowContainer<DialogButton>
                                 {
-                                    Text = Description,
                                     Origin = Anchor.TopCentre,
                                     Anchor = Anchor.TopCentre,
-                                    Shadow = true,
-                                    ShadowColour = new Color4(0, 0, 0, 0.25f)
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Direction = FillDirection.Vertical,
+                                    Masking = true,
+                                    EdgeEffect = new EdgeEffectParameters
+                                    {
+                                        Type = EdgeEffectType.Shadow,
+                                        Colour = Color4.Black.Opacity(0.6f),
+                                        Radius = 50
+                                    },
+                                },
+                                retryCounterContainer = new FillFlowContainer
+                                {
+                                    Origin = Anchor.TopCentre,
+                                    Anchor = Anchor.TopCentre,
+                                    AutoSizeAxes = Axes.Both,
                                 }
                             }
                         },
-                        InternalButtons = new SelectionCycleFillFlowContainer<DialogButton>
-                        {
-                            Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
-                            Masking = true,
-                            EdgeEffect = new EdgeEffectParameters
-                            {
-                                Type = EdgeEffectType.Shadow,
-                                Colour = Color4.Black.Opacity(0.6f),
-                                Radius = 50
-                            },
-                        },
-                        retryCounterContainer = new FillFlowContainer
-                        {
-                            Origin = Anchor.TopCentre,
-                            Anchor = Anchor.TopCentre,
-                            AutoSizeAxes = Axes.Both,
-                        }
                     }
                 },
                 new Container
@@ -149,7 +161,7 @@ namespace osu.Game.Screens.Play
                     RelativeSizeAxes = Axes.Y,
                     Width = SettingsToolboxGroup.CONTAINER_WIDTH + 25 * 2,
                     Padding = new MarginPadding { Vertical = 25, Horizontal = 25 },
-                    Child = new VisualSettings
+                    Child = VisualSettings = new VisualSettings
                     {
                         Expanded = { Value = true }
                     }
@@ -159,6 +171,27 @@ namespace osu.Game.Screens.Play
             State.ValueChanged += _ => InternalButtons.Deselect();
 
             updateRetryCount();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (inputManager.HoveredDrawables.Contains(VisualSettings))
+            {
+                MainContent.FadeOut(100);
+            }
+            else
+            {
+                MainContent.FadeIn(100);
+            }
         }
 
         private int retries;


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/3853

Allows players to modify visual settings when paused or failed.

https://github.com/ppy/osu/assets/34775378/b6fee247-b60b-4604-9f81-0293f3608769


