### PR TITLE
Use beatmap background artwork in Discord rich presence thumbnail

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -119,7 +119,7 @@ namespace osu.Desktop
                     };
 
                     presence.Assets.LargeImageKey = default_image_key;
-                    if (beatmapSetOnline.Value != null && Encoding.UTF8.GetByteCount(beatmapSetOnline.Value.Covers.ListLowRes) <= 256) // Ensure the URL will fit and not throw.
+                    if (beatmapSetOnline.Value != null && beatmapSetOnline.Value.Covers.List != null && Encoding.UTF8.GetByteCount(beatmapSetOnline.Value.Covers.List) <= 256) // Ensure the URL will fit and not throw.
                         presence.Assets.LargeImageKey = beatmapSetOnline.Value.Covers.List;
                 }
                 else


### PR DESCRIPTION
Modified the Rich Presence so the List artwork for the currently played beatmap set is visible. Also fixed a issues where the buttons were still visible once the user has left the beatmap and is back in the main menu.

![video showcasing dynamic images](https://i.lu.je/2023/Discord_lAPqafSLoO.mp4)

https://github.com/ppy/osu/assets/1355848/b67b5679-b553-4525-9a5c-a48a6dc8a199

**Notes:**
- Is calling the API suitable here if the BeatmapSetOnlineInfo is unavailable?
- Should it just be hard-code the asset URL `$@"https://assets.ppy.sh/beatmaps/{beatmap.BeatmapSet?.OnlineID}/covers/list.jpg";`
  - The API does returns timestamped versions for cache-busting purposes.
- Did **not** update `discord-rpc-csharp` to `1.2.1` as it didnt seem necessary. 
