### PR TITLE
Fix audio settings not displaying while watching a replay

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -42,7 +42,8 @@ namespace osu.Game.Screens.Play.HUD
                     //CollectionSettings = new CollectionSettings(),
                     //DiscussionSettings = new DiscussionSettings(),
                     PlaybackSettings = new PlaybackSettings { Expanded = { Value = false } },
-                    VisualSettings = new VisualSettings { Expanded = { Value = false } }
+                    VisualSettings = new VisualSettings { Expanded = { Value = false } },
+                    new AudioSettings { Expanded = { Value = false } }
                 }
             };
         }


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/discussions/23838.

Offset is a weird one but i think it's fine to have it there.