### PR TITLE
Adjust argon progress display to work well on bright backgrounds

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -91,6 +91,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("stop", gameplayClockContainer.Stop);
         }
 
+        [Test]
+        public void TestSeekToKnownTime()
+        {
+            AddStep("seek to known time", () => gameplayClockContainer.Seek(60000));
+            AddWaitStep("wait some for seek", 15);
+            AddStep("stop", () => gameplayClockContainer.Stop());
+        }
+
         private void applyToArgonProgress(Action<ArgonSongProgress> action) =>
             this.ChildrenOfType<ArgonSongProgress>().ForEach(action);
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSongProgress.cs
@@ -7,12 +7,15 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
+using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -20,6 +23,8 @@ namespace osu.Game.Tests.Visual.Gameplay
     public partial class TestSceneSongProgress : SkinnableHUDComponentTestScene
     {
         private GameplayClockContainer gameplayClockContainer = null!;
+
+        private Box background = null!;
 
         private const double skip_target_time = -2000;
 
@@ -30,11 +35,20 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             FrameStabilityContainer frameStabilityContainer;
 
-            Add(gameplayClockContainer = new MasterGameplayClockContainer(Beatmap.Value, skip_target_time)
+            AddRange(new Drawable[]
             {
-                Child = frameStabilityContainer = new FrameStabilityContainer
+                background = new Box
                 {
-                    MaxCatchUpFrames = 1
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.Both,
+                    Depth = float.MaxValue
+                },
+                gameplayClockContainer = new MasterGameplayClockContainer(Beatmap.Value, skip_target_time)
+                {
+                    Child = frameStabilityContainer = new FrameStabilityContainer
+                    {
+                        MaxCatchUpFrames = 1
+                    }
                 }
             });
 
@@ -70,6 +84,9 @@ namespace osu.Game.Tests.Visual.Gameplay
                 applyToDefaultProgress(s => s.ShowGraph.Value = b);
                 applyToArgonProgress(s => s.ShowGraph.Value = b);
             });
+
+            AddStep("set white background", () => background.FadeColour(Color4.White, 200, Easing.OutQuint));
+            AddStep("randomise background colour", () => background.FadeColour(new Colour4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1), 200, Easing.OutQuint));
 
             AddStep("stop", gameplayClockContainer.Stop);
         }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -95,7 +95,6 @@ namespace osu.Game.Screens.Play.HUD
         private void updateGraphVisibility()
         {
             graph.FadeTo(ShowGraph.Value ? 1 : 0, 200, Easing.In);
-            bar.ShowBackground = !ShowGraph.Value;
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -14,7 +14,6 @@ using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
 {
@@ -32,18 +31,8 @@ namespace osu.Game.Screens.Play.HUD
 
         private readonly Box background;
 
-        private readonly BindableBool showBackground = new BindableBool();
-
         private readonly ColourInfo mainColour;
-        private readonly ColourInfo mainColourDarkened;
         private ColourInfo catchUpColour;
-        private ColourInfo catchUpColourDarkened;
-
-        public bool ShowBackground
-        {
-            get => showBackground.Value;
-            set => showBackground.Value = value;
-        }
 
         public double StartTime
         {
@@ -95,7 +84,7 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     RelativeSizeAxes = Axes.Both,
                     Alpha = 0,
-                    Colour = Colour4.White.Darken(1 + 1 / 4f)
+                    Colour = OsuColour.Gray(0.2f),
                 },
                 catchupBar = new RoundedBar
                 {
@@ -112,12 +101,10 @@ namespace osu.Game.Screens.Play.HUD
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     CornerRadius = 5,
-                    AccentColour = mainColour = Color4.White,
+                    AccentColour = mainColour = OsuColour.Gray(0.9f),
                     RelativeSizeAxes = Axes.Both
                 },
             };
-
-            mainColourDarkened = Colour4.White.Darken(1 / 3f);
         }
 
         private void setupAlternateValue()
@@ -141,16 +128,15 @@ namespace osu.Game.Screens.Play.HUD
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            catchUpColour = colours.BlueLight;
-            catchUpColourDarkened = colours.BlueDark;
-
-            showBackground.BindValueChanged(_ => updateBackground(), true);
+            catchUpColour = colours.BlueDark;
         }
 
