### PR TITLE
Fix iOS visual tests having unusual bundle identifiers

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests.iOS/Info.plist
+++ b/osu.Game.Rulesets.Catch.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Game.Rulesets.Catch.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Game-Rulesets-Catch-Tests-iOS</string>
+	<string>sh.ppy.catch-ruleset-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/osu.Game.Rulesets.Mania.Tests.iOS/Info.plist
+++ b/osu.Game.Rulesets.Mania.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Game.Rulesets.Mania.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Game-Rulesets-Mania-Tests-iOS</string>
+	<string>sh.ppy.mania-ruleset-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/osu.Game.Rulesets.Osu.Tests.iOS/Info.plist
+++ b/osu.Game.Rulesets.Osu.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Game.Rulesets.Osu.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Game-Rulesets-Osu-Tests-iOS</string>
+	<string>sh.ppy.osu-ruleset-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/osu.Game.Rulesets.Taiko.Tests.iOS/Info.plist
+++ b/osu.Game.Rulesets.Taiko.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Game.Rulesets.Taiko.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Game-Rulesets-Taiko-Tests-iOS</string>
+	<string>sh.ppy.taiko-ruleset-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/osu.Game.Tests.iOS/Info.plist
+++ b/osu.Game.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Game.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Game-Tests-iOS</string>
+	<string>sh.ppy.osu-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Noticed while attempting to deploy visual tests to my phone.