### PR TITLE
Optimise mania density calculation during beatmap conversion

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -119,14 +119,12 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 yield return obj;
         }
 
-        private readonly List<double> prevNoteTimes = new List<double>(max_notes_for_density);
+        private readonly LimitedCapacityQueue<double> prevNoteTimes = new LimitedCapacityQueue<double>(max_notes_for_density);
         private double density = int.MaxValue;
 
         private void computeDensity(double newNoteTime)
         {
-            if (prevNoteTimes.Count == max_notes_for_density)
-                prevNoteTimes.RemoveAt(0);
-            prevNoteTimes.Add(newNoteTime);
+            prevNoteTimes.Enqueue(newNoteTime);
 
             if (prevNoteTimes.Count >= 2)
                 density = (prevNoteTimes[^1] - prevNoteTimes[0]) / prevNoteTimes.Count;


### PR DESCRIPTION
Since this list is going to be at-capacity 99.99% of the time, it'll incur a lot of memory copies when the first item is popped. `LimitedCapacityQueue<>` is tailored for this scenario.

| Before | After |
| --- | --- |
| ![image](https://github.com/ppy/osu/assets/1329837/1d2f6aca-3752-4dce-ac57-855942702cd5) | ![image](https://github.com/ppy/osu/assets/1329837/006ae78b-468d-4289-8ed5-a01c939a8d78) |

osu!mania diffcalc across all ranked mania-only sets takes `59m14s` down from `65m21s`.

- [x] Run diffcalc spreadsheet test (https://docs.google.com/spreadsheets/d/1hOnnkvx1dbOHZ6qzqgdefjuJutizDfJp0W96Fq37sSc/edit)

<details>
<summary>Test environment (for <a href="https://github.com/smoogipoo/diffcalc-sheet-generator">diffcalc-sheet-generator</a>)</summary>

```
OSU_A=https://github.com/ppy/osu/tree/2023.614.1
OSU_B=https://github.com/smoogipoo/osu/tree/backport-mania-density-optimisation

RULESET=mania

NO_CONVERTS=1
RANKED_ONLY=1

SCORE_PROCESSOR_A=https://github.com/smoogipoo/osu-queue-score-statistics/tree/temp-no-score-convert
SCORE_PROCESSOR_B=https://github.com/smoogipoo/osu-queue-score-statistics/tree/temp-no-score-convert
DIFFICULTY_CALCULATOR_A=https://github.com/ppy/osu-difficulty-calculator
DIFFICULTY_CALCULATOR_B=https://github.com/ppy/osu-difficulty-calculator
```

</details>