### PR TITLE
Fix osu!mania hold notes sometimes looking incorrect after rewind

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -242,17 +242,20 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
             bodyPiece.Y = (Direction.Value == ScrollingDirection.Up ? 1 : -1) * Head.Height / 2;
             bodyPiece.Height = DrawHeight - Head.Height / 2 + Tail.Height / 2;
 
-            // As the note is being held, adjust the size of the sizing container. This has two effects:
-            // 1. The contained masking container will mask the body and ticks.
-            // 2. The head note will move along with the new "head position" in the container.
-            //
-            // As per stable, this should not apply for early hits, waiting until the object starts to touch the
-            // judgement area first.
-            if (Head.IsHit && releaseTime == null && DrawHeight > 0 && Time.Current >= HitObject.StartTime)
+            if (Time.Current >= HitObject.StartTime)
             {
-                // How far past the hit target this hold note is.
-                float yOffset = Direction.Value == ScrollingDirection.Up ? -Y : Y;
-                sizingContainer.Height = 1 - yOffset / DrawHeight;
+                // As the note is being held, adjust the size of the sizing container. This has two effects:
+                // 1. The contained masking container will mask the body and ticks.
+                // 2. The head note will move along with the new "head position" in the container.
+                //
+                // As per stable, this should not apply for early hits, waiting until the object starts to touch the
+                // judgement area first.
+                if (Head.IsHit && releaseTime == null && DrawHeight > 0)
+                {
+                    // How far past the hit target this hold note is.
+                    float yOffset = Direction.Value == ScrollingDirection.Up ? -Y : Y;
+                    sizingContainer.Height = 1 - yOffset / DrawHeight;
+                }
             }
             else
                 sizingContainer.Height = 1;

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -254,6 +254,8 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 float yOffset = Direction.Value == ScrollingDirection.Up ? -Y : Y;
                 sizingContainer.Height = 1 - yOffset / DrawHeight;
             }
+            else
+                sizingContainer.Height = 1;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)


### PR DESCRIPTION
Regressed with 98f35f74.

Closes https://github.com/ppy/osu/issues/23923.

| before | after |
| -- | -- |
|![osu! 2023-06-16 at 05 55 22](https://github.com/ppy/osu/assets/191335/ad0382da-95f3-44fa-bfbd-74413c5c8c92)|![osu! 2023-06-16 at 05 55 36](https://github.com/ppy/osu/assets/191335/fbc548f1-3219-4367-8969-c1e7c88560cf)|