### PR TITLE
Implement detection for touch devices

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuTouchableTestScene.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuTouchableTestScene.cs
@@ -1,0 +1,229 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Framework.Input.States;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public abstract partial class OsuTouchableTestScene : OsuManualInputManagerTestScene
+    {
+        [Resolved]
+        protected OsuConfigManager Config { get; set; } = null!;
+
+        protected OsuInputManager OsuInputManager = null!;
+
+        private Container mainContent = null!;
+
+        protected DefaultKeyCounter LeftKeyCounter = null!;
+
+        protected DefaultKeyCounter RightKeyCounter = null!;
+
+        [SetUpSteps]
+        public virtual void SetUpSteps()
+        {
+            releaseAllTouches();
+
+            AddStep("Create tests", () =>
+            {
+                Children = new Drawable[]
+                {
+                    OsuInputManager = new OsuInputManager(new OsuRuleset().RulesetInfo)
+                    {
+                        Child = mainContent = new Container
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Children = new Drawable[]
+                            {
+                                LeftKeyCounter = new DefaultKeyCounter(new TestActionKeyCounterTrigger(OsuAction.LeftButton))
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.CentreRight,
+                                    Depth = float.MinValue,
+                                    X = -100
+                                },
+                                RightKeyCounter = new DefaultKeyCounter(new TestActionKeyCounterTrigger(OsuAction.RightButton))
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.CentreLeft,
+                                    Depth = float.MinValue,
+                                    X = 100
+                                },
+                                new OsuCursorContainer
+                                {
+                                    Depth = float.MinValue,
+                                }
+                            },
+                        }
+                    },
+                    new TouchVisualiser(),
+                };
+            });
+        }
+
+        private void releaseAllTouches()
+        {
+            AddStep("Release all touches", () =>
+            {
+                Config.SetValue(OsuSetting.MouseDisableButtons, false);
+                foreach (TouchSource source in InputManager.CurrentState.Touch.ActiveSources)
+                    InputManager.EndTouch(new Touch(source, OsuInputManager.ScreenSpaceDrawQuad.Centre));
+            });
+        }
+
+        protected void BeginTouch(TouchSource source, Vector2? screenSpacePosition = null) =>
+            AddStep($"Begin touch for {source}", () => InputManager.BeginTouch(new Touch(source, screenSpacePosition ??= GetSanePositionForSource(source))));
+
+        protected void EndTouch(TouchSource source, Vector2? screenSpacePosition = null) =>
+            AddStep($"Release touch for {source}", () => InputManager.EndTouch(new Touch(source, screenSpacePosition ??= GetSanePositionForSource(source))));
+
+        protected Vector2 GetSanePositionForSource(TouchSource source)
+        {
+            return new Vector2(
+                OsuInputManager.ScreenSpaceDrawQuad.Centre.X + OsuInputManager.ScreenSpaceDrawQuad.Width * (-1 + (int)source) / 8,
+                OsuInputManager.ScreenSpaceDrawQuad.Centre.Y - 100
+            );
+        }
+
+        public partial class TouchVisualiser : CompositeDrawable
+        {
+            private readonly Drawable?[] drawableTouches = new Drawable?[TouchState.MAX_TOUCH_COUNT];
+
+            public TouchVisualiser()
+            {
+                RelativeSizeAxes = Axes.Both;
+            }
+
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+
+            protected override bool OnTouchDown(TouchDownEvent e)
+            {
+                if (IsDisposed)
+                    return false;
+
+                var circle = new Circle
+                {
+                    Alpha = 0.5f,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(20),
+                    Position = e.Touch.Position,
+                    Colour = colourFor(e.Touch.Source),
+                };
+
+                AddInternal(circle);
+                drawableTouches[(int)e.Touch.Source] = circle;
+                return false;
+            }
+
+            protected override void OnTouchMove(TouchMoveEvent e)
+            {
+                if (IsDisposed)
+                    return;
+
+                var circle = drawableTouches[(int)e.Touch.Source];
+
+                Debug.Assert(circle != null);
+
+                AddInternal(new FadingCircle(circle));
+                circle.Position = e.Touch.Position;
+            }
+
+            protected override void OnTouchUp(TouchUpEvent e)
+            {
+                var circle = drawableTouches[(int)e.Touch.Source];
+
+                Debug.Assert(circle != null);
+
+                circle.FadeOut(200, Easing.OutQuint).Expire();
+                drawableTouches[(int)e.Touch.Source] = null;
+            }
+
+            private Color4 colourFor(TouchSource source)
+            {
+                return Color4.FromHsv(new Vector4((float)source / TouchState.MAX_TOUCH_COUNT, 1f, 1f, 1f));
+            }
+
+            private partial class FadingCircle : Circle
+            {
+                public FadingCircle(Drawable source)
+                {
+                    Origin = Anchor.Centre;
+                    Size = source.Size;
+                    Position = source.Position;
+                    Colour = source.Colour;
+                }
+
+                protected override void LoadComplete()
+                {
+                    base.LoadComplete();
+                    this.FadeOut(200).Expire();
+                }
+            }
+        }
+
+        protected void AddHitCircleAt(TouchSource source)
+        {
+            var hitCircle = new HitCircle();
+
+            hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+            mainContent.Add(new DrawableHitCircle(hitCircle)
+            {
+                Clock = new FramedClock(new ManualClock()),
+                Position = mainContent.ToLocalSpace(GetSanePositionForSource(source)),
+            });
+        }
+
+        protected void AddHitCircleAtStep(TouchSource source)
+        {
+            AddStep($"Add circle at {source}", () => AddHitCircleAt(source));
+        }
+
+        public partial class TestActionKeyCounterTrigger : InputTrigger, IKeyBindingHandler<OsuAction>
+        {
+            public OsuAction Action { get; }
+
+            public TestActionKeyCounterTrigger(OsuAction action)
+                : base(action.ToString())
+            {
+                Action = action;
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
+            {
+                if (e.Action == Action)
+                {
+                    Activate();
+                }
+
+                return false;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)
+            {
+                if (e.Action == Action)
+                    Deactivate();
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchDeviceDetector.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchDeviceDetector.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.UI;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    public partial class TestSceneOsuTouchDeviceDetector : OsuTouchableTestScene
+    {
+        private OsuTouchDeviceDetector osuTouchDeviceDetector => OsuInputManager.ChildrenOfType<OsuTouchDeviceDetector>().First();
+
+        public void TestTouchDevice(Action<Vector2> positionHandler)
+        {
+            int i = 0;
+
+            AddRepeatStep("Touch some", () =>
+            {
+                var source = i % 2 == 0 ? TouchSource.Touch1 : TouchSource.Touch2;
+
+                Vector2 position = GetSanePositionForSource(source);
+                positionHandler(position);
+
+                i++;
+            }, 11);
+
+            AddAssert("Is touch device", () => osuTouchDeviceDetector.DetectedTouchDevice);
+            AddAssert("Flagged 11 touch inputs", () => osuTouchDeviceDetector.FlaggedTouchesCount == 10);
+        }
+
+        [Test]
+        public void TestTouchDeviceDetectionWithTouchInput()
+        {
+            TestTouchDevice(pos =>
+            {
+                var touch = new Touch(TouchSource.Touch1, pos);
+
+                InputManager.BeginTouch(touch);
+                InputManager.EndTouch(touch);
+            });
+
+            BeginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch3);
+
+            AddAssert("Last touch input was not flagged", () => osuTouchDeviceDetector.FlaggedTouchesCount == 12);
+        }
+
+        [Test]
+        public void TestTouchDeviceDetectionWithMouseInput()
+        {
+            TestTouchDevice(pos =>
+                {
+                    InputManager.MoveMouseTo(pos);
+                    InputManager.Click(MouseButton.Left);
+                }
+            );
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuTouchInput.cs
@@ -1,100 +1,28 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
-using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
-using osu.Framework.Input.States;
-using osu.Framework.Testing;
-using osu.Framework.Timing;
 using osu.Framework.Utils;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Osu.Objects;
-using osu.Game.Rulesets.Osu.Objects.Drawables;
-using osu.Game.Rulesets.Osu.UI.Cursor;
-using osu.Game.Screens.Play.HUD;
-using osu.Game.Tests.Visual;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public partial class TestSceneOsuTouchInput : OsuManualInputManagerTestScene
+    public partial class TestSceneOsuTouchInput : OsuTouchableTestScene
     {
-        [Resolved]
-        private OsuConfigManager config { get; set; } = null!;
-
-        private DefaultKeyCounter leftKeyCounter = null!;
-
-        private DefaultKeyCounter rightKeyCounter = null!;
-
-        private OsuInputManager osuInputManager = null!;
-
-        private Container mainContent = null!;
-
-        [SetUpSteps]
-        public void SetUpSteps()
-        {
-            releaseAllTouches();
-
-            AddStep("Create tests", () =>
-            {
-                Children = new Drawable[]
-                {
-                    osuInputManager = new OsuInputManager(new OsuRuleset().RulesetInfo)
-                    {
-                        Child = mainContent = new Container
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Children = new Drawable[]
-                            {
-                                leftKeyCounter = new DefaultKeyCounter(new TestActionKeyCounterTrigger(OsuAction.LeftButton))
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.CentreRight,
-                                    Depth = float.MinValue,
-                                    X = -100,
-                                },
-                                rightKeyCounter = new DefaultKeyCounter(new TestActionKeyCounterTrigger(OsuAction.RightButton))
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.CentreLeft,
-                                    Depth = float.MinValue,
-                                    X = 100,
-                                },
-                                new OsuCursorContainer
-                                {
-                                    Depth = float.MinValue,
-                                }
-                            },
-                        }
-                    },
-                    new TouchVisualiser(),
-                };
-            });
-        }
-
         [Test]
         public void TestStreamInputVisual()
         {
-            addHitCircleAt(TouchSource.Touch1);
-            addHitCircleAt(TouchSource.Touch2);
+            AddHitCircleAtStep(TouchSource.Touch1);
+            AddHitCircleAtStep(TouchSource.Touch2);
 
-            beginTouch(TouchSource.Touch1);
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch2);
 
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
 
             int i = 0;
 
@@ -106,13 +34,13 @@ namespace osu.Game.Rulesets.Osu.Tests
                 // sometimes the user will end the previous touch before touching again, sometimes not.
                 if (RNG.NextBool())
                 {
-                    InputManager.BeginTouch(new Touch(down, getSanePositionForSource(down)));
-                    InputManager.EndTouch(new Touch(up, getSanePositionForSource(up)));
+                    InputManager.BeginTouch(new Touch(down, GetSanePositionForSource(down)));
+                    InputManager.EndTouch(new Touch(up, GetSanePositionForSource(up)));
                 }
                 else
                 {
-                    InputManager.EndTouch(new Touch(up, getSanePositionForSource(up)));
-                    InputManager.BeginTouch(new Touch(down, getSanePositionForSource(down)));
+                    InputManager.EndTouch(new Touch(up, GetSanePositionForSource(up)));
+                    InputManager.BeginTouch(new Touch(down, GetSanePositionForSource(down)));
                 }
 
                 i++;
@@ -122,13 +50,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestSimpleInput()
         {
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
@@ -136,10 +64,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch2);
 
             // Subsequent touches should be ignored (except position).
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
             checkPosition(TouchSource.Touch3);
 
-            beginTouch(TouchSource.Touch4);
+            BeginTouch(TouchSource.Touch4);
             checkPosition(TouchSource.Touch4);
 
             assertKeyCounter(1, 1);
@@ -156,20 +84,20 @@ namespace osu.Game.Rulesets.Osu.Tests
             // When a single touch has already travelled enough distance on screen, it should remain as the positional
             // tracking touch until released (unless a direct touch occurs).
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
             // cover some distance
-            beginTouch(TouchSource.Touch1, new Vector2(0));
-            beginTouch(TouchSource.Touch1, new Vector2(9999));
-            beginTouch(TouchSource.Touch1, new Vector2(0));
-            beginTouch(TouchSource.Touch1, new Vector2(9999));
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1, new Vector2(0));
+            BeginTouch(TouchSource.Touch1, new Vector2(9999));
+            BeginTouch(TouchSource.Touch1, new Vector2(0));
+            BeginTouch(TouchSource.Touch1, new Vector2(9999));
+            BeginTouch(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             checkNotPressed(OsuAction.LeftButton);
@@ -178,10 +106,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch1);
 
             // even if the second touch moves on the screen, the original tracking touch is retained.
-            beginTouch(TouchSource.Touch2, new Vector2(0));
-            beginTouch(TouchSource.Touch2, new Vector2(9999));
-            beginTouch(TouchSource.Touch2, new Vector2(0));
-            beginTouch(TouchSource.Touch2, new Vector2(9999));
+            BeginTouch(TouchSource.Touch2, new Vector2(0));
+            BeginTouch(TouchSource.Touch2, new Vector2(9999));
+            BeginTouch(TouchSource.Touch2, new Vector2(0));
+            BeginTouch(TouchSource.Touch2, new Vector2(9999));
 
             checkPosition(TouchSource.Touch1);
         }
