### PR TITLE
Fix hitsounds not playing before and during taiko drum rolls and swells

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -110,6 +110,35 @@ namespace osu.Game.Rulesets.Taiko.Tests
         }
 
         [Test]
+        public void TestDrumStrongHit()
+        {
+            AddStep("add strong hit with drum samples", () =>
+            {
+                var hit = new Hit
+                {
+                    StartTime = 100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum"),
+                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, "drum") // implies strong
+                    }
+                };
+                hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableHit = new DrawableHit(hit);
+                hitObjectContainer.Add(drawableHit);
+            });
+
+            AddAssert("most valid object is strong nested hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit.StrongNestedHit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+
+            AddStep("seek past hit", () => manualClock.CurrentTime = 200);
+            AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+        }
+
+        [Test]
         public void TestNormalDrumRoll()
         {
             AddStep("add drum roll with normal samples", () =>
@@ -178,6 +207,41 @@ namespace osu.Game.Rulesets.Taiko.Tests
         }
 
         [Test]
+        public void TestDrumStrongDrumRoll()
+        {
+            AddStep("add strong drum roll with drum samples", () =>
+            {
+                var drumRoll = new DrumRoll
+                {
+                    StartTime = 100,
+                    EndTime = 1100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum"),
+                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, "drum") // implies strong
+                    }
+                };
+                drumRoll.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableDrumRoll = new DrawableDrumRoll(drumRoll);
+                hitObjectContainer.Add(drawableDrumRoll);
+            });
+
+            AddAssert("most valid object is drum roll tick's nested strong hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick.StrongNestedHit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+
+            AddStep("seek to middle of drum roll", () => manualClock.CurrentTime = 600);
+            AddAssert("most valid object is drum roll tick's nested strong hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick.StrongNestedHit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+
+            AddStep("seek past drum roll", () => manualClock.CurrentTime = 1200);
+            AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+        }
+
+        [Test]
         public void TestNormalSwell()
         {
             AddStep("add swell with normal samples", () =>
@@ -216,7 +280,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             AddStep("add swell with drum samples", () =>
             {
-                var swell = new Swell()
+                var swell = new Swell
                 {
                     StartTime = 100,
                     EndTime = 1100,

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -1,0 +1,273 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public partial class TestSceneDrumSampleTriggerSource : OsuTestScene
+    {
+        private readonly ManualClock manualClock = new ManualClock();
+
+        [Cached(typeof(IScrollingInfo))]
+        private ScrollingTestContainer.TestScrollingInfo info = new ScrollingTestContainer.TestScrollingInfo
+        {
+            Direction = { Value = ScrollingDirection.Left },
+            TimeRange = { Value = 200 },
+        };
+
+        private ScrollingHitObjectContainer hitObjectContainer = null!;
+        private TestDrumSampleTriggerSource triggerSource = null!;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            hitObjectContainer = new ScrollingHitObjectContainer();
+            manualClock.CurrentTime = 0;
+
+            Child = new Container
+            {
+                Clock = new FramedClock(manualClock),
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    hitObjectContainer,
+                    triggerSource = new TestDrumSampleTriggerSource(hitObjectContainer)
+                }
+            };
+        });
+
+        [Test]
+        public void TestNormalHit()
+        {
+            AddStep("add hit with normal samples", () =>
+            {
+                var hit = new Hit
+                {
+                    StartTime = 100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
+                    }
+                };
+                hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableHit = new DrawableHit(hit);
+                hitObjectContainer.Add(drawableHit);
+            });
+
+            AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+
+            AddStep("seek past hit", () => manualClock.CurrentTime = 200);
+            AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+        }
+
+        [Test]
+        public void TestSoftHit()
+        {
+            AddStep("add hit with soft samples", () =>
+            {
+                var hit = new Hit
+                {
+                    StartTime = 100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "soft")
+                    }
+                };
+                hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableHit = new DrawableHit(hit);
+                hitObjectContainer.Add(drawableHit);
+            });
+
+            AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "soft");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "soft");
+
+            AddStep("seek past hit", () => manualClock.CurrentTime = 200);
+            AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "soft");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "soft");
+        }
+
+        [Test]
+        public void TestNormalDrumRoll()
+        {
+            AddStep("add drum roll with normal samples", () =>
+            {
+                var drumRoll = new DrumRoll
+                {
+                    StartTime = 100,
+                    EndTime = 1100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
+                    }
+                };
+                drumRoll.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableDrumRoll = new DrawableDrumRoll(drumRoll);
+                hitObjectContainer.Add(drawableDrumRoll);
+            });
+
+            AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+
+            AddStep("seek to middle of drum roll", () => manualClock.CurrentTime = 600);
+            AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+
+            AddStep("seek past drum roll", () => manualClock.CurrentTime = 1200);
+            AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+        }
+
+        [Test]
+        public void TestSoftDrumRoll()
+        {
+            AddStep("add drum roll with soft samples", () =>
+            {
+                var drumRoll = new DrumRoll
+                {
+                    StartTime = 100,
+                    EndTime = 1100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "soft")
+                    }
+                };
+                drumRoll.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableDrumRoll = new DrawableDrumRoll(drumRoll);
+                hitObjectContainer.Add(drawableDrumRoll);
+            });
+
+            AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "soft");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "soft");
+
+            AddStep("seek to middle of drum roll", () => manualClock.CurrentTime = 600);
+            AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "soft");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "soft");
+
+            AddStep("seek past drum roll", () => manualClock.CurrentTime = 1200);
+            AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "soft");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "soft");
+        }
+
+        [Test]
+        public void TestNormalSwell()
+        {
+            AddStep("add swell with normal samples", () =>
+            {
+                var swell = new Swell
+                {
+                    StartTime = 100,
+                    EndTime = 1100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
+                    }
+                };
+                swell.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableSwell = new DrawableSwell(swell);
+                hitObjectContainer.Add(drawableSwell);
+            });
+
+            AddAssert("most valid object is swell tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<SwellTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+
+            AddStep("seek to middle of swell", () => manualClock.CurrentTime = 600);
+            AddAssert("most valid object is swell tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<SwellTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+
+            AddStep("seek past swell", () => manualClock.CurrentTime = 1200);
+            AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+        }
+
+        [Test]
+        public void TestDrumSwell()
+        {
+            AddStep("add swell with drum samples", () =>
+            {
+                var swell = new Swell()
+                {
+                    StartTime = 100,
+                    EndTime = 1100,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum")
+                    }
+                };
+                swell.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+                var drawableSwell = new DrawableSwell(swell);
+                hitObjectContainer.Add(drawableSwell);
+            });
+
+            AddAssert("most valid object is swell tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<SwellTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+
+            AddStep("seek to middle of swell", () => manualClock.CurrentTime = 600);
+            AddAssert("most valid object is swell tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<SwellTick>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+
+            AddStep("seek past swell", () => manualClock.CurrentTime = 1200);
+            AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
+            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
+            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+        }
+
+        private void checkSound(HitType hitType, string expectedName, string expectedBank)
+        {
+            AddStep($"hit {hitType}", () => triggerSource.Play(hitType));
+            AddAssert($"last played sample is {expectedName}", () => triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().Single().Name, () => Is.EqualTo(expectedName));
+            AddAssert($"last played sample has {expectedBank} bank", () => triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().Single().Bank, () => Is.EqualTo(expectedBank));
+        }
+
+        private partial class TestDrumSampleTriggerSource : DrumSampleTriggerSource
+        {
+            public ISampleInfo[]? LastPlayedSamples { get; private set; }
+
+            public TestDrumSampleTriggerSource(HitObjectContainer hitObjectContainer)
+                : base(hitObjectContainer)
+            {
+            }
+
+            protected override void PlaySamples(ISampleInfo[] samples)
+            {
+                base.PlaySamples(samples);
+                LastPlayedSamples = samples;
+            }
+
+            public new HitObject GetMostValidObject() => base.GetMostValidObject();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -118,6 +118,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             public override bool RemoveWhenNotAlive => false;
         }
+
+        // Most osu!taiko hitsounds are managed by the drum (see DrumSampleTriggerSource).
+        public override IEnumerable<HitSampleInfo> GetSamples() => Enumerable.Empty<HitSampleInfo>();
     }
 
     public abstract partial class DrawableTaikoHitObject<TObject> : DrawableTaikoHitObject
@@ -156,9 +159,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             Content.Add(MainPiece = CreateMainPiece());
         }
