### PR TITLE
Enable AOT compilation on iOS release builds for much better performance

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.720.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.724.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="11.1.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.720.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.724.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.707.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -2,12 +2,19 @@
   <PropertyGroup>
     <CodesignKey>iPhone Developer</CodesignKey>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
-    <!-- Workaround for an upstream issue which Realm suffers from (https://github.com/dotnet/runtime/issues/69410). -->
-    <UseInterpreter>true</UseInterpreter>
     <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
          It only warns about not copying the library to the app bundle to save space,
          so there's nothing to be worried about. -->
     <NoWarn>$(NoWarn);MT7091</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- On debug configurations, we use Mono interpreter for faster compilation. -->
+    <UseInterpreter>true</UseInterpreter>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- On release configurations, we use AOT compiler for optimal performance, along with Mono Interpreter as a fallback for libraries such as AutoMapper. -->
+    <UseInterpreter>false</UseInterpreter>
+    <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -23,6 +23,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.720.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.724.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/5941
- Closes https://github.com/ppy/osu-framework/issues/5902

This also enables Mono Interpreter as a fallback for areas where dynamic code is utilised. I will look into the steps necessary to remove it to close up any remaining possibilities for gains, but I'll do that as a separate follow-up effort later because building osu! with AOT compilation is quite a tedious task, and the performance gain in this PR alone is probably more than enough.

Note that while checking for lazer's performance, I had this PR checked out along with https://github.com/ppy/osu-framework/pull/5888 to render the game at 0.5x scale (helps with crowded screens such as beatmap listing), and also https://github.com/smoogipoo/osu-framework/tree/masking-ssbo (+ osu/osu-resources changes).

In addition, I've removed mentioning of https://github.com/dotnet/runtime/issues/69410 as we plan to enable source generation on Realm, which will fix this (at least that's what I saw last time I tried this, because the failure was inside Fody's "weaved" code). Also, there's been work towards resolving that issue thread at a .NET-level starting at .NET 8 preview 7.

---

This adds a magnificent boost in rendering performance on iOS. Anyone who's been struggling with performance before on their iPhones/iPads should give this release a try!