### PR TITLE
Move all remaining osu!taiko sample playback logic out of `DrawableHitObject`s

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -72,13 +72,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
             seekTo(200);
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
         }
 
         [Test]
@@ -100,13 +100,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
 
             seekTo(200);
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
         }
 
         [Test]
@@ -145,23 +145,23 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is first hit", () => triggerSource.GetMostValidObject(), () => Is.EqualTo(first));
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_NORMAL);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_NORMAL);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_NORMAL);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_NORMAL);
 
             seekTo(120);
             AddAssert("most valid object is first hit", () => triggerSource.GetMostValidObject(), () => Is.EqualTo(first));
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_NORMAL);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_NORMAL);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_NORMAL);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_NORMAL);
 
             seekTo(480);
             AddAssert("most valid object is second hit", () => triggerSource.GetMostValidObject(), () => Is.EqualTo(second));
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
 
             seekTo(700);
             AddAssert("most valid object is second hit", () => triggerSource.GetMostValidObject(), () => Is.EqualTo(second));
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
         }
 
         [Test]
@@ -174,8 +174,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     StartTime = 100,
                     Samples = new List<HitSampleInfo>
                     {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum"),
-                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, "drum") // implies strong
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM),
+                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, HitSampleInfo.BANK_DRUM) // implies strong
                     }
                 };
                 hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
@@ -184,13 +184,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is nested strong hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit.StrongNestedHit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, $"{HitSampleInfo.HIT_NORMAL},{HitSampleInfo.HIT_FINISH}", HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, $"{HitSampleInfo.HIT_CLAP},{HitSampleInfo.HIT_WHISTLE}", HitSampleInfo.BANK_DRUM);
 
             seekTo(200);
             AddAssert("most valid object is hit", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Hit>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, $"{HitSampleInfo.HIT_NORMAL},{HitSampleInfo.HIT_FINISH}", HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, $"{HitSampleInfo.HIT_CLAP},{HitSampleInfo.HIT_WHISTLE}", HitSampleInfo.BANK_DRUM);
         }
 
         [Test]
@@ -213,18 +213,18 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
             seekTo(600);
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
             seekTo(1200);
             AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
         }
 
         [Test]
@@ -247,18 +247,18 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
 
             seekTo(600);
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
 
             seekTo(1200);
             AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT);
         }
 
         [Test]
@@ -272,8 +272,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     EndTime = 1100,
                     Samples = new List<HitSampleInfo>
                     {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum"),
-                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, "drum") // implies strong
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM),
+                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, HitSampleInfo.BANK_DRUM) // implies strong
                     }
                 };
                 drumRoll.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
@@ -282,18 +282,18 @@ namespace osu.Game.Rulesets.Taiko.Tests
             });
 
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, $"{HitSampleInfo.HIT_NORMAL},{HitSampleInfo.HIT_FINISH}", HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, $"{HitSampleInfo.HIT_CLAP},{HitSampleInfo.HIT_WHISTLE}", HitSampleInfo.BANK_DRUM);
 
             seekTo(600);
             AddAssert("most valid object is drum roll tick", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRollTick>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, $"{HitSampleInfo.HIT_NORMAL},{HitSampleInfo.HIT_FINISH}", HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, $"{HitSampleInfo.HIT_CLAP},{HitSampleInfo.HIT_WHISTLE}", HitSampleInfo.BANK_DRUM);
 
             seekTo(1200);
             AddAssert("most valid object is drum roll", () => triggerSource.GetMostValidObject(), Is.InstanceOf<DrumRoll>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, $"{HitSampleInfo.HIT_NORMAL},{HitSampleInfo.HIT_FINISH}", HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, $"{HitSampleInfo.HIT_CLAP},{HitSampleInfo.HIT_WHISTLE}", HitSampleInfo.BANK_DRUM);
         }
 
         [Test]
@@ -319,18 +319,18 @@ namespace osu.Game.Rulesets.Taiko.Tests
             // This works fine in gameplay because they are judged whenever the user pressed, rather than being timed hits.
             // But for sample playback purposes they can be ignored as noise.
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
             seekTo(600);
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
 
             seekTo(1200);
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, SampleControlPoint.DEFAULT_BANK);
         }
 
         [Test]
@@ -344,7 +344,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     EndTime = 1100,
                     Samples = new List<HitSampleInfo>
                     {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, "drum")
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM)
                     }
                 };
                 swell.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
