### PR TITLE
Add back the ability to close mod select using enter key

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -542,7 +542,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("clear search", () => modSelectOverlay.SearchTerm = string.Empty);
             AddStep("press enter", () => InputManager.Key(Key.Enter));
-            AddAssert("mod select still visible", () => modSelectOverlay.State.Value == Visibility.Visible);
+            AddAssert("mod select hidden", () => modSelectOverlay.State.Value == Visibility.Hidden);
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -638,7 +638,7 @@ namespace osu.Game.Overlays.Mods
                 case GlobalAction.Select:
                 {
                     // Pressing select should select first filtered mod if a search is in progress.
-                    // If nothing is selected, it should exit the dialog (a bit weird, but this is the expectation from stable).
+                    // If there is no search in progress, it should exit the dialog (a bit weird, but this is the expectation from stable).
                     if (string.IsNullOrEmpty(SearchTerm))
                     {
                         hideOverlay(true);

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -638,8 +638,12 @@ namespace osu.Game.Overlays.Mods
                 case GlobalAction.Select:
                 {
                     // Pressing select should select first filtered mod if a search is in progress.
+                    // If nothing is selected, it should exit the dialog (a bit weird, but this is the expectation from stable).
                     if (string.IsNullOrEmpty(SearchTerm))
+                    {
+                        Hide();
                         return true;
+                    }
 
                     ModState? firstMod = columnFlow.Columns.OfType<ModColumn>().FirstOrDefault(m => m.IsPresent)?.AvailableMods.FirstOrDefault(x => x.Visible);
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -641,7 +641,7 @@ namespace osu.Game.Overlays.Mods
                     // If nothing is selected, it should exit the dialog (a bit weird, but this is the expectation from stable).
                     if (string.IsNullOrEmpty(SearchTerm))
                     {
-                        Hide();
+                        hideOverlay(true);
                         return true;
                     }
 


### PR DESCRIPTION
I've seen this brought up a few times (with people thinking the fact it's not working is a bug) so we'll need to keep this behaviour for now.
