### PR TITLE
Bring realm library up-to-date

### DIFF
--- a/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
+++ b/osu.Game.Tests/Beatmaps/WorkingBeatmapManagerTest.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestCachedRetrievalWithFiles() => AddStep("run test", () =>
         {
-            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID).Detach());
+            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID)!.Detach());
 
             Assert.That(beatmap.BeatmapSet?.Files, Has.Count.GreaterThan(0));
 
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestForcedRefetchRetrievalWithFiles() => AddStep("run test", () =>
         {
-            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID).Detach());
+            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID)!.Detach());
 
             Assert.That(beatmap.BeatmapSet?.Files, Has.Count.GreaterThan(0));
 
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Beatmaps
         [Test]
         public void TestSavePreservesCollections() => AddStep("run test", () =>
         {
-            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID).Detach());
+            var beatmap = Realm.Run(r => r.Find<BeatmapInfo>(importedSet.Beatmaps.First().ID)!.Detach());
 
             var working = beatmaps.GetWorkingBeatmap(beatmap);
 

--- a/osu.Game.Tests/Database/BackgroundBeatmapProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundBeatmapProcessorTests.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tests.Database
             {
                 return Realm.Run(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
                 });
             });
@@ -51,7 +51,7 @@ namespace osu.Game.Tests.Database
             {
                 Realm.Write(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     foreach (var b in beatmapSetInfo.Beatmaps)
                         b.StarRating = -1;
                 });
@@ -66,7 +66,7 @@ namespace osu.Game.Tests.Database
             {
                 return Realm.Run(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
                 });
             });
@@ -79,7 +79,7 @@ namespace osu.Game.Tests.Database
             {
                 return Realm.Run(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
                 });
             });
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Database
             {
                 Realm.Write(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     foreach (var b in beatmapSetInfo.Beatmaps)
                         b.StarRating = -1;
                 });
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Database
             {
                 return Realm.Run(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     return beatmapSetInfo.Beatmaps.All(b => b.StarRating == -1);
                 });
             });
@@ -118,7 +118,7 @@ namespace osu.Game.Tests.Database
             {
                 return Realm.Run(r =>
                 {
-                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID);
+                    var beatmapSetInfo = r.Find<BeatmapSetInfo>(importedSet.ID)!;
                     return beatmapSetInfo.Beatmaps.All(b => b.StarRating > 0);
                 });
             });

--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Tests.Database
                     var beatmapInfo = s.Beatmaps.First(b => b.File?.Filename != removedFilename);
 
                     scoreTargetBeatmapHash = beatmapInfo.Hash;
-                    s.Realm.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
+                    s.Realm!.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
                 });
 
                 realm.Run(r => r.Refresh());
@@ -372,7 +372,7 @@ namespace osu.Game.Tests.Database
 
                     scoreTargetBeatmapHash = beatmapInfo.Hash;
 
-                    s.Realm.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
+                    s.Realm!.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
                 });
 
                 // locally modify beatmap
@@ -435,7 +435,7 @@ namespace osu.Game.Tests.Database
                 {
                     var beatmapInfo = s.Beatmaps.Last();
                     scoreTargetFilename = beatmapInfo.File?.Filename;
-                    s.Realm.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
+                    s.Realm!.Add(new ScoreInfo(beatmapInfo, s.Realm.All<RulesetInfo>().First(), new RealmUser()));
                 });
 
                 realm.Run(r => r.Refresh());
