### PR TITLE
Fix song select beatmap panels sometimes not displaying correct background shown in web

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -108,6 +108,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             Header.Children = new Drawable[]
             {
+                // Choice of background image matches BSS implementation (always uses the lowest `beatmap_id` from the set).
                 background = new DelayedLoadWrapper(() => new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID)))
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             Header.Children = new Drawable[]
             {
-                background = new DelayedLoadWrapper(() => new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.FirstOrDefault()))
+                background = new DelayedLoadWrapper(() => new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID)))
                 {
                     RelativeSizeAxes = Axes.Both,
                 }, 300)


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/7524

Tested with:
- https://osu.ppy.sh/beatmapsets/1324491#osu/2743549
- https://osu.ppy.sh/beatmapsets/932291#osu/2166563
- https://osu.ppy.sh/beatmapsets/41823#osu/131891

| Before | After | Web |
| --- | --- | --- |
| ![VF2t5VGbjU](https://github.com/ppy/osu/assets/35318437/8ae52deb-bf8a-40aa-93a1-50b220335f11) | ![bLXdAHvmos](https://github.com/ppy/osu/assets/35318437/f1f0bcf2-5d00-4a55-9771-586157ff3d02) | ![firefox_Oy7k69COKx](https://github.com/ppy/osu/assets/35318437/c69244b3-a31d-4a7a-9880-b3f297cbe669) |