### PR TITLE
Add reload tournaments list button to tourney setup screen

### DIFF
--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Tournament.Screens.Setup
     {
         private OsuDropdown<string> dropdown;
         private OsuButton folderButton;
+        private OsuButton reloadTournamentsButton;
 
         [Resolved]
         private TournamentGameBase game { get; set; }
@@ -27,6 +28,9 @@ namespace osu.Game.Tournament.Screens.Setup
             dropdown.Current = storage.CurrentTournament;
             dropdown.Items = storage.ListTournaments();
             dropdown.Current.BindValueChanged(v => Button.Enabled.Value = v.NewValue != startupTournament, true);
+
+            reloadTournamentsButton.Enabled.Value = true;
+            reloadTournamentsButton.Action = () => dropdown.Items = storage.ListTournaments();
 
             Action = () =>
             {
@@ -48,7 +52,13 @@ namespace osu.Game.Tournament.Screens.Setup
                 Width = BUTTON_SIZE
             });
 
-            FlowContainer.Insert(-2, dropdown = new OsuDropdown<string>
+            FlowContainer.Insert(-2, reloadTournamentsButton = new RoundedButton
+            {
+                Text = "Reload list",
+                Width = BUTTON_SIZE
+            });
+
+            FlowContainer.Insert(-3, dropdown = new OsuDropdown<string>
             {
                 Width = 510
             });

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -29,7 +29,6 @@ namespace osu.Game.Tournament.Screens.Setup
             dropdown.Items = storage.ListTournaments();
             dropdown.Current.BindValueChanged(v => Button.Enabled.Value = v.NewValue != startupTournament, true);
 
-            reloadTournamentsButton.Enabled.Value = true;
             reloadTournamentsButton.Action = () => dropdown.Items = storage.ListTournaments();
 
             Action = () =>

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tournament.Screens.Setup
 
             FlowContainer.Insert(-2, reloadTournamentsButton = new RoundedButton
             {
-                Text = "Reload list",
+                Text = "Refresh",
                 Width = BUTTON_SIZE
             });
 


### PR DESCRIPTION
The user needs to restart the game twice if they create a tournament folder after the tourney client has been started, once to see new tournament show in the list to select it and another time to actually switch to it. The reload button removes the need for the first restart.

While this doesn't happen often, it has happened to me enough times to warrant opening this PR 🙂 


https://github.com/ppy/osu/assets/1176059/1edc5506-4d94-4f85-9c11-a61cec295e9f