@@ -528,7 +528,7 @@ namespace osu.Game.Tests.Database
 
                 importBeforeUpdate.PerformWrite(s =>
                 {
-                    var beatmapCollection = s.Realm.Add(new BeatmapCollection("test collection"));
+                    var beatmapCollection = s.Realm!.Add(new BeatmapCollection("test collection"));
                     beatmapsToAddToCollection = s.Beatmaps.Count - (allOriginalBeatmapsInCollection ? 0 : 1);
 
                     for (int i = 0; i < beatmapsToAddToCollection; i++)
@@ -543,7 +543,7 @@ namespace osu.Game.Tests.Database
 
                 importAfterUpdate.PerformRead(updated =>
                 {
-                    updated.Realm.Refresh();
+                    updated.Realm!.Refresh();
 
                     string[] hashes = updated.Realm.All<BeatmapCollection>().Single().BeatmapMD5Hashes.ToArray();
 
@@ -593,7 +593,7 @@ namespace osu.Game.Tests.Database
 
                 importBeforeUpdate.PerformWrite(s =>
                 {
-                    var beatmapCollection = s.Realm.Add(new BeatmapCollection("test collection"));
+                    var beatmapCollection = s.Realm!.Add(new BeatmapCollection("test collection"));
                     originalHash = s.Beatmaps.Single(b => b.DifficultyName == "Hard").MD5Hash;
 
                     beatmapCollection.BeatmapMD5Hashes.Add(originalHash);
@@ -607,7 +607,7 @@ namespace osu.Game.Tests.Database
 
                 importAfterUpdate.PerformRead(updated =>
                 {
-                    updated.Realm.Refresh();
+                    updated.Realm!.Refresh();
 
                     string[] hashes = updated.Realm.All<BeatmapCollection>().Single().BeatmapMD5Hashes.ToArray();
                     string updatedHash = updated.Beatmaps.Single(b => b.DifficultyName == "Hard").MD5Hash;

--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Database
 
                 realm.RegisterCustomSubscription(r =>
                 {
-                    var subscription = r.All<BeatmapInfo>().QueryAsyncWithNotifications((_, _, _) =>
+                    var subscription = r.All<BeatmapInfo>().QueryAsyncWithNotifications((_, _) =>
                     {
                         realm.Run(_ =>
                         {

--- a/osu.Game.Tests/Database/RealmLiveTests.cs
+++ b/osu.Game.Tests/Database/RealmLiveTests.cs
@@ -355,7 +355,7 @@ namespace osu.Game.Tests.Database
                     return null;
                 });
 
-                void gotChange(IRealmCollection<BeatmapInfo> sender, ChangeSet changes, Exception error)
+                void gotChange(IRealmCollection<BeatmapInfo> sender, ChangeSet? changes)
                 {
                     changesTriggered++;
                 }

--- a/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
+++ b/osu.Game.Tests/Database/RealmSubscriptionRegistrationTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -54,7 +53,7 @@ namespace osu.Game.Tests.Database
                 registration.Dispose();
             });
 
-            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error)
+            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
             {
                 lastChanges = changes;
 
@@ -92,7 +91,7 @@ namespace osu.Game.Tests.Database
                 registration.Dispose();
             });
 
-            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error) => lastChanges = changes;
+            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes) => lastChanges = changes;
         }
 
         [Test]
@@ -185,7 +184,7 @@ namespace osu.Game.Tests.Database
                 }
             });
 
-            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error)
+            void onChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
             {
                 if (changes == null)
                     resolvedItems = sender;

--- a/osu.Game.Tests/Database/RulesetStoreTests.cs
+++ b/osu.Game.Tests/Database/RulesetStoreTests.cs
@@ -76,12 +76,12 @@ namespace osu.Game.Tests.Database
                     Available = true,
                 }));
 
-                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName).Available), Is.True);
+                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName)!.Available), Is.True);
 
                 // Availability is updated on construction of a RealmRulesetStore
                 var _ = new RealmRulesetStore(realm, storage);
 
-                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName).Available), Is.False);
+                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName)!.Available), Is.False);
             });
         }
 
@@ -101,18 +101,18 @@ namespace osu.Game.Tests.Database
                     Available = true,
                 }));
 
-                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName).Available), Is.True);
+                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName)!.Available), Is.True);
 
                 // Availability is updated on construction of a RealmRulesetStore
                 var _ = new RealmRulesetStore(realm, storage);
 
-                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName).Available), Is.False);
+                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName)!.Available), Is.False);
 
                 // Simulate the ruleset getting updated
                 LoadTestRuleset.Version = Ruleset.CURRENT_RULESET_API_VERSION;
                 var __ = new RealmRulesetStore(realm, storage);
 
-                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName).Available), Is.True);
+                Assert.That(realm.Run(r => r.Find<RulesetInfo>(rulesetShortName)!.Available), Is.True);
             });
         }
 

--- a/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
+++ b/osu.Game.Tests/Database/TestRealmKeyBindingStore.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Tests.Database
 
                 realm.Run(innerRealm =>
                 {
-                    var binding = innerRealm.ResolveReference(tsr);
+                    var binding = innerRealm.ResolveReference(tsr)!;
                     innerRealm.Write(() => binding.KeyCombination = new KeyCombination(InputKey.BackSpace));
                 });
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("results screen score has matching", () => (Player.GetChildScreen() as ResultsScreen)?.Score.Mods.First(), () => Is.EqualTo(playerMods.First()));
 
             AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
