### PR TITLE
Show text hints on the accuracy heat map to better explain direction

### DIFF
--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Rulesets.Osu.Statistics
         [BackgroundDependencyLoader]
         private void load()
         {
+            const float line_extension = 0.2f;
+
             InternalChild = new Container
             {
                 Anchor = Anchor.Centre,
@@ -97,81 +99,67 @@ namespace osu.Game.Rulesets.Osu.Statistics
                                     RelativeSizeAxes = Axes.Both,
                                     Children = new Drawable[]
                                     {
-                                        new Box
+                                        new Circle
                                         {
                                             Anchor = Anchor.Centre,
                                             Origin = Anchor.Centre,
-                                            EdgeSmoothness = new Vector2(1),
                                             RelativeSizeAxes = Axes.Y,
-                                            Width = line_thickness / 2, // adjust for edgesmoothness
-                                            Height = MathF.Sqrt(2),
+                                            Width = line_thickness,
+                                            Height = inner_portion + line_extension,
                                             Rotation = -rotation * 2,
-                                            Alpha = 0.3f,
+                                            Alpha = 0.6f,
                                         },
-                                        new Box
+                                        new Circle
                                         {
                                             Anchor = Anchor.Centre,
                                             Origin = Anchor.Centre,
-                                            EdgeSmoothness = new Vector2(1),
                                             RelativeSizeAxes = Axes.Y,
-                                            Width = line_thickness / 2, // adjust for edgesmoothness
-                                            Height = MathF.Sqrt(2),
+                                            Width = line_thickness,
+                                            Height = inner_portion + line_extension,
                                         },
                                         new OsuSpriteText
                                         {
-                                            Text = "Next",
+                                            Text = "Overshoot",
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.BottomRight,
+                                            Origin = Anchor.BottomCentre,
                                             Padding = new MarginPadding(3),
                                             RelativePositionAxes = Axes.Both,
-                                            Y = -inner_portion / 2,
+                                            Y = -(inner_portion + line_extension) / 2,
                                         },
                                         new OsuSpriteText
                                         {
-                                            Text = "object",
+                                            Text = "Undershoot",
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.BottomLeft,
+                                            Origin = Anchor.TopCentre,
                                             Padding = new MarginPadding(3),
                                             RelativePositionAxes = Axes.Both,
-                                            Y = -inner_portion / 2,
+                                            Y = (inner_portion + line_extension) / 2,
                                         },
-                                        new OsuSpriteText
+                                        new Circle
                                         {
-                                            Text = "Last",
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.TopRight,
-                                            Padding = new MarginPadding(3),
+                                            Origin = Anchor.TopCentre,
                                             RelativePositionAxes = Axes.Both,
-                                            Y = inner_portion / 2,
+                                            Y = -(inner_portion + line_extension) / 2,
+                                            Margin = new MarginPadding(-line_thickness / 2),
+                                            Width = line_thickness,
+                                            Height = 10,
+                                            Rotation = 45,
                                         },
-                                        new OsuSpriteText
+                                        new Circle
                                         {
-                                            Text = "object",
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.TopLeft,
-                                            Padding = new MarginPadding(3),
+                                            Origin = Anchor.TopCentre,
                                             RelativePositionAxes = Axes.Both,
-                                            Y = inner_portion / 2,
-                                        },
+                                            Y = -(inner_portion + line_extension) / 2,
+                                            Margin = new MarginPadding(-line_thickness / 2),
+                                            Width = line_thickness,
+                                            Height = 10,
+                                            Rotation = -45,
+                                        }
                                     }
                                 },
                             },
-                            new Box
-                            {
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                                Width = 10,
-                                EdgeSmoothness = new Vector2(1),
-                                Height = line_thickness / 2, // adjust for edgesmoothness
-                            },
-                            new Box
-                            {
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                                EdgeSmoothness = new Vector2(1),
-                                Width = line_thickness / 2, // adjust for edgesmoothness
-                                Height = 10,
-                            }
                         }
                     },
                     bufferedGrid = new BufferedContainer(cachedFrameBuffer: true)

