### PR TITLE
Re-enable connection retrying on discord connector

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -54,9 +54,6 @@ namespace osu.Desktop
 
             client.OnReady += onReady;
 
-            // safety measure for now, until we performance test / improve backoff for failed connections.
-            client.OnConnectionFailed += (_, _) => client.Deinitialize();
-
             client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);
 
             config.BindWith(OsuSetting.DiscordRichPresence, privacyMode);

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Clowd.Squirrel" Version="2.9.42" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
-    <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
+    <PackageReference Include="DiscordRichPresence" Version="1.1.4.20" />
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />


### PR DESCRIPTION
We disabled retry logic in https://github.com/ppy/osu/pull/7332 due to reported overheads (in stable), as a precautionary measure. I've revisited this (triggered by [this report](https://github.com/ppy/osu/discussions/24147#discussioncomment-6386783)) as it's pretty bad not having any kind of retry logic.

Over 5 failed connection attempts:

| Before | After |
|:------:|:-----:|
| ![Parallels Desktop 2021-09 at 09 36 44](https://github.com/ppy/osu/assets/191335/251691ce-aa21-47de-8768-33a24d29add2) | ![Parallels Desktop 2023-07-12 at 09 34 33](https://github.com/ppy/osu/assets/191335/a8575d49-4348-4ece-a1cd-9cbc4ca82912) |

Note that this is *running time*, not *all* time. It does not include actual `Thread.Sleep` sleep time, and the overhead seen here is actual CPU time being used.

Of note, the implementation of `NamedPipeClientStream` has some egregious use of `SpinOnce`:

https://github.com/dotnet/runtime/blob/d59af2cf097acb100ad6a9cba652be34be6f4a2e/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs#L151-L155

This adds perceivable overhead to the connect process, which we really don't want on a background thread.

To get around this, I've made a local copy of `ManagedNamedPipeClient` (https://github.com/Lachee/discord-rpc-csharp/blob/master/DiscordRPC/IO/ManagedNamedPipeClient.cs) and adjusted the connect timeout to 0, removing this overhead completely.

Tested on macOS and windows.

- [x] Test on linux (initial connection and reconnect after closing and reopening discord, should occur within 10 seconds)

When testing, this diff can be used to enable console log output:

```diff
diff --git a/osu.Desktop/DiscordRichPresence.cs b/osu.Desktop/DiscordRichPresence.cs
index 1ea85ee2e2..3446f39743 100644
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using DiscordRPC;
+using DiscordRPC.Logging;
 using DiscordRPC.Message;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -16,6 +17,7 @@
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Users;
+using LogLevel = osu.Framework.Logging.LogLevel;
 
 namespace osu.Desktop
 {
@@ -51,6 +53,8 @@ private void load(OsuConfigManager config)
                 SkipIdenticalPresence = false // handles better on discord IPC loss, see updateStatus call in onReady.
             };
 
+            client.Logger = new ConsoleLogger(DiscordRPC.Logging.LogLevel.Trace);
+
             client.OnReady += onReady;
 
             client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Code} {e.Message}", LoggingTarget.Network);

```