### PR TITLE
Add hotkey to save replay

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -111,6 +111,10 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnClick(ClickEvent e)
         {
+            // Handle case where a click is triggered via TriggerClick().
+            if (!IsHovered)
+                hover.FadeOutFromOne(1600);
+
             hover.FlashColour(FlashColour, 800, Easing.OutQuint);
             return base.OnClick(e);
         }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -119,6 +119,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
             new KeyBinding(InputKey.Tab, GlobalAction.ToggleChatFocus),
+            new KeyBinding(InputKey.F2, GlobalAction.SaveReplay),
         };
 
         public IEnumerable<KeyBinding> ReplayKeyBindings => new[]
@@ -366,5 +367,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleNextBeatSnapDivisor))]
         EditorCycleNextBeatSnapDivisor,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SaveReplay))]
+        SaveReplay,
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -119,7 +119,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
             new KeyBinding(InputKey.Tab, GlobalAction.ToggleChatFocus),
-            new KeyBinding(InputKey.F2, GlobalAction.SaveReplay),
+            new KeyBinding(InputKey.F1, GlobalAction.SaveReplay),
+            new KeyBinding(InputKey.F2, GlobalAction.ExportReplay),
         };
 
         public IEnumerable<KeyBinding> ReplayKeyBindings => new[]
@@ -370,5 +371,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.SaveReplay))]
         SaveReplay,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ExportReplay))]
+        ExportReplay,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -324,6 +324,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ToggleChatFocus => new TranslatableString(getKey(@"toggle_chat_focus"), @"Toggle chat focus");
 
+        /// <summary>
+        /// "Save replay"
+        /// </summary>
+        public static LocalisableString SaveReplay => new TranslatableString(getKey(@"save_replay"), @"Save replay");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -329,6 +329,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString SaveReplay => new TranslatableString(getKey(@"save_replay"), @"Save replay");
 
+        /// <summary>
+        /// "Export replay"
+        /// </summary>
+        public static LocalisableString ExportReplay => new TranslatableString(getKey(@"export_replay"), @"Export replay");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Play/SaveFailedScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveFailedScoreButton.cs
@@ -8,15 +8,18 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Database;
 using osu.Game.Scoring;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Online;
 using osuTK;
 
 namespace osu.Game.Screens.Play
 {
-    public partial class SaveFailedScoreButton : CompositeDrawable
+    public partial class SaveFailedScoreButton : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         private readonly Bindable<DownloadState> state = new Bindable<DownloadState>();
 
@@ -86,6 +89,22 @@ namespace osu.Game.Screens.Play
                         break;
                 }
             }, true);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.SaveReplay:
+                    button.TriggerClick();
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
     }
 }

--- a/osu.Game/Screens/Play/SaveFailedScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveFailedScoreButton.cs
@@ -15,6 +15,7 @@ using osu.Game.Scoring;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Online;
+using osu.Game.Online.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Screens.Play
@@ -63,7 +64,7 @@ namespace osu.Game.Screens.Play
                             {
                                 importedScore = realm.Run(r => r.Find<ScoreInfo>(t.GetResultSafely().ID)?.Detach());
                                 Schedule(() => state.Value = importedScore != null ? DownloadState.LocallyAvailable : DownloadState.NotDownloaded);
-                            });
+                            }).FireAndForget();
                             break;
                     }
                 }

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -1,30 +1,31 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Online;
 using osu.Game.Scoring;
 using osuTK;
 
 namespace osu.Game.Screens.Ranking
 {
-    public partial class ReplayDownloadButton : CompositeDrawable
+    public partial class ReplayDownloadButton : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         public readonly Bindable<ScoreInfo> Score = new Bindable<ScoreInfo>();
 
         protected readonly Bindable<DownloadState> State = new Bindable<DownloadState>();
 
-        private DownloadButton button;
-        private ShakeContainer shakeContainer;
+        private DownloadButton button = null!;
+        private ShakeContainer shakeContainer = null!;
 
-        private ScoreDownloadTracker downloadTracker;
+        private ScoreDownloadTracker? downloadTracker;
 
         private ReplayAvailability replayAvailability
         {
@@ -46,8 +47,8 @@ namespace osu.Game.Screens.Ranking
             Size = new Vector2(50, 30);
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuGame game, ScoreModelDownloader scores)
+        [BackgroundDependencyLoader]
+        private void load(OsuGame? game, ScoreModelDownloader scores)
         {
             InternalChild = shakeContainer = new ShakeContainer
             {
@@ -97,6 +98,22 @@ namespace osu.Game.Screens.Ranking
                 button.State.Value = state.NewValue;
                 updateState();
             }, true);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            switch (e.Action)
+            {
+                case GlobalAction.SaveReplay:
+                    button.TriggerClick();
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
 
         private void updateState()

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -103,6 +103,8 @@ namespace osu.Game.Screens.Ranking
             }, true);
         }
 
