### PR TITLE
Automatically disable tablet support on error

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1136,12 +1136,19 @@ namespace osu.Game
 
                 if (entry.Level == LogLevel.Error)
                 {
-                    Schedule(() => Notifications.Post(new SimpleNotification
+                    Schedule(() =>
                     {
-                        Text = $"Encountered tablet error: \"{message}\"",
-                        Icon = FontAwesome.Solid.PenSquare,
-                        IconColour = Colours.RedDark,
-                    }));
+                        Notifications.Post(new SimpleNotification
+                        {
+                            Text = $"Disabling tablet support due to error: \"{message}\"",
+                            Icon = FontAwesome.Solid.PenSquare,
+                            IconColour = Colours.RedDark,
+                        });
+
+                        var tabletHandler = Host.AvailableInputHandlers.OfType<ITabletHandler>().FirstOrDefault();
+                        if (tabletHandler != null)
+                            tabletHandler.Enabled.Value = false;
+                    });
                 }
                 else if (notifyOnWarning)
                 {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1145,8 +1145,11 @@ namespace osu.Game
                             IconColour = Colours.RedDark,
                         });
 
-                        var tabletHandler = Host.AvailableInputHandlers.OfType<ITabletHandler>().FirstOrDefault();
-                        if (tabletHandler != null)
+                        // We only have one tablet handler currently.
+                        // The loop here is weakly guarding against a future where more than one is added.
+                        // If this is ever the case, this logic needs adjustment as it should probably only
+                        // disable the relevant tablet handler rather than all.
+                        foreach (var tabletHandler in Host.AvailableInputHandlers.OfType<ITabletHandler>())
                             tabletHandler.Enabled.Value = false;
                     });
                 }


### PR DESCRIPTION
Closes #23710.

I was originally going to combine this logic with the rate limiting we have on other log messages, but this seems like a better path forward?

https://github.com/ppy/osu/assets/191335/0d700409-6458-4383-bf32-7332df2809d7

