### PR TITLE
Add support for `Ctrl` + `<` / `>` to rotate selection in editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -102,6 +102,38 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestRotateHotkeys()
+        {
+            HitCircle[] addedObjects = null;
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
+            {
+                new HitCircle { StartTime = 100 },
+                new HitCircle { StartTime = 200, Position = new Vector2(100) },
+                new HitCircle { StartTime = 300, Position = new Vector2(200) },
+                new HitCircle { StartTime = 400, Position = new Vector2(300) },
+            }));
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.AddRange(addedObjects));
+
+            AddStep("rotate clockwise", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Period);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("objects rotated clockwise", () => addedObjects[0].Position == new Vector2(300, 0));
+
+            AddStep("rotate counterclockwise", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Comma);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("objects reverted to original position", () => addedObjects[0].Position == new Vector2(0));
+        }
+
+        [Test]
         public void TestBasicSelect()
         {
             var addedObject = new HitCircle { StartTime = 100 };

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public Action OperationEnded;
 
         private SelectionBoxButton reverseButton;
+        private SelectionBoxButton rotateClockwiseButton;
+        private SelectionBoxButton rotateCounterClockwiseButton;
 
         private bool canReverse;
 
@@ -172,6 +174,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 case Key.G:
                     return reverseButton?.TriggerClick() ?? false;
+
+                case Key.Comma:
+                    return rotateCounterClockwiseButton?.TriggerClick() ?? false;
+
+                case Key.Period:
+                    return rotateClockwiseButton?.TriggerClick() ?? false;
             }
 
             return base.OnKeyDown(e);
@@ -254,8 +262,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addRotationComponents()
         {
-            addButton(FontAwesome.Solid.Undo, "Rotate 90 degrees counter-clockwise", () => OnRotation?.Invoke(-90));
-            addButton(FontAwesome.Solid.Redo, "Rotate 90 degrees clockwise", () => OnRotation?.Invoke(90));
+            rotateCounterClockwiseButton = addButton(FontAwesome.Solid.Undo, "Rotate 90 degrees counter-clockwise", () => OnRotation?.Invoke(-90));
+            rotateClockwiseButton = addButton(FontAwesome.Solid.Redo, "Rotate 90 degrees clockwise", () => OnRotation?.Invoke(90));
 
             addRotateHandle(Anchor.TopLeft);
             addRotateHandle(Anchor.TopRight);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -171,13 +171,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Key)
             {
                 case Key.G:
-                    return reverseButton?.TriggerClick() == true;
+                    return CanReverse && reverseButton?.TriggerClick() == true;
 
                 case Key.Comma:
-                    return rotateCounterClockwiseButton?.TriggerClick() == true;
+                    return CanRotate && rotateCounterClockwiseButton?.TriggerClick() == true;
 
                 case Key.Period:
-                    return rotateClockwiseButton?.TriggerClick() == true;
+                    return CanRotate && rotateClockwiseButton?.TriggerClick() == true;
             }
 
             return base.OnKeyDown(e);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -260,8 +260,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void addRotationComponents()
         {
-            rotateCounterClockwiseButton = addButton(FontAwesome.Solid.Undo, "Rotate 90 degrees counter-clockwise", () => OnRotation?.Invoke(-90));
-            rotateClockwiseButton = addButton(FontAwesome.Solid.Redo, "Rotate 90 degrees clockwise", () => OnRotation?.Invoke(90));
+            rotateCounterClockwiseButton = addButton(FontAwesome.Solid.Undo, "Rotate 90 degrees counter-clockwise (Ctrl-<)", () => OnRotation?.Invoke(-90));
+            rotateClockwiseButton = addButton(FontAwesome.Solid.Redo, "Rotate 90 degrees clockwise (Ctrl->)", () => OnRotation?.Invoke(90));
 
             addRotateHandle(Anchor.TopLeft);
             addRotateHandle(Anchor.TopRight);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public Action OperationStarted;
         public Action OperationEnded;
 
+        private SelectionBoxButton reverseButton;
+
         private bool canReverse;
 
         /// <summary>
@@ -166,19 +168,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (e.Repeat || !e.ControlPressed)
                 return false;
 
-            bool runOperationFromHotkey(Func<bool> operation)
-            {
-                operationStarted();
-                bool result = operation?.Invoke() ?? false;
-                operationEnded();
-
-                return result;
-            }
-
             switch (e.Key)
             {
                 case Key.G:
-                    return CanReverse && runOperationFromHotkey(OnReverse);
+                    return reverseButton?.TriggerClick() ?? false;
             }
 
             return base.OnKeyDown(e);
@@ -256,7 +249,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (CanFlipX) addXFlipComponents();
             if (CanFlipY) addYFlipComponents();
             if (CanRotate) addRotationComponents();
-            if (CanReverse) addButton(FontAwesome.Solid.Backward, "Reverse pattern (Ctrl-G)", () => OnReverse?.Invoke());
+            if (CanReverse) reverseButton = addButton(FontAwesome.Solid.Backward, "Reverse pattern (Ctrl-G)", () => OnReverse?.Invoke());
         }
 
         private void addRotationComponents()
