### PR TITLE
Fix ticks being created after the end of drum rolls in osu!taiko editor

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneDrumRollJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneDrumRollJudgements.cs
@@ -15,8 +15,6 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitAllDrumRoll()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
@@ -24,11 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(1001),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000
-            }));
+            }, CreateBeatmap(createDrumRoll(false)));
 
             AssertJudgementCount(3);
             AssertResult<DrumRollTick>(0, HitResult.SmallBonus);
@@ -39,18 +33,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitSomeDrumRoll()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000
-            }));
+            }, CreateBeatmap(createDrumRoll(false)));
 
             AssertJudgementCount(3);
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
@@ -61,16 +49,10 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitNoneDrumRoll()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000
-            }));
+            }, CreateBeatmap(createDrumRoll(false)));
 
             AssertJudgementCount(3);
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
@@ -81,8 +63,6 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitAllStrongDrumRollWithOneKey()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
@@ -90,12 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(1001),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000,
-                IsStrong = true
-            }));
+            }, CreateBeatmap(createDrumRoll(true)));
 
             AssertJudgementCount(6);
 
@@ -112,19 +87,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitSomeStrongDrumRollWithOneKey()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000,
-                IsStrong = true
-            }));
+            }, CreateBeatmap(createDrumRoll(true)));
 
             AssertJudgementCount(6);
 
@@ -141,8 +109,6 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitAllStrongDrumRollWithBothKeys()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
@@ -150,12 +116,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(1001),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000,
-                IsStrong = true
-            }));
+            }, CreateBeatmap(createDrumRoll(true)));
 
             AssertJudgementCount(6);
 
@@ -172,19 +133,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         [Test]
         public void TestHitSomeStrongDrumRollWithBothKeys()
         {
-            const double hit_time = 1000;
-
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
                 new TaikoReplayFrame(2001),
-            }, CreateBeatmap(new DrumRoll
-            {
-                StartTime = hit_time,
-                Duration = 1000,
-                IsStrong = true
-            }));
+            }, CreateBeatmap(createDrumRoll(true)));
 
             AssertJudgementCount(6);
 
@@ -197,5 +151,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
             AssertResult<StrongNestedHitObject>(2, HitResult.IgnoreHit);
         }
+
+        private DrumRoll createDrumRoll(bool strong) => new DrumRoll
+        {
+            StartTime = 1000,
+            Duration = 1000,
+            IsStrong = strong
+        };
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneDrumRollJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneDrumRollJudgements.cs
@@ -20,13 +20,22 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(1000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(1001),
+                new TaikoReplayFrame(1250, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1251),
+                new TaikoReplayFrame(1500, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1501),
+                new TaikoReplayFrame(1750, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1751),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(false)));
 
-            AssertJudgementCount(3);
+            AssertJudgementCount(6);
             AssertResult<DrumRollTick>(0, HitResult.SmallBonus);
             AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
+            AssertResult<DrumRollTick>(2, HitResult.SmallBonus);
+            AssertResult<DrumRollTick>(3, HitResult.SmallBonus);
+            AssertResult<DrumRollTick>(4, HitResult.SmallBonus);
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
         }
 
@@ -40,9 +49,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(false)));
 
-            AssertJudgementCount(3);
+            AssertJudgementCount(6);
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
-            AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
+            AssertResult<DrumRollTick>(1, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(2, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(3, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(4, HitResult.SmallBonus);
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
         }
 
@@ -54,9 +66,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(0),
             }, CreateBeatmap(createDrumRoll(false)));
 
-            AssertJudgementCount(3);
+            AssertJudgementCount(6);
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
             AssertResult<DrumRollTick>(1, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(2, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(3, HitResult.IgnoreMiss);
+            AssertResult<DrumRollTick>(4, HitResult.IgnoreMiss);
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
         }
 
@@ -68,20 +83,26 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(1000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(1001),
+                new TaikoReplayFrame(1250, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1251),
+                new TaikoReplayFrame(1500, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1501),
+                new TaikoReplayFrame(1750, TaikoAction.LeftCentre),
+                new TaikoReplayFrame(1751),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre),
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(true)));
 
-            AssertJudgementCount(6);
+            AssertJudgementCount(12);
 
-            AssertResult<DrumRollTick>(0, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(0, HitResult.LargeBonus);
-
-            AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(1, HitResult.LargeBonus);
+            for (int i = 0; i < 5; i++)
+            {
+                AssertResult<DrumRollTick>(i, HitResult.SmallBonus);
+                AssertResult<StrongNestedHitObject>(i, HitResult.LargeBonus);
+            }
 
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
-            AssertResult<StrongNestedHitObject>(2, HitResult.IgnoreHit);
+            AssertResult<StrongNestedHitObject>(5, HitResult.IgnoreHit);
         }
 
         [Test]
@@ -94,16 +115,16 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(true)));
 
-            AssertJudgementCount(6);
+            AssertJudgementCount(12);
 
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
             AssertResult<StrongNestedHitObject>(0, HitResult.IgnoreMiss);
 
-            AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(1, HitResult.LargeBonus);
+            AssertResult<DrumRollTick>(4, HitResult.SmallBonus);
+            AssertResult<StrongNestedHitObject>(4, HitResult.LargeBonus);
 
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
-            AssertResult<StrongNestedHitObject>(2, HitResult.IgnoreHit);
+            AssertResult<StrongNestedHitObject>(5, HitResult.IgnoreHit);
         }
 
         [Test]
