### PR TITLE
Adjust `GameplaySampleTriggerSource` to only switch samples when close enough to the next hit object

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -331,7 +331,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 LastPlayedSamples = samples;
             }
 
-            public new HitObject GetMostValidObject() => base.GetMostValidObject();
+            public new HitObject? GetMostValidObject() => base.GetMostValidObject();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
             checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
-            AddStep("seek past hit", () => gameplayClock.Seek(200));
+            seekTo(200);
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
             checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
             checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -315,6 +315,9 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 hitObjectContainer.Add(drawableSwell);
             });
 
+            // You might think that this should be a SwellTick since we're before the swell, but SwellTicks get no StartTime (ie. they are zero).
+            // This works fine in gameplay because they are judged whenever the user pressed, rather than being timed hits.
+            // But for sample playback purposes they can be ignored as noise.
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
             checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
             checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
@@ -349,6 +352,9 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 hitObjectContainer.Add(drawableSwell);
             });
 
+            // You might think that this should be a SwellTick since we're before the swell, but SwellTicks get no StartTime (ie. they are zero).
+            // This works fine in gameplay because they are judged whenever the user pressed, rather than being timed hits.
+            // But for sample playback purposes they can be ignored as noise.
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
             checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
             checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Storyboards;
 using osuTK;
@@ -62,25 +63,30 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 new HitCircle
                 {
+                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
                 },
                 new HitCircle
                 {
+                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_WHISTLE) }
                 },
                 new HitCircle
                 {
+                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT) },
                 },
                 new HitCircle
                 {
+                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                 },
                 new Slider
                 {
+                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Path = new SliderPath(PathType.Linear, new[] { Vector2.Zero, Vector2.UnitY * 200 }),
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_WHISTLE, HitSampleInfo.BANK_SOFT) },
@@ -131,7 +137,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("first object hit", () => getNextAliveObject()?.Entry?.Result?.HasResult == true);
 
-            checkValidObjectIndex(1);
+            // next object is too far away, so we still use the already hit object.
+            checkValidObjectIndex(0);
+
+            // still too far away.
+            seekBeforeIndex(1, 400);
+            checkValidObjectIndex(0);
 
             // Still object 1 as it's not hit yet.
             seekBeforeIndex(1);
@@ -168,9 +179,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             checkValidObjectIndex(4);
         }
 
-        private void seekBeforeIndex(int index)
+        private void seekBeforeIndex(int index, double amount = 100)
         {
-            AddStep($"seek to just before object {index}", () => Player.GameplayClockContainer.Seek(beatmap.HitObjects[index].StartTime - 100));
+            AddStep($"seek to {amount} ms before object {index}", () => Player.GameplayClockContainer.Seek(beatmap.HitObjects[index].StartTime - amount));
             waitForCatchUp();
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             base.SetUpSteps();
 
-            AddStep("Add trigger source", () => Player.HUDOverlay.Add(sampleTriggerSource = new TestGameplaySampleTriggerSource(Player.DrawableRuleset.Playfield.HitObjectContainer)));
+            AddStep("Add trigger source", () => Player.GameplayClockContainer.Add(sampleTriggerSource = new TestGameplaySampleTriggerSource(Player.DrawableRuleset.Playfield.HitObjectContainer)));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
             }
 
-            public new HitObject GetMostValidObject() => base.GetMostValidObject();
+            public new HitObject? GetMostValidObject() => base.GetMostValidObject();
         }
     }
 }

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.UI
         private HitObjectLifetimeEntry? mostValidObject;
 
         [Resolved]
-        private IGameplayClock gameplayClock { get; set; } = null!;
+        private IGameplayClock? gameplayClock { get; set; }
 
         public GameplaySampleTriggerSource(HitObjectContainer hitObjectContainer)
         {
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.UI
                 }
                 else
                 {
-                    if (isCloseEnoughToCurrentTime(candidate))
+                    if (isCloseEnoughToCurrentTime(candidate.HitObject))
                     {
                         mostValidObject = candidate;
                     }
@@ -107,11 +107,13 @@ namespace osu.Game.Rulesets.UI
 
             // Else we want the earliest valid nested.
             // In cases of nested objects, they will always have earlier sample data than their parent object.
-            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.StartTime).FirstOrDefault(h => h.StartTime > gameplayClock.CurrentTime) ?? mostValidObject.HitObject;
+            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.StartTime).FirstOrDefault(h => h.StartTime > getReferenceTime()) ?? mostValidObject.HitObject;
         }
 
         private bool isAlreadyHit(HitObjectLifetimeEntry h) => h.Result?.HasResult == true;