@@ -300,7 +293,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             addButton(FontAwesome.Solid.ArrowsAltV, "Flip vertically", () => OnFlip?.Invoke(Direction.Vertical, false));
         }
 
-        private void addButton(IconUsage icon, string tooltip, Action action)
+        private SelectionBoxButton addButton(IconUsage icon, string tooltip, Action action)
         {
             var button = new SelectionBoxButton(icon, tooltip)
             {
@@ -310,6 +303,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             button.OperationStarted += operationStarted;
             button.OperationEnded += operationEnded;
             buttons.Add(button);
+
+            return button;
         }
 
         private void addScaleHandle(Anchor anchor)

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -24,17 +22,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private const float button_padding = 5;
 
-        public Func<float, bool> OnRotation;
-        public Func<Vector2, Anchor, bool> OnScale;
-        public Func<Direction, bool, bool> OnFlip;
-        public Func<bool> OnReverse;
+        public Func<float, bool>? OnRotation;
+        public Func<Vector2, Anchor, bool>? OnScale;
+        public Func<Direction, bool, bool>? OnFlip;
+        public Func<bool>? OnReverse;
 
-        public Action OperationStarted;
-        public Action OperationEnded;
+        public Action? OperationStarted;
+        public Action? OperationEnded;
 
-        private SelectionBoxButton reverseButton;
-        private SelectionBoxButton rotateClockwiseButton;
-        private SelectionBoxButton rotateCounterClockwiseButton;
+        private SelectionBoxButton? reverseButton;
+        private SelectionBoxButton? rotateClockwiseButton;
+        private SelectionBoxButton? rotateCounterClockwiseButton;
 
         private bool canReverse;
 
@@ -138,7 +136,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private string text;
+        private string text = string.Empty;
 
         public string Text
         {
@@ -154,13 +152,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private SelectionBoxDragHandleContainer dragHandles;
-        private FillFlowContainer buttons;
+        private SelectionBoxDragHandleContainer dragHandles = null!;
+        private FillFlowContainer buttons = null!;
 
-        private OsuSpriteText selectionDetailsText;
+        private OsuSpriteText? selectionDetailsText;
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load() => recreate();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -171,13 +171,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Key)
             {
                 case Key.G:
-                    return reverseButton?.TriggerClick() ?? false;
+                    return reverseButton?.TriggerClick() == true;
 
                 case Key.Comma:
-                    return rotateCounterClockwiseButton?.TriggerClick() ?? false;
+                    return rotateCounterClockwiseButton?.TriggerClick() == true;
 
                 case Key.Period:
-                    return rotateClockwiseButton?.TriggerClick() ?? false;
+                    return rotateClockwiseButton?.TriggerClick() == true;
             }
 
             return base.OnKeyDown(e);

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -17,11 +15,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 {
     public sealed partial class SelectionBoxButton : SelectionBoxControl, IHasTooltip
     {
-        private SpriteIcon icon;
+        private SpriteIcon icon = null!;
 
         private readonly IconUsage iconUsage;
 
-        public Action Action;
+        public Action? Action;
 
         public SelectionBoxButton(IconUsage iconUsage, string tooltip)
         {
@@ -49,6 +47,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnClick(ClickEvent e)
         {
+            Circle.FlashColour(Colours.GrayF, 300);
+
             TriggerOperationStarted();
             Action?.Invoke();
             TriggerOperationEnded();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxControl.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public event Action OperationStarted;
         public event Action OperationEnded;
 
-        private Circle circle;
+        protected Circle Circle { get; private set; }
 
         /// <summary>
         /// Whether the user is currently holding the control with mouse.
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             InternalChildren = new Drawable[]
             {
-                circle = new Circle
+                Circle = new Circle
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
@@ -85,9 +85,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected virtual void UpdateHoverState()
         {
             if (IsHeld)
-                circle.FadeColour(Colours.GrayF, TRANSFORM_DURATION, Easing.OutQuint);
+                Circle.FadeColour(Colours.GrayF, TRANSFORM_DURATION, Easing.OutQuint);
             else
-                circle.FadeColour(IsHovered ? Colours.Red : Colours.YellowDark, TRANSFORM_DURATION, Easing.OutQuint);
+                Circle.FadeColour(IsHovered ? Colours.Red : Colours.YellowDark, TRANSFORM_DURATION, Easing.OutQuint);
 
             this.ScaleTo(IsHeld || IsHovered ? 1.5f : 1, TRANSFORM_DURATION, Easing.OutQuint);
         }


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/discussions/24048.

I've also added a visual effect when hotkeys are used to trigger the buttons for better visibility.

https://github.com/ppy/osu/assets/191335/7340a4c6-18b2-4b2f-9e9c-890e12a69ed0

