### PR TITLE
Allow notifications while the game is paused (or in break time)

### DIFF
--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Overlays
 
         private void updateProcessingMode()
         {
-            bool enabled = OverlayActivationMode.Value == OverlayActivation.All || State.Value == Visibility.Visible;
+            bool enabled = OverlayActivationMode.Value != OverlayActivation.Disabled || State.Value == Visibility.Visible;
 
             notificationsEnabler?.Cancel();
 


### PR DESCRIPTION
RFC. This is to allow notifications to show at the pause screen (specifically for #23967, where exports are now happening).

Not sure about the break time part of this, but might be fine? The toasts are immediately flushed before break time ends.