### PR TITLE
Revamp results screen statistics display

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -26,7 +26,10 @@ using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch
 {
@@ -218,5 +221,13 @@ namespace osu.Game.Rulesets.Catch
         public override HitObjectComposer CreateHitObjectComposer() => new CatchHitObjectComposer(this);
 
         public override IBeatmapVerifier CreateBeatmapVerifier() => new CatchBeatmapVerifier();
+
+        public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap)
+        {
+            return new[]
+            {
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+            };
+        }
     }
 }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Rulesets.Catch
         {
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.25f)),
             };
         }
     }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -405,11 +405,11 @@ namespace osu.Game.Rulesets.Mania
         {
             new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
             new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents), true, relativeSize: new Vector2(1, 0.2f)),
-            new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+            new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
             {
                 new AverageHitError(score.HitEvents),
                 new UnstableRate(score.HitEvents)
-            }), true, new Vector2(1, 0.2f))
+            }), true, new Vector2(1, 0.1f))
         };
 
         public override IRulesetFilterCriteria CreateRulesetFilterCriteria()

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -38,6 +38,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Mania
 {
@@ -402,21 +403,13 @@ namespace osu.Game.Rulesets.Mania
 
         public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
         {
-            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
-            {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y
-            }),
-            new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents)
-            {
-                RelativeSizeAxes = Axes.X,
-                Height = 250
-            }, true),
+            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+            new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents), true, relativeSize: new Vector2(1, 0.2f)),
             new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
             {
                 new AverageHitError(score.HitEvents),
                 new UnstableRate(score.HitEvents)
-            }), true)
+            }), true, new Vector2(1, 0.2f))
         };
 
         public override IRulesetFilterCriteria CreateRulesetFilterCriteria()

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -403,9 +403,9 @@ namespace osu.Game.Rulesets.Mania
 
         public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
         {
-            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.25f)),
             new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents), true, relativeSize: new Vector2(1, 0.2f)),
-            new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
+            new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
             {
                 new AverageHitError(score.HitEvents),
                 new UnstableRate(score.HitEvents)

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -38,6 +38,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu
 {
@@ -304,26 +305,17 @@ namespace osu.Game.Rulesets.Osu
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y
-                }),
-                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = 250
-                }, true),
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(0.75f, 0.2f)),
                 new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
                 {
-                    RelativeSizeAxes = Axes.X,
-                    Height = 250
-                }, true),
+                    RelativeSizeAxes = Axes.Both,
+                }, true, relativeSize: new Vector2(0.25f, 0.2f)),
                 new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)
-                }), true)
+                }), true, new Vector2(1, 0.2f))
             };
         }
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -305,13 +305,13 @@ namespace osu.Game.Rulesets.Osu
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
-                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(0.75f, 0.2f)),
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.25f)),
+                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(0.6f, 0.25f)),
                 new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
                 {
                     RelativeSizeAxes = Axes.Both,
-                }, true, relativeSize: new Vector2(0.25f, 0.2f)),
-                new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                }, true, relativeSize: new Vector2(0.4f, 0.25f)),
+                new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -311,11 +311,11 @@ namespace osu.Game.Rulesets.Osu
                 {
                     RelativeSizeAxes = Axes.Both,
                 }, true, relativeSize: new Vector2(0.25f, 0.2f)),
-                new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)
-                }), true, new Vector2(1, 0.2f))
+                }), true, new Vector2(1, 0.1f))
             };
         }
 

--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Scoring;
@@ -120,18 +121,22 @@ namespace osu.Game.Rulesets.Osu.Statistics
                                         new OsuSpriteText
                                         {
                                             Text = "Overshoot",
+                                            Font = OsuFont.GetFont(size: 12),
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.BottomCentre,
-                                            Padding = new MarginPadding(3),
+                                            Origin = Anchor.BottomLeft,
+                                            Padding = new MarginPadding(2),
+                                            Rotation = -rotation,
                                             RelativePositionAxes = Axes.Both,
                                             Y = -(inner_portion + line_extension) / 2,
                                         },
                                         new OsuSpriteText
                                         {
                                             Text = "Undershoot",
+                                            Font = OsuFont.GetFont(size: 12),
                                             Anchor = Anchor.Centre,
-                                            Origin = Anchor.TopCentre,
-                                            Padding = new MarginPadding(3),
+                                            Origin = Anchor.TopRight,
+                                            Rotation = -rotation,
+                                            Padding = new MarginPadding(2),
                                             RelativePositionAxes = Axes.Both,
                                             Y = (inner_portion + line_extension) / 2,
                                         },

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -247,9 +247,9 @@ namespace osu.Game.Rulesets.Taiko
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.25f)),
                 new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(1, 0.2f)),
-                new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -249,11 +249,11 @@ namespace osu.Game.Rulesets.Taiko
             {
                 new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
                 new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(1, 0.2f)),
-                new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
+                new StatisticItem(string.Empty, () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)
-                }), true, new Vector2(1, 0.2f))
+                }), true, new Vector2(1, 0.1f))
             };
         }
     }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -35,6 +35,7 @@ using osu.Game.Skinning;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Taiko.Configuration;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko
 {
@@ -246,21 +247,13 @@ namespace osu.Game.Rulesets.Taiko
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y
-                }),
-                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Height = 250
-                }, true),
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap), relativeSize: new Vector2(1, 0.2f)),
+                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents), true, relativeSize: new Vector2(1, 0.2f)),
                 new StatisticItem(string.Empty, () => new SimpleStatisticTable(3, new SimpleStatisticItem[]
                 {
                     new AverageHitError(timedHitEvents),
                     new UnstableRate(timedHitEvents)
-                }), true)
+                }), true, new Vector2(1, 0.2f))
             };
         }
     }

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -183,7 +183,6 @@ namespace osu.Game.Tests.Resources
             Accuracy = 0.95,
             MaxCombo = 999,
             Position = 1,
