### PR TITLE
Change spinner rotation animation to match input 1:1

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -72,9 +72,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             lastAngle = thisAngle;
 
-            IsSpinning.Value = isSpinnableTime && Math.Abs(currentRotation / 2 - Rotation) > 5f;
+            IsSpinning.Value = isSpinnableTime && Math.Abs(currentRotation - Rotation) > 10f;
 
-            Rotation = (float)Interpolation.Damp(Rotation, currentRotation / 2, 0.99, Math.Abs(Time.Elapsed));
+            Rotation = (float)Interpolation.Damp(Rotation, currentRotation, 0.99, Math.Abs(Time.Elapsed));
         }
 
         /// <summary>


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/discussions/24306. Originally this was halved to make the newer designs look "better" (subjectively) but in testing I think it's fine to apply this across the board. It definitely feels better as a user to have non-slipping control over spinners.