### PR TITLE
Compute the top local rank directly without an expensive detach call

### DIFF
--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -32,13 +32,5 @@ namespace osu.Game.Scoring
         /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
         /// <returns>The maximum achievable combo.</returns>
         public static int GetMaximumAchievableCombo(this ScoreInfo score) => score.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Sum(kvp => kvp.Value);
-
-        /// <summary>
-        /// Retrieves the <see cref="ScoreInfo"/> with the maximum total score.
-        /// </summary>
-        /// <param name="scores">An array of <see cref="ScoreInfo"/>s to retrieve the scoreInfo with maximum total score.</param>
-        /// <returns>The <see cref="ScoreInfo"/> instance with the maximum total score.</returns>
-        public static ScoreInfo? MaxByTopScore(this IEnumerable<ScoreInfo> scores)
-            => scores.MaxBy(info => (info.TotalScore, -info.OnlineID, -info.Date.UtcDateTime.Ticks));
     }
 }

--- a/osu.Game/Scoring/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/ScoreInfoExtensions.cs
@@ -32,5 +32,13 @@ namespace osu.Game.Scoring
         /// <param name="score">The <see cref="ScoreInfo"/> to compute the maximum achievable combo for.</param>
         /// <returns>The maximum achievable combo.</returns>
         public static int GetMaximumAchievableCombo(this ScoreInfo score) => score.MaximumStatistics.Where(kvp => kvp.Key.AffectsCombo()).Sum(kvp => kvp.Value);
+
+        /// <summary>
+        /// Retrieves the <see cref="ScoreInfo"/> with the maximum total score.
+        /// </summary>
+        /// <param name="scores">An array of <see cref="ScoreInfo"/>s to retrieve the scoreInfo with maximum total score.</param>
+        /// <returns>The <see cref="ScoreInfo"/> instance with the maximum total score.</returns>
+        public static ScoreInfo? MaxByTopScore(this IEnumerable<ScoreInfo> scores)
+            => scores.MaxBy(info => (info.TotalScore, -info.OnlineID, -info.Date.UtcDateTime.Ticks));
     }
 }

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -75,7 +74,7 @@ namespace osu.Game.Screens.Select.Carousel
                 if (changes?.HasCollectionChanges() == false)
                     return;
 
-                ScoreInfo? topScore = sender.Detach().OrderByTotalScore().FirstOrDefault();
+                ScoreInfo? topScore = sender.MaxByTopScore();
 
                 updateable.Rank = topScore?.Rank;
                 updateable.Alpha = topScore != null ? 1 : 0;

--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -74,8 +75,7 @@ namespace osu.Game.Screens.Select.Carousel
                 if (changes?.HasCollectionChanges() == false)
                     return;
 
-                ScoreInfo? topScore = sender.MaxByTopScore();
-
+                ScoreInfo? topScore = sender.MaxBy(info => (info.TotalScore, -info.Date.UtcDateTime.Ticks));
                 updateable.Rank = topScore?.Rank;
                 updateable.Alpha = topScore != null ? 1 : 0;
             }


### PR DESCRIPTION
The detach call can be slow because it has to access every properties of ScoreInfo and its descendants.