@@ -189,20 +117,20 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestPositionalInputUpdatesOnlyFromMostRecentTouch()
         {
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             checkPosition(TouchSource.Touch2);
 
-            beginTouch(TouchSource.Touch1, Vector2.One);
+            BeginTouch(TouchSource.Touch1, Vector2.One);
             checkPosition(TouchSource.Touch2);
 
-            endTouch(TouchSource.Touch2);
+            EndTouch(TouchSource.Touch2);
             checkPosition(TouchSource.Touch2);
 
             // note that touch1 was never ended, but is no longer valid for touch input due to touch 2 occurring.
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             checkPosition(TouchSource.Touch2);
         }
 
@@ -212,8 +140,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             // In this scenario, the user is tapping on the first object in a stream,
             // then using one or two fingers in empty space to continue the stream.
 
-            addHitCircleAt(TouchSource.Touch1);
-            beginTouch(TouchSource.Touch1);
+            AddHitCircleAtStep(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             // The first touch is handled as normal.
             assertKeyCounter(1, 0);
@@ -221,7 +149,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch1);
 
             // The second touch should release the first, and also act as a right button.
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             // Importantly, this is different from the simple case because an object was interacted with in the first touch, but not the second touch.
@@ -232,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch1);
 
             // In this scenario, a third touch should be allowed, and handled similarly to the second.
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
 
             assertKeyCounter(2, 1);
             checkPressed(OsuAction.LeftButton);