-            AddUntilStep("databased score has correct mods", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID)).Mods.First(), () => Is.EqualTo(playerMods.First()));
+            AddUntilStep("databased score has correct mods", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID))!.Mods.First(), () => Is.EqualTo(playerMods.First()));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -163,7 +163,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Key(Key.Enter);
             });
 
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
             AddAssert("ensure selection changed", () => selected != Beatmap.Value);
         }
 
@@ -186,7 +186,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Key(Key.Down);
             });
 
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
             AddAssert("ensure selection didn't change", () => selected == Beatmap.Value);
         }
 
@@ -215,7 +215,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.Key(Key.Enter);
             });
 
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
             AddAssert("ensure selection changed", () => selected != Beatmap.Value);
         }
 
@@ -244,7 +244,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 InputManager.ReleaseButton(MouseButton.Left);
             });
 
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
             AddAssert("ensure selection didn't change", () => selected == Beatmap.Value);
         }
 
@@ -257,7 +257,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             createSongSelect();
 
             AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
 
             AddStep("return", () => songSelect!.MakeCurrent());
             AddUntilStep("wait for current", () => songSelect!.IsCurrentScreen());
@@ -275,7 +275,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             createSongSelect();
 
             AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
 
             AddStep("change convert setting", () => config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
 
@@ -292,7 +292,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             createSongSelect();
 
             AddStep("push child screen", () => Stack.Push(new TestSceneOsuScreenStack.TestScreen("test child")));
-            AddUntilStep("wait for not current", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
 
             AddStep("update beatmap", () =>
             {
@@ -1011,7 +1011,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 });
             });
 
-            AddUntilStep("wait for results screen presented", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
 
             AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.MatchesOnlineID(getPresentBeatmap()));
             AddAssert("check ruleset is correct for score", () => Ruleset.Value.OnlineID == 0);
@@ -1040,7 +1040,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 songSelect!.PresentScore(TestResources.CreateTestScoreInfo(getPresentBeatmap()));
             });
 
-            AddUntilStep("wait for results screen presented", () => !songSelect!.IsCurrentScreen());
+            waitForDismissed();
 
             AddAssert("check beatmap is correct for score", () => Beatmap.Value.BeatmapInfo.MatchesOnlineID(getPresentBeatmap()));
             AddAssert("check ruleset is correct for score", () => Ruleset.Value.OnlineID == 0);
@@ -1160,6 +1160,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             if (rulesets.IsNotNull())
                 rulesets.Dispose();
         }
+
+        private void waitForDismissed() => AddUntilStep("wait for not current", () => !songSelect.AsNonNull().IsCurrentScreen());
 
         private partial class TestSongSelect : PlaySongSelect
         {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModPresetColumn.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                     var testPresets = createTestPresets();
                     foreach (var preset in testPresets)
-                        preset.Ruleset = realm.Find<RulesetInfo>(preset.Ruleset.ShortName);
+                        preset.Ruleset = realm.Find<RulesetInfo>(preset.Ruleset.ShortName)!;
 
                     realm.Add(testPresets);
                 });
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     new ManiaModNightcore(),
                     new ManiaModHardRock()
                 },
-                Ruleset = r.Find<RulesetInfo>("mania")
+                Ruleset = r.Find<RulesetInfo>("mania")!
             })));
             AddUntilStep("2 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 2);
 
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     new OsuModHidden(),
                     new OsuModHardRock()
                 },
-                Ruleset = r.Find<RulesetInfo>("osu")
+                Ruleset = r.Find<RulesetInfo>("osu")!
             })));
             AddUntilStep("2 panels visible", () => this.ChildrenOfType<ModPresetPanel>().Count() == 2);
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         Name = "AR0",
                         Description = "Too... many... circles...",
-                        Ruleset = r.Find<RulesetInfo>(OsuRuleset.SHORT_NAME),
+                        Ruleset = r.Find<RulesetInfo>(OsuRuleset.SHORT_NAME)!,
                         Mods = new[]
                         {
                             new OsuModDifficultyAdjust
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     {
                         Name = "Half Time 0.5x",
                         Description = "Very slow",
-                        Ruleset = r.Find<RulesetInfo>(OsuRuleset.SHORT_NAME),
+                        Ruleset = r.Find<RulesetInfo>(OsuRuleset.SHORT_NAME)!,
                         Mods = new[]
                         {
                             new OsuModHalfTime

--- a/osu.Game/BackgroundBeatmapProcessor.cs
+++ b/osu.Game/BackgroundBeatmapProcessor.cs
@@ -102,7 +102,7 @@ namespace osu.Game
                             }
                         }
 
-                        r.Find<RulesetInfo>(ruleset.ShortName).LastAppliedDifficultyVersion = currentVersion;
+                        r.Find<RulesetInfo>(ruleset.ShortName)!.LastAppliedDifficultyVersion = currentVersion;
                     });
 
                     Logger.Log($"Finished resetting {countReset} beatmap sets for {ruleset.Name}");
