### PR TITLE
Fix imported osu!stable scores being scaled by the classic scoring mode

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -902,25 +902,24 @@ namespace osu.Game.Database
                     foreach (var score in scores)
                     {
                         string? replayFilename = score.Files.FirstOrDefault(f => f.Filename.EndsWith(@".osr", StringComparison.InvariantCultureIgnoreCase))?.File.GetStoragePath();
-
                         if (replayFilename == null)
                             continue;
 
-                        using (var stream = files.Store.GetStream(replayFilename))
+                        try
                         {
-                            if (stream == null)
-                                continue;
-
-                            try
+                            using (var stream = files.Store.GetStream(replayFilename))
                             {
+                                if (stream == null)
+                                    continue;
+
                                 int version = new ReplayVersionParser().Parse(stream);
                                 if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
                                     score.IsLegacyScore = true;
                             }
-                            catch (Exception e)
-                            {
-                                Logger.Error(e, $"Failed to read replay {replayFilename}", LoggingTarget.Database);
-                            }
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error(e, $"Failed to read replay {replayFilename}", LoggingTarget.Database);
                         }
                     }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -924,7 +924,7 @@ namespace osu.Game.Database
                         }
                         catch (Exception e)
                         {
-                            Logger.Error(e, $"Failed to read replay {replayFilename}", LoggingTarget.Database);
+                            Logger.Error(e, $"Failed to read replay {replayFilename} during score migration", LoggingTarget.Database);
                         }
                     }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -22,12 +22,15 @@ using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Extensions;
 using osu.Game.Input.Bindings;
+using osu.Game.IO.Legacy;
 using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
 using osu.Game.Skinning;
 using Realms;
 using Realms.Exceptions;
@@ -72,8 +75,9 @@ namespace osu.Game.Database
         /// 25   2022-09-18    Remove skins to add with new naming.
         /// 26   2023-02-05    Added BeatmapHash to ScoreInfo.
         /// 27   2023-06-06    Added EditorTimestamp to BeatmapInfo.
+        /// 28   2023-06-08    Added IsLegacyScore to ScoreInfo, parsed from replay files.
         /// </summary>
-        private const int schema_version = 27;
+        private const int schema_version = 28;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -880,6 +884,7 @@ namespace osu.Game.Database
                     break;
 
                 case 26:
+                {
                     // Add ScoreInfo.BeatmapHash property to ensure scores correspond to the correct version of beatmap.
                     var scores = migration.NewRealm.All<ScoreInfo>();
 
@@ -887,6 +892,33 @@ namespace osu.Game.Database
                         score.BeatmapHash = score.BeatmapInfo.Hash;
 
                     break;
+                }
+
+                case 28:
+                {
+                    var files = new RealmFileStore(this, storage);
+                    var scores = migration.NewRealm.All<ScoreInfo>();
+
+                    foreach (var score in scores)
+                    {
+                        string? replayFilename = score.Files.FirstOrDefault(f => f.Filename.EndsWith(@".osr", StringComparison.InvariantCultureIgnoreCase))?.File.GetStoragePath();
+
+                        if (replayFilename == null)
+                            continue;
+
+                        using (var stream = files.Store.GetStream(replayFilename))
+                        {
+                            if (stream == null)
+                                continue;
+
+                            int version = new ReplayVersionParser().Parse(stream);
+                            if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
+                                score.IsLegacyScore = true;
+                        }
+                    }
+
+                    break;
+                }
             }
         }
 
@@ -1105,6 +1137,21 @@ namespace osu.Game.Database
                 realmRetrievalLock.Dispose();
 
                 isDisposed = true;
+            }
+        }
+
+        /// <summary>
+        /// A trimmed down <see cref="LegacyScoreDecoder"/> specialised to extract the version from replays.
+        /// </summary>
+        private class ReplayVersionParser
+        {
+            public int Parse(Stream stream)
+            {
+                using (SerializationReader sr = new SerializationReader(stream))
+                {
+                    sr.ReadByte(); // Ruleset.
+                    return sr.ReadInt32();
+                }
             }
         }
     }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -911,9 +911,16 @@ namespace osu.Game.Database
                             if (stream == null)
                                 continue;
 