@@ -240,7 +168,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             // Position is still ignored.
             checkPosition(TouchSource.Touch1);
 
-            endTouch(TouchSource.Touch2);
+            EndTouch(TouchSource.Touch2);
 
             checkPressed(OsuAction.LeftButton);
             checkNotPressed(OsuAction.RightButton);
@@ -248,7 +176,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             checkPosition(TouchSource.Touch1);
 
             // User continues streaming
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(2, 2);
             checkPressed(OsuAction.LeftButton);
@@ -258,12 +186,12 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             // In this mode a maximum of three touches should be supported.
             // A fourth touch should result in no changes anywhere.
-            beginTouch(TouchSource.Touch4);
+            BeginTouch(TouchSource.Touch4);
             assertKeyCounter(2, 2);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch1);
-            endTouch(TouchSource.Touch4);
+            EndTouch(TouchSource.Touch4);
         }
 
         [Test]
@@ -272,41 +200,41 @@ namespace osu.Game.Rulesets.Osu.Tests
             // In this scenario, the user is wanting to use stream input but we start with one finger still on the screen.
             // That finger is mapped to a left action.
 
-            addHitCircleAt(TouchSource.Touch2);
+            AddHitCircleAtStep(TouchSource.Touch2);
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
             // hits circle as right action
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
 
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
             checkNotPressed(OsuAction.LeftButton);
 
             // stream using other two fingers while touch2 tracks
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(2, 1);
             checkPressed(OsuAction.LeftButton);
             // right button is automatically released
             checkNotPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
 
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
             assertKeyCounter(2, 2);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
 
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
             checkNotPressed(OsuAction.LeftButton);
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(3, 2);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
@@ -319,44 +247,44 @@ namespace osu.Game.Rulesets.Osu.Tests
             // In this scenario, the user is wanting to use stream input but we start with one finger still on the screen.
             // That finger is mapped to a right action.
 