-            OnlineID = 1234,
             Rank = ScoreRank.S,
             Date = DateTimeOffset.Now,
             Statistics = new Dictionary<HitResult, int>

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -183,6 +183,7 @@ namespace osu.Game.Tests.Resources
             Accuracy = 0.95,
             MaxCombo = 999,
             Position = 1,
+            OnlineID = 1234,
             Rank = ScoreRank.S,
             Date = DateTimeOffset.Now,
             Statistics = new Dictionary<HitResult, int>

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 };
 
                 var score = TestResources.CreateTestScoreInfo();
+                score.OnlineID = 1234;
                 score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
 
                 stack.Push(screen = createResultsScreen(score));

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -82,7 +82,10 @@ namespace osu.Game.Tests.Visual.Ranking
                     RelativeSizeAxes = Axes.Both
                 };
 
-                stack.Push(screen = createResultsScreen());
+                var score = TestResources.CreateTestScoreInfo();
+                score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
+
+                stack.Push(screen = createResultsScreen(score));
             });
             AddUntilStep("wait for loaded", () => screen.IsLoaded);
             AddAssert("retry overlay not present", () => screen.RetryOverlay == null);

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -69,6 +69,30 @@ namespace osu.Game.Tests.Visual.Ranking
             }));
         }
 
+        [TestCase(1, ScoreRank.X)]
+        [TestCase(0.9999, ScoreRank.S)]
+        [TestCase(0.975, ScoreRank.S)]
+        [TestCase(0.925, ScoreRank.A)]
+        [TestCase(0.85, ScoreRank.B)]
+        [TestCase(0.75, ScoreRank.C)]
+        [TestCase(0.5, ScoreRank.D)]
+        [TestCase(0.2, ScoreRank.D)]
+        public void TestResultsWithPlayer(double accuracy, ScoreRank rank)
+        {
+            TestResultsScreen screen = null;
+
+            var score = TestResources.CreateTestScoreInfo();
+
+            score.OnlineID = 1234;
+            score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
+            score.Accuracy = accuracy;
+            score.Rank = rank;
+
+            loadResultsScreen(() => screen = createResultsScreen(score));
+            AddUntilStep("wait for loaded", () => screen.IsLoaded);
+            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
+        }
+
         [Test]
         public void TestResultsWithoutPlayer()
         {
@@ -83,35 +107,11 @@ namespace osu.Game.Tests.Visual.Ranking
                 };
 
                 var score = TestResources.CreateTestScoreInfo();
-                score.OnlineID = 1234;
-                score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
 
                 stack.Push(screen = createResultsScreen(score));
             });
             AddUntilStep("wait for loaded", () => screen.IsLoaded);
             AddAssert("retry overlay not present", () => screen.RetryOverlay == null);
-        }
-
-        [TestCase(0.2, ScoreRank.D)]
-        [TestCase(0.5, ScoreRank.D)]
-        [TestCase(0.75, ScoreRank.C)]
-        [TestCase(0.85, ScoreRank.B)]
-        [TestCase(0.925, ScoreRank.A)]
-        [TestCase(0.975, ScoreRank.S)]
-        [TestCase(0.9999, ScoreRank.S)]
-        [TestCase(1, ScoreRank.X)]
-        public void TestResultsWithPlayer(double accuracy, ScoreRank rank)
-        {
-            TestResultsScreen screen = null;
-
-            var score = TestResources.CreateTestScoreInfo();
-
-            score.Accuracy = accuracy;
-            score.Rank = rank;
-
-            loadResultsScreen(() => screen = createResultsScreen(score));
-            AddUntilStep("wait for loaded", () => screen.IsLoaded);
-            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
         }
 
         [Test]
@@ -332,13 +332,14 @@ namespace osu.Game.Tests.Visual.Ranking
             }
         }
 
