### PR TITLE
Implement 3-button/taiko navigation for main menu buttons

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -34,9 +34,15 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex, () => Is.EqualTo(4));
             AddRepeatStep("press left (keybind) 3 times", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup), 3);
             AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.PlayButton));
-            AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
+            AddStep("confirm selection", () => globalActionContainer.TriggerPressed(GlobalAction.Select));
             AddAssert("state is play buttons", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
-            AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
+            AddAssert("solo button is selected", () => buttons.SelectionIndex, () => Is.EqualTo(1));
+            AddStep("escape", () => globalActionContainer.TriggerPressed(GlobalAction.Back));
+            AddAssert("play button is selected", () => buttons.SelectionIndex, () => Is.EqualTo(1));
+            AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
+            AddStep("confirm selection", () => globalActionContainer.TriggerPressed(GlobalAction.Select));
+            AddAssert("state is play buttons", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
+            AddStep("confirm selection", () => globalActionContainer.TriggerPressed(GlobalAction.Select));
             AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
         }
 

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -29,7 +29,8 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("assume first button is 1 for following tests", () => buttons.SelectionIndex == 1);
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
             AddAssert("button 2 is selected", () => buttons.SelectionIndex == 2);
-            AddStep("press right (keybind) many times", () => {
+            AddStep("press right (keybind) many times", () =>
+            {
                 globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
                 globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
                 globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
@@ -39,7 +40,8 @@ namespace osu.Game.Tests.Visual.Navigation
                 globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
             });
             AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex == 4);
-            AddStep("press left (keybind) 3 times", () => {
+            AddStep("press left (keybind) 3 times", () =>
+            {
                 globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
                 globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
                 globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -62,46 +62,46 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
             AddAssert("auto focused first button", () => buttons.SelectionIndex == 1);
             AddAssert("settings button looks not hovered",
-                () => !buttons.CurrentButtonsList[0].LooksHovered);
+                () => !buttons.CurrentButtonsList![0].LooksHovered);
             AddAssert("first button looks hovered",
-                () => buttons.CurrentButtonsList[1].LooksHovered);
+                () => buttons.CurrentButtonsList![1].LooksHovered);
             AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList[2].LooksHovered);
+                () => !buttons.CurrentButtonsList![2].LooksHovered);
 
-            AddStep("hover second button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[2]));
+            AddStep("hover second button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![2]));
             AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList[1].LooksHovered);
+                () => !buttons.CurrentButtonsList![1].LooksHovered);
             AddAssert("second button looks hovered",
-                () => buttons.CurrentButtonsList[2].LooksHovered);
+                () => buttons.CurrentButtonsList![2].LooksHovered);
             AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList[3].LooksHovered);
+                () => !buttons.CurrentButtonsList![3].LooksHovered);
             AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
 
             AddStep("unhover buttons", () => InputManager.MoveMouseTo(Vector2.Zero));
             AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList[1].LooksHovered);
+                () => !buttons.CurrentButtonsList![1].LooksHovered);
             AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList[2].LooksHovered);
+                () => !buttons.CurrentButtonsList![2].LooksHovered);
             AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList[3].LooksHovered);
+                () => !buttons.CurrentButtonsList![3].LooksHovered);
 
-            AddStep("hover third button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[3]));
+            AddStep("hover third button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![3]));
             AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
             AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList[1].LooksHovered);
+                () => !buttons.CurrentButtonsList![1].LooksHovered);
             AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList[2].LooksHovered);
+                () => !buttons.CurrentButtonsList![2].LooksHovered);
             AddAssert("third button looks hovered",
-                () => buttons.CurrentButtonsList[3].LooksHovered);
+                () => buttons.CurrentButtonsList![3].LooksHovered);
 
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
             AddAssert("focused first button", () => buttons.SelectionIndex == 1);
             AddAssert("first button looks hovered",
-                () => buttons.CurrentButtonsList[1].LooksHovered);
+                () => buttons.CurrentButtonsList![1].LooksHovered);
             AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList[2].LooksHovered);
+                () => !buttons.CurrentButtonsList![2].LooksHovered);
             AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList[3].LooksHovered);
+                () => !buttons.CurrentButtonsList![3].LooksHovered);
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
             AddAssert("focused second button", () => buttons.SelectionIndex == 2);
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
@@ -109,7 +109,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
             AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
             AddAssert("focused first button", () => buttons.SelectionIndex == 1);
