### PR TITLE
Fix undo/redo not working for slider velocity and sample changes

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -93,6 +93,20 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestUndo()
+        {
+            clickDifficultyPiece(1);
+            velocityPopoverHasSingleValue(2);
+
+            setVelocityViaPopover(5);
+            hitObjectHasVelocity(1, 5);
+            dismissPopover();
+
+            AddStep("undo", () => Editor.Undo());
+            hitObjectHasVelocity(1, 2);
+        }
+
+        [Test]
         public void TestMultipleSelectionWithSameSliderVelocity()
         {
             AddStep("unify slider velocity", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -110,6 +110,21 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestUndo()
+        {
+            clickSamplePiece(1);
+            samplePopoverHasSingleBank("soft");
+            samplePopoverHasSingleVolume(60);
+
+            setVolumeViaPopover(90);
+            hitObjectHasSampleVolume(1, 90);
+            dismissPopover();
+
+            AddStep("undo", () => Editor.Undo());
+            hitObjectHasSampleVolume(1, 60);
+        }
+
+        [Test]
         public void TestMultipleSelectionWithSameSampleVolume()
         {
             AddStep("unify sample volume", () =>

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -15,7 +15,9 @@ using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Beatmaps.Legacy;
 using osu.Game.IO;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
 using Decoder = osu.Game.Beatmaps.Formats.Decoder;
 
@@ -42,6 +44,7 @@ namespace osu.Game.Screens.Edit
             editorBeatmap.BeginChange();
             processHitObjects(result, () => newBeatmap ??= readBeatmap(newState));
             processTimingPoints(() => newBeatmap ??= readBeatmap(newState));
+            processSliderVelocity(() => newBeatmap ??= readBeatmap(newState));
             editorBeatmap.EndChange();
         }
 
@@ -68,6 +71,17 @@ namespace osu.Game.Screens.Edit
                     foreach (var point in newGroup.ControlPoints)
                         editorBeatmap.ControlPointInfo.Add(newGroup.Time, point);
                 }
+            }
+        }
+
+        private void processSliderVelocity(Func<IBeatmap> getNewBeatmap)
+        {
+            var legacyControlPoints = (LegacyControlPointInfo)getNewBeatmap().ControlPointInfo;
+
+            foreach (var hitObject in editorBeatmap.HitObjects.Where(ho => ho is IHasSliderVelocity))
+            {
+                var difficultyPoint = legacyControlPoints.DifficultyPointAt(hitObject.StartTime);
+                ((IHasSliderVelocity)hitObject).SliderVelocity = difficultyPoint.SliderVelocity;
             }
         }
 

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -108,6 +108,11 @@ namespace osu.Game.Screens.Edit
 
             foreach (var (oldObject, newObject) in oldObjects.Zip(newObjects))
             {
+                // if `oldObject` and `newObject` are the same, it means that `oldObject` was inserted into `editorBeatmap` by `processHitObjects()`.
+                // in that case, there is nothing to do (and some of the subsequent changes may even prove destructive).
+                if (ReferenceEquals(oldObject, newObject))
+                    continue;
+
                 if (oldObject is IHasSliderVelocity oldWithVelocity && newObject is IHasSliderVelocity newWithVelocity)
                     oldWithVelocity.SliderVelocity = newWithVelocity.SliderVelocity;
 


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/23598.

The reason undo/redo is failing is that after sample/difficulty control points were moved out of `ControlPointInfo` into the hitobjects, nothing in the beatmap patcher was handling those changes anymore - `processHitObjects()` didn't because no object was technically added or removed with such changes, and `processTimingPoints()` didn't because it [discards legacy control points](https://github.com/ppy/osu/blob/7742904d2a49f0f68f59c1121692e710d90a47ec/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs#L50) - which both types that are relevant to this issue are.

Solution is admittedly a little _ad hoc_ but I don't really have many better ideas on how to fix this one.

Tested rather lightly. Tread with caution.