### PR TITLE
Remember state of replay settings visibility and allow key customisation

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
             SetDefault(OsuSetting.FadePlayfieldWhenHealthLow, true);
             SetDefault(OsuSetting.KeyOverlay, false);
+            SetDefault(OsuSetting.ReplaySettingsOverlay, true);
             SetDefault(OsuSetting.GameplayLeaderboard, true);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
@@ -382,6 +383,7 @@ namespace osu.Game.Configuration
         SafeAreaConsiderations,
         ComboColourNormalisationAmount,
         ProfileCoverExpanded,
-        EditorLimitedDistanceSnap
+        EditorLimitedDistanceSnap,
+        ReplaySettingsOverlay
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -116,6 +116,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.DecreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Shift, InputKey.Tab }, GlobalAction.ToggleInGameInterface),
+            new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
             new KeyBinding(InputKey.Tab, GlobalAction.ToggleChatFocus),
@@ -374,5 +375,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ExportReplay))]
         ExportReplay,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleReplaySettings))]
+        ToggleReplaySettings,
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -116,7 +116,6 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.DecreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Shift, InputKey.Tab }, GlobalAction.ToggleInGameInterface),
-            new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
             new KeyBinding(InputKey.Tab, GlobalAction.ToggleChatFocus),
@@ -130,6 +129,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.TogglePauseReplay),
             new KeyBinding(InputKey.Left, GlobalAction.SeekReplayBackward),
             new KeyBinding(InputKey.Right, GlobalAction.SeekReplayForward),
+            new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
         };
 
         public IEnumerable<KeyBinding> SongSelectKeyBindings => new[]

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -65,9 +65,14 @@ namespace osu.Game.Localisation
         public static LocalisableString HUDVisibilityMode => new TranslatableString(getKey(@"hud_visibility_mode"), @"HUD overlay visibility mode");
 
         /// <summary>
-        /// "Show health display even when you can't fail"
+        /// "Show health display even when you can&#39;t fail"
         /// </summary>
         public static LocalisableString ShowHealthDisplayWhenCantFail => new TranslatableString(getKey(@"show_health_display_when_cant_fail"), @"Show health display even when you can't fail");
+
+        /// <summary>
+        /// "Show replay settings overlay"
+        /// </summary>
+        public static LocalisableString ShowReplaySettingsOverlay => new TranslatableString(getKey(@"show_replay_settings_overlay"), @"Show replay settings overlay");
 
         /// <summary>
         /// "Fade playfield to red when health is low"
@@ -134,6 +139,6 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ClassicScoreDisplay => new TranslatableString(getKey(@"classic_score_display"), @"Classic");
 
-        private static string getKey(string key) => $"{prefix}:{key}";
+        private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -325,6 +325,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ToggleChatFocus => new TranslatableString(getKey(@"toggle_chat_focus"), @"Toggle chat focus");
 
         /// <summary>
+        /// "Toggle replay settings"
+        /// </summary>
+        public static LocalisableString ToggleReplaySettings => new TranslatableString(getKey(@"toggle_replay_settings"), @"Toggle replay settings");
+
+        /// <summary>
         /// "Save replay"
         /// </summary>
         public static LocalisableString SaveReplay => new TranslatableString(getKey(@"save_replay"), @"Save replay");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -25,10 +25,9 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
-                    ClassicDefault = false,
-                    LabelText = GameplaySettingsStrings.ShowHealthDisplayWhenCantFail,
-                    Current = config.GetBindable<bool>(OsuSetting.ShowHealthDisplayWhenCantFail),
-                    Keywords = new[] { "hp", "bar" }
+                    LabelText = GameplaySettingsStrings.ShowReplaySettingsOverlay,
+                    Current = config.GetBindable<bool>(OsuSetting.ReplaySettingsOverlay),
+                    Keywords = new[] { "hide" },
                 },
                 new SettingsCheckbox
                 {
@@ -40,6 +39,13 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     LabelText = GameplaySettingsStrings.AlwaysShowGameplayLeaderboard,
                     Current = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard),
+                },
+                new SettingsCheckbox
+                {
+                    ClassicDefault = false,
+                    LabelText = GameplaySettingsStrings.ShowHealthDisplayWhenCantFail,
+                    Current = config.GetBindable<bool>(OsuSetting.ShowHealthDisplayWhenCantFail),
+                    Keywords = new[] { "hp", "bar" }
                 },
             };
         }

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Screens.Play.HUD
                 Spacing = new Vector2(0, 20),
                 Children = new PlayerSettingsGroup[]
                 {
-                    //CollectionSettings = new CollectionSettings(),
-                    //DiscussionSettings = new DiscussionSettings(),
                     PlaybackSettings = new PlaybackSettings { Expanded = { Value = false } },
                     VisualSettings = new VisualSettings { Expanded = { Value = false } },
                     new AudioSettings { Expanded = { Value = false } }

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -3,10 +3,8 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input.Events;
 using osuTK;
 using osu.Game.Screens.Play.PlayerSettings;
-using osuTK.Input;
 
 namespace osu.Game.Screens.Play.HUD
 {
@@ -14,16 +12,12 @@ namespace osu.Game.Screens.Play.HUD
     {
         private const int fade_duration = 200;
 
-        public bool ReplayLoaded;
-
         public readonly PlaybackSettings PlaybackSettings;
 
         public readonly VisualSettings VisualSettings;
 
         public PlayerSettingsOverlay()
         {
-            AlwaysPresent = true;
-
             Anchor = Anchor.TopRight;
             Origin = Anchor.TopRight;
             AutoSizeAxes = Axes.Both;
@@ -46,24 +40,5 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override void PopIn() => this.FadeIn(fade_duration);
         protected override void PopOut() => this.FadeOut(fade_duration);
-
-        // We want to handle keyboard inputs all the time in order to trigger ToggleVisibility() when not visible
-        public override bool PropagateNonPositionalInputSubTree => true;
-
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.Repeat) return false;
-
-            if (e.ControlPressed)
-            {
-                if (e.Key == Key.H && ReplayLoaded)
-                {
-                    ToggleVisibility();
-                    return true;
-                }
-            }
-
-            return base.OnKeyDown(e);
-        }
     }
 }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -357,6 +357,10 @@ namespace osu.Game.Screens.Play
 
             switch (e.Action)
             {
+                case GlobalAction.ToggleReplaySettings:
+                    configSettingsOverlay.Value = !configSettingsOverlay.Value;
+                    return true;
+
                 case GlobalAction.HoldForHUD:
                     holdingForHUD.Value = true;
                     return true;

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -28,7 +28,6 @@ using osu.Game.Screens.Play.HUD.ClicksPerSecond;
 using osu.Game.Screens.Play.HUD.JudgementCounter;
 using osu.Game.Skinning;
 using osuTK;
-using MarginPadding = osu.Framework.Graphics.MarginPadding;
 
 namespace osu.Game.Screens.Play
 {


### PR DESCRIPTION
Ctrl+H could already be used to hide the replay settings overlay, but you'd have to reapply it each time. Now the state is persisted, exposed in settings, and the key is customisable should you ever want to change it.