### PR TITLE
Migrate old standardised scores to new algorithm

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -37,6 +37,7 @@ using osu.Game.Scoring.Legacy;
 using osu.Game.Skinning;
 using Realms;
 using Realms.Exceptions;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace osu.Game.Database
 {
@@ -728,6 +729,11 @@ namespace osu.Game.Database
 
         private void applyMigrationsForVersion(Migration migration, ulong targetVersion)
         {
+            Logger.Log($"Running realm migration to version {targetVersion}...");
+            Stopwatch stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+
             switch (targetVersion)
             {
                 case 7:
@@ -964,6 +970,8 @@ namespace osu.Game.Database
                     break;
                 }
             }
+
+            Logger.Log($"Migration completed in {stopwatch.ElapsedMilliseconds}ms");
         }
 
         private string? getRulesetShortNameFromLegacyID(long rulesetId)

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -1192,26 +1192,4 @@ namespace osu.Game.Database
             }
         }
     }
-
-    internal class FakeHit : HitObject
-    {
-        private readonly Judgement judgement;
-
-        public override Judgement CreateJudgement() => judgement;
-
-        public FakeHit(Judgement judgement)
-        {
-            this.judgement = judgement;
-        }
-    }
-
-    internal class FakeJudgement : Judgement
-    {
-        public override HitResult MaxResult { get; }
-
-        public FakeJudgement(HitResult result)
-        {
-            MaxResult = result;
-        }
-    }
 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -28,16 +28,12 @@ using osu.Game.IO.Legacy;
 using osu.Game.Models;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Skinning;
 using Realms;
 using Realms.Exceptions;
