### PR TITLE
Add ability to cycle beat snap divisor using hotkeys

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -51,9 +51,9 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestBindableBeatDivisor()
         {
-            AddRepeatStep("move previous", () => bindableBeatDivisor.Previous(), 2);
+            AddRepeatStep("move previous", () => bindableBeatDivisor.SelectPrevious(), 2);
             AddAssert("divisor is 4", () => bindableBeatDivisor.Value == 4);
-            AddRepeatStep("move next", () => bindableBeatDivisor.Next(), 1);
+            AddRepeatStep("move next", () => bindableBeatDivisor.SelectNext(), 1);
             AddAssert("divisor is 12", () => bindableBeatDivisor.Value == 8);
         }
 
@@ -101,6 +101,9 @@ namespace osu.Game.Tests.Visual.Editing
         public void TestBeatChevronNavigation()
         {
             switchBeatSnap(1);
+            assertBeatSnap(16);
+
+            switchBeatSnap(-4);
             assertBeatSnap(1);
 
             switchBeatSnap(3);
@@ -110,7 +113,7 @@ namespace osu.Game.Tests.Visual.Editing
             assertBeatSnap(4);
 
             switchBeatSnap(-3);
-            assertBeatSnap(16);
+            assertBeatSnap(1);
         }
 
         [Test]
@@ -207,7 +210,7 @@ namespace osu.Game.Tests.Visual.Editing
         }, Math.Abs(direction));
 
         private void assertBeatSnap(int expected) => AddAssert($"beat snap is {expected}",
-            () => bindableBeatDivisor.Value == expected);
+            () => bindableBeatDivisor.Value, () => Is.EqualTo(expected));
 
         private void switchPresets(int direction) => AddRepeatStep($"move presets {(direction > 0 ? "forward" : "backward")}", () =>
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -109,7 +109,10 @@ namespace osu.Game.Tests.Visual.Editing
             switchBeatSnap(3);
             assertBeatSnap(8);
 
-            switchBeatSnap(-1);
+            switchBeatSnap(3);
+            assertBeatSnap(16);
+
+            switchBeatSnap(-2);
             assertBeatSnap(4);
 
             switchBeatSnap(-3);

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -101,6 +101,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelDown }, GlobalAction.EditorDecreaseDistanceSpacing),
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelUp }, GlobalAction.EditorIncreaseDistanceSpacing),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelDown }, GlobalAction.EditorCyclePreviousBeatSnapDivisor),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelUp }, GlobalAction.EditorCycleNextBeatSnapDivisor),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -355,6 +357,12 @@ namespace osu.Game.Input.Bindings
         ToggleProfile,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCloneSelection))]
-        EditorCloneSelection
+        EditorCloneSelection,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCyclePreviousBeatSnapDivisor))]
+        EditorCyclePreviousBeatSnapDivisor,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleNextBeatSnapDivisor))]
+        EditorCycleNextBeatSnapDivisor,
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -101,8 +101,10 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.J }, GlobalAction.EditorFlipVertically),
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelDown }, GlobalAction.EditorDecreaseDistanceSpacing),
             new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.MouseWheelUp }, GlobalAction.EditorIncreaseDistanceSpacing),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelDown }, GlobalAction.EditorCyclePreviousBeatSnapDivisor),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelUp }, GlobalAction.EditorCycleNextBeatSnapDivisor),
+            // Framework automatically converts wheel up/down to left/right when shift is held.
+            // See https://github.com/ppy/osu-framework/blob/master/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs#L37-L38.
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelRight }, GlobalAction.EditorCyclePreviousBeatSnapDivisor),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelLeft }, GlobalAction.EditorCycleNextBeatSnapDivisor),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -280,6 +280,16 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorDecreaseDistanceSpacing => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Decrease distance spacing");
 
         /// <summary>
+        /// "Cycle previous beat snap divisor"
+        /// </summary>
+        public static LocalisableString EditorCyclePreviousBeatSnapDivisor => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Cycle previous beat snap divisor");
+
+        /// <summary>
+        /// "Cycle next beat snap divisor"
+        /// </summary>
+        public static LocalisableString EditorCycleNextBeatSnapDivisor => new TranslatableString(getKey(@"editor_increase_distance_spacing"), @"Cycle next beat snap divisor");
+
+        /// <summary>
         /// "Toggle skin editor"
         /// </summary>
         public static LocalisableString ToggleSkinEditor => new TranslatableString(getKey(@"toggle_skin_editor"), @"Toggle skin editor");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -282,12 +282,12 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Cycle previous beat snap divisor"
         /// </summary>
-        public static LocalisableString EditorCyclePreviousBeatSnapDivisor => new TranslatableString(getKey(@"editor_decrease_distance_spacing"), @"Cycle previous beat snap divisor");
+        public static LocalisableString EditorCyclePreviousBeatSnapDivisor => new TranslatableString(getKey(@"editor_cycle_previous_beat_snap_divisor"), @"Cycle previous beat snap divisor");
 
         /// <summary>
         /// "Cycle next beat snap divisor"
         /// </summary>