-                            int version = new ReplayVersionParser().Parse(stream);
-                            if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
-                                score.IsLegacyScore = true;
+                            try
+                            {
+                                int version = new ReplayVersionParser().Parse(stream);
+                                if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
+                                    score.IsLegacyScore = true;
+                            }
+                            catch (Exception e)
+                            {
+                                Logger.Error(e, $"Failed to read replay {replayFilename}", LoggingTarget.Database);
+                            }
                         }
                     }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -912,9 +912,14 @@ namespace osu.Game.Database
                                 if (stream == null)
                                     continue;
 
-                                int version = new ReplayVersionParser().Parse(stream);
-                                if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
-                                    score.IsLegacyScore = true;
+                                // Trimmed down logic from LegacyScoreDecoder to extract the version from replays.
+                                using (SerializationReader sr = new SerializationReader(stream))
+                                {
+                                    sr.ReadByte(); // Ruleset.
+                                    int version = sr.ReadInt32();
+                                    if (version < LegacyScoreEncoder.FIRST_LAZER_VERSION)
+                                        score.IsLegacyScore = true;
+                                }
                             }
                         }
                         catch (Exception e)
@@ -1143,21 +1148,6 @@ namespace osu.Game.Database
                 realmRetrievalLock.Dispose();
 
                 isDisposed = true;
-            }
-        }
-
-        /// <summary>
-        /// A trimmed down <see cref="LegacyScoreDecoder"/> specialised to extract the version from replays.
-        /// </summary>
-        private class ReplayVersionParser
-        {
-            public int Parse(Stream stream)
-            {
-                using (SerializationReader sr = new SerializationReader(stream))
-                {
-                    sr.ReadByte(); // Ruleset.
-                    return sr.ReadInt32();
-                }
             }
         }
     }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Scoring.Legacy
                 score.ScoreInfo = scoreInfo;
 
                 int version = sr.ReadInt32();
+
+                scoreInfo.IsLegacyScore = version < LegacyScoreEncoder.FIRST_LAZER_VERSION;
+
                 string beatmapHash = sr.ReadString();
 
                 workingBeatmap = GetBeatmap(beatmapHash);

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -16,7 +16,13 @@ namespace osu.Game.Scoring.Legacy
             => getDisplayScore(scoreProcessor.Ruleset.RulesetInfo.OnlineID, scoreProcessor.TotalScore.Value, mode, scoreProcessor.MaximumStatistics);
 
         public static long GetDisplayScore(this ScoreInfo scoreInfo, ScoringMode mode)
-            => getDisplayScore(scoreInfo.Ruleset.OnlineID, scoreInfo.TotalScore, mode, scoreInfo.MaximumStatistics);
+        {
+            // Temporary to not scale stable scores that are already in the XX-millions with the classic scoring mode.
+            if (scoreInfo.IsLegacyScore)
+                return scoreInfo.TotalScore;
+
+            return getDisplayScore(scoreInfo.Ruleset.OnlineID, scoreInfo.TotalScore, mode, scoreInfo.MaximumStatistics);
+        }
 
         private static long getDisplayScore(int rulesetId, long score, ScoringMode mode, IReadOnlyDictionary<HitResult, int> maximumStatistics)
         {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -181,8 +181,7 @@ namespace osu.Game.Scoring
         /// <summary>
         /// Whether this <see cref="ScoreInfo"/> represents a legacy (osu!stable) score.
         /// </summary>
-        [Ignored]
-        public bool IsLegacyScore => Mods.OfType<ModClassic>().Any();
+        public bool IsLegacyScore { get; set; }
 
         private Dictionary<HitResult, int>? statistics;
 


### PR DESCRIPTION
Temporary fix for https://github.com/ppy/osu/issues/23782 / https://github.com/ppy/osu/issues/23756, preventing stable scores going into the billions when using the classic scoring mode.

It does NOT fix old lazer scores (which likely won't/can't be fixed), and does NOT convert SV1 to SV2 yet.