### PR TITLE
Fix pressing Ctrl-C in composer not copying timestamp to system clipboard with empty selection

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -101,26 +101,31 @@ namespace osu.Game.Screens.Edit.Compose
 
         #region Clipboard operations
 
-        protected override void PerformCut()
+        public override void Cut()
         {
-            base.PerformCut();
+            if (!CanCut.Value)
+                return;
 
             Copy();
             EditorBeatmap.RemoveRange(EditorBeatmap.SelectedHitObjects.ToArray());
         }
 
-        protected override void PerformCopy()
+        public override void Copy()
         {
-            base.PerformCopy();
+            // on stable, pressing Ctrl-C would copy the current timestamp to system clipboard
+            // regardless of whether anything was even selected at all.
+            // UX-wise this is generally strange and unexpected, but make it work anyways to preserve muscle memory.
+            // note that this means that `getTimestamp()` must handle no-selection case, too.
+            host.GetClipboard()?.SetText(getTimestamp());
 
-            clipboard.Value = new ClipboardContent(EditorBeatmap).Serialize();
-
-            host.GetClipboard()?.SetText(formatSelectionAsString());
+            if (CanCopy.Value)
+                clipboard.Value = new ClipboardContent(EditorBeatmap).Serialize();
         }
 
-        protected override void PerformPaste()
+        public override void Paste()
         {
-            base.PerformPaste();
+            if (!CanPaste.Value)
+                return;
 
             var objects = clipboard.Value.Deserialize<ClipboardContent>().HitObjects;
 
@@ -147,7 +152,7 @@ namespace osu.Game.Screens.Edit.Compose
             CanPaste.Value = composer.IsLoaded && !string.IsNullOrEmpty(clipboard.Value);
         }
 
-        private string formatSelectionAsString()
+        private string getTimestamp()
         {
             if (composer == null)
                 return string.Empty;

--- a/osu.Game/Screens/Edit/EditorScreen.cs
+++ b/osu.Game/Screens/Edit/EditorScreen.cs
@@ -44,14 +44,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Performs a "cut to clipboard" operation appropriate for the given screen.
         /// </summary>
-        protected virtual void PerformCut()
+        /// <remarks>
+        /// Implementors are responsible for checking <see cref="CanCut"/> themselves.
+        /// </remarks>
+        public virtual void Cut()
         {
-        }
-
-        public void Cut()
-        {
-            if (CanCut.Value)
-                PerformCut();
         }
 
         public BindableBool CanCopy { get; } = new BindableBool();
@@ -59,14 +56,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Performs a "copy to clipboard" operation appropriate for the given screen.
         /// </summary>
-        protected virtual void PerformCopy()
-        {
-        }
-
+        /// <remarks>
+        /// Implementors are responsible for checking <see cref="CanCopy"/> themselves.
+        /// </remarks>
         public virtual void Copy()
         {
-            if (CanCopy.Value)
-                PerformCopy();
         }
 
         public BindableBool CanPaste { get; } = new BindableBool();
@@ -74,14 +68,11 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Performs a "paste from clipboard" operation appropriate for the given screen.
         /// </summary>
-        protected virtual void PerformPaste()
-        {
-        }
-
+        /// <remarks>
+        /// Implementors are responsible for checking <see cref="CanPaste"/> themselves.
+        /// </remarks>
         public virtual void Paste()
         {
-            if (CanPaste.Value)
-                PerformPaste();
         }
 
         #endregion


### PR DESCRIPTION
As noted [on discord](https://discord.com/channels/188630481301012481/188630652340404224/1127629611191250974).

As noted in the following discussion there, it's a weird one. UX-wise the copy item in editor menu shouldn't be unblocked while there is nothing selected (every single other editor does this), which is what `CanCopy` was responsible for (and was why this was broken for no selection despite the underlying method supporting this). I think the timestamp copy thing ideally would be a separate action but can't be due to mapper muscle memory so I'm just making work in a very hidden way for those that are used to it already.

This also nukes the `Cut` / `PerformCut` et al. structure because while you technically _could_ fix it just by overriding `Copy()`, having both `Copy()` and `PerformCopy()` overridden is......... not good.

No tests here because headless hosts don't have a clipboard to set, so it is currently untestable.