### PR TITLE
Fix storyboard being null if file doesn't exist

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Beatmaps
                     if (beatmapFileStream == null)
                     {
                         Logger.Log($"Beatmap failed to load (file {BeatmapInfo.Path} not found on disk at expected location {fileStorePath})", level: LogLevel.Error);
-                        return null;
+                        return new Storyboard();
                     }
 
                     using (var reader = new LineBufferedReader(beatmapFileStream))


### PR DESCRIPTION
It's expected that `WorkingBeatmap.Storyboard` is non-null.

An example fail case is in `BeatmapBackgroundWithStoryboard.load`.