-        private partial class TestResultsScreen : ResultsScreen
+        private partial class TestResultsScreen : SoloResultsScreen
         {
             public HotkeyRetryOverlay RetryOverlay;
 
             public TestResultsScreen(ScoreInfo score)
                 : base(score, true)
             {
+                ShowUserStatistics = true;
             }
 
             protected override void LoadComplete()

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -133,30 +133,6 @@ namespace osu.Game.Tests.Visual.Ranking
 
             public override string ShortName => string.Empty;
 
-            protected static Drawable CreatePlaceholderStatistic(string message) => new Container
-            {
-                RelativeSizeAxes = Axes.X,
-                Masking = true,
-                CornerRadius = 20,
-                Height = 250,
-                Children = new Drawable[]
-                {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = OsuColour.Gray(0.5f),
-                        Alpha = 0.5f
-                    },
-                    new OsuSpriteText
-                    {
-                        Origin = Anchor.CentreLeft,
-                        Anchor = Anchor.CentreLeft,
-                        Text = message,
-                        Margin = new MarginPadding { Left = 20 }
-                    }
-                }
-            };
-
             private class TestBeatmapConverter : IBeatmapConverter
             {
 #pragma warning disable CS0067 // The event is never used
@@ -180,8 +156,8 @@ namespace osu.Game.Tests.Visual.Ranking
         {
             public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
             {
-                new StatisticItem("Statistic Requiring Hit Events 1", () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true),
-                new StatisticItem("Statistic Requiring Hit Events 2", () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true)
+                new StatisticItem("Statistic Requiring Hit Events 1", () => createPlaceholderStatistic("Placeholder statistic. Requires hit events"), true, new Vector2(1, 0.2f)),
+                new StatisticItem("Statistic Requiring Hit Events 2", () => createPlaceholderStatistic("Placeholder statistic. Requires hit events"), true, new Vector2(1, 0.2f))
             };
         }
 
@@ -191,8 +167,8 @@ namespace osu.Game.Tests.Visual.Ranking
             {
                 return new[]
                 {
-                    new StatisticItem("Statistic Not Requiring Hit Events 1", () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events")),
-                    new StatisticItem("Statistic Not Requiring Hit Events 2", () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events"))
+                    new StatisticItem("Statistic Not Requiring Hit Events 1", () => createPlaceholderStatistic("Placeholder statistic. Does not require hit events"), false, new Vector2(1, 0.2f)),
+                    new StatisticItem("Statistic Not Requiring Hit Events 2", () => createPlaceholderStatistic("Placeholder statistic. Does not require hit events"), false, new Vector2(1, 0.2f))
                 };
             }
         }
@@ -203,10 +179,33 @@ namespace osu.Game.Tests.Visual.Ranking
             {
                 return new[]
                 {
-                    new StatisticItem("Statistic Requiring Hit Events", () => CreatePlaceholderStatistic("Placeholder statistic. Requires hit events"), true),
-                    new StatisticItem("Statistic Not Requiring Hit Events", () => CreatePlaceholderStatistic("Placeholder statistic. Does not require hit events"))
+                    new StatisticItem("Statistic Requiring Hit Events", () => createPlaceholderStatistic("Placeholder statistic. Requires hit events"), true, new Vector2(1, 0.2f)),
+                    new StatisticItem("Statistic Not Requiring Hit Events", () => createPlaceholderStatistic("Placeholder statistic. Does not require hit events"), false, new Vector2(1, 0.2f))
                 };
             }
         }
+
+        private static Drawable createPlaceholderStatistic(string message) => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Masking = true,
+            CornerRadius = 20,
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = OsuColour.Gray(0.5f),
+                    Alpha = 0.5f
+                },
+                new OsuSpriteText
+                {
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Text = message,
+                    Margin = new MarginPadding { Left = 20 }
+                }
+            }
+        };
     }
 }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -30,19 +30,19 @@ namespace osu.Game.Tests.Visual.Ranking
     public partial class TestSceneStatisticsPanel : OsuTestScene
     {
         [Test]
-        public void TestScoreWithTimeStatistics()
+        public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
+            score.HitEvents = createPositionDistributedHitEvents();
 
             loadPanel(score);
         }
 
         [Test]
-        public void TestScoreWithPositionStatistics()
+        public void TestScoreWithTimeStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = createPositionDistributedHitEvents();
+            score.HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
 
             loadPanel(score);
         }
@@ -89,18 +89,19 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private static List<HitEvent> createPositionDistributedHitEvents()
         {
-            var hitEvents = new List<HitEvent>();
+            var hitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
+
             // Use constant seed for reproducibility
             var random = new Random(0);
 
-            for (int i = 0; i < 500; i++)
+            for (int i = 0; i < hitEvents.Count; i++)
             {
                 double angle = random.NextDouble() * 2 * Math.PI;
                 double radius = random.NextDouble() * 0.5f * OsuHitObject.OBJECT_RADIUS;
 
                 var position = new Vector2((float)(radius * Math.Cos(angle)), (float)(radius * Math.Sin(angle)));
 
-                hitEvents.Add(new HitEvent(0, HitResult.Perfect, new HitCircle(), new HitCircle(), position));
+                hitEvents[i] = hitEvents[i].With(position);
             }
 
             return hitEvents;

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = createPositionDistributedHitEvents();
+            score.HitEvents = CreatePositionDistributedHitEvents();
 
             loadPanel(score);
         }
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Ranking
             };
         });
 
-        private static List<HitEvent> createPositionDistributedHitEvents()
+        public static List<HitEvent> CreatePositionDistributedHitEvents()
         {
             var hitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Tests.Resources;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Ranking
@@ -79,11 +81,12 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private void loadPanel(ScoreInfo score) => AddStep("load panel", () =>
         {
-            Child = new StatisticsPanel
+            Child = new SoloStatisticsPanel(score)
             {
                 RelativeSizeAxes = Axes.Both,
                 State = { Value = Visibility.Visible },
-                Score = { Value = score }
+                Score = { Value = score },
+                StatisticsUpdate = { Value = new SoloStatisticsUpdate(score, new UserStatistics(), new UserStatistics()) }
             };
         });
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -87,7 +87,44 @@ namespace osu.Game.Tests.Visual.Ranking
                 RelativeSizeAxes = Axes.Both,
                 State = { Value = Visibility.Visible },
                 Score = { Value = score },
-                StatisticsUpdate = { Value = new SoloStatisticsUpdate(score, new UserStatistics(), new UserStatistics()) }
+                StatisticsUpdate =
+                {
+                    Value = new SoloStatisticsUpdate(score, new UserStatistics
+                    {
+                        Level = new UserStatistics.LevelInfo
+                        {
+                            Current = 5,
+                            Progress = 20,
+                        },
+                        GlobalRank = 38000,
+                        CountryRank = 12006,
+                        PP = 2134,
+                        RankedScore = 21123849,
+                        Accuracy = 0.985,
+                        PlayCount = 13375,
+                        PlayTime = 354490,
+                        TotalScore = 128749597,
+                        TotalHits = 0,
+                        MaxCombo = 1233,
+                    }, new UserStatistics
+                    {
+                        Level = new UserStatistics.LevelInfo
+                        {
+                            Current = 5,
+                            Progress = 30,
+                        },
+                        GlobalRank = 36000,
+                        CountryRank = 12000,
+                        PP = (decimal)2134.5,
+                        RankedScore = 23897015,
+                        Accuracy = 0.984,
+                        PlayCount = 13376,
+                        PlayTime = 35789,
+                        TotalScore = 132218497,
+                        TotalHits = 0,
+                        MaxCombo = 1233,
+                    })
+                }
             };
         });
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
+            score.OnlineID = 1234;
             score.HitEvents = CreatePositionDistributedHitEvents();
 
             loadPanel(score);

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Game.Rulesets.Difficulty
 {
     /// <summary>
@@ -19,5 +17,16 @@ namespace osu.Game.Rulesets.Difficulty
         /// Performance of a perfect play for comparison.
         /// </summary>
         public PerformanceAttributes PerfectPerformance { get; set; }
+
+        /// <summary>
+        /// Create a new performance breakdown.
+        /// </summary>
+        /// <param name="performance">Actual gameplay performance.</param>
+        /// <param name="perfectPerformance">Performance of a perfect play for comparison.</param>
+        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes perfectPerformance)
+        {
+            Performance = performance;
+            PerfectPerformance = perfectPerformance;
+        }
     }
 }

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Difficulty
                 getPerfectPerformance(score, cancellationToken)
             ).ConfigureAwait(false);
 
