### PR TITLE
Fix weird right-toolbox distance snapping display in osu!catch editor

### DIFF
--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -125,6 +125,7 @@ namespace osu.Game.Rulesets.Edit
             if (currentSnap > DistanceSpacingMultiplier.MinValue)
             {
                 currentDistanceSpacingButton.Enabled.Value = currentDistanceSpacingButton.Expanded.Value
+                                                             && !DistanceSpacingMultiplier.Disabled
                                                              && !Precision.AlmostEquals(currentSnap, DistanceSpacingMultiplier.Value, DistanceSpacingMultiplier.Precision / 2);
                 currentDistanceSpacingButton.ContractedLabelText = $"current {currentSnap:N2}x";
                 currentDistanceSpacingButton.ExpandedLabelText = $"Use current ({currentSnap:N2}x)";
@@ -141,28 +142,31 @@ namespace osu.Game.Rulesets.Edit
         {
             base.LoadComplete();
 
-            if (!DistanceSpacingMultiplier.Disabled)
+            if (DistanceSpacingMultiplier.Disabled)
             {
-                DistanceSpacingMultiplier.Value = EditorBeatmap.BeatmapInfo.DistanceSpacing;
-                DistanceSpacingMultiplier.BindValueChanged(multiplier =>
-                {
-                    distanceSpacingSlider.ContractedLabelText = $"D. S. ({multiplier.NewValue:0.##x})";
-                    distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({multiplier.NewValue:0.##x})";
-
-                    if (multiplier.NewValue != multiplier.OldValue)
-                        onScreenDisplay?.Display(new DistanceSpacingToast(multiplier.NewValue.ToLocalisableString(@"0.##x"), multiplier));
-
-                    EditorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
-                }, true);
-
-                // Manual binding to handle enabling distance spacing when the slider is interacted with.
-                distanceSpacingSlider.Current.BindValueChanged(spacing =>
-                {
-                    DistanceSpacingMultiplier.Value = spacing.NewValue;
-                    DistanceSnapToggle.Value = TernaryState.True;
-                });
-                DistanceSpacingMultiplier.BindValueChanged(spacing => distanceSpacingSlider.Current.Value = spacing.NewValue);
+                distanceSpacingSlider.Hide();
+                return;
             }
+
+            DistanceSpacingMultiplier.Value = EditorBeatmap.BeatmapInfo.DistanceSpacing;
+            DistanceSpacingMultiplier.BindValueChanged(multiplier =>
+            {
+                distanceSpacingSlider.ContractedLabelText = $"D. S. ({multiplier.NewValue:0.##x})";
+                distanceSpacingSlider.ExpandedLabelText = $"Distance Spacing ({multiplier.NewValue:0.##x})";
+
+                if (multiplier.NewValue != multiplier.OldValue)
+                    onScreenDisplay?.Display(new DistanceSpacingToast(multiplier.NewValue.ToLocalisableString(@"0.##x"), multiplier));
+
+                EditorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
+            }, true);
+
+            // Manual binding to handle enabling distance spacing when the slider is interacted with.
+            distanceSpacingSlider.Current.BindValueChanged(spacing =>
+            {
+                DistanceSpacingMultiplier.Value = spacing.NewValue;
+                DistanceSnapToggle.Value = TernaryState.True;
+            });
+            DistanceSpacingMultiplier.BindValueChanged(spacing => distanceSpacingSlider.Current.Value = spacing.NewValue);
         }
 
         protected override IEnumerable<TernaryButton> CreateTernaryButtons() => base.CreateTernaryButtons().Concat(new[]


### PR DESCRIPTION
The eventual goal is to make the distance snapping grid in catch also support adjustable distance spacing, but right now that's not the case. Unfortunately the new controls on the right weren't disabled enough for this case, leaving them in a weird visual state.