### PR TITLE
Change osu!mania scoring ratio to 99% acc (to match previous lazer scoring)

### DIFF
--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -18,8 +18,8 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         protected override double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
         {
-            return 200000 * comboProgress
-                   + 800000 * Math.Pow(Accuracy.Value, 2 + 2 * Accuracy.Value) * accuracyProgress
+            return 10000 * comboProgress
+                   + 990000 * Math.Pow(Accuracy.Value, 2 + 2 * Accuracy.Value) * accuracyProgress
                    + bonusPortion;
         }
 


### PR DESCRIPTION
We've had a lot of negative feedback from users after switching to the new score v2 based scoring. While there's still plenty of time to balance things, this change reverts the combo/acc ratio to what we had, and what users were used to.

Of note, other rulesets didn't change in a similar way so match (roughly) correct.