-            return new PerformanceBreakdown { Performance = performanceArray[0], PerfectPerformance = performanceArray[1] };
+            return new PerformanceBreakdown(performanceArray[0] ?? new PerformanceAttributes(), performanceArray[1] ?? new PerformanceAttributes());
         }
 
         [ItemCanBeNull]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
@@ -48,9 +48,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             const float winner_background_half_height = 250;
 
-            VerticalScrollContent.Anchor = VerticalScrollContent.Origin = Anchor.TopCentre;
-            VerticalScrollContent.Scale = new Vector2(0.9f);
-            VerticalScrollContent.Y = 75;
+            Content.Anchor = Content.Origin = Anchor.TopCentre;
+            Content.Scale = new Vector2(0.9f);
+            Content.Y = 75;
 
             var redScore = teamScores.First().Value;
             var blueScore = teamScores.Last().Value;

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -131,7 +131,6 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             Container axisFlow;
 
-            const float axis_font_size = 12;
 
             InternalChild = new GridContainer
             {
@@ -154,7 +153,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                         axisFlow = new Container
                         {
                             RelativeSizeAxes = Axes.X,
-                            Height = axis_font_size,
+                            Height = StatisticItem.FONT_SIZE,
                         }
                     },
                 },
@@ -174,7 +173,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Text = "0",
-                Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
+                Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold)
             });
 
             for (int i = 1; i <= axis_points; i++)
@@ -191,7 +190,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                     X = -position / 2,
                     Alpha = alpha,
                     Text = axisValue.ToString("-0"),
-                    Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
+                    Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold)
                 });
 
                 axisFlow.Add(new OsuSpriteText
@@ -202,7 +201,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                     X = position / 2,
                     Alpha = alpha,
                     Text = axisValue.ToString("+0"),
-                    Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
+                    Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold)
                 });
             }
         }

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -330,9 +330,6 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                     var box = boxOriginals[i];
 
-                    box.Y = 0;
-                    box.Height = 0;
-
                     box.MoveToY(offsetForValue(offsetValue) * BoundingBox.Height, duration, Easing.OutQuint);
                     box.ResizeHeightTo(heightForValue(value), duration, Easing.OutQuint);
                     offsetValue -= value;

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -131,13 +131,11 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             Container axisFlow;
 
+            Padding = new MarginPadding { Horizontal = 5 };
 
             InternalChild = new GridContainer
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
                 RelativeSizeAxes = Axes.Both,
-                Width = 0.8f,
                 Content = new[]
                 {
                     new Drawable[]

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -113,94 +113,95 @@ namespace osu.Game.Screens.Ranking.Statistics
                 }
             }
 
-            if (barDrawables != null)
-            {
-                for (int i = 0; i < barDrawables.Length; i++)
-                {
-                    barDrawables[i].UpdateOffset(bins[i].Sum(b => b.Value));
-                }
-            }
+            if (barDrawables == null)
+                createBarDrawables();
             else
             {
-                int maxCount = bins.Max(b => b.Values.Sum());
-                barDrawables = bins.Select((bin, i) => new Bar(bins[i], maxCount, i == timing_distribution_centre_bin_index)).ToArray();
+                for (int i = 0; i < barDrawables.Length; i++)
+                    barDrawables[i].UpdateOffset(bins[i].Sum(b => b.Value));
+            }
+        }
 
-                Container axisFlow;
+        private void createBarDrawables()
+        {
+            int maxCount = bins.Max(b => b.Values.Sum());
+            barDrawables = bins.Select((_, i) => new Bar(bins[i], maxCount, i == timing_distribution_centre_bin_index)).ToArray();
 
-                const float axis_font_size = 12;
+            Container axisFlow;
 
-                InternalChild = new GridContainer
+            const float axis_font_size = 12;
+
+            InternalChild = new GridContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Width = 0.8f,
+                Content = new[]
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 0.8f,
-                    Content = new[]
+                    new Drawable[]
                     {
-                        new Drawable[]
+                        new GridContainer
                         {
-                            new GridContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Content = new[] { barDrawables }
-                            }
-                        },
-                        new Drawable[]
-                        {
-                            axisFlow = new Container
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                Height = axis_font_size,
-                            }
-                        },
+                            RelativeSizeAxes = Axes.Both,
+                            Content = new[] { barDrawables }
+                        }
                     },
-                    RowDimensions = new[]
+                    new Drawable[]
                     {
-                        new Dimension(),
-                        new Dimension(GridSizeMode.AutoSize),
-                    }
-                };
+                        axisFlow = new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = axis_font_size,
+                        }
+                    },
+                },
+                RowDimensions = new[]
+                {
+                    new Dimension(),
+                    new Dimension(GridSizeMode.AutoSize),
+                }
+            };
 
