### PR TITLE
Add exact match support for song select searches

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -160,6 +160,30 @@ namespace osu.Game.Tests.NonVisual.Filtering
         }
 
         [Test]
+        [TestCase("\"artist\"", false)]
+        [TestCase("\"arti\"", true)]
+        [TestCase("\"artist title author\"", true)]
+        [TestCase("\"artist\" \"title\" \"author\"", false)]
+        [TestCase("\"an artist\"", true)]
+        [TestCase("\"tags too\"", false)]
+        [TestCase("\"tags to\"", true)]
+        [TestCase("\"version\"", false)]
+        [TestCase("\"an auteur\"", true)]
+        public void TestCriteriaMatchingExactTerms(string terms, bool filtered)
+        {
+            var exampleBeatmapInfo = getExampleBeatmap();
+            var criteria = new FilterCriteria
+            {
+                Ruleset = new RulesetInfo { OnlineID = 6 },
+                AllowConvertedBeatmaps = true,
+                SearchText = terms
+            };
+            var carouselItem = new CarouselBeatmap(exampleBeatmapInfo);
+            carouselItem.Filter(criteria);
+            Assert.AreEqual(filtered, carouselItem.Filtered.Value);
+        }
+
+        [Test]
         [TestCase("", false)]
         [TestCase("The", false)]
         [TestCase("THE", false)]

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -169,6 +169,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("\"tags to\"", true)]
         [TestCase("\"version\"", false)]
         [TestCase("\"an auteur\"", true)]
+        [TestCase("\"\\\"", true)] // nasty case, covers properly escaping user input in underlying regex.
         public void TestCriteriaMatchingExactTerms(string terms, bool filtered)
         {
             var exampleBeatmapInfo = getExampleBeatmap();

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -23,6 +23,31 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual(4, filterCriteria.SearchTerms.Length);
         }
 
