### PR TITLE
Add beat snap grid for osu!catch editor

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBeatSnapGrid.cs
@@ -1,0 +1,180 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Caching;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Screens.Edit;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Catch.Edit
+{
+    /// <summary>
+    /// A grid which displays coloured beat divisor lines in proximity to the selection or placement cursor.
+    /// </summary>
+    /// <remarks>
+    /// This class heavily borrows from osu!mania's implementation (ManiaBeatSnapGrid).
+    /// If further changes are to be made, they should also be applied there.
+    /// If the scale of the changes are large enough, abstracting may be a good path.
+    /// </remarks>
+    public partial class CatchBeatSnapGrid : Component
+    {
+        private const double visible_range = 750;
+
+        /// <summary>
+        /// The range of time values of the current selection.
+        /// </summary>
+        public (double start, double end)? SelectionTimeRange
+        {
+            set
+            {
+                if (value == selectionTimeRange)
+                    return;
+
+                selectionTimeRange = value;
+                lineCache.Invalidate();
+            }
+        }
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private BindableBeatDivisor beatDivisor { get; set; } = null!;
+
+        private readonly Cached lineCache = new Cached();
+
+        private (double start, double end)? selectionTimeRange;
+
+        private ScrollingHitObjectContainer lineContainer = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(HitObjectComposer composer)
+        {
+            lineContainer = new ScrollingHitObjectContainer();
+
+            ((CatchPlayfield)composer.Playfield).UnderlayElements.Add(lineContainer);
+
+            beatDivisor.BindValueChanged(_ => createLines(), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!lineCache.IsValid)
+            {
+                lineCache.Validate();
+                createLines();
+            }
+        }
+
+        private readonly Stack<DrawableGridLine> availableLines = new Stack<DrawableGridLine>();
+
+        private void createLines()
+        {
+            foreach (var line in lineContainer.Objects.OfType<DrawableGridLine>())
+                availableLines.Push(line);
+
+            lineContainer.Clear();
+
+            if (selectionTimeRange == null)
+                return;
+
+            var range = selectionTimeRange.Value;
+
+            var timingPoint = beatmap.ControlPointInfo.TimingPointAt(range.start - visible_range);
+
+            double time = timingPoint.Time;
+            int beat = 0;
+
+            // progress time until in the visible range.
+            while (time < range.start - visible_range)
+            {
+                time += timingPoint.BeatLength / beatDivisor.Value;
+                beat++;
+            }
+
+            while (time < range.end + visible_range)
+            {
+                var nextTimingPoint = beatmap.ControlPointInfo.TimingPointAt(time);
+
+                // switch to the next timing point if we have reached it.
+                if (nextTimingPoint.Time > timingPoint.Time)
+                {
+                    beat = 0;
+                    time = nextTimingPoint.Time;
+                    timingPoint = nextTimingPoint;
+                }
+
+                Color4 colour = BindableBeatDivisor.GetColourFor(
+                    BindableBeatDivisor.GetDivisorForBeatIndex(Math.Max(1, beat), beatDivisor.Value), colours);
+
+                if (!availableLines.TryPop(out var line))
+                    line = new DrawableGridLine();
+
+                line.HitObject.StartTime = time;
+                line.Colour = colour;
+
+                lineContainer.Add(line);
+
+                beat++;
+                time += timingPoint.BeatLength / beatDivisor.Value;
+            }
+
+            // required to update ScrollingHitObjectContainer's cache.
+            lineContainer.UpdateSubTree();
+
+            foreach (var line in lineContainer.Objects.OfType<DrawableGridLine>())
+            {
+                time = line.HitObject.StartTime;
+
+                if (time >= range.start && time <= range.end)
+                    line.Alpha = 1;
+                else
+                {
+                    double timeSeparation = time < range.start ? range.start - time : time - range.end;
+                    line.Alpha = (float)Math.Max(0, 1 - timeSeparation / visible_range);
+                }
+            }
+        }
+
+        private partial class DrawableGridLine : DrawableHitObject
+        {
+            public DrawableGridLine()
+                : base(new HitObject())
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 2;
+
+                AddInternal(new Box { RelativeSizeAxes = Axes.Both });
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Origin = Anchor.BottomLeft;
+                Anchor = Anchor.BottomLeft;
+            }
+
+            protected override void UpdateInitialTransforms()
+            {
+                // don't perform any fading – we are handling that ourselves.
+                LifetimeEnd = HitObject.StartTime + visible_range;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Edit/CatchBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBeatSnapGrid.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                 }
 
                 Color4 colour = BindableBeatDivisor.GetColourFor(
-                    BindableBeatDivisor.GetDivisorForBeatIndex(Math.Max(1, beat), beatDivisor.Value), colours);
+                    BindableBeatDivisor.GetDivisorForBeatIndex(beat, beatDivisor.Value), colours);
 
                 if (!availableLines.TryPop(out var line))
                     line = new DrawableGridLine();

--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         private InputManager inputManager = null!;
 
+        private CatchBeatSnapGrid beatSnapGrid = null!;
+
         private readonly BindableDouble timeRangeMultiplier = new BindableDouble(1)
         {
             MinValue = 1,
@@ -65,6 +67,8 @@ namespace osu.Game.Rulesets.Catch.Edit
                 Catcher.BASE_DASH_SPEED, -Catcher.BASE_DASH_SPEED,
                 Catcher.BASE_WALK_SPEED, -Catcher.BASE_WALK_SPEED,
             }));
