### PR TITLE
Allow ladder editor grid to scale with content

### DIFF
--- a/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Tournament.Screens.Editors
                 {
                     new OsuMenuItem("Create new match", MenuItemType.Highlighted, () =>
                     {
-                        Vector2 pos = lastMatchesContainerMouseDownPosition;
+                        Vector2 pos = MatchesContainer.Count == 0 ? Vector2.Zero : lastMatchesContainerMouseDownPosition;
 
                         TournamentMatch newMatch = new TournamentMatch { Position = { Value = new Point((int)pos.X, (int)pos.Y) } };
 

--- a/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Tournament.Screens.Editors
 
         private WarningBox rightClickMessage;
 
+        private RectangularPositionSnapGrid grid;
+
         [Resolved(canBeNull: true)]
         [CanBeNull]
         private IDialogOverlay dialogOverlay { get; set; }
@@ -53,15 +55,25 @@ namespace osu.Game.Tournament.Screens.Editors
 
             AddInternal(rightClickMessage = new WarningBox("Right click to place and link matches"));
 
-            ScrollContent.Add(new RectangularPositionSnapGrid(Vector2.Zero)
+            ScrollContent.Add(grid = new RectangularPositionSnapGrid(Vector2.Zero)
             {
                 Spacing = new Vector2(GRID_SPACING),
-                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                BypassAutoSizeAxes = Axes.Both,
                 Depth = float.MaxValue
             });
 
             LadderInfo.Matches.CollectionChanged += (_, _) => updateMessage();
             updateMessage();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // Expand grid with the content to allow going beyond the bounds of the screen.
+            grid.Size = ScrollContent.Size + new Vector2(GRID_SPACING * 2);
         }
 
         private void updateMessage()

--- a/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
@@ -76,6 +76,14 @@ namespace osu.Game.Tournament.Screens.Editors
             grid.Size = ScrollContent.Size + new Vector2(GRID_SPACING * 2);
         }
 
+        private Vector2 lastMatchesContainerMouseDownPosition;
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            lastMatchesContainerMouseDownPosition = MatchesContainer.ToLocalSpace(e.ScreenSpaceMouseDownPosition);
+            return base.OnMouseDown(e);
+        }
+
         private void updateMessage()
         {
             rightClickMessage.Alpha = LadderInfo.Matches.Count > 0 ? 0 : 1;
@@ -97,7 +105,8 @@ namespace osu.Game.Tournament.Screens.Editors
                 {
                     new OsuMenuItem("Create new match", MenuItemType.Highlighted, () =>
                     {
-                        Vector2 pos = MatchesContainer.ToLocalSpace(GetContainingInputManager().CurrentState.Mouse.Position);
+                        Vector2 pos = lastMatchesContainerMouseDownPosition;
+
                         TournamentMatch newMatch = new TournamentMatch { Position = { Value = new Point((int)pos.X, (int)pos.Y) } };
 
                         LadderInfo.Matches.Add(newMatch);

--- a/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
+++ b/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
@@ -57,12 +57,15 @@ namespace osu.Game.Tournament.Screens.Ladder
                     },
                     ScrollContent = new LadderDragContainer
                     {
-                        RelativeSizeAxes = Axes.Both,
+                        AutoSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
                             paths = new Container<Path> { RelativeSizeAxes = Axes.Both },
                             headings = new Container { RelativeSizeAxes = Axes.Both },
-                            MatchesContainer = new Container<DrawableTournamentMatch> { RelativeSizeAxes = Axes.Both },
+                            MatchesContainer = new Container<DrawableTournamentMatch>
+                            {
+                                AutoSizeAxes = Axes.Both
+                            },
                         }
                     },
                 }

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -54,8 +54,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (!gridCache.IsValid)
             {
                 ClearInternal();
-                createContent();
-                gridCache.Validate();
+
+                if (DrawSize != Vector2.Zero)
+                {
+                    createContent();
+                    gridCache.Validate();
+                }
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/RectangularPositionSnapGrid.cs
@@ -55,11 +55,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 ClearInternal();
 
-                if (DrawSize != Vector2.Zero)
-                {
+                if (DrawWidth > 0 && DrawHeight > 0)
                     createContent();
-                    gridCache.Validate();
-                }
+
+                gridCache.Validate();
             }
         }
 


### PR DESCRIPTION
Also contains a couple of quick fixes:

- Fix placing new match via right click not using original click position
- Always place first match at (0,0)

---

Closes https://github.com/ppy/osu/issues/24378.
