### PR TITLE
Fix tournament chat potentially crashing due to null current match

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -63,18 +63,6 @@ namespace osu.Game.Tournament.Tests.Components
                 Origin = Anchor.Centre,
             });
 
-            ladderInfo.CurrentMatch.Value = new TournamentMatch
-            {
-                Team1 =
-                {
-                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { redUser } }
-                },
-                Team2 =
-                {
-                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { blueUser, blueUserWithCustomColour } }
-                }
-            };
-
             chatDisplay.Channel.Value = testChannel;
         }
 
@@ -87,6 +75,18 @@ namespace osu.Game.Tournament.Tests.Components
                 Sender = admin,
                 Content = "I am a wang!"
             }));
+
+            AddStep("set Current match", () => ladderInfo.CurrentMatch.Value = new TournamentMatch
+            {
+                Team1 =
+                {
+                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { redUser } }
+                },
+                Team2 =
+                {
+                    Value = new TournamentTeam { Players = new BindableList<TournamentUser> { blueUser, blueUserWithCustomColour } }
+                }
+            });
 
             AddStep("message from team red", () => testChannel.AddNewMessages(new Message(nextMessageId())
             {

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Tournament.Tests.Components
                 Content = "I am a wang!"
             }));
 
-            AddStep("set Current match", () => ladderInfo.CurrentMatch.Value = new TournamentMatch
+            AddStep("set current match", () => ladderInfo.CurrentMatch.Value = new TournamentMatch
             {
                 Team1 =
                 {

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -90,12 +90,13 @@ namespace osu.Game.Tournament.Components
             public MatchMessage(Message message, LadderInfo info)
                 : base(message)
             {
-                if (info.CurrentMatch.Value == null) return;
-
-                if (info.CurrentMatch.Value.Team1.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
-                    UsernameColour = TournamentGame.COLOUR_RED;
-                else if (info.CurrentMatch.Value.Team2.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
-                    UsernameColour = TournamentGame.COLOUR_BLUE;
+                if (info.CurrentMatch.Value is TournamentMatch match)
+                {
+                    if (match.Team1.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
+                        UsernameColour = TournamentGame.COLOUR_RED;
+                    else if (match.Team2.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
+                        UsernameColour = TournamentGame.COLOUR_BLUE;
+                }
             }
         }
     }

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -19,10 +17,10 @@ namespace osu.Game.Tournament.Components
     {
         private readonly Bindable<string> chatChannel = new Bindable<string>();
 
-        private ChannelManager manager;
+        private ChannelManager? manager;
 
         [Resolved]
-        private LadderInfo ladderInfo { get; set; }
+        private LadderInfo ladderInfo { get; set; } = null!;
 
         public TournamentMatchChatDisplay()
         {
@@ -35,7 +33,7 @@ namespace osu.Game.Tournament.Components
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(MatchIPCInfo ipc, IAPIProvider api)
+        private void load(MatchIPCInfo? ipc, IAPIProvider api)
         {
             if (ipc != null)
             {
@@ -92,6 +90,8 @@ namespace osu.Game.Tournament.Components
             public MatchMessage(Message message, LadderInfo info)
                 : base(message)
             {
+                if (info.CurrentMatch.Value == null) return;
+
                 if (info.CurrentMatch.Value.Team1.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
                     UsernameColour = TournamentGame.COLOUR_RED;
                 else if (info.CurrentMatch.Value.Team2.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tournament.Components
             CornerRadius = 0;
         }
 
-        [BackgroundDependencyLoader(true)]
+        [BackgroundDependencyLoader]
         private void load(MatchIPCInfo? ipc, IAPIProvider api)
         {
             if (ipc != null)

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -25,7 +27,7 @@ namespace osu.Game.Tournament.Models
         public List<TournamentProgression> Progressions = new List<TournamentProgression>();
 
         [JsonIgnore] // updated manually in TournamentGameBase
-        public Bindable<TournamentMatch?> CurrentMatch = new Bindable<TournamentMatch?>();
+        public Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
 
         public Bindable<int> ChromaKeyWidth = new BindableInt(1024)
         {

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -27,7 +25,7 @@ namespace osu.Game.Tournament.Models
         public List<TournamentProgression> Progressions = new List<TournamentProgression>();
 
         [JsonIgnore] // updated manually in TournamentGameBase
-        public Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
+        public Bindable<TournamentMatch?> CurrentMatch = new Bindable<TournamentMatch?>();
 
         public Bindable<int> ChromaKeyWidth = new BindableInt(1024)
         {


### PR DESCRIPTION
- related https://github.com/ppy/osu/pull/23890

When no bracket is selected, `ladderInfo.CurrentMatch.Value` is null.
and `LadderInfo.cs` have `#nullable disable` so there is no build warning