### PR TITLE
Fix paths blending with black causing ugly borders

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
@@ -68,5 +68,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         }
 
         protected float CalculatedBorderPortion => BorderSize * BORDER_PORTION;
+
+        protected DrawableSliderPath()
+        {
+            BackgroundColour = Color4.Transparent;
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Lines;
 using osuTK.Graphics;
 
@@ -25,6 +26,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                     return;
 
                 borderColour = value;
+                BackgroundColour = value.Opacity(0);
 
                 InvalidateTexture();
             }


### PR DESCRIPTION
Prereqs:
- [ ] https://github.com/ppy/osu-framework/pull/5830

This is quite literally an immersion-breaking issue for me, but just hadn't gotten around to fixing it until now.

Because we're rendering to an FBO, we're blending with its background colour which is transparent black in this case. This causes ugly borders, and we should be blending against the border colour instead. I believe this is one of those cases where premultiplied alpha will help? but I can't get that working.

Some comparisons:

| Before | After |
| --- | --- |
| ![image](https://github.com/ppy/osu/assets/1329837/d8191419-4581-414b-998a-95b28f6230cf) | ![image](https://github.com/ppy/osu/assets/1329837/eb37a481-021b-4488-997f-474b18b131e8) |
| ![image](https://github.com/ppy/osu/assets/1329837/1624e719-6024-4769-aa5b-718956b0e141) | ![image](https://github.com/ppy/osu/assets/1329837/5935e128-ea05-4772-b922-3570371356a3) |
| ![image](https://github.com/ppy/osu/assets/1329837/6e4f6eb7-15ef-403d-855c-c5e052fa2b63) | ![image](https://github.com/ppy/osu/assets/1329837/043ff5a6-0465-4e73-81e6-3e408b450fb0) |
| ![image](https://github.com/ppy/osu/assets/1329837/ffdd6e34-7fc3-446a-bbac-af43297cfd80) | ![image](https://github.com/ppy/osu/assets/1329837/a24e084d-4c6f-4f70-8e53-6c043a830676) |

(yes I also notice the AA being bad in general, that's another issue for another time)