### PR TITLE
Change tournament tests to use development folder

### DIFF
--- a/osu.Game.Tournament.Tests/TournamentTestRunner.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestRunner.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Tournament.Tests
         [STAThread]
         public static int Main(string[] args)
         {
-            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu", new HostOptions { BindIPC = true }))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(@"osu-development", new HostOptions { BindIPC = true }))
             {
                 host.Run(new TournamentTestBrowser());
                 return 0;


### PR DESCRIPTION
Unsure there was a reason for this not to be the case (looks to have
been an oversight).