@@ -184,7 +184,7 @@ namespace osu.Game
                     // ReSharper disable once MethodHasAsyncOverload
                     realmAccess.Write(r =>
                     {
-                        r.Find<ScoreInfo>(id).MaximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
+                        r.Find<ScoreInfo>(id)!.MaximumStatisticsJson = JsonConvert.SerializeObject(score.MaximumStatistics);
                     });
 
                     Logger.Log($"Populated maximum statistics for score {id}");
@@ -237,7 +237,7 @@ namespace osu.Game
                     // ReSharper disable once MethodHasAsyncOverload
                     realmAccess.Write(r =>
                     {
-                        ScoreInfo s = r.Find<ScoreInfo>(id);
+                        ScoreInfo s = r.Find<ScoreInfo>(id)!;
                         s.TotalScore = newTotalScore;
                         s.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
                     });

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Beatmaps
 
                 Logger.Log($"Beatmap \"{updated}\" update completed successfully", LoggingTarget.Database);
 
-                original = realm.Find<BeatmapSetInfo>(original.ID);
+                original = realm!.Find<BeatmapSetInfo>(original.ID)!;
 
                 // Generally the import process will do this for us if the OnlineIDs match,
                 // but that isn't a guarantee (ie. if the .osu file doesn't have OnlineIDs populated).

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -208,7 +208,7 @@ namespace osu.Game.Beatmaps
                 using (var transaction = r.BeginWrite())
                 {
                     if (!beatmapInfo.IsManaged)
-                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID);
+                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID)!;
 
                     beatmapInfo.Hidden = true;
                     transaction.Commit();
@@ -227,7 +227,7 @@ namespace osu.Game.Beatmaps
                 using (var transaction = r.BeginWrite())
                 {
                     if (!beatmapInfo.IsManaged)
-                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID);
+                        beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID)!;
 
                     beatmapInfo.Hidden = false;
                     transaction.Commit();
@@ -330,7 +330,7 @@ namespace osu.Game.Beatmaps
             Realm.Write(r =>
             {
                 if (!beatmapInfo.IsManaged)
-                    beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID);
+                    beatmapInfo = r.Find<BeatmapInfo>(beatmapInfo.ID)!;
 
                 Debug.Assert(beatmapInfo.BeatmapSet != null);
                 Debug.Assert(beatmapInfo.File != null);
@@ -460,7 +460,7 @@ namespace osu.Game.Beatmaps
 
                 Realm.Write(r =>
                 {
-                    var liveBeatmapSet = r.Find<BeatmapSetInfo>(setInfo.ID);
+                    var liveBeatmapSet = r.Find<BeatmapSetInfo>(setInfo.ID)!;
 
                     setInfo.CopyChangesToRealm(liveBeatmapSet);
 

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <param name="beatmapSet">The managed beatmap set to update. A transaction will be opened to apply changes.</param>
         /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
-        public void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst) => beatmapSet.Realm.Write(r =>
+        public void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst) => beatmapSet.Realm!.Write(_ =>
         {
             // Before we use below, we want to invalidate.
             workingBeatmapCache.Invalidate(beatmapSet);

--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Collections
             Current.BindValueChanged(selectionChanged);
         }
 
-        private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes, Exception error)
+        private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
         {
             var selectedItem = SelectedItem?.Value?.Collection;
 

--- a/osu.Game/Collections/DrawableCollectionList.cs
+++ b/osu.Game/Collections/DrawableCollectionList.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Collections
             realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), collectionsChanged);
         }
 
-        private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes, Exception error)
+        private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
         {
             Items.Clear();
             Items.AddRange(collections.AsEnumerable().Select(c => c.ToLive(realm)));

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -197,7 +197,7 @@ namespace osu.Game.Collections
                 return true;
             }
 
-            private void deleteCollection() => collection.PerformWrite(c => c.Realm.Remove(c));
+            private void deleteCollection() => collection.PerformWrite(c => c.Realm!.Remove(c));
         }
     }
 }

--- a/osu.Game/Database/EmptyRealmSet.cs
+++ b/osu.Game/Database/EmptyRealmSet.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Database
         IEnumerator IEnumerable.GetEnumerator() => emptySet.GetEnumerator();
         public int Count => emptySet.Count;
         public T this[int index] => emptySet[index];
