### PR TITLE
Fix uneven spacing on match connectors in tournament ladder screen

### DIFF
--- a/osu.Game.Tournament/Screens/Ladder/Components/ProgressionPath.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/ProgressionPath.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 
             var topLeft = new Vector2(minX, minY);
 
+            OriginPosition = new Vector2(PathRadius);
             Position = Parent.ToLocalSpace(topLeft);
             Vertices = points.Select(p => Parent.ToLocalSpace(p) - Parent.ToLocalSpace(topLeft)).ToList();
         }


### PR DESCRIPTION
Noticed in passing during review of #24347.

| before | after |
| :-: | :-: |
| ![1690234950](https://github.com/ppy/osu/assets/20418176/8cc08fb5-de15-4e31-8e97-a925606845c6) | ![1690234971](https://github.com/ppy/osu/assets/20418176/712617b0-035d-4eb3-984e-17042cc5a38c) |

Caused by not accounting for the fact that a `Path`'s position is not the same as the position of its first vertex (as it is the position of the entire path drawable, which includes path radius in its drawable bounds).