### PR TITLE
Optimize editor save action for huge Realm database

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -431,8 +431,9 @@ namespace osu.Game.Beatmaps
             beatmapInfo.Status = BeatmapOnlineStatus.LocallyModified;
             beatmapInfo.ResetOnlineInfo();
 
-            using (var stream = new MemoryStream())
+            Realm.Write(r =>
             {
+                using var stream = new MemoryStream();
                 using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
                     new LegacyBeatmapEncoder(beatmapContent, beatmapSkin).Encode(sw);
 
@@ -458,23 +459,20 @@ namespace osu.Game.Beatmaps
 
                 updateHashAndMarkDirty(setInfo);
 
-                Realm.Write(r =>
-                {
-                    var liveBeatmapSet = r.Find<BeatmapSetInfo>(setInfo.ID)!;
+                var liveBeatmapSet = r.Find<BeatmapSetInfo>(setInfo.ID)!;
 
-                    setInfo.CopyChangesToRealm(liveBeatmapSet);
+                setInfo.CopyChangesToRealm(liveBeatmapSet);
 
-                    if (transferCollections)
-                        beatmapInfo.TransferCollectionReferences(r, oldMd5Hash);
+                if (transferCollections)
+                    beatmapInfo.TransferCollectionReferences(r, oldMd5Hash);
 
-                    liveBeatmapSet.Beatmaps.Single(b => b.ID == beatmapInfo.ID)
-                                  .UpdateLocalScores(r);
+                liveBeatmapSet.Beatmaps.Single(b => b.ID == beatmapInfo.ID)
+                              .UpdateLocalScores(r);
 
-                    // do not look up metadata.
-                    // this is a locally-modified set now, so looking up metadata is busy work at best and harmful at worst.
-                    ProcessBeatmap?.Invoke(liveBeatmapSet, MetadataLookupScope.None);
-                });
-            }
+                // do not look up metadata.
+                // this is a locally-modified set now, so looking up metadata is busy work at best and harmful at worst.
+                ProcessBeatmap?.Invoke(liveBeatmapSet, MetadataLookupScope.None);
+            });
 
             Debug.Assert(beatmapInfo.BeatmapSet != null);
 


### PR DESCRIPTION
I have thousands of beatmaps imported in osu! lazer and I noticed that whenever I save in the editor, the editor would freeze for around 3 seconds before it would save. This issue might be related to #18048 but I experience it to a much lesser extend. 

Anyways I decided to profile osu! to see where the slowdown comes from and noticed that `begin_transaction`, triggered by `BeatmapManager.save()` was taking a lot of time. 
![rider64_T7Si4VU6Zk](https://github.com/ppy/osu/assets/17460441/582a613d-8afb-46cd-816b-1db4da056294)

`save()` does 3 transactions, so I tried to make it all one transaction instead to hopefully get a 3x speedup. Surprisingly this gave a 4x speedup because `begin_transaction` takes only 0.04 ms after this change and saving in the editor is noticeably faster now.
![rider64_Q1dLBwmijW](https://github.com/ppy/osu/assets/17460441/2dc9914b-4994-4a04-95ea-5c5e7a7a9ea4)

I hope this doesn't cause unintended consequences. Also I can't make a benchmark because I don't know how to reproduce this scenario in a test setting. Just trust me that it's faster.

Before:

https://github.com/ppy/osu/assets/17460441/6079f13a-8967-4ef3-800d-c67ca8994e7b

After:

https://github.com/ppy/osu/assets/17460441/9d87196f-e223-41c5-9840-898e7c1a1f85

