### PR TITLE
Ensure scroll-to-top button is displayed above all overlay content

### DIFF
--- a/osu.Game/Overlays/OnlineOverlay.cs
+++ b/osu.Game/Overlays/OnlineOverlay.cs
@@ -77,6 +77,14 @@ namespace osu.Game.Overlays
             base.Content.Add(mainContent);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // Ensure the scroll-to-top button is displayed above the fixed header.
+            AddInternal(ScrollFlow.Button.CreateProxy());
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();

--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Overlays
         /// </summary>
         private const int button_scroll_position = 200;
 
-        protected ScrollBackButton Button;
+        public ScrollBackButton Button { get; private set; }
 
         private readonly Bindable<float?> lastScrollTarget = new Bindable<float?>();
 

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -249,12 +249,14 @@ namespace osu.Game.Overlays
 
         private partial class ProfileSectionsContainer : SectionsContainer<ProfileSection>
         {
+            private OverlayScrollContainer scroll = null!;
+
             public ProfileSectionsContainer()
             {
                 RelativeSizeAxes = Axes.Both;
             }
 
-            protected override UserTrackingScrollContainer CreateScrollContainer() => new OverlayScrollContainer();
+            protected override UserTrackingScrollContainer CreateScrollContainer() => scroll = new OverlayScrollContainer();
 
             // Reverse child ID is required so expanding beatmap panels can appear above sections below them.
             // This can also be done by setting Depth when adding new sections above if using ReverseChildID turns out to have any issues.
@@ -267,6 +269,14 @@ namespace osu.Game.Overlays
                 Padding = new MarginPadding { Horizontal = 10 },
                 Margin = new MarginPadding { Bottom = 10 },
             };
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                // Ensure the scroll-to-top button is displayed above the fixed header.
+                AddInternal(scroll.Button.CreateProxy());
+            }
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23566.

Not going to overthink this one. Can be tested in test scenes using something like this:

```diff
diff --git a/osu.Game/Overlays/Profile/ProfileHeader.cs b/osu.Game/Overlays/Profile/ProfileHeader.cs
index 80d48ae09e..f45a742ce0 100644
--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -5,10 +5,12 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Overlays.Profile.Header;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Resources.Localisation.Web;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Profile
 {
@@ -71,6 +73,12 @@ public ProfileHeader()
                     RelativeSizeAxes = Axes.X,
                     User = { BindTarget = User },
                 },
+                new Box
+                {
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 300,
+                },
             }
         };
 
```