### PR TITLE
Redesign "local input" toggle in manual input tests to be more user-friendly

### DIFF
--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Framework.Testing.Input;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -25,8 +26,9 @@ namespace osu.Game.Tests.Visual
 
         protected readonly ManualInputManager InputManager;
 
-        private readonly RoundedButton buttonTest;
         private readonly RoundedButton buttonLocal;
+
+        private readonly Container takeControlOverlay;
 
         /// <summary>
         /// Whether to create a nested container to handle <see cref="GlobalAction"/>s that result from local (manual) test input.
@@ -66,12 +68,12 @@ namespace osu.Game.Tests.Visual
                     UseParentInput = true,
                     Child = mainContent
                 },
-                new Container
+                takeControlOverlay = new Container
                 {
                     AutoSizeAxes = Axes.Both,
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
-                    Margin = new MarginPadding(5),
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Margin = new MarginPadding(40),
                     CornerRadius = 5,
                     Masking = true,
                     Children = new Drawable[]
@@ -80,28 +82,28 @@ namespace osu.Game.Tests.Visual
                         {
                             Colour = Color4.Black,
                             RelativeSizeAxes = Axes.Both,
-                            Alpha = 0.5f,
+                            Alpha = 0.4f,
                         },
                         new FillFlowContainer
                         {
                             AutoSizeAxes = Axes.Both,
                             Direction = FillDirection.Vertical,
-                            Margin = new MarginPadding(5),
-                            Spacing = new Vector2(5),
+                            Margin = new MarginPadding(10),
+                            Spacing = new Vector2(10),
                             Children = new Drawable[]
                             {
                                 new OsuSpriteText
                                 {
                                     Anchor = Anchor.TopCentre,
                                     Origin = Anchor.TopCentre,
-                                    Text = "Input Priority"
+                                    Font = OsuFont.Default.With(weight: FontWeight.Bold),
+                                    Text = "The test is currently overriding local input",
                                 },
                                 new FillFlowContainer
                                 {
                                     AutoSizeAxes = Axes.Both,
                                     Anchor = Anchor.TopCentre,
                                     Origin = Anchor.TopCentre,
-                                    Margin = new MarginPadding(5),
                                     Spacing = new Vector2(5),
                                     Direction = FillDirection.Horizontal,
 
@@ -109,15 +111,9 @@ namespace osu.Game.Tests.Visual
                                     {
                                         buttonLocal = new RoundedButton
                                         {
-                                            Text = "local",
-                                            Size = new Vector2(50, 30),
-                                            Action = returnUserInput
-                                        },
-                                        buttonTest = new RoundedButton
-                                        {
-                                            Text = "test",
-                                            Size = new Vector2(50, 30),
-                                            Action = returnTestInput
+                                            Text = "Take control back",
+                                            Size = new Vector2(180, 30),
+                                            Action = () => InputManager.UseParentInput = true
                                         },
                                     }
                                 },
@@ -126,6 +122,13 @@ namespace osu.Game.Tests.Visual
                     }
                 },
             });
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            takeControlOverlay.Alpha = InputManager.UseParentInput ? 0 : 1;
         }
 
         /// <summary>
@@ -146,19 +149,5 @@ namespace osu.Game.Tests.Visual
                 InputManager.Click(MouseButton.Left);
             });
         }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            buttonTest.Enabled.Value = InputManager.UseParentInput;
-            buttonLocal.Enabled.Value = !InputManager.UseParentInput;
-        }
-
-        private void returnUserInput() =>
-            InputManager.UseParentInput = true;
-
-        private void returnTestInput() =>
-            InputManager.UseParentInput = false;
     }
 }

--- a/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuManualInputManagerTestScene.cs
@@ -26,8 +26,6 @@ namespace osu.Game.Tests.Visual
 
         protected readonly ManualInputManager InputManager;
 
-        private readonly RoundedButton buttonLocal;
-
         private readonly Container takeControlOverlay;
 
         /// <summary>
@@ -109,7 +107,7 @@ namespace osu.Game.Tests.Visual
 
                                     Children = new Drawable[]
                                     {
-                                        buttonLocal = new RoundedButton
+                                        new RoundedButton
                                         {
                                             Text = "Take control back",
                                             Size = new Vector2(180, 30),


### PR DESCRIPTION
- Only displays when required (there's literally zero case we want to return input to the test, as this is automatic on next action)
- No longer hugs the right side of the screen (blocking visibility of some tests).


https://github.com/ppy/osu/assets/191335/7dc6071e-dd19-495b-b7fb-6354228866fd

