### PR TITLE
Add a checkbox to toggle line breaking for each mod in tournament mappool screen

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Tournament.Tests.Screens
                 Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
 
                 for (int i = 0; i < 11; i++)
-                    addBeatmap(i > 4 ? $"M{i}" : "NM");
+                    addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
             });
 
             AddStep("reset match", () =>
@@ -118,7 +118,7 @@ namespace osu.Game.Tournament.Tests.Screens
                 Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
 
                 for (int i = 0; i < 12; i++)
-                    addBeatmap(i > 4 ? $"M{i}" : "NM");
+                    addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
             });
 
             AddStep("reset match", () =>
@@ -130,7 +130,7 @@ namespace osu.Game.Tournament.Tests.Screens
             assertThreeWide();
         }
 
-        private void addBeatmap(string mods = "nm")
+        private void addBeatmap(string mods = "NM")
         {
             Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Add(new RoundBeatmap
             {

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Tournament.Tests.Screens
         }
 
         [Test]
-        public void TestDisableMapsPerMod()
+        public void TestSplitMapPoolByMods()
         {
             AddStep("load many maps", () =>
             {
@@ -144,7 +144,7 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
             });
 
-            AddStep("disable maps per mod", () => Ladder.SplitMapPoolByMods.Value = false);
+            AddStep("disable splitting map pool by mods", () => Ladder.SplitMapPoolByMods.Value = false);
 
             AddStep("reset match", () =>
             {

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -24,6 +24,9 @@ namespace osu.Game.Tournament.Tests.Screens
             Add(screen = new MapPoolScreen { Width = 0.7f });
         }
 
+        [SetUp]
+        public void SetUp() => Schedule(() => Ladder.SplitMapPoolByMods.Value = true);
+
         [Test]
         public void TestFewMaps()
         {
@@ -128,6 +131,26 @@ namespace osu.Game.Tournament.Tests.Screens
             });
 
             assertThreeWide();
+        }
+
+        [Test]
+        public void TestDisableMapsPerMod()
+        {
+            AddStep("load many maps", () =>
+            {
+                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+
+                for (int i = 0; i < 12; i++)
+                    addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
+            });
+
+            AddStep("disable maps per mod", () => Ladder.SplitMapPoolByMods.Value = false);
+
+            AddStep("reset match", () =>
+            {
+                Ladder.CurrentMatch.Value = new TournamentMatch();
+                Ladder.CurrentMatch.Value = Ladder.Matches.First();
+            });
         }
 
         private void addBeatmap(string mods = "NM")

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -42,5 +42,7 @@ namespace osu.Game.Tournament.Models
         };
 
         public Bindable<bool> AutoProgressScreens = new BindableBool(true);
+
+        public Bindable<bool> SplitMapPoolByMods = new BindableBool(true);
     }
 }


### PR DESCRIPTION
This makes it possible to disable mappool from taking a new row when the mod changes. It benefints tournaments which have a lot of modpools, such as [PTSP](https://osu.ppy.sh/community/forums/topics/1744250?n=1) that I am working on. 

https://github.com/ppy/osu/assets/31556924/32bd0270-c374-463c-86fe-c9611776895d

It's on the proof-of-concept state for now, as I didn't make the test cases nor did polish the UI; however it works. Can this feature be acceptable?