-            AddStep("hover first button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[1]));
+            AddStep("hover first button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![1]));
             AddStep("click", () => InputManager.Click(MouseButton.Left));
 
             AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -9,6 +9,7 @@ using osu.Framework.Testing;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select;
 using osu.Game.Input.Bindings;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation
@@ -51,6 +52,67 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);
             AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
             AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+        }
+
+        [Test]
+        public void TestKeyboardNavigationMouseInterrupted()
+        {
+            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+            AddAssert("auto focused first button", () => buttons.SelectionIndex == 1);
+            AddAssert("settings button looks not hovered",
+                () => !buttons.CurrentButtonsList[0].LooksHovered);
+            AddAssert("first button looks hovered",
+                () => buttons.CurrentButtonsList[1].LooksHovered);
+            AddAssert("second button looks not hovered",
+                () => !buttons.CurrentButtonsList[2].LooksHovered);
+
+            AddStep("hover second button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[2]));
+            AddAssert("first button looks not hovered",
+                () => !buttons.CurrentButtonsList[1].LooksHovered);
+            AddAssert("second button looks hovered",
+                () => buttons.CurrentButtonsList[2].LooksHovered);
+            AddAssert("third button looks not hovered",
+                () => !buttons.CurrentButtonsList[3].LooksHovered);
+            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
+
+            AddStep("unhover buttons", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddAssert("first button looks not hovered",
+                () => !buttons.CurrentButtonsList[1].LooksHovered);
+            AddAssert("second button looks not hovered",
+                () => !buttons.CurrentButtonsList[2].LooksHovered);
+            AddAssert("third button looks not hovered",
+                () => !buttons.CurrentButtonsList[3].LooksHovered);
+
+            AddStep("hover third button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[3]));
+            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
+            AddAssert("first button looks not hovered",
+                () => !buttons.CurrentButtonsList[1].LooksHovered);
+            AddAssert("second button looks not hovered",
+                () => !buttons.CurrentButtonsList[2].LooksHovered);
+            AddAssert("third button looks hovered",
+                () => buttons.CurrentButtonsList[3].LooksHovered);
+
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("focused first button", () => buttons.SelectionIndex == 1);
+            AddAssert("first button looks hovered",
+                () => buttons.CurrentButtonsList[1].LooksHovered);
+            AddAssert("second button looks not hovered",
+                () => !buttons.CurrentButtonsList[2].LooksHovered);
+            AddAssert("third button looks not hovered",
+                () => !buttons.CurrentButtonsList[3].LooksHovered);
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("focused second button", () => buttons.SelectionIndex == 2);
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("focused third button", () => buttons.SelectionIndex == 3);
+            AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
+            AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
+            AddAssert("focused first button", () => buttons.SelectionIndex == 1);
+            AddStep("hover first button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList[1]));
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select;
+using osu.Game.Input.Bindings;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Navigation
@@ -15,6 +16,40 @@ namespace osu.Game.Tests.Visual.Navigation
     public partial class TestSceneButtonSystemNavigation : OsuGameTestScene
     {
         private ButtonSystem buttons => ((MainMenu)Game.ScreenStack.CurrentScreen).ChildrenOfType<ButtonSystem>().Single();
+
+        private GlobalActionContainer globalActionContainer => Game.ChildrenOfType<GlobalActionContainer>().First();
+
+        [Test]
+        public void TestKeyboardNavigation()
+        {
+            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+            AddAssert("auto focused first button", () => buttons.CurrentSelection == buttons.PlayButton);
+            AddAssert("assume first button is 1 for following tests", () => buttons.SelectionIndex == 1);
+            AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
+            AddAssert("button 2 is selected", () => buttons.SelectionIndex == 2);
+            AddStep("press right (keybind) many times", () => {
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
+            });
+            AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex == 4);
+            AddStep("press left (keybind) 3 times", () => {
+                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
+                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
+            });
+            AddAssert("auto focused first button", () => buttons.CurrentSelection == buttons.PlayButton);
+            AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
+            AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);
+            AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
+            AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+        }
 
         [Test]
         public void TestGlobalActionHasPriority()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -26,14 +26,14 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
             AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
-            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.playButton));
+            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.PlayButton));
             AddAssert("assume play button is 1 for following tests", () => buttons.SelectionIndex, () => Is.EqualTo(1));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
             AddAssert("button 2 is selected", () => buttons.SelectionIndex, () => Is.EqualTo(2));
             AddRepeatStep("press right (keybind) many times", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup), 7);
             AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex, () => Is.EqualTo(4));
             AddRepeatStep("press left (keybind) 3 times", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup), 3);
