### PR TITLE
Fix beatmap info not showing individual difficulty bpm

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/BasicStats.cs
+++ b/osu.Game/Overlays/BeatmapSet/BasicStats.cs
@@ -58,16 +58,18 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void updateDisplay()
         {
-            bpm.Value = BeatmapSet?.BPM.ToLocalisableString(@"0.##") ?? (LocalisableString)"-";
-
             if (beatmapInfo == null)
             {
+                bpm.Value = "-";
+
                 length.Value = string.Empty;
                 circleCount.Value = string.Empty;
                 sliderCount.Value = string.Empty;
             }
             else
             {
+                bpm.Value = beatmapInfo.BPM.ToLocalisableString(@"0.##");
+
                 length.Value = TimeSpan.FromMilliseconds(beatmapInfo.Length).ToFormattedDuration();
 
                 if (beatmapInfo is not IBeatmapOnlineInfo onlineInfo) return;


### PR DESCRIPTION
- Noticed after merge of https://github.com/ppy/osu/pull/23954

Tested with last two diffs of https://osu.ppy.sh/beatmapsets/29157#osu/156352:

| Before | After | Web |
| --- | --- | --- |
| ![Cj2csXuyAr](https://github.com/ppy/osu/assets/35318437/bda68692-d683-4ae7-b391-95628d51c933) | ![osu!_kN7UldQOyD](https://github.com/ppy/osu/assets/35318437/4fa6cb69-055b-4d01-a31b-0e5196cefdb6) | ![firefox_M6ibWTW6KX](https://github.com/ppy/osu/assets/35318437/3f691271-9d63-4133-8965-f96a828cfa35) |