### PR TITLE
Fix reimporting old lazer scores undoing standardised score recalculation

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -945,22 +945,26 @@ namespace osu.Game.Database
 
                     foreach (var score in scores)
                     {
-                        // Recalculate the old-style standardised score to see if this was an old lazer score.
-                        bool oldScoreMatchesExpectations = StandardisedScoreMigrationTools.GetOldStandardised(score) == score.TotalScore;
-                        // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.
-                        bool scoreIsVeryOld = score.Date < new DateTime(2023, 1, 1, 0, 0, 0);
-
-                        if (oldScoreMatchesExpectations || scoreIsVeryOld)
+                        try
                         {
-                            try
+                            // Recalculate the old-style standardised score to see if this was an old lazer score.
+                            bool oldScoreMatchesExpectations = StandardisedScoreMigrationTools.GetOldStandardised(score) == score.TotalScore;
+                            // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.
+                            bool scoreIsVeryOld = score.Date < new DateTime(2023, 1, 1, 0, 0, 0);
+
+                            if (oldScoreMatchesExpectations || scoreIsVeryOld)
                             {
-                                long calculatedNew = StandardisedScoreMigrationTools.GetNewStandardised(score);
-                                score.TotalScore = calculatedNew;
-                            }
-                            catch
-                            {
+                                try
+                                {
+                                    long calculatedNew = StandardisedScoreMigrationTools.GetNewStandardised(score);
+                                    score.TotalScore = calculatedNew;
+                                }
+                                catch
+                                {
+                                }
                             }
                         }
+                        catch { }
                     }
 
                     break;

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -947,12 +947,7 @@ namespace osu.Game.Database
                     {
                         try
                         {
-                            // Recalculate the old-style standardised score to see if this was an old lazer score.
-                            bool oldScoreMatchesExpectations = StandardisedScoreMigrationTools.GetOldStandardised(score) == score.TotalScore;
-                            // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.
-                            bool scoreIsVeryOld = score.Date < new DateTime(2023, 1, 1, 0, 0, 0);
-
-                            if (oldScoreMatchesExpectations || scoreIsVeryOld)
+                            if (StandardisedScoreMigrationTools.ShouldMigrateToNewStandardised(score))
                             {
                                 try
                                 {

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -13,6 +14,19 @@ namespace osu.Game.Database
 {
     public static class StandardisedScoreMigrationTools
     {
+        public static bool ShouldMigrateToNewStandardised(ScoreInfo score)
+        {
+            if (score.IsLegacyScore)
+                return false;
+
+            // Recalculate the old-style standardised score to see if this was an old lazer score.
+            bool oldScoreMatchesExpectations = GetOldStandardised(score) == score.TotalScore;
+            // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.
+            bool scoreIsVeryOld = score.Date < new DateTime(2023, 1, 1, 0, 0, 0);
+
+            return oldScoreMatchesExpectations || scoreIsVeryOld;
+        }
+
         public static long GetNewStandardised(ScoreInfo score)
         {
             int maxJudgementIndex = 0;

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -83,6 +83,11 @@ namespace osu.Game.Scoring
 
             if (string.IsNullOrEmpty(model.MaximumStatisticsJson))
                 model.MaximumStatisticsJson = JsonConvert.SerializeObject(model.MaximumStatistics);
+
+            // for pre-ScoreV2 lazer scores, apply a best-effort conversion of total score to ScoreV2.
+            // this requires: max combo, statistics, max statistics (where available), and mods to already be populated on the score.
+            if (StandardisedScoreMigrationTools.ShouldMigrateToNewStandardised(model))
+                model.TotalScore = StandardisedScoreMigrationTools.GetNewStandardised(model);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23929.

Opted to reuse same guard used in the realm migration rather than invent something new for consistency (with a slight modification to also include `IsLegacyScore` for that case to work correctly in the import flow, which is a bit superfluous in the migration case, as it filters out non-legacy scores earlier, but alas).

Notably, diff also includes d83bf029239bf54c4ef290b210c8d8dc232b206f, which [was applied on the `release` branch](https://github.com/ppy/osu/commit/fbcb68466add1d727c6050cb143b3983193c79ee) but [which has not yet been merged back into `master`](https://github.com/ppy/osu/blob/6f0c8c286b5de39e20cbe3afc86724e4eee3ce96/osu.Game/Database/RealmAccess.cs#L946-L964). Only picked up on it by accident when looking at the `RealmAccess` code to reuse the guard and getting the feeling that something was off in that the `try..catch` was not where I remembered it being.