--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -36,8 +34,8 @@ namespace osu.Game.Rulesets.Osu.Statistics
 
         private const float rotation = 45;
 
-        private BufferedContainer bufferedGrid;
-        private GridContainer pointGrid;
+        private BufferedContainer bufferedGrid = null!;
+        private GridContainer pointGrid = null!;
 
         private readonly ScoreInfo score;
         private readonly IBeatmap playableBeatmap;

--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Scoring;
 using osuTK;
@@ -64,34 +65,36 @@ namespace osu.Game.Rulesets.Osu.Statistics
                 FillMode = FillMode.Fit,
                 Children = new Drawable[]
                 {
-                    new CircularContainer
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                        Size = new Vector2(inner_portion),
-                        Masking = true,
-                        BorderThickness = line_thickness,
-                        BorderColour = Color4.White,
-                        Child = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = Color4Extensions.FromHex("#202624")
-                        }
-                    },
                     new Container
                     {
                         RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
+                            new CircularContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                RelativeSizeAxes = Axes.Both,
+                                Size = new Vector2(inner_portion),
+                                Masking = true,
+                                BorderThickness = line_thickness,
+                                BorderColour = Color4.White,
+                                Child = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4Extensions.FromHex("#202624")
+                                }
+                            },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Padding = new MarginPadding(1),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Rotation = rotation,
                                 Child = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Masking = true,
                                     Children = new Drawable[]
                                     {
                                         new Box
@@ -100,9 +103,9 @@ namespace osu.Game.Rulesets.Osu.Statistics
                                             Origin = Anchor.Centre,
                                             EdgeSmoothness = new Vector2(1),
                                             RelativeSizeAxes = Axes.Y,
-                                            Height = 2, // We're rotating along a diagonal - we don't really care how big this is.
-                                            Width = line_thickness / 2,
-                                            Rotation = -rotation,
+                                            Width = line_thickness / 2, // adjust for edgesmoothness
+                                            Height = MathF.Sqrt(2),
+                                            Rotation = -rotation * 2,
                                             Alpha = 0.3f,
                                         },
                                         new Box
@@ -111,9 +114,44 @@ namespace osu.Game.Rulesets.Osu.Statistics
                                             Origin = Anchor.Centre,
                                             EdgeSmoothness = new Vector2(1),
                                             RelativeSizeAxes = Axes.Y,
-                                            Height = 2, // We're rotating along a diagonal - we don't really care how big this is.
                                             Width = line_thickness / 2, // adjust for edgesmoothness
-                                            Rotation = rotation
+                                            Height = MathF.Sqrt(2),
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Text = "Next",
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.BottomRight,
+                                            Padding = new MarginPadding(3),
+                                            RelativePositionAxes = Axes.Both,
+                                            Y = -inner_portion / 2,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Text = "object",
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.BottomLeft,
+                                            Padding = new MarginPadding(3),
+                                            RelativePositionAxes = Axes.Both,
+                                            Y = -inner_portion / 2,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Text = "Last",
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.TopRight,
+                                            Padding = new MarginPadding(3),
+                                            RelativePositionAxes = Axes.Both,
+                                            Y = inner_portion / 2,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Text = "object",
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.TopLeft,
+                                            Padding = new MarginPadding(3),
+                                            RelativePositionAxes = Axes.Both,
+                                            Y = inner_portion / 2,
                                         },
                                     }
                                 },


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11579

I've chosen not to use the "overaim" / "underaim" terminology because they aren't great words. Also they don't completely explain that the whole directionality is based on previous and next objects. Open to feedback.

Note that this disabled masking on the display (to better allow aligning everything without too much manual math), which allows points to render outside the circle. I don't think this is a huge deal (it would be cool to display misses like this if we could, but that's not supported in the gameplay / judgement flow yet). Masking could be restored if required.

![osu! 2023-06-02 at 03 01 23](https://github.com/ppy/osu/assets/191335/a01527ec-c496-4069-869d-f1066c34821b)
