### PR TITLE
Fix settings jump buttons not always seeking to correct location the first time

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
@@ -81,6 +81,24 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestCorrectScrollToWhenContentLoads()
+        {
+            AddRepeatStep("add many sections", () => append(1f), 3);
+
+            AddStep("add section with delayed load content", () =>
+            {
+                container.Add(new TestDelayedLoadSection("delayed"));
+            });
+
+            AddStep("add final section", () => append(0.5f));
+
+            AddStep("scroll to final section", () => container.ScrollTo(container.Children.Last()));
+
+            AddUntilStep("correct section selected", () => container.SelectedSection.Value == container.Children.Last());
+            AddUntilStep("wait for scroll to section", () => container.ScreenSpaceDrawQuad.AABBFloat.Contains(container.Children.Last().ScreenSpaceDrawQuad.AABBFloat));
+        }
+
+        [Test]
         public void TestSelection()
         {
             AddStep("clear", () => container.Clear());
@@ -194,6 +212,33 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             InputManager.MoveMouseTo(container);
             InputManager.ScrollVerticalBy(direction);
+        }
+
+        private partial class TestDelayedLoadSection : TestSection
+        {
+            public TestDelayedLoadSection(string label)
+                : base(label)
+            {
+                BackgroundColour = default_colour;
+                Width = 300;
+                AutoSizeAxes = Axes.Y;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Box box;
+
+                Add(box = new Box
+                {
+                    Alpha = 0.01f,
+                    RelativeSizeAxes = Axes.X,
+                });
+
+                // Emulate an operation that will be inhibited by IsMaskedAway.
+                box.ResizeHeightTo(2000, 50);
+            }
         }
 
         private partial class TestSection : TestBox

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -328,7 +328,7 @@ namespace osu.Game.Overlays
                 base.UpdateAfterChildren();
 
                 // no null check because the usage of this class is strict
-                HeaderBackground.Alpha = -ExpandableHeader.Y / ExpandableHeader.LayoutSize.Y;
+                HeaderBackground!.Alpha = -ExpandableHeader!.Y / ExpandableHeader.LayoutSize.Y;
             }
         }
     }

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Overlays
                 if (lastSection != section.NewValue)
                 {
                     lastSection = section.NewValue;
-                    tabs.Current.Value = lastSection;
+                    tabs.Current.Value = lastSection!;
                 }
             };
 

--- a/osu.Game/Screens/Edit/Setup/SetupScreenHeader.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreenHeader.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Edit.Setup
         {
             base.LoadComplete();
 
-            sections.SelectedSection.BindValueChanged(section => tabControl.Current.Value = section.NewValue);
+            sections.SelectedSection.BindValueChanged(section => tabControl.Current.Value = section.NewValue!);
             tabControl.Current.BindValueChanged(section =>
             {
                 if (section.NewValue != sections.SelectedSection.Value)


### PR DESCRIPTION
- Supersedes and closes https://github.com/ppy/osu/pull/23125.
- Closes https://github.com/ppy/osu/issues/23123.
- Closes https://github.com/ppy/osu/issues/14631.

This method is as proposed [in review](https://github.com/ppy/osu/pull/23125#issuecomment-1496362374) of my last attempt.