### PR TITLE
Display API responses in client language

### DIFF
--- a/osu.Game/Extensions/LanguageExtensions.cs
+++ b/osu.Game/Extensions/LanguageExtensions.cs
@@ -21,7 +21,12 @@ namespace osu.Game.Extensions
         /// This is required as enum member names are not allowed to contain hyphens.
         /// </remarks>
         public static string ToCultureCode(this Language language)
-            => language.ToString().Replace("_", "-");
+        {
+            if (language == Language.zh_hant)
+                return @"zh-tw";
+
+            return language.ToString().Replace("_", "-");
+        }
 
         /// <summary>
         /// Attempts to parse the supplied <paramref name="cultureCode"/> to a <see cref="Language"/> value.
@@ -30,7 +35,15 @@ namespace osu.Game.Extensions
         /// <param name="language">The parsed <see cref="Language"/>. Valid only if the return value of the method is <see langword="true" />.</param>
         /// <returns>Whether the parsing succeeded.</returns>
         public static bool TryParseCultureCode(string cultureCode, out Language language)
-            => Enum.TryParse(cultureCode.Replace("-", "_"), out language);
+        {
+            if (cultureCode == @"zh-tw")
+            {
+                language = Language.zh_hant;
+                return true;
+            }
+
+            return Enum.TryParse(cultureCode.Replace("-", "_"), out language);
+        }
 
         /// <summary>
         /// Parses the <see cref="Language"/> that is specified in <paramref name="frameworkLocale"/>,

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -18,6 +18,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Configuration;
+using osu.Game.Localisation;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Notifications;
@@ -28,6 +29,7 @@ namespace osu.Game.Online.API
 {
     public partial class APIAccess : Component, IAPIProvider
     {
+        private readonly OsuGameBase game;
         private readonly OsuConfigManager config;
 
         private readonly string versionHash;
@@ -52,6 +54,8 @@ namespace osu.Game.Online.API
         public IBindableList<APIUser> Friends => friends;
         public IBindable<UserActivity> Activity => activity;
 
+        public Language Language => game.CurrentLanguage.Value;
+
         private Bindable<APIUser> localUser { get; } = new Bindable<APIUser>(createGuestUser());
 
         private BindableList<APIUser> friends { get; } = new BindableList<APIUser>();
@@ -64,8 +68,9 @@ namespace osu.Game.Online.API
 
         private readonly Logger log;
 
-        public APIAccess(OsuConfigManager config, EndpointConfiguration endpointConfiguration, string versionHash)
+        public APIAccess(OsuGameBase game, OsuConfigManager config, EndpointConfiguration endpointConfiguration, string versionHash)
         {
+            this.game = game;
             this.config = config;
             this.versionHash = versionHash;
 

--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.IO.Network;
 using osu.Framework.Logging;
+using osu.Game.Extensions;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Online.API
@@ -116,10 +117,11 @@ namespace osu.Game.Online.API
             WebRequest.Failed += Fail;
             WebRequest.AllowRetryOnTimeout = false;
 
-            WebRequest.AddHeader("x-api-version", API.APIVersion.ToString(CultureInfo.InvariantCulture));
+            WebRequest.AddHeader(@"Accept-Language", API.Language.ToCultureCode());
+            WebRequest.AddHeader(@"x-api-version", API.APIVersion.ToString(CultureInfo.InvariantCulture));
 
             if (!string.IsNullOrEmpty(API.AccessToken))
-                WebRequest.AddHeader("Authorization", $"Bearer {API.AccessToken}");
+                WebRequest.AddHeader(@"Authorization", $@"Bearer {API.AccessToken}");
 
             if (isFailing) return;
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Notifications;
 using osu.Game.Tests;
@@ -28,6 +29,8 @@ namespace osu.Game.Online.API
         public BindableList<APIUser> Friends { get; } = new BindableList<APIUser>();
 
         public Bindable<UserActivity> Activity { get; } = new Bindable<UserActivity>();
+
+        public Language Language => Language.en;
 
         public string AccessToken => "token";
 

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
+using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Notifications;
 using osu.Game.Users;
@@ -26,6 +27,11 @@ namespace osu.Game.Online.API
         /// The current user's activity.
         /// </summary>
         IBindable<UserActivity> Activity { get; }
+
+        /// <summary>
+        /// The language supplied by this provider to API requests.
+        /// </summary>
+        Language Language { get; }
 
         /// <summary>
         /// Retrieve the OAuth access token.

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -296,7 +296,6 @@ namespace osu.Game
 
             MessageFormatter.WebsiteRootUrl = endpoints.WebsiteRootUrl;
 
-            dependencies.CacheAs(API ??= new APIAccess(LocalConfig, endpoints, VersionHash));
             frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
             frameworkLocale.BindValueChanged(_ => updateLanguage());
 
@@ -305,6 +304,7 @@ namespace osu.Game
 
             CurrentLanguage.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
 
+            dependencies.CacheAs(API ??= new APIAccess(this, LocalConfig, endpoints, VersionHash));
 
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -14,6 +14,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
@@ -27,6 +28,7 @@ using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Input.Handlers.Touch;
 using osu.Framework.IO.Stores;
+using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Timing;
@@ -36,11 +38,13 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
 using osu.Game.IO;
+using osu.Game.Localisation;
 using osu.Game.Online;
 using osu.Game.Online.API;
 using osu.Game.Online.Chat;
@@ -157,6 +161,11 @@ namespace osu.Game
 
         protected Storage Storage { get; set; }
 
+        /// <summary>
+        /// The language in which the game is currently displayed in.
+        /// </summary>
+        public Bindable<Language> CurrentLanguage { get; } = new Bindable<Language>();
+
         protected Bindable<WorkingBeatmap> Beatmap { get; private set; } // cached via load() method
 
         /// <summary>
@@ -216,6 +225,10 @@ namespace osu.Game
 
         private readonly BindableNumber<double> globalTrackVolumeAdjust = new BindableNumber<double>(global_track_volume_adjust);
 
+        private Bindable<string> frameworkLocale = null!;
+
+        private IBindable<LocalisationParameters> localisationParameters = null!;
+
         /// <summary>
         /// Number of unhandled exceptions to allow before aborting execution.
         /// </summary>
@@ -238,7 +251,7 @@ namespace osu.Game
         }
 
         [BackgroundDependencyLoader]
-        private void load(ReadableKeyCombinationProvider keyCombinationProvider)
+        private void load(ReadableKeyCombinationProvider keyCombinationProvider, FrameworkConfigManager frameworkConfig)
         {
             try
             {
@@ -284,6 +297,14 @@ namespace osu.Game
             MessageFormatter.WebsiteRootUrl = endpoints.WebsiteRootUrl;
 
             dependencies.CacheAs(API ??= new APIAccess(LocalConfig, endpoints, VersionHash));
+            frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
+            frameworkLocale.BindValueChanged(_ => updateLanguage());
+
+            localisationParameters = Localisation.CurrentParameters.GetBoundCopy();
+            localisationParameters.BindValueChanged(_ => updateLanguage(), true);
+
+            CurrentLanguage.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
+
 
             var defaultBeatmap = new DummyWorkingBeatmap(Audio, Textures);
 
@@ -393,6 +414,8 @@ namespace osu.Game
             Ruleset.BindValueChanged(onRulesetChanged);
             Beatmap.BindValueChanged(onBeatmapChanged);
         }
+
+        private void updateLanguage() => CurrentLanguage.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, localisationParameters.Value);
 
         private void addFilesWarning()
         {

--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -2,35 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Extensions;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.General
 {
     public partial class LanguageSettings : SettingsSubsection
     {
-        private SettingsDropdown<Language> languageSelection = null!;
-        private Bindable<string> frameworkLocale = null!;
-        private IBindable<LocalisationParameters> localisationParameters = null!;
-
         protected override LocalisableString Header => GeneralSettingsStrings.LanguageHeader;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager frameworkConfig, OsuConfigManager config, LocalisationManager localisation)
+        private void load(OsuGame game, OsuConfigManager config, FrameworkConfigManager frameworkConfig)
         {
-            frameworkLocale = frameworkConfig.GetBindable<string>(FrameworkSetting.Locale);
-            localisationParameters = localisation.CurrentParameters.GetBoundCopy();
-
             Children = new Drawable[]
             {
-                languageSelection = new SettingsEnumDropdown<Language>
+                new SettingsEnumDropdown<Language>
                 {
                     LabelText = GeneralSettingsStrings.LanguageDropdown,
+                    Current = game.CurrentLanguage,
                 },
                 new SettingsCheckbox
                 {
@@ -43,14 +35,6 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     Current = config.GetBindable<bool>(OsuSetting.Prefer24HourTime)
                 },
             };
-
-            frameworkLocale.BindValueChanged(_ => updateSelection());
-            localisationParameters.BindValueChanged(_ => updateSelection(), true);
-
-            languageSelection.Current.BindValueChanged(val => frameworkLocale.Value = val.NewValue.ToCultureCode());
         }
-
-        private void updateSelection() =>
-            languageSelection.Current.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, localisationParameters.Value);
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/LanguageSettings.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
         protected override LocalisableString Header => GeneralSettingsStrings.LanguageHeader;
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame game, OsuConfigManager config, FrameworkConfigManager frameworkConfig)
+        private void load(OsuGameBase game, OsuConfigManager config, FrameworkConfigManager frameworkConfig)
         {
             Children = new Drawable[]
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/14662

Now with https://github.com/ppy/osu-web/pull/9958, we can supply the `Accept-Language` header in API requests and have all responses sent in the language currently set by the user in the client.

I've borrowed the `zh-tw`–`zh_Hant` handling from https://github.com/ppy/osu/pull/23296 in here for API responses to display correctly in Traditional Chinese.

https://github.com/ppy/osu/assets/22781491/1b5da5a6-e6f5-444d-9c75-6dc572d9ece8

