### PR TITLE
Fix skip not always triggering in multiplayer

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -378,9 +378,6 @@ namespace osu.Game.Screens.Play
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
 
-            if (Configuration.AutomaticallySkipIntro)
-                skipIntroOverlay.SkipWhenReady();
-
             loadLeaderboard();
         }
 
@@ -1087,6 +1084,9 @@ namespace osu.Game.Screens.Play
                 throw new InvalidOperationException($"{nameof(StartGameplay)} should not be called when the gameplay clock is already running");
 
             GameplayClockContainer.Reset(startClock: true);
+
+            if (Configuration.AutomaticallySkipIntro)
+                skipIntroOverlay.SkipWhenReady();
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23583
- Supersedes / closes https://github.com/ppy/osu/pull/23627

This is just the actual fix from https://github.com/ppy/osu/pull/23627, without any of the other faff. Normally I wouldn't care about "clean history" but I don't want that travesty of a history over there in blame, and reverting everything that's happened there is 10 times more time-consuming than just cherrypicking the actual fix off to a separate branch. And no, I can't force push to that PR, git doesn't let me.

No testing because this is annoying to test and can be trivially tested manually (bug reproduced for me 50% of the time with just 2 clients on dev), and fix is trivial too.