### PR TITLE
Allow changing map conversion source ruleset

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -380,5 +380,22 @@ namespace osu.Game.Rulesets
         /// Can be overridden to add a ruleset-specific section to the editor beatmap setup screen.
         /// </summary>
         public virtual RulesetSetupSection? CreateEditorSetupSection() => null;
+
+        /// <summary>
+        /// <para>
+        /// The Ruleset Online ID that maps need to have to be able to get
+        /// converted from. Defaults to 0 (osu! maps), but can be changed to
+        /// other IDs to not use osu! maps, but instead only use taiko (1),
+        /// catch (2) or mania (3) maps as source maps.
+        /// </para>
+        /// <para>
+        /// Furthermore the player needs to allow converted maps in the settings
+        /// in order for converted maps to show, as well as the ruleset map
+        /// convertor returned by
+        /// <see cref="Ruleset.CreateBeatmapConverter(IBeatmap)"/>
+        /// needing to be able to convert them.
+        /// </para>
+        /// </summary>
+        public virtual int ConversionSourceRulesetID => 0;
     }
 }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Screens.Select.Carousel
                 criteria.Ruleset == null ||
                 BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
                 (BeatmapInfo.Ruleset.OnlineID == criteria.ConversionSourceRulesetID
-                && criteria.Ruleset.OnlineID != criteria.ConversionSourceRulesetID
-                && criteria.AllowConvertedBeatmaps);
+                 && criteria.Ruleset.OnlineID != criteria.ConversionSourceRulesetID
+                 && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -34,7 +34,9 @@ namespace osu.Game.Screens.Select.Carousel
             bool match =
                 criteria.Ruleset == null ||
                 BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
-                (BeatmapInfo.Ruleset.OnlineID == 0 && criteria.Ruleset.OnlineID != 0 && criteria.AllowConvertedBeatmaps);
+                (BeatmapInfo.Ruleset.OnlineID == criteria.ConversionSourceRulesetID
+                    && criteria.Ruleset.OnlineID != criteria.ConversionSourceRulesetID
+                    && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Screens.Select.Carousel
                 criteria.Ruleset == null ||
                 BeatmapInfo.Ruleset.ShortName == criteria.Ruleset.ShortName ||
                 (BeatmapInfo.Ruleset.OnlineID == criteria.ConversionSourceRulesetID
-                    && criteria.Ruleset.OnlineID != criteria.ConversionSourceRulesetID
-                    && criteria.AllowConvertedBeatmaps);
+                && criteria.Ruleset.OnlineID != criteria.ConversionSourceRulesetID
+                && criteria.AllowConvertedBeatmaps);
 
             if (BeatmapInfo.BeatmapSet?.Equals(criteria.SelectedBeatmapSet) == true)
             {

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -72,6 +72,7 @@ namespace osu.Game.Screens.Select
                 criteria.UserStarDifficulty.Max = maximumStars.Value;
 
             criteria.RulesetCriteria = ruleset.Value.CreateInstance().CreateRulesetFilterCriteria();
+            criteria.ConversionSourceRulesetID = ruleset.Value.CreateInstance().ConversionSourceRulesetID;
 
             FilterQueryParser.ApplyQueries(criteria, query);
             return criteria;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -45,6 +45,13 @@ namespace osu.Game.Screens.Select
         public RulesetInfo Ruleset;
         public bool AllowConvertedBeatmaps;
 
+        /// <summary>
+        /// The online ruleset ID that the current filter criteria will show
+        /// for map conversions, when enabled. (always standard osu! in standard
+        /// rulesets)
+        /// </summary>
+        public int ConversionSourceRulesetID = 0;
+
         private string searchText;
 
         /// <summary>

--- a/osu.Game/Screens/Select/NoResultsPlaceholder.cs
+++ b/osu.Game/Screens/Select/NoResultsPlaceholder.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Select
 
                 // TODO: Add realm queries to hint at which ruleset results are available in (and allow clicking to switch).
                 // TODO: Make this message more certain by ensuring the osu! beatmaps exist before suggesting.
-                if (filter?.Ruleset?.OnlineID != 0 && filter?.AllowConvertedBeatmaps == false)
+                if (filter?.Ruleset?.OnlineID != (filter?.ConversionSourceRulesetID ?? 0) && filter?.AllowConvertedBeatmaps == false)
                 {
                     textFlow.AddParagraph("- Try");
                     textFlow.AddLink(" enabling ", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));


### PR DESCRIPTION
For custom rulesets that rather want to only base converted maps on different rulesets, such as taiko, insteead of standard osu maps.

Previously when using a custom ruleset, all maps except osu! standard maps would be hidden in the song list when auto-converting maps. Now all maps except for the specified ruleset maps are hidden in the song list when auto-converting maps.

This is the most simple thing I could think of to not hurt performance, but ideally in the future we might want to change this API to support multiple source rulesets, to show e.g. all osu! and taiko and mania maps when auto-converting and not just a single source ruleset.

For sample usage, see https://github.com/WebFreak001/katsudon