### PR TITLE
Refactor `IWorkingBeatmap.Background` to `GetBackground()`

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -231,7 +231,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
             protected override IBeatmap GetBeatmap() => beatmap;
 
-            protected override Texture GetBackground() => throw new NotImplementedException();
+            public override Texture GetBackground() => throw new NotImplementedException();
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             var mock = new Mock<IWorkingBeatmap>();
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
-            mock.SetupGet(w => w.GetBackground()).Returns(background);
+            mock.Setup(w => w.GetBackground()).Returns(background);
             mock.Setup(w => w.GetStream(It.IsAny<string>())).Returns(stream);
 
             return mock;

--- a/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckBackgroundQualityTest.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Editing.Checks
 
             var mock = new Mock<IWorkingBeatmap>();
             mock.SetupGet(w => w.Beatmap).Returns(beatmap);
-            mock.SetupGet(w => w.Background).Returns(background);
+            mock.SetupGet(w => w.GetBackground()).Returns(background);
             mock.Setup(w => w.GetStream(It.IsAny<string>())).Returns(stream);
 
             return mock;

--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Tests.Visual.Background
                 this.renderer = renderer;
             }
 
-            protected override Texture GetBackground() => renderer.CreateTexture(1, 1);
+            public override Texture GetBackground() => renderer.CreateTexture(1, 1);
         }
 
         private partial class TestWorkingBeatmapWithStoryboard : TestWorkingBeatmap

--- a/osu.Game.Tests/WaveformTestBeatmap.cs
+++ b/osu.Game.Tests/WaveformTestBeatmap.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Tests
 
         protected override IBeatmap GetBeatmap() => beatmap;
 
-        protected override Texture GetBackground() => null;
+        public override Texture GetBackground() => null;
 
         protected override Waveform GetWaveform() => new Waveform(trackStore.GetStream(firstAudioFile));
 

--- a/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/BeatmapBackgroundSprite.cs
@@ -23,8 +23,9 @@ namespace osu.Game.Beatmaps.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (working.Background != null)
-                Texture = working.Background;
+            var background = working.GetBackground();
+            if (background != null)
+                Texture = background;
         }
     }
 }

--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
 
         protected override IBeatmap GetBeatmap() => new Beatmap();
 
-        protected override Texture GetBackground() => textures?.Get(@"Backgrounds/bg4");
+        public override Texture GetBackground() => textures?.Get(@"Backgrounds/bg4");
 
         protected override Track GetBeatmapTrack() => GetVirtualTrack();
 

--- a/osu.Game/Beatmaps/FlatFileWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/FlatFileWorkingBeatmap.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps
         }
 
         protected override IBeatmap GetBeatmap() => beatmap;
-        protected override Texture GetBackground() => throw new NotImplementedException();
+        public override Texture GetBackground() => throw new NotImplementedException();
         protected override Track GetBeatmapTrack() => throw new NotImplementedException();
         protected internal override ISkin GetSkin() => throw new NotImplementedException();
         public override Stream GetStream(string storagePath) => throw new NotImplementedException();

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves the background for this <see cref="IWorkingBeatmap"/>.
         /// </summary>
-        Texture Background { get; }
+        Texture GetBackground();
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Beatmaps
 
         public Storyboard Storyboard => storyboard.Value;
 
-        public Texture Background => GetBackground(); // Texture uses ref counting, so we want to return a new instance every usage.
-
         public ISkin Skin => skin.Value;
 
         private AudioManager audioManager { get; }
@@ -67,7 +65,7 @@ namespace osu.Game.Beatmaps
         protected virtual Storyboard GetStoryboard() => new Storyboard { BeatmapInfo = BeatmapInfo };
 
         protected abstract IBeatmap GetBeatmap();
-        protected abstract Texture GetBackground();
+        public abstract Texture GetBackground();
         protected abstract Track GetBeatmapTrack();
 
         /// <summary>

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            protected override Texture GetBackground()
+            public override Texture GetBackground()
             {
                 if (string.IsNullOrEmpty(Metadata?.BackgroundFile))
                     return null;

--- a/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
+++ b/osu.Game/Graphics/Backgrounds/BeatmapBackground.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Graphics.Backgrounds
         [BackgroundDependencyLoader]
         private void load(LargeTextureStore textures)
         {
-            Sprite.Texture = Beatmap?.Background ?? textures.Get(fallbackTextureName);
+            Sprite.Texture = Beatmap?.GetBackground() ?? textures.Get(fallbackTextureName);
         }
 
         public override bool Equals(Background other)

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -415,7 +415,7 @@ namespace osu.Game.Overlays
             [BackgroundDependencyLoader]
             private void load(LargeTextureStore textures)
             {
-                sprite.Texture = beatmap?.Background ?? textures.Get(@"Backgrounds/bg4");
+                sprite.Texture = beatmap?.GetBackground() ?? textures.Get(@"Backgrounds/bg4");
             }
         }
 

--- a/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckBackgroundQuality.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Edit.Checks
             if (backgroundFile == null)
                 yield break;
 
-            var texture = context.WorkingBeatmap.Background;
+            var texture = context.WorkingBeatmap.GetBackground();
             if (texture == null)
                 yield break;
 

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -204,7 +204,7 @@ namespace osu.Game.Screens.Edit
 
             protected override IBeatmap GetBeatmap() => beatmap;
 
-            protected override Texture GetBackground() => throw new NotImplementedException();
+            public override Texture GetBackground() => throw new NotImplementedException();
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 

--- a/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/PlaylistItemBackground.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             if (Beatmap?.BeatmapSet is IBeatmapSetOnlineInfo online)
                 texture = textures.Get(online.Covers.Cover);
 
-            Sprite.Texture = texture ?? beatmaps.DefaultBeatmap.Background;
+            Sprite.Texture = texture ?? beatmaps.DefaultBeatmap.GetBackground();
         }
 
         public override bool Equals(Background? other)

--- a/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
+++ b/osu.Game/Screens/Play/BeatmapMetadataDisplay.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Screens.Play
                                 new Sprite
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Texture = beatmap.Background,
+                                    Texture = beatmap.GetBackground(),
                                     Origin = Anchor.Centre,
                                     Anchor = Anchor.Centre,
                                     FillMode = FillMode.Fill,

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Screens.Play.HUD
 
             protected override IBeatmap GetBeatmap() => gameplayBeatmap;
 
-            protected override Texture GetBackground() => throw new NotImplementedException();
+            public override Texture GetBackground() => throw new NotImplementedException();
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 

--- a/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
+++ b/osu.Game/Tests/Beatmaps/BeatmapConversionTest.cs
@@ -232,7 +232,7 @@ namespace osu.Game.Tests.Beatmaps
 
             protected override IBeatmap GetBeatmap() => beatmap;
 
-            protected override Texture GetBackground() => throw new NotImplementedException();
+            public override Texture GetBackground() => throw new NotImplementedException();
 
             protected override Track GetBeatmapTrack() => throw new NotImplementedException();
 

--- a/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
+++ b/osu.Game/Tests/Beatmaps/TestWorkingBeatmap.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Beatmaps
 
         public override Stream? GetStream(string storagePath) => null;
 
-        protected override Texture? GetBackground() => null;
+        public override Texture? GetBackground() => null;
 
         protected override Track? GetBeatmapTrack() => null;
     }


### PR DESCRIPTION
This property has been misleading for a long time (see comment about a new texture being returned each time due to refcounting), so I propose we rename it in line with our standards to avoid any confusion.