-                // Our axis will contain one centre element + 5 points on each side, each with a value depending on the number of bins * bin size.
-                double maxValue = timing_distribution_bins * binSize;
-                double axisValueStep = maxValue / axis_points;
+            // Our axis will contain one centre element + 5 points on each side, each with a value depending on the number of bins * bin size.
+            double maxValue = timing_distribution_bins * binSize;
+            double axisValueStep = maxValue / axis_points;
+
+            axisFlow.Add(new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = "0",
+                Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
+            });
+
+            for (int i = 1; i <= axis_points; i++)
+            {
+                double axisValue = i * axisValueStep;
+                float position = (float)(axisValue / maxValue);
+                float alpha = 1f - position * 0.8f;
 
                 axisFlow.Add(new OsuSpriteText
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Text = "0",
+                    RelativePositionAxes = Axes.X,
+                    X = -position / 2,
+                    Alpha = alpha,
+                    Text = axisValue.ToString("-0"),
                     Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
                 });
 
-                for (int i = 1; i <= axis_points; i++)
+                axisFlow.Add(new OsuSpriteText
                 {
-                    double axisValue = i * axisValueStep;
-                    float position = (float)(axisValue / maxValue);
-                    float alpha = 1f - position * 0.8f;
-
-                    axisFlow.Add(new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativePositionAxes = Axes.X,
-                        X = -position / 2,
-                        Alpha = alpha,
-                        Text = axisValue.ToString("-0"),
-                        Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
-                    });
-
-                    axisFlow.Add(new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativePositionAxes = Axes.X,
-                        X = position / 2,
-                        Alpha = alpha,
-                        Text = axisValue.ToString("+0"),
-                        Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
-                    });
-                }
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.X,
+                    X = position / 2,
+                    Alpha = alpha,
+                    Text = axisValue.ToString("+0"),
+                    Font = OsuFont.GetFont(size: axis_font_size, weight: FontWeight.SemiBold)
+                });
             }
         }
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "Achieved PP",
                                         Colour = Color4Extensions.FromHex("#66FFCC")
                                     },
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 14),
+                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
                                         Colour = Color4Extensions.FromHex("#66FFCC")
                                     }
                                 },
@@ -115,7 +115,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "Maximum",
                                         Colour = OsuColour.Gray(0.7f)
                                     },
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Colour = OsuColour.Gray(0.7f)
                                     }
                                 }
@@ -208,7 +208,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
-                    Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
+                    Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                     Text = attribute.DisplayName,
                     Colour = Colour4.White
                 },
@@ -233,7 +233,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     Origin = Anchor.CentreRight,
                     Anchor = Anchor.CentreRight,
-                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 14),
+                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
                     Text = percentage.ToLocalisableString("0%"),
                     Colour = Colour4.White
                 }

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 18),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
                                         Text = "Achieved PP",
                                         Colour = Color4Extensions.FromHex("#66FFCC")
                                     },
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 18),
+                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 14),
                                         Colour = Color4Extensions.FromHex("#66FFCC")
                                     }
                                 },
@@ -115,7 +115,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 18),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
                                         Text = "Maximum",
                                         Colour = OsuColour.Gray(0.7f)
                                     },
@@ -123,7 +123,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 18),
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
                                         Colour = OsuColour.Gray(0.7f)
                                     }
                                 }
@@ -208,7 +208,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     Origin = Anchor.CentreLeft,
                     Anchor = Anchor.CentreLeft,
-                    Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                    Font = OsuFont.GetFont(weight: FontWeight.Regular, size: 14),
                     Text = attribute.DisplayName,
                     Colour = Colour4.White
                 },
@@ -233,7 +233,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     Origin = Anchor.CentreRight,
                     Anchor = Anchor.CentreRight,
-                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold),
+                    Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: 14),
                     Text = percentage.ToLocalisableString("0%"),
                     Colour = Colour4.White
                 }

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
@@ -44,13 +44,13 @@ namespace osu.Game.Screens.Ranking.Statistics
                     Text = Name,
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
-                    Font = OsuFont.GetFont(size: 14)
+                    Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE)
                 },
                 value = new OsuSpriteText
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
-                    Font = OsuFont.GetFont(size: 14, weight: FontWeight.Bold)
+                    Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.Bold)
                 }
             });
         }

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             Direction = FillDirection.Vertical
         };
 
-        private partial class Spacer : CompositeDrawable
+        public partial class Spacer : CompositeDrawable
         {
             public Spacer()
             {

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
@@ -103,7 +103,6 @@ namespace osu.Game.Screens.Ranking.Statistics
             public Spacer()
             {
                 RelativeSizeAxes = Axes.Both;
-                Padding = new MarginPadding { Vertical = 4 };
 
                 InternalChild = new CircularContainer
                 {

--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 items = items.Append(new StatisticItem("Overall Ranking", () => new OverallRanking
                 {
                     StatisticsUpdate = { BindTarget = StatisticsUpdate }
-                }, relativeSize: new Vector2(1, 0.25f))).ToArray();
+                }, relativeSize: new Vector2(1, 0.22f))).ToArray();
             }
 
             return items;

--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 items = items.Append(new StatisticItem("Overall Ranking", () => new OverallRanking
                 {
                     StatisticsUpdate = { BindTarget = StatisticsUpdate }
-                }, relativeSize: new Vector2(1, 0.4f))).ToArray();
+                }, relativeSize: new Vector2(1, 0.25f))).ToArray();
             }
 
             return items;

--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -4,11 +4,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Solo;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking.Statistics.User;
+using osuTK;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -34,12 +34,8 @@ namespace osu.Game.Screens.Ranking.Statistics
             {
                 items = items.Append(new StatisticItem("Overall Ranking", () => new OverallRanking
                 {
-                    RelativeSizeAxes = Axes.X,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Width = 0.5f,
                     StatisticsUpdate = { BindTarget = StatisticsUpdate }
-                })).ToArray();
+                }, relativeSize: new Vector2(1, 0.4f))).ToArray();
             }
 
             return items;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
