### PR TITLE
Adjust realm startup for added reliability

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -912,7 +912,7 @@ namespace osu.Game.Database
 
             int attempts = 10;
 
-            while (attempts-- > 0)
+            while (true)
             {
                 try
                 {
@@ -930,6 +930,9 @@ namespace osu.Game.Database
                 }
                 catch (IOException)
                 {
+                    if (attempts-- <= 0)
+                        throw;
+
                     // file may be locked during use.
                     Thread.Sleep(500);
                 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -179,8 +179,8 @@ namespace osu.Game.Database
                 applyFilenameSchemaSuffix(ref Filename);
 #endif
 
+            // `prepareFirstRealmAccess()` triggers the first `getRealmInstance` call, which will implicitly run realm migrations and bring the schema up-to-date.
             using (var realm = prepareFirstRealmAccess())
-                // This method triggers the first `getRealmInstance` call, which will implicitly run realm migrations and bring the schema up-to-date.
                 cleanupPendingDeletions(realm);
         }
 


### PR DESCRIPTION
Two changes here:

## a0be526266 Adjust realm backup procedure to hard fail if running out of attempts

Previously, if the backup procedure failed, startup would continue and the user's realm database may be deleted. I think in such a fail case I'd rather the game didn't startup so the user gets in touch (or reads the log files themselves) rather than potentially losing data.

## 79694897be Ensure a potential exception from `cleanupPendingDeletions` doesn't mark realm corrupt

The whole restructure here is to move the nested call out of the `try-catch`. I noticed this while looking at a corrupt database issue a user reported (https://github.com/ppy/osu/discussions/23694).

It's not the first time we've seen a corrupt database error where the "corrupt" version works just fine on a second attempt.

Maybe this isn't the issue and it's just a transitive file access violation but it definitely feels like this should be fixed regardless.