### PR TITLE
Fix auto advance screens sometimes not advancing

### DIFF
--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Diagnostics.Contracts;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -159,6 +160,25 @@ namespace osu.Game.Tournament.Screens.Gameplay
         private TourneyState lastState;
         private MatchHeader header;
 
+        private void contract()
+        {
+            SongBar.Expanded = false;
+            scoreDisplay.FadeOut(100);
+            using (chat?.BeginDelayedSequence(500))
+                chat?.Expand();
+        }
+
+        private void expand()
+        {
+            chat?.Contract();
+
+            using (BeginDelayedSequence(300))
+            {
+                scoreDisplay.FadeIn(100);
+                SongBar.Expanded = true;
+            }
+        }
+
         private void stateChanged(ValueChangedEvent<TourneyState> state)
         {
             try
@@ -174,25 +194,6 @@ namespace osu.Game.Tournament.Screens.Gameplay
                 }
 
                 scheduledOperation?.Cancel();
-
-                void expand()
-                {
-                    chat?.Contract();
-
-                    using (BeginDelayedSequence(300))
-                    {
-                        scoreDisplay.FadeIn(100);
-                        SongBar.Expanded = true;
-                    }
-                }
-
-                void contract()
-                {
-                    SongBar.Expanded = false;
-                    scoreDisplay.FadeOut(100);
-                    using (chat?.BeginDelayedSequence(500))
-                        chat?.Expand();
-                }
 
                 switch (state.NewValue)
                 {
@@ -234,7 +235,14 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
         public override void Hide()
         {
-            scheduledOperation?.Cancel();
+            if (scheduledOperation != null)
+            {
+                scheduledOperation.Cancel();
+
+                if (State.Value == TourneyState.Ranking)
+                    contract();
+            }
+
             base.Hide();
         }
 

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -234,15 +234,15 @@ namespace osu.Game.Tournament.Screens.Gameplay
 
         public override void Hide()
         {
-            if (scheduledOperation != null)
-            {
-                scheduledOperation.Cancel();
-
-                if (State.Value == TourneyState.Ranking)
-                    contract();
-            }
+            scheduledOperation?.Cancel();
 
             base.Hide();
+        }
+
+        public override void Show()
+        {
+            stateChanged(new ValueChangedEvent<TourneyState>(TourneyState.Idle, State.Value));
+            base.Show();
         }
 
         private partial class ChromaArea : CompositeDrawable

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -232,6 +232,12 @@ namespace osu.Game.Tournament.Screens.Gameplay
             }
         }
 
+        public override void Hide()
+        {
+            scheduledOperation?.Cancel();
+            base.Hide();
+        }
+
         private partial class ChromaArea : CompositeDrawable
         {
             [Resolved]

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Diagnostics.Contracts;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Tournament.Screens.MapPool
         private OsuButton buttonRedPick;
         private OsuButton buttonBluePick;
 
+        private ScheduledDelegate scheduledScreenChange;
+
         [BackgroundDependencyLoader]
         private void load(MatchIPCInfo ipc)
         {
@@ -188,8 +190,6 @@ namespace osu.Game.Tournament.Screens.MapPool
             setNextMode();
         }
 
-        private ScheduledDelegate scheduledChange;
-
         private void addForBeatmap(int beatmapId)
         {
             if (CurrentMatch.Value == null)
@@ -216,15 +216,15 @@ namespace osu.Game.Tournament.Screens.MapPool
             {
                 if (pickType == ChoiceType.Pick && CurrentMatch.Value.PicksBans.Any(i => i.Type == ChoiceType.Pick))
                 {
-                    scheduledChange?.Cancel();
-                    scheduledChange = Scheduler.AddDelayed(() => { sceneManager?.SetScreen(typeof(GameplayScreen)); }, 10000);
+                    scheduledScreenChange?.Cancel();
+                    scheduledScreenChange = Scheduler.AddDelayed(() => { sceneManager?.SetScreen(typeof(GameplayScreen)); }, 10000);
                 }
             }
         }
 
         public override void Hide()
         {
-            scheduledChange?.Cancel();
+            scheduledScreenChange?.Cancel();
             base.Hide();
         }
 

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -222,6 +222,12 @@ namespace osu.Game.Tournament.Screens.MapPool
             }
         }
 
+        public override void Hide()
+        {
+            scheduledChange?.Cancel();
+            base.Hide();
+        }
+
         protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
         {
             base.CurrentMatchChanged(match);


### PR DESCRIPTION
In the tournament client, auto advance screens and screen switching will appear to not work.

To reproduce: 
- Open lazer tournament client, select a match, and go to gameplay screen. 
- Open a shell to the directory containing the ipc files
- Run `echo Playing >ipc-state.txt && sleep 2; echo Ranking >ipc-state.txt; sleep 2; echo Idle >ipc-state.txt; echo "Switch to mappool screen manually now\!"`
- When the above returns, manually press M/click the Map Pool button and wait a few seconds

Now, the next time auto advance screen tries to go to the Gameplay screen (or user manually switches to Gameplay screen), the Gameplay screen will execute its scheduled task to switch to the Mappool screen. 