### PR TITLE
Remove `OsuScreen.ApplyLogoArrivingDefaults()`

### DIFF
--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -233,7 +233,13 @@ namespace osu.Game.Screens
         /// </summary>
         protected virtual void LogoArriving(OsuLogo logo, bool resuming)
         {
-            ApplyLogoArrivingDefaults(logo);
+            logo.Action = null;
+            logo.FadeOut(300, Easing.OutQuint);
+            logo.Anchor = Anchor.TopLeft;
+            logo.Origin = Anchor.Centre;
+            logo.RelativePositionAxes = Axes.Both;
+            logo.Triangles = true;
+            logo.Ripple = true;
         }
 
         private void applyArrivingDefaults(bool isResuming)
@@ -242,22 +248,6 @@ namespace osu.Game.Screens
             {
                 if (this.IsCurrentScreen()) LogoArriving(logo, isResuming);
             }, true);
-        }
-
-        /// <summary>
-        /// Applies default animations to an arriving logo.
-        /// Todo: This should not exist.
-        /// </summary>
-        /// <param name="logo">The logo to apply animations to.</param>
-        public static void ApplyLogoArrivingDefaults(OsuLogo logo)
-        {
-            logo.Action = null;
-            logo.FadeOut(300, Easing.OutQuint);
-            logo.Anchor = Anchor.TopLeft;
-            logo.Origin = Anchor.Centre;
-            logo.RelativePositionAxes = Axes.Both;
-            logo.Triangles = true;
-            logo.Ripple = true;
         }
 
         private void onExitingLogo()


### PR DESCRIPTION
Resolves the todo in the method. It was added as a workaround in https://github.com/ppy/osu/commit/117703374e0620bde7ed6e1000e0a629cc727863, and the usage was only removed in https://github.com/ppy/osu/commit/d5cce850a8bd035f376912c72ec384ec6e8bd79b.