-            beginTouch(TouchSource.Touch1);
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
 
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
 
-            addHitCircleAt(TouchSource.Touch1);
+            AddHitCircleAtStep(TouchSource.Touch1);
 
             // hits circle as left action
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(2, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch1);
 
-            endTouch(TouchSource.Touch2);
+            EndTouch(TouchSource.Touch2);
 
             // stream using other two fingers while touch1 tracks
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             assertKeyCounter(2, 2);
             checkPressed(OsuAction.RightButton);
             // left button is automatically released
             checkNotPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
             assertKeyCounter(3, 2);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch1);
 
-            endTouch(TouchSource.Touch2);
+            EndTouch(TouchSource.Touch2);
             checkNotPressed(OsuAction.RightButton);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             assertKeyCounter(3, 3);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
@@ -369,24 +297,24 @@ namespace osu.Game.Rulesets.Osu.Tests
             // In this scenario, the user is tapping on three circles directly while correctly releasing the first touch.
             // All three should be recognised.
 
-            addHitCircleAt(TouchSource.Touch1);
-            addHitCircleAt(TouchSource.Touch2);
-            addHitCircleAt(TouchSource.Touch3);
+            AddHitCircleAtStep(TouchSource.Touch1);
+            AddHitCircleAtStep(TouchSource.Touch2);
+            AddHitCircleAtStep(TouchSource.Touch3);
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
 
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
             assertKeyCounter(2, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
@@ -399,22 +327,22 @@ namespace osu.Game.Rulesets.Osu.Tests
             // In this scenario, the user is tapping on three circles directly without releasing any touches.
             // The first two should be recognised, but a third should not (as the user already has two fingers down).
 
-            addHitCircleAt(TouchSource.Touch1);
-            addHitCircleAt(TouchSource.Touch2);
-            addHitCircleAt(TouchSource.Touch3);
+            AddHitCircleAtStep(TouchSource.Touch1);
+            AddHitCircleAtStep(TouchSource.Touch2);
+            AddHitCircleAtStep(TouchSource.Touch3);
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
             checkPosition(TouchSource.Touch2);
 
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
@@ -426,26 +354,25 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             // aka "autopilot" mod
 
-            AddStep("Disallow gameplay cursor movement", () => osuInputManager.AllowUserCursorMovement = false);
+            AddStep("Disallow gameplay cursor movement", () => OsuInputManager.AllowUserCursorMovement = false);
 
             Vector2? positionBefore = null;
 
-            AddStep("Store cursor position", () => positionBefore = osuInputManager.CurrentState.Mouse.Position);
-            beginTouch(TouchSource.Touch1);
+            AddStep("Store cursor position", () => positionBefore = OsuInputManager.CurrentState.Mouse.Position);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
-            AddAssert("Cursor position unchanged", () => osuInputManager.CurrentState.Mouse.Position, () => Is.EqualTo(positionBefore));
+            AddAssert("Cursor position unchanged", () => OsuInputManager.CurrentState.Mouse.Position, () => Is.EqualTo(positionBefore));
         }
 
         [Test]
         public void TestActionWhileDisallowed()
         {
             // aka "relax" mod
+            AddStep("Disallow gameplay actions", () => OsuInputManager.AllowGameplayInputs = false);
 
-            AddStep("Disallow gameplay actions", () => osuInputManager.AllowGameplayInputs = false);
-
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(0, 0);
             checkNotPressed(OsuAction.LeftButton);
@@ -455,15 +382,15 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestInputWhileMouseButtonsDisabled()
         {
-            AddStep("Disable mouse buttons", () => config.SetValue(OsuSetting.MouseDisableButtons, true));
+            AddStep("Disable mouse buttons", () => Config.SetValue(OsuSetting.MouseDisableButtons, true));
 
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(0, 0);
             checkNotPressed(OsuAction.LeftButton);
             checkPosition(TouchSource.Touch1);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(0, 0);
             checkNotPressed(OsuAction.LeftButton);
@@ -474,12 +401,12 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestAlternatingInput()
         {
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
@@ -487,22 +414,22 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             for (int i = 0; i < 2; i++)
             {
-                endTouch(TouchSource.Touch1);
+                EndTouch(TouchSource.Touch1);
 
                 checkPressed(OsuAction.RightButton);
                 checkNotPressed(OsuAction.LeftButton);
 
-                beginTouch(TouchSource.Touch1);
+                BeginTouch(TouchSource.Touch1);
 
                 checkPressed(OsuAction.LeftButton);
                 checkPressed(OsuAction.RightButton);
 
-                endTouch(TouchSource.Touch2);
+                EndTouch(TouchSource.Touch2);
 
                 checkPressed(OsuAction.LeftButton);
                 checkNotPressed(OsuAction.RightButton);
 
-                beginTouch(TouchSource.Touch2);
+                BeginTouch(TouchSource.Touch2);
 
                 checkPressed(OsuAction.LeftButton);
                 checkPressed(OsuAction.RightButton);
@@ -512,26 +439,26 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestPressReleaseOrder()
         {
-            beginTouch(TouchSource.Touch1);
-            beginTouch(TouchSource.Touch2);
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch3);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.LeftButton);
             checkPressed(OsuAction.RightButton);
 
             // Touch 3 was ignored, but let's ensure that if 1 or 2 are released, 3 will be handled a second attempt.
-            endTouch(TouchSource.Touch1);
+            EndTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.RightButton);
 
-            endTouch(TouchSource.Touch3);
+            EndTouch(TouchSource.Touch3);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.RightButton);
 
-            beginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch3);
 
             assertKeyCounter(2, 1);
             checkPressed(OsuAction.LeftButton);
