### PR TITLE
Fix edge cases where selection buttons go outside playfield bounds

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -381,6 +381,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 buttons.Anchor = Anchor.BottomCentre;
                 buttons.Origin = Anchor.BottomCentre;
+                buttons.Y = Math.Min(0, ToLocalSpace(Parent.ScreenSpaceDrawQuad.BottomLeft).Y - DrawHeight);
             }
             else if (topExcess > bottomExcess)
             {

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -377,7 +377,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             float leftExcess = thisQuad.TopLeft.X - parentQuad.TopLeft.X;
             float rightExcess = parentQuad.TopRight.X - thisQuad.TopRight.X;
 
-            if (topExcess + bottomExcess < buttons.Height + button_padding)
+            float minHeight = buttons.ScreenSpaceDrawQuad.Height;
+
+            if (topExcess < minHeight && bottomExcess < minHeight)
             {
                 buttons.Anchor = Anchor.BottomCentre;
                 buttons.Origin = Anchor.BottomCentre;


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/23599#discussioncomment-6300885.

Current `master`:

https://github.com/ppy/osu/assets/20418176/e402678e-530c-4e76-bb1a-0171975ee651

This PR:

https://github.com/ppy/osu/assets/20418176/30117922-e491-42d8-9934-b19a9fb5b0a5

Not adding automated testing until requested because it is annoying to do so (behaviour partially depends on window size).