### PR TITLE
Remove flavour text from the pause / fail screens

### DIFF
--- a/osu.Game/Screens/Play/FailOverlay.cs
+++ b/osu.Game/Screens/Play/FailOverlay.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Screens.Play
         public Func<Task<ScoreInfo>> SaveReplay;
 
         public override string Header => "failed";
-        public override string Description => "you're dead, try again?";
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -20,6 +17,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -38,8 +36,8 @@ namespace osu.Game.Screens.Play
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
-        public Action OnRetry;
-        public Action OnQuit;
+        public Action? OnRetry;
+        public Action? OnQuit;
 
         /// <summary>
         /// Action that is invoked when <see cref="GlobalAction.Back"/> is triggered.
@@ -53,10 +51,13 @@ namespace osu.Game.Screens.Play
 
         public abstract string Header { get; }
 
-        protected SelectionCycleFillFlowContainer<DialogButton> InternalButtons;
+        protected SelectionCycleFillFlowContainer<DialogButton> InternalButtons = null!;
         public IReadOnlyList<DialogButton> Buttons => InternalButtons;
 
-        private FillFlowContainer retryCounterContainer;
+        private TextFlowContainer playInfoText = null!;
+
+        [Resolved]
+        private GlobalActionContainer globalAction { get; set; } = null!;
 
         protected GameplayMenuOverlay()
         {
@@ -84,28 +85,13 @@ namespace osu.Game.Screens.Play
                     Anchor = Anchor.Centre,
                     Children = new Drawable[]
                     {
-                        new FillFlowContainer
+                        new OsuSpriteText
                         {
+                            Text = Header,
+                            Font = OsuFont.GetFont(size: 48),
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Direction = FillDirection.Vertical,
-                            Spacing = new Vector2(0, 20),
-                            Children = new Drawable[]
-                            {
-                                new OsuSpriteText
-                                {
-                                    Text = Header,
-                                    Font = OsuFont.GetFont(size: 30),
-                                    Spacing = new Vector2(5, 0),
-                                    Origin = Anchor.TopCentre,
-                                    Anchor = Anchor.TopCentre,
-                                    Colour = colours.Yellow,
-                                    Shadow = true,
-                                    ShadowColour = new Color4(0, 0, 0, 0.25f)
-                                },
-                            }
+                            Colour = colours.Yellow,
                         },
                         InternalButtons = new SelectionCycleFillFlowContainer<DialogButton>
                         {
@@ -122,10 +108,11 @@ namespace osu.Game.Screens.Play
                                 Radius = 50
                             },
                         },
-                        retryCounterContainer = new FillFlowContainer
+                        playInfoText = new OsuTextFlowContainer(cp => cp.Font = OsuFont.GetFont(size: 18))
                         {
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
+                            TextAnchor = Anchor.TopCentre,
                             AutoSizeAxes = Axes.Both,
                         }
                     }
@@ -147,7 +134,8 @@ namespace osu.Game.Screens.Play
                     return;
 
                 retries = value;
-                if (retryCounterContainer != null)
+
+                if (IsLoaded)
                     updateRetryCount();
             }
         }
@@ -160,7 +148,7 @@ namespace osu.Game.Screens.Play
 
         protected override bool OnMouseMove(MouseMoveEvent e) => true;
 
-        protected void AddButton(string text, Color4 colour, Action action)
+        protected void AddButton(string text, Color4 colour, Action? action)
         {
             var button = new Button
             {
@@ -212,30 +200,9 @@ namespace osu.Game.Screens.Play
             // "You've retried 1,065 times in this session"
             // "You've retried 1 time in this session"
 
-            retryCounterContainer.Children = new Drawable[]
-            {
-                new OsuSpriteText
-                {
-                    Text = "You've retried ",
-                    Shadow = true,
-                    ShadowColour = new Color4(0, 0, 0, 0.25f),
-                    Font = OsuFont.GetFont(size: 18),
-                },
-                new OsuSpriteText
-                {
-                    Text = "time".ToQuantity(retries),
-                    Font = OsuFont.GetFont(weight: FontWeight.Bold, size: 18),
-                    Shadow = true,
-                    ShadowColour = new Color4(0, 0, 0, 0.25f),
-                },
-                new OsuSpriteText
-                {
-                    Text = " in this session",
-                    Shadow = true,
-                    ShadowColour = new Color4(0, 0, 0, 0.25f),
-                    Font = OsuFont.GetFont(size: 18),
-                }
-            };
+            playInfoText.Clear();
+            playInfoText.AddText("Retry count: ");
+            playInfoText.AddText(retries.ToString(), cp => cp.Font = cp.Font.With(weight: FontWeight.Bold));
         }
 
         private partial class Button : DialogButton
@@ -249,9 +216,6 @@ namespace osu.Game.Screens.Play
                 return base.OnMouseMove(e);
             }
         }
-
-        [Resolved]
-        private GlobalActionContainer globalAction { get; set; }
 
         protected override bool Handle(UIEvent e)
         {

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -17,7 +17,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osu.Game.Rulesets.UI;
 using osuTK;
 using osuTK.Graphics;
 

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -53,8 +53,6 @@ namespace osu.Game.Screens.Play
 
         public abstract string Header { get; }
 
-        public abstract string Description { get; }
-
         protected SelectionCycleFillFlowContainer<DialogButton> InternalButtons;
         public IReadOnlyList<DialogButton> Buttons => InternalButtons;
 
@@ -107,14 +105,6 @@ namespace osu.Game.Screens.Play
                                     Shadow = true,
                                     ShadowColour = new Color4(0, 0, 0, 0.25f)
                                 },
-                                new OsuSpriteText
-                                {
-                                    Text = Description,
-                                    Origin = Anchor.TopCentre,
-                                    Anchor = Anchor.TopCentre,
-                                    Shadow = true,
-                                    ShadowColour = new Color4(0, 0, 0, 0.25f)
-                                }
                             }
                         },
                         InternalButtons = new SelectionCycleFillFlowContainer<DialogButton>

--- a/osu.Game/Screens/Play/PauseOverlay.cs
+++ b/osu.Game/Screens/Play/PauseOverlay.cs
@@ -24,7 +24,6 @@ namespace osu.Game.Screens.Play
         public override bool IsPresent => base.IsPresent || pauseLoop.IsPlaying;
 
         public override string Header => "paused";
-        public override string Description => "you're not going to do what i think you're going to do, are ya?";
 
         private SkinnableSound pauseLoop;
 


### PR DESCRIPTION
Didn't read too well, can't think of anything better so let's chop it.

Brought up in review of https://github.com/ppy/osu/pull/23640.


| before | after |
| -- | -- |
|![osu Game Tests 2023-05-24 at 09 26 13](https://github.com/ppy/osu/assets/191335/8ee54084-5f88-4d65-8574-9b29466b9c74)|![osu Game Tests 2023-05-24 at 09 27 44](https://github.com/ppy/osu/assets/191335/e5794cb4-c6e7-4f32-8c64-975bea067bab)|