### PR TITLE
Update CFS to NET6.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "codefilesanity": {
-      "version": "0.0.36",
+      "version": "0.0.37",
       "commands": [
         "CodeFileSanity"
       ]


### PR DESCRIPTION
`0.0.37` updates to .NET 6. Currently it's running on .Net Core 3 which I don't (and likely few people have) installed.