-            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.playButton));
+            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.PlayButton));
             AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
             AddAssert("state is play buttons", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
             AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));

--- a/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneButtonSystemNavigation.cs
@@ -23,33 +23,19 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestKeyboardNavigation()
         {
-            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
-            AddAssert("auto focused first button", () => buttons.CurrentSelection == buttons.PlayButton);
-            AddAssert("assume first button is 1 for following tests", () => buttons.SelectionIndex == 1);
+            AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
+            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.playButton));
+            AddAssert("assume play button is 1 for following tests", () => buttons.SelectionIndex, () => Is.EqualTo(1));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("button 2 is selected", () => buttons.SelectionIndex == 2);
-            AddStep("press right (keybind) many times", () =>
-            {
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup);
-            });
-            AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex == 4);
-            AddStep("press left (keybind) 3 times", () =>
-            {
-                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
-                globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup);
-            });
-            AddAssert("auto focused first button", () => buttons.CurrentSelection == buttons.PlayButton);
+            AddAssert("button 2 is selected", () => buttons.SelectionIndex, () => Is.EqualTo(2));
+            AddRepeatStep("press right (keybind) many times", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup), 7);
+            AddAssert("last button is selected (exit button)", () => buttons.SelectionIndex, () => Is.EqualTo(4));
+            AddRepeatStep("press left (keybind) 3 times", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup), 3);
+            AddAssert("auto focused play button", () => buttons.CurrentSelection, () => Is.EqualTo(buttons.playButton));
             AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
-            AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);
+            AddAssert("state is play buttons", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
             AddStep("press down (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNext));
             AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
         }
@@ -57,88 +43,74 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestKeyboardNavigationMouseInterrupted()
         {
-            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
-            AddAssert("auto focused first button", () => buttons.SelectionIndex == 1);
-            AddAssert("settings button looks not hovered",
-                () => !buttons.CurrentButtonsList![0].LooksHovered);
-            AddAssert("first button looks hovered",
-                () => buttons.CurrentButtonsList![1].LooksHovered);
-            AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList![2].LooksHovered);
+            AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
+            AddAssert("auto focused first button", () => buttons.SelectionIndex, () => Is.EqualTo(1));
+            AddAssert("settings button looks not hovered", () => !buttons.CurrentButtonsList![0].LooksHovered);
+            AddAssert("first button looks hovered", () => buttons.CurrentButtonsList![1].LooksHovered);
+            AddAssert("second button looks not hovered", () => !buttons.CurrentButtonsList![2].LooksHovered);
 
             AddStep("hover second button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![2]));
-            AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList![1].LooksHovered);
-            AddAssert("second button looks hovered",
-                () => buttons.CurrentButtonsList![2].LooksHovered);
-            AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList![3].LooksHovered);
-            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
+            AddAssert("first button looks not hovered", () => !buttons.CurrentButtonsList![1].LooksHovered);
+            AddAssert("second button looks hovered", () => buttons.CurrentButtonsList![2].LooksHovered);
+            AddAssert("third button looks not hovered", () => !buttons.CurrentButtonsList![3].LooksHovered);
+            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex, () => Is.EqualTo(null));
 
             AddStep("unhover buttons", () => InputManager.MoveMouseTo(Vector2.Zero));
