### PR TITLE
Fix score migration not migrating all scores properly

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -77,8 +77,9 @@ namespace osu.Game.Database
         /// 27   2023-06-06    Added EditorTimestamp to BeatmapInfo.
         /// 28   2023-06-08    Added IsLegacyScore to ScoreInfo, parsed from replay files.
         /// 29   2023-06-12    Run migration of old lazer scores to be best-effort in the new scoring number space. No actual realm changes.
+        /// 30   2023-06-16    Run migration of old lazer scores again. This time with more correct rounding considerations.
         /// </summary>
-        private const int schema_version = 29;
+        private const int schema_version = 30;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -938,6 +939,7 @@ namespace osu.Game.Database
                 }
 
                 case 29:
+                case 30:
                 {
                     var scores = migration.NewRealm
                                           .All<ScoreInfo>()

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Database
             foreach (var mod in score.Mods)
                 modMultiplier *= mod.ScoreMultiplier;
 
-            return (long)((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
+            return (long)Math.Round((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
         }
 
         private class FakeHit : HitObject


### PR DESCRIPTION
We were missing a rounding consideration which means that.. probably half of the scores which should have been converted were not being. Luckily this is easy to resolve and can be simply re-run on top of an existing database with no further considerations.

Will probably push this out in another hotfix release.

See https://github.com/ppy/osu/issues/23931#issuecomment-1594096430 for full diagnosis.

Closes https://github.com/ppy/osu/issues/23931.