@@ -356,25 +356,26 @@ namespace osu.Game.Rulesets.Taiko.Tests
             // This works fine in gameplay because they are judged whenever the user pressed, rather than being timed hits.
             // But for sample playback purposes they can be ignored as noise.
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_DRUM);
 
             seekTo(600);
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_DRUM);
 
             seekTo(1200);
             AddAssert("most valid object is swell", () => triggerSource.GetMostValidObject(), Is.InstanceOf<Swell>);
-            checkSound(HitType.Centre, HitSampleInfo.HIT_NORMAL, "drum");
-            checkSound(HitType.Rim, HitSampleInfo.HIT_CLAP, "drum");
+            checkSamples(HitType.Centre, HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM);
+            checkSamples(HitType.Rim, HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_DRUM);
         }
 
-        private void checkSound(HitType hitType, string expectedName, string expectedBank)
+        private void checkSamples(HitType hitType, string expectedSamplesCsv, string expectedBank)
         {
             AddStep($"hit {hitType}", () => triggerSource.Play(hitType));
-            AddAssert($"last played sample is {expectedName}", () => triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().Single().Name, () => Is.EqualTo(expectedName));
-            AddAssert($"last played sample has {expectedBank} bank", () => triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().Single().Bank, () => Is.EqualTo(expectedBank));
+            AddAssert($"last played sample is {expectedSamplesCsv}", () => string.Join(',', triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().Select(s => s.Name)),
+                () => Is.EqualTo(expectedSamplesCsv));
+            AddAssert($"last played sample has {expectedBank} bank", () => triggerSource.LastPlayedSamples!.OfType<HitSampleInfo>().First().Bank, () => Is.EqualTo(expectedBank));
         }
 
         private void seekTo(double time) => AddStep($"seek to {time}", () => gameplayClock.Seek(time));

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneSampleOutput.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneSampleOutput.cs
@@ -3,15 +3,16 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Testing;
-using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.UI;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
     /// <summary>
-    /// Taiko has some interesting rules for legacy mappings.
+    /// Taiko doesn't output any samples. They are all handled externally by <see cref="DrumSamplePlayer"/>.
     /// </summary>
     [HeadlessTest]
     public partial class TestSceneSampleOutput : TestSceneTaikoPlayer
@@ -26,10 +27,10 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 string.Empty,
                 string.Empty,
                 string.Empty,
-                HitSampleInfo.HIT_FINISH,
-                HitSampleInfo.HIT_WHISTLE,
-                HitSampleInfo.HIT_WHISTLE,
-                HitSampleInfo.HIT_WHISTLE,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
             };
 
             var actualSampleNames = new List<string>();
@@ -46,7 +47,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             AddUntilStep("all samples collected", () => actualSampleNames.Count == expectedSampleNames.Length);
 
-            AddAssert("samples are correct", () => actualSampleNames.SequenceEqual(expectedSampleNames));
+            AddAssert("samples are correct", () => actualSampleNames, () => Is.EqualTo(expectedSampleNames));
         }
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TaikoBeatmapConversionTest().GetBeatmap("sample-to-type-conversions");

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -4,14 +4,12 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
-using osu.Game.Audio;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -92,40 +90,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         protected override SkinnableDrawable CreateMainPiece() => HitObject.Type == HitType.Centre
             ? new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.CentreHit), _ => new CentreHitCirclePiece(), confineMode: ConfineMode.ScaleToFit)
             : new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.RimHit), _ => new RimHitCirclePiece(), confineMode: ConfineMode.ScaleToFit);
-
-        public override IEnumerable<HitSampleInfo> GetSamples()
-        {
-            // normal and claps are always handled by the drum (see DrumSampleMapping).
-            // in addition, whistles are excluded as they are an alternative rim marker.
-
-            var samples = HitObject.Samples.Where(s =>
-                s.Name != HitSampleInfo.HIT_NORMAL
-                && s.Name != HitSampleInfo.HIT_CLAP
-                && s.Name != HitSampleInfo.HIT_WHISTLE);
-
-            if (HitObject.Type == HitType.Rim && HitObject.IsStrong)
-            {
-                // strong + rim always maps to whistle.
-                // TODO: this should really be in the legacy decoder, but can't be because legacy encoding parity would be broken.
-                // when we add a taiko editor, this is probably not going to play nice.
-
-                var corrected = samples.ToList();
-
-                for (int i = 0; i < corrected.Count; i++)
-                {
-                    var s = corrected[i];
-
-                    if (s.Name != HitSampleInfo.HIT_FINISH)
-                        continue;
-
-                    corrected[i] = s.With(HitSampleInfo.HIT_WHISTLE);
-                }
-
-                return corrected;
-            }
-
-            return samples;
-        }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -119,8 +119,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             public override bool RemoveWhenNotAlive => false;
         }
 