-        public int IndexOf(object item) => emptySet.IndexOf((T)item);
-        public bool Contains(object item) => emptySet.Contains((T)item);
+        public int IndexOf(object? item) => item == null ? -1 : emptySet.IndexOf((T)item);
+        public bool Contains(object? item) => item != null && emptySet.Contains((T)item);
 
         public event NotifyCollectionChangedEventHandler? CollectionChanged
         {

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -34,13 +34,13 @@ namespace osu.Game.Database
         }
 
         public void DeleteFile(TModel item, RealmNamedFileUsage file) =>
-            performFileOperation(item, managed => DeleteFile(managed, managed.Files.First(f => f.Filename == file.Filename), managed.Realm));
+            performFileOperation(item, managed => DeleteFile(managed, managed.Files.First(f => f.Filename == file.Filename), managed.Realm!));
 
         public void ReplaceFile(TModel item, RealmNamedFileUsage file, Stream contents) =>
-            performFileOperation(item, managed => ReplaceFile(file, contents, managed.Realm));
+            performFileOperation(item, managed => ReplaceFile(file, contents, managed.Realm!));
 
         public void AddFile(TModel item, Stream contents, string filename) =>
-            performFileOperation(item, managed => AddFile(managed, contents, filename, managed.Realm));
+            performFileOperation(item, managed => AddFile(managed, contents, filename, managed.Realm!));
 
         private void performFileOperation(TModel item, Action<TModel> operation)
         {
@@ -178,13 +178,14 @@ namespace osu.Game.Database
             // (ie. if an async import finished very recently).
             return Realm.Write(realm =>
             {
-                if (!item.IsManaged)
-                    item = realm.Find<TModel>(item.ID);
+                TModel? processableItem = item;
+                if (!processableItem.IsManaged)
+                    processableItem = realm.Find<TModel>(item.ID);
 
-                if (item?.DeletePending != false)
+                if (processableItem?.DeletePending != false)
                     return false;
 
-                item.DeletePending = true;
+                processableItem.DeletePending = true;
                 return true;
             });
         }
@@ -195,13 +196,14 @@ namespace osu.Game.Database
             // (ie. if an async import finished very recently).
             Realm.Write(realm =>
             {
-                if (!item.IsManaged)
-                    item = realm.Find<TModel>(item.ID);
+                TModel? processableItem = item;
+                if (!processableItem.IsManaged)
+                    processableItem = realm.Find<TModel>(item.ID);
 
-                if (item?.DeletePending != true)
+                if (processableItem?.DeletePending != true)
                     return;
 
-                item.DeletePending = false;
+                processableItem.DeletePending = false;
             });
         }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -535,7 +535,7 @@ namespace osu.Game.Database
             lock (notificationsResetMap)
             {
                 // Store an action which is used when blocking to ensure consumers don't use results of a stale changeset firing.
-                notificationsResetMap.Add(action, () => callback(new EmptyRealmSet<T>(), null, null));
+                notificationsResetMap.Add(action, () => callback(new EmptyRealmSet<T>(), null));
             }
 
             return RegisterCustomSubscription(action);
@@ -755,10 +755,10 @@ namespace osu.Game.Database
 
                         for (int i = 0; i < itemCount; i++)
                         {
-                            dynamic? oldItem = oldItems.ElementAt(i);
-                            dynamic? newItem = newItems.ElementAt(i);
+                            dynamic oldItem = oldItems.ElementAt(i);
+                            dynamic newItem = newItems.ElementAt(i);
 
-                            long? nullableOnlineID = oldItem?.OnlineID;
+                            long? nullableOnlineID = oldItem.OnlineID;
                             newItem.OnlineID = (int)(nullableOnlineID ?? -1);
                         }
                     }
