### PR TITLE
Use `FontAwesome.Download` for updates instead of `FontAwesome.Upload`

### DIFF
--- a/osu.Game/Updater/NoActionUpdateManager.cs
+++ b/osu.Game/Updater/NoActionUpdateManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -47,7 +47,7 @@ namespace osu.Game.Updater
                     {
                         Text = $"A newer release of osu! has been found ({version} → {latestTagName}).\n\n"
                                + "Check with your package manager / provider to bring osu! up-to-date!",
-                        Icon = FontAwesome.Solid.Upload,
+                        Icon = FontAwesome.Solid.Download,
                     });
 
                     return true;

--- a/osu.Game/Updater/SimpleUpdateManager.cs
+++ b/osu.Game/Updater/SimpleUpdateManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -54,7 +54,7 @@ namespace osu.Game.Updater
                     {
                         Text = $"A newer release of osu! has been found ({version} → {latestTagName}).\n\n"
                                + "Click here to download the new version, which can be installed over the top of your existing installation",
-                        Icon = FontAwesome.Solid.Upload,
+                        Icon = FontAwesome.Solid.Download,
                         Activated = () =>
                         {
                             host.OpenUrlExternally(getBestUrl(latest));

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Updater
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Icon = FontAwesome.Solid.Upload,
+                        Icon = FontAwesome.Solid.Download,
                         Size = new Vector2(34),
                         Colour = OsuColour.Gray(0.2f),
                         Depth = float.MaxValue,


### PR DESCRIPTION
Pointed out by JankoGoo [on discord](https://discord.com/channels/188630481301012481/1097318920991559880/1130206922335866991). Couldn't unsee once I read it.

Tested visually with `SimpleUpdateManager`, but not the other two.