### PR TITLE
Remove the ability to cancel all "in progress" tasks

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNotificationOverlay.cs
@@ -53,6 +53,32 @@ namespace osu.Game.Tests.Visual.UserInterface
         });
 
         [Test]
+        public void TestBasicFlow()
+        {
+            setState(Visibility.Visible);
+            AddStep(@"simple #1", sendHelloNotification);
+            AddStep(@"simple #2", sendAmazingNotification);
+            AddStep(@"progress #1", sendUploadProgress);
+            AddStep(@"progress #2", sendDownloadProgress);
+
+            checkProgressingCount(2);
+
+            setState(Visibility.Hidden);
+
+            AddRepeatStep(@"add many simple", sendManyNotifications, 3);
+
+            waitForCompletion();
+
+            AddStep(@"progress #3", sendUploadProgress);
+
+            checkProgressingCount(1);
+
+            checkDisplayedCount(33);
+
+            waitForCompletion();
+        }
+
+        [Test]
         public void TestForwardWithFlingRight()
         {
             bool activated = false;
@@ -409,32 +435,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("click notification", () => completionNotification?.TriggerClick());
 
             AddUntilStep("wait for update applied", () => applyUpdate);
-        }
-
-        [Test]
-        public void TestBasicFlow()
-        {
-            setState(Visibility.Visible);
-            AddStep(@"simple #1", sendHelloNotification);
-            AddStep(@"simple #2", sendAmazingNotification);
-            AddStep(@"progress #1", sendUploadProgress);
-            AddStep(@"progress #2", sendDownloadProgress);
-
-            checkProgressingCount(2);
-
-            setState(Visibility.Hidden);
-
-            AddRepeatStep(@"add many simple", sendManyNotifications, 3);
-
-            waitForCompletion();
-
-            AddStep(@"progress #3", sendUploadProgress);
-
-            checkProgressingCount(1);
-
-            checkDisplayedCount(33);
-
-            waitForCompletion();
         }
 
         [Test]

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -30,11 +30,6 @@ namespace osu.Game.Localisation
         public static LocalisableString ClearAll => new TranslatableString(getKey(@"clear_all"), @"Clear All");
 
         /// <summary>
-        /// "Cancel All"
-        /// </summary>
-        public static LocalisableString CancelAll => new TranslatableString(getKey(@"cancel_all"), @"Cancel All");
-
-        /// <summary>
         /// "Your battery level is low! Charge your device to prevent interruptions during gameplay."
         /// </summary>
         public static LocalisableString BatteryLow => new TranslatableString(getKey(@"battery_low"), @"Your battery level is low! Charge your device to prevent interruptions during gameplay.");

--- a/osu.Game/Overlays/INotificationOverlay.cs
+++ b/osu.Game/Overlays/INotificationOverlay.cs
@@ -44,6 +44,6 @@ namespace osu.Game.Overlays
         /// <summary>
         /// All ongoing operations (ie. any <see cref="ProgressNotification"/> not in a completed state).
         /// </summary>
-        public IEnumerable<ProgressNotification> OngoingOperations => AllNotifications.OfType<ProgressNotification>().Where(p => p.State != ProgressNotificationState.Completed && p.State != ProgressNotificationState.Cancelled);
+        public IEnumerable<ProgressNotification> OngoingOperations => AllNotifications.OfType<ProgressNotification>().Where(p => !p.CompletedOrCancelled);
     }
 }

--- a/osu.Game/Overlays/INotificationOverlay.cs
+++ b/osu.Game/Overlays/INotificationOverlay.cs
@@ -42,8 +42,8 @@ namespace osu.Game.Overlays
         IEnumerable<Notification> AllNotifications { get; }
 
         /// <summary>
-        /// All ongoing operations (ie. any <see cref="ProgressNotification"/> not in a completed state).
+        /// All ongoing operations (ie. any <see cref="ProgressNotification"/> not in a completed or cancelled state).
         /// </summary>
