### PR TITLE
Fix alive hitobjects blocking hits in taiko with HD

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
@@ -37,6 +37,28 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         }
 
         [Test]
+        public void TestHitWithBothKeysOnSameFrameDoesNotFallThroughToNextObject()
+        {
+            PerformTest(new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(0),
+                new TaikoReplayFrame(1000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
+            }, CreateBeatmap(new Hit
+            {
+                Type = HitType.Centre,
+                StartTime = 1000,
+            }, new Hit
+            {
+                Type = HitType.Centre,
+                StartTime = 1020
+            }));
+
+            AssertJudgementCount(2);
+            AssertResult<Hit>(0, HitResult.Great);
+            AssertResult<Hit>(1, HitResult.Miss);
+        }
+
+        [Test]
         public void TestHitRimHit()
         {
             const double hit_time = 1000;

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
@@ -1,24 +1,71 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Tests.Mods
 {
     public partial class TestSceneTaikoModHidden : TaikoModTestScene
     {
+        private Func<bool> checkAllMaxResultJudgements(int count) => ()
+            => Player.ScoreProcessor.JudgedHits >= count
+               && Player.Results.All(result => result.Type == result.Judgement.MaxResult);
+
         [Test]
         public void TestDefaultBeatmapTest() => CreateModTest(new ModTestData
         {
             Mod = new TaikoModHidden(),
             Autoplay = true,
-            PassCondition = checkSomeAutoplayHits
+            PassCondition = checkAllMaxResultJudgements(4),
         });
 
-        private bool checkSomeAutoplayHits()
-            => Player.ScoreProcessor.JudgedHits >= 4
-               && Player.Results.All(result => result.Type == result.Judgement.MaxResult);
+        [Test]
+        public void TestHitTwoNotesWithinShortPeriod()
+        {
+            const double hit_time = 1;
+
+            var beatmap = new Beatmap<TaikoHitObject>
+            {
+                HitObjects = new List<TaikoHitObject>
+                {
+                    new Hit
+                    {
+                        Type = HitType.Rim,
+                        StartTime = hit_time,
+                    },
+                    new Hit
+                    {
+                        Type = HitType.Centre,
+                        StartTime = hit_time * 2,
+                    },
+                },
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        SliderTickRate = 4,
+                        OverallDifficulty = 0,
+                    },
+                    Ruleset = new TaikoRuleset().RulesetInfo
+                },
+            };
+
+            beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new TaikoModHidden(),
+                Autoplay = true,
+                PassCondition = checkAllMaxResultJudgements(2),
+                Beatmap = beatmap,
+            });
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -57,6 +57,12 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     {
                         hitObject.FadeOut(duration);
 
+                        // Keep updating the object even after it stopped being visible.
+                        // This is required because of the custom logic in DrawableHit's Update method.
+                        // Specifically, pressHandledThisFrame wasn't reset, which caused further hits
+                        // within the object's lifetime to be rejected.
+                        hitObject.AlwaysPresent = true;
+
                         // DrawableHitObject sets LifetimeEnd to LatestTransformEndTime if it isn't manually changed.
                         // in order for the object to not be killed before its actual end time (as the latest transform ends earlier), set lifetime end explicitly.
                         hitObject.LifetimeEnd = state == ArmedState.Idle || !hitObject.AllJudged

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModHidden.cs
@@ -57,12 +57,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
                     {
                         hitObject.FadeOut(duration);
 
-                        // Keep updating the object even after it stopped being visible.
-                        // This is required because of the custom logic in DrawableHit's Update method.
-                        // Specifically, pressHandledThisFrame wasn't reset, which caused further hits
-                        // within the object's lifetime to be rejected.
-                        hitObject.AlwaysPresent = true;
-
                         // DrawableHitObject sets LifetimeEnd to LatestTransformEndTime if it isn't manually changed.
                         // in order for the object to not be killed before its actual end time (as the latest transform ends earlier), set lifetime end explicitly.
                         hitObject.LifetimeEnd = state == ArmedState.Idle || !hitObject.AllJudged

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private bool validActionPressed;
 
-        private bool pressHandledThisFrame;
+        private double? lastPressHandleTime;
 
         private readonly Bindable<HitType> type = new Bindable<HitType>();
 
@@ -76,7 +76,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             HitActions = null;
             HitAction = null;
-            validActionPressed = pressHandledThisFrame = false;
+            validActionPressed = false;
+            lastPressHandleTime = null;
         }
 
         private void updateActionsFromType()
@@ -114,7 +115,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e)
         {
-            if (pressHandledThisFrame)
+            if (lastPressHandleTime == Time.Current)
                 return true;
             if (Judged)
                 return false;
@@ -128,7 +129,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
             // Regardless of whether we've hit or not, any secondary key presses in the same frame should be discarded
             // E.g. hitting a non-strong centre as a strong should not fall through and perform a hit on the next note
-            pressHandledThisFrame = true;
+            lastPressHandleTime = Time.Current;
             return result;
         }
 
@@ -137,15 +138,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (e.Action == HitAction)
                 HitAction = null;
             base.OnReleased(e);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // The input manager processes all input prior to us updating, so this is the perfect time
-            // for us to remove the extra press blocking, before input is handled in the next frame
-            pressHandledThisFrame = false;
         }
 
         protected override void UpdateHitStateTransforms(ArmedState state)


### PR DESCRIPTION
Update wasn't called on the objects between them becoming invisible and the end of their lifetime. Update is responsible for resetting `pressHandledThisFrame` (which blocks all input for this object until the next update), allowing the next branch (check for `Judged`) to activate and stop input handling for this object, making the next hitobject take input.

What this means is a second object couldn't be hit until the previous object (that's been hit) dies.

(side note, I'm not sure whether the lifetime override in hidden mod is needed, to my knowledge lifetime is set in DrawableHitObject *before* any mods are applied; I'm not touching it in this PR since it shouldn't affect much but you might want to look into that)