### PR TITLE
Disable source generator analysers for non-release configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,4 +38,9 @@
     <Copyright>Copyright (c) 2022 ppy Pty Ltd</Copyright>
     <PackageTags>osu game</PackageTags>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' != 'Release'">
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <RunAnalyzers>false</RunAnalyzers>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is intended to be a stop-gap solution. It doesn't solve the fact that there is considerable overhead in our source generators, but does allow us to make fixing this a lower priority task.

Reference: https://learn.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2019#net-framework-projects

Building `osu.Desktop` with a change to `OsuGameBase.cs`:

Before:

Time Elapsed 00:00:15.21
Time Elapsed 00:00:15.56
Time Elapsed 00:00:21.05

After:

Time Elapsed 00:00:09.02
Time Elapsed 00:00:09.67
Time Elapsed 00:00:10.01

Note that I tested this same change on framework-side, but due to the smaller project size the difference is not large at all.

We can potentially add CI runs to cover the source gen case (or prefer it for all runs) if required.