-        // Most osu!taiko hitsounds are managed by the drum (see DrumSampleTriggerSource).
-        public override IEnumerable<HitSampleInfo> GetSamples() => Enumerable.Empty<HitSampleInfo>();
+        // osu!taiko hitsounds are managed by the drum (see DrumSampleTriggerSource).
+        public sealed override IEnumerable<HitSampleInfo> GetSamples() => Enumerable.Empty<HitSampleInfo>();
     }
 
     public abstract partial class DrawableTaikoHitObject<TObject> : DrawableTaikoHitObject

--- a/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.UI;
@@ -23,18 +22,20 @@ namespace osu.Game.Rulesets.Taiko.UI
             if (hitObject == null)
                 return;
 
-            List<ISampleInfo> samplesToPlay = new List<ISampleInfo>
-            {
-                hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_CLAP : HitSampleInfo.HIT_NORMAL)
-            };
+            var baseSample = hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_CLAP : HitSampleInfo.HIT_NORMAL);
 
-            // strong + rim always maps to whistle.
             if ((hitObject as TaikoStrongableHitObject)?.IsStrong == true || hitObject is StrongNestedHitObject)
             {
-                samplesToPlay.Add(hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH));
+                PlaySamples(new ISampleInfo[]
+                {
+                    hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH),
+                    baseSample
+                });
             }
-
-            PlaySamples(samplesToPlay.ToArray());
+            else
+            {
+                PlaySamples(new ISampleInfo[] { baseSample });
+            }
         }
 
         public override void Play() => throw new InvalidOperationException(@"Use override with HitType parameter instead");

--- a/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.UI;
@@ -18,12 +18,23 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public void Play(HitType hitType)
         {
-            var hitSample = GetMostValidObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
+            TaikoHitObject? hitObject = GetMostValidObject() as TaikoHitObject;
 
-            if (hitSample == null)
+            if (hitObject == null)
                 return;
 
-            PlaySamples(new ISampleInfo[] { new HitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_CLAP : HitSampleInfo.HIT_NORMAL, hitSample.Bank, volume: hitSample.Volume) });
+            List<ISampleInfo> samplesToPlay = new List<ISampleInfo>
+            {
+                hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_CLAP : HitSampleInfo.HIT_NORMAL)
+            };
+
+            // strong + rim always maps to whistle.
+            if ((hitObject as TaikoStrongableHitObject)?.IsStrong == true)
+            {
+                samplesToPlay.Add(hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH));
+            }
+
+            PlaySamples(samplesToPlay.ToArray());
         }
 
         public override void Play() => throw new InvalidOperationException(@"Use override with HitType parameter instead");

--- a/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             };
 
             // strong + rim always maps to whistle.
-            if ((hitObject as TaikoStrongableHitObject)?.IsStrong == true)
+            if ((hitObject as TaikoStrongableHitObject)?.IsStrong == true || hitObject is StrongNestedHitObject)
             {
                 samplesToPlay.Add(hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH));
             }

--- a/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrumSampleTriggerSource.cs
@@ -28,8 +28,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 PlaySamples(new ISampleInfo[]
                 {
-                    hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH),
-                    baseSample
+                    baseSample,
+                    hitObject.CreateHitSampleInfo(hitType == HitType.Rim ? HitSampleInfo.HIT_WHISTLE : HitSampleInfo.HIT_FINISH)
                 });
             }
             else


### PR DESCRIPTION
Let's bring taiko hitsound playback to a baseline sanity. Rather than doing some convoluted logic in `DrawableHit` just to playback the whistle sample locally, let's do this in the trigger source.

This change ensures that all taiko sample playback is now handled in one central location. This will allow for upcoming changes where skins can take control of this playback and override the default behaviour.