### PR TITLE
Reduce application of UI scale at results screen to make things fit better

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -183,7 +183,6 @@ namespace osu.Game.Tests.Resources
             Accuracy = 0.95,
             MaxCombo = 999,
             Position = 1,
-            OnlineID = 1234,
             Rank = ScoreRank.S,
             Date = DateTimeOffset.Now,
             Statistics = new Dictionary<HitResult, int>

--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -183,6 +183,7 @@ namespace osu.Game.Tests.Resources
             Accuracy = 0.95,
             MaxCombo = 999,
             Position = 1,
+            OnlineID = 1234,
             Rank = ScoreRank.S,
             Date = DateTimeOffset.Now,
             Statistics = new Dictionary<HitResult, int>

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -83,6 +83,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 };
 
                 var score = TestResources.CreateTestScoreInfo();
+                score.OnlineID = 1234;
                 score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
 
                 stack.Push(screen = createResultsScreen(score));

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -82,7 +82,10 @@ namespace osu.Game.Tests.Visual.Ranking
                     RelativeSizeAxes = Axes.Both
                 };
 
-                stack.Push(screen = createResultsScreen());
+                var score = TestResources.CreateTestScoreInfo();
+                score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
+
+                stack.Push(screen = createResultsScreen(score));
             });
             AddUntilStep("wait for loaded", () => screen.IsLoaded);
             AddAssert("retry overlay not present", () => screen.RetryOverlay == null);

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -69,6 +69,30 @@ namespace osu.Game.Tests.Visual.Ranking
             }));
         }
 
+        [TestCase(1, ScoreRank.X)]
+        [TestCase(0.9999, ScoreRank.S)]
+        [TestCase(0.975, ScoreRank.S)]
+        [TestCase(0.925, ScoreRank.A)]
+        [TestCase(0.85, ScoreRank.B)]
+        [TestCase(0.75, ScoreRank.C)]
+        [TestCase(0.5, ScoreRank.D)]
+        [TestCase(0.2, ScoreRank.D)]
+        public void TestResultsWithPlayer(double accuracy, ScoreRank rank)
+        {
+            TestResultsScreen screen = null;
+
+            var score = TestResources.CreateTestScoreInfo();
+
+            score.OnlineID = 1234;
+            score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
+            score.Accuracy = accuracy;
+            score.Rank = rank;
+
+            loadResultsScreen(() => screen = createResultsScreen(score));
+            AddUntilStep("wait for loaded", () => screen.IsLoaded);
+            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
+        }
+
         [Test]
         public void TestResultsWithoutPlayer()
         {
@@ -83,35 +107,11 @@ namespace osu.Game.Tests.Visual.Ranking
                 };
 
                 var score = TestResources.CreateTestScoreInfo();
-                score.OnlineID = 1234;
-                score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
 
                 stack.Push(screen = createResultsScreen(score));
             });
             AddUntilStep("wait for loaded", () => screen.IsLoaded);
             AddAssert("retry overlay not present", () => screen.RetryOverlay == null);
-        }
-
-        [TestCase(0.2, ScoreRank.D)]
-        [TestCase(0.5, ScoreRank.D)]
-        [TestCase(0.75, ScoreRank.C)]
-        [TestCase(0.85, ScoreRank.B)]
-        [TestCase(0.925, ScoreRank.A)]
-        [TestCase(0.975, ScoreRank.S)]
-        [TestCase(0.9999, ScoreRank.S)]
-        [TestCase(1, ScoreRank.X)]
-        public void TestResultsWithPlayer(double accuracy, ScoreRank rank)
-        {
-            TestResultsScreen screen = null;
-
-            var score = TestResources.CreateTestScoreInfo();
-
-            score.Accuracy = accuracy;
-            score.Rank = rank;
-
-            loadResultsScreen(() => screen = createResultsScreen(score));
-            AddUntilStep("wait for loaded", () => screen.IsLoaded);
-            AddAssert("retry overlay present", () => screen.RetryOverlay != null);
         }
 
         [Test]
@@ -332,13 +332,14 @@ namespace osu.Game.Tests.Visual.Ranking
             }
         }
 
-        private partial class TestResultsScreen : ResultsScreen
+        private partial class TestResultsScreen : SoloResultsScreen
         {
             public HotkeyRetryOverlay RetryOverlay;
 
             public TestResultsScreen(ScoreInfo score)
                 : base(score, true)
             {
+                ShowUserStatistics = true;
             }
 
             protected override void LoadComplete()

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -30,19 +30,19 @@ namespace osu.Game.Tests.Visual.Ranking
     public partial class TestSceneStatisticsPanel : OsuTestScene
     {
         [Test]
-        public void TestScoreWithTimeStatistics()
+        public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
+            score.HitEvents = createPositionDistributedHitEvents();
 
             loadPanel(score);
         }
 
         [Test]
-        public void TestScoreWithPositionStatistics()
+        public void TestScoreWithTimeStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = createPositionDistributedHitEvents();
+            score.HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
 
             loadPanel(score);
         }