-        public IEnumerable<ProgressNotification> OngoingOperations => AllNotifications.OfType<ProgressNotification>().Where(p => !p.CompletedOrCancelled);
+        public IEnumerable<ProgressNotification> OngoingOperations => AllNotifications.OfType<ProgressNotification>().Where(p => p.Ongoing);
     }
 }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -108,8 +108,8 @@ namespace osu.Game.Overlays
                                     RelativeSizeAxes = Axes.X,
                                     Children = new[]
                                     {
-                                        new NotificationSection(AccountsStrings.NotificationsTitle, new[] { typeof(SimpleNotification) }, NotificationsStrings.ClearAll),
-                                        new NotificationSection(NotificationsStrings.RunningTasks, new[] { typeof(ProgressNotification) }, NotificationsStrings.CancelAll),
+                                        new NotificationSection(AccountsStrings.NotificationsTitle, new[] { typeof(SimpleNotification) }, true),
+                                        new NotificationSection(NotificationsStrings.RunningTasks, new[] { typeof(ProgressNotification) }, false),
                                     }
                                 }
                             }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -108,8 +108,8 @@ namespace osu.Game.Overlays
                                     RelativeSizeAxes = Axes.X,
                                     Children = new[]
                                     {
-                                        new NotificationSection(AccountsStrings.NotificationsTitle, new[] { typeof(SimpleNotification) }, true),
-                                        new NotificationSection(NotificationsStrings.RunningTasks, new[] { typeof(ProgressNotification) }, false),
+                                        new NotificationSection(AccountsStrings.NotificationsTitle, new[] { typeof(SimpleNotification) }),
+                                        new NotificationSection(NotificationsStrings.RunningTasks, new[] { typeof(ProgressNotification) }),
                                     }
                                 }
                             }

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Overlays.Notifications
 
         private void clearAll() => notifications.Children.ForEach(c =>
         {
-            if (c is not ProgressNotification p || p.CompletedOrCancelled)
+            if (c is not ProgressNotification p || !p.Ongoing)
                 c.Close(true);
         });
 

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Overlays.Notifications
                     {
                         new ClearAllButton
                         {
-                            Text = NotificationsStrings.ClearAll,
+                            Text = NotificationsStrings.ClearAll.ToUpper(),
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
                             Action = clearAll

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -41,14 +41,11 @@ namespace osu.Game.Overlays.Notifications
 
         private readonly LocalisableString titleText;
 
-        private readonly bool allowClear;
-
-        public NotificationSection(LocalisableString title, IEnumerable<Type> acceptedNotificationTypes, bool allowClear)
+        public NotificationSection(LocalisableString title, IEnumerable<Type> acceptedNotificationTypes)
         {
             AcceptedNotificationTypes = acceptedNotificationTypes.ToArray();
 
             titleText = title;
-            this.allowClear = allowClear;
         }
 
         [BackgroundDependencyLoader]
@@ -72,17 +69,15 @@ namespace osu.Game.Overlays.Notifications
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Children = new[]
+                    Children = new Drawable[]
                     {
-                        allowClear
-                            ? new ClearAllButton
-                            {
-                                Text = NotificationsStrings.ClearAll,
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                                Action = clearAll
-                            }
-                            : Empty(),
+                        new ClearAllButton
+                        {
+                            Text = NotificationsStrings.ClearAll,
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Action = clearAll
+                        },
                         new FillFlowContainer
                         {
                             Margin = new MarginPadding
@@ -118,7 +113,11 @@ namespace osu.Game.Overlays.Notifications
             });
         }
 
-        private void clearAll() => notifications.Children.ForEach(c => c.Close(true));
+        private void clearAll() => notifications.Children.ForEach(c =>
+        {
+            if (c is not ProgressNotification p || p.CompletedOrCancelled)
+                c.Close(true);
+        });
 
         protected override void Update()
         {

--- a/osu.Game/Overlays/Notifications/NotificationSection.cs
+++ b/osu.Game/Overlays/Notifications/NotificationSection.cs
@@ -13,6 +13,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osuTK;
 
 namespace osu.Game.Overlays.Notifications
@@ -38,16 +39,16 @@ namespace osu.Game.Overlays.Notifications
 
         public IEnumerable<Type> AcceptedNotificationTypes { get; }
 
-        private readonly LocalisableString clearButtonText;
-
         private readonly LocalisableString titleText;
 
-        public NotificationSection(LocalisableString title, IEnumerable<Type> acceptedNotificationTypes, LocalisableString clearButtonText)
+        private readonly bool allowClear;
+
+        public NotificationSection(LocalisableString title, IEnumerable<Type> acceptedNotificationTypes, bool allowClear)
         {
             AcceptedNotificationTypes = acceptedNotificationTypes.ToArray();
 
-            this.clearButtonText = clearButtonText.ToUpper();
             titleText = title;
+            this.allowClear = allowClear;
         }
 
         [BackgroundDependencyLoader]
@@ -71,15 +72,17 @@ namespace osu.Game.Overlays.Notifications
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Children = new Drawable[]
+                    Children = new[]
                     {
-                        new ClearAllButton
-                        {
-                            Text = clearButtonText,
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            Action = clearAll
-                        },
+                        allowClear
+                            ? new ClearAllButton
+                            {
+                                Text = NotificationsStrings.ClearAll,
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                Action = clearAll
+                            }
+                            : Empty(),
                         new FillFlowContainer
                         {
                             Margin = new MarginPadding
@@ -115,10 +118,7 @@ namespace osu.Game.Overlays.Notifications
             });
         }
 
-        private void clearAll()
-        {
-            notifications.Children.ForEach(c => c.Close(true));
-        }
+        private void clearAll() => notifications.Children.ForEach(c => c.Close(true));
 
         protected override void Update()
         {

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Overlays.Notifications
 
         public Func<bool>? CancelRequested { get; set; }
 
+        public bool CompletedOrCancelled => State == ProgressNotificationState.Completed || State == ProgressNotificationState.Cancelled;
+
         protected override bool AllowFlingDismiss => false;
 
         /// <summary>

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -25,7 +25,10 @@ namespace osu.Game.Overlays.Notifications
 
         public Func<bool>? CancelRequested { get; set; }
 
-        public bool CompletedOrCancelled => State == ProgressNotificationState.Completed || State == ProgressNotificationState.Cancelled;
+        /// <summary>
+        /// Whether the operation represented by the <see cref="ProgressNotification"/> is still ongoing.
+        /// </summary>
+        public bool Ongoing => State != ProgressNotificationState.Completed && State != ProgressNotificationState.Cancelled;
 
         protected override bool AllowFlingDismiss => false;
 


### PR DESCRIPTION
Brought up by @nekodex.

I don't think anyone would want to do this. It could only be a misclick. For ongoing operations, a user should have to cancel each one manually.