### PR TITLE
Fix beatmap info length tooltip not showing actual drain length

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapSetOverlay.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Tests.Visual.Online
                             StarRating = 9.99,
                             DifficultyName = @"TEST",
                             Length = 456000,
+                            HitLength = 400000,
                             RulesetID = 3,
                             CircleSize = 1,
                             DrainRate = 2.3f,

--- a/osu.Game/Beatmaps/IBeatmapInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapInfo.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Beatmaps
         IBeatmapSetInfo? BeatmapSet { get; }
 
         /// <summary>
-        /// The playable length in milliseconds of this beatmap.
+        /// The total length in milliseconds of this beatmap.
         /// </summary>
         double Length { get; }
 

--- a/osu.Game/Beatmaps/IBeatmapOnlineInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapOnlineInfo.cs
@@ -59,5 +59,10 @@ namespace osu.Game.Beatmaps
         int PassCount { get; }
 
         APIFailTimes? FailTimes { get; }
+
+        /// <summary>
+        /// The playable length in milliseconds of this beatmap.
+        /// </summary>
+        double HitLength { get; }
     }
 }

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -63,6 +63,16 @@ namespace osu.Game.Online.API.Requests.Responses
             set => Length = TimeSpan.FromSeconds(value).TotalMilliseconds;
         }
 
+        [JsonIgnore]
+        public double HitLength { get; set; }
+
+        [JsonProperty(@"hit_length")]
+        private double hitLengthInSeconds
+        {
+            get => TimeSpan.FromMilliseconds(HitLength).TotalSeconds;
+            set => HitLength = TimeSpan.FromSeconds(value).TotalMilliseconds;
+        }
+
         [JsonProperty(@"convert")]
         public bool Convert { get; set; }
 

--- a/osu.Game/Overlays/BeatmapSet/BasicStats.cs
+++ b/osu.Game/Overlays/BeatmapSet/BasicStats.cs
@@ -68,13 +68,13 @@ namespace osu.Game.Overlays.BeatmapSet
             }
             else
             {
-                length.TooltipText = BeatmapsetsStrings.ShowStatsTotalLength(TimeSpan.FromMilliseconds(beatmapInfo.Length).ToFormattedDuration());
                 length.Value = TimeSpan.FromMilliseconds(beatmapInfo.Length).ToFormattedDuration();
 
-                var onlineInfo = beatmapInfo as IBeatmapOnlineInfo;
+                if (beatmapInfo is not IBeatmapOnlineInfo onlineInfo) return;
 
-                circleCount.Value = (onlineInfo?.CircleCount ?? 0).ToLocalisableString(@"N0");
-                sliderCount.Value = (onlineInfo?.SliderCount ?? 0).ToLocalisableString(@"N0");
+                circleCount.Value = onlineInfo.CircleCount.ToLocalisableString(@"N0");
+                sliderCount.Value = onlineInfo.SliderCount.ToLocalisableString(@"N0");
+                length.TooltipText = BeatmapsetsStrings.ShowStatsTotalLength(TimeSpan.FromMilliseconds(onlineInfo.HitLength).ToFormattedDuration());
             }
         }
 


### PR DESCRIPTION
| Before | After | Web |
| --- | --- | --- |
| ![osu!_bEoqV19jk6](https://github.com/ppy/osu/assets/35318437/ddd6ae02-1a07-40ad-807c-16a4e243bb2b) | ![osu!_XBYVh3hnyk](https://github.com/ppy/osu/assets/35318437/995ccbc0-9bc8-44e0-8942-f02cb4af3718) | ![firefox_rz1m6WNMVS](https://github.com/ppy/osu/assets/35318437/bf2f6ff3-9475-4759-b538-934529c9c59e) |