### PR TITLE
Fix random button hover state sticking when rewinding using right mouse button

### DIFF
--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -93,14 +93,20 @@ namespace osu.Game.Screens.Select
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            updateText(e.ShiftPressed);
+            updateText(e);
             return base.OnKeyDown(e);
         }
 
         protected override void OnKeyUp(KeyUpEvent e)
         {
-            updateText(e.ShiftPressed);
+            updateText(e);
             base.OnKeyUp(e);
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            updateText(e);
+            return base.OnMouseDown(e);
         }
 
         protected override bool OnClick(ClickEvent e)
@@ -126,6 +132,8 @@ namespace osu.Game.Screens.Select
                 rewindSearch = true;
                 TriggerClick();
             }
+
+            updateText(e);
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
@@ -150,10 +158,12 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void updateText(bool rewind = false)
+        private void updateText(UIEvent e)
         {
-            randomSpriteText.Alpha = rewind ? 0 : 1;
-            rewindSpriteText.Alpha = rewind ? 1 : 0;
+            bool aboutToRewind = e.ShiftPressed || e.CurrentState.Mouse.IsPressed(MouseButton.Right);
+
+            randomSpriteText.Alpha = aboutToRewind ? 0 : 1;
+            rewindSpriteText.Alpha = aboutToRewind ? 1 : 0;
         }
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonRandom.cs
+++ b/osu.Game/Screens/Select/FooterButtonRandom.cs
@@ -119,14 +119,13 @@ namespace osu.Game.Screens.Select
 
         protected override void OnMouseUp(MouseUpEvent e)
         {
+            base.OnMouseUp(e);
+
             if (e.Button == MouseButton.Right && IsHovered)
             {
                 rewindSearch = true;
                 TriggerClick();
-                return;
             }
-
-            base.OnMouseUp(e);
         }
 
         public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)


### PR DESCRIPTION
Also improves the temporary "rewind" text display to start showing when right mouse is first pressed, giving the user a better understanding of what is coming.

Closes https://github.com/ppy/osu/issues/23574.

https://github.com/ppy/osu/assets/191335/f7bacedf-492b-4590-b8d8-da3bd783e593

