### PR TITLE
Update design of "revert to default" button

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -195,16 +195,16 @@ namespace osu.Game.Tests.Visual.Settings
                 InputManager.ReleaseKey(Key.P);
             });
 
-            AddUntilStep("restore button shown", () => settingsKeyBindingRow.ChildrenOfType<RestoreDefaultValueButton<bool>>().First().Alpha > 0);
+            AddUntilStep("restore button shown", () => settingsKeyBindingRow.ChildrenOfType<RevertToDefaultButton<bool>>().First().Alpha > 0);
 
             AddStep("click reset button for bindings", () =>
             {
-                var resetButton = settingsKeyBindingRow.ChildrenOfType<RestoreDefaultValueButton<bool>>().First();
+                var resetButton = settingsKeyBindingRow.ChildrenOfType<RevertToDefaultButton<bool>>().First();
 
                 resetButton.TriggerClick();
             });
 
-            AddUntilStep("restore button hidden", () => settingsKeyBindingRow.ChildrenOfType<RestoreDefaultValueButton<bool>>().First().Alpha == 0);
+            AddUntilStep("restore button hidden", () => settingsKeyBindingRow.ChildrenOfType<RevertToDefaultButton<bool>>().First().Alpha == 0);
 
             AddAssert("binding cleared",
                 () => settingsKeyBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(0).KeyBinding.KeyCombination.Equals(settingsKeyBindingRow.Defaults.ElementAt(0)));
@@ -225,7 +225,7 @@ namespace osu.Game.Tests.Visual.Settings
                 InputManager.ReleaseKey(Key.P);
             });
 
-            AddUntilStep("restore button shown", () => settingsKeyBindingRow.ChildrenOfType<RestoreDefaultValueButton<bool>>().First().Alpha > 0);
+            AddUntilStep("restore button shown", () => settingsKeyBindingRow.ChildrenOfType<RevertToDefaultButton<bool>>().First().Alpha > 0);
 
             AddStep("click reset button for bindings", () =>
             {
@@ -234,7 +234,7 @@ namespace osu.Game.Tests.Visual.Settings
                 resetButton.TriggerClick();
             });
 
-            AddUntilStep("restore button hidden", () => settingsKeyBindingRow.ChildrenOfType<RestoreDefaultValueButton<bool>>().First().Alpha == 0);
+            AddUntilStep("restore button hidden", () => settingsKeyBindingRow.ChildrenOfType<RevertToDefaultButton<bool>>().First().Alpha == 0);
 
             AddAssert("binding cleared",
                 () => settingsKeyBindingRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(0).KeyBinding.KeyCombination.Equals(settingsKeyBindingRow.Defaults.ElementAt(0)));

