### PR TITLE
Adjust background colour used in `LabelledDrawable`s to allow visibility of some elements

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledDrawable.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [BackgroundDependencyLoader(true)]
         private void load(OverlayColourProvider? colourProvider, OsuColour osuColour)
         {
-            background.Colour = colourProvider?.Background5 ?? Color4Extensions.FromHex(@"1c2125");
+            background.Colour = colourProvider?.Background4 ?? Color4Extensions.FromHex(@"1c2125");
             descriptionText.Colour = osuColour.Yellow;
         }
 


### PR DESCRIPTION
Not sure how good this is visually, but might as well fix the usability for now?

Fixes both dropdowns and slider bars

| before | after |
| -- | -- |
|![osu! 2023-05-31 at 14 26 02](https://github.com/ppy/osu/assets/191335/cfca1cbe-93b9-4f7a-9580-4fed65372366)|![osu! 2023-05-31 at 14 24 52](https://github.com/ppy/osu/assets/191335/54df16ef-f741-43a9-90c5-dcd875db96e1)|

Closes #23706