-            AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList![1].LooksHovered);
-            AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList![2].LooksHovered);
-            AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList![3].LooksHovered);
+            AddAssert("first button looks not hovered", () => !buttons.CurrentButtonsList![1].LooksHovered);
+            AddAssert("second button looks not hovered", () => !buttons.CurrentButtonsList![2].LooksHovered);
+            AddAssert("third button looks not hovered", () => !buttons.CurrentButtonsList![3].LooksHovered);
 
             AddStep("hover third button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![3]));
-            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex == -1);
-            AddAssert("first button looks not hovered",
-                () => !buttons.CurrentButtonsList![1].LooksHovered);
-            AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList![2].LooksHovered);
-            AddAssert("third button looks hovered",
-                () => buttons.CurrentButtonsList![3].LooksHovered);
+            AddAssert("keyboard focus is gone", () => buttons.SelectionIndex, () => Is.EqualTo(null));
+            AddAssert("first button looks not hovered", () => !buttons.CurrentButtonsList![1].LooksHovered);
+            AddAssert("second button looks not hovered", () => !buttons.CurrentButtonsList![2].LooksHovered);
+            AddAssert("third button looks hovered", () => buttons.CurrentButtonsList![3].LooksHovered);
 
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("focused first button", () => buttons.SelectionIndex == 1);
-            AddAssert("first button looks hovered",
-                () => buttons.CurrentButtonsList![1].LooksHovered);
-            AddAssert("second button looks not hovered",
-                () => !buttons.CurrentButtonsList![2].LooksHovered);
-            AddAssert("third button looks not hovered",
-                () => !buttons.CurrentButtonsList![3].LooksHovered);
+            // we reset keyboard focus when hovering - for the usecase to use a taiko controller for navigation, this feels most natural
+            AddAssert("focused first button", () => buttons.SelectionIndex, () => Is.EqualTo(1));
+            AddAssert("first button looks hovered", () => buttons.CurrentButtonsList![1].LooksHovered);
+            AddAssert("second button looks not hovered", () => !buttons.CurrentButtonsList![2].LooksHovered);
+            AddAssert("third button looks not hovered", () => !buttons.CurrentButtonsList![3].LooksHovered);
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("focused second button", () => buttons.SelectionIndex == 2);
+            AddAssert("focused second button", () => buttons.SelectionIndex, () => Is.EqualTo(2));
             AddStep("press right (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectNextGroup));
-            AddAssert("focused third button", () => buttons.SelectionIndex == 3);
+            AddAssert("focused third button", () => buttons.SelectionIndex, () => Is.EqualTo(3));
             AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
             AddStep("press left (keybind)", () => globalActionContainer.TriggerPressed(GlobalAction.SelectPreviousGroup));
-            AddAssert("focused first button", () => buttons.SelectionIndex == 1);
+            AddAssert("focused first button", () => buttons.SelectionIndex, () => Is.EqualTo(1));
             AddStep("hover first button", () => InputManager.MoveMouseTo(buttons.CurrentButtonsList![1]));
             AddStep("click", () => InputManager.Click(MouseButton.Left));
 
-            AddAssert("state is play buttons", () => buttons.State == ButtonSystemState.Play);
+            AddAssert("state is play buttons", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
         }
 
         [Test]
         public void TestGlobalActionHasPriority()
         {
-            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
 
             // triggering the cookie in the initial state with any key should only happen if no other action is bound to that key.
             // here, F10 is bound to GlobalAction.ToggleGameplayMouseButtons.
             AddStep("press F10", () => InputManager.Key(Key.F10));
-            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
 
             AddStep("press P", () => InputManager.Key(Key.P));
-            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+            AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
         }
 
         [Test]
         public void TestShortcutKeys()
         {
-            AddAssert("state is initial", () => buttons.State == ButtonSystemState.Initial);
+            AddAssert("state is initial", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Initial));
 
             AddStep("press P", () => InputManager.Key(Key.P));
-            AddAssert("state is top level", () => buttons.State == ButtonSystemState.TopLevel);
+            AddAssert("state is top level", () => buttons.State, () => Is.EqualTo(ButtonSystemState.TopLevel));
 
             AddStep("press P", () => InputManager.Key(Key.P));
-            AddAssert("state is play", () => buttons.State == ButtonSystemState.Play);
+            AddAssert("state is play", () => buttons.State, () => Is.EqualTo(ButtonSystemState.Play));
 
             AddStep("press P", () => InputManager.Key(Key.P));
             AddAssert("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -96,14 +96,17 @@ namespace osu.Game.Screens.Menu
             {
                 switch (State)
                 {
-                    case ButtonSystemState.TopLevel: return buttonsTopLevel;
-                    case ButtonSystemState.Play: return buttonsPlay;
-                    default: return null;
+                    case ButtonSystemState.TopLevel:
+                        return buttonsTopLevel;
+                    case ButtonSystemState.Play:
+                        return buttonsPlay;
+                    default:
+                        return null;
                 }
             }
         }
 
-        private int? selectionIndex = null;
+        private int? selectionIndex;
 
         public int? SelectionIndex
         {
@@ -134,7 +137,7 @@ namespace osu.Game.Screens.Menu
         /// input. Reset to Vector2.Zero when hovering over buttons. When a
         /// hover is registered very close to this position, we ignore the hover.
         /// </summary>
-        private Vector2? blockedMousePosition = null;
+        private Vector2? blockedMousePosition;
 
         private Sample sampleBack;
 

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -126,8 +126,8 @@ namespace osu.Game.Screens.Menu
 
         [CanBeNull]
         public Container CurrentSelection =>
-            (SelectionIndex >= 0 && SelectionIndex < currentButtonsList?.Count)
-                ? currentButtonsList[SelectionIndex]
+            (SelectionIndex >= 0 && SelectionIndex < CurrentButtonsList?.Count)
+                ? CurrentButtonsList[SelectionIndex]
                 : logo;
 
         private Sample sampleBack;
@@ -330,7 +330,7 @@ namespace osu.Game.Screens.Menu
                 State = ButtonSystemState.TopLevel;
                 SelectionIndex = 1;
             }
-            else if (currentButtonsList == null)
+            else if (CurrentButtonsList == null)
             {
                 SelectionIndex = -1;
             }
@@ -338,8 +338,8 @@ namespace osu.Game.Screens.Menu
             {
                 int nextSelection = SelectionIndex + d;
 
-                if (nextSelection >= currentButtonsList.Count)
-                    nextSelection = currentButtonsList.Count - 1;
+                if (nextSelection >= CurrentButtonsList.Count)
+                    nextSelection = CurrentButtonsList.Count - 1;
                 else if (nextSelection < 0)
                     nextSelection = 0;
 
@@ -357,9 +357,9 @@ namespace osu.Game.Screens.Menu
 
         public void ClearKeyboardSelection(HoverEvent e)
         {
-            if (currentButtonsList != null)
+            if (CurrentButtonsList != null)
             {
-                foreach (var btn in currentButtonsList)
+                foreach (var btn in CurrentButtonsList)
                 {
                     if (btn != e.Target)
                     {

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -95,11 +95,11 @@ namespace osu.Game.Screens.Menu
 
         [CanBeNull]
         private List<MainMenuButton> currentButtonsList => State switch
-            {
-                ButtonSystemState.TopLevel => buttonsTopLevel,
-                ButtonSystemState.Play => buttonsPlay,
-                _ => null
-            };
+        {
+            ButtonSystemState.TopLevel => buttonsTopLevel,
+            ButtonSystemState.Play => buttonsPlay,
+            _ => null
+        };
 
         private int selectionIndex = -1;
         public int SelectionIndex

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -394,6 +394,17 @@ namespace osu.Game.Screens.Menu
         public void PreferKeyboardNavigation()
         {
             blockedMousePosition = GetContainingInputManager().CurrentState.Mouse.Position;
+
+            if (CurrentButtonsList != null)
+            {
+                foreach (var btn in CurrentButtonsList)
+                {
+                    if (btn != CurrentSelection)
+                    {
+                        btn.SimulateHoverLost();
+                    }
+                }
+            }
         }
 
         public bool ConfirmHover(Vector2 currentMousePosition)

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -98,8 +98,10 @@ namespace osu.Game.Screens.Menu
                 {
                     case ButtonSystemState.TopLevel:
                         return buttonsTopLevel;
+
                     case ButtonSystemState.Play:
                         return buttonsPlay;
+
                     default:
                         return null;
                 }

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Menu
         private readonly MainMenuButton settingsButton;
 
         [CanBeNull]
-        internal MainMenuButton playButton;
+        internal MainMenuButton PlayButton;
 
         private readonly List<MainMenuButton> buttonsTopLevel = new List<MainMenuButton>();
         private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
@@ -154,9 +154,10 @@ namespace osu.Game.Screens.Menu
 
             buttonArea.AddRange(new Drawable[]
             {
-                settingsButton = new MainMenuButton(ButtonSystemStrings.Settings, string.Empty, FontAwesome.Solid.Cog, new Color4(85, 85, 85, 255), () => OnSettings?.Invoke(), -WEDGE_WIDTH, Key.O, hoverAction: ProcessHover),
+                settingsButton = new MainMenuButton(ButtonSystemStrings.Settings, string.Empty, FontAwesome.Solid.Cog, new Color4(85, 85, 85, 255), () => OnSettings?.Invoke(),
+                    -WEDGE_WIDTH, Key.O, hoverAction: processMenuButtonHover),
                 backButton = new MainMenuButton(ButtonSystemStrings.Back, @"button-back-select", OsuIcon.LeftCircle, new Color4(51, 58, 94, 255), () => State = ButtonSystemState.TopLevel,
-                    -WEDGE_WIDTH, hoverAction: ProcessHover)
+                    -WEDGE_WIDTH, hoverAction: processMenuButtonHover)
                 {
                     VisibleState = ButtonSystemState.Play,
                 },
@@ -178,21 +179,28 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P, hoverAction: ProcessHover));
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M, hoverAction: ProcessHover));
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists, 0, Key.L, hoverAction: ProcessHover));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(),
+                WEDGE_WIDTH, Key.P, hoverAction: processMenuButtonHover));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer,
+                0, Key.M, hoverAction: processMenuButtonHover));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists,
+                0, Key.L, hoverAction: processMenuButtonHover));
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
 
             buttonsTopLevel.Add(
-                playButton = new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH,
-                    Key.P, hoverAction: ProcessHover)
+                PlayButton = new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play,
+                    WEDGE_WIDTH, Key.P, hoverAction: processMenuButtonHover)
             );
