### PR TITLE
Reattach any orphaned scores when a beatmap is imported

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -423,6 +423,7 @@ namespace osu.Game.Tests.Database
             RunTestWithRealmAsync(async (realm, storage) =>
             {
                 var importer = new BeatmapImporter(storage, realm);
+                using var store = new RealmRulesetStore(realm, storage);
 
                 string? temp = TestResources.GetTestBeatmapForImport();
 

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -18,6 +18,7 @@ using osu.Game.Extensions;
 using osu.Game.Models;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
+using osu.Game.Scoring;
 using osu.Game.Tests.Resources;
 using Realms;
 using SharpCompress.Archives;
@@ -413,6 +414,51 @@ namespace osu.Game.Tests.Database
                 {
                     Directory.Delete(extractedFolder, true);
                 }
+            });
+        }
+
+        [Test]
+        public void TestImport_ThenChangeMapWithScore_ThenImport()
+        {
+            RunTestWithRealmAsync(async (realm, storage) =>
+            {
+                var importer = new BeatmapImporter(storage, realm);
+
+                string? temp = TestResources.GetTestBeatmapForImport();
+
+                var imported = await LoadOszIntoStore(importer, realm.Realm);
+
+                await createScoreForBeatmap(realm.Realm, imported.Beatmaps.First());
+
+                //editor work imitation
+                realm.Run(r =>
+                {
+                    r.Write(() =>
+                    {
+                        BeatmapInfo beatmap = imported.Beatmaps.First();
+                        beatmap.Hash = "new_hash";
+                        beatmap.ResetOnlineInfo();
+                    });
+                });
+
+                Assert.That(imported.Beatmaps.First().Scores.Any());
+
+                var importedSecondTime = await importer.Import(new ImportTask(temp));
+
+                EnsureLoaded(realm.Realm);
+
+                // check the newly "imported" beatmap is not the original.
+                Assert.NotNull(importedSecondTime);
+                Debug.Assert(importedSecondTime != null);
+                Assert.That(imported.ID != importedSecondTime.ID);
+
+                var importedFirstTimeBeatmap = imported.Beatmaps.First();
+                var importedSecondTimeBeatmap = importedSecondTime.PerformRead(s => s.Beatmaps.First());
+
+                Assert.That(importedFirstTimeBeatmap.ID != importedSecondTimeBeatmap.ID);
+                Assert.That(importedFirstTimeBeatmap.Hash != importedSecondTimeBeatmap.Hash);
+                Assert.That(!importedFirstTimeBeatmap.Scores.Any());
+                Assert.That(importedSecondTimeBeatmap.Scores.Count() == 1);
             });
         }
 
@@ -1074,18 +1120,16 @@ namespace osu.Game.Tests.Database
             Assert.IsTrue(realm.All<BeatmapSetInfo>().First(_ => true).DeletePending);
         }
 