@@ -541,19 +468,19 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestWithDisallowedUserCursor()
         {
-            beginTouch(TouchSource.Touch1);
+            BeginTouch(TouchSource.Touch1);
 
             assertKeyCounter(1, 0);
             checkPressed(OsuAction.LeftButton);
 
-            beginTouch(TouchSource.Touch2);
+            BeginTouch(TouchSource.Touch2);
 
             assertKeyCounter(1, 1);
             checkPressed(OsuAction.RightButton);
 
             // Subsequent touches should be ignored.
-            beginTouch(TouchSource.Touch3);
-            beginTouch(TouchSource.Touch4);
+            BeginTouch(TouchSource.Touch3);
+            BeginTouch(TouchSource.Touch4);
 
             assertKeyCounter(1, 1);
 
@@ -563,159 +490,16 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertKeyCounter(1, 1);
         }
 
-        private void addHitCircleAt(TouchSource source)
-        {
-            AddStep($"Add circle at {source}", () =>
-            {
-                var hitCircle = new HitCircle();
-
-                hitCircle.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-
-                mainContent.Add(new DrawableHitCircle(hitCircle)
-                {
-                    Clock = new FramedClock(new ManualClock()),
-                    Position = mainContent.ToLocalSpace(getSanePositionForSource(source)),
-                });
-            });
-        }
-
-        private void beginTouch(TouchSource source, Vector2? screenSpacePosition = null) =>
-            AddStep($"Begin touch for {source}", () => InputManager.BeginTouch(new Touch(source, screenSpacePosition ??= getSanePositionForSource(source))));
-
-        private void endTouch(TouchSource source, Vector2? screenSpacePosition = null) =>
-            AddStep($"Release touch for {source}", () => InputManager.EndTouch(new Touch(source, screenSpacePosition ??= getSanePositionForSource(source))));
-
-        private Vector2 getSanePositionForSource(TouchSource source)
-        {
-            return new Vector2(
-                osuInputManager.ScreenSpaceDrawQuad.Centre.X + osuInputManager.ScreenSpaceDrawQuad.Width * (-1 + (int)source) / 8,
-                osuInputManager.ScreenSpaceDrawQuad.Centre.Y - 100
-            );
-        }
-
         private void checkPosition(TouchSource touchSource) =>
