### PR TITLE
Fix legacy mod difficulty calculation creating all mods unnecessarily

### DIFF
--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Difficulty
 
             foreach (var combination in CreateDifficultyAdjustmentModCombinations())
             {
-                Mod classicMod = rulesetInstance.CreateAllMods().SingleOrDefault(m => m is ModClassic);
+                Mod classicMod = rulesetInstance.CreateMod<ModClassic>();
 
                 var finalCombination = ModUtils.FlattenMod(combination);
                 if (classicMod != null)


### PR DESCRIPTION
This only affected server diffcalcs that use this method (i.e. `osu-difficulty-calculator`).

I noticed this in profiling via:

![image](https://github.com/ppy/osu/assets/1329837/6c384bad-cf3a-41c6-960d-a601202b2032)

With backtraces:

![image](https://github.com/ppy/osu/assets/1329837/621fb6af-96df-4e36-be25-6e2ca9ae30f2)

Which brings up _multiple_ issues, but performance is the purpose of this PR - `OsuModBubbles` should never be instantiated in this case because it's not a legacy mod.

The issues are:
1. Diffcalc creating all mods (this PR).
2. `OsuModBubbles` creates a `DrawablePool` on instantiation.
3. `OsuModBubbles` never adds the `DrawablePool` to the hierarchy (surprised this works...).
4. `GlobalStatistics.Get()` should probably be a no-op in headless.