### PR TITLE
When an exit request is triggered, pause active gameplay first before actually exiting

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -120,11 +120,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             waitForAliveObjectIndex(0);
             checkValidObjectIndex(0);
 
-            AddAssert("first object not hit", () => getNextAliveObject()?.Entry?.Result?.HasResult != true);
+            AddAssert("first object not hit", () => GetNextAliveObject()?.Entry?.Result?.HasResult != true);
 
             AddStep("hit first object", () =>
             {
-                var next = getNextAliveObject();
+                var next = GetNextAliveObject();
 
                 if (next != null)
                 {
@@ -135,7 +135,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 }
             });
 
-            AddAssert("first object hit", () => getNextAliveObject()?.Entry?.Result?.HasResult == true);
+            AddAssert("first object hit", () => GetNextAliveObject()?.Entry?.Result?.HasResult == true);
 
             // next object is too far away, so we still use the already hit object.
             checkValidObjectIndex(0);
@@ -199,16 +199,13 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void waitForAliveObjectIndex(int? index)
         {
             if (index == null)
-                AddUntilStep("wait for no alive objects", getNextAliveObject, () => Is.Null);
+                AddUntilStep("wait for no alive objects", GetNextAliveObject, () => Is.Null);
             else
-                AddUntilStep($"wait for next alive to be {index}", () => getNextAliveObject()?.HitObject, () => Is.EqualTo(beatmap.HitObjects[index.Value]));
+                AddUntilStep($"wait for next alive to be {index}", () => GetNextAliveObject()?.HitObject, () => Is.EqualTo(beatmap.HitObjects[index.Value]));
         }
 
         private void checkValidObjectIndex(int index) =>
             AddAssert($"check object at index {index} is correct", () => sampleTriggerSource.GetMostValidObject(), () => Is.EqualTo(beatmap.HitObjects[index]));
-
-        private DrawableHitObject? getNextAliveObject() =>
-            Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.FirstOrDefault();
 
         [Test]
         public void TestSampleTriggering()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -14,7 +14,6 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -488,7 +488,7 @@ namespace osu.Game.Screens.Play
 
         private void updatePauseOnFocusLostState()
         {
-            if (!PauseOnFocusLost || !pausingSupportedByCurrentState || breakTracker.IsBreakTime.Value)
+            if (!PauseOnFocusLost || !PausingSupportedByCurrentState || breakTracker.IsBreakTime.Value)
                 return;
 
             if (gameActive.Value == false)
@@ -591,7 +591,7 @@ namespace osu.Game.Screens.Play
                 }
 
                 // even if this call has requested a dialog, there is a chance the current player mode doesn't support pausing.
-                if (pausingSupportedByCurrentState)
+                if (PausingSupportedByCurrentState)
                 {
                     // in the case a dialog needs to be shown, attempt to pause and show it.
                     // this may fail (see internal checks in Pause()) but the fail cases are temporary, so don't fall through to Exit().
@@ -956,7 +956,7 @@ namespace osu.Game.Screens.Play
         /// pausing to be attempted via <see cref="Pause"/>. If false, the game should generally exit if a user pause
         /// is attempted.
         /// </summary>
-        private bool pausingSupportedByCurrentState =>
+        protected bool PausingSupportedByCurrentState =>
             // must pass basic screen conditions (beatmap loaded, instance allows pause)
             LoadedBeatmapSuccessfully && Configuration.AllowPause && ValidForResume
             // replays cannot be paused and exit immediately
@@ -974,7 +974,7 @@ namespace osu.Game.Screens.Play
 
         public bool Pause()
         {
-            if (!pausingSupportedByCurrentState) return false;
+            if (!PausingSupportedByCurrentState) return false;
 
             if (!IsResuming && PauseCooldownActive)
                 return false;

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
@@ -155,11 +156,18 @@ namespace osu.Game.Screens.Play
 
         public override bool OnExiting(ScreenExitEvent e)
         {
-            // If in a playing state, require visiting the pause menu before exiting.
-            if (Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0) && !GameplayState.HasPassed && !GameplayState.HasFailed && !GameplayClockContainer.IsPaused.Value && Configuration.AllowPause)
+            // If an exit is requested and some objects have already been hit, show the pause screen as a method of
+            // confirming the exit operation.
+            if (PausingSupportedByCurrentState)
             {
-                Pause();
-                return true;
+                bool isValuableScore = Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0);
+                bool hasConfirmed = PauseOverlay?.State.Value == Visibility.Visible;
+
+                if (isValuableScore && !hasConfirmed)
+                {
+                    Pause();
+                    return true;
+                }
             }
 
             bool exiting = base.OnExiting(e);

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -155,6 +155,13 @@ namespace osu.Game.Screens.Play
 
         public override bool OnExiting(ScreenExitEvent e)
         {
+            // If in a playing state, require visiting the pause menu before exiting.
+            if (Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0) && !GameplayState.HasPassed && !GameplayState.HasFailed && !GameplayClockContainer.IsPaused.Value)
+            {
+                Pause();
+                return true;
+            }
+
             bool exiting = base.OnExiting(e);
 
             if (LoadedBeatmapSuccessfully)

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Screens.Play
         public override bool OnExiting(ScreenExitEvent e)
         {
             // If in a playing state, require visiting the pause menu before exiting.
-            if (Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0) && !GameplayState.HasPassed && !GameplayState.HasFailed && !GameplayClockContainer.IsPaused.Value)
+            if (Score.ScoreInfo.Statistics.Any(s => s.Key.IsHit() && s.Value > 0) && !GameplayState.HasPassed && !GameplayState.HasFailed && !GameplayClockContainer.IsPaused.Value && Configuration.AllowPause)
             {
                 Pause();
                 return true;

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -12,6 +12,7 @@ using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
 
 namespace osu.Game.Tests.Visual
 {
@@ -105,6 +106,10 @@ namespace osu.Game.Tests.Visual
             Player = CreatePlayer(ruleset);
             LoadScreen(Player);
         }
+
+        [CanBeNull]
+        protected DrawableHitObject GetNextAliveObject() =>
+            Player.DrawableRuleset.Playfield.HitObjectContainer.AliveObjects.FirstOrDefault();
 
         protected override void Dispose(bool isDisposing)
         {


### PR DESCRIPTION
This gives the user a chance to back out if it wasn't intentional. Of note, the second attempt will succeed.

This will only trigger if a score is actually in progress. Maybe we want special handling for multiplayer where it bypasses the `IsHit` check?

Closes https://github.com/ppy/osu/issues/24237.