### PR TITLE
Avoid humanizer regex compilation overhead when opening song select for the first time

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Humanizer;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -864,7 +863,7 @@ namespace osu.Game.Screens.Select
         {
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).
-            FilterControl.InformationalText = $"{"match".ToQuantity(Carousel.CountDisplayed, "#,0")}";
+            FilterControl.InformationalText = Carousel.CountDisplayed != 1 ? $"{Carousel.CountDisplayed} matches" : $"{Carousel.CountDisplayed} match";
         }
 
         private bool boundLocalBindables;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -863,7 +863,7 @@ namespace osu.Game.Screens.Select
         {
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).
-            FilterControl.InformationalText = Carousel.CountDisplayed != 1 ? $"{Carousel.CountDisplayed} matches" : $"{Carousel.CountDisplayed} match";
+            FilterControl.InformationalText = Carousel.CountDisplayed != 1 ? $"{Carousel.CountDisplayed:#,0} matches" : $"{Carousel.CountDisplayed:#,0} match";
         }
 
         private bool boundLocalBindables;


### PR DESCRIPTION
![2023-06-18 02 22 21@2x](https://github.com/ppy/osu/assets/191335/d941b850-8956-4c85-a07d-e6a39c8ceeae)

This only affects the first run. Here's a subsequent run on `master` confirming that:

![2023-06-18 02 24 40@2x](https://github.com/ppy/osu/assets/191335/a5d8cccd-a5de-49a3-95a2-1f80a61b4162)

I attempted to fix this by warming up the regex, but it's pretty complicated to do this correctly (there's one regex per matching rule in humanizer).