### PR TITLE
Add handling of "unknown" beatmap availability in multiplayer flow

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -107,6 +107,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestBeatmapDownloadingStates()
         {
+            AddStep("set to unknown", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Unknown()));
             AddStep("set to no map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.NotDownloaded()));
             AddStep("set to downloading map", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.Downloading(0)));
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerParticipantsList.cs
@@ -383,6 +383,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for list to load", () => participantsList?.IsLoaded == true);
+
+            AddStep("set beatmap available", () => MultiplayerClient.ChangeBeatmapAvailability(BeatmapAvailability.LocallyAvailable()));
         }
 
         private void checkProgressBarVisibility(bool visible) =>

--- a/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerRoomUser.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Online.Multiplayer
         /// The availability state of the current beatmap.
         /// </summary>
         [Key(2)]
-        public BeatmapAvailability BeatmapAvailability { get; set; } = BeatmapAvailability.LocallyAvailable();
+        public BeatmapAvailability BeatmapAvailability { get; set; } = BeatmapAvailability.Unknown();
 
         /// <summary>
         /// Any mods applicable only to the local user.

--- a/osu.Game/Online/Rooms/BeatmapAvailability.cs
+++ b/osu.Game/Online/Rooms/BeatmapAvailability.cs
@@ -34,6 +34,7 @@ namespace osu.Game.Online.Rooms
             DownloadProgress = downloadProgress;
         }
 
+        public static BeatmapAvailability Unknown() => new BeatmapAvailability(DownloadState.Unknown);
         public static BeatmapAvailability NotDownloaded() => new BeatmapAvailability(DownloadState.NotDownloaded);
         public static BeatmapAvailability Downloading(float progress) => new BeatmapAvailability(DownloadState.Downloading, progress);
         public static BeatmapAvailability Importing() => new BeatmapAvailability(DownloadState.Importing);

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -124,6 +124,9 @@ namespace osu.Game.Online.Rooms
             switch (downloadTracker.State.Value)
             {
                 case DownloadState.Unknown:
+                    availability.Value = BeatmapAvailability.Unknown();
+                    break;
+
                 case DownloadState.NotDownloaded:
                     availability.Value = BeatmapAvailability.NotDownloaded();
                     break;

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -60,6 +60,15 @@ namespace osu.Game.Online.Rooms
                 if (item.NewValue == null)
                     return;
 
+                // Initially set to unknown until we have attained a good state.
+                // This has the wanted side effect of forcing a state change when the current playlist
+                // item changes at the server but our local availability doesn't necessarily change
+                // (ie. we have both the previous and next item LocallyAvailable).
+                //
+                // Note that even without this, the server will trigger a state change and things will work.
+                // This is just for safety.
+                availability.Value = BeatmapAvailability.Unknown();
+
                 downloadTracker?.RemoveAndDisposeImmediately();
                 selectedBeatmap = null;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -313,16 +313,26 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             client.ChangeBeatmapAvailability(availability.NewValue).FireAndForget();
 
-            if (availability.NewValue.State != DownloadState.LocallyAvailable)
+            switch (availability.NewValue.State)
             {
-                // while this flow is handled server-side, this covers the edge case of the local user being in a ready state and then deleting the current beatmap.
-                if (client.LocalUser?.State == MultiplayerUserState.Ready)
-                    client.ChangeState(MultiplayerUserState.Idle);
-            }
-            else if (client.LocalUser?.State == MultiplayerUserState.Spectating
-                     && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
-            {
-                onLoadRequested();
+                case DownloadState.LocallyAvailable:
+                    if (client.LocalUser?.State == MultiplayerUserState.Spectating
+                        && (client.Room?.State == MultiplayerRoomState.WaitingForLoad || client.Room?.State == MultiplayerRoomState.Playing))
+                    {
+                        onLoadRequested();
+                    }
+
+                    break;
+
+                case DownloadState.Unknown:
+                    // Don't do anything rash in an unknown state.
+                    break;
+
+                default:
+                    // while this flow is handled server-side, this covers the edge case of the local user being in a ready state and then deleting the current beatmap.
+                    if (client.LocalUser?.State == MultiplayerUserState.Ready)
+                        client.ChangeState(MultiplayerUserState.Idle);
+                    break;
             }
         }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -154,6 +154,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     this.FadeOut(fade_time);
                     break;
 
+                case DownloadState.Unknown:
+                    text.Text = "checking availability";
+                    icon.Icon = FontAwesome.Solid.Question;
+                    icon.Colour = colours.Orange0;
+                    break;
+
                 case DownloadState.NotDownloaded:
                     text.Text = "no map";
                     icon.Icon = FontAwesome.Solid.MinusCircle;


### PR DESCRIPTION
This is a prerequisite for the flow being introduced in https://github.com/ppy/osu-server-spectator/pull/170.

Until now, the server was not resetting beatmap availability when the current beatmap changes. The clients would be left to update their state at their own accord. This was roughly okay, hinging on the fact that the client would not allow a user to enter the ready state unless they have the beatmap available (and the server *was* resetting ready states on beatmap change), but as we are now going to allow idle players to participate in gameplay, this needs to change.

Unknown state is exposed in the UI like this:

![osu Game Tests 2023-06-28 at 07 05 46](https://github.com/ppy/osu/assets/191335/cd9e2ace-a8ff-42b1-b07d-bf6c9aea98b7)

Here's what things look like with the server side flow implemented (with an induced delay to show the state changes):

https://github.com/ppy/osu/assets/191335/c9274c2d-8ddc-4e06-918c-d2534a7535e3

