### PR TITLE
Adjust the default accuracy-combo split to 50-50 for osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreProcessor.cs
@@ -20,8 +20,8 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
         protected override double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
         {
-            return 700000 * comboProgress
-                   + 300000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress
+            return 500000 * comboProgress
+                   + 500000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress
                    + bonusPortion;
         }
     }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -972,22 +972,19 @@ namespace osu.Game.Database
                 {
                     var scores = migration.NewRealm
                                           .All<ScoreInfo>()
+                                          .Where(s => !s.IsLegacyScore)
                                           .Where(s => s.RulesetID == 0);
 
                     foreach (var score in scores)
                     {
                         try
                         {
-                            if (StandardisedScoreMigrationTools.ShouldMigrateToNewStandardised(score))
+                            try
                             {
-                                try
-                                {
-                                    long calculatedNew = StandardisedScoreMigrationTools.ChangeComboRatio(score, 0.7, 0.5);
-                                    score.TotalScore = calculatedNew;
-                                }
-                                catch
-                                {
-                                }
+                                score.TotalScore = StandardisedScoreMigrationTools.ChangeComboRatio(score, 0.7, 0.5);
+                            }
+                            catch
+                            {
                             }
                         }
                         catch { }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -979,15 +979,11 @@ namespace osu.Game.Database
                     {
                         try
                         {
-                            try
-                            {
-                                score.TotalScore = StandardisedScoreMigrationTools.ChangeComboRatio(score, 0.7, 0.5);
-                            }
-                            catch
-                            {
-                            }
+                            score.TotalScore = StandardisedScoreMigrationTools.ChangeOsuComboRatio(score, 0.7, 0.5);
                         }
-                        catch { }
+                        catch
+                        {
+                        }
                     }
 
                     break;

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -206,5 +206,9 @@ namespace osu.Game.Database
                 MaxResult = maxResult;
             }
         }
+
+        public static long ChangeComboRatio(ScoreInfo score, double oldComboPortion, double newComboPortion)
+        {
+        }
     }
 }

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -187,8 +187,11 @@ namespace osu.Game.Database
             return (long)Math.Round((1000000 * (accuracyPortion * accuracyScore + (1 - accuracyPortion) * comboScore) + bonusScore) * modMultiplier);
         }
 
-        public static long ChangeComboRatio(ScoreInfo score, double oldComboPortion, double newComboPortion)
+        public static long ChangeOsuComboRatio(ScoreInfo score, double oldComboPortion, double newComboPortion)
         {
+            if (score.RulesetID != 0)
+                throw new ArgumentException($"{nameof(score)} must be an osu! ruleset score");
+
             // Assume the incoming score already has a total score in the newest standardised calculation method.
             double totalScore = score.TotalScore;
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -333,8 +333,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected virtual double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
         {
-            return 500000 * comboProgress +
-                   500000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress +
+            return 700000 * comboProgress +
+                   300000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress +
                    bonusPortion;
         }
 

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -49,6 +49,21 @@ namespace osu.Game.Rulesets.Scoring
         public readonly BindableLong TotalScore = new BindableLong { MinValue = 0 };
 
         /// <summary>
+        /// The portion of the total score attributed from combo (before mod multiplier and any scaling is applied).
+        /// </summary>
+        public double ComboPortion { get; private set; }
+
+        /// <summary>
+        /// The portion of the total score attributed from accuracy (before mod multiplier and any scaling is applied).
+        /// </summary>
+        public double AccuracyPortion { get; private set; }
+
+        /// <summary>
+        /// The portion of the total score attributed from bonus (before mod multiplier and any scaling is applied).
+        /// </summary>
+        public double BonusPortion { get; private set; }
+
+        /// <summary>
         /// The current accuracy.
         /// </summary>
         public readonly BindableDouble Accuracy = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
@@ -309,10 +324,11 @@ namespace osu.Game.Rulesets.Scoring
             MinimumAccuracy.Value = maximumBaseScore > 0 ? currentBaseScore / maximumBaseScore : 0;
             MaximumAccuracy.Value = maximumBaseScore > 0 ? (currentBaseScore + (maximumBaseScore - currentMaximumBaseScore)) / maximumBaseScore : 1;
 
-            double comboProgress = maximumComboPortion > 0 ? currentComboPortion / maximumComboPortion : 1;
-            double accuracyProcess = maximumAccuracyJudgementCount > 0 ? (double)currentAccuracyJudgementCount / maximumAccuracyJudgementCount : 1;
+            ComboPortion = maximumComboPortion > 0 ? currentComboPortion / maximumComboPortion : 1;
+            AccuracyPortion = maximumAccuracyJudgementCount > 0 ? (double)currentAccuracyJudgementCount / maximumAccuracyJudgementCount : 1;
+            BonusPortion = currentBonusPortion;
 
-            TotalScore.Value = (long)Math.Round(ComputeTotalScore(comboProgress, accuracyProcess, currentBonusPortion) * scoreMultiplier);
+            TotalScore.Value = (long)Math.Round(ComputeTotalScore(ComboPortion, AccuracyPortion, currentBonusPortion) * scoreMultiplier);
         }
 
         protected virtual double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
@@ -356,6 +372,10 @@ namespace osu.Game.Rulesets.Scoring
             currentAccuracyJudgementCount = 0;
             currentComboPortion = 0;
             currentBonusPortion = 0;
+
+            AccuracyPortion = 0;
+            ComboPortion = 0;
+            BonusPortion = 0;
 
             TotalScore.Value = 0;
             Accuracy.Value = 1;

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -317,8 +317,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected virtual double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
         {
-            return 700000 * comboProgress +
-                   300000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress +
+            return 500000 * comboProgress +
+                   500000 * Math.Pow(Accuracy.Value, 10) * accuracyProgress +
                    bonusPortion;
         }
 


### PR DESCRIPTION
RFC

Ratio is open to adjustment. I haven't tested this code – I want to get feedback to ensure this is the correct direction and that I haven't overlooked anything first.