### PR TITLE
Fix potential startup crash due to early application of animations

### DIFF
--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -136,11 +136,11 @@ namespace osu.Game.Tournament.Components
             if (match.NewValue != null)
                 match.NewValue.PicksBans.CollectionChanged += picksBansOnCollectionChanged;
 
-            updateState();
+            Scheduler.AddOnce(updateState);
         }
 
         private void picksBansOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-            => updateState();
+            => Scheduler.AddOnce(updateState);
 
         private BeatmapChoice? choice;
 


### PR DESCRIPTION
This was always haphazard code, but by luck it never triggered before drawable load until now. With the recently nullability changes, this would be triggered when `flash` is not yet constructed.

Switching to `AddOnce` seems safer to avoid multiple applications, regardless.