-        private static Task createScoreForBeatmap(Realm realm, BeatmapInfo beatmap)
-        {
-            // TODO: reimplement when we have score support in realm.
-            // return ImportScoreTest.LoadScoreIntoOsu(osu, new ScoreInfo
-            // {
-            //     OnlineID = 2,
-            //     Beatmap = beatmap,
-            //     BeatmapInfoID = beatmap.ID
-            // }, new ImportScoreTest.TestArchiveReader());
-
-            return Task.CompletedTask;
-        }
+        private static Task createScoreForBeatmap(Realm realm, BeatmapInfo beatmap) =>
+            realm.WriteAsync(() =>
+            {
+                realm.Add(new ScoreInfo
+                {
+                    OnlineID = 2,
+                    BeatmapInfo = beatmap,
+                    BeatmapHash = beatmap.Hash
+                });
+            });
 
         private static void checkBeatmapSetCount(Realm realm, int expected, bool includeDeletePending = false)
         {

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -432,14 +432,12 @@ namespace osu.Game.Tests.Database
                 await createScoreForBeatmap(realm.Realm, imported.Beatmaps.First());
 
                 // imitate making local changes via editor
-                realm.Run(r =>
+                // ReSharper disable once MethodHasAsyncOverload
+                realm.Write(_ =>
                 {
-                    r.Write(() =>
-                    {
-                        BeatmapInfo beatmap = imported.Beatmaps.First();
-                        beatmap.Hash = "new_hash";
-                        beatmap.ResetOnlineInfo();
-                    });
+                    BeatmapInfo beatmap = imported.Beatmaps.First();
+                    beatmap.Hash = "new_hash";
+                    beatmap.ResetOnlineInfo();
                 });
 
                 // for now, making changes to a beatmap doesn't remove the backlink from the score to the beatmap.

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -431,7 +431,7 @@ namespace osu.Game.Tests.Database
 
                 await createScoreForBeatmap(realm.Realm, imported.Beatmaps.First());
 
-                //editor work imitation
+                // imitate making local changes via editor
                 realm.Run(r =>
                 {
                     r.Write(() =>
@@ -442,6 +442,9 @@ namespace osu.Game.Tests.Database
                     });
                 });
 
+                // for now, making changes to a beatmap doesn't remove the backlink from the score to the beatmap.
+                // the logic of ensuring that scores match the beatmap is upheld via comparing the hash in usages (see: https://github.com/ppy/osu/pull/22539).
+                // TODO: revisit when fixing https://github.com/ppy/osu/issues/24069.
                 Assert.That(imported.Beatmaps.First().Scores.Any());
 
                 var importedSecondTime = await importer.Import(new ImportTask(temp));

--- a/osu.Game.Tests/Database/BeatmapImporterTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterTests.cs
@@ -418,7 +418,7 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
-        public void TestImport_ThenChangeMapWithScore_ThenImport()
+        public void TestImport_ThenModifyMapWithScore_ThenImport()
         {
             RunTestWithRealmAsync(async (realm, storage) =>
             {

--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -348,7 +348,7 @@ namespace osu.Game.Tests.Database
         }
 
         [Test]
-        public void TestDandlingScoreTransferred()
+        public void TestDanglingScoreTransferred()
         {
             RunTestWithRealmAsync(async (realm, storage) =>
             {

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Beatmaps
         {
             base.PostImport(model, realm, parameters);
 
-            // Scores are stored separately from beatmaps, and persisted when a beatmap is modified or deleted.
+            // Scores are stored separately from beatmaps, and persist even when a beatmap is modified or deleted.
             // Let's reattach any matching scores that exist in the database, based on hash.
             foreach (BeatmapInfo beatmap in model.Beatmaps)
             {

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -201,7 +201,7 @@ namespace osu.Game.Beatmaps
                 }
             }
 
-            //Because of specific score storing in Osu! database can already contain scores for imported beatmap.
+            //Because of specific score storing in Osu! database, it can already contain scores for imported beatmap.
             //To restore scores we need to manually reassign them to new/re-exported beatmap.
             foreach (BeatmapInfo beatmap in beatmapSet.Beatmaps)
             {

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -200,21 +200,22 @@ namespace osu.Game.Beatmaps
                     LogForModel(beatmapSet, $"Found existing beatmap set with same OnlineID ({beatmapSet.OnlineID}). It will be disassociated and marked for deletion.");
                 }
             }
+        }
+
+        protected override void PostImport(BeatmapSetInfo model, Realm realm, ImportParameters parameters)
+        {
+            base.PostImport(model, realm, parameters);
 
             //Because of specific score storing in Osu! database, it can already contain scores for imported beatmap.
             //To restore scores we need to manually reassign them to new/re-exported beatmap.
-            foreach (BeatmapInfo beatmap in beatmapSet.Beatmaps)
+            foreach (BeatmapInfo beatmap in model.Beatmaps)
             {
                 IQueryable<ScoreInfo> scores = realm.All<ScoreInfo>().Where(score => score.BeatmapHash == beatmap.Hash);
 
                 if (scores.Any())
                     scores.ForEach(score => score.BeatmapInfo = beatmap); //We intentionally ignore BeatmapHash because we checked hash equality
             }
-        }
 
-        protected override void PostImport(BeatmapSetInfo model, Realm realm, ImportParameters parameters)
-        {
-            base.PostImport(model, realm, parameters);
             ProcessBeatmap?.Invoke(model, parameters.Batch ? MetadataLookupScope.LocalCacheFirst : MetadataLookupScope.OnlineFirst);
         }
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Scoring
         {
             Ruleset = ruleset ?? new RulesetInfo();
             BeatmapInfo = beatmap ?? new BeatmapInfo();
+            BeatmapHash = BeatmapInfo.Hash;
             RealmUser = realmUser ?? new RealmUser();
             ID = Guid.NewGuid();
         }


### PR DESCRIPTION
I saw [discussion](https://github.com/ppy/osu/discussions/24047) about scores not being restored after beatmap re-installation. This shouldn't be the case as scores are still persist in database but don't re-assign to newly imported beatmap. This PR fixes it.
Showcase:

https://github.com/ppy/osu/assets/50776304/7efab42a-e034-476f-b666-49ba85e13f58
