### PR TITLE
Change "floating fruits" mod to only apply adjustments to the playfield

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
@@ -21,10 +21,10 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
         {
-            drawableRuleset.Anchor = Anchor.Centre;
-            drawableRuleset.Origin = Anchor.Centre;
+            drawableRuleset.PlayfieldAdjustmentContainer.Anchor = Anchor.Centre;
+            drawableRuleset.PlayfieldAdjustmentContainer.Origin = Anchor.Centre;
 
-            drawableRuleset.Scale = new Vector2(1, -1);
+            drawableRuleset.PlayfieldAdjustmentContainer.Scale = new Vector2(1, -1);
         }
     }
 }

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -71,6 +71,12 @@ namespace osu.Game.Rulesets.UI
 
         private readonly AudioContainer audioContainer = new AudioContainer { RelativeSizeAxes = Axes.Both };
 
+        /// <summary>
+        /// A container which encapsulates the <see cref="Playfield"/> and provides any adjustments to
+        /// ensure correct scale and position.
+        /// </summary>
+        public virtual PlayfieldAdjustmentContainer PlayfieldAdjustmentContainer { get; private set; }
+
         public override Container FrameStableComponents { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         public override IFrameStableClock FrameStableClock => frameStabilityContainer;
@@ -178,7 +184,7 @@ namespace osu.Game.Rulesets.UI
                     audioContainer.WithChild(KeyBindingInputManager
                         .WithChildren(new Drawable[]
                         {
-                            CreatePlayfieldAdjustmentContainer()
+                            PlayfieldAdjustmentContainer = CreatePlayfieldAdjustmentContainer()
                                 .WithChild(Playfield),
                             Overlays
                         })),


### PR DESCRIPTION
Avoids things like touch screen inputs also being flipped.

Note that these adjustments can't be applied directly to the playfield due to how playfields are used in various rulesets (basically relying on the `PlayfieldAdjustContainer` to get things in the right place).

Closes #24000.