### PR TITLE
Fix column colours not being correctly applied on Triangles skin with Dual Stages mod active

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestScenePlayfield.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestScenePlayfield.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.UI;
+using osuTK;
 
 namespace osu.Game.Rulesets.Mania.Tests.Skinning
 {
@@ -25,22 +26,35 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                     new StageDefinition(2)
                 };
 
-                SetContents(_ => new ManiaPlayfield(stageDefinitions));
+                SetContents(_ => new ManiaInputManager(new ManiaRuleset().RulesetInfo, 2)
+                {
+                    Child = new ManiaPlayfield(stageDefinitions)
+                });
             });
         }
 
-        [Test]
-        public void TestDualStages()
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(5)]
+        public void TestDualStages(int columnCount)
         {
             AddStep("create stage", () =>
             {
                 stageDefinitions = new List<StageDefinition>
                 {
-                    new StageDefinition(2),
-                    new StageDefinition(2)
+                    new StageDefinition(columnCount),
+                    new StageDefinition(columnCount)
                 };
 
-                SetContents(_ => new ManiaPlayfield(stageDefinitions));
+                SetContents(_ => new ManiaInputManager(new ManiaRuleset().RulesetInfo, (int)PlayfieldType.Dual + 2 * columnCount)
+                {
+                    Child = new ManiaPlayfield(stageDefinitions)
+                    {
+                        // bit of a hack to make sure the dual stages fit on screen without overlapping each other.
+                        Size = new Vector2(1.5f),
+                        Scale = new Vector2(1 / 1.5f)
+                    }
+                });
             });
         }
 

--- a/osu.Game.Rulesets.Mania/Skinning/Default/ManiaTrianglesSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/ManiaTrianglesSkinTransformer.cs
@@ -35,10 +35,12 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
 
                         var stage = beatmap.GetStageForColumnIndex(column);
 
-                        if (stage.IsSpecialColumn(column))
+                        int columnInStage = column % stage.Columns;
+
+                        if (stage.IsSpecialColumn(columnInStage))
                             return SkinUtils.As<TValue>(new Bindable<Color4>(colourSpecial));
 
-                        int distanceToEdge = Math.Min(column, (stage.Columns - 1) - column);
+                        int distanceToEdge = Math.Min(columnInStage, (stage.Columns - 1) - columnInStage);
                         return SkinUtils.As<TValue>(new Bindable<Color4>(distanceToEdge % 2 == 0 ? colourOdd : colourEven));
                 }
             }


### PR DESCRIPTION
## What?
Fixes the bug where Triangles skin is not symmetric with Dual Stages enabled.
## Why?
Fixes https://github.com/ppy/osu/issues/21685
## How?
`distanceToEdge` could be negative in Dual Stage mode, so I use relative position for each stage
## Testing?
I tested manually with different numbers of columns and ran InspectCode.ps1 , not sure if anything else is needed
## Screenshots (optional)
The one from the issue page:
![image](https://user-images.githubusercontent.com/20128322/208264276-4b9e1946-7e3e-4548-afe4-8ec2bccfa7bb.png)
And how it looks now:
![image](https://github.com/ppy/osu/assets/20128322/6ae78231-f0cd-4626-bea4-96804c1268a6)
## Anything Else?
Have a good day