@@ -26,31 +26,20 @@ namespace osu.Game.Screens.Ranking.Statistics
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            InternalChild = new GridContainer
+            InternalChild = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Content = new[]
+                Children = new[]
                 {
-                    new[]
+                    createHeader(item),
+                    new Container
                     {
-                        createHeader(item)
-                    },
-                    new Drawable[]
-                    {
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Margin = new MarginPadding { Top = 15 },
-                            Child = item.CreateContent()
-                        }
-                    },
-                },
-                RowDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.AutoSize),
-                    new Dimension(GridSizeMode.AutoSize),
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Margin = new MarginPadding { Top = 15 },
+                        Child = item.CreateContent()
+                    }
                 }
             };
         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -26,15 +27,36 @@ namespace osu.Game.Screens.Ranking.Statistics
             RelativeSizeAxes = Axes.Both;
             Size = item.RelativeSize;
 
-            InternalChildren = new[]
+            Padding = new MarginPadding(5);
+
+            InternalChild = new Container
             {
-                createHeader(item),
-                new Container
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                CornerRadius = 10,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Padding = new MarginPadding { Top = 15 },
-                    Masking = true,
-                    Child = item.CreateContent().With(d => d.RelativeSizeAxes = Axes.Both)
+                    new Box
+                    {
+                        Colour = Color4.Black,
+                        Alpha = 0.5f,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding(5),
+                        Children = new[]
+                        {
+                            createHeader(item),
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Padding = new MarginPadding(5) { Top = 20 },
+                                Child = item.CreateContent().With(d => d.RelativeSizeAxes = Axes.Both)
+                            }
+                        }
+                    },
                 }
             };
         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticContainer.cs
@@ -23,23 +23,18 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="item">The <see cref="StatisticItem"/> to display.</param>
         public StatisticContainer(StatisticItem item)
         {
-            RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.Both;
+            Size = item.RelativeSize;
 
-            InternalChild = new FillFlowContainer
+            InternalChildren = new[]
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Children = new[]
+                createHeader(item),
+                new Container
                 {
-                    createHeader(item),
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Margin = new MarginPadding { Top = 15 },
-                        Child = item.CreateContent()
-                    }
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = 15 },
+                    Masking = true,
+                    Child = item.CreateContent().With(d => d.RelativeSizeAxes = Axes.Both)
                 }
             };
         }
@@ -52,7 +47,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             return new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
+                Height = 15,
                 Direction = FillDirection.Horizontal,
                 Spacing = new Vector2(5, 0),
                 Children = new Drawable[]

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Screens.Ranking.Statistics
     public class StatisticItem
     {
         /// <summary>
+        /// The recommended font size to use in statistic items to make sure they match others.
+        /// </summary>
+        public const float FONT_SIZE = 13;
+
+        /// <summary>
         /// The name of this item.
         /// </summary>
         public readonly LocalisableString Name;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osuTK;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -23,6 +24,14 @@ namespace osu.Game.Screens.Ranking.Statistics
         public readonly Func<Drawable> CreateContent;
 
         /// <summary>
+        /// The relative size of the statistics panel which should be consumed by this item.
+        /// </summary>
+        /// <remarks>
+        /// A relative size of (1, 1) implies one full screen (before scrolling).
+        /// </remarks>
+        public readonly Vector2 RelativeSize;
+
+        /// <summary>
         /// Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.
         /// </summary>
         public readonly bool RequiresHitEvents;
@@ -33,11 +42,13 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="name">The name of the item. Can be <see langword="null"/> to hide the item header.</param>
         /// <param name="createContent">A function returning the <see cref="Drawable"/> content to be displayed.</param>
         /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
-        public StatisticItem(LocalisableString name, Func<Drawable> createContent, bool requiresHitEvents = false)
+        /// <param name="relativeSize">The relative size of the statistics panel which should be consumed by this item.</param>
+        public StatisticItem(LocalisableString name, Func<Drawable> createContent, bool requiresHitEvents = false, Vector2? relativeSize = null)
         {
             Name = name;
             RequiresHitEvents = requiresHitEvents;
             CreateContent = createContent;
+            RelativeSize = relativeSize ?? Vector2.One;
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -24,8 +24,8 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="item">The <see cref="StatisticItem"/> to display.</param>
         public StatisticItemContainer(StatisticItem item)
         {
-            RelativeSizeAxes = Axes.Both;
-            Size = item.RelativeSize;
+            RelativeSizeAxes = Axes.X;
+            Size = item.RelativeSize * new Vector2(1, 720);
 
             Padding = new MarginPadding(5);
 

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
                         Text = item.Name,
-                        Font = OsuFont.GetFont(size: 14, weight: FontWeight.SemiBold),
+                        Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold),
                     }
                 }
             };

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -16,13 +16,13 @@ namespace osu.Game.Screens.Ranking.Statistics
     /// <summary>
     /// Wraps a <see cref="StatisticItem"/> to add a header and suitable layout for use in <see cref="ResultsScreen"/>.
     /// </summary>
