### PR TITLE
Fix osu!taiko editor playfield missing a piece

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -11,6 +11,8 @@ namespace osu.Game.Rulesets.Taiko.Edit
 {
     public partial class TaikoHitObjectComposer : HitObjectComposer<TaikoHitObject>
     {
+        protected override bool ApplyVerticalCentering => false;
+
         public TaikoHitObjectComposer(TaikoRuleset ruleset)
             : base(ruleset)
         {

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
 {
     public partial class TaikoHitObjectComposer : HitObjectComposer<TaikoHitObject>
     {
-        protected override bool ApplyVerticalCentering => false;
+        protected override bool ApplyHorizontalCentering => false;
 
         public TaikoHitObjectComposer(TaikoRuleset ruleset)
             : base(ruleset)

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Rulesets.Edit
         where TObject : HitObject
     {
         /// <summary>
-        /// Whether the playfield should be centered vertically. Should be disabled for playfields which span the full horizontal width.
+        /// Whether the playfield should be centered horizontally. Should be disabled for playfields which span the full horizontal width.
         /// </summary>
-        protected virtual bool ApplyVerticalCentering => true;
+        protected virtual bool ApplyHorizontalCentering => true;
 
         protected IRulesetConfigManager Config { get; private set; }
 
@@ -245,7 +245,7 @@ namespace osu.Game.Rulesets.Edit
             base.Update();
 
             // Ensure that the playfield is always centered but also doesn't get cut off by toolboxes.
-            if (ApplyVerticalCentering)
+            if (ApplyHorizontalCentering)
             {
                 PlayfieldContentContainer.Anchor = Anchor.Centre;
                 PlayfieldContentContainer.Origin = Anchor.Centre;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -244,12 +244,12 @@ namespace osu.Game.Rulesets.Edit
         {
             base.Update();
 
-            // Ensure that the playfield is always centered but also doesn't get cut off by toolboxes.
             if (ApplyHorizontalCentering)
             {
                 PlayfieldContentContainer.Anchor = Anchor.Centre;
                 PlayfieldContentContainer.Origin = Anchor.Centre;
 
+                // Ensure that the playfield is always centered but also doesn't get cut off by toolboxes.
                 PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - TOOLBOX_CONTRACTED_SIZE_RIGHT * 2;
                 PlayfieldContentContainer.X = 0;
             }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -124,8 +124,6 @@ namespace osu.Game.Rulesets.Edit
                 {
                     Name = "Playfield content",
                     RelativeSizeAxes = Axes.Y,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
                     Children = new Drawable[]
                     {
                         // layers below playfield
@@ -247,7 +245,22 @@ namespace osu.Game.Rulesets.Edit
             base.Update();
 
             // Ensure that the playfield is always centered but also doesn't get cut off by toolboxes.
-            PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - (ApplyVerticalCentering ? TOOLBOX_CONTRACTED_SIZE_RIGHT : TOOLBOX_CONTRACTED_SIZE_LEFT) * 2;
+            if (ApplyVerticalCentering)
+            {
+                PlayfieldContentContainer.Anchor = Anchor.Centre;
+                PlayfieldContentContainer.Origin = Anchor.Centre;
+
+                PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - TOOLBOX_CONTRACTED_SIZE_RIGHT * 2;
+                PlayfieldContentContainer.X = 0;
+            }
+            else
+            {
+                PlayfieldContentContainer.Anchor = Anchor.CentreLeft;
+                PlayfieldContentContainer.Origin = Anchor.CentreLeft;
+
+                PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - (TOOLBOX_CONTRACTED_SIZE_LEFT + TOOLBOX_CONTRACTED_SIZE_RIGHT);
+                PlayfieldContentContainer.X = TOOLBOX_CONTRACTED_SIZE_LEFT;
+            }
         }
 
         public override Playfield Playfield => drawableRulesetWrapper.Playfield;

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Rulesets.Edit
     public abstract partial class HitObjectComposer<TObject> : HitObjectComposer, IPlacementHandler
         where TObject : HitObject
     {
+        /// <summary>
+        /// Whether the playfield should be centered vertically. Should be disabled for playfields which span the full horizontal width.
+        /// </summary>
+        protected virtual bool ApplyVerticalCentering => true;
+
         protected IRulesetConfigManager Config { get; private set; }
 
         // Provides `Playfield`
@@ -242,7 +247,7 @@ namespace osu.Game.Rulesets.Edit
             base.Update();
 
             // Ensure that the playfield is always centered but also doesn't get cut off by toolboxes.
-            PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - TOOLBOX_CONTRACTED_SIZE_RIGHT * 2;
+            PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - (ApplyVerticalCentering ? TOOLBOX_CONTRACTED_SIZE_RIGHT : TOOLBOX_CONTRACTED_SIZE_LEFT) * 2;
         }
 
         public override Playfield Playfield => drawableRulesetWrapper.Playfield;


### PR DESCRIPTION
Regressed with recent centering changes in https://github.com/ppy/osu/pull/24220

| Before | After |
| :---: | :---: |
| <img width="1694" alt="2023-07-27 02 23 36@2x" src="https://github.com/ppy/osu/assets/191335/90044bbd-488e-4fa7-bd47-f64f3f7fbf3d"> | <img width="1694" alt="2023-07-27 02 24 18@2x" src="https://github.com/ppy/osu/assets/191335/d0ca9704-d830-44f0-becf-38faed2917ba"> |