### PR TITLE
Disallow interacting with the global track state in `Player` and `Editor`

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -170,6 +170,39 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("time is correct", () => getEditor().ChildrenOfType<EditorClock>().First().CurrentTime, () => Is.EqualTo(1234));
         }
 
+        [Test]
+        public void TestAttemptGlobalMusicOperationFromEditor()
+        {
+            BeatmapSetInfo beatmapSet = null!;
+
+            AddStep("import test beatmap", () => Game.BeatmapManager.Import(TestResources.GetTestBeatmapForImport()).WaitSafely());
+            AddStep("retrieve beatmap", () => beatmapSet = Game.BeatmapManager.QueryBeatmapSet(set => !set.Protected).AsNonNull().Value.Detach());
+
+            AddStep("present beatmap", () => Game.PresentBeatmap(beatmapSet));
+            AddUntilStep("wait for song select",
+                () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
+                      && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
+                      && songSelect.IsLoaded);
+
+            AddUntilStep("wait for music playing", () => Game.MusicController.IsPlaying);
+            AddStep("user request stop", () => Game.MusicController.Stop(requestedByUser: true));
+            AddUntilStep("wait for music stopped", () => !Game.MusicController.IsPlaying);
+
+            AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));
+            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
+
+            AddUntilStep("music still stopped", () => !Game.MusicController.IsPlaying);
+            AddStep("user request play", () => Game.MusicController.Play(requestedByUser: true));
+            AddUntilStep("music still stopped", () => !Game.MusicController.IsPlaying);
+
+            AddStep("exit to song select", () => Game.PerformFromScreen(_ => { }, typeof(PlaySongSelect).Yield()));
+            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+
+            AddUntilStep("wait for music playing", () => Game.MusicController.IsPlaying);
+            AddStep("user request stop", () => Game.MusicController.Stop(requestedByUser: true));
+            AddUntilStep("wait for music stopped", () => !Game.MusicController.IsPlaying);
+        }
+
         private EditorBeatmap getEditorBeatmap() => getEditor().ChildrenOfType<EditorBeatmap>().Single();
 
         private Editor getEditor() => (Editor)Game.ScreenStack.CurrentScreen;

