### PR TITLE
Prevent feedback with display resolution bindable by using atomic `.ReplaceRange()`

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -11,7 +11,7 @@
     <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.513.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.521.0" />
   </ItemGroup>
   <ItemGroup>
     <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)osu.Android\Properties\AndroidManifestOverlay.xml" />

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -193,16 +193,11 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             currentDisplay.BindValueChanged(display => Schedule(() =>
             {
-                resolutions.RemoveRange(1, resolutions.Count - 1);
-
-                if (display.NewValue != null)
-                {
-                    resolutions.AddRange(display.NewValue.DisplayModes
-                                                .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
-                                                .OrderByDescending(m => Math.Max(m.Size.Height, m.Size.Width))
-                                                .Select(m => m.Size)
-                                                .Distinct());
-                }
+                resolutions.ReplaceRange(1, resolutions.Count - 1, display.NewValue.DisplayModes
+                                                                          .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
+                                                                          .OrderByDescending(m => Math.Max(m.Size.Height, m.Size.Width))
+                                                                          .Select(m => m.Size)
+                                                                          .Distinct());
 
                 updateDisplaySettingsVisibility();
             }), true);

--- a/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/LayoutSettings.cs
@@ -193,6 +193,12 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
 
             currentDisplay.BindValueChanged(display => Schedule(() =>
             {
+                if (display.NewValue == null)
+                {
+                    resolutions.Clear();
+                    return;
+                }
+
                 resolutions.ReplaceRange(1, resolutions.Count - 1, display.NewValue.DisplayModes
                                                                           .Where(m => m.Size.Width >= 800 && m.Size.Height >= 600)
                                                                           .OrderByDescending(m => Math.Max(m.Size.Height, m.Size.Width))

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="7.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ppy.LocalisationAnalyser" Version="2022.809.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.513.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.521.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.510.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -16,6 +16,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.513.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.521.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Alternative to / closes #23572

Depends on:
- [x] ppy/osu-framework#5797
- [x] Framework bump

I've checked that the display will never be null.