+        #region Export via hotkey logic (also in SaveFailedScoreButton)
+
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             switch (e.Action)
@@ -112,18 +114,11 @@ namespace osu.Game.Screens.Ranking
                     return true;
 
                 case GlobalAction.ExportReplay:
-                    if (State.Value == DownloadState.NotDownloaded)
-                    {
+                    State.BindValueChanged(exportWhenReady, true);
+
+                    // start the import via button
+                    if (State.Value != DownloadState.LocallyAvailable)
                         button.TriggerClick();
-                    }
-
-                    State.ValueChanged += importAfterDownload;
-
-                    void importAfterDownload(ValueChangedEvent<DownloadState> valueChangedEvent)
-                    {
-                        scoreManager.Export(Score.Value);
-                        State.ValueChanged -= importAfterDownload;
-                    }
 
                     return true;
             }
@@ -134,6 +129,17 @@ namespace osu.Game.Screens.Ranking
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
         }
+
+        private void exportWhenReady(ValueChangedEvent<DownloadState> state)
+        {
+            if (state.NewValue != DownloadState.LocallyAvailable) return;
+
+            scoreManager.Export(Score.Value);
+
+            State.ValueChanged -= exportWhenReady;
+        }
+
+        #endregion
 
         private void updateState()
         {

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Screens.Ranking
 
         private ScoreDownloadTracker? downloadTracker;
 
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
         private ReplayAvailability replayAvailability
         {
             get
@@ -48,7 +51,7 @@ namespace osu.Game.Screens.Ranking
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuGame? game, ScoreModelDownloader scores)
+        private void load(OsuGame? game, ScoreModelDownloader scoreDownloader)
         {
             InternalChild = shakeContainer = new ShakeContainer
             {
@@ -68,7 +71,7 @@ namespace osu.Game.Screens.Ranking
                         break;
 
                     case DownloadState.NotDownloaded:
-                        scores.Download(Score.Value);
+                        scoreDownloader.Download(Score.Value);
                         break;
 
                     case DownloadState.Importing:
@@ -106,6 +109,22 @@ namespace osu.Game.Screens.Ranking
             {
                 case GlobalAction.SaveReplay:
                     button.TriggerClick();
+                    return true;
+
+                case GlobalAction.ExportReplay:
+                    if (State.Value == DownloadState.NotDownloaded)
+                    {
+                        button.TriggerClick();
+                    }
+
+                    State.ValueChanged += importAfterDownload;
+
+                    void importAfterDownload(ValueChangedEvent<DownloadState> valueChangedEvent)
+                    {
+                        scoreManager.Export(Score.Value);
+                        State.ValueChanged -= importAfterDownload;
+                    }
+
                     return true;
             }
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Screens.Ranking
 
             if (allowWatchingReplay)
             {
-                buttons.Add(new ReplayDownloadButton(null)
+                buttons.Add(new ReplayDownloadButton(SelectedScore.Value)
                 {
                     Score = { BindTarget = SelectedScore },
                     Width = 300


### PR DESCRIPTION
Defaults to `F2` aka stable. Note that a second press watches the replay. I think this feels pretty natural, but open to suggestion (maybe the binding text should be changed to reflect that?). Of note, stable uses F1 to watch replay, but it has a different flow – doesn't require save first while we currently do.