### PR TITLE
Fix not being able to receive full score for extremely short sliders with repeats

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -1,22 +1,29 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
 {
     public partial class TestSceneOsuModAutoplay : OsuModTestScene
     {
+        protected override bool AllowFail => true;
+
         [Test]
         public void TestCursorPositionStoredToJudgement()
         {
@@ -43,6 +50,36 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 InitialRate = { Value = 0.7 },
                 FinalRate = { Value = 1.3 }
             });
+
+        [Test]
+        public void TestPerfectScoreOnShortSliderWithRepeat()
+        {
+            AddStep("set score to standardised", () => LocalConfig.SetValue(OsuSetting.ScoreDisplayMode, ScoringMode.Standardised));
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = true,
+                Beatmap = new Beatmap
+                {
+                    HitObjects = new List<HitObject>
+                    {
+                        new Slider
+                        {
+                            StartTime = 500,
+                            Position = new Vector2(256, 192),
+                            Path = new SliderPath(new[]
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 6.25f))
+                            }),
+                            RepeatCount = 1,
+                            SliderVelocity = 10
+                        }
+                    }
+                },
+                PassCondition = () => Player.ScoreProcessor.TotalScore.Value == 1_000_000
+            });
+        }
 
         private void runSpmTest(Mod mod)
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -75,18 +75,24 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
+            tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both };
+
             AddRangeInternal(new Drawable[]
             {
                 shakeContainer = new ShakeContainer
                 {
                     ShakeDuration = 30,
                     RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Children = new[]
                     {
                         Body = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling),
-                        tailContainer = new Container<DrawableSliderTail> { RelativeSizeAxes = Axes.Both },
+                        // proxied here so that the tail is drawn under repeats/ticks - legacy skins rely on this
+                        tailContainer.CreateProxy(),
                         tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
                         repeatContainer = new Container<DrawableSliderRepeat> { RelativeSizeAxes = Axes.Both },
+                        // actual tail container is placed here to ensure that tail hitobjects are processed after ticks/repeats.
+                        // this is required for the correct operation of Score V2.
+                        tailContainer,
                     }
                 },
                 // slider head is not included in shake as it handles hit detection, and handles its own shaking.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23862.

Score V2 is a scoring algorithm, which aside from the raw numerical values of each judgement, incorporates a combo component, wherein each judgement's "combo score" is derived from both the raw numerical value of the object and the current combo after the given judgement. In particular, this means that Score V2 is sensitive to the _order_ of judging objects, as if two objects with the same start time are judged using different ordering, they can end up having a different "combo score".

The issue that this change is fixing is an instance of one such reordering. Upon inspection, it turned out that the simulated autoplay run, which is used to determine max possible score so that it can be standardised to 1 million again, was processing a slider repeat before a slider tail circle, while actual gameplay was processing the same slider repeat _after_ the slider tail circle.

The cause of that behaviour is unfortunately due to `LegacyLastTick`. The sliders which cause the issue are extremely short. Stable had a behaviour, in which to provide leniency, slider tails were artificially offset back by 36ms. However, if the slider is not long enough to make this possible, the last tick is placed in the middle of the slider. If that slider also happens to have exactly 1 repeat, then this means that the last tick and the repeat have the same time instant.

Because of the time equality, what begins to matter now is the _order_ of processing the elements of the drawable slider in the hierarchy. For the purposes of legacy skins, tail circles were moved below ticks in https://github.com/ppy/osu/commit/fce3eacd7de3254ce75619efaa2d15d59d564623 - but in this particular case, it means that the order of processing the slider elements is now inadvertently inverted, causing the entire debacle.

While the fact that scoring depends on order of processing of visuals is suboptimal, there isn't a great way to address this without significant restructuring. Due to the structure of processing judgements currently in place, in which each judgement is processed independently from others by its corresponding drawable hit object, this is probably the best that can be done for the time being at least.

---

This case seems relatively rare, so it's probably not worth a special hotfix. This is also why I'm not bumping the score version in the legacy score encoder again.