-        private bool isCloseEnoughToCurrentTime(HitObjectLifetimeEntry h) => gameplayClock.CurrentTime >= h.HitObject.StartTime - h.HitObject.HitWindows.WindowFor(HitResult.Miss) * 2;
+        private bool isCloseEnoughToCurrentTime(HitObject h) => getReferenceTime() >= h.StartTime - h.HitWindows.WindowFor(HitResult.Miss) * 2;
+
+        private double getReferenceTime() => (gameplayClock?.CurrentTime ?? Clock.CurrentTime);
 
         private IEnumerable<HitObject> getAllNested(HitObject hitObject)
         {

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Rulesets.UI
 
             // Else we want the earliest valid nested.
             // In cases of nested objects, they will always have earlier sample data than their parent object.
-            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.StartTime).FirstOrDefault(h => h.StartTime > getReferenceTime()) ?? mostValidObject.HitObject;
+            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.GetEndTime()).SkipWhile(h => h.GetEndTime() <= getReferenceTime()).FirstOrDefault() ?? mostValidObject.HitObject;
         }
 
         private bool isAlreadyHit(HitObjectLifetimeEntry h) => h.Result?.HasResult == true;

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.UI
         private bool isAlreadyHit(HitObjectLifetimeEntry h) => h.Result?.HasResult == true;
         private bool isCloseEnoughToCurrentTime(HitObject h) => getReferenceTime() >= h.StartTime - h.HitWindows.WindowFor(HitResult.Miss) * 2;
 
-        private double getReferenceTime() => (gameplayClock?.CurrentTime ?? Clock.CurrentTime);
+        private double getReferenceTime() => gameplayClock?.CurrentTime ?? Clock.CurrentTime;
 
         private IEnumerable<HitObject> getAllNested(HitObject hitObject)
         {

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -5,10 +5,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.UI
@@ -28,6 +30,9 @@ namespace osu.Game.Rulesets.UI
         private int nextHitSoundIndex;
 
         private readonly Container<SkinnableSound> hitSounds;
+
+        [Resolved]
+        private IGameplayClock gameplayClock { get; set; }
 
         public GameplaySampleTriggerSource(HitObjectContainer hitObjectContainer)
         {
@@ -104,11 +109,11 @@ namespace osu.Game.Rulesets.UI
 
             // Else we want the earliest valid nested.
             // In cases of nested objects, they will always have earlier sample data than their parent object.
-            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.StartTime).FirstOrDefault(h => h.StartTime > Time.Current) ?? mostValidObject.HitObject;
+            return getAllNested(mostValidObject.HitObject).OrderBy(h => h.StartTime).FirstOrDefault(h => h.StartTime > gameplayClock.CurrentTime) ?? mostValidObject.HitObject;
         }
 
         private bool isAlreadyHit(HitObjectLifetimeEntry h) => h.Result?.HasResult == true;
-        private bool isCloseEnoughToCurrentTime(HitObjectLifetimeEntry h) => Time.Current >= h.HitObject.StartTime - h.HitObject.HitWindows.WindowFor(HitResult.Miss) * 2;
+        private bool isCloseEnoughToCurrentTime(HitObjectLifetimeEntry h) => gameplayClock.CurrentTime >= h.HitObject.StartTime - h.HitObject.HitWindows.WindowFor(HitResult.Miss) * 2;
 
         private IEnumerable<HitObject> getAllNested(HitObject hitObject)
         {

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -31,8 +29,10 @@ namespace osu.Game.Rulesets.UI
 
         private readonly Container<SkinnableSound> hitSounds;
 
+        private HitObjectLifetimeEntry? mostValidObject;
+
         [Resolved]
-        private IGameplayClock gameplayClock { get; set; }
+        private IGameplayClock gameplayClock { get; set; } = null!;
 
         public GameplaySampleTriggerSource(HitObjectContainer hitObjectContainer)
         {
@@ -45,14 +45,12 @@ namespace osu.Game.Rulesets.UI
             };
         }
 
-        private HitObjectLifetimeEntry mostValidObject;
-
         /// <summary>
         /// Play the most appropriate hit sound for the current point in time.
         /// </summary>
         public virtual void Play()
         {
-            var nextObject = GetMostValidObject();
+            HitObject? nextObject = GetMostValidObject();
 
             if (nextObject == null)
                 return;
@@ -71,7 +69,7 @@ namespace osu.Game.Rulesets.UI
             hitSound.Play();
         });
 
-        protected HitObject GetMostValidObject()
+        protected HitObject? GetMostValidObject()
         {
             if (mostValidObject == null || isAlreadyHit(mostValidObject))
             {


### PR DESCRIPTION
This changes the logic substantially. Rather than reading the diff, going through the code fresh is probably recommended. Hopefully the inline commenting should convey purpose.

Closes #23963.