### PR TITLE
Use `Anchor`/`Origin` instead of `GridContainer` for drawable room background gradient

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -103,25 +103,19 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                             CornerRadius = CORNER_RADIUS,
                             Children = new Drawable[]
                             {
-                                new FillFlowContainer
+                                new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    Direction = FillDirection.Horizontal,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = colours.Background5,
-                                            Width = 0.2f,
-                                        },
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f)),
-                                            Width = 0.8f,
-                                        },
-                                    },
+                                    Colour = colours.Background5,
+                                    Width = 0.2f,
+                                },
+                                new Box
+                                {
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f)),
+                                    Width = 0.8f,
                                 },
                                 new Container
                                 {

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/DrawableRoom.cs
@@ -103,29 +103,25 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                             CornerRadius = CORNER_RADIUS,
                             Children = new Drawable[]
                             {
-                                new GridContainer
+                                new FillFlowContainer
                                 {
                                     RelativeSizeAxes = Axes.Both,
-                                    ColumnDimensions = new[]
+                                    Direction = FillDirection.Horizontal,
+                                    Children = new Drawable[]
                                     {
-                                        new Dimension(GridSizeMode.Relative, 0.2f)
-                                    },
-                                    Content = new[]
-                                    {
-                                        new Drawable[]
+                                        new Box
                                         {
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = colours.Background5,
-                                            },
-                                            new Box
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f))
-                                            },
-                                        }
-                                    }
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.Background5,
+                                            Width = 0.2f,
+                                        },
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = ColourInfo.GradientHorizontal(colours.Background5, colours.Background5.Opacity(0.3f)),
+                                            Width = 0.8f,
+                                        },
+                                    },
                                 },
                                 new Container
                                 {


### PR DESCRIPTION
Not sure if it improves performance but maybe readability. There's also a similar case:
https://github.com/ppy/osu/blob/af3fbdbfbebb4a70fc3af48aa8fa6b10db4c7c2c/osu.Game/Screens/Select/Carousel/SetPanelBackground.cs#L33-L70