### PR TITLE
Add tooltips to truncated text

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardExtra.cs
@@ -106,12 +106,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                                             {
                                                 new Drawable[]
                                                 {
-                                                    new OsuSpriteText
+                                                    new TruncatingSpriteText
                                                     {
                                                         Text = new RomanisableString(BeatmapSet.TitleUnicode, BeatmapSet.Title),
                                                         Font = OsuFont.Default.With(size: 22.5f, weight: FontWeight.SemiBold),
                                                         RelativeSizeAxes = Axes.X,
-                                                        Truncate = true
                                                     },
                                                     titleBadgeArea = new FillFlowContainer
                                                     {
@@ -140,21 +139,19 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                                             {
                                                 new[]
                                                 {
-                                                    new OsuSpriteText
+                                                    new TruncatingSpriteText
                                                     {
                                                         Text = createArtistText(),
                                                         Font = OsuFont.Default.With(size: 17.5f, weight: FontWeight.SemiBold),
                                                         RelativeSizeAxes = Axes.X,
-                                                        Truncate = true
                                                     },
                                                     Empty()
                                                 },
                                             }
                                         },
-                                        new OsuSpriteText
+                                        new TruncatingSpriteText
                                         {
                                             RelativeSizeAxes = Axes.X,
-                                            Truncate = true,
                                             Text = BeatmapSet.Source,
                                             Shadow = false,
                                             Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -107,12 +107,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                                             {
                                                 new Drawable[]
                                                 {
-                                                    new OsuSpriteText
+                                                    new TruncatingSpriteText
                                                     {
                                                         Text = new RomanisableString(BeatmapSet.TitleUnicode, BeatmapSet.Title),
                                                         Font = OsuFont.Default.With(size: 22.5f, weight: FontWeight.SemiBold),
                                                         RelativeSizeAxes = Axes.X,
-                                                        Truncate = true
                                                     },
                                                     titleBadgeArea = new FillFlowContainer
                                                     {
@@ -141,12 +140,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                                             {
                                                 new[]
                                                 {
-                                                    new OsuSpriteText
+                                                    new TruncatingSpriteText
                                                     {
                                                         Text = createArtistText(),
                                                         Font = OsuFont.Default.With(size: 17.5f, weight: FontWeight.SemiBold),
                                                         RelativeSizeAxes = Axes.X,
-                                                        Truncate = true
                                                     },
                                                     Empty()
                                                 },

--- a/osu.Game/Graphics/Sprites/OsuSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/OsuSpriteText.cs
@@ -3,12 +3,19 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Game.Graphics.Sprites
 {
     public partial class OsuSpriteText : SpriteText
     {
+        [Obsolete("Use TruncatingSpriteText instead.")]
+        public new bool Truncate
+        {
+            set => throw new InvalidOperationException($"Use {nameof(TruncatingSpriteText)} instead.");
+        }
+
         public OsuSpriteText()
         {
             Shadow = true;

--- a/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.Sprites
@@ -14,7 +15,7 @@ namespace osu.Game.Graphics.Sprites
 
         public TruncatingSpriteText()
         {
-            Truncate = true;
+            ((SpriteText)this).Truncate = true;
         }
     }
 }

--- a/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
@@ -7,8 +7,14 @@ using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.Sprites
 {
+    /// <summary>
+    /// A derived version of <see cref="OsuSpriteText"/> which automatically shows non-truncated text in tooltip when required.
+    /// </summary>
     public sealed partial class TruncatingSpriteText : OsuSpriteText, IHasTooltip
     {
+        /// <summary>
+        /// Whether a tooltip should be shown with non-truncated text on hover.
+        /// </summary>
         public bool ShowTooltip { get; init; } = true;
 
         public LocalisableString TooltipText => Text;

--- a/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+
+namespace osu.Game.Graphics.Sprites
+{
+    public sealed partial class TruncatingSpriteText : OsuSpriteText, IHasTooltip
+    {
+        public LocalisableString TooltipText => Text;
+
+        public override bool HandlePositionalInput => IsTruncated;
+
+        public TruncatingSpriteText()
+        {
+            Truncate = true;
+        }
+    }
+}

--- a/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/TruncatingSpriteText.cs
@@ -9,9 +9,11 @@ namespace osu.Game.Graphics.Sprites
 {
     public sealed partial class TruncatingSpriteText : OsuSpriteText, IHasTooltip
     {
+        public bool ShowTooltip { get; init; } = true;
+
         public LocalisableString TooltipText => Text;
 
-        public override bool HandlePositionalInput => IsTruncated;
+        public override bool HandlePositionalInput => IsTruncated && ShowTooltip;
 
         public TruncatingSpriteText()
         {

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -335,12 +335,11 @@ namespace osu.Game.Graphics.UserInterface
                     {
                         new Drawable[]
                         {
-                            Text = new OsuSpriteText
+                            Text = new TruncatingSpriteText
                             {
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 RelativeSizeAxes = Axes.X,
-                                Truncate = true,
                             },
                             Icon = new SpriteIcon
                             {

--- a/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
+++ b/osu.Game/Overlays/Chat/ChannelList/ChannelListItem.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Overlays.Chat.ChannelList
                             new Drawable?[]
                             {
                                 createIcon(),
-                                text = new OsuSpriteText
+                                text = new TruncatingSpriteText
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -94,7 +94,6 @@ namespace osu.Game.Overlays.Chat.ChannelList
                                     Colour = colourProvider.Light3,
                                     Margin = new MarginPadding { Bottom = 2 },
                                     RelativeSizeAxes = Axes.X,
-                                    Truncate = true,
                                 },
                                 createMentionPill(),
                                 close = createCloseButton(),

--- a/osu.Game/Overlays/Chat/ChatTextBar.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBar.cs
@@ -73,14 +73,13 @@ namespace osu.Game.Overlays.Chat
                                 Width = chatting_text_width,
                                 Masking = true,
                                 Padding = new MarginPadding { Horizontal = padding },
-                                Child = chattingText = new OsuSpriteText
+                                Child = chattingText = new TruncatingSpriteText
                                 {
                                     MaxWidth = chatting_text_width - padding * 2,
                                     Font = OsuFont.Torus.With(size: 20),
                                     Colour = colourProvider.Background1,
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Truncate = true,
                                 },
                             },
                             searchIconContainer = new Container

--- a/osu.Game/Overlays/Chat/DrawableChatUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableChatUsername.cs
@@ -83,10 +83,9 @@ namespace osu.Game.Overlays.Chat
 
             Action = openUserProfile;
 
-            drawableText = new OsuSpriteText
+            drawableText = new TruncatingSpriteText
             {
                 Shadow = false,
-                Truncate = true,
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             };

--- a/osu.Game/Overlays/Chat/DrawableChatUsername.cs
+++ b/osu.Game/Overlays/Chat/DrawableChatUsername.cs
@@ -87,7 +87,6 @@ namespace osu.Game.Overlays.Chat
             {
                 Shadow = false,
                 Truncate = true,
-                EllipsisString = "…",
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
             };

--- a/osu.Game/Overlays/Dashboard/Home/DashboardBeatmapPanel.cs
+++ b/osu.Game/Overlays/Dashboard/Home/DashboardBeatmapPanel.cs
@@ -100,17 +100,15 @@ namespace osu.Game.Overlays.Dashboard.Home
                                         Direction = FillDirection.Vertical,
                                         Children = new Drawable[]
                                         {
-                                            new OsuSpriteText
+                                            new TruncatingSpriteText
                                             {
                                                 RelativeSizeAxes = Axes.X,
-                                                Truncate = true,
                                                 Font = OsuFont.GetFont(weight: FontWeight.Regular),
                                                 Text = BeatmapSet.Title
                                             },
-                                            new OsuSpriteText
+                                            new TruncatingSpriteText
                                             {
                                                 RelativeSizeAxes = Axes.X,
-                                                Truncate = true,
                                                 Font = OsuFont.GetFont(size: 12, weight: FontWeight.Regular),
                                                 Text = BeatmapSet.Artist
                                             },

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -127,14 +127,14 @@ namespace osu.Game.Overlays.Mods
                                         {
                                             Left = -18 * ShearedOverlayContainer.SHEAR
                                         },
-                                        ShowTooltip = false,
+                                        ShowTooltip = false, // Tooltip is handled by `IncompatibilityDisplayingModPanel`.
                                     },
                                     descriptionText = new TruncatingSpriteText
                                     {
                                         Font = OsuFont.Default.With(size: 12),
                                         RelativeSizeAxes = Axes.X,
                                         Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                        ShowTooltip = false,
+                                        ShowTooltip = false, // Tooltip is handled by `IncompatibilityDisplayingModPanel`.
                                     }
                                 }
                             }

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -126,13 +126,15 @@ namespace osu.Game.Overlays.Mods
                                         Margin = new MarginPadding
                                         {
                                             Left = -18 * ShearedOverlayContainer.SHEAR
-                                        }
+                                        },
+                                        ShowTooltip = false,
                                     },
                                     descriptionText = new TruncatingSpriteText
                                     {
                                         Font = OsuFont.Default.With(size: 12),
                                         RelativeSizeAxes = Axes.X,
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)
+                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
+                                        ShowTooltip = false,
                                     }
                                 }
                             }

--- a/osu.Game/Overlays/Mods/ModSelectPanel.cs
+++ b/osu.Game/Overlays/Mods/ModSelectPanel.cs
@@ -118,22 +118,20 @@ namespace osu.Game.Overlays.Mods
                                 Direction = FillDirection.Vertical,
                                 Children = new[]
                                 {
-                                    titleText = new OsuSpriteText
+                                    titleText = new TruncatingSpriteText
                                     {
                                         Font = OsuFont.TorusAlternate.With(size: 18, weight: FontWeight.SemiBold),
                                         RelativeSizeAxes = Axes.X,
-                                        Truncate = true,
                                         Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
                                         Margin = new MarginPadding
                                         {
                                             Left = -18 * ShearedOverlayContainer.SHEAR
                                         }
                                     },
-                                    descriptionText = new OsuSpriteText
+                                    descriptionText = new TruncatingSpriteText
                                     {
                                         Font = OsuFont.Default.With(size: 12),
                                         RelativeSizeAxes = Axes.X,
-                                        Truncate = true,
                                         Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0)
                                     }
                                 }

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboardScore.cs
@@ -235,7 +235,7 @@ namespace osu.Game.Screens.Play.HUD
                                                             }
                                                         }
                                                     },
-                                                    usernameText = new OsuSpriteText
+                                                    usernameText = new TruncatingSpriteText
                                                     {
                                                         RelativeSizeAxes = Axes.X,
                                                         Width = 0.6f,
@@ -244,7 +244,6 @@ namespace osu.Game.Screens.Play.HUD
                                                         Colour = Color4.White,
                                                         Font = OsuFont.Torus.With(size: 14, weight: FontWeight.SemiBold),
                                                         Text = User?.Username ?? string.Empty,
-                                                        Truncate = true,
                                                         Shadow = false,
                                                     }
                                                 }

--- a/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
+++ b/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs
@@ -101,23 +101,21 @@ namespace osu.Game.Screens.Ranking.Expanded
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
-                            new OsuSpriteText
+                            new TruncatingSpriteText
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 Text = new RomanisableString(metadata.TitleUnicode, metadata.Title),
                                 Font = OsuFont.Torus.With(size: 20, weight: FontWeight.SemiBold),
                                 MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
-                                Truncate = true,
                             },
-                            new OsuSpriteText
+                            new TruncatingSpriteText
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
                                 Text = new RomanisableString(metadata.ArtistUnicode, metadata.Artist),
                                 Font = OsuFont.Torus.With(size: 14, weight: FontWeight.SemiBold),
                                 MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
-                                Truncate = true,
                             },
                             new Container
                             {
@@ -156,14 +154,13 @@ namespace osu.Game.Screens.Ranking.Expanded
                                 AutoSizeAxes = Axes.Both,
                                 Children = new Drawable[]
                                 {
-                                    new OsuSpriteText
+                                    new TruncatingSpriteText
                                     {
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
                                         Text = beatmap.DifficultyName,
                                         Font = OsuFont.Torus.With(size: 16, weight: FontWeight.SemiBold),
                                         MaxWidth = ScorePanel.EXPANDED_WIDTH - padding * 2,
-                                        Truncate = true,
                                     },
                                     new OsuTextFlowContainer(s => s.Font = OsuFont.Torus.With(size: 12))
                                     {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -233,12 +233,11 @@ namespace osu.Game.Screens.Select
                         RelativeSizeAxes = Axes.X,
                         Children = new Drawable[]
                         {
-                            VersionLabel = new OsuSpriteText
+                            VersionLabel = new TruncatingSpriteText
                             {
                                 Text = beatmapInfo.DifficultyName,
                                 Font = OsuFont.GetFont(size: 24, italics: true),
                                 RelativeSizeAxes = Axes.X,
-                                Truncate = true,
                             },
                         }
                     },
@@ -286,19 +285,17 @@ namespace osu.Game.Screens.Select
                         RelativeSizeAxes = Axes.X,
                         Children = new Drawable[]
                         {
-                            TitleLabel = new OsuSpriteText
+                            TitleLabel = new TruncatingSpriteText
                             {
                                 Current = { BindTarget = titleBinding },
                                 Font = OsuFont.GetFont(size: 28, italics: true),
                                 RelativeSizeAxes = Axes.X,
-                                Truncate = true,
                             },
-                            ArtistLabel = new OsuSpriteText
+                            ArtistLabel = new TruncatingSpriteText
                             {
                                 Current = { BindTarget = artistBinding },
                                 Font = OsuFont.GetFont(size: 17, italics: true),
                                 RelativeSizeAxes = Axes.X,
-                                Truncate = true,
                             },
                             MapperContainer = new FillFlowContainer
                             {


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/6120

![osu Game Tests_ejYwxMSqYJ](https://github.com/ppy/osu/assets/35318437/5f2095c3-fbc4-41ce-99b5-236ec54332e4)

Made the changes said in https://github.com/ppy/osu-framework/pull/5636#issuecomment-1403254480 + simplifying the tooltip `IsTruncated ? Text : string.Empty` to just `Text` as it wasn't needed (i.e. the `HandlePositionalInput` override already disables tooltip showing).

Looking again, `TruncatingSpriteText` may be better suited for framework. `OsuSpriteText` is already a simple class with just two lines, so inheritance isn't a problem and could be `TruncatingSpriteText : SpriteText` for framework and `OsuTruncatingSpriteText : TruncatingSpriteText` for osu!-side.

---

I also tried centralising the `MaxWidth` and `RelativeSizeAxes = Axes.X` assigning to `TruncatingSpriteText` (https://github.com/Joehuu/osu/commit/dd8e1ba68d3a7fb46b128b6268446929f1e01e61), but not sure about the solution as I'm working around a framework limitation and probably should be done more directly in `SpriteText`.