### PR TITLE
Fix presenting beatmaps while in a multiplayer room not working

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
+        [Resolved]
+        private OsuGame game { get; set; }
+
         private AddItemButton addItemButton;
 
         public MultiplayerMatchSubScreen(Room room)
@@ -403,18 +406,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!this.IsCurrentScreen())
                 return;
 
-            if (client.Room == null)
-                return;
+            // If there's only one playlist item and we are the host, assume we want to change it. Else we're add a new one.
+            PlaylistItem itemToEdit = client.IsHost && Room.Playlist.Count == 1 ? Room.Playlist.Single() : null;
 
-            if (!client.IsHost)
-            {
-                // todo: should handle this when the request queue is implemented.
-                // if we decide that the presentation should exit the user from the multiplayer game, the PresentBeatmap
-                // flow may need to change to support an "unable to present" return value.
-                return;
-            }
+            OpenSongSelection(itemToEdit);
 
-            this.Push(new MultiplayerMatchSongSelect(Room, Room.Playlist.Single(item => item.ID == client.Room.Settings.PlaylistItemId)));
+            // Re-run PresentBeatmap now that we've pushed a song select that can handle it.
+            game?.PresentBeatmap(beatmap.BeatmapSetInfo, b => b.ID == beatmap.BeatmapInfo.ID);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -411,7 +411,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!localUserCanAddItem)
                 return;
 
-            // If there's only one playlist item and we are the host, assume we want to change it. Else we're add a new one.
+            // If there's only one playlist item and we are the host, assume we want to change it. Else add a new one.
             PlaylistItem itemToEdit = client.IsHost && Room.Playlist.Count == 1 ? Room.Playlist.Single() : null;
 
             OpenSongSelection(itemToEdit);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -337,10 +337,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             updateCurrentItem();
 
-            addItemButton.Alpha = client.IsHost || Room.QueueMode.Value != QueueMode.HostOnly ? 1 : 0;
+            addItemButton.Alpha = localUserCanAddItem ? 1 : 0;
 
             Scheduler.AddOnce(UpdateMods);
         }
+
+        private bool localUserCanAddItem => client.IsHost || Room.QueueMode.Value != QueueMode.HostOnly;
 
         private void updateCurrentItem()
         {
@@ -404,6 +406,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
         {
             if (!this.IsCurrentScreen())
+                return;
+
+            if (!localUserCanAddItem)
                 return;
 
             // If there's only one playlist item and we are the host, assume we want to change it. Else we're add a new one.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved]
         private MultiplayerClient client { get; set; }
 
-        [Resolved]
+        [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
 
         private AddItemButton addItemButton;


### PR DESCRIPTION
Regressed with https://github.com/ppy/osu/pull/20178.

This time around, it supports all scenarios, including the one requested at https://github.com/ppy/osu/discussions/23956.

- If you are host, and at the match setup screen, it will update the beatmap to open the room with.
- If you are host and there's only one item in the playlist, it will open song select to edit that item.
- If you are host and there's more than one item, or if you are a player and the room supports it, it will open song select to add a new item.

Should this have tests? Probably.