### PR TITLE
Reduce argon Taiko kiai flashing

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
 
         private const double pre_beat_transition_time = 80;
 
-        private const float flash_opacity = 0.3f;
+        private const float flash_opacity = 0.15f;
 
         private ColourInfo accentColour;
 

--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonCirclePiece.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
 
         private const double pre_beat_transition_time = 80;
 
-        private const float flash_opacity = 0.15f;
+        private const float kiai_flash_opacity = 0.15f;
 
         private ColourInfo accentColour;
 
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
             if (drawableHitObject.State.Value == ArmedState.Idle)
             {
                 flash
-                    .FadeTo(flash_opacity)
+                    .FadeTo(kiai_flash_opacity)
                     .Then()
                     .FadeOut(timingPoint.BeatLength * 0.75, Easing.OutSine);
             }

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
 
         private const double pre_beat_transition_time = 80;
 
-        private const float flash_opacity = 0.15f;
+        private const float kiai_flash_opacity = 0.15f;
 
         [Resolved]
         private DrawableHitObject drawableHitObject { get; set; } = null!;
@@ -187,7 +187,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             if (drawableHitObject.State.Value == ArmedState.Idle)
             {
                 flashBox
-                    .FadeTo(flash_opacity)
+                    .FadeTo(kiai_flash_opacity)
                     .Then()
                     .FadeOut(timingPoint.BeatLength * 0.75, Easing.OutSine);
             }

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/CirclePiece.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
 
         private const double pre_beat_transition_time = 80;
 
-        private const float flash_opacity = 0.3f;
+        private const float flash_opacity = 0.15f;
 
         [Resolved]
         private DrawableHitObject drawableHitObject { get; set; } = null!;


### PR DESCRIPTION
https://github.com/ppy/osu/issues/21569

I tried taiko and found kiai to be unplayable due to flashing, cut brightness from 0.3 to 0.15 and it was much better.

The videos don't show how bad the issue was. It was really bad with high note density + the rest of the screen being dark, https://github.com/ppy/osu/issues/21569 has a better showcase

Old
https://github.com/ppy/osu/assets/30382015/ac57138e-32de-42d5-9f3c-bd3408c1be7b

new
https://github.com/ppy/osu/assets/30382015/15656b87-2f7e-49f4-a63b-2af75118e236