-            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E, hoverAction: ProcessHover));
-            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-direct-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(), 0,
-                Key.D, hoverAction: ProcessHover));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(),
+                0, Key.E, hoverAction: processMenuButtonHover));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-direct-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(),
+                0, Key.D, hoverAction: processMenuButtonHover));
 
             if (host.CanExit)
-                buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q, hoverAction: ProcessHover));
+            {
+                buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(),
+                    0, Key.Q, hoverAction: processMenuButtonHover));
+            }
 
             buttonArea.AddRange(buttonsPlay);
             buttonArea.AddRange(buttonsTopLevel);
@@ -363,14 +371,14 @@ namespace osu.Game.Screens.Menu
         public void SelectUp()
         {
             // if we come from play, focus play button again
-            int? parentSelection = State == ButtonSystemState.Play ? buttonsTopLevel.FindIndex(b => b == playButton) : null;
+            int? parentSelection = State == ButtonSystemState.Play ? buttonsTopLevel.FindIndex(b => b == PlayButton) : null;
             if (parentSelection == -1)
                 parentSelection = null;
             goBack();
             SelectionIndex = parentSelection;
         }
 
-        private bool ProcessHover(Vector2 screenSpacePosition, [CanBeNull] Drawable hoverElement)
+        private bool processMenuButtonHover(Vector2 screenSpacePosition, [CanBeNull] Drawable hoverElement)
         {
             if (!ConfirmHover(screenSpacePosition))
                 return false;
@@ -452,7 +460,7 @@ namespace osu.Game.Screens.Menu
                     return true;
 
                 case ButtonSystemState.TopLevel:
-                    playButton!.TriggerClick();
+                    PlayButton!.TriggerClick();
                     return false;
 
                 case ButtonSystemState.Play:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -83,18 +83,15 @@ namespace osu.Game.Screens.Menu
         private readonly MainMenuButton backButton;
         private readonly MainMenuButton settingsButton;
 
-        [CanBeNull]
-        private MainMenuButton playButton;
-
         // public for tests
         [CanBeNull]
-        public MainMenuButton PlayButton => playButton;
+        public MainMenuButton playButton { get; private set; }
 
         private readonly List<MainMenuButton> buttonsTopLevel = new List<MainMenuButton>();
         private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
 
         [CanBeNull]
-        private List<MainMenuButton> currentButtonsList => State switch
+        public List<MainMenuButton> CurrentButtonsList => State switch
         {
             ButtonSystemState.TopLevel => buttonsTopLevel,
             ButtonSystemState.Play => buttonsPlay,
@@ -102,6 +99,7 @@ namespace osu.Game.Screens.Menu
         };
 
         private int selectionIndex = -1;
+
         public int SelectionIndex
         {
             get => selectionIndex;
@@ -110,7 +108,9 @@ namespace osu.Game.Screens.Menu
                 MainMenuButton previousButton = null;
                 if (CurrentSelection is MainMenuButton button)
                     previousButton = button;
+
                 selectionIndex = value;
+
                 if (CurrentSelection is MainMenuButton newButton)
                 {
                     if (previousButton != newButton)
@@ -358,9 +358,16 @@ namespace osu.Game.Screens.Menu
         public void ClearKeyboardSelection(HoverEvent e)
         {
             if (currentButtonsList != null)
+            {
                 foreach (var btn in currentButtonsList)
+                {
                     if (btn != e.Target)
+                    {
                         btn.SimulateHoverLost();
+                    }
+                }
+            }
+
             selectionIndex = -1;
         }
 
@@ -394,7 +401,7 @@ namespace osu.Game.Screens.Menu
                     return true;
 
                 case ButtonSystemState.TopLevel:
-                    playButton.TriggerClick();
+                    playButton!.TriggerClick();
                     return false;
 
                 case ButtonSystemState.Play:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Menu
 
         // public for tests
         [CanBeNull]
-        public MainMenuButton playButton { get; private set; }
+        public MainMenuButton PlayButton { get; private set; }
 
         private readonly List<MainMenuButton> buttonsTopLevel = new List<MainMenuButton>();
         private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.Menu
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
 
             buttonsTopLevel.Add(
-                playButton = new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH,
+                PlayButton = new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH,
                     Key.P, hoverAction: ClearKeyboardSelection)
             );
             buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E, hoverAction: ClearKeyboardSelection));
