### PR TITLE
Fix `OnResume` / `OnSuspending` potentially getting called before `OnEntering` on a sub screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Screens.OnlinePlay
 
             Debug.Assert(screenStack.CurrentScreen != null);
 
-            // if a subscreen was pushed to the nested stack while this screen was not present, this path will proxy `OnResuming()`
+            // if a subscreen was pushed to the nested stack while the stack was not present, this path will proxy `OnResuming()`
             // to the subscreen before `OnEntering()` can even be called for the subscreen, breaking ordering expectations.
             // to work around this, do not proxy resume to screens that haven't loaded yet.
             if ((screenStack.CurrentScreen as Drawable)?.IsLoaded == true)
@@ -149,7 +149,10 @@ namespace osu.Game.Screens.OnlinePlay
 
             Debug.Assert(screenStack.CurrentScreen != null);
 
-            if (screenStack.CurrentScreen.IsCurrentScreen())
+            // if a subscreen was pushed to the nested stack while the stack was not present, this path will proxy `OnSuspending()`
+            // to the subscreen before `OnEntering()` can even be called for the subscreen, breaking ordering expectations.
+            // to work around this, do not proxy suspend to screens that haven't loaded yet.
+            if ((screenStack.CurrentScreen as Drawable)?.IsLoaded == true)
                 screenStack.CurrentScreen.OnSuspending(e);
         }
 

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -133,7 +133,10 @@ namespace osu.Game.Screens.OnlinePlay
 
             Debug.Assert(screenStack.CurrentScreen != null);
 
-            if (screenStack.CurrentScreen.IsCurrentScreen())
+            // if a subscreen was pushed to the nested stack while this screen was not present, this path will proxy `OnResuming()`
+            // to the subscreen before `OnEntering()` can even be called for the subscreen, breaking ordering expectations.
+            // to work around this, do not proxy resume to screens that haven't loaded yet.
+            if ((screenStack.CurrentScreen as Drawable)?.IsLoaded == true)
                 screenStack.CurrentScreen.OnResuming(e);
 
             base.OnResuming(e);

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -132,7 +132,9 @@ namespace osu.Game.Screens.OnlinePlay
             this.ScaleTo(1, 250, Easing.OutSine);
 
             Debug.Assert(screenStack.CurrentScreen != null);
-            screenStack.CurrentScreen.OnResuming(e);
+
+            if (screenStack.CurrentScreen.IsCurrentScreen())
+                screenStack.CurrentScreen.OnResuming(e);
 
             base.OnResuming(e);
         }
@@ -143,7 +145,9 @@ namespace osu.Game.Screens.OnlinePlay
             this.FadeOut(250);
 
             Debug.Assert(screenStack.CurrentScreen != null);
-            screenStack.CurrentScreen.OnSuspending(e);
+
+            if (screenStack.CurrentScreen.IsCurrentScreen())
+                screenStack.CurrentScreen.OnSuspending(e);
         }
 
         public override bool OnExiting(ScreenExitEvent e)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23611.

*but peppy, why are there no tests??*

Well, be my guest but don't say i didn't warn you. Here's a starting point (~1.5 hours spent and I give up). TLDR, using `TestMultiplayerComponents` completely breaks the screen stack flow so the erroneous code doesn't get called in the first place. You can't *not* use `TestMultiplayerComponents` because there will be no connection to the server, so you can't get into the screen required to test this.

I tried the simple solution of forwarding `OnResuming` etc. through `TestMultiplayerComponents` but it doesn't fix the issue.

```diff
diff --git a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
index c054792168..2536870816 100644
--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -11,17 +11,75 @@
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
+using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Menu;
+using osu.Game.Screens.OnlinePlay.Lounge;
+using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Match;
 using osu.Game.Screens.Select;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation
 {
     public partial class TestScenePresentBeatmap : OsuGameTestScene
     {
+        /// <summary>
+        /// This tests the case where the user presents a beatmap from something like gameplay, while in a multiplayer game.
+        /// It should be presented after gameplay ends, and done so by the multiplayer song select mechanism if the user is host.
+        ///
+        /// Of note, we can't use `TestMultiplayerComponents` for this test because it hides the sub screen stack and therefore doesn't get
+        /// recognised by OsuGame as an `IHandlePresentBeatmap`.
+        /// </summary>
+        [Test]
+        public void TestFromMultiplayerWithChildScreenPushed()
+        {
+            TestMultiplayerComponents multiplayerComponents = null;
+
+            PushAndConfirm(() => multiplayerComponents = new TestMultiplayerComponents());
+
+            AddUntilStep("wait for lounge", () => multiplayerComponents.ChildrenOfType<LoungeSubScreen>().SingleOrDefault()?.IsLoaded == true);
+
+            AddStep("open room", () => multiplayerComponents.ChildrenOfType<LoungeSubScreen>().Single().Open(new Room
+            {
+                Name = { Value = "Test Room" },
+                Playlist =
+                {
+                    new PlaylistItem(Game.BeatmapManager.QueryBeatmap(_ => true)!)
+                    {
+                        RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                    }
+                }
+            }));
+
+            AddUntilStep("wait for room open", () => this.ChildrenOfType<MultiplayerMatchSubScreen>().FirstOrDefault()?.IsLoaded == true);
+            AddWaitStep("wait for transition", 2);
+
+            AddUntilStep("create room button enabled", () => this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single().Enabled.Value);
+            AddStep("create room", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("wait for join", () => multiplayerComponents.MultiplayerClient.RoomJoined);
+
+            PushAndConfirm(() => new TestSceneOsuScreenStack.TestScreen("test"));
+
+            AddStep("present beatmap", () =>
+            {
+                Game.PresentBeatmap(Game.BeatmapManager.QueryBeatmapSet(_ => true)!.Value);
+            });
+
+            AddStep("return to lounge", () => Game.ScreenStack.CurrentScreen.Exit());
+            AddUntilStep("wait for lounge", () => Game.ScreenStack.CurrentScreen is MultiplayerMatchSubScreen);
+
+            // should have crashed
+        }
+
         [Test]
         public void TestFromMainMenu()
         {
diff --git a/osu.Game.Tests/Visual/TestMultiplayerComponents.cs b/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
index 1814fb70c8..efa3a13ddd 100644
--- a/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
+++ b/osu.Game.Tests/Visual/TestMultiplayerComponents.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual
     /// </list>
     /// </p>
     /// </summary>
-    public partial class TestMultiplayerComponents : OsuScreen
+    public partial class TestMultiplayerComponents : OsuScreen, IHasSubScreenStack
     {
         public Screens.OnlinePlay.Multiplayer.Multiplayer MultiplayerScreen => multiplayerScreen;
 
@@ -98,5 +98,7 @@ private partial class TestMultiplayer : Screens.OnlinePlay.Multiplayer.Multiplay
 
             protected override RoomManager CreateRoomManager() => RoomManager = new TestMultiplayerRoomManager(RequestsHandler = new TestRoomRequestsHandler());
         }
+
+        public ScreenStack SubScreenStack => screenStack;
     }
 }

```