### PR TITLE
Add support for cyclic selection in beatmap editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -286,6 +286,85 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("first selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(firstObject));
         }
 
+        [Test]
+        public void TestCyclicSelection()
+        {
+            var firstObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 0 };
+            var secondObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 300 };
+            var thirdObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 600 };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[] { firstObject, secondObject, thirdObject }));
+
+            moveMouseToObject(() => firstObject);
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("first selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(firstObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("second selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(secondObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));
+
+            // cycle around
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("first selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(firstObject));
+        }
+
+        [Test]
+        public void TestCyclicSelectionOutwards()
+        {
+            var firstObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 0 };
+            var secondObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 300 };
+            var thirdObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 600 };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[] { firstObject, secondObject, thirdObject }));
+
+            moveMouseToObject(() => firstObject);
+
+            AddStep("seek near first", () => EditorClock.Seek(320));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("second selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(secondObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("first selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(firstObject));
+
+            // cycle around
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("second selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(secondObject));
+        }
+
+        [Test]
+        public void TestCyclicSelectionBackwards()
+        {
+            var firstObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 0 };
+            var secondObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 300 };
+            var thirdObject = new HitCircle { Position = new Vector2(256, 192), StartTime = 600 };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[] { firstObject, secondObject, thirdObject }));
+
+            moveMouseToObject(() => firstObject);
+
+            AddStep("seek near first", () => EditorClock.Seek(600));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("second selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(secondObject));
+
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("first selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(firstObject));
+
+            // cycle around
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void TestMultiSelectFromDrag(bool alreadySelectedBeforeDrag)

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -363,6 +363,20 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));
         }
 
+        [Test]
+        public void TestDoubleClickToSeek()
+        {
+            var hitCircle = new HitCircle { Position = new Vector2(256, 192), StartTime = 600 };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[] { hitCircle }));
+
+            moveMouseToObject(() => hitCircle);
+
+            AddRepeatStep("double click", () => InputManager.Click(MouseButton.Left), 2);
+
+            AddUntilStep("seeked to circle", () => EditorClock.CurrentTime, () => Is.EqualTo(600));
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void TestMultiSelectFromDrag(bool alreadySelectedBeforeDrag)

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -320,7 +320,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             moveMouseToObject(() => firstObject);
 
