### PR TITLE
Fix distance snap grid circles not correctly being centred on snap point

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -185,7 +185,18 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddAssert("Ensure cursor is on a grid line", () =>
             {
-                return grid.ChildrenOfType<CircularProgress>().Any(p => Precision.AlmostEquals(p.ScreenSpaceDrawQuad.TopRight.X, grid.ToScreenSpace(cursor.LastSnappedPosition).X));
+                return grid.ChildrenOfType<CircularProgress>().Any(ring =>
+                {
+                    // the grid rings are actually slightly _larger_ than the snapping radii.
+                    // this is done such that the snapping radius falls right in the middle of each grid ring thickness-wise,
+                    // but it does however complicate the following calculations slightly.
+
+                    // we want to calculate the coordinates of the rightmost point on the grid line, which is in the exact middle of the ring thickness-wise.
+                    // for the X component, we take the entire width of the ring, minus one half of the inner radius (since we want the middle of the line on the right side).
+                    // for the Y component, we just take 0.5f.
+                    var rightMiddleOfGridLine = ring.ToScreenSpace(ring.DrawSize * new Vector2(1 - ring.InnerRadius / 2, 0.5f));
+                    return Precision.AlmostEquals(rightMiddleOfGridLine.X, grid.ToScreenSpace(cursor.LastSnappedPosition).X);
+                });
             });
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -65,14 +65,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             for (int i = 0; i < requiredCircles; i++)
             {
-                float diameter = (offset + (i + 1) * DistanceBetweenTicks) * 2;
                 const float thickness = 4;
+                float diameter = (offset + (i + 1) * DistanceBetweenTicks + thickness / 2) * 2;
 
                 AddInternal(new Ring(ReferenceObject, GetColourForIndexFromPlacement(i))
                 {
                     Position = StartPosition,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(diameter + thickness / 2),
+                    Size = new Vector2(diameter),
                     InnerRadius = thickness * 1f / diameter,
                 });
             }

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -63,13 +63,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
             for (int i = 0; i < requiredCircles; i++)
             {
                 float diameter = (offset + (i + 1) * DistanceBetweenTicks) * 2;
+                const float thickness = 4;
 
                 AddInternal(new Ring(ReferenceObject, GetColourForIndexFromPlacement(i))
                 {
                     Position = StartPosition,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(diameter),
-                    InnerRadius = 4 * 1f / diameter,
+                    Size = new Vector2(diameter + thickness / 2),
+                    InnerRadius = thickness * 1f / diameter,
                 });
             }
         }


### PR DESCRIPTION
| before | after |
| -- | -- |
|![Pixelmator Pro 2023-06-16 at 08 21 16](https://github.com/ppy/osu/assets/191335/a720c4f1-fdef-4a76-a9ab-421e67c92141)|![Pixelmator Pro 2023-06-16 at 08 22 25](https://github.com/ppy/osu/assets/191335/52281760-5aba-47e7-82fe-2966d152be57)|

(red lines are added in post)