### PR TITLE
Reduce delays and fades for carousel panels to improve song select initial display performance

### DIFF
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -112,11 +112,11 @@ namespace osu.Game.Screens.Select.Carousel
                 background = new DelayedLoadWrapper(() => new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID)))
                 {
                     RelativeSizeAxes = Axes.Both,
-                }, 300)
+                }, 200)
                 {
                     RelativeSizeAxes = Axes.Both
                 },
-                mainFlow = new DelayedLoadWrapper(() => new SetPanelContent((CarouselBeatmapSet)Item), 100)
+                mainFlow = new DelayedLoadWrapper(() => new SetPanelContent((CarouselBeatmapSet)Item), 50)
                 {
                     RelativeSizeAxes = Axes.Both
                 },
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.Select.Carousel
             mainFlow.DelayedLoadComplete += fadeContentIn;
         }
 
-        private void fadeContentIn(Drawable d) => d.FadeInFromZero(750, Easing.OutQuint);
+        private void fadeContentIn(Drawable d) => d.FadeInFromZero(150);
 
         protected override void Deselected()
         {


### PR DESCRIPTION
Entering song select has seen a hit since the new renderer implementations. The underlying cause is large numbers of vertex buffer uploads (the counter hits >200k for me during the transition).

Song select is in the process of being redesigned, and we are probably going to make improvements to the renderer to alleviate this, but in the mean time we can greatly improve the user experience by reducing how long the initial fade in delays take on panels.

Visually this doesn't look too jarring, and gives a more immediate feeling when scrolling. It's also more feasible to load elements sooner with https://github.com/ppy/osu/pull/23809 applied.

Hard to show this in action, but my average frame rate when entering song select is almost acceptable now, whereas before the game would basically skip the whole animation.