### PR TITLE
Bump replay version in encoder after Score V2 changes

### DIFF
--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -28,9 +28,10 @@ namespace osu.Game.Scoring.Legacy
         /// <remarks>
         /// <list type="bullet">
         /// <item><description>30000001: Appends <see cref="LegacyReplaySoloScoreInfo"/> to the end of scores.</description></item>
+        /// <item><description>30000002: Score stored to replay calculated using the Score V2 algorithm.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000001;
+        public const int LATEST_VERSION = 30000002;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
One release too late, but this may help in the future if we need to discern replays set with Score V2 from older lazer replays for whatever reason.

Partially inspired by https://discord.com/channels/188630481301012481/1097318920991559880/1116706748061982770.