-            AddAssert("Cursor position is correct", () => osuInputManager.CurrentState.Mouse.Position, () => Is.EqualTo(getSanePositionForSource(touchSource)));
+            AddAssert("Cursor position is correct", () => OsuInputManager.CurrentState.Mouse.Position, () => Is.EqualTo(GetSanePositionForSource(touchSource)));
 
         private void assertKeyCounter(int left, int right)
         {
-            AddAssert($"The left key was pressed {left} times", () => leftKeyCounter.CountPresses.Value, () => Is.EqualTo(left));
-            AddAssert($"The right key was pressed {right} times", () => rightKeyCounter.CountPresses.Value, () => Is.EqualTo(right));
+            AddAssert($"The left key was pressed {left} times", () => LeftKeyCounter.CountPresses.Value, () => Is.EqualTo(left));
+            AddAssert($"The right key was pressed {right} times", () => RightKeyCounter.CountPresses.Value, () => Is.EqualTo(right));
         }
 
-        private void releaseAllTouches()
-        {
-            AddStep("Release all touches", () =>
-            {
-                config.SetValue(OsuSetting.MouseDisableButtons, false);
-                foreach (TouchSource source in InputManager.CurrentState.Touch.ActiveSources)
-                    InputManager.EndTouch(new Touch(source, osuInputManager.ScreenSpaceDrawQuad.Centre));
-            });
-        }
-
-        private void checkNotPressed(OsuAction action) => AddAssert($"Not pressing {action}", () => !osuInputManager.PressedActions.Contains(action));
-        private void checkPressed(OsuAction action) => AddAssert($"Is pressing {action}", () => osuInputManager.PressedActions.Contains(action));
-
-        public partial class TestActionKeyCounterTrigger : InputTrigger, IKeyBindingHandler<OsuAction>
-        {
-            public OsuAction Action { get; }
-
-            public TestActionKeyCounterTrigger(OsuAction action)
-                : base(action.ToString())
-            {
-                Action = action;
-            }
-
-            public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
-            {
-                if (e.Action == Action)
-                {
-                    Activate();
-                }
-
-                return false;
-            }
-
-            public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)
-            {
-                if (e.Action == Action)
-                    Deactivate();
-            }
-        }
-
-        public partial class TouchVisualiser : CompositeDrawable
-        {
-            private readonly Drawable?[] drawableTouches = new Drawable?[TouchState.MAX_TOUCH_COUNT];
-
-            public TouchVisualiser()
-            {
-                RelativeSizeAxes = Axes.Both;
-            }
-
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
-
-            protected override bool OnTouchDown(TouchDownEvent e)
-            {
-                if (IsDisposed)
-                    return false;
-
-                var circle = new Circle
-                {
-                    Alpha = 0.5f,
-                    Origin = Anchor.Centre,
-                    Size = new Vector2(20),
-                    Position = e.Touch.Position,
-                    Colour = colourFor(e.Touch.Source),
-                };
-
-                AddInternal(circle);
-                drawableTouches[(int)e.Touch.Source] = circle;
-                return false;
-            }
-
-            protected override void OnTouchMove(TouchMoveEvent e)
-            {
-                if (IsDisposed)
-                    return;
-
-                var circle = drawableTouches[(int)e.Touch.Source];
-
-                Debug.Assert(circle != null);
-
-                AddInternal(new FadingCircle(circle));
-                circle.Position = e.Touch.Position;
-            }
-
-            protected override void OnTouchUp(TouchUpEvent e)
-            {
-                var circle = drawableTouches[(int)e.Touch.Source];
-
-                Debug.Assert(circle != null);
-
-                circle.FadeOut(200, Easing.OutQuint).Expire();
-                drawableTouches[(int)e.Touch.Source] = null;
-            }
-
-            private Color4 colourFor(TouchSource source)
-            {
-                return Color4.FromHsv(new Vector4((float)source / TouchState.MAX_TOUCH_COUNT, 1f, 1f, 1f));
-            }
-
-            private partial class FadingCircle : Circle
-            {
-                public FadingCircle(Drawable source)
-                {
-                    Origin = Anchor.Centre;
-                    Size = source.Size;
-                    Position = source.Position;
-                    Colour = source.Colour;
-                }
-
-                protected override void LoadComplete()
-                {
-                    base.LoadComplete();
-                    this.FadeOut(200).Expire();
-                }
-            }
-        }
+        private void checkNotPressed(OsuAction action) => AddAssert($"Not pressing {action}", () => !OsuInputManager.PressedActions.Contains(action));
+        private void checkPressed(OsuAction action) => AddAssert($"Is pressing {action}", () => OsuInputManager.PressedActions.Contains(action));
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -57,7 +57,13 @@ namespace osu.Game.Rulesets.Osu
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(new OsuTouchInputMapper(this) { RelativeSizeAxes = Axes.Both });
+            var osuTouchDeviceDetector = new OsuTouchDeviceDetector { RelativeSizeAxes = Axes.Both };
+
+            AddRange(new Drawable[]
+            {
+                osuTouchDeviceDetector,
+                new OsuTouchInputMapper(this, osuTouchDeviceDetector) { RelativeSizeAxes = Axes.Both }
+            });
         }
 
         protected override bool Handle(UIEvent e)

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchDeviceDetector.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchDeviceDetector.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Play;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.UI
+{
+    public partial class OsuTouchDeviceDetector : Drawable
+    {
+        /// <summary>
+        /// The distance required for a mouse input to be considered a touchscreen input relative to a previous mouse input.
+        /// </summary>
+        private const int mouse_input_touchscreen_distance = 100;
+
+        /// <summary>
+        /// The max amount of <see cref="flaggedTouchesCount"/> that is required for <see cref="OsuModTouchDevice"/> to be applied.
+        /// </summary>
+        private const int max_flagged_touches = 10;
+
+        /// <summary>
+        /// Tracks the amount of inputs that got flagged as a touch device input.
+        /// </summary>
+        private int flaggedTouchesCount;
+
+        /// <summary>
+        /// Whether touch device input is already detected.
+        /// </summary>
+        private bool detectedTouchDevice;
+
+        [Resolved(CanBeNull = true)]
+        private Player? player { get; set; }
+
+        private Vector2? previousTouchPos;
+
+        /// <summary>
+        /// Checks whether a given input position is likely to be from a touch device.
+        /// This is done by comparing said position with the previous touch position.
+        /// </summary>
+        /// <param name="inputPosition">The input position to be compared.</param>
+        private bool isTouchInput(Vector2 inputPosition) =>
+            previousTouchPos != null && Vector2.Distance(previousTouchPos.Value, inputPosition) > mouse_input_touchscreen_distance;
+
+        /// <summary>
+        /// Detects and applies the <see cref="OsuModTouchDevice"/> to the player mods.
+        /// </summary>
+        /// <param name="newTouchPosition">The new touch position to be checked against <see cref="isTouchInput"/></param>
+        private void detectTouchInput(Vector2 newTouchPosition)
+        {
+            if (player != null && !detectedTouchDevice && isTouchInput(newTouchPosition))
+            {
+                detectedTouchDevice = ++flaggedTouchesCount > max_flagged_touches;
+
+                if (detectedTouchDevice)
+                    player.Score.ScoreInfo.Mods = player.Score.ScoreInfo.Mods.Append(new OsuModTouchDevice()).ToArray();
+            }
+
+            previousTouchPos = newTouchPosition;
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            detectTouchInput(e.MousePosition);
+
+            return base.OnMouseDown(e);
+        }
+
+        public void OnDirectTouch(TouchDownEvent e)
+        {
+            detectTouchInput(e.TouchDownPosition);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -86,10 +86,8 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 osuInputManager.KeyBindingContainer.TriggerPressed(action);
 
-                if (newTouch.DirectTouch)
-                {
-                    osuTouchTouchDeviceDetector.OnDirectTouch(e);
-                }
+                if (newTouch == positionTrackingTouch)
+                    osuTouchTouchDeviceDetector.OnPositionTrackerDown(e);
             }
 
             return true;

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Rulesets.Osu.UI
             base.OnTouchUp(e);
         }
 
-        public class TrackedTouch
+        private class TrackedTouch
         {
             public readonly TouchSource Source;
 

--- a/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuTouchInputMapper.cs
@@ -33,11 +33,14 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly OsuInputManager osuInputManager;
 
+        private readonly OsuTouchDeviceDetector osuTouchTouchDeviceDetector;
+
         private Bindable<bool> mouseDisabled = null!;
 
-        public OsuTouchInputMapper(OsuInputManager inputManager)
+        public OsuTouchInputMapper(OsuInputManager inputManager, OsuTouchDeviceDetector touchDeviceDetector)
         {
             osuInputManager = inputManager;
+            osuTouchTouchDeviceDetector = touchDeviceDetector;
         }
 
         [BackgroundDependencyLoader]
@@ -80,7 +83,14 @@ namespace osu.Game.Rulesets.Osu.UI
             handleTouchMovement(e);
 
             if (shouldResultInAction)
+            {
                 osuInputManager.KeyBindingContainer.TriggerPressed(action);
+
+                if (newTouch.DirectTouch)
+                {
+                    osuTouchTouchDeviceDetector.OnDirectTouch(e);
+                }
+            }
 
             return true;
         }
@@ -155,7 +165,7 @@ namespace osu.Game.Rulesets.Osu.UI
             base.OnTouchUp(e);
         }
 
-        private class TrackedTouch
+        public class TrackedTouch
         {
             public readonly TouchSource Source;
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -50,4 +50,7 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Rulesets\Mods\ModAutoApplied.cs" />
+  </ItemGroup>
 </Project>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -50,7 +50,4 @@
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="Rulesets\Mods\ModAutoApplied.cs" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Naive implementation of touch device detection. This aims to provide at least the TD mod when submitting a score. It does not work for skin elements such as the PP counter.
The reason for this being implemented at least as is, is because multiple scores are being sent to the Lazer servers without being properly flagged as TD, so it would be better for new scores as of now to be properly flagged.

