### PR TITLE
Add 'Paste' to `OsuTextBox` right click/long tap context menu

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneLoginOverlay.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneLoginOverlay.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
@@ -20,19 +19,19 @@ namespace osu.Game.Tests.Visual.Menus
     {
         private LoginOverlay loginOverlay = null!;
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            Child = loginOverlay = new LoginOverlay
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            };
-        }
+        private OsuPasswordTextBox passwordTextBox => loginOverlay.ChildrenOfType<OsuPasswordTextBox>().First();
 
         [SetUpSteps]
         public void SetUpSteps()
         {
+            AddStep("create login overlay", () =>
+            {
+                Child = loginOverlay = new LoginOverlay
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                };
+            });
             AddStep("show login overlay", () => loginOverlay.Show());
         }
 
@@ -41,7 +40,7 @@ namespace osu.Game.Tests.Visual.Menus
         {
             AddStep("logout", () => API.Logout());
 
-            AddStep("enter password", () => loginOverlay.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("enter password", () => passwordTextBox.Text = "password");
             AddStep("submit", () => loginOverlay.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
         }
 
@@ -54,7 +53,7 @@ namespace osu.Game.Tests.Visual.Menus
                 ((DummyAPIAccess)API).FailNextLogin();
             });
 
-            AddStep("enter password", () => loginOverlay.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("enter password", () => passwordTextBox.Text = "password");
             AddStep("submit", () => loginOverlay.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
         }
 
@@ -67,7 +66,7 @@ namespace osu.Game.Tests.Visual.Menus
                 ((DummyAPIAccess)API).PauseOnConnectingNextLogin();
             });
 
