### PR TITLE
Ensure editor selection buttons remain on screen when selection is near edge

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -376,7 +376,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float leftExcess = thisQuad.TopLeft.X - parentQuad.TopLeft.X;
             float rightExcess = parentQuad.TopRight.X - thisQuad.TopRight.X;
 
-            if (topExcess > bottomExcess)
+            if (topExcess + bottomExcess < buttons.Height + button_padding)
+            {
+                buttons.Anchor = Anchor.BottomCentre;
+                buttons.Origin = Anchor.BottomCentre;
+            }
+            else if (topExcess > bottomExcess)
             {
                 buttons.Anchor = Anchor.TopCentre;
                 buttons.Origin = Anchor.BottomCentre;
@@ -387,8 +392,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 buttons.Origin = Anchor.TopCentre;
             }
 
-            if (leftExcess < 0) buttons.X += ToLocalSpace(thisQuad.TopLeft - new Vector2(leftExcess)).X;
-            if (rightExcess < 0) buttons.X += ToLocalSpace(thisQuad.TopLeft + new Vector2(rightExcess)).X;
+            buttons.X += ToLocalSpace(thisQuad.TopLeft - new Vector2(Math.Min(0, leftExcess)) + new Vector2(Math.Min(0, rightExcess))).X;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
     {
         public const float BORDER_RADIUS = 3;
 
+        private const float button_padding = 5;
+
         public Func<float, bool> OnRotation;
         public Func<Vector2, Anchor, bool> OnScale;
         public Func<Direction, bool, bool> OnFlip;
@@ -182,6 +184,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return base.OnKeyDown(e);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            ensureButtonsOnScreen();
+        }
+
         private void recreate()
         {
             if (LoadState < LoadState.Loading)
@@ -234,11 +243,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 },
                 buttons = new FillFlowContainer
                 {
-                    Y = 20,
-                    AutoSizeAxes = Axes.Both,
+                    AutoSizeAxes = Axes.X,
+                    Height = 30,
                     Direction = FillDirection.Horizontal,
+                    Margin = new MarginPadding(button_padding),
                     Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.Centre
+                    Origin = Anchor.TopCentre
                 }
             };
 
@@ -351,6 +361,30 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             if (activeOperations++ == 0)
                 OperationStarted?.Invoke();
+        }
+
+        private void ensureButtonsOnScreen()
+        {
+            buttons.Position = Vector2.Zero;
+
+            var buttonsQuad = buttons.ScreenSpaceDrawQuad;
+            var thisQuad = ScreenSpaceDrawQuad;
+
+            // Shrink the parent quad to give a bit of padding so the buttons don't stick *right* on the border.
+            // AABBFloat assumes no rotation. one would hope the whole editor is not being rotated.
+            var parentQuad = Parent.ScreenSpaceDrawQuad.AABBFloat.Shrink(ToLocalSpace(thisQuad.TopLeft + new Vector2(button_padding * 2)));
+
+            float leftExcess = buttonsQuad.TopLeft.X - parentQuad.TopLeft.X;
+            float rightExcess = parentQuad.TopRight.X - buttonsQuad.TopRight.X;
+            float bottomExcess = thisQuad.BottomLeft.Y + buttonsQuad.Height - parentQuad.BottomLeft.Y;
+
+            if (leftExcess < 0)
+                buttons.X += ToLocalSpace(thisQuad.TopLeft - new Vector2(leftExcess)).X;
+            else if (rightExcess < 0)
+                buttons.X -= ToLocalSpace(thisQuad.TopLeft - new Vector2(rightExcess)).X;
+
+            if (bottomExcess > 0)
+                buttons.Y += ToLocalSpace(thisQuad.TopLeft - new Vector2(bottomExcess)).X;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -247,8 +247,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     Height = 30,
                     Direction = FillDirection.Horizontal,
                     Margin = new MarginPadding(button_padding),
-                    Anchor = Anchor.BottomCentre,
-                    Origin = Anchor.TopCentre
                 }
             };
 
@@ -367,24 +365,30 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             buttons.Position = Vector2.Zero;
 
-            var buttonsQuad = buttons.ScreenSpaceDrawQuad;
             var thisQuad = ScreenSpaceDrawQuad;
 
             // Shrink the parent quad to give a bit of padding so the buttons don't stick *right* on the border.
             // AABBFloat assumes no rotation. one would hope the whole editor is not being rotated.
             var parentQuad = Parent.ScreenSpaceDrawQuad.AABBFloat.Shrink(ToLocalSpace(thisQuad.TopLeft + new Vector2(button_padding * 2)));
 
-            float leftExcess = buttonsQuad.TopLeft.X - parentQuad.TopLeft.X;
-            float rightExcess = parentQuad.TopRight.X - buttonsQuad.TopRight.X;
-            float bottomExcess = thisQuad.BottomLeft.Y + buttonsQuad.Height - parentQuad.BottomLeft.Y;
+            float topExcess = thisQuad.TopLeft.Y - parentQuad.TopLeft.Y;
+            float bottomExcess = parentQuad.BottomLeft.Y - thisQuad.BottomLeft.Y;
+            float leftExcess = thisQuad.TopLeft.X - parentQuad.TopLeft.X;
+            float rightExcess = parentQuad.TopRight.X - thisQuad.TopRight.X;
 
-            if (leftExcess < 0)
-                buttons.X += ToLocalSpace(thisQuad.TopLeft - new Vector2(leftExcess)).X;
-            else if (rightExcess < 0)
-                buttons.X -= ToLocalSpace(thisQuad.TopLeft - new Vector2(rightExcess)).X;
+            if (topExcess > bottomExcess)
+            {
+                buttons.Anchor = Anchor.TopCentre;
+                buttons.Origin = Anchor.BottomCentre;
+            }
+            else
+            {
+                buttons.Anchor = Anchor.BottomCentre;
+                buttons.Origin = Anchor.TopCentre;
+            }
 
-            if (bottomExcess > 0)
-                buttons.Y += ToLocalSpace(thisQuad.TopLeft - new Vector2(bottomExcess)).X;
+            if (leftExcess < 0) buttons.X += ToLocalSpace(thisQuad.TopLeft - new Vector2(leftExcess)).X;
+            if (rightExcess < 0) buttons.X += ToLocalSpace(thisQuad.TopLeft + new Vector2(rightExcess)).X;
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/23599.

Purely visual and if it regresses in the future, it's going to be in a completely unpredictable way, so opting to not add tests.