@@ -795,7 +795,7 @@ namespace osu.Game.Database
 
                     for (int i = 0; i < metadataCount; i++)
                     {
-                        dynamic? oldItem = oldMetadata.ElementAt(i);
+                        dynamic oldItem = oldMetadata.ElementAt(i);
                         var newItem = newMetadata.ElementAt(i);
 
                         string username = oldItem.Author;
@@ -818,7 +818,7 @@ namespace osu.Game.Database
 
                     for (int i = 0; i < newSettings.Count; i++)
                     {
-                        dynamic? oldItem = oldSettings.ElementAt(i);
+                        dynamic oldItem = oldSettings.ElementAt(i);
                         var newItem = newSettings.ElementAt(i);
 
                         long rulesetId = oldItem.RulesetID;
@@ -843,7 +843,7 @@ namespace osu.Game.Database
 
                     for (int i = 0; i < newKeyBindings.Count; i++)
                     {
-                        dynamic? oldItem = oldKeyBindings.ElementAt(i);
+                        dynamic oldItem = oldKeyBindings.ElementAt(i);
                         var newItem = newKeyBindings.ElementAt(i);
 
                         if (oldItem.RulesetID == null)

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Database
 
             PerformRead(t =>
             {
-                using (var transaction = t.Realm.BeginWrite())
+                using (var transaction = t.Realm!.BeginWrite())
                 {
                     perform(t);
                     transaction.Commit();
@@ -133,7 +133,7 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            if (dataIsFromUpdateThread && !data.Realm.IsClosed)
+            if (dataIsFromUpdateThread && !data.Realm!.IsClosed)
             {
                 RealmLiveStatistics.USAGE_UPDATE_IMMEDIATE.Value++;
                 return;
@@ -154,7 +154,7 @@ namespace osu.Game.Database
                 // To ensure that behaviour matches what we'd expect (the object *is* available), force
                 // a refresh to bring in any off-thread changes immediately.
                 realm.Refresh();
-                found = realm.Find<T>(ID);
+                found = realm.Find<T>(ID)!;
             }
 
             return found;

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using osu.Framework.Development;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Statistics;
 using Realms;
 
@@ -133,7 +134,7 @@ namespace osu.Game.Database
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            if (dataIsFromUpdateThread && !data.Realm!.IsClosed)
+            if (dataIsFromUpdateThread && !data.Realm.AsNonNull().IsClosed)
             {
                 RealmLiveStatistics.USAGE_UPDATE_IMMEDIATE.Value++;
                 return;

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -282,8 +282,6 @@ namespace osu.Game.Database
         /// <returns>
         /// A subscription token. It must be kept alive for as long as you want to receive change notifications.
         /// To stop receiving notifications, call <see cref="M:System.IDisposable.Dispose" />.
-        ///
-        /// May be null in the case the provided collection is not managed.
         /// </returns>
         /// <seealso cref="M:Realms.CollectionExtensions.SubscribeForNotifications``1(System.Collections.Generic.IList{``0},Realms.NotificationCallbackDelegate{``0})" />
         /// <seealso cref="M:Realms.CollectionExtensions.SubscribeForNotifications``1(System.Linq.IQueryable{``0},Realms.NotificationCallbackDelegate{``0})" />

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Database
              .ForMember(s => s.BeatmapSet, cc => cc.Ignore())
              .AfterMap((s, d) =>
              {
-                 d.Ruleset = d.Realm.Find<RulesetInfo>(s.Ruleset.ShortName);
+                 d.Ruleset = d.Realm!.Find<RulesetInfo>(s.Ruleset.ShortName)!;
                  copyChangesToRealm(s.Difficulty, d.Difficulty);
                  copyChangesToRealm(s.Metadata, d.Metadata);
              });
@@ -57,7 +57,7 @@ namespace osu.Game.Database
                      // Importantly, search all of realm for the beatmap (not just the set's beatmaps).
                      // It may have gotten detached, and if that's the case let's use this opportunity to fix
                      // things up.
-                     var existingBeatmap = d.Realm.Find<BeatmapInfo>(beatmap.ID);
+                     var existingBeatmap = d.Realm!.Find<BeatmapInfo>(beatmap.ID);
 
                      if (existingBeatmap != null)
                      {
@@ -77,7 +77,7 @@ namespace osu.Game.Database
                          {
                              ID = beatmap.ID,
                              BeatmapSet = d,
-                             Ruleset = d.Realm.Find<RulesetInfo>(beatmap.Ruleset.ShortName)
+                             Ruleset = d.Realm.Find<RulesetInfo>(beatmap.Ruleset.ShortName)!
                          };
 
                          d.Beatmaps.Add(newBeatmap);
@@ -287,7 +287,7 @@ namespace osu.Game.Database
         /// </returns>
         /// <seealso cref="M:Realms.CollectionExtensions.SubscribeForNotifications``1(System.Collections.Generic.IList{``0},Realms.NotificationCallbackDelegate{``0})" />
         /// <seealso cref="M:Realms.CollectionExtensions.SubscribeForNotifications``1(System.Linq.IQueryable{``0},Realms.NotificationCallbackDelegate{``0})" />
-        public static IDisposable? QueryAsyncWithNotifications<T>(this IRealmCollection<T> collection, NotificationCallbackDelegate<T> callback)
+        public static IDisposable QueryAsyncWithNotifications<T>(this IRealmCollection<T> collection, NotificationCallbackDelegate<T> callback)
             where T : RealmObjectBase
         {
             if (!RealmAccess.CurrentThreadSubscriptionsAllowed)

--- a/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
+++ b/osu.Game/Input/Bindings/DatabasedKeyBindingContainer.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Input.Bindings
 
         protected override void LoadComplete()
         {
-            realmSubscription = realm.RegisterForNotifications(queryRealmKeyBindings, (sender, _, _) =>
+            realmSubscription = realm.RegisterForNotifications(queryRealmKeyBindings, (sender, _) =>
             {
                 // The first fire of this is a bit redundant as this is being called in base.LoadComplete,
                 // but this is safest in case the subscription is restored after a context recycle.

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, _, _) =>
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, _) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
+++ b/osu.Game/Online/Rooms/OnlinePlayBeatmapAvailabilityTracker.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Online.Rooms
 
             // handles changes to hash that didn't occur from the import process (ie. a user editing the beatmap in the editor, somehow).
             realmSubscription?.Dispose();
-            realmSubscription = realm.RegisterForNotifications(_ => filteredBeatmaps(), (_, changes, _) =>
+            realmSubscription = realm.RegisterForNotifications(_ => filteredBeatmaps(), (_, changes) =>
             {
                 if (changes == null)
                     return;

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Online
             realmSubscription = realm.RegisterForNotifications(r => r.All<ScoreInfo>().Where(s =>
                 ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID)
                  || (!string.IsNullOrEmpty(s.Hash) && s.Hash == TrackedItem.Hash))
-                && !s.DeletePending), (items, _, _) =>
+                && !s.DeletePending), (items, _) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBeatmaps.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             beatmapSubscription?.Dispose();
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception error) => Schedule(() =>
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes) => Schedule(() =>
         {
             currentlyLoadedBeatmaps.Text = FirstRunSetupBeatmapScreenStrings.CurrentlyLoadedBeatmaps(sender.Count);
 

--- a/osu.Game/Overlays/Mods/AddPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/AddPresetPopover.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Mods
                 Name = nameTextBox.Current.Value,
                 Description = descriptionTextBox.Current.Value,
                 Mods = selectedMods.Value.ToArray(),
-                Ruleset = r.Find<RulesetInfo>(ruleset.Value.ShortName)
+                Ruleset = r.Find<RulesetInfo>(ruleset.Value.ShortName)!
             }));
 
             this.HidePopover();

--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Mods
         private Task? latestLoadTask;
         internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true;
 
-        private void asyncLoadPanels(IRealmCollection<ModPreset> presets, ChangeSet changes, Exception error)
+        private void asyncLoadPanels(IRealmCollection<ModPreset> presets, ChangeSet? changes)
         {
             cancellationTokenSource?.Cancel();
 

--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -109,7 +109,7 @@ namespace osu.Game.Overlays.Music
             beatmap.BindValueChanged(working => list.SelectedSet.Value = working.NewValue.BeatmapSetInfo.ToLive(realm), true);
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes, Exception error)
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet changes)
         {
             if (changes == null)
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -440,7 +440,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         }
 
         private void updateStoreFromButton(KeyButton button) =>
-            realm.WriteAsync(r => r.Find<RealmKeyBinding>(button.KeyBinding.ID).KeyCombinationString = button.KeyBinding.KeyCombinationString);
+            realm.WriteAsync(r => r.Find<RealmKeyBinding>(button.KeyBinding.ID)!.KeyCombinationString = button.KeyBinding.KeyCombinationString);
 
         private void updateIsDefaultValue()
         {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Overlays.Settings.Sections
             });
         }
 
-        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes, Exception error)
+        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes)
         {
             // This can only mean that realm is recycling, else we would see the protected skins.
             // Because we are using `Live<>` in this class, we don't need to worry about this scenario too much.

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -66,10 +66,10 @@ namespace osu.Game.Scoring
         {
             // Ensure the beatmap is not detached.
             if (!model.BeatmapInfo.IsManaged)
-                model.BeatmapInfo = realm.Find<BeatmapInfo>(model.BeatmapInfo.ID);
+                model.BeatmapInfo = realm.Find<BeatmapInfo>(model.BeatmapInfo.ID)!;
 
             if (!model.Ruleset.IsManaged)
-                model.Ruleset = realm.Find<RulesetInfo>(model.Ruleset.ShortName);
+                model.Ruleset = realm.Find<RulesetInfo>(model.Ruleset.ShortName)!;
 
             // These properties are known to be non-null, but these final checks ensure a null hasn't come from somewhere (or the refetch has failed).
             // Under no circumstance do we want these to be written to realm as null.

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -141,7 +141,7 @@ namespace osu.Game.Scoring
         {
             Realm.Run(r =>
             {
-                var beatmapScores = r.Find<BeatmapInfo>(beatmap.ID).Scores.ToList();
+                var beatmapScores = r.Find<BeatmapInfo>(beatmap.ID)!.Scores.ToList();
                 Delete(beatmapScores, silent);
             });
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Screens.Select
             subscriptionHiddenBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
-        private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception? error)
+        private void deletedBeatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
         {
             // If loading test beatmaps, avoid overwriting with realm subscription callbacks.
             if (loadedTestBeatmaps)
@@ -236,7 +236,7 @@ namespace osu.Game.Screens.Select
                 removeBeatmapSet(sender[i].ID);
         }
 
-        private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes, Exception? error)
+        private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
         {
             // If loading test beatmaps, avoid overwriting with realm subscription callbacks.
             if (loadedTestBeatmaps)
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.Select
                 foreach (var id in realmSets)
                 {
                     if (!root.BeatmapSetsByID.ContainsKey(id))
-                        UpdateBeatmapSet(realm.Realm.Find<BeatmapSetInfo>(id).Detach());
+                        UpdateBeatmapSet(realm.Realm.Find<BeatmapSetInfo>(id)!.Detach());
                 }
 
                 foreach (var id in root.BeatmapSetsByID.Keys)
@@ -315,7 +315,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapInfo> sender, ChangeSet? changes, Exception? error)
+        private void beatmapsChanged(IRealmCollection<BeatmapInfo> sender, ChangeSet? changes)
         {
             // we only care about actual changes in hidden status.
             if (changes == null)

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Select.Carousel
                     localScoresChanged);
             }, true);
 
-            void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes, Exception _)
+            void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes)
             {
                 // This subscription may fire from changes to linked beatmaps, which we don't care about.
                 // It's currently not possible for a score to be modified after insertion, so we can safely ignore callbacks with only modifications.

--- a/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
+++ b/osu.Game/Screens/Select/Leaderboards/BeatmapLeaderboard.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Screens.Select.Leaderboards
                                           + $" AND {nameof(ScoreInfo.DeletePending)} == false"
                     , beatmapInfo.ID, ruleset.Value.ShortName), localScoresChanged);
 
-            void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes, Exception exception)
+            void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return;

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Spectate
             }));
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> items, ChangeSet changes, Exception ___)
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> items, ChangeSet changes)
         {
             if (changes?.InsertedIndices == null) return;
 

--- a/osu.Game/Skinning/RealmBackedResourceStore.cs
+++ b/osu.Game/Skinning/RealmBackedResourceStore.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Skinning
             realmSubscription?.Dispose();
         }
 
