### PR TITLE
Allow Rulesets to define custom score & accuracy values for HitResult

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneScoreAccuracy.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneScoreAccuracy.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    public partial class TestSceneScoreAccuracy : RateAdjustedBeatmapTestScene
+    {
+        private ScoreAccessibleReplayPlayer currentPlayer = null!;
+
+        private List<JudgementResult> judgementResults = new List<JudgementResult>();
+
+        [Test]
+        public void TestPerfectAccuracyWithGreats()
+        {
+            performTest(
+                new List<ManiaHitObject>
+                {
+                    new Note
+                    {
+                        StartTime = 1000,
+                        Column = 0,
+                    },
+                    new Note
+                    {
+                        StartTime = 2000,
+                        Column = 1
+                    },
+                    new Note
+                    {
+                        StartTime = 3000,
+                        Column = 3
+                    },
+                    new Note
+                    {
+                        StartTime = 4000,
+                        Column = 4
+                    }
+                },
+                new List<ReplayFrame>
+                {
+                    new ManiaReplayFrame(1020, ManiaAction.Key1),
+                    new ManiaReplayFrame(1022),
+                    new ManiaReplayFrame(2020, ManiaAction.Key2),
+                    new ManiaReplayFrame(2022),
+                    new ManiaReplayFrame(3020, ManiaAction.Key3),
+                    new ManiaReplayFrame(3022),
+                    new ManiaReplayFrame(4020, ManiaAction.Key4),
+                    new ManiaReplayFrame(4022),
+                });
+
+            AddAssert("reached max accuracy",
+                () => currentPlayer.ScoreProcessor.Accuracy.Value,
+                () => Is.EqualTo(1).Within(Precision.DOUBLE_EPSILON));
+            AddAssert("score is not 1 million", () => currentPlayer.ScoreProcessor.TotalScore.Value, () => Is.LessThan(1_000_000));
+        }
+
+        private void performTest(List<ManiaHitObject> hitObjects, List<ReplayFrame> frames)
+        {
+            var beatmap = new Beatmap<ManiaHitObject>
+            {
+                HitObjects = hitObjects,
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty { SliderTickRate = 4 },
+                    Ruleset = new ManiaRuleset().RulesetInfo
+                },
+            };
+
+            beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+
+            AddStep("load player", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(beatmap);
+
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+
+                p.OnLoadComplete += _ =>
+                {
+                    p.ScoreProcessor.NewJudgement += result =>
+                    {
+                        if (currentPlayer == p) judgementResults.Add(result);
+                    };
+                };
+
+                LoadScreen(currentPlayer = p);
+                judgementResults = new List<JudgementResult>();
+            });
+
+            AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
+        }
+
+        private partial class ScoreAccessibleReplayPlayer : ReplayPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            protected override bool PauseOnFocusLost => false;
+
+            public ScoreAccessibleReplayPlayer(Score score)
+                : base(score, new PlayerConfiguration
+                {
+                    AllowPause = false,
+                    ShowResults = false,
+                })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -37,5 +37,41 @@ namespace osu.Game.Rulesets.Mania.Judgements
                     return base.HealthIncreaseFor(result);
             }
         }
+
+        public static int ToAccuracyWeight(HitResult result)
+        {
+            switch (result)
+            {
+                default:
+                    return 0;
+
+                case HitResult.SmallTickHit:
+                    return 10;
+
+                case HitResult.LargeTickHit:
+                    return 30;
+
+                case HitResult.Meh:
+                    return 50;
+
+                case HitResult.Ok:
+                    return 100;
+
+                case HitResult.Good:
+                    return 200;
+
+                case HitResult.Great:
+                    return 300;
+
+                case HitResult.Perfect:
+                    return 300;
+
+                case HitResult.SmallBonus:
+                    return SMALL_BONUS_SCORE;
+
+                case HitResult.LargeBonus:
+                    return LARGE_BONUS_SCORE;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Judgements;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
@@ -33,6 +34,8 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         protected override double GetComboScoreChange(JudgementResult result)
             => Judgement.ToNumericResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
+
+        protected override int GetHitAccuracyValue(HitResult result) => ManiaJudgement.ToAccuracyWeight(result);
 
         private class JudgementOrderComparer : IComparer<HitObject>
         {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -325,9 +325,9 @@ namespace osu.Game.Rulesets.Scoring
             updateScore();
         }
 
-        protected virtual double GetBonusScoreChange(JudgementResult result) => Judgement.ToNumericResult(result.Type);
+        protected virtual double GetBonusScoreChange(JudgementResult result) => GetHitScoreValue(result.Type);
 
-        protected virtual double GetComboScoreChange(JudgementResult result) => Judgement.ToNumericResult(result.Type) * (1 + result.ComboAfterJudgement / 10d);
+        protected virtual double GetComboScoreChange(JudgementResult result) => GetHitScoreValue(result.Type) * (1 + result.ComboAfterJudgement / 10d);
 
         protected virtual void ApplyScoreChange(JudgementResult result)
         {


### PR DESCRIPTION
This closes #24238 

I'm not sure about how clean the implementation is, but this PR make mania accuracy the same as stable, where GREATs do not affect player accuracy.

@bdach I didn't found any way to not affect other ruleset other than making an overridable method.