+        [Test]
+        public void TestApplyQueriesBareWordsWithExactMatch()
+        {
+            const string query = "looking for \"a beatmap\" like \"this\"";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("looking for \"a beatmap\" like \"this\"", filterCriteria.SearchText);
+            Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
+
+            Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("a beatmap"));
+            Assert.That(filterCriteria.SearchTerms[0].Exact, Is.True);
+
+            Assert.That(filterCriteria.SearchTerms[1].SearchTerm, Is.EqualTo("this"));
+            Assert.That(filterCriteria.SearchTerms[1].Exact, Is.True);
+
+            Assert.That(filterCriteria.SearchTerms[2].SearchTerm, Is.EqualTo("looking"));
+            Assert.That(filterCriteria.SearchTerms[2].Exact, Is.False);
+
+            Assert.That(filterCriteria.SearchTerms[3].SearchTerm, Is.EqualTo("for"));
+            Assert.That(filterCriteria.SearchTerms[3].Exact, Is.False);
+
+            Assert.That(filterCriteria.SearchTerms[4].SearchTerm, Is.EqualTo("like"));
+            Assert.That(filterCriteria.SearchTerms[4].Exact, Is.False);
+        }
+
         /*
          * The following tests have been written a bit strangely (they don't check exact
          * bound equality with what the filter says).
@@ -235,6 +260,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
+            Assert.That(filterCriteria.Artist.Exact, Is.False);
         }
 
         [Test]
@@ -246,6 +272,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
+            Assert.That(filterCriteria.Artist.Exact, Is.True);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("collection filter still selected", () => control.CreateCriteria().CollectionBeatmapMD5Hashes?.Any() ?? false);
+            AddAssert("collection filter still selected", () => control.CreateCriteria().CollectionBeatmapMD5Hashes?.Any() == true);
 
             AddAssert("filter request not fired", () => !received);
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneFilterControl.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("collection filter still selected", () => control.CreateCriteria().CollectionBeatmapMD5Hashes.Any());
+            AddAssert("collection filter still selected", () => control.CreateCriteria().CollectionBeatmapMD5Hashes?.Any() ?? false);
 
             AddAssert("filter request not fired", () => !received);
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Screens.Select.Filter;
@@ -65,16 +64,16 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (criteria.SearchTerms.Length > 0)
             {
-                var terms = BeatmapInfo.GetSearchableTerms();
+                var searchableTerms = BeatmapInfo.GetSearchableTerms();
 
-                foreach (string criteriaTerm in criteria.SearchTerms)
+                foreach (FilterCriteria.OptionalTextFilter criteriaTerm in criteria.SearchTerms)
                 {
                     bool any = false;
 
                     // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
-                    foreach (string term in terms)
+                    foreach (string searchTerm in searchableTerms)
                     {
-                        if (!term.Contains(criteriaTerm, StringComparison.InvariantCultureIgnoreCase)) continue;
+                        if (!criteriaTerm.Matches(searchTerm)) continue;
 
                         any = true;
                         break;
@@ -98,7 +97,6 @@ namespace osu.Game.Screens.Select.Carousel
             if (!match) return false;
 
             match &= criteria.CollectionBeatmapMD5Hashes?.Contains(BeatmapInfo.MD5Hash) ?? true;
-
             if (match && criteria.RulesetCriteria != null)
                 match &= criteria.RulesetCriteria.Matches(BeatmapInfo);
 

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -1,12 +1,10 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿#nullable enable
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Rulesets;
@@ -20,7 +18,7 @@ namespace osu.Game.Screens.Select
         public GroupMode Group;
         public SortMode Sort;
 
-        public BeatmapSetInfo SelectedBeatmapSet;
+        public BeatmapSetInfo? SelectedBeatmapSet;
 
         public OptionalRange<double> StarDifficulty;
         public OptionalRange<float> ApproachRate;
@@ -42,10 +40,10 @@ namespace osu.Game.Screens.Select
 
         public string[] SearchTerms = Array.Empty<string>();
 
-        public RulesetInfo Ruleset;
+        public RulesetInfo? Ruleset;
         public bool AllowConvertedBeatmaps;
 
-        private string searchText;
+        private string searchText = string.Empty;
 
         /// <summary>
         /// <see cref="SearchText"/> as a number (if it can be parsed as one).
@@ -70,11 +68,9 @@ namespace osu.Game.Screens.Select
         /// <summary>
         /// Hashes from the <see cref="BeatmapCollection"/> to filter to.
         /// </summary>
-        [CanBeNull]
-        public IEnumerable<string> CollectionBeatmapMD5Hashes { get; set; }
+        public IEnumerable<string>? CollectionBeatmapMD5Hashes { get; set; }
 
-        [CanBeNull]
-        public IRulesetFilterCriteria RulesetCriteria { get; set; }
+        public IRulesetFilterCriteria? RulesetCriteria { get; set; }
 
         public struct OptionalRange<T> : IEquatable<OptionalRange<T>>
             where T : struct

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Select
                     return false;
 
                 if (Exact)
-                    return Regex.IsMatch(value, $@"(^|\s){searchTerm}($|\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                    return Regex.IsMatch(value, $@"(^|\s){Regex.Escape(searchTerm)}($|\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
                 return value.Contains(SearchTerm, StringComparison.InvariantCultureIgnoreCase);
             }

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Screens.Select
             switch (op)
             {
                 case Operator.Equal:
-                    textFilter.SearchTerm = value.Trim('"');
+                    textFilter.SearchTerm = value;
                     return true;
 
                 default:


### PR DESCRIPTION
As requested at https://github.com/ppy/osu/discussions/24005#discussioncomment-6263062. Seemed like a quick one to add and quite beneficial QoL wise so knocked it out.

Of note, this could possibly be implemented in the following code block instead:

https://github.com/ppy/osu/blob/a74547c43cf0328d69ec5671635f2a4a4c05356a/osu.Game/Screens/Select/FilterQueryParser.cs#L22-L35

Only noticed this after writing the version I did. Not sure if it makes more or less sense.