### PR TITLE
Fix incorrect slider stacking on very old beatmaps

### DIFF
--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapProcessor.cs
@@ -214,17 +214,24 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                         ? currSlider.Position + currSlider.Path.PositionAt(1)
                         : currHitObject.Position;
 
+                    // Note the use of `StartTime` in the code below doesn't match stable's use of `EndTime`.
+                    // This is because in the stable implementation, `UpdateCalculations` is not called on the inner-loop hitobject (j)
+                    // and therefore it does not have a correct `EndTime`, but instead the default of `EndTime = StartTime`.
+                    //
+                    // Effects of this can be seen on https://osu.ppy.sh/beatmapsets/243#osu/1146 at sliders around 86647 ms, where
+                    // if we use `EndTime` here it would result in unexpected stacking.
+
                     if (Vector2Extensions.Distance(beatmap.HitObjects[j].Position, currHitObject.Position) < stack_distance)
                     {
                         currHitObject.StackHeight++;
-                        startTime = beatmap.HitObjects[j].GetEndTime();
+                        startTime = beatmap.HitObjects[j].StartTime;
                     }
                     else if (Vector2Extensions.Distance(beatmap.HitObjects[j].Position, position2) < stack_distance)
                     {
                         // Case for sliders - bump notes down and right, rather than up and left.
                         sliderStack++;
                         beatmap.HitObjects[j].StackHeight -= sliderStack;
-                        startTime = beatmap.HitObjects[j].GetEndTime();
+                        startTime = beatmap.HitObjects[j].StartTime;
                     }
                 }
             }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24185

The stable code has had a bug in this logic forever. So we'll need to reimplement the bug.

Basically, sliders have to have `UpdateCalculations` run in order to have a correct `Position2` and `EndTime`, but this wasn't being called in the inner loop before use of `EndTime` at https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/HitObjectManager.cs#L1813.

![Parallels Desktop 2023-07-12 at 08 23 20](https://github.com/ppy/osu/assets/191335/5194956f-ecb4-4406-bc17-ba1e51739f03)

At this same point in lazer's execution, we have the *correct* `EndTime` (also note the FP difference, I'm not sure if we should fix that while we're here......):

![JetBrains Rider 2023-07-12 at 08 26 50](https://github.com/ppy/osu/assets/191335/27698b6c-319b-4a77-a5fd-b3fef8972bb7)

To fix this, we use `StartTime` in the inner loop to reproduce the bug.

Before:

![osu! 2023-07-12 at 08 34 41](https://github.com/ppy/osu/assets/191335/3ea0dde6-ec2c-4813-b420-2a97460c5bff)

After:

![osu! 2023-07-12 at 08 31 49](https://github.com/ppy/osu/assets/191335/cb003b0f-8ee4-4417-b4f9-03fe20835b8a)

