### PR TITLE
Trigger state change when flipping via hotkey in the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -134,6 +134,32 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestGlobalFlipHotkeys()
+        {
+            HitCircle addedObject = null;
+
+            AddStep("add hitobjects", () => EditorBeatmap.Add(addedObject = new HitCircle { StartTime = 100 }));
+
+            AddStep("select objects", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+
+            AddStep("flip horizontally across playfield", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.H);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("objects flipped horizontally", () => addedObject.Position == new Vector2(OsuPlayfield.BASE_SIZE.X, 0));
+
+            AddStep("flip vertically across playfield", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.J);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("objects flipped vertically", () => addedObject.Position == OsuPlayfield.BASE_SIZE);
+        }
+
+        [Test]
         public void TestBasicSelect()
         {
             var addedObject = new HitCircle { StartTime = 100 };

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -160,21 +160,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (e.Repeat)
                 return false;
 
+            bool handled;
+
             switch (e.Action)
             {
                 case GlobalAction.EditorFlipHorizontally:
                     ChangeHandler?.BeginChange();
-                    HandleFlip(Direction.Horizontal, true);
+                    handled = HandleFlip(Direction.Horizontal, true);
                     ChangeHandler?.EndChange();
 
-                    return true;
+                    return handled;
 
                 case GlobalAction.EditorFlipVertically:
                     ChangeHandler?.BeginChange();
-                    HandleFlip(Direction.Vertical, true);
+                    handled = HandleFlip(Direction.Vertical, true);
                     ChangeHandler?.EndChange();
 
-                    return true;
+                    return handled;
             }
 
             return false;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -163,10 +163,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Action)
             {
                 case GlobalAction.EditorFlipHorizontally:
-                    return HandleFlip(Direction.Horizontal, true);
+                    ChangeHandler?.BeginChange();
+                    HandleFlip(Direction.Horizontal, true);
+                    ChangeHandler?.EndChange();
+
+                    return true;
 
                 case GlobalAction.EditorFlipVertically:
-                    return HandleFlip(Direction.Vertical, true);
+                    ChangeHandler?.BeginChange();
+                    HandleFlip(Direction.Vertical, true);
+                    ChangeHandler?.EndChange();
+
+                    return true;
             }
 
             return false;


### PR DESCRIPTION
This will trigger a change even if nothing happens. But I think that's okay (not easy to avoid) because the change handler should be aware that nothing changed, if anything.

Closes https://github.com/ppy/osu/issues/24065.

I tested this, but I couldn't actually make the hotkeys flip. The code is definitely running so maybe I'm just missing something about the expectations of these origin-based-flips? Or something else is broken unrelated to this PR.