### PR TITLE
Fix delete difficulty flow not actually deleting the difficulty from realm

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultyDelete.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultyDelete.cs
@@ -72,9 +72,13 @@ namespace osu.Game.Tests.Visual.Editing
                     AddUntilStep("wait for dialog", () => DialogOverlay.CurrentDialog != null);
                     AddStep("confirm", () => InputManager.Key(Key.Number1));
 
-                    AddAssert($"difficulty {i} is deleted", () => Beatmap.Value.BeatmapSetInfo.Beatmaps.Select(b => b.ID), () => Does.Not.Contain(deletedDifficultyID));
-                    AddAssert("count decreased by one", () => Beatmap.Value.BeatmapSetInfo.Beatmaps.Count, () => Is.EqualTo(countBeforeDeletion - 1));
+                    AddAssert($"difficulty {i} is unattached from set",
+                        () => Beatmap.Value.BeatmapSetInfo.Beatmaps.Select(b => b.ID), () => Does.Not.Contain(deletedDifficultyID));
+                    AddAssert("beatmap set difficulty count decreased by one",
+                        () => Beatmap.Value.BeatmapSetInfo.Beatmaps.Count, () => Is.EqualTo(countBeforeDeletion - 1));
                     AddAssert("set hash changed", () => Beatmap.Value.BeatmapSetInfo.Hash, () => Is.Not.EqualTo(beatmapSetHashBefore));
+                    AddAssert($"difficulty {i} is deleted from realm",
+                        () => Realm.Run(r => r.Find<BeatmapInfo>(deletedDifficultyID)), () => Is.Null);
                 }
             }
         }

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -339,6 +339,8 @@ namespace osu.Game.Beatmaps
 
                 DeleteFile(setInfo, beatmapInfo.File);
                 setInfo.Beatmaps.Remove(beatmapInfo);
+                r.Remove(beatmapInfo.Metadata);
+                r.Remove(beatmapInfo);
 
                 updateHashAndMarkDirty(setInfo);
                 workingBeatmapCache.Invalidate(setInfo);


### PR DESCRIPTION
As alluded to in https://github.com/ppy/osu/pull/24060#discussion_r1244151161

Mind you, as stated there, I don't really see how this can be related to the corruption users are seeing in https://github.com/ppy/osu/issues/24034 et al., but it is one possible case wherein a beatmap could get detached from its set in realm.