-    internal partial class StatisticContainer : CompositeDrawable
+    internal partial class StatisticItemContainer : CompositeDrawable
     {
         /// <summary>
-        /// Creates a new <see cref="StatisticContainer"/>.
+        /// Creates a new <see cref="StatisticItemContainer"/>.
         /// </summary>
         /// <param name="item">The <see cref="StatisticItem"/> to display.</param>
-        public StatisticContainer(StatisticItem item)
+        public StatisticItemContainer(StatisticItem item)
         {
             RelativeSizeAxes = Axes.Both;
             Size = item.RelativeSize;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         public StatisticItemContainer(StatisticItem item)
         {
             RelativeSizeAxes = Axes.X;
-            Size = item.RelativeSize * new Vector2(1, 720);
+            Size = item.RelativeSize * new Vector2(1, StatisticsPanel.USABLE_SPACE.Y);
 
             Padding = new MarginPadding(5);
 

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -3,13 +3,13 @@
 
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -33,13 +33,16 @@ namespace osu.Game.Screens.Ranking.Statistics
             {
                 RelativeSizeAxes = Axes.Both,
                 Masking = true,
-                CornerRadius = 10,
+                CornerRadius = 6,
                 Children = new Drawable[]
                 {
                     new Box
                     {
-                        Colour = Color4.Black,
-                        Alpha = 0.5f,
+                        Colour = ColourInfo.GradientVertical(
+                            OsuColour.Gray(0.25f),
+                            OsuColour.Gray(0.18f)
+                        ),
+                        Alpha = 0.95f,
                         RelativeSizeAxes = Axes.Both,
                     },
                     new Container

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding(5) { Top = 20 },
+                                Padding = new MarginPadding(10) { Top = 30 },
                                 Child = item.CreateContent().With(d => d.RelativeSizeAxes = Axes.Both)
                             }
                         }
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             return new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 15,
+                Height = 20,
                 Direction = FillDirection.Horizontal,
                 Spacing = new Vector2(5, 0),
                 Children = new Drawable[]

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -26,6 +27,11 @@ namespace osu.Game.Screens.Ranking.Statistics
 {
     public partial class StatisticsPanel : VisibilityContainer
     {
+        /// <summary>
+        /// The usable absolute screen region which can be filled with statistics items.
+        /// </summary>
+        public static readonly Vector2 USABLE_SPACE = new Vector2(720, 720);
+
         public const float SIDE_PADDING = 30;
 
         public readonly Bindable<ScoreInfo> Score = new Bindable<ScoreInfo>();
@@ -142,7 +148,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                         ColumnDimensions = new[]
                         {
                             new Dimension(),
-                            new Dimension(GridSizeMode.Distributed, 540, 540, 720),
+                            new Dimension(GridSizeMode.Distributed, 540, 540, USABLE_SPACE.X),
                             new Dimension(),
                         },
                         RowDimensions = new[]
@@ -231,7 +237,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         {
             base.Update();
             if (flow != null)
-                scroll.Height = flow.DrawHeight;
+                scroll.Height = Math.Min(flow.DrawHeight, USABLE_SPACE.Y);
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                     content = new Container
                     {
                         RelativeSizeAxes = Axes.X,
-                        Height = 640,
+                        AutoSizeAxes = Axes.Y,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     },
@@ -113,11 +113,12 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                 if (!hitEventsAvailable && statisticItems.All(c => c.RequiresHitEvents))
                 {
-                    container = new FillFlowContainer
+                    container = flow = new FillFlowContainer
                     {
-                        RelativeSizeAxes = Axes.Both,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
@@ -135,13 +136,18 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     container = new GridContainer
                     {
-                        RelativeSizeAxes = Axes.Both,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
                         Alpha = 0,
                         ColumnDimensions = new[]
                         {
                             new Dimension(),
                             new Dimension(GridSizeMode.Distributed, 540, 540, 720),
                             new Dimension(),
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize)
                         },
                         Content = new[]
                         {
@@ -150,12 +156,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                 Empty(),
                                 scroll = new OsuScrollContainer(Direction.Vertical)
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    Masking = false,
+                                    RelativeSizeAxes = Axes.X,
                                     Children = new[]
                                     {
                                         flow = new FillFlowContainer
                                         {
                                             RelativeSizeAxes = Axes.X,
+                                            AutoSizeAxes = Axes.Y,
                                             Direction = FillDirection.Full,
                                         }
                                     }
@@ -223,7 +231,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         {
             base.Update();
             if (flow != null)
-                flow.Height = scroll.DrawHeight;
+                scroll.Height = flow.DrawHeight;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             continue;
                         }
 
-                        flow.Add(new StatisticContainer(item));
+                        flow.Add(new StatisticItemContainer(item));
                     }
 
                     if (anyRequiredHitEvents)

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 }
                 else
                 {
-                    FillFlowContainer rows;
+                    FillFlowContainer flow;
                     container = new OsuScrollContainer(Direction.Vertical)
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -133,11 +133,12 @@ namespace osu.Game.Screens.Ranking.Statistics
                         Alpha = 0,
                         Children = new[]
                         {
-                            rows = new FillFlowContainer
+                            flow = new FillFlowContainer
                             {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Spacing = new Vector2(30, 15)
+                                Spacing = new Vector2(30, 15),
+                                Direction = FillDirection.Full,
                             }
                         }
                     };
@@ -146,35 +147,22 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                     foreach (var item in statisticItems)
                     {
-                        var columnContent = new List<Drawable>();
-
                         if (!hitEventsAvailable && item.RequiresHitEvents)
                         {
                             anyRequiredHitEvents = true;
                             continue;
                         }
 
-                        columnContent.Add(new StatisticContainer(item)
+                        flow.Add(new StatisticContainer(item)
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                        });
-
-                        rows.Add(new GridContainer
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Content = new[] { columnContent.ToArray() },
-                            ColumnDimensions = new[] { new Dimension() },
-                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
                         });
                     }
 
                     if (anyRequiredHitEvents)
                     {
-                        rows.Add(new FillFlowContainer
+                        flow.Add(new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <summary>
         /// The usable absolute screen region which can be filled with statistics items.
         /// </summary>
-        public static readonly Vector2 USABLE_SPACE = new Vector2(720, 720);
+        public static readonly Vector2 USABLE_SPACE = new Vector2(960, 720);
 
         public const float SIDE_PADDING = 30;
 

--- a/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Solo;
-using osuTK;
 
 namespace osu.Game.Screens.Ranking.Statistics.User
 {
@@ -18,7 +17,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
         public Bindable<SoloStatisticsUpdate?> StatisticsUpdate { get; } = new Bindable<SoloStatisticsUpdate?>();
 
         private LoadingLayer loadingLayer = null!;
-        private FillFlowContainer content = null!;
+        private GridContainer content = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -29,21 +28,47 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                 {
                     RelativeSizeAxes = Axes.Both,
                 },
-                content = new FillFlowContainer
+                content = new GridContainer
                 {
                     AlwaysPresent = true,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(5),
-                    Children = new Drawable[]
+                    ColumnDimensions = new[]
                     {
-                        new GlobalRankChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
-                        new AccuracyChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
-                        new MaximumComboChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
-                        new RankedScoreChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
-                        new TotalScoreChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
-                        new PerformancePointsChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } }
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, 30),
+                        new Dimension(),
+                    },
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, 10),
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, 10),
+                        new Dimension(GridSizeMode.AutoSize),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new GlobalRankChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                            new SimpleStatisticTable.Spacer(),
+                            new PerformancePointsChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                        },
+                        new Drawable[] { },
+                        new Drawable[]
+                        {
+                            new MaximumComboChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                            new SimpleStatisticTable.Spacer(),
+                            new AccuracyChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                        },
+                        new Drawable[] { },
+                        new Drawable[]
+                        {
+                            new RankedScoreChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                            new SimpleStatisticTable.Spacer(),
+                            new TotalScoreChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },
+                        }
                     }
                 }
             };

--- a/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(10),
+                    Spacing = new Vector2(5),
                     Children = new Drawable[]
                     {
                         new GlobalRankChangeRow { StatisticsUpdate = { BindTarget = StatisticsUpdate } },

--- a/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/OverallRanking.cs
@@ -23,10 +23,6 @@ namespace osu.Game.Screens.Ranking.Statistics.User
         [BackgroundDependencyLoader]
         private void load()
         {
-            AutoSizeAxes = Axes.Y;
-            AutoSizeEasing = Easing.OutQuint;
-            AutoSizeDuration = transition_duration;
-
             InternalChildren = new Drawable[]
             {
                 loadingLayer = new LoadingLayer(withBox: false)

--- a/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -46,7 +47,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                 new OsuSpriteText
                 {
                     Text = Label,
-                    Font = OsuFont.Default.With(size: 18)
+                    Font = OsuFont.Default.With(size: 14)
                 },
                 new FillFlowContainer
                 {
@@ -65,17 +66,31 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                             Spacing = new Vector2(5),
                             Children = new Drawable[]
                             {
-                                changeIcon = new SpriteIcon
+                                new Container
                                 {
+                                    Size = new Vector2(14),
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Size = new Vector2(18)
+                                    Children = new Drawable[]
+                                    {
+                                        new Circle
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = colours.Gray1
+                                        },
+                                        changeIcon = new SpriteIcon
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Size = new Vector2(10),
+                                        },
+                                    }
                                 },
                                 currentValueText = new OsuSpriteText
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Font = OsuFont.Default.With(size: 18, weight: FontWeight.Bold)
+                                    Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold)
                                 },
                             }
                         },
