### PR TITLE
Update languages to match osu-web 

### DIFF
--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -47,8 +47,9 @@ namespace osu.Game.Localisation
         [Description(@"Suomi")]
         fi,
 
-        [Description(@"Filipino")]
-        fil,
+        // TODO: Doesn't work as appropriate satellite assemblies aren't copied from resources (see: https://github.com/ppy/osu/discussions/18851#discussioncomment-3042170)
+        // [Description(@"Filipino")]
+        // fil,
 
         [Description(@"français")]
         fr,

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -40,8 +40,9 @@ namespace osu.Game.Localisation
         [Description(@"español")]
         es,
 
-        [Description(@"فارسی")]
-        fa_ir,
+        // TODO: Requires Arabic glyphs to be added to resources (and possibly also RTL support).
+        // [Description(@"فارسی")]
+        // fa_ir,
 
         [Description(@"Suomi")]
         fi,
@@ -52,8 +53,9 @@ namespace osu.Game.Localisation
         [Description(@"français")]
         fr,
 
-        [Description(@"עברית")]
-        he,
+        // TODO: Requires Hebrew glyphs to be added to resources (and possibly also RTL support).
+        // [Description(@"עברית")]
+        // he,
 
         [Description(@"Hrvatski")]
         hr_hr,
@@ -103,8 +105,10 @@ namespace osu.Game.Localisation
         [Description(@"Русский")]
         ru,
 
-        [Description(@"සිංහල")]
-        si_lk,
+        // TODO: Requires Sinhala glyphs to be added to resources.
+        // Additionally, no translations available yet.
+        // [Description(@"සිංහල")]
+        // si_lk,
 
         [Description(@"Slovenčina")]
         sk,

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -122,8 +122,10 @@ namespace osu.Game.Localisation
         [Description(@"Svenska")]
         sv,
 
-        [Description(@"Тоҷикӣ")]
-        tg_tj,
+        // Tajik has no associated localisations yet, and is not supported on Windows versions <10.
+        // TODO: update language mapping in osu-resources to redirect tg-TJ to tg-Cyrl-TJ (which is supported on earlier Windows versions)
+        // [Description(@"Тоҷикӣ")]
+        // tg_tj,
 
         [Description(@"ไทย")]
         th,

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -141,9 +141,6 @@ namespace osu.Game.Localisation
         [Description(@"简体中文")]
         zh,
 
-        [Description(@"繁體中文")]
-        zh_tw,
-
         // Traditional Chinese (Hong Kong) is listed in web sources but has no associated localisations,
         // and was wrongly falling back to Simplified Chinese.
         // Can be revisited if localisations ever arrive.

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Localisation
         [Description(@"Български")]
         bg,
 
+        [Description(@"Català")]
+        ca,
+
         [Description(@"Česky")]
         cs,
 
@@ -37,11 +40,23 @@ namespace osu.Game.Localisation
         [Description(@"español")]
         es,
 
+        [Description(@"فارسی")]
+        fa_ir,
+
         [Description(@"Suomi")]
         fi,
 
+        [Description(@"Filipino")]
+        fil,
+
         [Description(@"français")]
         fr,
+
+        [Description(@"עברית")]
+        he,
+
+        [Description(@"Hrvatski")]
+        hr_hr,
 
         [Description(@"Magyar")]
         hu,
@@ -57,6 +72,15 @@ namespace osu.Game.Localisation
 
         [Description(@"한국어")]
         ko,
+
+        [Description(@"Lietuvių")]
+        lt,
+
+        [Description(@"Latviešu")]
+        lv_lv,
+
+        [Description(@"Melayu")]
+        ms_my,
 
         [Description(@"Nederlands")]
         nl,
@@ -79,11 +103,23 @@ namespace osu.Game.Localisation
         [Description(@"Русский")]
         ru,
 
+        [Description(@"සිංහල")]
+        si_lk,
+
         [Description(@"Slovenčina")]
         sk,
 
+        [Description(@"Slovenščina")]
+        sl,
+
+        [Description(@"Српски")]
+        sr,
+
         [Description(@"Svenska")]
         sv,
+
+        [Description(@"Тоҷикӣ")]
+        tg_tj,
 
         [Description(@"ไทย")]
         th,
@@ -104,6 +140,9 @@ namespace osu.Game.Localisation
 
         [Description(@"简体中文")]
         zh,
+
+        [Description(@"繁體中文")]
+        zh_tw,
 
         // Traditional Chinese (Hong Kong) is listed in web sources but has no associated localisations,
         // and was wrongly falling back to Simplified Chinese.


### PR DESCRIPTION
Updated Language.cs to match the list of languages in osu! web (at least the ones I found in [osu-web/resources/lang](https://github.com/ppy/osu-web/tree/master/resources/lang))
Added Catalan, Persian, Filipino, Hebrew, Croatian, Lithuanian, Latvian, Malay, Slovenian, Serbian, Tajik, and Sinhala. 

Requested by peppy on Discord (https://discord.com/channels/188630481301012481/188630652340404224/1113739668358443038)