-
-        // Most osu!taiko hitsounds are managed by the drum (see DrumSampleMapping).
-        public override IEnumerable<HitSampleInfo> GetSamples() => Enumerable.Empty<HitSampleInfo>();
 
         protected abstract SkinnableDrawable CreateMainPiece();
     }

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -107,7 +107,11 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
 
-        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit { StartTime = startTime };
+        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit
+        {
+            StartTime = startTime,
+            Samples = Samples
+        };
 
         public class StrongNestedHit : StrongNestedHitObject
         {

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -3,11 +3,9 @@
 
 #nullable disable
 
-using System.Linq;
 using osu.Game.Rulesets.Objects.Types;
 using System.Threading;
 using osu.Framework.Bindables;
-using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -98,7 +96,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
                     TickSpacing = tickSpacing,
                     StartTime = t,
                     IsStrong = IsStrong,
-                    Samples = Samples.Where(s => s.Name == HitSampleInfo.HIT_FINISH).ToList()
+                    Samples = Samples
                 });
 
                 first = false;

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRollTick.cs
@@ -33,7 +33,11 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
         public override double MaximumJudgementOffset => HitWindow;
 
-        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit { StartTime = startTime };
+        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit
+        {
+            StartTime = startTime,
+            Samples = Samples
+        };
 
         public class StrongNestedHit : StrongNestedHitObject
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -72,7 +72,11 @@ namespace osu.Game.Rulesets.Taiko.Objects
             }
         }
 
