### PR TITLE
Fix fallback for `Judged` to be more correct

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrawableHitObject.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
@@ -80,7 +81,9 @@ namespace osu.Game.Tests.Gameplay
         {
             TestLifetimeEntry entry = null;
             AddStep("Create entry", () => entry = new TestLifetimeEntry(new HitObject()) { LifetimeStart = 1 });
+            assertJudged(() => entry, false);
             AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
+            assertJudged(() => entry, false);
             AddAssert("Lifetime is updated", () => entry.LifetimeStart == -TestLifetimeEntry.INITIAL_LIFETIME_OFFSET);
 
             TestDrawableHitObject dho = null;
@@ -91,6 +94,7 @@ namespace osu.Game.Tests.Gameplay
             });
             AddStep("ApplyDefaults", () => entry.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty()));
             AddAssert("Lifetime is correct", () => dho.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY && entry.LifetimeStart == TestDrawableHitObject.LIFETIME_ON_APPLY);
+            assertJudged(() => entry, false);
         }
 
         [Test]
@@ -139,6 +143,29 @@ namespace osu.Game.Tests.Gameplay
         }
 
         [Test]
+        public void TestJudgedStateThroughLifetime()
+        {
+            TestDrawableHitObject dho = null;
+            HitObjectLifetimeEntry lifetimeEntry = null;
+
+            AddStep("Create lifetime entry", () => lifetimeEntry = new HitObjectLifetimeEntry(new HitObject { StartTime = Time.Current }));
+
+            assertJudged(() => lifetimeEntry, false);
+
+            AddStep("Create DHO and apply entry", () =>
+            {
+                Child = dho = new TestDrawableHitObject();
+                dho.Apply(lifetimeEntry);
+            });
+
+            assertJudged(() => lifetimeEntry, false);
+
+            AddStep("Apply result", () => dho.MissForcefully());
+
+            assertJudged(() => lifetimeEntry, true);
+        }
+
+        [Test]
         public void TestResultSetBeforeLoadComplete()
         {
             TestDrawableHitObject dho = null;
@@ -154,14 +181,19 @@ namespace osu.Game.Tests.Gameplay
                     }
                 };
             });
+            assertJudged(() => lifetimeEntry, true);
             AddStep("Create DHO and apply entry", () =>
             {
                 dho = new TestDrawableHitObject();
                 dho.Apply(lifetimeEntry);
                 Child = dho;
             });
+            assertJudged(() => lifetimeEntry, true);
             AddAssert("DHO state is correct", () => dho.State.Value, () => Is.EqualTo(ArmedState.Hit));
         }
+
+        private void assertJudged(Func<HitObjectLifetimeEntry> entry, bool val) =>
+            AddAssert(val ? "Is judged" : "Not judged", () => entry().Judged, () => Is.EqualTo(val));
 
         private partial class TestDrawableHitObject : DrawableHitObject
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -112,12 +112,12 @@ namespace osu.Game.Rulesets.Objects.Drawables
         /// Whether this <see cref="DrawableHitObject"/> has been judged.
         /// Note: This does NOT include nested hitobjects.
         /// </summary>
-        public bool Judged => Entry?.Judged ?? true;
+        public bool Judged => Entry?.Judged ?? false;
 
         /// <summary>
         /// Whether this <see cref="DrawableHitObject"/> and all of its nested <see cref="DrawableHitObject"/>s have been judged.
         /// </summary>
-        public bool AllJudged => Entry?.AllJudged ?? true;
+        public bool AllJudged => Entry?.AllJudged ?? false;
 
         /// <summary>
         /// The relative X position of this hit object for sample playback balance adjustment.

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Objects
         /// Whether <see cref="HitObject"/> has been judged.
         /// Note: This does NOT include nested hitobjects.
         /// </summary>
-        public bool Judged => Result?.HasResult ?? true;
+        public bool Judged => Result?.HasResult ?? false;
 
         /// <summary>
         /// Whether <see cref="HitObject"/> and all of its nested objects have been judged.


### PR DESCRIPTION
Without this change, when the `Judged` value is checked on an `HitObjectLifetimeEntry` it would return `true` if a `DrawableHitObject` has not yet been associated with the entry. Which is completely wrong.

Of note, the usage in `DrawableHitObject` will have never fallen through to this incorrect value as they always have a result populated:

https://github.com/ppy/osu/blob/f26f001e1d01ca6bb53225da7bf06c0ad21153c5/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs#L721-L726