### PR TITLE
Fix `OpenUserProfile` links having multiple argument types

### DIFF
--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -74,13 +74,7 @@ namespace osu.Game.Graphics.Containers
         }
 
         public void AddUserLink(IUser user, Action<SpriteText> creationParameters = null)
-        {
-            string argument = user.OnlineID > 1
-                ? user.OnlineID.ToString()
-                : user.Username;
-
-            createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, argument), "view profile");
-        }
+            => createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user), "view profile");
 
         private void createLink(ITextPart textPart, LinkDetails link, LocalisableString tooltipText, Action action = null)
         {

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -74,7 +74,13 @@ namespace osu.Game.Graphics.Containers
         }
 
         public void AddUserLink(IUser user, Action<SpriteText> creationParameters = null)
-            => createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user), "view profile");
+        {
+            string argument = user.OnlineID > 1
+                ? user.OnlineID.ToString()
+                : user.Username;
+
+            createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, argument), "view profile");
+        }
 
         private void createLink(ITextPart textPart, LinkDetails link, LocalisableString tooltipText, Action action = null)
         {

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Online.Chat
 {
@@ -172,7 +173,7 @@ namespace osu.Game.Online.Chat
 
                             case "u":
                             case "users":
-                                return new LinkDetails(LinkAction.OpenUserProfile, mainArg);
+                                return getUserLink(mainArg);
 
                             case "wiki":
                                 return new LinkDetails(LinkAction.OpenWiki, string.Join('/', args.Skip(3)));
@@ -230,8 +231,7 @@ namespace osu.Game.Online.Chat
                             break;
 
                         case "u":
-                            linkType = LinkAction.OpenUserProfile;
-                            break;
+                            return getUserLink(args[2]);
 
                         default:
                             return new LinkDetails(LinkAction.External, url);
@@ -244,6 +244,14 @@ namespace osu.Game.Online.Chat
             }
 
             return new LinkDetails(LinkAction.External, url);
+        }
+
+        private static LinkDetails getUserLink(string argument)
+        {
+            if (int.TryParse(argument, out int userId))
+                return new LinkDetails(LinkAction.OpenUserProfile, new APIUser { Id = userId });
+
+            return new LinkDetails(LinkAction.OpenUserProfile, new APIUser { Username = argument });
         }
 
         private static MessageFormatterResult format(string toFormat, int startIndex = 0, int space = 3)

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -446,15 +446,11 @@ namespace osu.Game
                     break;
 
                 case LinkAction.OpenUserProfile:
-                    if (!(link.Argument is IUser user))
-                    {
-                        user = int.TryParse(argString, out int userId)
-                            ? new APIUser { Id = userId }
-                            : new APIUser { Username = argString };
-                    }
+                    var user = int.TryParse(argString, out int userId)
+                        ? new APIUser { Id = userId }
+                        : new APIUser { Username = argString };
 
                     ShowUser(user);
-
                     break;
 
                 case LinkAction.OpenWiki:

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -45,7 +45,6 @@ using osu.Game.Input.Bindings;
 using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Online;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapListing;
@@ -446,11 +445,7 @@ namespace osu.Game
                     break;
 
                 case LinkAction.OpenUserProfile:
-                    var user = int.TryParse(argString, out int userId)
-                        ? new APIUser { Id = userId }
-                        : new APIUser { Username = argString };
-
-                    ShowUser(user);
+                    ShowUser((IUser)link.Argument);
                     break;
 
                 case LinkAction.OpenWiki:

--- a/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
+++ b/osu.Game/Overlays/Profile/Sections/Recent/DrawableRecentActivity.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Overlays.Profile.Sections.Recent
         private void addBeatmapsetLink()
             => content.AddLink(activity.Beatmapset.AsNonNull().Title, LinkAction.OpenBeatmapSet, getLinkArgument(activity.Beatmapset.AsNonNull().Url), creationParameters: t => t.Font = getLinkFont());
 
-        private string getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.WebsiteRootUrl}{url}").Argument.ToString().AsNonNull();
+        private object getLinkArgument(string url) => MessageFormatter.GetLinkDetails($"{api.WebsiteRootUrl}{url}").Argument.AsNonNull();
 
         private FontUsage getLinkFont(FontWeight fontWeight = FontWeight.Regular)
             => OsuFont.GetFont(size: font_size, weight: fontWeight, italics: true);


### PR DESCRIPTION
- See https://github.com/ppy/osu/pull/23334#discussion_r1232402302 and https://github.com/ppy/osu/pull/23334#discussion_r1233416588

`OpenUserProfile` having more than one argument type makes it hard to retrieve the URL from `LinkDetails` as done in the PR linked above, and generally convolutes the process of handling `OpenUserProfile` basically anywhere. 

Besides that, `LinkDetails` having arguments of type `object` is already bad on its own, but [the whole structure is bad](https://github.com/ppy/osu/issues/11754) anyway.