### PR TITLE
Fix beatmap panel background looking different than usual

### DIFF
--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -66,7 +66,10 @@ namespace osu.Game.Beatmaps
             textureUpload.Dispose();
 
             Size size = image.Size();
-            int usableWidth = Math.Min(max_width, size.Width);
+
+            float aspectRatio = (float)size.Width / size.Height;
+
+            int usableWidth = Math.Min((int)(max_width * aspectRatio), size.Width);
             int usableHeight = Math.Min(max_height, size.Height);
 
             // Crop the centre region of the background for now.

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -17,9 +17,8 @@ namespace osu.Game.Beatmaps
     // If issues are found it's worth checking to make sure similar issues exist there.
     public class BeatmapPanelBackgroundTextureLoaderStore : IResourceStore<TextureUpload>
     {
-        // These numbers are taken from the draw visualiser size requirements for song select panel textures at extreme aspect ratios.
-        private const int max_height = 130;
-        private const int max_width = 1280;
+        // The aspect ratio of SetPanelBackground at its maximum size (very tall window).
+        private const float minimum_display_ratio = 512 / 80f;
 
         private readonly IResourceStore<TextureUpload>? textureStore;
 
@@ -67,16 +66,18 @@ namespace osu.Game.Beatmaps
 
             Size size = image.Size();
 
-            float aspectRatio = (float)size.Width / size.Height;
-
-            int usableWidth = Math.Min((int)(max_width * aspectRatio), size.Width);
-            int usableHeight = Math.Min(max_height, size.Height);
+            // Assume that panel backgrounds are always displayed using `FillMode.Fill`.
+            // Also assume that all backgrounds are wider than they are tall, so the
+            // fill is always going to be based on width.
+            //
+            // We need to include enough height to make this work for all ratio panels are displayed at.
+            int usableHeight = (int)Math.Ceiling(size.Width * 1 / minimum_display_ratio);
 
             // Crop the centre region of the background for now.
             Rectangle cropRectangle = new Rectangle(
-                (size.Width - usableWidth) / 2,
+                0,
                 (size.Height - usableHeight) / 2,
-                usableWidth,
+                size.Width,
                 usableHeight
             );
 

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -73,6 +73,8 @@ namespace osu.Game.Beatmaps
             // We need to include enough height to make this work for all ratio panels are displayed at.
             int usableHeight = (int)Math.Ceiling(size.Width * 1 / minimum_display_ratio);
 
+            usableHeight = Math.Min(size.Height, usableHeight);
+
             // Crop the centre region of the background for now.
             Rectangle cropRectangle = new Rectangle(
                 0,


### PR DESCRIPTION
This was initially meant as a review comment in https://github.com/ppy/osu/pull/23809, but the PR got merged already. See https://github.com/ppy/osu/pull/23809#issuecomment-1584015603 for more information.

This can be closed if the new display is deemed acceptable.