### PR TITLE
Fix attempting to report a chat message from multiplayer failing

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneStandAloneChatDisplay.cs
@@ -1,21 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Game.Online.Chat;
-using osuTK;
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Online
@@ -47,14 +46,14 @@ namespace osu.Game.Tests.Visual.Online
             Id = 5,
         };
 
-        private ChannelManager channelManager;
+        private ChannelManager channelManager = null!;
 
-        private TestStandAloneChatDisplay chatDisplay;
-        private TestStandAloneChatDisplay chatWithTextBox;
-        private TestStandAloneChatDisplay chatWithTextBox2;
+        private TestStandAloneChatDisplay chatDisplay = null!;
+        private TestStandAloneChatDisplay chatWithTextBox = null!;
+        private TestStandAloneChatDisplay chatWithTextBox2 = null!;
         private int messageIdSequence;
 
-        private Channel testChannel;
+        private Channel testChannel = null!;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -171,6 +170,26 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestReportUserPopover()
+        {
+            sendRegularMessages();
+
+            AddStep("right click user to show menu", () =>
+            {
+                InputManager.MoveMouseTo(chatWithTextBox.ChildrenOfType<DrawableChatUsername>().Last());
+                InputManager.Click(MouseButton.Right);
+            });
+
+            AddStep("click report button", () =>
+            {
+                InputManager.MoveMouseTo(chatWithTextBox.ChildrenOfType<DrawableOsuMenuItem>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("wait for popover", () => this.ChildrenOfType<ReportChatPopover>().Any());
+        }
+
+        [Test]
         public void TestManyMessages()
         {
             sendRegularMessages();
@@ -209,7 +228,7 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestMessageHighlighting()
         {
-            Message highlighted = null;
+            Message? highlighted = null;
 
             sendRegularMessages();
 

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -62,6 +62,8 @@ namespace osu.Game.Online.Chat
                 },
             };
 
+            // TODO: move this to MatchChatDisplay as it is the only usage.
+            // This will allow removing the weird nullability logic around TextBox.
             if (postingTextBox)
             {
                 AddInternal(TextBox = new ChatTextBox

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -21,18 +20,19 @@ using osuTK.Input;
 namespace osu.Game.Online.Chat
 {
     /// <summary>
-    /// Display a chat channel in an insolated region.
+    /// Display a chat channel in an isolated region.
     /// </summary>
     public partial class StandAloneChatDisplay : CompositeDrawable
     {
         [Cached]
-        public readonly Bindable<Channel> Channel = new Bindable<Channel>();
+        public readonly Bindable<Channel?> Channel = new Bindable<Channel?>();
 
-        protected readonly ChatTextBox TextBox;
+        protected readonly ChatTextBox? TextBox;
 
-        private ChannelManager channelManager;
+        [Resolved]
+        private ChannelManager? channelManager { get; set; }
 
-        private StandAloneDrawableChannel drawableChannel;
+        private StandAloneDrawableChannel? drawableChannel;
 
         private readonly bool postingTextBox;
 
@@ -78,14 +78,13 @@ namespace osu.Game.Online.Chat
 
                 TextBox.OnCommit += postMessage;
             }
-
-            Channel.BindValueChanged(channelChanged);
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(ChannelManager manager)
+        protected override void LoadComplete()
         {
-            channelManager ??= manager;
+            base.LoadComplete();
+
+            Channel.BindValueChanged(channelChanged, true);
         }
 
         protected virtual StandAloneDrawableChannel CreateDrawableChannel(Channel channel) =>
@@ -93,6 +92,8 @@ namespace osu.Game.Online.Chat
 
         private void postMessage(TextBox sender, bool newText)
         {
+            Debug.Assert(TextBox != null);
+
             string text = TextBox.Text.Trim();
 
             if (string.IsNullOrWhiteSpace(text))
@@ -108,7 +109,7 @@ namespace osu.Game.Online.Chat
 
         protected virtual ChatLine CreateMessage(Message message) => new StandAloneMessage(message);
 
-        private void channelChanged(ValueChangedEvent<Channel> e)
+        private void channelChanged(ValueChangedEvent<Channel?> e)
         {
             drawableChannel?.Expire();
 
@@ -128,6 +129,8 @@ namespace osu.Game.Online.Chat
 
         public partial class ChatTextBox : HistoryTextBox
         {
+            public Action? FocusLost;
+
             protected override bool OnKeyDown(KeyDownEvent e)
             {
                 // Chat text boxes are generally used in places where they retain focus, but shouldn't block interaction with other
@@ -158,20 +161,23 @@ namespace osu.Game.Online.Chat
                 base.OnFocusLost(e);
                 FocusLost?.Invoke();
             }
-
-            public Action FocusLost;
         }
 
         public partial class StandAloneDrawableChannel : DrawableChannel
         {
-            public Func<Message, ChatLine> CreateChatLineAction;
+            public Func<Message, ChatLine>? CreateChatLineAction;
 
             public StandAloneDrawableChannel(Channel channel)
                 : base(channel)
             {
             }
 
-            protected override ChatLine CreateChatLine(Message m) => CreateChatLineAction(m);
+            protected override ChatLine CreateChatLine(Message m)
+            {
+                Debug.Assert(CreateChatLineAction != null);
+
+                return CreateChatLineAction.Invoke(m);
+            }
 
             protected override DaySeparator CreateDaySeparator(DateTimeOffset time) => new StandAloneDaySeparator(time);
         }

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -18,6 +18,7 @@ using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
@@ -376,9 +377,13 @@ namespace osu.Game
                     (GlobalCursorDisplay = new GlobalCursorDisplay
                     {
                         RelativeSizeAxes = Axes.Both
-                    }).WithChild(content = new OsuTooltipContainer(GlobalCursorDisplay.MenuCursor)
+                    }).WithChild(new PopoverContainer
                     {
-                        RelativeSizeAxes = Axes.Both
+                        RelativeSizeAxes = Axes.Both,
+                        Child = content = new OsuTooltipContainer(GlobalCursorDisplay.MenuCursor)
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
                     }),
                     // to avoid positional input being blocked by children, ensure the GlobalActionContainer is above everything.
                     globalBindings = new GlobalActionContainer(this)

--- a/osu.Game/Overlays/Chat/ReportChatPopover.cs
+++ b/osu.Game/Overlays/Chat/ReportChatPopover.cs
@@ -15,8 +15,10 @@ namespace osu.Game.Overlays.Chat
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
+        // Nullability only required here for test coverage (even though TestSceneChatOverlay caches a ChannelManager,
+        // it is not seen by the PopoverContainer which is at a higher level in some cases).
         [Resolved]
-        private ChannelManager channelManager { get; set; } = null!;
+        private ChannelManager? channelManager { get; set; }
 
         private readonly Message message;
 
@@ -33,7 +35,7 @@ namespace osu.Game.Overlays.Chat
         {
             var request = new ChatReportRequest(message.Id, reason, comments);
 
-            request.Success += () => channelManager.CurrentChannel.Value.AddNewMessages(new InfoMessage(UsersStrings.ReportThanks.ToString()));
+            request.Success += () => channelManager?.CurrentChannel.Value.AddNewMessages(new InfoMessage(UsersStrings.ReportThanks.ToString()));
 
             api.Queue(request);
         }

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
@@ -135,13 +134,9 @@ namespace osu.Game.Overlays
                                     },
                                     Children = new Drawable[]
                                     {
-                                        new PopoverContainer
+                                        currentChannelContainer = new Container<DrawableChannel>
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            Child = currentChannelContainer = new Container<DrawableChannel>
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                            }
                                         },
                                         loading = new LoadingLayer(true),
                                         channelListing = new ChannelListing

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using JetBrains.Annotations;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -18,9 +16,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
     public partial class GameplayChatDisplay : MatchChatDisplay, IKeyBindingHandler<GlobalAction>
     {
-        [Resolved(CanBeNull = true)]
-        [CanBeNull]
-        private ILocalUserPlayInfo localUserInfo { get; set; }
+        [Resolved]
+        private ILocalUserPlayInfo? localUserInfo { get; set; }
 
         private readonly IBindable<bool> localUserPlaying = new Bindable<bool>();
 
@@ -41,6 +38,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             Background.Alpha = 0.2f;
 
+            Debug.Assert(TextBox != null);
+
             TextBox.FocusLost = () => expandedFromTextBoxFocus.Value = false;
         }
 
@@ -48,6 +47,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void LoadComplete()
         {
+            Debug.Assert(TextBox != null);
+
             base.LoadComplete();
 
             if (localUserInfo != null)
@@ -79,6 +80,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            Debug.Assert(TextBox != null);
+
             switch (e.Action)
             {
                 case GlobalAction.Back:

--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
@@ -50,9 +51,13 @@ namespace osu.Game.Tests.Visual
             {
                 var cursorDisplay = new GlobalCursorDisplay { RelativeSizeAxes = Axes.Both };
 
-                cursorDisplay.Add(content = new OsuTooltipContainer(cursorDisplay.MenuCursor)
+                cursorDisplay.Add(new PopoverContainer
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Child = content = new OsuTooltipContainer(cursorDisplay.MenuCursor)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
                 });
 
                 mainContent.Add(cursorDisplay);


### PR DESCRIPTION
..by adding a global `PopoverContainer`. It's still recommended to use local ones where it can work for now. In this case, making a local one would cause the popover to not have enough space to display.

Addresses https://github.com/ppy/osu/discussions/23684.
Closes #23477.