@@ -350,7 +350,7 @@ namespace osu.Game.Screens.Menu
         public void SelectUp()
         {
             // if we come from play, focus play button again
-            int parentSelection = State == ButtonSystemState.Play ? buttonsTopLevel.FindIndex(b => b == playButton) : -1;
+            int parentSelection = State == ButtonSystemState.Play ? buttonsTopLevel.FindIndex(b => b == PlayButton) : -1;
             goBack();
             SelectionIndex = parentSelection;
         }
@@ -401,7 +401,7 @@ namespace osu.Game.Screens.Menu
                     return true;
 
                 case ButtonSystemState.TopLevel:
-                    playButton!.TriggerClick();
+                    PlayButton!.TriggerClick();
                     return false;
 
                 case ButtonSystemState.Play:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -312,20 +312,15 @@ namespace osu.Game.Screens.Menu
             {
                 case GlobalAction.Back:
                     PreferKeyboardNavigation();
-                    return goBack();
+                    SelectUp();
+                    return true;
 
                 case GlobalAction.Select:
-                case GlobalAction.SelectNext:
                     PreferKeyboardNavigation();
                     CurrentSelection?.TriggerClick();
                     // keyboard navgiation into submenu
                     if (State != ButtonSystemState.EnteringMode)
                         SelectionIndex = 1; // 1 to skip the back/settings btn
-                    return true;
-
-                case GlobalAction.SelectPrevious:
-                    PreferKeyboardNavigation();
-                    SelectUp();
                     return true;
 
                 case GlobalAction.SelectNextGroup:

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Screens.Menu
 
         public readonly Key TriggerKey;
 
+        private readonly ButtonSystem buttonSystem;
         private readonly Container iconText;
         private readonly Container box;
         private readonly Box boxHoverLayer;
@@ -52,14 +53,18 @@ namespace osu.Game.Screens.Menu
         private Sample sampleClick;
         private Sample sampleHover;
 
+        // for tests
+        public bool LooksHovered { get; private set; }
+
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
-        public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown,
-                              Action<HoverEvent> hoverAction = null)
+        public MainMenuButton(ButtonSystem buttonSystem, LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0,
+                              Key triggerKey = Key.Unknown, Action<HoverEvent> hoverAction = null)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;
             this.hoverAction = hoverAction;
