### PR TITLE
Fix timeline blueprint display not showing correct combo number / colour during placement

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
@@ -24,9 +21,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
 
         private bool isPlacingEnd;
 
-        [Resolved(CanBeNull = true)]
-        [CanBeNull]
-        private IBeatSnapProvider beatSnapProvider { get; set; }
+        [Resolved]
+        private IBeatSnapProvider? beatSnapProvider { get; set; }
 
         public SpinnerPlacementBlueprint()
             : base(new Spinner { Position = OsuPlayfield.BASE_SIZE / 2 })

--- a/osu.Game/Beatmaps/BeatmapProcessor.cs
+++ b/osu.Game/Beatmaps/BeatmapProcessor.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Game.Rulesets.Objects.Types;
 
@@ -22,34 +20,17 @@ namespace osu.Game.Beatmaps
 
         public virtual void PreProcess()
         {
-            IHasComboInformation lastObj = null;
-
-            bool isFirst = true;
+            IHasComboInformation? lastObj = null;
 
             foreach (var obj in Beatmap.HitObjects.OfType<IHasComboInformation>())
             {
-                if (isFirst)
+                if (lastObj == null)
                 {
-                    obj.NewCombo = true;
-
                     // first hitobject should always be marked as a new combo for sanity.
-                    isFirst = false;
+                    obj.NewCombo = true;
                 }
 
-                obj.ComboIndex = lastObj?.ComboIndex ?? 0;
-                obj.ComboIndexWithOffsets = lastObj?.ComboIndexWithOffsets ?? 0;
-                obj.IndexInCurrentCombo = (lastObj?.IndexInCurrentCombo + 1) ?? 0;
-
-                if (obj.NewCombo)
-                {
-                    obj.IndexInCurrentCombo = 0;
-                    obj.ComboIndex++;
-                    obj.ComboIndexWithOffsets += obj.ComboOffset + 1;
-
-                    if (lastObj != null)
-                        lastObj.LastInCombo = true;
-                }
-
+                obj.UpdateComboInformation(lastObj);
                 lastObj = obj;
             }
         }

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
@@ -38,16 +36,16 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         public readonly HitObject HitObject;
 
-        [Resolved(canBeNull: true)]
-        protected EditorClock EditorClock { get; private set; }
+        [Resolved]
+        protected EditorClock? EditorClock { get; private set; }
 
         [Resolved]
-        private EditorBeatmap beatmap { get; set; }
+        private EditorBeatmap beatmap { get; set; } = null!;
 
-        private Bindable<double> startTimeBindable;
+        private Bindable<double> startTimeBindable = null!;
 
         [Resolved]
-        private IPlacementHandler placementHandler { get; set; }
+        private IPlacementHandler placementHandler { get; set; } = null!;
 
         /// <summary>
         /// Whether this blueprint is currently in a state that can be committed.

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Rulesets.Edit
 
         private Bindable<double> startTimeBindable = null!;
 
+        private HitObject? getPreviousHitObject() => beatmap.HitObjects.TakeWhile(h => h.StartTime <= startTimeBindable.Value).LastOrDefault();
+
         [Resolved]
         private IPlacementHandler placementHandler { get; set; } = null!;
 
@@ -84,7 +86,7 @@ namespace osu.Game.Rulesets.Edit
         protected void BeginPlacement(bool commitStart = false)
         {
             // Take the hitnormal sample of the last hit object
-            var lastHitNormal = beatmap.HitObjects.LastOrDefault(h => h.GetEndTime() < HitObject.StartTime)?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
+            var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
             if (lastHitNormal != null)
                 HitObject.Samples[0] = lastHitNormal;
 

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -14,6 +14,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
 using osuTK;
@@ -148,7 +149,12 @@ namespace osu.Game.Rulesets.Edit
         public virtual void UpdateTimeAndPosition(SnapResult result)
         {
             if (PlacementActive == PlacementState.Waiting)
+            {
                 HitObject.StartTime = result.Time ?? EditorClock?.CurrentTime ?? Time.Current;
+
+                if (HitObject is IHasComboInformation comboInformation)
+                    comboInformation.UpdateComboInformation(getPreviousHitObject() as IHasComboInformation);
+            }
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Edit
         public readonly HitObject HitObject;
 
         [Resolved]
-        protected EditorClock? EditorClock { get; private set; }
+        protected EditorClock EditorClock { get; private set; } = null!;
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Edit
         {
             if (PlacementActive == PlacementState.Waiting)
             {
-                HitObject.StartTime = result.Time ?? EditorClock?.CurrentTime ?? Time.Current;
+                HitObject.StartTime = result.Time ?? EditorClock.CurrentTime;
 
                 if (HitObject is IHasComboInformation comboInformation)
                     comboInformation.UpdateComboInformation(getPreviousHitObject() as IHasComboInformation);

--- a/osu.Game/Rulesets/Objects/Types/IHasComboInformation.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasComboInformation.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Game.Skinning;
 using osuTK.Graphics;
@@ -64,6 +62,27 @@ namespace osu.Game.Rulesets.Objects.Types
         protected static Color4 GetSkinComboColour(IHasComboInformation combo, ISkin skin, int comboIndex)
         {
             return skin.GetConfig<SkinComboColourLookup, Color4>(new SkinComboColourLookup(comboIndex, combo))?.Value ?? Color4.White;
+        }
+
+        /// <summary>
+        /// Given the previous object in the beatmap, update relevant combo information.
+        /// </summary>
+        /// <param name="lastObj">The previous hitobject, or null if this is the first object in the beatmap.</param>
+        void UpdateComboInformation(IHasComboInformation? lastObj)
+        {
+            ComboIndex = lastObj?.ComboIndex ?? 0;
+            ComboIndexWithOffsets = lastObj?.ComboIndexWithOffsets ?? 0;
+            IndexInCurrentCombo = (lastObj?.IndexInCurrentCombo + 1) ?? 0;
+
+            if (NewCombo || lastObj == null)
+            {
+                IndexInCurrentCombo = 0;
+                ComboIndex++;
+                ComboIndexWithOffsets += ComboOffset + 1;
+
+                if (lastObj != null)
+                    lastObj.LastInCombo = true;
+            }
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 placementBlueprint = CreateBlueprintFor(obj.NewValue).AsNonNull();
 
-                placementBlueprint.Colour = Color4.MediumPurple;
+                placementBlueprint.Colour = OsuColour.Gray(0.9f);
 
                 SelectionBlueprints.Add(placementBlueprint);
             }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 placementBlueprint.Colour = OsuColour.Gray(0.9f);
 
+                // TODO: this is out of order, causing incorrect stacking height.
                 SelectionBlueprints.Add(placementBlueprint);
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23533.

| before | after |
| -- | -- |
|![osu Game Tests 2023-05-17 at 08 50 29](https://github.com/ppy/osu/assets/191335/5761c55e-131a-4939-b0e8-7df15cc6f872)|![osu Game Tests 2023-05-17 at 08 54 31](https://github.com/ppy/osu/assets/191335/d9d198e2-90e6-41d6-a112-c150323a46b7)| 

https://github.com/ppy/osu/assets/191335/5b376c4e-ab77-40e3-8f3f-256abb3bfa6e

Of note, in stable the way the editor behaves is slightly differently. The placement object is inserted into the beatmap before being placed, causing future objects to update their combo index, colour, etc.

I'm not ready to commit to that same behaviour (it will probably be a bit more complicated to manage anyway), but will deal with feedback on this in the future.