@@ -123,7 +138,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
             }
             else
             {
-                comparisonColour = colours.Orange1;
+                comparisonColour = colours.Gray4;
                 icon = FontAwesome.Solid.Minus;
             }
 

--- a/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
                     Direction = FillDirection.Vertical,
-                    AutoSizeAxes = Axes.Both,
+                    AutoSizeAxes = Axes.X,
+                    Height = StatisticItem.FONT_SIZE * 2,
                     Children = new Drawable[]
                     {
                         new FillFlowContainer
@@ -98,7 +99,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                         {
                             Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
-                            Font = OsuFont.Default.With(weight: FontWeight.Bold)
+                            Font = OsuFont.Default.With(size: StatisticItem.FONT_SIZE, weight: FontWeight.Bold)
                         }
                     }
                 }

--- a/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
+++ b/osu.Game/Screens/Ranking/Statistics/User/RankingChangeRow.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                 new OsuSpriteText
                 {
                     Text = Label,
-                    Font = OsuFont.Default.With(size: 14)
+                    Font = OsuFont.Default.With(size: StatisticItem.FONT_SIZE)
                 },
                 new FillFlowContainer
                 {
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Ranking.Statistics.User
                                 {
                                     Anchor = Anchor.CentreRight,
                                     Origin = Anchor.CentreRight,
-                                    Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold)
+                                    Font = OsuFont.Default.With(size: StatisticItem.FONT_SIZE, weight: FontWeight.Bold)
                                 },
                             }
                         },


### PR DESCRIPTION
PRing for initial feedback. Still have a few tidying tasks before this is ready for merge.

This isn't intended to be a final design or even something matching flyte's newer designs. It's an initial effort to tidy up how statistics are provided and presented on the results screen. I've taken liberties in colour choice and positioning.

| Before | After |
|:------:|:-----:|
| ![osu! 2021-09 at 09 38 45](https://github.com/ppy/osu/assets/191335/5cb28fea-d59c-4a5b-84ce-df76dbe01310) | ![osu! 2023-07-07 at 09 49 32](https://github.com/ppy/osu/assets/191335/703d61d2-ebe3-431f-9ea0-92706191ee62) |

- Resolves https://github.com/ppy/osu/issues/27580
- [x] Depends on https://github.com/ppy/osu/pull/24152
- [x] Depends on https://github.com/ppy/osu/pull/24191
- [x] Depends on https://github.com/ppy/osu/pull/24203
- [x] Depends on https://github.com/ppy/osu/pull/24204
- [x] Depends on https://github.com/ppy/osu/pull/24206

Todo:

- [x] Fix vertical centering when ruleset is not providing a full grid of content
- [ ] Fix UI scale breaking things at extremes (maybe a separate PR)