### PR TITLE
Adjust results screen transition tweens to feel better

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -305,7 +305,7 @@ namespace osu.Game.Screens.Ranking
                 float origLocation = detachedPanelContainer.ToLocalSpace(screenSpacePos).X;
                 expandedPanel.MoveToX(origLocation)
                              .Then()
-                             .MoveToX(StatisticsPanel.SIDE_PADDING, 150, Easing.OutQuint);
+                             .MoveToX(StatisticsPanel.SIDE_PADDING, 400, Easing.OutElasticQuarter);
 
                 // Hide contracted panels.
                 foreach (var contracted in ScorePanelList.GetScorePanels().Where(p => p.State == PanelState.Contracted))
@@ -313,7 +313,7 @@ namespace osu.Game.Screens.Ranking
                 ScorePanelList.HandleInput = false;
 
                 // Dim background.
-                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(0.1f), 150));
+                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(0.4f), 400, Easing.OutQuint));
 
                 detachedPanel = expandedPanel;
             }
@@ -329,7 +329,7 @@ namespace osu.Game.Screens.Ranking
                 float origLocation = detachedPanel.Parent.ToLocalSpace(screenSpacePos).X;
                 detachedPanel.MoveToX(origLocation)
                              .Then()
-                             .MoveToX(0, 150, Easing.OutQuint);
+                             .MoveToX(0, 250, Easing.OutElasticQuarter);
 
                 // Show contracted panels.
                 foreach (var contracted in ScorePanelList.GetScorePanels().Where(p => p.State == PanelState.Contracted))
@@ -337,7 +337,7 @@ namespace osu.Game.Screens.Ranking
                 ScorePanelList.HandleInput = true;
 
                 // Un-dim background.
-                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(0.5f), 150));
+                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(0.5f), 250, Easing.OutQuint));
 
                 detachedPanel = null;
             }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
         protected override void PopIn()
         {
-            this.FadeIn(150, Easing.OutQuint);
+            this.FadeIn(350, Easing.OutQuint);
 
             popInSample?.Play();
             wasOpened = true;
@@ -231,7 +231,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
         protected override void PopOut()
         {
-            this.FadeOut(150, Easing.OutQuint);
+            this.FadeOut(250, Easing.OutQuint);
 
             if (wasOpened)
                 popOutSample?.Play();


### PR DESCRIPTION

The background no longer dims as much. This was a complaint as users want to be able to recognise the background when taking a screenshot. It will play better once I update the rest of the results statistics items to have their own backgrounds.

Before:


https://github.com/ppy/osu/assets/191335/d0474125-dd02-4be9-a11f-0e9ab4344d69

After:

https://github.com/ppy/osu/assets/191335/fa540996-b844-4119-b736-d83011faa659
