### PR TITLE
Prevent users from setting tablet area offset to Vector2.Zero

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         protected override void OnDrag(DragEvent e)
         {
             var newPos = Position + e.Delta;
-            this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero, Parent.Size));
+            this.MoveTo(Vector2.Clamp(newPos, Vector2.One * 0.5f, Parent.Size));
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly Bindable<Vector2> areaSize = new Bindable<Vector2>();
         private readonly IBindable<TabletInfo> tablet = new Bindable<TabletInfo>();
 
-        private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0 };
-        private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0 };
+        private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0.5f };
+        private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0.5f };
 
         private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10 };
         private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10 };


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/issues/23415

Reading my latest comment on the bug report should give a good idea of what's going on. However the resetting behavior occurs from the framework itself, as an initialization method
The following code excerpt comes from osu-framework, OpenTabletDriverHandler.cs, lines 163 to 166
```
            // likewise with the position, use the centre point if it has not been configured.
            // it's safe to assume no user would set their centre point to 0,0 for now.
            if (AreaOffset.Value == Vector2.Zero)
                AreaOffset.SetDefault();
```
While its true that probably no user would set their centre point to `0,0`, the game currently allows an easy way to do so by dragging the offset sliders all the way to the left, or dragging the tablet area box to the top left of the visual. 
Because of this it resets back to the centre, and if done while dragging, it enters some sort of bindable feedback loop.

Therefore my proposed solution adds a minimum of `0.5f` for both user interactions.  I chose this number as it has already been used as a leniency factor for `checkBounds()`
The slider tooltips still display the min value as 0, so it won't look off to the user.

https://github.com/ppy/osu/assets/35996393/3067e27e-c628-43d7-a044-813db130ccb0
