### PR TITLE
Show break time in tooltip at song select

### DIFF
--- a/osu.Game.Tests/Editing/Checks/CheckDrainLengthTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckDrainLengthTest.cs
@@ -14,7 +14,7 @@ using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Editing.Checks
 {
-    public class CheckDrainTimeTest
+    public class CheckDrainLengthTest
     {
         private CheckDrainLength check = null!;
 

--- a/osu.Game.Tests/Editing/Checks/CheckDrainTimeTest.cs
+++ b/osu.Game.Tests/Editing/Checks/CheckDrainTimeTest.cs
@@ -16,12 +16,12 @@ namespace osu.Game.Tests.Editing.Checks
 {
     public class CheckDrainTimeTest
     {
-        private CheckDrainTime check = null!;
+        private CheckDrainLength check = null!;
 
         [SetUp]
         public void Setup()
         {
-            check = new CheckDrainTime();
+            check = new CheckDrainLength();
         }
 
         [Test]
@@ -40,7 +40,7 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
-            Assert.That(issues.Single().Template is CheckDrainTime.IssueTemplateTooShort);
+            Assert.That(issues.Single().Template is CheckDrainLength.IssueTemplateTooShort);
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Editing.Checks
             var issues = check.Run(context).ToList();
 
             Assert.That(issues, Has.Count.EqualTo(1));
-            Assert.That(issues.Single().Template is CheckDrainTime.IssueTemplateTooShort);
+            Assert.That(issues.Single().Template is CheckDrainLength.IssueTemplateTooShort);
         }
 
         [Test]

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -111,6 +111,11 @@ namespace osu.Game.Beatmaps
         public static double CalculatePlayableLength(this IBeatmap beatmap) => CalculatePlayableLength(beatmap.HitObjects);
 
         /// <summary>
+        /// Find the total milliseconds between the first and last hittable objects, excluding any break time.
+        /// </summary>
+        public static double CalculateDrainLength(this IBeatmap beatmap) => CalculatePlayableLength(beatmap.HitObjects) - beatmap.TotalBreakTime;
+
+        /// <summary>
         /// Find the timestamps in milliseconds of the start and end of the playable region.
         /// </summary>
         public static (double start, double end) CalculatePlayableBounds(this IBeatmap beatmap) => CalculatePlayableBounds(beatmap.HitObjects);

--- a/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
+++ b/osu.Game/Rulesets/Edit/BeatmapVerifier.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Edit
             new CheckUnsnappedObjects(),
             new CheckConcurrentObjects(),
             new CheckZeroLengthObjects(),
-            new CheckDrainTime(),
+            new CheckDrainLength(),
 
             // Timing
             new CheckPreviewTime(),

--- a/osu.Game/Rulesets/Edit/Checks/CheckDrainLength.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckDrainLength.cs
@@ -7,10 +7,11 @@ using osu.Game.Rulesets.Edit.Checks.Components;
 
 namespace osu.Game.Rulesets.Edit.Checks
 {
-    public class CheckDrainTime : ICheck
+    public class CheckDrainLength : ICheck
     {
         private const int min_drain_threshold = 30 * 1000;
-        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Compose, "Too short drain time");
+
+        public CheckMetadata Metadata => new CheckMetadata(CheckCategory.Compose, "Drain length is too short");
 
         public IEnumerable<IssueTemplate> PossibleTemplates => new IssueTemplate[]
         {
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.Edit.Checks
 
         public IEnumerable<Issue> Run(BeatmapVerifierContext context)
         {
-            double drainTime = context.Beatmap.CalculatePlayableLength() - context.Beatmap.TotalBreakTime;
+            double drainTime = context.Beatmap.CalculateDrainLength();
 
             if (drainTime < min_drain_threshold)
                 yield return new IssueTemplateTooShort(this).Create((int)(drainTime / 1000));

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -371,7 +371,7 @@ namespace osu.Game.Screens.Select
                     {
                         new InfoLabel(new BeatmapStatistic
                         {
-                            Name = $"Length (Drain: {playableBeatmap.CalculateDrainLength().ToFormattedDuration().ToString()})",
+                            Name = $"Length (Breaks: {playableBeatmap.TotalBreakTime.ToFormattedDuration().ToString()})",
                             CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
                             Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
                         }),

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -352,29 +352,6 @@ namespace osu.Game.Screens.Select
                 if (working.Beatmap?.HitObjects.Any() != true)
                     return;
 
-                infoLabelContainer.Children = new Drawable[]
-                {
-                    new InfoLabel(new BeatmapStatistic
-                    {
-                        Name = "Length",
-                        CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
-                        Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
-                    }),
-                    bpmLabelContainer = new Container
-                    {
-                        AutoSizeAxes = Axes.Both,
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Spacing = new Vector2(20, 0),
-                        Children = getRulesetInfoLabels()
-                    }
-                };
-            }
-
-            private InfoLabel[] getRulesetInfoLabels()
-            {
                 try
                 {
                     IBeatmap playableBeatmap;
@@ -390,14 +367,30 @@ namespace osu.Game.Screens.Select
                         playableBeatmap = working.GetPlayableBeatmap(working.BeatmapInfo.Ruleset, Array.Empty<Mod>());
                     }
 
-                    return playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)).ToArray();
+                    infoLabelContainer.Children = new Drawable[]
+                    {
+                        new InfoLabel(new BeatmapStatistic
+                        {
+                            Name = $"Length (Drain: {playableBeatmap.CalculateDrainLength().ToFormattedDuration().ToString()})",
+                            CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
+                            Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
+                        }),
+                        bpmLabelContainer = new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Spacing = new Vector2(20, 0),
+                            Children = playableBeatmap.GetStatistics().Select(s => new InfoLabel(s)).ToArray()
+                        }
+                    };
                 }
                 catch (Exception e)
                 {
                     Logger.Error(e, "Could not load beatmap successfully!");
                 }
-
-                return Array.Empty<InfoLabel>();
             }
 
             private void refreshBPMLabel()

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -371,7 +371,7 @@ namespace osu.Game.Screens.Select
                     {
                         new InfoLabel(new BeatmapStatistic
                         {
-                            Name = $"Length (Breaks: {playableBeatmap.TotalBreakTime.ToFormattedDuration().ToString()})",
+                            Name = $"Length (Drain: {playableBeatmap.CalculateDrainLength().ToFormattedDuration().ToString()})",
                             CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
                             Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
                         }),


### PR DESCRIPTION
The song select design is changing, so not overthinking this one. Felt like a quick usability change I could get in in 5 minutes.

As requested in https://github.com/ppy/osu/discussions/24351.

I ended up going with only showing the total break time, rather than the drain length as I think it's a more useful display method. Open to feedback.