### PR TITLE
Fix `TestSceneUnknownMod` failing due to null reference

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneUnknownMod.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneUnknownMod.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             CreateModTest(new ModTestData
             {
-                Beatmap = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo).Beatmap,
                 Mod = new UnknownMod("WNG"),
                 PassCondition = () => Player.IsLoaded && !Player.LoadedBeatmapSuccessfully
             });


### PR DESCRIPTION
I don't know why this isn't failing on CI, but I get it on `master`. Cause is pretty obvious – `CreateWorkingBeatmap` was being called before `AudioManager` was constructed.

```csharp
System.NullReferenceException : Object reference not set to an instance of an object.
   at osu.Game.Beatmaps.WorkingBeatmap.GetVirtualTrack(Double emptyLength) in /Users/dean/Projects/osu/osu.Game/Beatmaps/WorkingBeatmap.cs:line 173
   at osu.Game.Beatmaps.WorkingBeatmap.LoadTrack() in /Users/dean/Projects/osu/osu.Game/Beatmaps/WorkingBeatmap.cs:line 108
   at osu.Game.Tests.Visual.OsuTestScene.ClockBackedTestWorkingBeatmap..ctor(IBeatmap beatmap, Storyboard storyboard, IFrameBasedClock referenceClock, AudioManager audio) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 371
   at osu.Game.Tests.Visual.OsuTestScene.CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 310
   at osu.Game.Tests.Visual.OsuTestScene.CreateWorkingBeatmap(RulesetInfo ruleset) in /Users/dean/Projects/osu/osu.Game/Tests/Visual/OsuTestScene.cs:line 307
   at osu.Game.Tests.Visual.Gameplay.TestSceneUnknownMod.TestUnknownModDoesntEnterGameplay() in /Users/dean/Projects/osu/osu.Game.Tests/Visual/Gameplay/TestSceneUnknownMod.cs:line 21



-----

One or more child tests had errors
  Exception doesn't have a stacktrace



[performance] 2023-07-25 10:07:11 [verbose]: TextureAtlas initialised (1024x1024)
[runtime] 2023-07-25 10:07:11 [verbose]: 💨 Class: TestSceneUnknownMod
[runtime] 2023-07-25 10:07:11 [verbose]: 🔶 Test:  TestUnknownModDoesntEnterGameplay
[runtime] 2023-07-25 10:07:11 [verbose]: 🔸 Step #1 exit all screens
[runtime] 2023-07-25 10:07:11 [verbose]: 🔸 Step #2 test passed
[runtime] 2023-07-25 10:07:11 [verbose]: 🔸 Step #3 exit all screens
[runtime] 2023-07-25 10:07:11 [verbose]: ✅ TestSceneUnknownMod completed
```