### PR TITLE
Pin builds to .NET 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestFeature"
+  }
+}
+


### PR DESCRIPTION
As more things move to having the 7 SDK installed, let's pin for now.

This helps with mobile build scenarios, which fall over on the new SDKs and require further attention.

(this was triggered as a prereq of moving the lazer build + deploy to github actions, currently failing on android and iOS)