### PR TITLE
Fix several issues in multiplayer exit-on-disconnection flow

### DIFF
--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Overlays.Dialog
         {
             // Buttons are regularly added in BDL or LoadComplete, so let's schedule to ensure
             // they are ready to be pressed.
-            Schedule(() => Buttons.OfType<T>().FirstOrDefault()?.TriggerClick());
+            Scheduler.AddOnce(() => Buttons.OfType<T>().FirstOrDefault()?.TriggerClick());
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -17,6 +17,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Cursor;
 using osu.Game.Online;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -48,6 +49,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         [Resolved]
         private MultiplayerClient client { get; set; }
+
+        [Resolved]
+        private IAPIProvider api { get; set; }
 
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
@@ -251,10 +255,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         public override bool OnExiting(ScreenExitEvent e)
         {
             // the room may not be left immediately after a disconnection due to async flow,
-            // so checking the IsConnected status is also required.
-            if (client.Room == null || !client.IsConnected.Value)
+            // so checking the MultiplayerClient / IAPIAccess statuses is also required.
+            if (client.Room == null || !client.IsConnected.Value || api.State.Value != APIState.Online)
             {
-                // room has not been created yet; exit immediately.
+                // room has not been created yet or we're offline; exit immediately.
                 return base.OnExiting(e);
             }
 


### PR DESCRIPTION
This changeset is spurred by https://sentry.ppy.sh/share/issue/a4281e89f2ae4b5b878981d9d5f1057a/ which is a new issue in the latest build.

## cd02a8a9ca599b26304f3ef7b39796bbf2c8a68b: Fix `PopupDialog` potentially accumulating schedules during load

This is a safety intended to eliminate the possibility of encountering the following part of the aforementioned sentry issue ever again:

![1689526302](https://github.com/ppy/osu/assets/20418176/4b31aa1b-299e-47fc-93f7-52611465a2b0)

The cause of the accumulating schedules was [this loop](https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs#L105-L106) [cramming schedules](https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L263-L264) onto the exit dialog pushed [here](https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L267-L271) while it was loading.

## 7fbd47e9eec893409211a4a1f49e9819f0ded742: Fix `MultiplayerMatchSubScreen` erroneously pushing exit dialog on API failure

This change intends to address the root cause of the issue.

If `IAPIProvider.State` changes from `Online` at any point when being on an `OnlinePlayScreen`, it will be forcefully exited from:

https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs#L78-L82
https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs#L98-L114

However, `MultiplayerMatchSubScreen` had local logic that suppressed the exit in order to show a confirmation dialog:

https://github.com/ppy/osu/blob/acb51dfca312c6b6583445c03394a7da97dfa642/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs#L251-L275

The problem is, that in the suppression logic, `MultiplayerMatchSubScreen` was checking `MultiplayerClient.IsConnected`, which is a SignalR flag, and was not checking `IAPIAccess.State`, which is maintained separately. Due to differing timeouts and failure thresholds, it is not impossible to (temporarily) have `MultiplayerClient.IsConnected == true` but `IAPIAccess.State != APIState.Online`.

In such a case, the match subscreen would wrongly consider itself to be still online and due to that, push useless confirmation dialogs, while being in the process of being forcefully exited. This then caused the dialog to cause a crash, as it was calling `.Exit()` on the screen which would already have been exited by that point, by the force-exit flow.