### PR TITLE
Fix clicking area of news sidebar post links

### DIFF
--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Platform;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -39,12 +38,12 @@ namespace osu.Game.Overlays.News
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, GameHost host)
+        private void load(OverlayColourProvider colourProvider, OsuGame? game)
         {
             if (post.Slug != null)
             {
                 TooltipText = "view in browser";
-                Action = () => host.OpenUrlExternally("https://osu.ppy.sh/home/news/" + post.Slug);
+                Action = () => game?.OpenUrlExternally(@"/home/news/" + post.Slug);
             }
 
             AddRange(new Drawable[]

--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
@@ -27,8 +25,8 @@ namespace osu.Game.Overlays.News
 
         private readonly APINewsPost post;
 
-        private Box background;
-        private TextFlowContainer main;
+        private Box background = null!;
+        private TextFlowContainer main = null!;
 
         public NewsCard(APINewsPost post)
         {

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -20,7 +20,7 @@ using System.Diagnostics;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.LocalisationExtensions;
-using osu.Framework.Platform;
+using osu.Game.Online.Chat;
 
 namespace osu.Game.Overlays.News.Sidebar
 {
@@ -123,35 +123,14 @@ namespace osu.Game.Overlays.News.Sidebar
             }
         }
 
-        private partial class PostButton : OsuHoverContainer
+        private partial class PostButton : LinkFlowContainer
         {
-            protected override IEnumerable<Drawable> EffectTargets => new[] { text };
-
-            private readonly TextFlowContainer text;
-            private readonly APINewsPost post;
-
             public PostButton(APINewsPost post)
+                : base(t => t.Font = OsuFont.GetFont(size: 12))
             {
-                this.post = post;
-
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
-                Child = text = new TextFlowContainer(t => t.Font = OsuFont.GetFont(size: 12))
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Text = post.Title
-                };
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider overlayColours, GameHost host)
-            {
-                IdleColour = overlayColours.Light2;
-                HoverColour = overlayColours.Light1;
-
-                TooltipText = "view in browser";
-                Action = () => host.OpenUrlExternally("https://osu.ppy.sh/home/news/" + post.Slug);
+                AddLink(post.Title, LinkAction.External, "https://osu.ppy.sh/home/news/" + post.Slug, "view in browser");
             }
         }
 

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Overlays.News.Sidebar
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
-                AddLink(post.Title, LinkAction.External, "https://osu.ppy.sh/home/news/" + post.Slug, "view in browser");
+                AddLink(post.Title, LinkAction.External, @"/home/news/" + post.Slug, "view in browser");
             }
         }
 

--- a/osu.Game/Overlays/News/Sidebar/MonthSection.cs
+++ b/osu.Game/Overlays/News/Sidebar/MonthSection.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Overlays.News.Sidebar
                     new PostsContainer
                     {
                         Expanded = { BindTarget = Expanded },
-                        Children = posts.Select(p => new PostButton(p)).ToArray()
+                        Children = posts.Select(p => new PostLink(p)).ToArray()
                     }
                 }
             };
@@ -123,9 +123,9 @@ namespace osu.Game.Overlays.News.Sidebar
             }
         }
 
-        private partial class PostButton : LinkFlowContainer
+        private partial class PostLink : LinkFlowContainer
         {
-            public PostButton(APINewsPost post)
+            public PostLink(APINewsPost post)
                 : base(t => t.Font = OsuFont.GetFont(size: 12))
             {
                 RelativeSizeAxes = Axes.X;


### PR DESCRIPTION
Side effect is that the hover color is yellow and pressing it opens an external dialog, but those are temporary (pending implementation of link underline to make `Light1` hover more readable and set at a higher level and news pages).

| Before | After | Web |
| --- | --- | --- |
| ![osu!_kFzrceitNM](https://github.com/ppy/osu/assets/35318437/3f28e1cd-0e95-4d22-b12f-1f956debcfb5) | ![iHWDkVoOyu](https://github.com/ppy/osu/assets/35318437/0939ea5d-fe2e-4fcf-b8ca-8fb023ba2e87) | ![6HAiowPjgU](https://github.com/ppy/osu/assets/35318437/e3093d4a-4671-463f-b1e4-98bcf56621b7) |