+
+            AddInternal(beatSnapGrid = new CatchBeatSnapGrid());
         }
 
         protected override void LoadComplete()
@@ -72,6 +76,29 @@ namespace osu.Game.Rulesets.Catch.Edit
             base.LoadComplete();
 
             inputManager = GetContainingInputManager();
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            if (BlueprintContainer.CurrentTool is SelectTool)
+            {
+                if (EditorBeatmap.SelectedHitObjects.Any())
+                {
+                    beatSnapGrid.SelectionTimeRange = (EditorBeatmap.SelectedHitObjects.Min(h => h.StartTime), EditorBeatmap.SelectedHitObjects.Max(h => h.GetEndTime()));
+                }
+                else
+                    beatSnapGrid.SelectionTimeRange = null;
+            }
+            else
+            {
+                var result = FindSnappedPositionAndTime(inputManager.CurrentState.Mouse.Position);
+                if (result.Time is double time)
+                    beatSnapGrid.SelectionTimeRange = (time, time);
+                else
+                    beatSnapGrid.SelectionTimeRange = null;
+            }
         }
 
         protected override double ReadCurrentDistanceSnap(HitObject before, HitObject after)

--- a/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatchPlayfield.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
@@ -41,6 +42,8 @@ namespace osu.Game.Rulesets.Catch.UI
 
         internal CatcherArea CatcherArea { get; private set; } = null!;
 
+        public Container UnderlayElements { get; private set; } = null!;
+
         private readonly IBeatmapDifficultyInfo difficulty;
 
         public CatchPlayfield(IBeatmapDifficultyInfo difficulty)
@@ -62,6 +65,10 @@ namespace osu.Game.Rulesets.Catch.UI
 
             AddRangeInternal(new[]
             {
+                UnderlayElements = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
                 droppedObjectContainer,
                 Catcher.CreateProxiedContent(),
                 HitObjectContainer.CreateProxy(),

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBeatSnapGrid.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                 }
 
                 Color4 colour = BindableBeatDivisor.GetColourFor(
-                    BindableBeatDivisor.GetDivisorForBeatIndex(Math.Max(1, beat), beatDivisor.Value), colours);
+                    BindableBeatDivisor.GetDivisorForBeatIndex(beat, beatDivisor.Value), colours);
 
                 foreach (var grid in grids)
                 {


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/discussions/23462.

I haven't added test coverage for this because it's basically the same class as the osu!mania one, and can be easily tested from the editor test scene.

I chose not to abstract the mania implementation for now because it would require a bit of thinking (due to mania having multiple timelines), and I'm not sure it's worth it. Isolated implementations may be better as we move forward with differing editor implementations.