### PR TITLE
Fix potential crash in confirm exit dialog while attempting to exit game

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -728,17 +728,14 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("set hold delay to 0", () => Game.LocalConfig.SetValue(OsuSetting.UIHoldActivationDelay, 0.0));
             AddUntilStep("wait for dialog overlay", () => Game.ChildrenOfType<DialogOverlay>().SingleOrDefault() != null);
 
-            ProgressNotification progressNotification = null!;
-
             AddStep("start ongoing operation", () =>
             {
-                progressNotification = new ProgressNotification
+                Game.Notifications.Post(new ProgressNotification
                 {
                     Text = "Something is still running",
                     Progress = 0.5f,
                     State = ProgressNotificationState.Active,
-                };
-                Game.Notifications.Post(progressNotification);
+                });
             });
 
             AddStep("attempt exit", () =>

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -723,6 +723,33 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestForceExitWithOperationInProgress()
+        {
+            AddStep("set hold delay to 0", () => Game.LocalConfig.SetValue(OsuSetting.UIHoldActivationDelay, 0.0));
+            AddUntilStep("wait for dialog overlay", () => Game.ChildrenOfType<DialogOverlay>().SingleOrDefault() != null);
+
+            ProgressNotification progressNotification = null!;
+
+            AddStep("start ongoing operation", () =>
+            {
+                progressNotification = new ProgressNotification
+                {
+                    Text = "Something is still running",
+                    Progress = 0.5f,
+                    State = ProgressNotificationState.Active,
+                };
+                Game.Notifications.Post(progressNotification);
+            });
+
+            AddStep("attempt exit", () =>
+            {
+                for (int i = 0; i < 2; ++i)
+                    Game.ScreenStack.CurrentScreen.Exit();
+            });
+            AddUntilStep("stopped at exit confirm", () => Game.ChildrenOfType<DialogOverlay>().Single().CurrentDialog is ConfirmExitDialog);
+        }
+
+        [Test]
         public void TestExitGameFromSongSelect()
         {
             PushAndConfirm(() => new TestPlaySongSelect());

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Overlays.Dialog
         {
             // Buttons are regularly added in BDL or LoadComplete, so let's schedule to ensure
             // they are ready to be pressed.
-            Schedule(() => Buttons.OfType<T>().First().TriggerClick());
+            Schedule(() => Buttons.OfType<T>().FirstOrDefault()?.TriggerClick());
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)


### PR DESCRIPTION
Fixes https://sentry.ppy.sh/share/issue/db44214ba32e412a85f05f5c664fec24/

I'm not entirely sure how this is hittable in game. The reproduction scenario is probably somewhat close to:

- start background operations
- force close game while the background operations are still in progress (somehow? can't repro this part on linux)
- due to ongoing operations, the exit confirm dialog is shown through this conditional branch:
  https://github.com/ppy/osu/blob/50e6f0aee9c0a297a7c5d0b05b3306ab177d6abb/osu.Game/Screens/Menu/ConfirmExitDialog.cs#L36-L60
- in the branch in question there is no `PopupDialogOkButton` present, causing the failure of `.First()` to locate it in `PopupDialog`.

If you have any ideas how the second bullet may occur it may be worth following up because that seems potentially dangerous. But the fix is still probably a good safety to have in general usages.