--- a/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Settings
         [Test]
         public void TestStates()
         {
-            CreateThemedContent(OverlayColourScheme.Purple);
+            AddStep("create content", () => CreateThemedContent(OverlayColourScheme.Purple));
             AddSliderStep("set scale", 1, 4, 1, scale =>
             {
                 this.scale = scale;

--- a/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Tests.Visual.Settings
 {
-    public partial class TestSceneRestoreDefaultValueButton : OsuTestScene
+    public partial class TestSceneRevertToDefaultButton : OsuTestScene
     {
         [Resolved]
         private OsuColour colours { get; set; }
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Settings
         [Test]
         public void TestBasic()
         {
-            RestoreDefaultValueButton<float> restoreDefaultValueButton = null;
+            RevertToDefaultButton<float> revertToDefaultButton = null;
 
             AddStep("create button", () => Child = new Container
             {
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Settings
                         RelativeSizeAxes = Axes.Both,
                         Colour = colours.GreySeaFoam
                     },
-                    restoreDefaultValueButton = new RestoreDefaultValueButton<float>
+                    revertToDefaultButton = new RevertToDefaultButton<float>
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -55,8 +55,8 @@ namespace osu.Game.Tests.Visual.Settings
             AddSliderStep("set scale", 1, 4, 1, scale =>
             {
                 this.scale = scale;
-                if (restoreDefaultValueButton != null)
-                    restoreDefaultValueButton.Scale = new Vector2(scale);
+                if (revertToDefaultButton != null)
+                    revertToDefaultButton.Scale = new Vector2(scale);
             });
             AddToggleStep("toggle default state", state => current.Value = state ? default : 1);
             AddToggleStep("toggle disabled state", state => current.Disabled = state);

--- a/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
@@ -1,15 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -17,10 +14,10 @@ namespace osu.Game.Tests.Visual.Settings
 {
     public partial class TestSceneRevertToDefaultButton : OsuTestScene
     {
-        [Resolved]
-        private OsuColour colours { get; set; }
-
         private float scale = 1;
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         private readonly Bindable<float> current = new Bindable<float>
         {
@@ -31,7 +28,7 @@ namespace osu.Game.Tests.Visual.Settings
         [Test]
         public void TestBasic()
         {
-            RevertToDefaultButton<float> revertToDefaultButton = null;
+            RevertToDefaultButton<float> revertToDefaultButton = null!;
 
             AddStep("create button", () => Child = new Container
             {
@@ -41,7 +38,7 @@ namespace osu.Game.Tests.Visual.Settings
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeaFoam
+                        Colour = colourProvider.Background2,
                     },
                     revertToDefaultButton = new RevertToDefaultButton<float>
                     {

--- a/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneRevertToDefaultButton.cs
@@ -2,22 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Game.Overlays;
+using osu.Game.Tests.Visual.UserInterface;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Settings
 {
-    public partial class TestSceneRevertToDefaultButton : OsuTestScene
+    public partial class TestSceneRevertToDefaultButton : ThemeComparisonTestScene
     {
         private float scale = 1;
-
-        [Cached]
-        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         private readonly Bindable<float> current = new Bindable<float>
         {
@@ -25,35 +22,29 @@ namespace osu.Game.Tests.Visual.Settings
             Value = 1,
         };
 
-        [Test]
-        public void TestBasic()
+        protected override Drawable CreateContent() => new Container
         {
-            RevertToDefaultButton<float> revertToDefaultButton = null!;
-
-            AddStep("create button", () => Child = new Container
+            AutoSizeAxes = Axes.Both,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Child = new RevertToDefaultButton<float>
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
-                {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colourProvider.Background2,
-                    },
-                    revertToDefaultButton = new RevertToDefaultButton<float>
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Scale = new Vector2(scale),
-                        Current = current,
-                    }
-                }
-            });
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(scale),
+                Current = current,
+            }
+        };
+
+        [Test]
+        public void TestStates()
+        {
+            CreateThemedContent(OverlayColourScheme.Purple);
             AddSliderStep("set scale", 1, 4, 1, scale =>
             {
                 this.scale = scale;
-                if (revertToDefaultButton != null)
-                    revertToDefaultButton.Scale = new Vector2(scale);
+                foreach (var revertToDefaultButton in this.ChildrenOfType<RevertToDefaultButton<float>>())
+                    revertToDefaultButton.Parent!.Scale = new Vector2(scale);
             });
             AddToggleStep("toggle default state", state => current.Value = state ? default : 1);
             AddToggleStep("toggle disabled state", state => current.Disabled = state);

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Tests.Visual.Settings
         public void TestRestoreDefaultValueButtonVisibility()
         {
             SettingsTextBox textBox = null;
-            RestoreDefaultValueButton<string> restoreDefaultValueButton = null;
+            RevertToDefaultButton<string> revertToDefaultButton = null;
 
             AddStep("create settings item", () =>
             {
@@ -33,22 +33,22 @@ namespace osu.Game.Tests.Visual.Settings
                 };
             });
             AddUntilStep("wait for loaded", () => textBox.IsLoaded);
-            AddStep("retrieve restore default button", () => restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single());
+            AddStep("retrieve restore default button", () => revertToDefaultButton = textBox.ChildrenOfType<RevertToDefaultButton<string>>().Single());
 
-            AddAssert("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
+            AddAssert("restore button hidden", () => revertToDefaultButton.Alpha == 0);
 
             AddStep("change value from default", () => textBox.Current.Value = "non-default");
-            AddUntilStep("restore button shown", () => restoreDefaultValueButton.Alpha > 0);
+            AddUntilStep("restore button shown", () => revertToDefaultButton.Alpha > 0);
 
             AddStep("restore default", () => textBox.Current.SetDefault());
-            AddUntilStep("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
+            AddUntilStep("restore button hidden", () => revertToDefaultButton.Alpha == 0);
         }
 
         [Test]
         public void TestSetAndClearLabelText()
         {
             SettingsTextBox textBox = null;
-            RestoreDefaultValueButton<string> restoreDefaultValueButton = null;
+            RevertToDefaultButton<string> revertToDefaultButton = null;
             OsuTextBox control = null;
 
             AddStep("create settings item", () =>
@@ -61,25 +61,25 @@ namespace osu.Game.Tests.Visual.Settings
             AddUntilStep("wait for loaded", () => textBox.IsLoaded);
             AddStep("retrieve components", () =>
             {
-                restoreDefaultValueButton = textBox.ChildrenOfType<RestoreDefaultValueButton<string>>().Single();
+                revertToDefaultButton = textBox.ChildrenOfType<RevertToDefaultButton<string>>().Single();
                 control = textBox.ChildrenOfType<OsuTextBox>().Single();
             });
 
-            AddStep("set non-default value", () => restoreDefaultValueButton.Current.Value = "non-default");
-            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
+            AddStep("set non-default value", () => revertToDefaultButton.Current.Value = "non-default");
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(revertToDefaultButton.Parent.DrawHeight, control.DrawHeight, 1));
 
             AddStep("set label", () => textBox.LabelText = "label text");
             AddAssert("default value button centre aligned to label size", () =>
             {
                 var label = textBox.ChildrenOfType<OsuSpriteText>().Single(spriteText => spriteText.Text == "label text");
-                return Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, label.DrawHeight, 1);
+                return Precision.AlmostEquals(revertToDefaultButton.Parent.DrawHeight, label.DrawHeight, 1);
             });
 
             AddStep("clear label", () => textBox.LabelText = default);
-            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(revertToDefaultButton.Parent.DrawHeight, control.DrawHeight, 1));
 
             AddStep("set warning text", () => textBox.SetNoticeText("This is some very important warning text! Hopefully it doesn't break the alignment of the default value indicator...", true));
-            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(restoreDefaultValueButton.Parent.DrawHeight, control.DrawHeight, 1));
+            AddAssert("default value button centre aligned to control size", () => Precision.AlmostEquals(revertToDefaultButton.Parent.DrawHeight, control.DrawHeight, 1));
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace osu.Game.Tests.Visual.Settings
         {
             BindableFloat current = null;
             SettingsSlider<float> sliderBar = null;
-            RestoreDefaultValueButton<float> restoreDefaultValueButton = null;
+            RevertToDefaultButton<float> revertToDefaultButton = null;
 
             AddStep("create settings item", () =>
             {
@@ -107,15 +107,15 @@ namespace osu.Game.Tests.Visual.Settings
                 };
             });
             AddUntilStep("wait for loaded", () => sliderBar.IsLoaded);
-            AddStep("retrieve restore default button", () => restoreDefaultValueButton = sliderBar.ChildrenOfType<RestoreDefaultValueButton<float>>().Single());
+            AddStep("retrieve restore default button", () => revertToDefaultButton = sliderBar.ChildrenOfType<RevertToDefaultButton<float>>().Single());
 
-            AddAssert("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
+            AddAssert("restore button hidden", () => revertToDefaultButton.Alpha == 0);
 
             AddStep("change value to next closest", () => sliderBar.Current.Value += current.Precision * 0.6f);
-            AddUntilStep("restore button shown", () => restoreDefaultValueButton.Alpha > 0);
+            AddUntilStep("restore button shown", () => revertToDefaultButton.Alpha > 0);
 
             AddStep("restore default", () => sliderBar.Current.SetDefault());
-            AddUntilStep("restore button hidden", () => restoreDefaultValueButton.Alpha == 0);
+            AddUntilStep("restore button hidden", () => revertToDefaultButton.Alpha == 0);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -793,7 +793,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("open customisation area", () => modSelectOverlay.CustomisationButton!.TriggerClick());
             AddStep("reset half time speed to default", () => modSelectOverlay.ChildrenOfType<ModSettingsArea>().Single()
-                                                                              .ChildrenOfType<RestoreDefaultValueButton<double>>().Single().TriggerClick());
+                                                                              .ChildrenOfType<RevertToDefaultButton<double>>().Single().TriggerClick());
             AddUntilStep("difficulty multiplier display shows correct value", () => modSelectOverlay.ChildrenOfType<DifficultyMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.7));
         }
 

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Overlays
 
             Enabled.Value = !current.Disabled;
 
-            this.FadeTo(current.Disabled ? 0.2f : (Current.IsDefault ? 0 : 1), fade_duration, Easing.OutQuint);
+            this.FadeTo(current.Disabled ? 0.2f : (current.IsDefault ? 0 : 1), fade_duration, Easing.OutQuint);
 
             if (IsHovered && Enabled.Value)
             {

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -64,7 +64,6 @@ namespace osu.Game.Overlays
         [BackgroundDependencyLoader]
         private void load()
         {
-            // size intentionally much larger than actual drawn content, so that the button is easier to click.
             Size = new Vector2(14);
 
             AddRange(new Drawable[]

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -33,7 +34,10 @@ namespace osu.Game.Overlays
         private Circle circle = null!;
 
         [Resolved]
-        private OverlayColourProvider colours { get; set; } = null!;
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider? colourProvider { get; set; }
 
         public Bindable<T> Current
         {
@@ -124,16 +128,16 @@ namespace osu.Game.Overlays
             {
                 icon.RotateTo(-40, 500, Easing.OutQuint);
 
-                icon.FadeColour(colours.Light1, 300, Easing.OutQuint);
-                circle.FadeColour(colours.Background2, 300, Easing.OutQuint);
+                icon.FadeColour(colourProvider?.Light1 ?? colours.YellowLight, 300, Easing.OutQuint);
+                circle.FadeColour(colourProvider?.Background2 ?? colours.Gray6, 300, Easing.OutQuint);
                 this.ScaleTo(1.2f, 300, Easing.OutQuint);
             }
             else
             {
                 icon.RotateTo(0, 100, Easing.OutQuint);
 
-                icon.FadeColour(colours.Colour0, 100, Easing.OutQuint);
-                circle.FadeColour(colours.Background3, 100, Easing.OutQuint);
+                icon.FadeColour(colourProvider?.Colour0 ?? colours.Yellow, 100, Easing.OutQuint);
+                circle.FadeColour(colourProvider?.Background3 ?? colours.Gray3, 100, Easing.OutQuint);
                 this.ScaleTo(1f, 100, Easing.OutQuint);
             }
         }

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -22,7 +22,7 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Overlays
 {
-    public partial class RestoreDefaultValueButton<T> : OsuClickableContainer, IHasCurrentValue<T>
+    public partial class RevertToDefaultButton<T> : OsuClickableContainer, IHasCurrentValue<T>
     {
         public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays
         private CircularContainer circle = null!;
         private Box background = null!;
 
-        public RestoreDefaultValueButton()
+        public RevertToDefaultButton()
             : base(HoverSampleSet.Button)
         {
         }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 {
                     RelativeSizeAxes = Axes.Y,
                     Width = SettingsPanel.CONTENT_MARGINS,
-                    Child = new RestoreDefaultValueButton<bool>
+                    Child = new RevertToDefaultButton<bool>
                     {
                         Current = isDefault,
                         Action = RestoreDefaults,

--- a/osu.Game/Overlays/Settings/SettingsItem.cs
+++ b/osu.Game/Overlays/Settings/SettingsItem.cs
@@ -217,7 +217,7 @@ namespace osu.Game.Overlays.Settings
             // intentionally done before LoadComplete to avoid overhead.
             if (ShowsDefaultIndicator)
             {
-                defaultValueIndicatorContainer.Add(new RestoreDefaultValueButton<T>
+                defaultValueIndicatorContainer.Add(new RevertToDefaultButton<T>
                 {
                     Current = controlWithCurrent.Current,
                     Anchor = Anchor.Centre,


### PR DESCRIPTION
I keep getting feedback that the old design looked like anything *but* a button to revert defaults. Including people clicking it expecting opposite behaviour.

This is intended to be a temporary design until we get the full new UI components online (where this is moved to the right-hand-side).

| before | after |
| -- | -- |
|![osu! 2023-07-13 at 05 32 10](https://github.com/ppy/osu/assets/191335/b7f1f8ef-16c5-4614-8174-cecc4e837433)|![osu! 2023-07-13 at 05 29 24](https://github.com/ppy/osu/assets/191335/7fa99cc3-0fba-4cf4-9d07-47be78deb10b)|

Figma:

![Safari 2023-07-13 at 05 28 35](https://github.com/ppy/osu/assets/191335/2ee5285e-ff7e-4c5f-8427-a3673ab62456)


