### PR TITLE
Enforce a hard minimum window size for tournament client

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneDrawingsScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneDrawingsScreen.cs
@@ -10,7 +10,7 @@ using osu.Game.Tournament.Screens.Drawings;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneDrawingsScreen : TournamentTestScene
+    public partial class TestSceneDrawingsScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load(Storage storage)

--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -15,7 +15,7 @@ using osu.Game.Tournament.Screens.Gameplay.Components;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneGameplayScreen : TournamentTestScene
+    public partial class TestSceneGameplayScreen : TournamentScreenTestScene
     {
         [Cached]
         private TournamentMatchChatDisplay chat = new TournamentMatchChatDisplay { Width = 0.5f };

--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -21,6 +21,20 @@ namespace osu.Game.Tournament.Tests.Screens
         private TournamentMatchChatDisplay chat = new TournamentMatchChatDisplay { Width = 0.5f };
 
         [Test]
+        public void TestWarmup()
+        {
+            createScreen();
+
+            checkScoreVisibility(false);
+
+            toggleWarmup();
+            checkScoreVisibility(true);
+
+            toggleWarmup();
+            checkScoreVisibility(false);
+        }
+
+        [Test]
         public void TestStartupState([Values] TourneyState state)
         {
             AddStep("set state", () => IPCInfo.State.Value = state);
@@ -33,20 +47,6 @@ namespace osu.Game.Tournament.Tests.Screens
             AddStep("set null current", () => Ladder.CurrentMatch.Value = null);
             AddStep("set state", () => IPCInfo.State.Value = state);
             createScreen();
-        }
-
-        [Test]
-        public void TestWarmup()
-        {
-            createScreen();
-
-            checkScoreVisibility(false);
-
-            toggleWarmup();
-            checkScoreVisibility(true);
-
-            toggleWarmup();
-            checkScoreVisibility(false);
         }
 
         private void createScreen()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneLadderEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneLadderEditorScreen.cs
@@ -8,7 +8,7 @@ using osu.Game.Tournament.Screens.Editors;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneLadderEditorScreen : TournamentTestScene
+    public partial class TestSceneLadderEditorScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneLadderScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneLadderScreen.cs
@@ -8,7 +8,7 @@ using osu.Game.Tournament.Screens.Ladder;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneLadderScreen : TournamentTestScene
+    public partial class TestSceneLadderScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -14,7 +14,7 @@ using osu.Game.Tournament.Screens.MapPool;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneMapPoolScreen : TournamentTestScene
+    public partial class TestSceneMapPoolScreen : TournamentScreenTestScene
     {
         private MapPoolScreen screen;
 

--- a/osu.Game.Tournament.Tests/Screens/TestSceneRoundEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneRoundEditorScreen.cs
@@ -5,7 +5,7 @@ using osu.Game.Tournament.Screens.Editors;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneRoundEditorScreen : TournamentTestScene
+    public partial class TestSceneRoundEditorScreen : TournamentScreenTestScene
     {
         public TestSceneRoundEditorScreen()
         {

--- a/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
@@ -12,7 +12,7 @@ using osu.Game.Tournament.Screens.Schedule;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneScheduleScreen : TournamentTestScene
+    public partial class TestSceneScheduleScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
@@ -7,7 +7,7 @@ using osu.Game.Tournament.Screens.Editors;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneSeedingEditorScreen : TournamentTestScene
+    public partial class TestSceneSeedingEditorScreen : TournamentScreenTestScene
     {
         [Cached]
         private readonly LadderInfo ladder = new LadderInfo();

--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingScreen.cs
@@ -12,7 +12,7 @@ using osu.Game.Tournament.Screens.TeamIntro;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneSeedingScreen : TournamentTestScene
+    public partial class TestSceneSeedingScreen : TournamentScreenTestScene
     {
         [Cached]
         private readonly LadderInfo ladder = new LadderInfo

--- a/osu.Game.Tournament.Tests/Screens/TestSceneSetupScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSetupScreen.cs
@@ -6,7 +6,7 @@ using osu.Game.Tournament.Screens.Setup;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneSetupScreen : TournamentTestScene
+    public partial class TestSceneSetupScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneShowcaseScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneShowcaseScreen.cs
@@ -6,7 +6,7 @@ using osu.Game.Tournament.Screens.Showcase;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneShowcaseScreen : TournamentTestScene
+    public partial class TestSceneShowcaseScreen : TournamentScreenTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Screens/TestSceneStablePathSelectScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneStablePathSelectScreen.cs
@@ -5,7 +5,7 @@ using osu.Game.Tournament.Screens.Setup;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneStablePathSelectScreen : TournamentTestScene
+    public partial class TestSceneStablePathSelectScreen : TournamentScreenTestScene
     {
         public TestSceneStablePathSelectScreen()
         {

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamEditorScreen.cs
@@ -5,7 +5,7 @@ using osu.Game.Tournament.Screens.Editors;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneTeamEditorScreen : TournamentTestScene
+    public partial class TestSceneTeamEditorScreen : TournamentScreenTestScene
     {
         public TestSceneTeamEditorScreen()
         {

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
@@ -9,7 +9,7 @@ using osu.Game.Tournament.Screens.TeamIntro;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneTeamIntroScreen : TournamentTestScene
+    public partial class TestSceneTeamIntroScreen : TournamentScreenTestScene
     {
         [Cached]
         private readonly LadderInfo ladder = new LadderInfo();

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamWinScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamWinScreen.cs
@@ -8,7 +8,7 @@ using osu.Game.Tournament.Screens.TeamWin;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
-    public partial class TestSceneTeamWinScreen : TournamentTestScene
+    public partial class TestSceneTeamWinScreen : TournamentScreenTestScene
     {
         [Test]
         public void TestBasic()

--- a/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -15,5 +16,11 @@ namespace osu.Game.Tournament.Tests
             Scale = new Vector2(1920 / (float)(1920 + TournamentSceneManager.CONTROL_AREA_WIDTH)),
             RelativeSizeAxes = Axes.Both
         };
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            base.Content.Add(Content);
+        }
     }
 }

--- a/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace osu.Game.Tournament.Tests
+{
+    public abstract partial class TournamentScreenTestScene : TournamentTestScene
+    {
+        protected override Container<Drawable> Content { get; } = new DrawSizePreservingFillContainer
+        {
+            TargetDrawSize = new Vector2(1920, 1080),
+            Scale = new Vector2(1920 / (float)(1920 + TournamentSceneManager.CONTROL_AREA_WIDTH)),
+            RelativeSizeAxes = Axes.Both
+        };
+    }
+}

--- a/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentScreenTestScene.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -10,17 +11,28 @@ namespace osu.Game.Tournament.Tests
 {
     public abstract partial class TournamentScreenTestScene : TournamentTestScene
     {
-        protected override Container<Drawable> Content { get; } = new DrawSizePreservingFillContainer
-        {
-            TargetDrawSize = new Vector2(1920, 1080),
-            Scale = new Vector2(1920 / (float)(1920 + TournamentSceneManager.CONTROL_AREA_WIDTH)),
-            RelativeSizeAxes = Axes.Both
-        };
+        protected override Container<Drawable> Content { get; } = new TournamentScalingContainer();
 
         [BackgroundDependencyLoader]
         private void load()
         {
             base.Content.Add(Content);
+        }
+
+        private partial class TournamentScalingContainer : DrawSizePreservingFillContainer
+        {
+            public TournamentScalingContainer()
+            {
+                TargetDrawSize = new Vector2(1920, 1080);
+                RelativeSizeAxes = Axes.Both;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                Scale = new Vector2(Math.Min(1, Content.DrawWidth / (1920 + TournamentSceneManager.CONTROL_AREA_WIDTH)));
+            }
         }
     }
 }

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -43,8 +43,6 @@ namespace osu.Game.Tournament.Tests
 
             Ruleset.BindTo(Ladder.Ruleset);
             Dependencies.CacheAs(new StableInfo(storage));
-
-            base.Content.Add(Content);
         }
 
         [SetUpSteps]

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
@@ -20,16 +18,16 @@ namespace osu.Game.Tournament.Tests
 {
     public abstract partial class TournamentTestScene : OsuTestScene
     {
-        private TournamentMatch match;
-
         [Cached]
         protected LadderInfo Ladder { get; private set; } = new LadderInfo();
 
-        [Resolved]
-        private RulesetStore rulesetStore { get; set; }
-
         [Cached]
         protected MatchIPCInfo IPCInfo { get; private set; } = new MatchIPCInfo();
+
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; } = null!;
+
+        private TournamentMatch match = null!;
 
         [BackgroundDependencyLoader]
         private void load(TournamentStorage storage)
@@ -45,6 +43,8 @@ namespace osu.Game.Tournament.Tests
 
             Ruleset.BindTo(Ladder.Ruleset);
             Dependencies.CacheAs(new StableInfo(storage));
+
+            base.Content.Add(Content);
         }
 
         [SetUpSteps]
@@ -167,7 +167,7 @@ namespace osu.Game.Tournament.Tests
 
         public partial class TournamentTestSceneTestRunner : TournamentGameBase, ITestSceneTestRunner
         {
-            private TestSceneTestRunner.TestRunner runner;
+            private TestSceneTestRunner.TestRunner runner = null!;
 
             protected override void LoadAsyncComplete()
             {

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -35,14 +35,19 @@ namespace osu.Game.Tournament
 
         public static readonly Color4 TEXT_COLOUR = Color4Extensions.FromHex("#fff");
         private Drawable heightWarning;
-        private Bindable<Size> windowSize;
+
         private Bindable<WindowMode> windowMode;
+        private readonly BindableSize windowSize = new BindableSize();
+
         private LoadingSpinner loadingSpinner;
 
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager frameworkConfig, GameHost host)
         {
-            windowSize = frameworkConfig.GetBindable<Size>(FrameworkSetting.WindowedSize);
+            frameworkConfig.BindWith(FrameworkSetting.WindowedSize, windowSize);
+
+            windowSize.MinValue = new Size(TournamentSceneManager.REQUIRED_WIDTH, TournamentSceneManager.STREAM_AREA_HEIGHT);
+
             windowMode = frameworkConfig.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
 
             Add(loadingSpinner = new LoadingSpinner(true, true)

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -38,11 +38,14 @@ namespace osu.Game.Tournament
         private Container screens;
         private TourneyVideo video;
 
-        public const float CONTROL_AREA_WIDTH = 200;
+        public const int CONTROL_AREA_WIDTH = 200;
 
-        public const float STREAM_AREA_WIDTH = 1366;
+        public const int STREAM_AREA_WIDTH = 1366;
+        public const int STREAM_AREA_HEIGHT = (int)(STREAM_AREA_WIDTH / ASPECT_RATIO);
 
-        public const double REQUIRED_WIDTH = CONTROL_AREA_WIDTH * 2 + STREAM_AREA_WIDTH;
+        public const float ASPECT_RATIO = 16 / 9f;
+
+        public const int REQUIRED_WIDTH = CONTROL_AREA_WIDTH * 2 + STREAM_AREA_WIDTH;
 
         [Cached]
         private TournamentMatchChatDisplay chat = new TournamentMatchChatDisplay();
@@ -65,7 +68,7 @@ namespace osu.Game.Tournament
                     RelativeSizeAxes = Axes.Y,
                     X = CONTROL_AREA_WIDTH,
                     FillMode = FillMode.Fit,
-                    FillAspectRatio = 16 / 9f,
+                    FillAspectRatio = ASPECT_RATIO,
                     Anchor = Anchor.TopLeft,
                     Origin = Anchor.TopLeft,
                     Width = STREAM_AREA_WIDTH,

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -75,6 +75,13 @@ namespace osu.Game.Tournament
                     //Masking = true,
                     Children = new Drawable[]
                     {
+                        new Box
+                        {
+                            Colour = new Color4(20, 20, 20, 255),
+                            Anchor = Anchor.TopRight,
+                            RelativeSizeAxes = Axes.Both,
+                            Width = 10,
+                        },
                         video = new TourneyVideo("main", true)
                         {
                             Loop = true,


### PR DESCRIPTION
This also adds a non-black background when the window is too wide (looks nicer), and improve testability when screen isn't wide enough (tournament screen tests will now display scaled down to include the screen and control panel).