--- a/osu.Game.Tests/Visual/TestSceneOsuScreenStack.cs
+++ b/osu.Game.Tests/Visual/TestSceneOsuScreenStack.cs
@@ -56,38 +56,38 @@ namespace osu.Game.Tests.Visual
         public void AllowTrackAdjustmentsTest()
         {
             AddStep("push allowing screen", () => stack.Push(loadNewScreen<AllowScreen>()));
-            AddAssert("allows adjustments 1", () => musicController.AllowTrackAdjustments);
+            AddAssert("allows adjustments 1", () => musicController.ApplyModTrackAdjustments);
 
             AddStep("push inheriting screen", () => stack.Push(loadNewScreen<InheritScreen>()));
-            AddAssert("allows adjustments 2", () => musicController.AllowTrackAdjustments);
+            AddAssert("allows adjustments 2", () => musicController.ApplyModTrackAdjustments);
 
             AddStep("push disallowing screen", () => stack.Push(loadNewScreen<DisallowScreen>()));
-            AddAssert("disallows adjustments 3", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 3", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("push inheriting screen", () => stack.Push(loadNewScreen<InheritScreen>()));
-            AddAssert("disallows adjustments 4", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 4", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("push inheriting screen", () => stack.Push(loadNewScreen<InheritScreen>()));
-            AddAssert("disallows adjustments 5", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 5", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("push allowing screen", () => stack.Push(loadNewScreen<AllowScreen>()));
-            AddAssert("allows adjustments 6", () => musicController.AllowTrackAdjustments);
+            AddAssert("allows adjustments 6", () => musicController.ApplyModTrackAdjustments);
 
             // Now start exiting from screens
             AddStep("exit screen", () => stack.Exit());
-            AddAssert("disallows adjustments 7", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 7", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("exit screen", () => stack.Exit());
-            AddAssert("disallows adjustments 8", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 8", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("exit screen", () => stack.Exit());
-            AddAssert("disallows adjustments 9", () => !musicController.AllowTrackAdjustments);
+            AddAssert("disallows adjustments 9", () => !musicController.ApplyModTrackAdjustments);
 
             AddStep("exit screen", () => stack.Exit());
-            AddAssert("allows adjustments 10", () => musicController.AllowTrackAdjustments);
+            AddAssert("allows adjustments 10", () => musicController.ApplyModTrackAdjustments);
 
             AddStep("exit screen", () => stack.Exit());
-            AddAssert("allows adjustments 11", () => musicController.AllowTrackAdjustments);
+            AddAssert("allows adjustments 11", () => musicController.ApplyModTrackAdjustments);
         }
 
         public partial class TestScreen : ScreenWithBeatmapBackground
@@ -129,12 +129,12 @@ namespace osu.Game.Tests.Visual
 
         private partial class AllowScreen : OsuScreen
         {
-            public override bool? AllowTrackAdjustments => true;
+            public override bool? ApplyModTrackAdjustments => true;
         }
 
         public partial class DisallowScreen : OsuScreen
         {
-            public override bool? AllowTrackAdjustments => false;
+            public override bool? ApplyModTrackAdjustments => false;
         }
 
         private partial class InheritScreen : OsuScreen

--- a/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenUIScale.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Overlays.FirstRunSetup
         {
             protected override bool ControlGlobalMusic => false;
 
-            public override bool? AllowTrackAdjustments => false;
+            public override bool? ApplyModTrackAdjustments => false;
         }
 
         private partial class UIScaleSlider : RoundedSliderBar<float>

--- a/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
+++ b/osu.Game/Overlays/Music/MusicKeyBindingHandler.cs
@@ -30,20 +30,14 @@ namespace osu.Game.Overlays.Music
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
 
-        [Resolved]
-        private OsuGame game { get; set; } = null!;
-
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            if (e.Repeat)
+            if (e.Repeat || !musicController.AllowTrackControl.Value)
                 return false;
 
             switch (e.Action)
             {
                 case GlobalAction.MusicPlay:
-                    if (game.LocalUserPlaying.Value)
-                        return false;
-
                     // use previous state as TogglePause may not update the track's state immediately (state update is run on the audio thread see https://github.com/ppy/osu/issues/9880#issuecomment-674668842)
                     bool wasPlaying = musicController.IsPlaying;
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -356,20 +356,20 @@ namespace osu.Game.Overlays
                 NextTrack();
         }
 
-        private bool allowTrackAdjustments;
+        private bool applyModTrackAdjustments;
 
         /// <summary>
         /// Whether mod track adjustments are allowed to be applied.
         /// </summary>
-        public bool AllowTrackAdjustments
+        public bool ApplyModTrackAdjustments
         {
-            get => allowTrackAdjustments;
+            get => applyModTrackAdjustments;
             set
             {
-                if (allowTrackAdjustments == value)
+                if (applyModTrackAdjustments == value)
                     return;
 
-                allowTrackAdjustments = value;
+                applyModTrackAdjustments = value;
                 ResetTrackAdjustments();
             }
         }
@@ -377,7 +377,7 @@ namespace osu.Game.Overlays
         private AudioAdjustments modTrackAdjustments;
 
         /// <summary>
-        /// Resets the adjustments currently applied on <see cref="CurrentTrack"/> and applies the mod adjustments if <see cref="AllowTrackAdjustments"/> is <c>true</c>.
+        /// Resets the adjustments currently applied on <see cref="CurrentTrack"/> and applies the mod adjustments if <see cref="ApplyModTrackAdjustments"/> is <c>true</c>.
         /// </summary>
         /// <remarks>
         /// Does not reset any adjustments applied directly to the beatmap track.
@@ -390,7 +390,7 @@ namespace osu.Game.Overlays
             CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Tempo);
             CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Volume);
 
-            if (allowTrackAdjustments)
+            if (applyModTrackAdjustments)
             {
                 CurrentTrack.BindAdjustments(modTrackAdjustments = new AudioAdjustments());
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays
         public bool UserPauseRequested { get; private set; }
 
         /// <summary>
-        /// Whether control of the global track should be allowed.
+        /// Whether user control of the global track should be allowed.
         /// </summary>
         public readonly BindableBool AllowTrackControl = new BindableBool(true);
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -68,6 +68,8 @@ namespace osu.Game.Screens.Edit
 
         public override bool? ApplyModTrackAdjustments => false;
 
+        public override bool? AllowGlobalTrackControl => false;
+
         protected override bool PlayExitSound => !ExitConfirmed && !switchingDifficulty;
 
         protected bool HasUnsavedChanges

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Edit
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
-        public override bool? AllowTrackAdjustments => false;
+        public override bool? ApplyModTrackAdjustments => false;
 
         protected override bool PlayExitSound => !ExitConfirmed && !switchingDifficulty;
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -68,8 +68,6 @@ namespace osu.Game.Screens.Edit
 
         public override bool? ApplyModTrackAdjustments => false;
 
-        public override bool? AllowGlobalTrackControl => false;
-
         protected override bool PlayExitSound => !ExitConfirmed && !switchingDifficulty;
 
         protected bool HasUnsavedChanges

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Screens.Edit
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
+        public override bool? AllowGlobalTrackControl => false;
+
         [Resolved]
         private BeatmapManager beatmapManager { get; set; }
 

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -70,6 +70,12 @@ namespace osu.Game.Screens
         bool? ApplyModTrackAdjustments { get; }
 
         /// <summary>
+        /// Whether control of the global track should be allowed via the music controller / now playing overlay.
+        /// A <see langword="null"/> value means that the parent screen's value of this setting will be used.
+        /// </summary>
+        bool? AllowGlobalTrackControl { get; }
+
+        /// <summary>
         /// Invoked when the back button has been pressed to close any overlays before exiting this <see cref="IOsuScreen"/>.
         /// </summary>
         /// <remarks>

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Screens
         /// Whether mod track adjustments should be applied on entering this screen.
         /// A <see langword="null"/> value means that the parent screen's value of this setting will be used.
         /// </summary>
-        bool? AllowTrackAdjustments { get; }
+        bool? ApplyModTrackAdjustments { get; }
 
         /// <summary>
         /// Invoked when the back button has been pressed to close any overlays before exiting this <see cref="IOsuScreen"/>.

--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.OnlinePlay.Match
         [Cached(typeof(IBindable<PlaylistItem>))]
         public readonly Bindable<PlaylistItem> SelectedItem = new Bindable<PlaylistItem>();
 
-        public override bool? AllowTrackAdjustments => true;
+        public override bool? ApplyModTrackAdjustments => true;
 
         protected override BackgroundScreen CreateBackground() => new RoomBackgroundScreen(Room.Playlist.FirstOrDefault())
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
         // We are managing our own adjustments. For now, this happens inside the Player instances themselves.
-        public override bool? AllowTrackAdjustments => false;
+        public override bool? ApplyModTrackAdjustments => false;
 
         /// <summary>
         /// Whether all spectating players have finished loading.

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens
         [Resolved]
         private MusicController musicController { get; set; }
 
-        public virtual bool? AllowTrackAdjustments => null;
+        public virtual bool? ApplyModTrackAdjustments => null;
 
         public Bindable<WorkingBeatmap> Beatmap { get; private set; }
 
@@ -95,7 +95,7 @@ namespace osu.Game.Screens
 
         private OsuScreenDependencies screenDependencies;
 
-        private bool? trackAdjustmentStateAtSuspend;
+        private bool? modTrackAdjustmentStateAtSuspend;
 
         internal void CreateLeasedDependencies(IReadOnlyDependencyContainer dependencies) => createDependencies(dependencies);
 
@@ -178,8 +178,8 @@ namespace osu.Game.Screens
 
             // it's feasible to resume to a screen if the target screen never loaded successfully.
             // in such a case there's no need to restore this value.
-            if (trackAdjustmentStateAtSuspend != null)
-                musicController.AllowTrackAdjustments = trackAdjustmentStateAtSuspend.Value;
+            if (modTrackAdjustmentStateAtSuspend != null)
+                musicController.ApplyModTrackAdjustments = modTrackAdjustmentStateAtSuspend.Value;
 
             base.OnResuming(e);
         }
@@ -188,7 +188,7 @@ namespace osu.Game.Screens
         {
             base.OnSuspending(e);
 
-            trackAdjustmentStateAtSuspend = musicController.AllowTrackAdjustments;
+            modTrackAdjustmentStateAtSuspend = musicController.ApplyModTrackAdjustments;
 
             onSuspendingLogo();
         }
@@ -197,8 +197,8 @@ namespace osu.Game.Screens
         {
             applyArrivingDefaults(false);
 
-            if (AllowTrackAdjustments != null)
-                musicController.AllowTrackAdjustments = AllowTrackAdjustments.Value;
+            if (ApplyModTrackAdjustments != null)
+                musicController.ApplyModTrackAdjustments = ApplyModTrackAdjustments.Value;
 
             if (backgroundStack?.Push(ownedBackground = CreateBackground()) != true)
             {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -87,6 +87,8 @@ namespace osu.Game.Screens
 
         public virtual bool? ApplyModTrackAdjustments => null;
 
+        public virtual bool? AllowGlobalTrackControl => null;
+
         public Bindable<WorkingBeatmap> Beatmap { get; private set; }
 
         public Bindable<RulesetInfo> Ruleset { get; private set; }
@@ -94,6 +96,8 @@ namespace osu.Game.Screens
         public Bindable<IReadOnlyList<Mod>> Mods { get; private set; }
 
         private OsuScreenDependencies screenDependencies;
+
+        private bool? globalMusicControlStateAtSuspend;
 
         private bool? modTrackAdjustmentStateAtSuspend;
 
@@ -180,6 +184,8 @@ namespace osu.Game.Screens
             // in such a case there's no need to restore this value.
             if (modTrackAdjustmentStateAtSuspend != null)
                 musicController.ApplyModTrackAdjustments = modTrackAdjustmentStateAtSuspend.Value;
+            if (globalMusicControlStateAtSuspend != null)
+                musicController.AllowTrackControl.Value = globalMusicControlStateAtSuspend.Value;
 
             base.OnResuming(e);
         }
@@ -189,6 +195,7 @@ namespace osu.Game.Screens
             base.OnSuspending(e);
 
             modTrackAdjustmentStateAtSuspend = musicController.ApplyModTrackAdjustments;
+            globalMusicControlStateAtSuspend = musicController.AllowTrackControl.Value;
 
             onSuspendingLogo();
         }
@@ -199,6 +206,9 @@ namespace osu.Game.Screens
 
             if (ApplyModTrackAdjustments != null)
                 musicController.ApplyModTrackAdjustments = ApplyModTrackAdjustments.Value;
+
+            if (AllowGlobalTrackControl != null)
+                musicController.AllowTrackControl.Value = AllowGlobalTrackControl.Value;
 
             if (backgroundStack?.Push(ownedBackground = CreateBackground()) != true)
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -71,6 +71,8 @@ namespace osu.Game.Screens.Play
         // We are managing our own adjustments (see OnEntering/OnExiting).
         public override bool? ApplyModTrackAdjustments => false;
 
+        public override bool? AllowGlobalTrackControl => false;
+
         private readonly IBindable<bool> gameActive = new Bindable<bool>(true);
 
         private readonly Bindable<bool> samplePlaybackDisabled = new Bindable<bool>();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -71,8 +71,6 @@ namespace osu.Game.Screens.Play
         // We are managing our own adjustments (see OnEntering/OnExiting).
         public override bool? ApplyModTrackAdjustments => false;
 
-        public override bool? AllowGlobalTrackControl => false;
-
         private readonly IBindable<bool> gameActive = new Bindable<bool>(true);
 
         private readonly Bindable<bool> samplePlaybackDisabled = new Bindable<bool>();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Play
         protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;
 
         // We are managing our own adjustments (see OnEntering/OnExiting).
-        public override bool? AllowTrackAdjustments => false;
+        public override bool? ApplyModTrackAdjustments => false;
 
         private readonly IBindable<bool> gameActive = new Bindable<bool>(true);
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Screens.Play
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
+        public override bool? AllowGlobalTrackControl => false;
+
         // Here because IsHovered will not update unless we do so.
         public override bool HandlePositionalInput => true;
 

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -36,6 +36,8 @@ namespace osu.Game.Screens.Ranking
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
 
+        public override bool? AllowGlobalTrackControl => true;
+
         // Temporary for now to stop dual transitions. Should respect the current toolbar mode, but there's no way to do so currently.
         public override bool HideOverlaysOnEnter => true;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Select
 
         protected virtual bool ShowFooter => true;
 
-        public override bool? AllowTrackAdjustments => true;
+        public override bool? ApplyModTrackAdjustments => true;
 
         /// <summary>
         /// Can be null if <see cref="ShowFooter"/> is false.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24271
- Closes https://github.com/ppy/osu/issues/14816
- Closes https://github.com/ppy/osu/issues/24385

This PR also renames `AllowTrackAdjustments` to more understandable `ApplyModTrackAdjustments`
