### PR TITLE
Allow scrolling in tournament setup screen to avoid information ending up off-screen

### DIFF
--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -57,14 +58,18 @@ namespace osu.Game.Tournament.Screens.Setup
                     RelativeSizeAxes = Axes.Both,
                     Colour = OsuColour.Gray(0.2f),
                 },
-                fillFlow = new FillFlowContainer
+                new OsuScrollContainer
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding(10),
-                    Spacing = new Vector2(10),
-                }
+                    RelativeSizeAxes = Axes.Both,
+                    Child = fillFlow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Padding = new MarginPadding(10),
+                        Spacing = new Vector2(10),
+                    },
+                },
             };
 
             api.LocalUser.BindValueChanged(_ => Schedule(reload));


### PR DESCRIPTION
The tournament switcher's dropdown menu can overflow the window if the list is long enough. This PR limits the maximum height of the dropdown menu such that it no longer overflows the window. 

One caveat: the max height is hard-coded to 360 and might break if the position of the `TournamentSwitcher` changes in the setup screen, though I don't expect it to change all that often.

before:


https://github.com/ppy/osu/assets/1176059/b9505501-9daf-417c-9d29-234be76ba636


after:

https://github.com/ppy/osu/assets/1176059/07fd48c5-978e-4d23-9843-8d538ead01f0