@@ -89,18 +89,19 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private static List<HitEvent> createPositionDistributedHitEvents()
         {
-            var hitEvents = new List<HitEvent>();
+            var hitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
+
             // Use constant seed for reproducibility
             var random = new Random(0);
 
-            for (int i = 0; i < 500; i++)
+            for (int i = 0; i < hitEvents.Count; i++)
             {
                 double angle = random.NextDouble() * 2 * Math.PI;
                 double radius = random.NextDouble() * 0.5f * OsuHitObject.OBJECT_RADIUS;
 
                 var position = new Vector2((float)(radius * Math.Cos(angle)), (float)(radius * Math.Sin(angle)));
 
-                hitEvents.Add(new HitEvent(0, HitResult.Perfect, new HitCircle(), new HitCircle(), position));
+                hitEvents[i] = hitEvents[i].With(position);
             }
 
             return hitEvents;

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
-            score.HitEvents = createPositionDistributedHitEvents();
+            score.HitEvents = CreatePositionDistributedHitEvents();
 
             loadPanel(score);
         }
@@ -90,7 +90,7 @@ namespace osu.Game.Tests.Visual.Ranking
             };
         });
 
-        private static List<HitEvent> createPositionDistributedHitEvents()
+        public static List<HitEvent> CreatePositionDistributedHitEvents()
         {
             var hitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents();
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Tests.Resources;
+using osu.Game.Users;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Ranking
@@ -79,11 +81,12 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private void loadPanel(ScoreInfo score) => AddStep("load panel", () =>
         {
-            Child = new StatisticsPanel
+            Child = new SoloStatisticsPanel(score)
             {
                 RelativeSizeAxes = Axes.Both,
                 State = { Value = Visibility.Visible },
-                Score = { Value = score }
+                Score = { Value = score },
+                StatisticsUpdate = { Value = new SoloStatisticsUpdate(score, new UserStatistics(), new UserStatistics()) }
             };
         });
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -87,7 +87,44 @@ namespace osu.Game.Tests.Visual.Ranking
                 RelativeSizeAxes = Axes.Both,
                 State = { Value = Visibility.Visible },
                 Score = { Value = score },
-                StatisticsUpdate = { Value = new SoloStatisticsUpdate(score, new UserStatistics(), new UserStatistics()) }
+                StatisticsUpdate =
+                {
+                    Value = new SoloStatisticsUpdate(score, new UserStatistics
+                    {
+                        Level = new UserStatistics.LevelInfo
+                        {
+                            Current = 5,
+                            Progress = 20,
+                        },
+                        GlobalRank = 38000,
+                        CountryRank = 12006,
+                        PP = 2134,
+                        RankedScore = 21123849,
+                        Accuracy = 0.985,
+                        PlayCount = 13375,
+                        PlayTime = 354490,
+                        TotalScore = 128749597,
+                        TotalHits = 0,
+                        MaxCombo = 1233,
+                    }, new UserStatistics
+                    {
+                        Level = new UserStatistics.LevelInfo
+                        {
+                            Current = 5,
+                            Progress = 30,
+                        },
+                        GlobalRank = 36000,
+                        CountryRank = 12000,
+                        PP = (decimal)2134.5,
+                        RankedScore = 23897015,
+                        Accuracy = 0.984,
+                        PlayCount = 13376,
+                        PlayTime = 35789,
+                        TotalScore = 132218497,
+                        TotalHits = 0,
+                        MaxCombo = 1233,
+                    })
+                }
             };
         });
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneStatisticsPanel.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Tests.Visual.Ranking
         public void TestScoreWithPositionStatistics()
         {
             var score = TestResources.CreateTestScoreInfo();
+            score.OnlineID = 1234;
             score.HitEvents = CreatePositionDistributedHitEvents();
 
             loadPanel(score);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
@@ -48,9 +48,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             const float winner_background_half_height = 250;
 
-            VerticalScrollContent.Anchor = VerticalScrollContent.Origin = Anchor.TopCentre;
-            VerticalScrollContent.Scale = new Vector2(0.9f);
-            VerticalScrollContent.Y = 75;
+            Content.Anchor = Content.Origin = Anchor.TopCentre;
+            Content.Scale = new Vector2(0.9f);
+            Content.Y = 75;
 
             var redScore = teamScores.First().Value;
             var blueScore = teamScores.Last().Value;


### PR DESCRIPTION
This also removes the vertical scroll container completely, simplifying the whole interaction of the results screen.

I've bundled some test improvements from #24153 to get them split out of that PR. Note that the scale adjust in the results screen test scene will not work for testing this change as it's not applying proper UI scale.

| Before | After |
|:------:|:-----:|
| ![osu! 2021-09 at 07 46 29](https://github.com/ppy/osu/assets/191335/130b504e-aef4-4469-b2ec-0613f981ebbb) | ![osu! 2023-07-13 at 07 47 23](https://github.com/ppy/osu/assets/191335/8cdfb6ce-dc7f-4f6f-99fa-d90a1c49e156) |


I've tested this on iPhone mini (probably the smallest device available these days?) and everything is still legible. I hope we can do better than this in the upcoming redesign, but for now I'm just looking to get things in a sane initial state we can work with.