-        private void updateBackground()
+        protected override void LoadComplete()
         {
-            background.FadeTo(showBackground.Value ? 1 / 4f : 0, 200, Easing.In);
-            playfieldBar.TransformTo(nameof(playfieldBar.AccentColour), ShowBackground ? mainColour : mainColourDarkened, 200, Easing.In);
+            base.LoadComplete();
+
+            background.FadeTo(0.3f, 200, Easing.In);
+            playfieldBar.TransformTo(nameof(playfieldBar.AccentColour), mainColour, 200, Easing.In);
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -190,8 +176,8 @@ namespace osu.Game.Screens.Play.HUD
 
             catchupBar.AccentColour = Interpolation.ValueAt(
                 Math.Min(timeDelta, colour_transition_threshold),
-                ShowBackground ? mainColour : mainColourDarkened,
-                ShowBackground ? catchUpColour : catchUpColourDarkened,
+                mainColour,
+                catchUpColour,
                 0, colour_transition_threshold,
                 Easing.OutQuint);
 

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressGraph.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressGraph.cs
@@ -4,8 +4,10 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Graphics.UserInterface;
 
@@ -13,6 +15,10 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class ArgonSongProgressGraph : SegmentedGraph<int>
     {
+        private const int tier_count = 5;
+
+        private const int display_granularity = 200;
+
         private IEnumerable<HitObject>? objects;
 
         public IEnumerable<HitObject> Objects
@@ -21,8 +27,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 objects = value;
 
-                const int granularity = 200;
-                int[] values = new int[granularity];
+                int[] values = new int[display_granularity];
 
                 if (!objects.Any())
                     return;
@@ -32,7 +37,7 @@ namespace osu.Game.Screens.Play.HUD
                 if (lastHit == 0)
                     lastHit = objects.Last().StartTime;
 
-                double interval = (lastHit - firstHit + 1) / granularity;
+                double interval = (lastHit - firstHit + 1) / display_granularity;
 
                 foreach (var h in objects)
                 {
@@ -51,12 +56,12 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         public ArgonSongProgressGraph()
-            : base(5)
+            : base(tier_count)
         {
             var colours = new List<Colour4>();
 
-            for (int i = 0; i < 5; i++)
-                colours.Add(Colour4.White.Darken(1 + 1 / 5f).Opacity(1 / 5f));
+            for (int i = 0; i < tier_count; i++)
+                colours.Add(OsuColour.Gray(0.2f).Opacity(0.1f));
 
             TierColours = colours;
         }


### PR DESCRIPTION
I tried adding colour but nothing really feels right yet. Would want to wait until more of the argon hud comes online (as some other elements have colour). So I tried to keep the current feel while also better supporting bright backgrounds.

Tested with worst case scenarios (note that pure white is very rare, so even though it's still a bit harder to read, I encourage you test on beatmaps):

| before | after |
|--------|--------|
| ![osu Game Tests 2023-06-12 at 07 26 47](https://github.com/ppy/osu/assets/191335/d9372a46-e2ba-48d5-a091-abc5e92ff30e) | ![osu Game Tests 2023-06-12 at 07 28 31](https://github.com/ppy/osu/assets/191335/5e53f288-fcdb-4e61-9e12-e70980c29179) |
| ![osu Game Tests 2023-06-12 at 07 27 30](https://github.com/ppy/osu/assets/191335/523176c8-7b28-452c-8834-b80f52c6b743) | ![osu Game Tests 2023-06-12 at 07 28 45](https://github.com/ppy/osu/assets/191335/3c2ca7df-338a-4c54-b5f4-ba7f45404b9b) |
| ![osu Game Tests 2023-06-12 at 07 31 58](https://github.com/ppy/osu/assets/191335/c679a4c7-430d-46fa-8466-4981efea49f1) | ![osu Game Tests 2023-06-12 at 07 29 43](https://github.com/ppy/osu/assets/191335/33b0f0d1-ce63-4069-a927-1001c73084a4) | 
| ![osu Game Tests 2023-06-12 at 07 32 10](https://github.com/ppy/osu/assets/191335/8d4e9711-8bab-440a-927e-8964bd018f00) | ![osu Game Tests 2023-06-12 at 07 29 01](https://github.com/ppy/osu/assets/191335/45658979-2d61-4042-b520-77c586edc16e) | 

Addresses feedback in https://github.com/ppy/osu/discussions/23856.