-        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit { StartTime = startTime };
+        protected override StrongNestedHitObject CreateStrongNestedHit(double startTime) => new StrongNestedHit
+        {
+            StartTime = startTime,
+            Samples = Samples
+        };
 
         public class StrongNestedHit : StrongNestedHitObject
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Swell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Swell.cs
@@ -33,7 +33,10 @@ namespace osu.Game.Rulesets.Taiko.Objects
             for (int i = 0; i < RequiredHits; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                AddNested(new SwellTick());
+                AddNested(new SwellTick
+                {
+                    Samples = Samples
+                });
             }
         }
 

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.UI
             PlaySamples(samples);
         }
 
-        protected void PlaySamples(ISampleInfo[] samples) => Schedule(() =>
+        protected virtual void PlaySamples(ISampleInfo[] samples) => Schedule(() =>
         {
             var hitSound = getNextSample();
             hitSound.Samples = samples;


### PR DESCRIPTION
Closes #23565.

## 6d325651dcca275091d51bbfbad3e59fa4ce4dc8: Propagate samples to drum roll/swell ticks for correct playback

In https://github.com/ppy/osu/commit/d97daee96be2c10f90709cc30beceb1f369ae225, `DrumSampleTriggerSource` was changed such that in order to play sounds for the user's inputs, the bank of the normal sound would always be used.

The problem is that in the case of taiko objects which have nested objects (swells and drum rolls), the samples were not propagated fully (drum rolls, where only the finish sample was kept, for the purposes of determining strongability), or not propagated at all (swells) to ticks.

As ticks of both objects are valid return values of `GetMostValidHitObject()`, this would lead to the drum making no sounds if the next object was a drum roll or swell, until that drum roll or swell was completed. To fix, propagate the full set of samples, so that `DrumSampleTriggerSource` can retrieve the normal sound to copy the bank from.

Note that this may not necessarily reproduce prior behaviour. This is because it is not guaranteed that all realised samples for a given hitobject have the same bank - some may have been overriden locally on a given hitobject. Previously, the bank would have been retrieved from the sample control point, wherein there is only one possible bank to use; however, when deciding the sound to play on the basis of a constructed hitobject, it is possible that there are cases wherein the hitnormal sample was overridden on that given hitobject, and in such cases, this PR would make samples _play_, but not necessarily the _same_ samples as prior to https://github.com/ppy/osu/pull/23308.

If that turns out to be the case, this will have to be revisited.

## 4a7b011a53773d547b60401f609d7e394482a3ab: Propagate samples to strong nested hits too

The rationale is the same as in https://github.com/ppy/osu/commit/6d325651dcca275091d51bbfbad3e59fa4ce4dc8. Due to the recursive nature of `GameplaySampleTriggerSource.GetMostValidObject()`, in the case of strong hits, drum rolls and drum roll ticks, the nested strong hits would become the most valid object, and so without propagating the samples down to that level too, nothing would play.

## 9915fac2c825a5b06555bf440f61748b10cccd06: Fix sample silence being one level too low

https://github.com/ppy/osu/commit/4a7b011a53773d547b60401f609d7e394482a3ab inadvertently unearthed that nested strong hits could play samples of their own accord, rather than delegating to `DrumSampleTriggerSource` as they were supposed to. This was an unfortunate omission due to how the inheritance structure of `TaikoHitObject` looks like (some irrelevant classes omitted for brevity):

	DrawableTaikoHitObject
		DrawableTaikoHitObject<TObject> <-- `GetSamples()` was overridden to empty here
			DrawableTaikoStrongableHitObject
				DrawableHit
				DrawableDrumRoll
				DrawableDrumRollTick
			DrawableSwell
			DrawableSwellTick
		DrawableStrongNestedHit <-- all strong nested hits are here => didn't receive `GetSamples()` override
			DrawableHit.StrongNestedHit
			DrawableDrumRoll.StrongNestedHit
			DrawableDrumRollTick.StrongNestedHit

To fix, move the `GetSamples()` override one level higher, to the non-generic `DrawableTaikoHitObject`, to suppress the spurious sample playbacks.

The stale reference in the comment was also updated to match current code.