### PR TITLE
Replace mania scroll "time" with scroll "speed"

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -11,7 +11,7 @@
     <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.521.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.531.0" />
   </ItemGroup>
   <ItemGroup>
     <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)osu.Android\Properties\AndroidManifestOverlay.xml" />

--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -15,33 +15,27 @@ namespace osu.Game.Rulesets.Mania.Configuration
         public ManiaRulesetConfigManager(SettingsStore? settings, RulesetInfo ruleset, int? variant = null)
             : base(settings, ruleset, variant)
         {
-            migrate();
         }
 
         protected override void InitialiseDefaults()
         {
             base.InitialiseDefaults();
 
-#pragma warning disable CS0618
-            // Although obsolete, this is still required to populate the bindable from the database in case migration is required.
-            SetDefault<double?>(ManiaRulesetSetting.ScrollTime, null);
-#pragma warning restore CS0618
-
             SetDefault(ManiaRulesetSetting.ScrollSpeed, 8, 1, 40);
             SetDefault(ManiaRulesetSetting.ScrollDirection, ManiaScrollingDirection.Down);
             SetDefault(ManiaRulesetSetting.TimingBasedNoteColouring, false);
-        }
 
 #pragma warning disable CS0618
-        private void migrate()
-        {
+            // Although obsolete, this is still required to populate the bindable from the database in case migration is required.
+            SetDefault<double?>(ManiaRulesetSetting.ScrollTime, null);
+
             if (Get<double?>(ManiaRulesetSetting.ScrollTime) is double scrollTime)
             {
                 SetValue(ManiaRulesetSetting.ScrollSpeed, (int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / scrollTime));
                 SetValue<double?>(ManiaRulesetSetting.ScrollTime, null);
             }
-        }
 #pragma warning restore CS0618
+        }
 
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {

--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -15,24 +15,41 @@ namespace osu.Game.Rulesets.Mania.Configuration
         public ManiaRulesetConfigManager(SettingsStore? settings, RulesetInfo ruleset, int? variant = null)
             : base(settings, ruleset, variant)
         {
+            migrate();
         }
 
         protected override void InitialiseDefaults()
         {
             base.InitialiseDefaults();
 
-            SetDefault(ManiaRulesetSetting.ScrollTime, 1500.0, DrawableManiaRuleset.MIN_TIME_RANGE, DrawableManiaRuleset.MAX_TIME_RANGE, 5);
+#pragma warning disable CS0618
+            // Although obsolete, this is still required to populate the bindable from the database in case migration is required.
+            SetDefault<double?>(ManiaRulesetSetting.ScrollTime, null);
+#pragma warning restore CS0618
+
+            SetDefault(ManiaRulesetSetting.ScrollSpeed, 8, 1, 40);
             SetDefault(ManiaRulesetSetting.ScrollDirection, ManiaScrollingDirection.Down);
             SetDefault(ManiaRulesetSetting.TimingBasedNoteColouring, false);
         }
 
+#pragma warning disable CS0618
+        private void migrate()
+        {
+            if (Get<double?>(ManiaRulesetSetting.ScrollTime) is double scrollTime)
+            {
+                SetValue(ManiaRulesetSetting.ScrollSpeed, (int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / scrollTime));
+                SetValue<double?>(ManiaRulesetSetting.ScrollTime, null);
+            }
+        }
+#pragma warning restore CS0618
+
         public override TrackedSettings CreateTrackedSettings() => new TrackedSettings
         {
-            new TrackedSetting<double>(ManiaRulesetSetting.ScrollTime,
-                scrollTime => new SettingDescription(
-                    rawValue: scrollTime,
+            new TrackedSetting<int>(ManiaRulesetSetting.ScrollSpeed,
+                speed => new SettingDescription(
+                    rawValue: speed,
                     name: RulesetSettingsStrings.ScrollSpeed,
-                    value: RulesetSettingsStrings.ScrollSpeedTooltip(scrollTime, (int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / scrollTime))
+                    value: RulesetSettingsStrings.ScrollSpeedTooltip(DrawableManiaRuleset.ComputeScrollTime(speed), speed)
                 )
             )
         };
@@ -40,7 +57,9 @@ namespace osu.Game.Rulesets.Mania.Configuration
 
     public enum ManiaRulesetSetting
     {
+        [Obsolete("Use ScrollSpeed instead.")] // Can be removed 2023-11-30
         ScrollTime,
+        ScrollSpeed,
         ScrollDirection,
         TimingBasedNoteColouring
     }

--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
@@ -34,10 +33,10 @@ namespace osu.Game.Rulesets.Mania
                     LabelText = RulesetSettingsStrings.ScrollingDirection,
                     Current = config.GetBindable<ManiaScrollingDirection>(ManiaRulesetSetting.ScrollDirection)
                 },
-                new SettingsSlider<double, ManiaScrollSlider>
+                new SettingsSlider<int, ManiaScrollSlider>
                 {
                     LabelText = RulesetSettingsStrings.ScrollSpeed,
-                    Current = config.GetBindable<double>(ManiaRulesetSetting.ScrollTime),
+                    Current = config.GetBindable<int>(ManiaRulesetSetting.ScrollSpeed),
                     KeyboardStep = 5
                 },
                 new SettingsCheckbox
@@ -48,9 +47,9 @@ namespace osu.Game.Rulesets.Mania
             };
         }
 
-        private partial class ManiaScrollSlider : RoundedSliderBar<double>
+        private partial class ManiaScrollSlider : RoundedSliderBar<int>
         {
-            public override LocalisableString TooltipText => RulesetSettingsStrings.ScrollSpeedTooltip(Current.Value, (int)Math.Round(DrawableManiaRuleset.MAX_TIME_RANGE / Current.Value));
+            public override LocalisableString TooltipText => RulesetSettingsStrings.ScrollSpeedTooltip(DrawableManiaRuleset.ComputeScrollTime(Current.Value), Current.Value);
         }
     }
 }

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "{0}ms (speed {1})"
         /// </summary>
-        public static LocalisableString ScrollSpeedTooltip(double arg0, int arg1) => new TranslatableString(getKey(@"ruleset"), @"{0}ms (speed {1})", arg0, arg1);
+        public static LocalisableString ScrollSpeedTooltip(double scrollTime, int scrollSpeed) => new TranslatableString(getKey(@"ruleset"), @"{0:0}ms (speed {1})", scrollTime, scrollSpeed);
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.521.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.531.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.510.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -16,6 +16,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.521.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.531.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/5815

Resolves https://github.com/ppy/osu/discussions/21130

I've changed everything to use the 1-40 scroll "speed" as I think it's a more natural scale for most players - I've never seen a request to be able to change the scroll time by millisecond values. Plus, it wouldn't be possible anyway if only the 1-40 range was exposed in the game options.