+            this.buttonSystem = buttonSystem;
             TriggerKey = triggerKey;
 
             AutoSizeAxes = Axes.Both;
@@ -161,8 +166,11 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnHover(HoverEvent e)
         {
-            SimulateHover();
+            if (!buttonSystem.ConfirmHover(e.ScreenSpaceMousePosition))
+                return false;
+
             hoverAction?.Invoke(e);
+            SimulateHover();
             return true;
         }
 
@@ -173,6 +181,7 @@ namespace osu.Game.Screens.Menu
             sampleHover?.Play();
 
             box.ScaleTo(new Vector2(1.5f, 1), 500, Easing.OutElastic);
+            LooksHovered = true;
 
             double duration = TimeUntilNextBeat;
 
@@ -188,6 +197,8 @@ namespace osu.Game.Screens.Menu
 
         public void SimulateHoverLost()
         {
+            LooksHovered = false;
+
             icon.ClearTransforms();
             icon.RotateTo(0, 500, Easing.Out);
             icon.MoveTo(Vector2.Zero, 500, Easing.Out);

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Menu
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
         public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown,
-                      Action<HoverEvent> hoverAction = null)
+                              Action<HoverEvent> hoverAction = null)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Screens.Menu
 
         public readonly Key TriggerKey;
 
-        private readonly ButtonSystem buttonSystem;
         private readonly Container iconText;
         private readonly Container box;
         private readonly Box boxHoverLayer;
@@ -49,22 +48,21 @@ namespace osu.Game.Screens.Menu
         public ButtonSystemState VisibleState = ButtonSystemState.TopLevel;
 
         private readonly Action clickAction;
