### PR TITLE
Fix some UI elements in legacy skins not always aligning correctly

### DIFF
--- a/osu.Game/Skinning/LegacyAccuracyCounter.cs
+++ b/osu.Game/Skinning/LegacyAccuracyCounter.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Skinning
             Anchor = Anchor.TopRight;
             Origin = Anchor.TopRight;
 
-            Scale = new Vector2(0.6f);
-            Margin = new MarginPadding(10);
+            Scale = new Vector2(0.6f * 0.96f);
+            Margin = new MarginPadding { Vertical = 9, Horizontal = 17 };
         }
 
         protected sealed override OsuSpriteText CreateSpriteText() => new LegacySpriteText(LegacyFont.Score)

--- a/osu.Game/Skinning/LegacyScoreCounter.cs
+++ b/osu.Game/Skinning/LegacyScoreCounter.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Skinning
             Origin = Anchor.TopRight;
 
             Scale = new Vector2(0.96f);
-            Margin = new MarginPadding(10);
+            Margin = new MarginPadding { Horizontal = 10 };
         }
 
         protected sealed override OsuSpriteText CreateSpriteText() => new LegacySpriteText(LegacyFont.Score)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -368,7 +368,7 @@ namespace osu.Game.Skinning
                                 {
                                     songProgress.Anchor = Anchor.TopRight;
                                     songProgress.Origin = Anchor.CentreRight;
-                                    songProgress.X = -accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).X - 10;
+                                    songProgress.X = -accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).X - 20;
                                     songProgress.Y = container.ToLocalSpace(accuracy.ScreenSpaceDrawQuad.TopLeft).Y + (accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).Y / 2);
                                 }
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -397,8 +397,8 @@ namespace osu.Game.Skinning
                                     new LegacyComboCounter(),
                                     new LegacyScoreCounter(),
                                     new LegacyAccuracyCounter(),
-                                    new LegacyHealthDisplay(),
                                     new LegacySongProgress(),
+                                    new LegacyHealthDisplay(),
                                     new BarHitErrorMeter(),
                                     new DefaultKeyCounterDisplay()
                                 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -368,7 +368,7 @@ namespace osu.Game.Skinning
                                 {
                                     songProgress.Anchor = Anchor.TopRight;
                                     songProgress.Origin = Anchor.CentreRight;
-                                    songProgress.X = -accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).X - 20;
+                                    songProgress.X = -accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).X - 18;
                                     songProgress.Y = container.ToLocalSpace(accuracy.ScreenSpaceDrawQuad.TopLeft).Y + (accuracy.ScreenSpaceDeltaToParentSpace(accuracy.ScreenSpaceDrawQuad.Size).Y / 2);
                                 }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21048#issuecomment-1634970568

Numbers are ballparked to <1px.

![osu! 2023-07-19 at 08 47 51](https://github.com/ppy/osu/assets/191335/e45137e5-16f8-440b-ae6a-0961f35e7605)

![osu! 2023-07-19 at 08 51 50](https://github.com/ppy/osu/assets/191335/2f2b978b-fcb6-45ac-a956-30c745a9e2ae)
