### PR TITLE
Make hit flash toggle-able

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         private readonly Container kiaiContainer;
 
         private Bindable<bool> configHitLighting = null!;
+        private Bindable<bool> configHitFlash = null!;
 
         private static readonly Vector2 circle_size = new Vector2(OsuHitObject.OBJECT_RADIUS * 2);
 
@@ -121,6 +122,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
 
             configHitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
+            configHitFlash = config.GetBindable<bool>(OsuSetting.HitFlash);
         }
 
         protected override void LoadComplete()
@@ -205,10 +207,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         {
                             outerGradient.ResizeTo(OUTER_GRADIENT_SIZE * shrink_size, resize_duration, Easing.OutElasticHalf);
 
-                            outerGradient
-                                .FadeColour(Color4.White, 80)
-                                .Then()
-                                .FadeOut(flash_in_duration);
+                            if (configHitFlash.Value) {
+                                outerGradient
+                                    .FadeColour(Color4.White, 80)
+                                    .Then()
+                                    .FadeOut(flash_in_duration);
+                            } else {
+                                outerGradient
+                                    .FadeColour(Color4.White, flash_in_duration)
+                                    .FadeOut(flash_in_duration);
+                            }
                         }
 
                         if (configHitLighting.Value)
@@ -217,6 +225,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                             flash.FadeTo(1, flash_in_duration, Easing.OutQuint);
 
                             this.FadeOut(fade_out_time, Easing.OutQuad);
+                        }
+                        else if (!configHitFlash.Value) {
+                            flash.HitLighting = false;
+                            this.FadeOut(fade_out_time / 2, Easing.OutQuad);
                         }
                         else
                         {

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -126,6 +126,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LightenDuringBreaks, true);
 
             SetDefault(OsuSetting.HitLighting, true);
+            SetDefault(OsuSetting.HitFlash, true);
 
             SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
             SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
@@ -370,6 +371,7 @@ namespace osu.Game.Configuration
         NotifyOnPrivateMessage,
         UIHoldActivationDelay,
         HitLighting,
+        HitFlash,
         MenuBackgroundSource,
         GameplayDisableWinKey,
         SeasonalBackgroundMode,

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Localisation
         public static LocalisableString HitLighting => new TranslatableString(getKey(@"hit_lighting"), @"Hit lighting");
 
         /// <summary>
+        /// "Hit flash"
+        /// </summary>
+        public static LocalisableString HitFlash => new TranslatableString(getKey(@"hit_flash"), @"Hit flash");
+
+        /// <summary>
         /// "Screenshots"
         /// </summary>
         public static LocalisableString Screenshots => new TranslatableString(getKey(@"screenshots"), @"Screenshots");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = GraphicsSettingsStrings.HitLighting,
                     Current = config.GetBindable<bool>(OsuSetting.HitLighting)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = GraphicsSettingsStrings.HitFlash,
+                    Current = config.GetBindable<bool>(OsuSetting.HitFlash)
+                },
             };
         }
     }


### PR DESCRIPTION
As per the comment here (https://github.com/ppy/osu/pull/22440#issuecomment-1407398686), create a `HitFlash` setting to toggle the flash on Argon for osu standard.

Still doesn't feel perfect to me, but I'm not a designer so not making any design changes. This just toggles the changes in #22440 on or off.