-using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace osu.Game.Database
 {

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -951,7 +951,7 @@ namespace osu.Game.Database
                     {
                         // Recalculate the old-style standardised score to see if this was an old lazer score.
                         bool oldScoreMatchesExpectations = StandardisedScoreMigrationTools.GetOldStandardised(score) == score.TotalScore;
-                        // Some older score don't have correct statistics populated, so let's give them benefit of doubt.
+                        // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.
                         bool scoreIsVeryOld = score.Date < new DateTime(2023, 1, 1, 0, 0, 0);
 
                         if (oldScoreMatchesExpectations || scoreIsVeryOld)

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Database
             foreach (var judgement in maximumJudgements)
                 beatmap.HitObjects.Add(new FakeHit(judgement));
             processor.ApplyBeatmap(beatmap);
+            processor.Mods.Value = score.Mods;
 
             // Insert all misses into a queue.
             // These will be nibbled at whenever we need to reset the combo.
@@ -162,7 +163,12 @@ namespace osu.Game.Database
                     break;
             }
 
-            return (long)(1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore);
+            double modMultiplier = 1;
+
+            foreach (var mod in score.Mods)
+                modMultiplier *= mod.ScoreMultiplier;
+
+            return (long)((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
         }
 
         private class FakeHit : HitObject

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -14,6 +14,9 @@ namespace osu.Game.Database
     {
         public static long GetNewStandardised(ScoreInfo score)
         {
+            // Avoid retrieving from realm inside loops.
+            int maxCombo = score.MaxCombo;
+
             var ruleset = score.Ruleset.CreateInstance();
             var processor = ruleset.CreateScoreProcessor();
 
@@ -61,7 +64,7 @@ namespace osu.Game.Database
                 if (result == HitResult.Miss || result == HitResult.LargeTickMiss)
                     continue;
 
-                if (processor.Combo.Value == score.MaxCombo)
+                if (processor.Combo.Value == maxCombo)
                 {
                     if (misses.Count > 0)
                     {

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Database
             var ruleset = score.Ruleset.CreateInstance();
             var processor = ruleset.CreateScoreProcessor();
 
+            processor.TrackHitEvents = false;
+
             var beatmap = new Beatmap();
 
             HitResult maxRulesetJudgement = ruleset.GetHitResults().First().result;

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -148,6 +149,28 @@ namespace osu.Game.Database
             }
 
             return (long)(1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore);
+        }
+
+        private class FakeHit : HitObject
+        {
+            private readonly Judgement judgement;
+
+            public override Judgement CreateJudgement() => judgement;
+
+            public FakeHit(Judgement judgement)
+            {
+                this.judgement = judgement;
+            }
+        }
+
+        private class FakeJudgement : Judgement
+        {
+            public override HitResult MaxResult { get; }
+
+            public FakeJudgement(HitResult result)
+            {
+                MaxResult = result;
+            }
         }
     }
 }

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -1,0 +1,100 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace osu.Game.Database
+{
+    public static class StandardisedScoreMigrationTools
+    {
+        public static long GetNewStandardised(ScoreInfo score)
+        {
+            var processor = score.Ruleset.CreateInstance().CreateScoreProcessor();
+
+            var beatmap = new Beatmap();
+
+            var maximumJudgements = score.MaximumStatistics
+                                         .Where(kvp => kvp.Key.AffectsCombo())
+                                         .OrderByDescending(kvp => Judgement.ToNumericResult(kvp.Key))
+                                         .SelectMany(kvp => Enumerable.Repeat(new FakeJudgement(kvp.Key), kvp.Value))
+                                         .ToList();
+
+            // This is a list of all results, ordered from best to worst.
+            // We are constructing a "best possible" score from the statistics provided because it's the best we can do.
+            List<HitResult> sortedHits = score.Statistics
+                                              .Where(kvp => kvp.Key.AffectsCombo() && kvp.Key != HitResult.Miss && kvp.Key != HitResult.LargeTickMiss)
+                                              .OrderByDescending(kvp => Judgement.ToNumericResult(kvp.Key))
+                                              .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value))
+                                              .ToList();
+
+            foreach (var judgement in maximumJudgements)
+                beatmap.HitObjects.Add(new FakeHit(judgement));
+
+            processor.ApplyBeatmap(beatmap);
+
+            Queue<HitResult> misses = new Queue<HitResult>(score.Statistics
+                                                                .Where(kvp => kvp.Key == HitResult.Miss || kvp.Key == HitResult.LargeTickMiss)
+                                                                .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value)));
+
+            int maxJudgementIndex = 0;
+
+            foreach (var result in sortedHits)
+            {
+                if (processor.Combo.Value == score.MaxCombo)
+                {
+                    processor.ApplyResult(new JudgementResult(null!, maximumJudgements[maxJudgementIndex++])
+                    {
+                        Type = misses.Dequeue(),
+                    });
+                }
+
+                // TODO: pass a Judgement with correct MaxResult
+                processor.ApplyResult(new JudgementResult(null!, maximumJudgements[maxJudgementIndex++])
+                {
+                    Type = result
+                });
+            }
+
+            var bonusHits = score.Statistics
+                                 .Where(kvp => kvp.Key.IsBonus())
+                                 .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value));
+
+            foreach (var result in bonusHits)
+                processor.ApplyResult(new JudgementResult(null!, new FakeJudgement(result)) { Type = result });
+
+            Debug.Assert(processor.HighestCombo.Value == score.MaxCombo);
+
+            return processor.TotalScore.Value;
+        }
+
+        public static long GetOldStandardised(ScoreInfo score)
+        {
+            double accuracyScore =
+                (double)score.Statistics.Where(kvp => kvp.Key.AffectsAccuracy()).Sum(kvp => Judgement.ToNumericResult(kvp.Key) * kvp.Value)
+                / score.MaximumStatistics.Where(kvp => kvp.Key.AffectsAccuracy()).Sum(kvp => Judgement.ToNumericResult(kvp.Key) * kvp.Value);
+            double comboScore = (double)score.MaxCombo / score.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Sum(kvp => kvp.Value);
+            double bonusScore = score.Statistics.Where(kvp => kvp.Key.IsBonus()).Sum(kvp => Judgement.ToNumericResult(kvp.Key) * kvp.Value);
+
+            double accuracyPortion = 0.3;
+
+            switch (score.RulesetID)
+            {
+                case 1:
+                    accuracyPortion = 0.75;
+                    break;
+
+                case 3:
+                    accuracyPortion = 0.99;
+                    break;
+            }
+
+            return (long)(1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/JudgementProcessor.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Rulesets.Scoring
         protected int MaxHits { get; private set; }
 
         /// <summary>
+        /// Whether <see cref="SimulateAutoplay"/> is currently running.
+        /// </summary>
+        protected bool IsSimulating { get; private set; }
+
+        /// <summary>
         /// The total number of judged <see cref="HitObject"/>s at the current point in time.
         /// </summary>
         public int JudgedHits { get; private set; }
@@ -146,6 +151,8 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="beatmap">The <see cref="IBeatmap"/> to simulate.</param>
         protected virtual void SimulateAutoplay(IBeatmap beatmap)
         {
+            IsSimulating = true;
+
             foreach (var obj in beatmap.HitObjects)
                 simulate(obj);
 
@@ -163,6 +170,8 @@ namespace osu.Game.Rulesets.Scoring
                 result.Type = GetSimulatedHitResult(judgement);
                 ApplyResult(result);
             }
+
+            IsSimulating = false;
         }
 
         protected override void Update()

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Rulesets.Scoring
         private const double accuracy_cutoff_d = 0;
 
         /// <summary>
+        /// Whether <see cref="HitEvents"/> should be populated during application of results.
+        /// </summary>
+        internal bool TrackHitEvents = true;
+
+        /// <summary>
         /// Invoked when this <see cref="ScoreProcessor"/> was reset from a replay frame.
         /// </summary>
         public event Action? OnResetFromReplayFrame;
@@ -226,7 +231,7 @@ namespace osu.Game.Rulesets.Scoring
 
             ApplyScoreChange(result);
 
-            if (!IsSimulating)
+            if (!IsSimulating && TrackHitEvents)
             {
                 hitEvents.Add(CreateHitEvent(result));
                 lastHitObject = result.HitObject;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -328,6 +328,9 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="storeResults">Whether to store the current state of the <see cref="ScoreProcessor"/> for future use.</param>
         protected override void Reset(bool storeResults)
         {
+            // Run one last time to store max values.
+            updateScore();
+
             base.Reset(storeResults);
 
             hitEvents.Clear();

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -226,10 +226,13 @@ namespace osu.Game.Rulesets.Scoring
 
             ApplyScoreChange(result);
 
-            hitEvents.Add(CreateHitEvent(result));
-            lastHitObject = result.HitObject;
+            if (!IsSimulating)
+            {
+                hitEvents.Add(CreateHitEvent(result));
+                lastHitObject = result.HitObject;
 
-            updateScore();
+                updateScore();
+            }
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -33,6 +33,9 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// Whether <see cref="HitEvents"/> should be populated during application of results.
         /// </summary>
+        /// <remarks>
+        /// Should only be disabled for special cases.
+        /// When disabled, <see cref="JudgementProcessor.RevertResult"/> cannot be used.</remarks>
         internal bool TrackHitEvents = true;
 
         /// <summary>
@@ -231,10 +234,13 @@ namespace osu.Game.Rulesets.Scoring
 
             ApplyScoreChange(result);
 
-            if (!IsSimulating && TrackHitEvents)
+            if (!IsSimulating)
             {
-                hitEvents.Add(CreateHitEvent(result));
-                lastHitObject = result.HitObject;
+                if (TrackHitEvents)
+                {
+                    hitEvents.Add(CreateHitEvent(result));
+                    lastHitObject = result.HitObject;
+                }
 
                 updateScore();
             }
@@ -250,6 +256,9 @@ namespace osu.Game.Rulesets.Scoring
 
         protected sealed override void RevertResultInternal(JudgementResult result)
         {
+            if (!TrackHitEvents)
+                throw new InvalidOperationException(@$"Rewind is not supported when {nameof(TrackHitEvents)} is disabled.");
+
             Combo.Value = result.ComboAtJudgement;
             HighestCombo.Value = result.HighestComboAtJudgement;
 


### PR DESCRIPTION
This is a best-effort implementation. It inserts misses in a way that gives the user the best possible combo streaks considering the only information we know (`MaxCombo`).

For around 7.5k scores:

```
[runtime] 2023-06-12 16:44:13 [verbose]: Running realm migration to version 27...
[runtime] 2023-06-12 16:44:13 [verbose]: Migration completed in 0ms
[runtime] 2023-06-12 16:44:13 [verbose]: Running realm migration to version 28...
[runtime] 2023-06-12 16:44:13 [verbose]: Migration completed in 97ms
[runtime] 2023-06-12 16:44:13 [verbose]: Running realm migration to version 29...
[runtime] 2023-06-12 16:44:19 [verbose]: Migration completed in 5977ms
```

I'll do a quick profile to see if it can be optimised further, but also not too bad. Most users won't notice it with less scores.