-            AddStep("enter password", () => loginOverlay.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("enter password", () => passwordTextBox.Text = "password");
             AddStep("submit", () => loginOverlay.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
         }
 
@@ -75,7 +74,7 @@ namespace osu.Game.Tests.Visual.Menus
         public void TestClickingOnFlagClosesOverlay()
         {
             AddStep("logout", () => API.Logout());
-            AddStep("enter password", () => loginOverlay.ChildrenOfType<OsuPasswordTextBox>().First().Text = "password");
+            AddStep("enter password", () => passwordTextBox.Text = "password");
             AddStep("submit", () => loginOverlay.ChildrenOfType<OsuButton>().First(b => b.Text.ToString() == "Sign in").TriggerClick());
 
             AddStep("click on flag", () =>

--- a/osu.Game/Graphics/ScreenshotManager.cs
+++ b/osu.Game/Graphics/ScreenshotManager.cs
@@ -43,6 +43,9 @@ namespace osu.Game.Graphics
         [Resolved]
         private GameHost host { get; set; }
 
+        [Resolved]
+        private Clipboard clipboard { get; set; }
+
         private Storage storage;
 
         [Resolved]
@@ -116,7 +119,7 @@ namespace osu.Game.Graphics
 
                 using (var image = await host.TakeScreenshotAsync().ConfigureAwait(false))
                 {
-                    host.GetClipboard()?.SetImage(image);
+                    clipboard.SetImage(image);
 
                     (string filename, var stream) = getWritableStream();
 

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Graphics.UserInterface
         private GameHost host { get; set; } = null!;
 
         [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
+        [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
 
         private readonly SpriteIcon linkIcon;
@@ -92,8 +95,11 @@ namespace osu.Game.Graphics.UserInterface
 
         private void copyUrl()
         {
-            host.GetClipboard()?.SetText(Link);
-            onScreenDisplay?.Display(new CopyUrlToast());
+            if (Link != null)
+            {
+                clipboard.SetText(Link);
+                onScreenDisplay?.Display(new CopyUrlToast());
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -14,17 +14,20 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Platform;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public partial class OsuTextBox : BasicTextBox
+    public partial class OsuTextBox : BasicTextBox, IHasContextMenu
     {
         /// <summary>
         /// Whether to allow playing a different samples based on the type of character.
@@ -35,6 +38,31 @@ namespace osu.Game.Graphics.UserInterface
         protected override float LeftRightPadding => 10;
 
         protected override float CaretWidth => 3;
+
+        [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
+        public MenuItem[]? ContextMenuItems
+        {
+            get
+            {
+                if (ReadOnly)
+                    return null;
+
+                return new MenuItem[]
+                {
+                    new OsuMenuItem(CommonStrings.Paste, MenuItemType.Highlighted, () =>
+                    {
+                        InsertString(clipboard.GetText());
+                        Schedule(() => GetContainingInputManager()?.ChangeFocus(this));
+                    })
+                    {
+                        // disable the item if there's nothing to paste.
+                        Action = { Disabled = string.IsNullOrEmpty(clipboard.GetText()) }
+                    }
+                };
+            }
+        }
 
         protected override SpriteText CreatePlaceholder() => new OsuSpriteText
         {

--- a/osu.Game/Online/Chat/ExternalLinkOpener.cs
+++ b/osu.Game/Online/Chat/ExternalLinkOpener.cs
@@ -18,6 +18,9 @@ namespace osu.Game.Online.Chat
         [Resolved]
         private GameHost host { get; set; } = null!;
 
+        [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
         [Resolved(CanBeNull = true)]
         private IDialogOverlay? dialogOverlay { get; set; }
 
@@ -32,7 +35,7 @@ namespace osu.Game.Online.Chat
         public void OpenUrlExternally(string url, bool bypassWarning = false)
         {
             if (!bypassWarning && externalLinkWarning.Value && dialogOverlay != null)
-                dialogOverlay.Push(new ExternalLinkDialog(url, () => host.OpenUrlExternally(url), () => host.GetClipboard()?.SetText(url)));
+                dialogOverlay.Push(new ExternalLinkDialog(url, () => host.OpenUrlExternally(url), () => clipboard.SetText(url)));
             else
                 host.OpenUrlExternally(url);
         }

--- a/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
+++ b/osu.Game/Overlays/AccountCreation/ScreenEntry.cs
@@ -15,6 +15,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -56,75 +57,79 @@ namespace osu.Game.Overlays.AccountCreation
         {
             InternalChildren = new Drawable[]
             {
-                new FillFlowContainer
+                new OsuContextMenuContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    Padding = new MarginPadding(20),
-                    Spacing = new Vector2(0, 10),
-                    Children = new Drawable[]
+                    Child = new FillFlowContainer
                     {
-                        new OsuSpriteText
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Padding = new MarginPadding(20),
+                        Spacing = new Vector2(0, 10),
+                        Children = new Drawable[]
                         {
-                            Margin = new MarginPadding { Vertical = 10 },
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Font = OsuFont.GetFont(size: 20),
-                            Text = AccountCreationStrings.LetsCreateAnAccount
-                        },
-                        usernameTextBox = new OsuTextBox
-                        {
-                            PlaceholderText = UsersStrings.LoginUsername.ToLower(),
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this
-                        },
-                        usernameDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        emailTextBox = new OsuTextBox
-                        {
-                            PlaceholderText = ModelValidationStrings.UserAttributesUserEmail.ToLower(),
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this
-                        },
-                        emailAddressDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        passwordTextBox = new OsuPasswordTextBox
-                        {
-                            PlaceholderText = UsersStrings.LoginPassword.ToLower(),
-                            RelativeSizeAxes = Axes.X,
-                            TabbableContentContainer = this,
-                        },
-                        passwordDescription = new ErrorTextFlowContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Children = new Drawable[]
+                            new OsuSpriteText
                             {
-                                registerShake = new ShakeContainer
+                                Margin = new MarginPadding { Vertical = 10 },
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Font = OsuFont.GetFont(size: 20),
+                                Text = AccountCreationStrings.LetsCreateAnAccount
+                            },
+                            usernameTextBox = new OsuTextBox
+                            {
+                                PlaceholderText = UsersStrings.LoginUsername.ToLower(),
+                                RelativeSizeAxes = Axes.X,
+                                TabbableContentContainer = this
+                            },
+                            usernameDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            emailTextBox = new OsuTextBox
+                            {
+                                PlaceholderText = ModelValidationStrings.UserAttributesUserEmail.ToLower(),
+                                RelativeSizeAxes = Axes.X,
+                                TabbableContentContainer = this
+                            },
+                            emailAddressDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            passwordTextBox = new OsuPasswordTextBox
+                            {
+                                PlaceholderText = UsersStrings.LoginPassword.ToLower(),
+                                RelativeSizeAxes = Axes.X,
+                                TabbableContentContainer = this,
+                            },
+                            passwordDescription = new ErrorTextFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Children = new Drawable[]
                                 {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Child = new SettingsButton
+                                    registerShake = new ShakeContainer
                                     {
-                                        Text = LoginPanelStrings.Register,
-                                        Margin = new MarginPadding { Vertical = 20 },
-                                        Action = performRegistration
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Child = new SettingsButton
+                                        {
+                                            Text = LoginPanelStrings.Register,
+                                            Margin = new MarginPadding { Vertical = 20 },
+                                            Action = performRegistration
+                                        }
                                     }
                                 }
-                            }
+                            },
                         },
                     },
                 },

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Overlays.Comments
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private GameHost host { get; set; } = null!;
+        private Clipboard clipboard { get; set; } = null!;
 
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
@@ -444,7 +444,7 @@ namespace osu.Game.Overlays.Comments
 
         private void copyUrl()
         {
-            host.GetClipboard()?.SetText($@"{api.APIEndpointUrl}/comments/{Comment.Id}");
+            clipboard.SetText($@"{api.APIEndpointUrl}/comments/{Comment.Id}");
             onScreenDisplay?.Display(new CopyUrlToast());
         }
 

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Edit.Compose
     public partial class ComposeScreen : EditorScreenWithTimeline, IGameplaySettings
     {
         [Resolved]
-        private GameHost host { get; set; }
+        private Clipboard hostClipboard { get; set; } = null!;
 
         [Resolved]
         private EditorClock clock { get; set; }
@@ -116,7 +116,7 @@ namespace osu.Game.Screens.Edit.Compose
             // regardless of whether anything was even selected at all.
             // UX-wise this is generally strange and unexpected, but make it work anyways to preserve muscle memory.
             // note that this means that `getTimestamp()` must handle no-selection case, too.
-            host.GetClipboard()?.SetText(getTimestamp());
+            hostClipboard.SetText(getTimestamp());
 
             if (CanCopy.Value)
                 clipboard.Value = new ClipboardContent(EditorBeatmap).Serialize();


### PR DESCRIPTION
- Partially resolves https://github.com/ppy/osu/discussions/22565
- Resolves https://github.com/ppy/osu/discussions/15346

**Depends on:**
- [ ] https://github.com/ppy/osu/pull/24183 (for tests / mergeability)

Since using `IHasContextMenu` requires a parent `OsuContextMenuContainer`, right click to paste doesn't work in all text boxes. Instead of nesting text boxes in `OsuContextMenuContainer` everywhere, I've only added it to places where user account passwords are entered.

Only paste is added (so no copy/cut) as that's most important. Additionally, having `Copy` doesn't really work, as the selection changes from the right click (would require a framework change) and opening the context menu removes focus from the text box, rendering the selection invisible (bad UX).