-            AddStep("seek near first", () => EditorClock.Seek(320));
+            AddStep("seek near second", () => EditorClock.Seek(320));
 
             AddStep("left click", () => InputManager.Click(MouseButton.Left));
             AddAssert("second selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(secondObject));
@@ -347,7 +347,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             moveMouseToObject(() => firstObject);
 
-            AddStep("seek near first", () => EditorClock.Seek(600));
+            AddStep("seek to third", () => EditorClock.Seek(600));
 
             AddStep("left click", () => InputManager.Click(MouseButton.Left));
             AddAssert("third selected", () => EditorBeatmap.SelectedHitObjects.Single(), () => Is.EqualTo(thirdObject));

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -82,7 +80,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestNudgeSelection()
         {
-            HitCircle[] addedObjects = null;
+            HitCircle[] addedObjects = null!;
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
             {
@@ -104,7 +102,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestRotateHotkeys()
         {
-            HitCircle[] addedObjects = null;
+            HitCircle[] addedObjects = null!;
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
             {
@@ -136,7 +134,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestGlobalFlipHotkeys()
         {
-            HitCircle addedObject = null;
+            HitCircle addedObject = null!;
 
             AddStep("add hitobjects", () => EditorBeatmap.Add(addedObject = new HitCircle { StartTime = 100 }));
 
@@ -369,7 +367,7 @@ namespace osu.Game.Tests.Visual.Editing
         [TestCase(true)]
         public void TestMultiSelectFromDrag(bool alreadySelectedBeforeDrag)
         {
-            HitCircle[] addedObjects = null;
+            HitCircle[] addedObjects = null!;
 
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects = new[]
             {
@@ -468,7 +466,7 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestQuickDeleteRemovesSliderControlPoint()
         {
-            Slider slider = null;
+            Slider slider = null!;
 
             PathControlPoint[] points =
             {

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Overlays.SkinEditor
         [Resolved]
         private SkinEditor editor { get; set; } = null!;
 
-        protected override bool AllowCyclicSelection => true;
-
         public SkinBlueprintContainer(ISerialisableDrawableContainer targetContainer)
         {
             this.targetContainer = targetContainer;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -425,7 +425,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a click selection was active.</returns>
         private bool endClickSelection(MouseButtonEvent e)
         {
-            // If already handled a selection or drag, we don't want to perform a mouse up / click action.
+            // If already handled a selection, double-click, or drag, we don't want to perform a mouse up / click action.
             if (clickSelectionHandled || doubleClickHandled || isDraggingBlueprint) return true;
 
             if (e.Button != MouseButton.Left) return false;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -46,15 +46,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected readonly BindableList<T> SelectedItems = new BindableList<T>();
 
-        /// <summary>
-        /// Whether to allow cyclic selection on clicking multiple times.
-        /// </summary>
-        /// <remarks>
-        /// Disabled by default as it does not work well with editors that support double-clicking or other advanced interactions.
-        /// Can probably be made to work with more thought.
-        /// </remarks>
-        protected virtual bool AllowCyclicSelection => false;
-
         protected BlueprintContainer()
         {
             RelativeSizeAxes = Axes.Both;
@@ -167,6 +158,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (ClickedBlueprint == null || SelectionHandler.SelectedBlueprints.FirstOrDefault(b => b.IsHovered) != ClickedBlueprint)
                 return false;
 
+            doubleClickHandled = true;
             return true;
         }
 
@@ -177,6 +169,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 endClickSelection(e);
                 clickSelectionHandled = false;
+                doubleClickHandled = false;
                 isDraggingBlueprint = false;
                 wasDragStarted = false;
             });
@@ -377,6 +370,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool clickSelectionHandled;
 
         /// <summary>
+        /// Whether a blueprint was double-clicked since last mouse down.
+        /// </summary>
+        private bool doubleClickHandled;
+
+        /// <summary>
         /// Whether the selected blueprint(s) were already selected on mouse down. Generally used to perform selection cycling on mouse up in such a case.
         /// </summary>
         private bool selectedBlueprintAlreadySelectedOnMouseDown;
@@ -424,7 +422,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool endClickSelection(MouseButtonEvent e)
         {
             // If already handled a selection or drag, we don't want to perform a mouse up / click action.
-            if (clickSelectionHandled || isDraggingBlueprint) return true;
+            if (clickSelectionHandled || doubleClickHandled || isDraggingBlueprint) return true;
 
             if (e.Button != MouseButton.Left) return false;
 
@@ -440,7 +438,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 return false;
             }
 
-            if (!wasDragStarted && selectedBlueprintAlreadySelectedOnMouseDown && SelectedItems.Count == 1 && AllowCyclicSelection)
+            if (!wasDragStarted && selectedBlueprintAlreadySelectedOnMouseDown && SelectedItems.Count == 1)
             {
                 // If a click occurred and was handled by the currently selected blueprint but didn't result in a drag,
                 // cycle between other blueprints which are also under the cursor.


### PR DESCRIPTION
![osu! 2023-07-19 at 08 26 24](https://github.com/ppy/osu/assets/191335/65e343e8-0e2d-4a26-945a-b0a580709328)

This was disabled due to double-click handling concerns, so I fixed that case. Double-click is still giving precedence if it happens from a no-selection state, and still works in cases of non-stacked hitobjects. In all other cases, cycling is given precedence. I think this feels okay:

![osu! 2023-07-19 at 08 26 45](https://github.com/ppy/osu/assets/191335/daf5f8d2-5922-4e12-9a79-b47b5256e2ea)

- [x] Depends on https://github.com/ppy/osu/pull/24289 (skin editor test updates mostly)