### PR TITLE
Add support for matching full terms at song select using suffixed `!`

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -169,6 +169,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("\"tags to\"", true)]
         [TestCase("\"version\"", false)]
         [TestCase("\"an auteur\"", true)]
+        [TestCase("\"Artist\"!", true)]
+        [TestCase("\"The Artist\"!", false)]
         [TestCase("\"\\\"", true)] // nasty case, covers properly escaping user input in underlying regex.
         public void TestCriteriaMatchingExactTerms(string terms, bool filtered)
         {
@@ -213,6 +215,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("the artist AND then something else", true)]
         [TestCase("unicode too", false)]
         [TestCase("unknown", true)]
+        [TestCase("\"Artist\"!", true)]
+        [TestCase("\"The Artist\"!", false)]
         public void TestCriteriaMatchingArtist(string artistName, bool filtered)
         {
             var exampleBeatmapInfo = getExampleBeatmap();

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -171,6 +171,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("\"an auteur\"", true)]
         [TestCase("\"Artist\"!", true)]
         [TestCase("\"The Artist\"!", false)]
+        [TestCase("\"the artist\"!", false)]
         [TestCase("\"\\\"", true)] // nasty case, covers properly escaping user input in underlying regex.
         public void TestCriteriaMatchingExactTerms(string terms, bool filtered)
         {
@@ -238,6 +239,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCase("unknown", true)]
         [TestCase("\"Artist\"!", true)]
         [TestCase("\"The Artist\"!", false)]
