### PR TITLE
Fix old widescreen videos with black bars not correctly filling screen (again)

### DIFF
--- a/osu.Game.Tests/Resources/storyboard_only_video.osu
+++ b/osu.Game.Tests/Resources/storyboard_only_video.osu
@@ -1,0 +1,31 @@
+osu file format v14
+
+[Events]
+//Background and Video events
+0,0,"BG.jpg",0,0
+Video,0,"video.avi"
+//Break Periods
+//Storyboard Layer 0 (Background)
+//Storyboard Layer 1 (Fail)
+//Storyboard Layer 2 (Pass)
+//Storyboard Layer 3 (Foreground)
+//Storyboard Layer 4 (Overlay)
+//Storyboard Sound Samples
+
+[TimingPoints]
+1674,333.333333333333,4,2,1,70,1,0
+1674,-100,4,2,1,70,0,0
+3340,-100,4,2,1,70,0,0
+3507,-100,4,2,1,70,0,0
+3673,-100,4,2,1,70,0,0
+
+[Colours]
+Combo1 : 240,80,80
+Combo2 : 171,252,203
+Combo3 : 128,128,255
+Combo4 : 249,254,186
+
+[HitObjects]
+148,303,1674,5,6,3:2:0:0:
+378,252,1840,1,0,0:0:0:0:
+389,270,2340,5,2,0:1:0:0:

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -8,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Timing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
@@ -40,6 +42,18 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestStoryboardMissingVideo()
         {
             AddStep("Load storyboard with missing video", () => loadStoryboard("storyboard_no_video.osu"));
+        }
+
+        [Test]
+        public void TestVideoSize()
+        {
+            AddStep("load storyboard with only video", () =>
+            {
+                // LegacyStoryboardDecoder doesn't parse WidescreenStoryboard, so it is set manually
+                loadStoryboard("storyboard_only_video.osu", s => s.BeatmapInfo.WidescreenStoryboard = false);
+            });
+
+            AddAssert("storyboard is correct width", () => Precision.AlmostEquals(storyboard?.Width ?? 0f, 480 * 16 / 9f));
         }
 
         [BackgroundDependencyLoader]
@@ -102,7 +116,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             decoupledClock.ChangeSource(Beatmap.Value.Track);
         }
 
-        private void loadStoryboard(string filename)
+        private void loadStoryboard(string filename, Action<Storyboard>? setUpStoryboard = null)
         {
             Storyboard loaded;
 
@@ -112,6 +126,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                 var decoder = new LegacyStoryboardDecoder();
                 loaded = decoder.Decode(bfr);
             }
+
+            setUpStoryboard?.Invoke(loaded);
 
             loadStoryboard(loaded);
         }

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Storyboards.Drawables
 
             Size = new Vector2(640, 480);
 
-            bool onlyHasVideoElements = Storyboard.Layers.SelectMany(l => l.Elements).Any(e => !(e is StoryboardVideo));
+            bool onlyHasVideoElements = Storyboard.Layers.SelectMany(l => l.Elements).All(e => e is StoryboardVideo);
 
             Width = Height * (storyboard.BeatmapInfo.WidescreenStoryboard || onlyHasVideoElements ? 16 / 9f : 4 / 3f);
 


### PR DESCRIPTION
Regressed in a refactor commit at [`342acad` (#12946)](https://github.com/ppy/osu/pull/12946/commits/342acadae2381c0822c596f5f3c71efcdc9afef5).

Simply putting a `!` makes Rider hint of using `All`, and I think that's better as no negations are good.
![image](https://github.com/ppy/osu/assets/35318437/8f62e144-428a-41a2-a953-8ab205908f7b)