-        private readonly Action<HoverEvent> hoverAction;
+        private readonly Func<Vector2, Drawable, bool> hoverAction;
         private Sample sampleClick;
         private Sample sampleHover;
 
         // for tests
-        public bool LooksHovered { get; private set; }
+        internal bool LooksHovered { get; private set; }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
-        public MainMenuButton(ButtonSystem buttonSystem, LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0,
-                              Key triggerKey = Key.Unknown, Action<HoverEvent> hoverAction = null)
+        public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0,
+                              Key triggerKey = Key.Unknown, Func<Vector2, Drawable, bool> hoverAction = null)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;
             this.hoverAction = hoverAction;
-            this.buttonSystem = buttonSystem;
             TriggerKey = triggerKey;
 
             AutoSizeAxes = Axes.Both;
@@ -166,10 +164,9 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnHover(HoverEvent e)
         {
-            if (!buttonSystem.ConfirmHover(e.ScreenSpaceMousePosition))
+            if (hoverAction?.Invoke(e.ScreenSpaceMousePosition, e.Target) == false)
                 return false;
 
-            hoverAction?.Invoke(e);
             SimulateHover();
             return true;
         }
@@ -192,7 +189,7 @@ namespace osu.Game.Screens.Menu
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            if (!buttonSystem.ConfirmHover(e.ScreenSpaceMousePosition))
+            if (hoverAction?.Invoke(e.ScreenSpaceMousePosition, null) == false)
                 return;
 
             SimulateHoverLost();

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -192,6 +192,9 @@ namespace osu.Game.Screens.Menu
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
+            if (!buttonSystem.ConfirmHover(e.ScreenSpaceMousePosition))
+                return;
+
             SimulateHoverLost();
         }
 

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -48,15 +48,18 @@ namespace osu.Game.Screens.Menu
         public ButtonSystemState VisibleState = ButtonSystemState.TopLevel;
 
         private readonly Action clickAction;
+        private readonly Action<HoverEvent> hoverAction;
         private Sample sampleClick;
         private Sample sampleHover;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
-        public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown)
+        public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown,
+            Action<HoverEvent> hoverAction = null)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;
+            this.hoverAction = hoverAction;
             TriggerKey = triggerKey;
 
             AutoSizeAxes = Axes.Both;
@@ -158,7 +161,14 @@ namespace osu.Game.Screens.Menu
 
         protected override bool OnHover(HoverEvent e)
         {
-            if (State != ButtonState.Expanded) return true;
+            SimulateHover();
+            hoverAction?.Invoke(e);
+            return true;
+        }
+
+        public void SimulateHover()
+        {
+            if (State != ButtonState.Expanded) return;
 
             sampleHover?.Play();
 
@@ -169,10 +179,14 @@ namespace osu.Game.Screens.Menu
             icon.ClearTransforms();
             icon.RotateTo(rightward ? -10 : 10, duration, Easing.InOutSine);
             icon.ScaleTo(new Vector2(1, 0.9f), duration, Easing.Out);
-            return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
+        {
+            SimulateHoverLost();
+        }
+
+        public void SimulateHoverLost()
         {
             icon.ClearTransforms();
             icon.RotateTo(0, 500, Easing.Out);

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Menu
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
         public MainMenuButton(LocalisableString text, string sampleName, IconUsage symbol, Color4 colour, Action clickAction = null, float extraWidth = 0, Key triggerKey = Key.Unknown,
-            Action<HoverEvent> hoverAction = null)
+                      Action<HoverEvent> hoverAction = null)
         {
             this.sampleName = sampleName;
             this.clickAction = clickAction;


### PR DESCRIPTION
I mainly intended to use this myself to navigate osu with a taiko controller, just starting out with the navigation screen here where it's quite simple to design.

For taiko controller usage it's intended to have left/right rim for left or right navigation and center drums as Select button. For a nicer experience on arrow keys, up and down acts pretty much the same as escape and enter respectively.

TODO: currently we reuse the hover effect for the focused main menu buttons. The styling should be made a bit more visible for keyboard navigation, since the hover isn't that visible afterwards if you didn't see the animation.

Sample video:

https://github.com/ppy/osu/assets/2035977/1f6ac201-41bd-4eee-8902-eb7306b9abf7

I think the hover effect / maybe only the keyboard focus effect could take design inspiration from previous iterations of lazer, like for example re-adding the gradient/glow around menu items like this:

**suggestion for the future** (please excuse the programmer art)

![image](https://github.com/ppy/osu/assets/2035977/c0d20594-4ce4-4874-8a58-39c5a29888d9)