+        [TestCase("\"the artist\"!", false)]
         public void TestCriteriaMatchingArtist(string artistName, bool filtered)
         {
             var exampleBeatmapInfo = getExampleBeatmap();

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -39,13 +39,13 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.That(filterCriteria.SearchTerms[1].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
 
             Assert.That(filterCriteria.SearchTerms[2].SearchTerm, Is.EqualTo("looking"));
-            Assert.That(filterCriteria.SearchTerms[2].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
+            Assert.That(filterCriteria.SearchTerms[2].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
 
             Assert.That(filterCriteria.SearchTerms[3].SearchTerm, Is.EqualTo("for"));
-            Assert.That(filterCriteria.SearchTerms[3].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
+            Assert.That(filterCriteria.SearchTerms[3].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
 
             Assert.That(filterCriteria.SearchTerms[4].SearchTerm, Is.EqualTo("like"));
-            Assert.That(filterCriteria.SearchTerms[4].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
+            Assert.That(filterCriteria.SearchTerms[4].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
         }
 
         /*
@@ -272,7 +272,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
-            Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
+            Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -76,8 +76,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("\"!", filterCriteria.SearchText);
             Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
 
-            Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("\"!"));
-            Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
+            Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("!"));
+            Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
         }
 
         /*

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -48,6 +48,38 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.That(filterCriteria.SearchTerms[4].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
         }
 
+        [Test]
+        public void TestApplyFullPhraseQueryWithExclamationPointInTerm()
+        {
+            const string query = "looking for \"circles!\"!";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("looking for \"circles!\"!", filterCriteria.SearchText);
+            Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
+
+            Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("circles!"));
+            Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
+
+            Assert.That(filterCriteria.SearchTerms[1].SearchTerm, Is.EqualTo("looking"));
+            Assert.That(filterCriteria.SearchTerms[1].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
+
+            Assert.That(filterCriteria.SearchTerms[2].SearchTerm, Is.EqualTo("for"));
+            Assert.That(filterCriteria.SearchTerms[2].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
+        }
+
+        [Test]
+        public void TestApplyBrokenFullPhraseQuery()
+        {
+            const string query = "\"!";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.AreEqual("\"!", filterCriteria.SearchText);
+            Assert.AreEqual(1, filterCriteria.SearchTerms.Length);
+
+            Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("\"!"));
+            Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.Substring));
+        }
+
         /*
          * The following tests have been written a bit strangely (they don't check exact
          * bound equality with what the filter says).

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -26,26 +26,26 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestApplyQueriesBareWordsWithExactMatch()
         {
-            const string query = "looking for \"a beatmap\" like \"this\"";
+            const string query = "looking for \"a beatmap\"! like \"this\"";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
-            Assert.AreEqual("looking for \"a beatmap\" like \"this\"", filterCriteria.SearchText);
+            Assert.AreEqual("looking for \"a beatmap\"! like \"this\"", filterCriteria.SearchText);
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
 
             Assert.That(filterCriteria.SearchTerms[0].SearchTerm, Is.EqualTo("a beatmap"));
-            Assert.That(filterCriteria.SearchTerms[0].Exact, Is.True);
+            Assert.That(filterCriteria.SearchTerms[0].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
 
             Assert.That(filterCriteria.SearchTerms[1].SearchTerm, Is.EqualTo("this"));
-            Assert.That(filterCriteria.SearchTerms[1].Exact, Is.True);
+            Assert.That(filterCriteria.SearchTerms[1].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
 
             Assert.That(filterCriteria.SearchTerms[2].SearchTerm, Is.EqualTo("looking"));
-            Assert.That(filterCriteria.SearchTerms[2].Exact, Is.False);
+            Assert.That(filterCriteria.SearchTerms[2].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
 
             Assert.That(filterCriteria.SearchTerms[3].SearchTerm, Is.EqualTo("for"));
-            Assert.That(filterCriteria.SearchTerms[3].Exact, Is.False);
+            Assert.That(filterCriteria.SearchTerms[3].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
 
             Assert.That(filterCriteria.SearchTerms[4].SearchTerm, Is.EqualTo("like"));
-            Assert.That(filterCriteria.SearchTerms[4].Exact, Is.False);
+            Assert.That(filterCriteria.SearchTerms[4].MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
         }
 
         /*
@@ -260,7 +260,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("find me songs by  please", filterCriteria.SearchText.Trim());
             Assert.AreEqual(5, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("singer", filterCriteria.Artist.SearchTerm);
-            Assert.That(filterCriteria.Artist.Exact, Is.False);
+            Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.None));
         }
 
         [Test]
@@ -272,7 +272,19 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.AreEqual("really like  yes", filterCriteria.SearchText.Trim());
             Assert.AreEqual(3, filterCriteria.SearchTerms.Length);
             Assert.AreEqual("name with space", filterCriteria.Artist.SearchTerm);
-            Assert.That(filterCriteria.Artist.Exact, Is.True);
+            Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.IsolatedPhrase));
+        }
+
+        [Test]
+        public void TestApplyArtistQueriesWithSpacesFullPhrase()
+        {
+            const string query = "artist=\"The Only One\"!";
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, query);
+            Assert.That(filterCriteria.SearchText.Trim(), Is.Empty);
+            Assert.AreEqual(0, filterCriteria.SearchTerms.Length);
+            Assert.AreEqual("The Only One", filterCriteria.Artist.SearchTerm);
+            Assert.That(filterCriteria.Artist.MatchMode, Is.EqualTo(FilterCriteria.MatchMode.FullPhrase));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Screens.Select
                 switch (MatchMode)
                 {
                     default:
-                    case MatchMode.None:
+                    case MatchMode.Substring:
                         return value.Contains(SearchTerm, StringComparison.InvariantCultureIgnoreCase);
 
                     case MatchMode.IsolatedPhrase:
@@ -185,7 +185,7 @@ namespace osu.Game.Screens.Select
                         MatchMode = MatchMode.IsolatedPhrase;
                     }
                     else
-                        MatchMode = MatchMode.None;
+                        MatchMode = MatchMode.Substring;
                 }
             }
 
@@ -197,7 +197,7 @@ namespace osu.Game.Screens.Select
             /// <summary>
             /// Match using a simple "contains" substring match.
             /// </summary>
-            None,
+            Substring,
 
             /// <summary>
             /// Match for the search phrase being isolated by spaces, or at the start or end of the text.

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -174,15 +174,19 @@ namespace osu.Game.Screens.Select
                 {
                     searchTerm = value;
 
-                    if (searchTerm.EndsWith("\"!", StringComparison.Ordinal))
+                    if (searchTerm.StartsWith('\"'))
                     {
-                        searchTerm = searchTerm.Trim('!', '\"');
-                        MatchMode = MatchMode.FullPhrase;
-                    }
-                    else if (searchTerm.StartsWith('\"'))
-                    {
-                        searchTerm = searchTerm.Trim('\"');
-                        MatchMode = MatchMode.IsolatedPhrase;
+                        // length check ensures that the quote character in the `StartsWith()` check above and the `EndsWith()` check below is not the same character.
+                        if (searchTerm.EndsWith("\"!", StringComparison.Ordinal) && searchTerm.Length >= 3)
+                        {
+                            searchTerm = searchTerm.TrimEnd('!').Trim('\"');
+                            MatchMode = MatchMode.FullPhrase;
+                        }
+                        else
+                        {
+                            searchTerm = searchTerm.Trim('\"');
+                            MatchMode = MatchMode.IsolatedPhrase;
+                        }
                     }
                     else
                         MatchMode = MatchMode.Substring;

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Select
     public static class FilterQueryParser
     {
         private static readonly Regex query_syntax_regex = new Regex(
-            @"\b(?<key>\w+)(?<op>(:|=|(>|<)(:|=)?))(?<value>("".*"")|(\S*))",
+            @"\b(?<key>\w+)(?<op>(:|=|(>|<)(:|=)?))(?<value>("".*""[!]?)|(\S*))",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         internal static void ApplyQueries(FilterCriteria criteria, string query)


### PR DESCRIPTION
Given the following beatmap artists:

- artist
- The artist name
- The artistic

You now have three methods of searching:

- `artist` will match all three (term can appear anywhere, even inside a word)
- `"artist"` will match the first two (term must be isolated in a phrase, not inside a word)
- `"artist"!` will only match the first (full term must match)

The `!` suffix is non-standard, but feels like it will work well and also be easy for users to remember. It also has the advantage that you can add it without moving the cursor backwards in the string (which... is not currently possible at song select).

Tested to work with `artist="test"!` style searches too.