### PR TITLE
Add new notification sounds

### DIFF
--- a/osu.Game/Online/Chat/MessageNotifier.cs
+++ b/osu.Game/Online/Chat/MessageNotifier.cs
@@ -171,6 +171,8 @@ namespace osu.Game.Online.Chat
 
         public abstract partial class HighlightMessageNotification : SimpleNotification
         {
+            public override string PopInSampleName => "UI/notification-mention";
+
             protected HighlightMessageNotification(Message message, Channel channel)
             {
                 this.message = message;

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays
 
             Logger.Log($"⚠️ {notification.Text}");
 
-            notification.Closed += notificationClosed;
+            notification.Closed += () => notificationClosed(notification);
 
             if (notification is IHasCompletionTarget hasCompletionTarget)
                 hasCompletionTarget.CompletionTarget = Post;
@@ -229,17 +229,20 @@ namespace osu.Game.Overlays
             mainContent.FadeEdgeEffectTo(0, WaveContainer.DISAPPEAR_DURATION, Easing.In);
         }
 
-        private void notificationClosed() => Schedule(() =>
+        private void notificationClosed(Notification notification) => Schedule(() =>
         {
             updateCounts();
 
             // this debounce is currently shared between popin/popout sounds, which means one could potentially not play when the user is expecting it.
             // popout is constant across all notification types, and should therefore be handled using playback concurrency instead, but seems broken at the moment.
-            playDebouncedSample("UI/overlay-pop-out");
+            playDebouncedSample(notification.PopOutSampleName);
         });
 
         private void playDebouncedSample(string sampleName)
         {
+            if (string.IsNullOrEmpty(sampleName))
+                return;
+
             if (lastSamplePlayback == null || Time.Current - lastSamplePlayback > OsuGameBase.SAMPLE_DEBOUNCE_TIME)
             {
                 audio.Samples.Get(sampleName)?.Play();

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -229,7 +229,14 @@ namespace osu.Game.Overlays
             mainContent.FadeEdgeEffectTo(0, WaveContainer.DISAPPEAR_DURATION, Easing.In);
         }
 
-        private void notificationClosed() => Schedule(updateCounts);
+        private void notificationClosed() => Schedule(() =>
+        {
+            updateCounts();
+
+            // this debounce is currently shared between popin/popout sounds, which means one could potentially not play when the user is expecting it.
+            // popout is constant across all notification types, and should therefore be handled using playback concurrency instead, but seems broken at the moment.
+            playDebouncedSample("UI/overlay-pop-out");
+        });
 
         private void playDebouncedSample(string sampleName)
         {

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -229,14 +229,7 @@ namespace osu.Game.Overlays
             mainContent.FadeEdgeEffectTo(0, WaveContainer.DISAPPEAR_DURATION, Easing.In);
         }
 
-        private void notificationClosed() => Schedule(() =>
-        {
-            updateCounts();
-
-            // this debounce is currently shared between popin/popout sounds, which means one could potentially not play when the user is expecting it.
-            // popout is constant across all notification types, and should therefore be handled using playback concurrency instead, but seems broken at the moment.
-            playDebouncedSample("UI/overlay-pop-out");
-        });
+        private void notificationClosed() => Schedule(updateCounts);
 
         private void playDebouncedSample(string sampleName)
         {

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -51,6 +51,7 @@ namespace osu.Game.Overlays.Notifications
         public virtual bool DisplayOnTop => true;
 
         public virtual string PopInSampleName => "UI/notification-default";
+        public virtual string PopOutSampleName => "UI/overlay-pop-out";
 
         protected NotificationLight Light;
 

--- a/osu.Game/Overlays/Notifications/Notification.cs
+++ b/osu.Game/Overlays/Notifications/Notification.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Notifications
         /// </summary>
         public virtual bool DisplayOnTop => true;
 
-        public virtual string PopInSampleName => "UI/notification-pop-in";
+        public virtual string PopInSampleName => "UI/notification-default";
 
         protected NotificationLight Light;
 

--- a/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressCompletionNotification.cs
@@ -10,6 +10,8 @@ namespace osu.Game.Overlays.Notifications
 {
     public partial class ProgressCompletionNotification : SimpleNotification
     {
+        public override string PopInSampleName => "UI/notification-done";
+
         public ProgressCompletionNotification()
         {
             Icon = FontAwesome.Solid.Check;

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Overlays.Notifications
 
         protected override bool AllowFlingDismiss => false;
 
+        public override string PopOutSampleName => State is ProgressNotificationState.Cancelled ? base.PopOutSampleName : "";
+
         /// <summary>
         /// The function to post completion notifications back to.
         /// </summary>

--- a/osu.Game/Overlays/Notifications/ProgressNotification.cs
+++ b/osu.Game/Overlays/Notifications/ProgressNotification.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -122,6 +124,7 @@ namespace osu.Game.Overlays.Notifications
                     cancellationTokenSource.Cancel();
 
                     IconContent.FadeColour(ColourInfo.GradientVertical(Color4.Gray, Color4.Gray.Lighten(0.5f)), colour_fade_duration);
+                    cancelSample?.Play();
                     loadingSpinner.Hide();
 
                     var icon = new SpriteIcon
@@ -190,6 +193,8 @@ namespace osu.Game.Overlays.Notifications
 
         private LoadingSpinner loadingSpinner = null!;
 
+        private Sample? cancelSample;
+
         private readonly TextFlowContainer textDrawable;
 
         public ProgressNotification()
@@ -217,7 +222,7 @@ namespace osu.Game.Overlays.Notifications
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load(OsuColour colours, AudioManager audioManager)
         {
             colourQueued = colours.YellowDark;
             colourActive = colours.Blue;
@@ -236,6 +241,8 @@ namespace osu.Game.Overlays.Notifications
                     Size = new Vector2(loading_spinner_size),
                 }
             });
+
+            cancelSample = audioManager.Samples.Get(@"UI/notification-cancel");
         }
 
         public override void Close(bool runFlingAnimation)

--- a/osu.Game/Overlays/Notifications/SimpleErrorNotification.cs
+++ b/osu.Game/Overlays/Notifications/SimpleErrorNotification.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Overlays.Notifications
 {
     public partial class SimpleErrorNotification : SimpleNotification
     {
-        public override string PopInSampleName => "UI/error-notification-pop-in";
+        public override string PopInSampleName => "UI/notification-error";
 
         public SimpleErrorNotification()
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="10.20.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.625.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.625.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.707.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Beep boop, new notification sounds.

Replaces:
- Default (`Notification` and children)
- Error (`SimpleErrorNotification`)

Adds:
- Cancel (`ProgressNotification`)
- Done (`ProgressNotification`)
- Mention (`HighlightMessageNotification`)

ps: Hitting 'Cancel All' with a bunch of active `ProgressNotification`s will blast ears, but will be 'fixed' by #24144.

- [x] Depends on ppy/osu-resources#268