### PR TITLE
Fix osu!mania scores failing to convert to new standardised score due to cast failure

### DIFF
--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -48,14 +48,13 @@ namespace osu.Game.Rulesets.Mania.Scoring
                 if (result != 0)
                     return result;
 
-                var xNote = x as Note;
-                var yNote = y as Note;
-
                 // due to the way input is handled in mania, notes take precedence over ticks in judging order.
-                if (xNote != null && yNote == null) return -1;
-                if (xNote == null && yNote != null) return 1;
+                if (x is Note && y is not Note) return -1;
+                if (x is not Note && y is Note) return 1;
 
-                return xNote!.Column.CompareTo(yNote!.Column);
+                return x is ManiaHitObject maniaX && y is ManiaHitObject maniaY
+                    ? maniaX.Column.CompareTo(maniaY.Column)
+                    : 0;
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mania.Scoring
         }
 
         protected override IEnumerable<HitObject> EnumerateHitObjects(IBeatmap beatmap)
-            => base.EnumerateHitObjects(beatmap).OrderBy(ho => (ManiaHitObject)ho, JudgementOrderComparer.DEFAULT);
+            => base.EnumerateHitObjects(beatmap).OrderBy(ho => ho, JudgementOrderComparer.DEFAULT);
 
         protected override double ComputeTotalScore(double comboProgress, double accuracyProgress, double bonusPortion)
         {
@@ -34,11 +34,11 @@ namespace osu.Game.Rulesets.Mania.Scoring
         protected override double GetComboScoreChange(JudgementResult result)
             => Judgement.ToNumericResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
 
-        private class JudgementOrderComparer : IComparer<ManiaHitObject>
+        private class JudgementOrderComparer : IComparer<HitObject>
         {
             public static readonly JudgementOrderComparer DEFAULT = new JudgementOrderComparer();
 
-            public int Compare(ManiaHitObject? x, ManiaHitObject? y)
+            public int Compare(HitObject? x, HitObject? y)
             {
                 if (ReferenceEquals(x, y)) return 0;
                 if (ReferenceEquals(x, null)) return -1;
@@ -48,11 +48,14 @@ namespace osu.Game.Rulesets.Mania.Scoring
                 if (result != 0)
                     return result;
 
-                // due to the way input is handled in mania, notes take precedence over ticks in judging order.
-                if (x is Note && y is not Note) return -1;
-                if (x is not Note && y is Note) return 1;
+                var xNote = x as Note;
+                var yNote = y as Note;
 
-                return x.Column.CompareTo(y.Column);
+                // due to the way input is handled in mania, notes take precedence over ticks in judging order.
+                if (xNote != null && yNote == null) return -1;
+                if (xNote == null && yNote != null) return 1;
+
+                return xNote!.Column.CompareTo(yNote!.Column);
             }
         }
     }

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Database
             if (score.IsLegacyScore)
                 return false;
 
+            if (score.TotalScoreVersion > 30000002)
+                return false;
+
             // Recalculate the old-style standardised score to see if this was an old lazer score.
             bool oldScoreMatchesExpectations = GetOldStandardised(score) == score.TotalScore;
             // Some older scores don't have correct statistics populated, so let's give them benefit of doubt.

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -49,6 +49,13 @@ namespace osu.Game.Scoring.Legacy
 
                 scoreInfo.IsLegacyScore = version < LegacyScoreEncoder.FIRST_LAZER_VERSION;
 
+                // TotalScoreVersion gets initialised to LATEST_VERSION.
+                // In the case where the incoming score has either an osu!stable or old lazer version, we need
+                // to mark it with the correct version increment to trigger reprocessing to new standardised scoring.
+                //
+                // See StandardisedScoreMigrationTools.ShouldMigrateToNewStandardised().
+                scoreInfo.TotalScoreVersion = version < 30000002 ? 30000001 : LegacyScoreEncoder.LATEST_VERSION;
+
                 string beatmapHash = sr.ReadString();
 
                 workingBeatmap = GetBeatmap(beatmapHash);


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/23917.
Closes #24217.

Haven't tested yet as I don't have a database ready to do so.

Of note, the reporting issue mentions this happened during a gameplay flow, which should definitely not be possible. If anyone has any ideas how this can happen, I'm all ears. We should definitely get to the bottom of that before pushing out the release.