### PR TITLE
Apply osu! side changes in line with `FocusedOverlayContainer.PopIn` `abstract` change

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -11,7 +11,7 @@
     <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.608.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.618.0" />
   </ItemGroup>
   <ItemGroup>
     <AndroidManifestOverlay Include="$(MSBuildThisFileDirectory)osu.Android\Properties\AndroidManifestOverlay.xml" />

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayContainer.cs
@@ -101,6 +101,10 @@ namespace osu.Game.Tests.Visual.UserInterface
                     },
                 };
             }
+
+            protected override void PopIn()
+            {
+            }
         }
     }
 }

--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -114,8 +114,6 @@ namespace osu.Game.Collections
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             lowPassFilter.CutoffTo(300, 100, Easing.OutCubic);
             this.FadeIn(enter_duration, Easing.OutQuint);
             this.ScaleTo(0.9f).Then().ScaleTo(1f, enter_duration, Easing.OutQuint);

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -152,7 +152,6 @@ namespace osu.Game.Graphics.Containers
 
         protected override void PopOut()
         {
-            base.PopOut();
             previewTrackManager.StopAnyPlaying(this);
         }
 

--- a/osu.Game/Overlays/AccountCreationOverlay.cs
+++ b/osu.Game/Overlays/AccountCreationOverlay.cs
@@ -90,7 +90,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
             this.FadeIn(transition_time, Easing.OutQuint);
 
             if (welcomeScreen.GetChildScreen() != null)

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -276,8 +276,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             this.MoveToY(0, transition_length, Easing.OutQuint);
             this.FadeIn(transition_length, Easing.OutQuint);
         }

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -99,7 +99,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
             lowPassFilter.CutoffTo(300, 100, Easing.OutCubic);
         }
 

--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -75,8 +75,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             panel.Bounding = true;
             this.FadeIn(transition_time, Easing.OutQuint);
 

--- a/osu.Game/Overlays/MedalOverlay.cs
+++ b/osu.Game/Overlays/MedalOverlay.cs
@@ -246,9 +246,13 @@ namespace osu.Game.Overlays
             }
         }
 
+        protected override void PopIn()
+        {
+            this.FadeIn(200);
+        }
+
         protected override void PopOut()
         {
-            base.PopOut();
             this.FadeOut(200);
         }
 

--- a/osu.Game/Overlays/Mods/ShearedOverlayContainer.cs
+++ b/osu.Game/Overlays/Mods/ShearedOverlayContainer.cs
@@ -130,7 +130,6 @@ namespace osu.Game.Overlays.Mods
         {
             const double fade_in_duration = 400;
 
-            base.PopIn();
             this.FadeIn(fade_in_duration, Easing.OutQuint);
 
             Header.MoveToY(0, fade_in_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -206,8 +206,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             this.MoveToX(0, TRANSITION_LENGTH, Easing.OutQuint);
             mainContent.FadeTo(1, TRANSITION_LENGTH, Easing.OutQuint);
             mainContent.FadeEdgeEffectTo(WaveContainer.SHADOW_OPACITY, WaveContainer.APPEAR_DURATION, Easing.Out);

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -229,8 +229,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             this.FadeIn(transition_length, Easing.OutQuint);
             dragContainer.ScaleTo(1, transition_length, Easing.OutElastic);
         }

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -163,8 +163,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             ContentContainer.MoveToX(ExpandedPosition, TRANSITION_LENGTH, Easing.OutQuint);
 
             SectionsContainer.FadeEdgeEffectTo(WaveContainer.SHADOW_OPACITY, WaveContainer.APPEAR_DURATION, Easing.Out);

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Overlays
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             Waves.Show();
             this.FadeIn(100, Easing.OutQuint);
         }

--- a/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/RoomSettingsOverlay.cs
@@ -54,14 +54,12 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
 
         protected override void PopIn()
         {
-            base.PopIn();
             Settings.MoveToY(0, TRANSITION_DURATION, Easing.OutQuint);
             Settings.FadeIn(TRANSITION_DURATION / 2);
         }
 
         protected override void PopOut()
         {
-            base.PopOut();
             Settings.MoveToY(-1, TRANSITION_DURATION, Easing.InSine);
             Settings.Delay(TRANSITION_DURATION / 2).FadeOut(TRANSITION_DURATION / 2);
         }

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -86,8 +86,6 @@ namespace osu.Game.Screens.Select.Options
 
         protected override void PopIn()
         {
-            base.PopIn();
-
             this.FadeIn(transition_duration, Easing.OutQuint);
 
             if (buttonsContainer.Position.X == 1 || Alpha == 0)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.608.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.618.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.605.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -16,6 +16,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.608.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.618.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/5834
- [x] Depends on framework bump

Have confirmed that behaviour this side feels normal for popovers / overlays. Also, tests pass:

![JetBrains Rider 2023-06-12 at 05 14 25](https://github.com/ppy/osu/assets/191335/bab1a61f-a9cf-4bc4-844b-7f2061d111e7)