@@ -114,20 +135,26 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(1000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
                 new TaikoReplayFrame(1001),
+                new TaikoReplayFrame(1250, TaikoAction.LeftCentre, TaikoAction.RightCentre),
+                new TaikoReplayFrame(1251),
+                new TaikoReplayFrame(1500, TaikoAction.LeftCentre, TaikoAction.RightCentre),
+                new TaikoReplayFrame(1501),
+                new TaikoReplayFrame(1750, TaikoAction.LeftCentre, TaikoAction.RightCentre),
+                new TaikoReplayFrame(1751),
                 new TaikoReplayFrame(2000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(true)));
 
-            AssertJudgementCount(6);
+            AssertJudgementCount(12);
 
-            AssertResult<DrumRollTick>(0, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(0, HitResult.LargeBonus);
-
-            AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(1, HitResult.LargeBonus);
+            for (int i = 0; i < 5; i++)
+            {
+                AssertResult<DrumRollTick>(i, HitResult.SmallBonus);
+                AssertResult<StrongNestedHitObject>(i, HitResult.LargeBonus);
+            }
 
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
-            AssertResult<StrongNestedHitObject>(2, HitResult.IgnoreHit);
+            AssertResult<StrongNestedHitObject>(5, HitResult.IgnoreHit);
         }
 
         [Test]
@@ -140,16 +167,16 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 new TaikoReplayFrame(2001),
             }, CreateBeatmap(createDrumRoll(true)));
 
-            AssertJudgementCount(6);
+            AssertJudgementCount(12);
 
             AssertResult<DrumRollTick>(0, HitResult.IgnoreMiss);
             AssertResult<StrongNestedHitObject>(0, HitResult.IgnoreMiss);
 
-            AssertResult<DrumRollTick>(1, HitResult.SmallBonus);
-            AssertResult<StrongNestedHitObject>(1, HitResult.LargeBonus);
+            AssertResult<DrumRollTick>(4, HitResult.SmallBonus);
+            AssertResult<StrongNestedHitObject>(4, HitResult.LargeBonus);
 
             AssertResult<DrumRoll>(0, HitResult.IgnoreHit);
-            AssertResult<StrongNestedHitObject>(2, HitResult.IgnoreHit);
+            AssertResult<StrongNestedHitObject>(5, HitResult.IgnoreHit);
         }
 
         private DrumRoll createDrumRoll(bool strong) => new DrumRoll

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -92,6 +92,14 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 }).ToList();
             }
 
+            // TODO: stable makes the last tick of a drumroll non-required when the next object is too close.
+            // This probably needs to be reimplemented:
+            //
+            // List<HitObject> hitobjects = hitObjectManager.hitObjects;
+            // int ind = hitobjects.IndexOf(this);
+            // if (i < hitobjects.Count - 1 && hitobjects[i + 1].HittableStartTime - (EndTime + (int)TickSpacing) <= (int)TickSpacing)
+            //     lastTickHittable = false;
+
             return converted;
         }
 

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -133,7 +133,6 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             StartTime = obj.StartTime,
                             Samples = obj.Samples,
                             Duration = taikoDuration,
-                            TickRate = beatmap.Difficulty.SliderTickRate == 3 ? 3 : 4,
                             SliderVelocity = obj is IHasSliderVelocity velocityData ? velocityData.SliderVelocity : 1
                         };
                     }

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Game.Rulesets.Objects.Types;
 using System.Threading;
 using osu.Framework.Bindables;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -86,7 +85,10 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
             bool first = true;
 
-            for (double t = StartTime; t < EndTime + tickSpacing / 2; t += tickSpacing)
+            // TODO: this implementation of drum roll tick does not match stable.
+            // Stable uses next-object intrinsics to decide whether the end of a drum roll gets a tick.
+            // It also changes the rate of ticks based on BPM. This is quite important.
+            for (double t = StartTime; Precision.AlmostBigger(EndTime, t, 1); t += tickSpacing)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
             bool first = true;
 
-            for (double t = StartTime; t < EndTime + tickSpacing; t += tickSpacing)
+            for (double t = StartTime; t < EndTime + tickSpacing / 2; t += tickSpacing)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -4,7 +4,6 @@
 using osu.Game.Rulesets.Objects.Types;
 using System.Threading;
 using osu.Framework.Bindables;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -68,6 +67,8 @@ namespace osu.Game.Rulesets.Taiko.Objects
             double scoringDistance = base_distance * difficulty.SliderMultiplier * SliderVelocity;
             Velocity = scoringDistance / timingPoint.BeatLength;
 
+            TickRate = difficulty.SliderTickRate == 3 ? 3 : 4;
+
             tickSpacing = timingPoint.BeatLength / TickRate;
         }
 
@@ -85,10 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
             bool first = true;
 
-            // TODO: this implementation of drum roll tick does not match stable.
-            // Stable uses next-object intrinsics to decide whether the end of a drum roll gets a tick.
-            // It also changes the rate of ticks based on BPM. This is quite important.
-            for (double t = StartTime; Precision.AlmostBigger(EndTime, t, 1); t += tickSpacing)
+            for (double t = StartTime; t < EndTime + tickSpacing; t += tickSpacing)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23135.

~~If this is merged, a new issue should be opened tracking how broken drum rolls are (if it hasn't been already).~~

This also fixes tick rate not getting propagated correctly to new drum rolls placed in the editor.