### PR TITLE
Greatly improve song select performance by cropping beatmap backgrounds before display

### DIFF
--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+
+namespace osu.Game.Beatmaps
+{
+    // Implementation of this class is based off of `MaxDimensionLimitedTextureLoaderStore`.
+    // If issues are found it's worth checking to make sure similar issues exist there.
+    public class BeatmapPanelBackgroundTextureLoaderStore : IResourceStore<TextureUpload>
+    {
+        // These numbers are taken from the draw visualiser size requirements for song select panel textures at extreme aspect ratios.
+        private const int height = 130;
+        private const int max_width = 1280;
+
+        private readonly IResourceStore<TextureUpload>? textureStore;
+
+        public BeatmapPanelBackgroundTextureLoaderStore(IResourceStore<TextureUpload>? textureStore)
+        {
+            this.textureStore = textureStore;
+        }
+
+        public void Dispose()
+        {
+            textureStore?.Dispose();
+        }
+
+        public TextureUpload Get(string name)
+        {
+            var textureUpload = textureStore?.Get(name);
+
+            // NRT not enabled on framework side classes (IResourceStore / TextureLoaderStore), welp.
+            if (textureUpload == null)
+                return null!;
+
+            return limitTextureUploadSize(textureUpload);
+        }
+
+        public async Task<TextureUpload> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+        {
+            // NRT not enabled on framework side classes (IResourceStore / TextureLoaderStore), welp.
+            if (textureStore == null)
+                return null!;
+
+            var textureUpload = await textureStore.GetAsync(name, cancellationToken).ConfigureAwait(false);
+
+            if (textureUpload == null)
+                return null!;
+
+            return await Task.Run(() => limitTextureUploadSize(textureUpload), cancellationToken).ConfigureAwait(false);
+        }
+
+        private TextureUpload limitTextureUploadSize(TextureUpload textureUpload)
+        {
+            var image = Image.LoadPixelData(textureUpload.Data.ToArray(), textureUpload.Width, textureUpload.Height);
+
+            // The original texture upload will no longer be returned or used.
+            textureUpload.Dispose();
+
+            Size size = image.Size();
+            int usableWidth = Math.Min(max_width, size.Width);
+
+            // Crop the centre region of the background for now.
+            Rectangle cropRectangle = new Rectangle(
+                (size.Width - usableWidth) / 2,
+                size.Height / 2 - height / 2,
+                usableWidth,
+                height
+            );
+
+            image.Mutate(i => i.Crop(cropRectangle));
+
+            return new TextureUpload(image);
+        }
+
+        public Stream? GetStream(string name) => textureStore?.GetStream(name);
+
+        public IEnumerable<string> GetAvailableResources() => textureStore?.GetAvailableResources() ?? Array.Empty<string>();
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Beatmaps
     public class BeatmapPanelBackgroundTextureLoaderStore : IResourceStore<TextureUpload>
     {
         // These numbers are taken from the draw visualiser size requirements for song select panel textures at extreme aspect ratios.
-        private const int height = 130;
+        private const int max_height = 130;
         private const int max_width = 1280;
 
         private readonly IResourceStore<TextureUpload>? textureStore;
@@ -67,13 +67,14 @@ namespace osu.Game.Beatmaps
 
             Size size = image.Size();
             int usableWidth = Math.Min(max_width, size.Width);
+            int usableHeight = Math.Min(max_height, size.Height);
 
             // Crop the centre region of the background for now.
             Rectangle cropRectangle = new Rectangle(
                 (size.Width - usableWidth) / 2,
-                size.Height / 2 - height / 2,
+                (size.Height - usableHeight) / 3,
                 usableWidth,
-                height
+                usableHeight
             );
 
             image.Mutate(i => i.Crop(cropRectangle));

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Beatmaps
             // Crop the centre region of the background for now.
             Rectangle cropRectangle = new Rectangle(
                 (size.Width - usableWidth) / 2,
-                (size.Height - usableHeight) / 3,
+                (size.Height - usableHeight) / 2,
                 usableWidth,
                 usableHeight
             );

--- a/osu.Game/Beatmaps/IBeatmapResourceProvider.cs
+++ b/osu.Game/Beatmaps/IBeatmapResourceProvider.cs
@@ -9,7 +9,7 @@ using osu.Game.IO;
 
 namespace osu.Game.Beatmaps
 {
-    public interface IBeatmapResourceProvider : IStorageResourceProvider
+    internal interface IBeatmapResourceProvider : IStorageResourceProvider
     {
         /// <summary>
         /// Retrieve a global large texture store, used for loading beatmap backgrounds.

--- a/osu.Game/Beatmaps/IBeatmapResourceProvider.cs
+++ b/osu.Game/Beatmaps/IBeatmapResourceProvider.cs
@@ -17,6 +17,11 @@ namespace osu.Game.Beatmaps
         TextureStore LargeTextureStore { get; }
 
         /// <summary>
+        /// Retrieve a global large texture store, used specifically for retrieving cropped beatmap panel backgrounds.
+        /// </summary>
+        TextureStore BeatmapPanelTextureStore { get; }
+
+        /// <summary>
         /// Access a global track store for retrieving beatmap tracks from.
         /// </summary>
         ITrackStore Tracks { get; }

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves a cropped background for this <see cref="IWorkingBeatmap"/> used for display on panels.
         /// </summary>
-        internal Texture GetPanelBackground();
+        Texture GetPanelBackground();
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -32,12 +32,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Whether the Beatmap has finished loading.
         ///</summary>
-        public bool BeatmapLoaded { get; }
+        bool BeatmapLoaded { get; }
 
         /// <summary>
         /// Whether the Track has finished loading.
         ///</summary>
-        public bool TrackLoaded { get; }
+        bool TrackLoaded { get; }
 
         /// <summary>
         /// Retrieves the <see cref="IBeatmap"/> which this <see cref="IWorkingBeatmap"/> represents.
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Retrieves a cropped background for this <see cref="IWorkingBeatmap"/> used for display on panels.
         /// </summary>
-        Texture GetPanelBackground();
+        internal Texture GetPanelBackground();
 
         /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
@@ -129,12 +129,12 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// Beings loading the contents of this <see cref="IWorkingBeatmap"/> asynchronously.
         /// </summary>
-        public void BeginAsyncLoad();
+        void BeginAsyncLoad();
 
         /// <summary>
         /// Cancels the asynchronous loading of the contents of this <see cref="IWorkingBeatmap"/>.
         /// </summary>
-        public void CancelAsyncLoad();
+        void CancelAsyncLoad();
 
         /// <summary>
         /// Reads the correct track restart point from beatmap metadata and sets looping to enabled.

--- a/osu.Game/Beatmaps/IWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/IWorkingBeatmap.cs
@@ -50,6 +50,11 @@ namespace osu.Game.Beatmaps
         Texture GetBackground();
 
         /// <summary>
+        /// Retrieves a cropped background for this <see cref="IWorkingBeatmap"/> used for display on panels.
+        /// </summary>
+        Texture GetPanelBackground();
+
+        /// <summary>
         /// Retrieves the <see cref="Waveform"/> for the <see cref="Track"/> of this <see cref="IWorkingBeatmap"/>.
         /// </summary>
         Waveform Waveform { get; }

--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Beatmaps
 
         protected abstract IBeatmap GetBeatmap();
         public abstract Texture GetBackground();
+        public virtual Texture GetPanelBackground() => GetBackground();
         protected abstract Track GetBeatmapTrack();
 
         /// <summary>

--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Beatmaps
         private readonly AudioManager audioManager;
         private readonly IResourceStore<byte[]> resources;
         private readonly LargeTextureStore largeTextureStore;
+        private readonly LargeTextureStore beatmapPanelTextureStore;
         private readonly ITrackStore trackStore;
         private readonly IResourceStore<byte[]> files;
 
@@ -58,6 +59,7 @@ namespace osu.Game.Beatmaps
             this.host = host;
             this.files = files;
             largeTextureStore = new LargeTextureStore(host?.Renderer ?? new DummyRenderer(), host?.CreateTextureLoaderStore(files));
+            beatmapPanelTextureStore = new LargeTextureStore(host?.Renderer ?? new DummyRenderer(), new BeatmapPanelBackgroundTextureLoaderStore(host?.CreateTextureLoaderStore(files)));
             this.trackStore = trackStore;
         }
 
@@ -110,6 +112,7 @@ namespace osu.Game.Beatmaps
         #region IResourceStorageProvider
 
         TextureStore IBeatmapResourceProvider.LargeTextureStore => largeTextureStore;
+        TextureStore IBeatmapResourceProvider.BeatmapPanelTextureStore => beatmapPanelTextureStore;
         ITrackStore IBeatmapResourceProvider.Tracks => trackStore;
         IRenderer IStorageResourceProvider.Renderer => host?.Renderer ?? new DummyRenderer();
         AudioManager IStorageResourceProvider.AudioManager => audioManager;
@@ -160,7 +163,11 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            public override Texture GetBackground()
+            public override Texture GetPanelBackground() => getBackgroundFromStore(resources.BeatmapPanelTextureStore);
+
+            public override Texture GetBackground() => getBackgroundFromStore(resources.LargeTextureStore);
+
+            private Texture getBackgroundFromStore(TextureStore store)
             {
                 if (string.IsNullOrEmpty(Metadata?.BackgroundFile))
                     return null;
@@ -168,7 +175,7 @@ namespace osu.Game.Beatmaps
                 try
                 {
                     string fileStorePath = BeatmapSetInfo.GetPathForFile(Metadata.BackgroundFile);
-                    var texture = resources.LargeTextureStore.Get(fileStorePath);
+                    var texture = store.Get(fileStorePath);
 
                     if (texture == null)
                     {

--- a/osu.Game/Screens/Select/Carousel/SetPanelBackground.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelBackground.cs
@@ -1,12 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -21,7 +23,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             Children = new Drawable[]
             {
-                new BeatmapBackgroundSprite(working)
+                new PanelBeatmapBackground(working)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
@@ -67,6 +69,24 @@ namespace osu.Game.Screens.Select.Carousel
                     }
                 },
             };
+        }
+
+        public partial class PanelBeatmapBackground : Sprite
+        {
+            private readonly IWorkingBeatmap working;
+
+            public PanelBeatmapBackground(IWorkingBeatmap working)
+            {
+                ArgumentNullException.ThrowIfNull(working);
+
+                this.working = working;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Texture = working.GetPanelBackground();
+            }
         }
     }
 }


### PR DESCRIPTION
This is an effort to improve general performance at song select. At least on the metal renderer, I can notice very high draw frame overheads related to texture uploads.

By reducing the size of the texture uploads to roughly match what is actually being displayed on screen (using a relatively inexpensive crop operation), we can bastly reduce stuttering both during initial load and carousel scroll.

You might ask if it's safe to disable mipmapping, but I've tested with lower resolutions and bilinear filtering seems to handle just fine. Bilinear without mipmaps only falls apart when you scale below 50% and we're not going too far past that at minimum game scale, if at all.

I also tested removing the `BufferedContainer` in `SetPanelBackground`, but this has a slightly reduction in performance (due to more layering) so I've left it in place for now.

A future effort could see that the cropped versions are cached to a disk store. It could also potentially be used in `UpdateableBeatmapBackgroundSprite`, at least for local display cases.

- [x] Depends on https://github.com/ppy/osu/pull/23808


Before:

https://github.com/ppy/osu/assets/191335/e825cf3d-9cab-41fe-93d9-0ef78c6e763c

After:

https://github.com/ppy/osu/assets/191335/f9a7f05b-3b01-40f7-a0aa-930a370d09be