-        public static LocalisableString EditorCycleNextBeatSnapDivisor => new TranslatableString(getKey(@"editor_increase_distance_spacing"), @"Cycle next beat snap divisor");
+        public static LocalisableString EditorCycleNextBeatSnapDivisor => new TranslatableString(getKey(@"editor_cycle_next_snap_divisor"), @"Cycle next beat snap divisor");
 
         /// <summary>
         /// "Toggle skin editor"

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -59,16 +59,18 @@ namespace osu.Game.Screens.Edit
                 Value = 1;
         }
 
-        public void Next()
+        public void SelectNext()
         {
             var presets = ValidDivisors.Value.Presets;
-            Value = presets.Cast<int?>().SkipWhile(preset => preset != Value).ElementAtOrDefault(1) ?? presets[0];
+            if (presets.Cast<int?>().SkipWhile(preset => preset != Value).ElementAtOrDefault(1) is int newValue)
+                Value = newValue;
         }
 
-        public void Previous()
+        public void SelectPrevious()
         {
             var presets = ValidDivisors.Value.Presets;
-            Value = presets.Cast<int?>().TakeWhile(preset => preset != Value).LastOrDefault() ?? presets[^1];
+            if (presets.Cast<int?>().TakeWhile(preset => preset != Value).LastOrDefault() is int newValue)
+                Value = newValue;
         }
 
         protected override int DefaultPrecision => 1;

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -16,12 +16,14 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
@@ -29,7 +31,7 @@ using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    public partial class BeatDivisorControl : CompositeDrawable
+    public partial class BeatDivisorControl : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         private readonly BindableBeatDivisor beatDivisor = new BindableBeatDivisor();
 
@@ -218,6 +220,36 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
 
             return base.OnKeyDown(e);
+        }
+
+        public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.EditorCycleNextBeatSnapDivisor:
+                    cycle(1);
+                    return true;
+
+                case GlobalAction.EditorCyclePreviousBeatSnapDivisor:
+                    cycle(-1);
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void cycle(int direction)
+        {
+            var presets = beatDivisor.ValidDivisors.Value.Presets;
+
+            int selectedIndex = presets.Count(e => e < beatDivisor.Value);
+            int newIndex = Math.Clamp(selectedIndex + direction, 0, presets.Count - 1);
+
+            beatDivisor.Value = presets[newIndex];
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
 
         internal partial class DivisorDisplay : OsuAnimatedButton, IHasPopover

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -222,7 +222,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return base.OnKeyDown(e);
         }
 
-        public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             switch (e.Action)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -238,16 +238,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             return false;
         }
 
-        private void cycle(int direction)
-        {
-            var presets = beatDivisor.ValidDivisors.Value.Presets;
-
-            int selectedIndex = presets.Count(e => e < beatDivisor.Value);
-            int newIndex = Math.Clamp(selectedIndex + direction, 0, presets.Count - 1);
-
-            beatDivisor.Value = presets[newIndex];
-        }
-
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
         }

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -103,13 +103,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
                                                     new ChevronButton
                                                     {
                                                         Icon = FontAwesome.Solid.ChevronLeft,
-                                                        Action = beatDivisor.Previous
+                                                        Action = beatDivisor.SelectPrevious
                                                     },
                                                     new DivisorDisplay { BeatDivisor = { BindTarget = beatDivisor } },
                                                     new ChevronButton
                                                     {
                                                         Icon = FontAwesome.Solid.ChevronRight,
-                                                        Action = beatDivisor.Next
+                                                        Action = beatDivisor.SelectNext
                                                     }
                                                 },
                                             },
@@ -227,11 +227,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Action)
             {
                 case GlobalAction.EditorCycleNextBeatSnapDivisor:
-                    cycle(1);
+                    beatDivisor.SelectNext();
                     return true;
 
                 case GlobalAction.EditorCyclePreviousBeatSnapDivisor:
-                    cycle(-1);
+                    beatDivisor.SelectPrevious();
                     return true;
             }
 
@@ -474,12 +474,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 switch (e.Key)
                 {
                     case Key.Right:
-                        beatDivisor.Next();
+                        beatDivisor.SelectNext();
                         OnUserChange(Current.Value);
                         return true;
 
                     case Key.Left:
-                        beatDivisor.Previous();
+                        beatDivisor.SelectPrevious();
                         OnUserChange(Current.Value);
                         return true;
 


### PR DESCRIPTION
Defaults to Ctrl+Shift+Wheel (as per stable).

Of note, this doesn't work by default on macOS becauseli `MouseUp` becomes `MouseLeft` when holding shift. But that's probably fine for the user to figure out if they really need this shortcut.

- [x] Test the defaults work correctly on windows

Closes #23785.