### PR TITLE
Fix spinner rotation not being rewound correctly in the editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -115,18 +115,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             isSpinning.BindValueChanged(updateSpinningSample);
         }
 
-        protected override void OnApply()
-        {
-            base.OnApply();
-
-            RotationTracker.Reset();
-        }
-
         protected override void OnFree()
         {
             base.OnFree();
 
             spinningSample.ClearSamples();
+            RotationTracker.Reset();
         }
 
         protected override void LoadSamples()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -296,28 +296,28 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             int spins = (int)(Result.RateAdjustedRotation / 360);
 
+            if (wholeSpins == spins)
+                return;
+
             if (spins < wholeSpins)
             {
                 // rewinding, silently handle
                 wholeSpins = spins;
-                return;
             }
-
-            while (wholeSpins != spins)
+            else
             {
-                var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
-
-                // tick may be null if we've hit the spin limit.
-                if (tick != null)
+                while (wholeSpins < spins)
                 {
-                    tick.TriggerResult(true);
+                    var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
 
-                    if (tick is DrawableSpinnerBonusTick)
-                        gainedBonus.Value = score_per_tick * (spins - HitObject.SpinsRequired);
+                    // tick may be null if we've hit the spin limit.
+                    tick?.TriggerResult(true);
+
+                    wholeSpins++;
                 }
-
-                wholeSpins++;
             }
+
+            gainedBonus.Value = Math.Max(0, score_per_tick * (spins - HitObject.SpinsRequired));
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -115,6 +115,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             isSpinning.BindValueChanged(updateSpinningSample);
         }
 
+        protected override void OnApply()
+        {
+            base.OnApply();
+
+            RotationTracker.Reset();
+        }
+
         protected override void OnFree()
         {
             base.OnFree();

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -35,14 +35,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             InternalChildren = new Drawable[]
             {
-                bonusCounter = new OsuSpriteText
-                {
-                    Alpha = 0,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Font = OsuFont.Default.With(size: 24),
-                    Y = -120,
-                },
                 new ArgonSpinnerDisc
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -89,15 +89,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 // and I'd rather not potentially break that in the process.
                 var clock = (gameplayClock ?? Clock);
 
-                if (clock.ElapsedFrameTime < 0)
+                while (rotationHistory.TryPeek(out (double time, float rotation) pair))
                 {
-                    while (rotationHistory.TryPop(out (double time, float rotation) pair))
-                    {
-                        if (pair.time < clock.CurrentTime)
-                            break;
+                    if (pair.time < clock.CurrentTime)
+                        break;
 
-                        drawableSpinner.Result.RateAdjustedRotation = pair.rotation;
-                    }
+                    drawableSpinner.Result.RateAdjustedRotation = pair.rotation;
+                    rotationHistory.Pop();
                 }
             }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -4,12 +4,10 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Screens.Play;
 using osuTK;
@@ -35,7 +33,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         public SpinnerRotationTracker(DrawableSpinner drawableSpinner)
         {
             this.drawableSpinner = drawableSpinner;
-            drawableSpinner.HitObjectApplied += resetState;
 
             RelativeSizeAxes = Axes.Both;
         }
@@ -112,21 +109,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             drawableSpinner.Result.RateAdjustedRotation += (float)(Math.Abs(angle) * (gameplayClock?.GetTrueGameplayRate() ?? Clock.Rate));
         }
 
-        private void resetState(DrawableHitObject obj)
+        public void Reset()
         {
             Tracking = false;
             IsSpinning.Value = false;
             mousePosition = default;
             lastAngle = currentRotation = Rotation = 0;
             rotationTransferred = false;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableSpinner.IsNotNull())
-                drawableSpinner.HitObjectApplied -= resetState;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -35,22 +35,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         [Resolved]
         private IFrameStableClock? frameStableClock { get; set; }
 
-        private Stack<(double time, float rotation)> rotationHistory = new Stack<(double time, float rotation)>();
+        private readonly Stack<(double time, float rotation)> rotationHistory = new Stack<(double time, float rotation)>();
 
         public SpinnerRotationTracker(DrawableSpinner drawableSpinner)
         {
             this.drawableSpinner = drawableSpinner;
 
             RelativeSizeAxes = Axes.Both;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            if (frameStableClock == null)
-            {
-                rotationHistory = new Stack<(double time, float rotation)>();
-            }
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
@@ -161,7 +152,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             mousePosition = default;
             lastAngle = currentRotation = Rotation = 0;
             rotationTransferred = false;
-            rotationHistory?.Clear();
+            rotationHistory.Clear();
         }
     }
 }

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.UI
         /// <summary>
         /// Whether to enable frame-stable playback.
         /// </summary>
-        internal bool FrameStablePlayback { get; set; } = true;
+        public bool FrameStablePlayback { get; internal set; } = true;
 
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate && state != PlaybackState.NotValid;
 

--- a/osu.Game/Rulesets/UI/IFrameStableClock.cs
+++ b/osu.Game/Rulesets/UI/IFrameStableClock.cs
@@ -14,5 +14,10 @@ namespace osu.Game.Rulesets.UI
         /// Whether the frame stable clock is waiting on new frames to arrive to be able to progress time.
         /// </summary>
         IBindable<bool> WaitingOnFrames { get; }
+
+        /// <summary>
+        /// Whether playback is currently frame stable in nature. This may change at any point in execution.
+        /// </summary>
+        bool FrameStablePlayback { get; }
     }
 }


### PR DESCRIPTION
This is a local fix that is intended to make things roughly work until we figure the larger issue of "editor-is-not-frame-stable" (which has other side-effects).

I'm proposing that we make this change for now becuase of the number of times this has been [reported](https://github.com/ppy/osu/issues/10455).

Resolves part of #10455.