-        private void skinChanged(IRealmCollection<T> sender, ChangeSet changes, Exception error) => invalidateCache();
+        private void skinChanged(IRealmCollection<T> sender, ChangeSet? changes) => invalidateCache();
 
         protected override IEnumerable<string> GetFilenames(string name)
         {

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Skinning
 
                 using (var streamContent = new MemoryStream(Encoding.UTF8.GetBytes(skinInfoJson)))
                 {
-                    modelManager.AddFile(s, streamContent, skin_info_file, s.Realm);
+                    modelManager.AddFile(s, streamContent, skin_info_file, s.Realm!);
                 }
 
                 // Then serialise each of the drawable component groups into respective files.
@@ -213,9 +213,9 @@ namespace osu.Game.Skinning
                         var oldFile = s.GetFile(filename);
 
                         if (oldFile != null)
-                            modelManager.ReplaceFile(oldFile, streamContent, s.Realm);
+                            modelManager.ReplaceFile(oldFile, streamContent, s.Realm!);
                         else
-                            modelManager.AddFile(s, streamContent, filename, s.Realm);
+                            modelManager.AddFile(s, streamContent, filename, s.Realm!);
                     }
                 }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Realm" Version="10.20.0" />
+    <PackageReference Include="Realm" Version="11.1.2" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.625.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.625.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />


### PR DESCRIPTION
Liberal usage of `!`. If all these calls worked until now, right?

This fixes opening realm studio on a live database instance when osu! is running, yay.

![Realm Studio 2023-07-06 at 04 37 34](https://github.com/ppy/osu/assets/191335/be2389f7-e2c8-4a23-88fa-6bb3da415448)
