### PR TITLE
Disallow game to check for updates while gameplay is active

### DIFF
--- a/osu.Desktop/Updater/SquirrelUpdateManager.cs
+++ b/osu.Desktop/Updater/SquirrelUpdateManager.cs
@@ -9,6 +9,7 @@ using osu.Framework.Logging;
 using osu.Game;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Screens.Play;
 using Squirrel;
 using Squirrel.SimpleSplat;
 using LogLevel = Squirrel.SimpleSplat.LogLevel;
@@ -36,6 +37,9 @@ namespace osu.Desktop.Updater
         [Resolved]
         private OsuGameBase game { get; set; } = null!;
 
+        [Resolved]
+        private ILocalUserPlayInfo? localUserInfo { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(INotificationOverlay notifications)
         {
@@ -55,6 +59,10 @@ namespace osu.Desktop.Updater
 
             try
             {
+                // Avoid any kind of update checking while gameplay is running.
+                if (localUserInfo?.IsPlaying.Value == true)
+                    return false;
+
                 updateManager ??= new GithubUpdateManager(@"https://github.com/ppy/osu", false, github_token, @"osulazer");
 
                 var info = await updateManager.CheckForUpdate(!useDeltaPatching).ConfigureAwait(false);


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/discussions/23624.

Should probably be done at a higher level, see https://github.com/ppy/osu/issues/23635. For another day as per-platform updaters are definitely not in a final state.