### PR TITLE
Remove #nullable disable in tournament

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Tournament.Tests.Components
 {
     public partial class TestSceneDateTextBox : OsuManualInputManagerTestScene
     {
-        private DateTextBox textBox;
+        private DateTextBox textBox = null!;
 
         [SetUp]
         public void Setup() => Schedule(() =>

--- a/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneDateTextBox.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Game.Tests.Visual;
 using osu.Game.Tournament.Components;

--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -22,7 +20,7 @@ namespace osu.Game.Tournament.Tests.Components
         [Test]
         public void TestSongBar()
         {
-            SongBar songBar = null;
+            SongBar songBar = null!;
 
             AddStep("create bar", () => Child = songBar = new SongBar
             {

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -17,12 +17,12 @@ namespace osu.Game.Tournament.Tests.Components
     public partial class TestSceneTournamentModDisplay : TournamentTestScene
     {
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private IRulesetStore rulesets { get; set; }
+        private IRulesetStore rulesets { get; set; } = null!;
 
-        private FillFlowContainer<TournamentBeatmapPanel> fillFlow;
+        private FillFlowContainer<TournamentBeatmapPanel> fillFlow = null!;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentModDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tournament.Tests.Components
 
         private void success(APIBeatmap beatmap)
         {
-            var ruleset = rulesets.GetRuleset(Ladder.Ruleset.Value.OnlineID);
+            var ruleset = rulesets.GetRuleset(Ladder.Ruleset.Value?.OnlineID ?? -1);
 
             if (ruleset == null)
                 return;

--- a/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
@@ -79,11 +79,11 @@ namespace osu.Game.Tournament.Tests.NonVisual
         public partial class TestTournament : TournamentGameBase
         {
             private readonly bool resetRuleset;
-            private readonly Action runOnLoadComplete;
+            private readonly Action? runOnLoadComplete;
 
             public new Task BracketLoadTask => base.BracketLoadTask;
 
-            public TestTournament(bool resetRuleset = false, [InstantHandle] Action runOnLoadComplete = null)
+            public TestTournament(bool resetRuleset = false, [InstantHandle] Action? runOnLoadComplete = null)
             {
                 this.resetRuleset = resetRuleset;
                 this.runOnLoadComplete = runOnLoadComplete;

--- a/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/DataLoadTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/IPCLocationTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -36,11 +34,11 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 {
                     var osu = LoadTournament(host);
                     TournamentStorage storage = (TournamentStorage)osu.Dependencies.Get<Storage>();
-                    FileBasedIPC ipc = null;
+                    FileBasedIPC? ipc = null;
 
                     WaitForOrAssert(() => (ipc = osu.Dependencies.Get<MatchIPCInfo>() as FileBasedIPC)?.IsLoaded == true, @"ipc could not be populated in a reasonable amount of time");
 
-                    Assert.True(ipc.SetIPCLocation(testStableInstallDirectory));
+                    Assert.True(ipc!.SetIPCLocation(testStableInstallDirectory));
                     Assert.True(storage.AllTournaments.Exists("stable.json"));
                 }
                 finally

--- a/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using NUnit.Framework;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Tests.NonVisual
@@ -35,8 +36,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 PlayersPerTeam = { Value = 4 },
                 Teams =
                 {
-                    match.Team1.Value,
-                    match.Team2.Value,
+                    match.Team1.Value.AsNonNull(),
+                    match.Team2.Value.AsNonNull(),
                 },
                 Rounds =
                 {

--- a/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/LadderInfoSerialisationTest.cs
@@ -3,7 +3,6 @@
 
 using Newtonsoft.Json;
 using NUnit.Framework;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Tests.NonVisual
@@ -36,8 +35,8 @@ namespace osu.Game.Tournament.Tests.NonVisual
                 PlayersPerTeam = { Value = 4 },
                 Teams =
                 {
-                    match.Team1.Value.AsNonNull(),
-                    match.Team2.Value.AsNonNull(),
+                    match.Team1.Value!,
+                    match.Team2.Value!,
                 },
                 Rounds =
                 {

--- a/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
+++ b/osu.Game.Tournament.Tests/NonVisual/TournamentHostTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,7 +11,7 @@ namespace osu.Game.Tournament.Tests.NonVisual
 {
     public abstract class TournamentHostTest
     {
-        public static TournamentGameBase LoadTournament(GameHost host, TournamentGameBase tournament = null)
+        public static TournamentGameBase LoadTournament(GameHost host, TournamentGameBase? tournament = null)
         {
             tournament ??= new TournamentGameBase();
             Task.Factory.StartNew(() => host.Run(tournament), TaskCreationOptions.LongRunning)

--- a/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneGameplayScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Game.Tournament.Tests/Screens/TestSceneLadderEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneLadderEditorScreen.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Tournament.Tests.Screens
 
             AddStep("release mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("assert ladder teams reset", () => Ladder.CurrentMatch.Value.Team1.Value == null && Ladder.CurrentMatch.Value.Team2.Value == null);
+            AddAssert("assert ladder teams reset", () => Ladder.CurrentMatch.Value?.Team1.Value == null && Ladder.CurrentMatch.Value?.Team2.Value == null);
         }
     }
 }

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
@@ -31,7 +30,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load few maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 8; i++)
                     addBeatmap();
@@ -51,7 +50,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load just enough maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 18; i++)
                     addBeatmap();
@@ -71,7 +70,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 19; i++)
                     addBeatmap();
@@ -91,7 +90,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 11; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -117,7 +116,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 12; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -137,7 +136,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
+                Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Clear();
 
                 for (int i = 0; i < 12; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -154,7 +153,7 @@ namespace osu.Game.Tournament.Tests.Screens
 
         private void addBeatmap(string mods = "NM")
         {
-            Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Add(new RoundBeatmap
+            Ladder.CurrentMatch.Value!.Round.Value!.Beatmaps.Add(new RoundBeatmap
             {
                 Beatmap = CreateSampleBeatmap(),
                 Mods = mods

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -1,11 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
@@ -16,7 +15,7 @@ namespace osu.Game.Tournament.Tests.Screens
 {
     public partial class TestSceneMapPoolScreen : TournamentScreenTestScene
     {
-        private MapPoolScreen screen;
+        private MapPoolScreen screen = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -32,7 +31,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load few maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 8; i++)
                     addBeatmap();
@@ -52,7 +51,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load just enough maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 18; i++)
                     addBeatmap();
@@ -72,7 +71,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 19; i++)
                     addBeatmap();
@@ -92,7 +91,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 11; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -118,7 +117,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 12; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -138,7 +137,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             AddStep("load many maps", () =>
             {
-                Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Clear();
+                Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Clear();
 
                 for (int i = 0; i < 12; i++)
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
@@ -155,7 +154,7 @@ namespace osu.Game.Tournament.Tests.Screens
 
         private void addBeatmap(string mods = "NM")
         {
-            Ladder.CurrentMatch.Value.Round.Value.Beatmaps.Add(new RoundBeatmap
+            Ladder.CurrentMatch.Value.AsNonNull().Round.Value.AsNonNull().Beatmaps.Add(new RoundBeatmap
             {
                 Beatmap = CreateSampleBeatmap(),
                 Mods = mods

--- a/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneScheduleScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneSeedingEditorScreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.Editors;
 
@@ -17,7 +18,7 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             var match = CreateSampleMatch();
 
-            Add(new SeedingEditorScreen(match.Team1.Value, new TeamEditorScreen())
+            Add(new SeedingEditorScreen(match.Team1.Value.AsNonNull(), new TeamEditorScreen())
             {
                 Width = 0.85f // create room for control panel
             });

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tournament.Tests.Screens
             {
                 Team1 = { Value = Ladder.Teams.FirstOrDefault(t => t.Acronym.Value == "USA") },
                 Team2 = { Value = Ladder.Teams.FirstOrDefault(t => t.Acronym.Value == "JPN") },
-                Round = { Value = Ladder.Rounds.FirstOrDefault(g => g.Name.Value == "Finals") }
+                Round = { Value = Ladder.Rounds.First(g => g.Name.Value == "Quarterfinals") }
             };
 
             Add(new TeamIntroScreen

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamIntroScreen.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tournament.Tests.Screens
             {
                 Team1 = { Value = Ladder.Teams.FirstOrDefault(t => t.Acronym.Value == "USA") },
                 Team2 = { Value = Ladder.Teams.FirstOrDefault(t => t.Acronym.Value == "JPN") },
-                Round = { Value = Ladder.Rounds.First(g => g.Name.Value == "Quarterfinals") }
+                Round = { Value = Ladder.Rounds.FirstOrDefault(g => g.Name.Value == "Finals") }
             };
 
             Add(new TeamIntroScreen

--- a/osu.Game.Tournament.Tests/Screens/TestSceneTeamWinScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneTeamWinScreen.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Tournament.Tests.Screens
             {
                 var match = Ladder.CurrentMatch.Value!;
 
-                match.Round.Value = Ladder.Rounds.FirstOrDefault(g => g.Name.Value == "Finals");
+                match.Round.Value = Ladder.Rounds.First(g => g.Name.Value == "Quarterfinals");
                 match.Completed.Value = true;
             });
 

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -40,10 +41,10 @@ namespace osu.Game.Tournament.Tests
 
             match = CreateSampleMatch();
 
-            Ladder.Rounds.Add(match.Round.Value);
+            Ladder.Rounds.Add(match.Round.Value.AsNonNull());
             Ladder.Matches.Add(match);
-            Ladder.Teams.Add(match.Team1.Value);
-            Ladder.Teams.Add(match.Team2.Value);
+            Ladder.Teams.Add(match.Team1.Value.AsNonNull());
+            Ladder.Teams.Add(match.Team2.Value.AsNonNull());
 
             Ruleset.BindTo(Ladder.Ruleset);
             Dependencies.CacheAs(new StableInfo(storage));
@@ -152,7 +153,7 @@ namespace osu.Game.Tournament.Tests
             },
             Round =
             {
-                Value = new TournamentRound { Name = { Value = "Quarterfinals" } }
+                Value = new TournamentRound { Name = { Value = "Quarterfinals" } },
             }
         };
 

--- a/osu.Game.Tournament.Tests/TournamentTestScene.cs
+++ b/osu.Game.Tournament.Tests/TournamentTestScene.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -41,10 +40,10 @@ namespace osu.Game.Tournament.Tests
 
             match = CreateSampleMatch();
 
-            Ladder.Rounds.Add(match.Round.Value.AsNonNull());
+            Ladder.Rounds.Add(match.Round.Value!);
             Ladder.Matches.Add(match);
-            Ladder.Teams.Add(match.Team1.Value.AsNonNull());
-            Ladder.Teams.Add(match.Team2.Value.AsNonNull());
+            Ladder.Teams.Add(match.Team1.Value!);
+            Ladder.Teams.Add(match.Team2.Value!);
 
             Ruleset.BindTo(Ladder.Ruleset);
             Dependencies.CacheAs(new StableInfo(storage));

--- a/osu.Game.Tournament/Components/DrawableTeamFlag.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamFlag.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -17,14 +15,14 @@ namespace osu.Game.Tournament.Components
 {
     public partial class DrawableTeamFlag : Container
     {
-        private readonly TournamentTeam team;
+        private readonly TournamentTeam? team;
 
         [UsedImplicitly]
-        private Bindable<string> flag;
+        private Bindable<string>? flag;
 
-        private Sprite flagSprite;
+        private Sprite? flagSprite;
 
-        public DrawableTeamFlag(TournamentTeam team)
+        public DrawableTeamFlag(TournamentTeam? team)
         {
             this.team = team;
         }

--- a/osu.Game.Tournament/Components/DrawableTeamTitle.cs
+++ b/osu.Game.Tournament/Components/DrawableTeamTitle.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -12,12 +10,12 @@ namespace osu.Game.Tournament.Components
 {
     public partial class DrawableTeamTitle : TournamentSpriteTextWithBackground
     {
-        private readonly TournamentTeam team;
+        private readonly TournamentTeam? team;
 
         [UsedImplicitly]
-        private Bindable<string> acronym;
+        private Bindable<string>? acronym;
 
-        public DrawableTeamTitle(TournamentTeam team)
+        public DrawableTeamTitle(TournamentTeam? team)
         {
             this.team = team;
         }

--- a/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
+++ b/osu.Game.Tournament/Components/DrawableTournamentTeam.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -14,15 +12,15 @@ namespace osu.Game.Tournament.Components
 {
     public abstract partial class DrawableTournamentTeam : CompositeDrawable
     {
-        public readonly TournamentTeam Team;
+        public readonly TournamentTeam? Team;
 
         protected readonly Container Flag;
         protected readonly TournamentSpriteText AcronymText;
 
         [UsedImplicitly]
-        private Bindable<string> acronym;
+        private Bindable<string>? acronym;
 
-        protected DrawableTournamentTeam(TournamentTeam team)
+        protected DrawableTournamentTeam(TournamentTeam? team)
         {
             Team = team;
 
@@ -36,7 +34,8 @@ namespace osu.Game.Tournament.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (Team == null) return;
+            if (Team == null)
+                return;
 
             (acronym = Team.Acronym.GetBoundCopy()).BindValueChanged(_ => AcronymText.Text = Team?.Acronym.Value?.ToUpperInvariant() ?? string.Empty, true);
         }

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Tournament.Components
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
-        public TournamentBeatmap Beatmap
+        public TournamentBeatmap? Beatmap
         {
             set
             {

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -24,12 +22,12 @@ namespace osu.Game.Tournament.Components
 {
     public partial class SongBar : CompositeDrawable
     {
-        private TournamentBeatmap beatmap;
+        private TournamentBeatmap? beatmap;
 
         public const float HEIGHT = 145 / 2f;
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; }
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
         public TournamentBeatmap Beatmap
         {
@@ -55,7 +53,7 @@ namespace osu.Game.Tournament.Components
             }
         }
 
-        private FillFlowContainer flow;
+        private FillFlowContainer flow = null!;
 
         private bool expanded;
 

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tournament.Components
 
         private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
 
-        private Box? flash;
+        private Box flash = null!;
 
         public TournamentBeatmapPanel(TournamentBeatmap? beatmap, string mod = "")
         {
@@ -135,11 +135,12 @@ namespace osu.Game.Tournament.Components
                 match.OldValue.PicksBans.CollectionChanged -= picksBansOnCollectionChanged;
             if (match.NewValue != null)
                 match.NewValue.PicksBans.CollectionChanged += picksBansOnCollectionChanged;
-            updateState();
+
+            Scheduler.AddOnce(updateState);
         }
 
         private void picksBansOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-            => updateState();
+            => Scheduler.AddOnce(updateState);
 
         private BeatmapChoice? choice;
 
@@ -157,7 +158,7 @@ namespace osu.Game.Tournament.Components
             if (newChoice != null)
             {
                 if (shouldFlash)
-                    flash?.FadeOutFromOne(500).Loop(0, 10);
+                    flash.FadeOutFromOne(500).Loop(0, 10);
 
                 BorderThickness = 6;
 

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tournament.Components
     {
         public readonly TournamentBeatmap? Beatmap;
 
-        private readonly string? mod;
+        private readonly string mod;
 
         public const float HEIGHT = 50;
 

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -22,13 +22,13 @@ namespace osu.Game.Tournament.Components
     {
         public readonly TournamentBeatmap? Beatmap;
 
-        private readonly string mod;
+        private readonly string? mod;
 
         public const float HEIGHT = 50;
 
         private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
 
-        private Box flash = null!;
+        private Box? flash;
 
         public TournamentBeatmapPanel(TournamentBeatmap? beatmap, string mod = "")
         {
@@ -135,25 +135,29 @@ namespace osu.Game.Tournament.Components
                 match.OldValue.PicksBans.CollectionChanged -= picksBansOnCollectionChanged;
             if (match.NewValue != null)
                 match.NewValue.PicksBans.CollectionChanged += picksBansOnCollectionChanged;
-
-            Scheduler.AddOnce(updateState);
+            updateState();
         }
 
         private void picksBansOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-            => Scheduler.AddOnce(updateState);
+            => updateState();
 
         private BeatmapChoice? choice;
 
         private void updateState()
         {
-            var newChoice = currentMatch.Value?.PicksBans.FirstOrDefault(p => p.BeatmapID == Beatmap?.OnlineID);
+            if (currentMatch.Value == null)
+            {
+                return;
+            }
+
+            var newChoice = currentMatch.Value.PicksBans.FirstOrDefault(p => p.BeatmapID == Beatmap?.OnlineID);
 
             bool shouldFlash = newChoice != choice;
 
             if (newChoice != null)
             {
                 if (shouldFlash)
-                    flash.FadeOutFromOne(500).Loop(0, 10);
+                    flash?.FadeOutFromOne(500).Loop(0, 10);
 
                 BorderThickness = 6;
 

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -92,9 +92,9 @@ namespace osu.Game.Tournament.Components
             {
                 if (info.CurrentMatch.Value is TournamentMatch match)
                 {
-                    if (match.Team1.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
+                    if (match.Team1.Value?.Players.Any(u => u.OnlineID == Message.Sender.OnlineID) == true)
                         UsernameColour = TournamentGame.COLOUR_RED;
-                    else if (match.Team2.Value.Players.Any(u => u.OnlineID == Message.Sender.OnlineID))
+                    else if (match.Team2.Value?.Players.Any(u => u.OnlineID == Message.Sender.OnlineID) == true)
                         UsernameColour = TournamentGame.COLOUR_BLUE;
                 }
             }

--- a/osu.Game.Tournament/Components/TourneyVideo.cs
+++ b/osu.Game.Tournament/Components/TourneyVideo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -19,8 +17,8 @@ namespace osu.Game.Tournament.Components
     {
         private readonly string filename;
         private readonly bool drawFallbackGradient;
-        private Video video;
-        private ManualClock manualClock;
+        private Video? video;
+        private ManualClock? manualClock;
 
         public bool VideoAvailable => video != null;
 

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.Win32;
@@ -181,7 +180,7 @@ namespace osu.Game.Tournament.IPC
         /// <returns>Whether an IPC directory was successfully auto-detected.</returns>
         public bool AutoDetectIPCLocation() => SetIPCLocation(findStablePath());
 
-        private static bool ipcFileExistsInDirectory([NotNullWhen(true)] string? p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
+        private static bool ipcFileExistsInDirectory(string? p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
 
         private string? findStablePath()
         {
@@ -202,7 +201,7 @@ namespace osu.Game.Tournament.IPC
                 string? stableInstallPath = Environment.GetEnvironmentVariable("OSU_STABLE_PATH");
 
                 if (ipcFileExistsInDirectory(stableInstallPath))
-                    return stableInstallPath;
+                    return stableInstallPath!;
             }
             catch
             {

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
-using JetBrains.Annotations;
 using Microsoft.Win32;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -24,36 +21,35 @@ namespace osu.Game.Tournament.IPC
 {
     public partial class FileBasedIPC : MatchIPCInfo
     {
-        public Storage IPCStorage { get; private set; }
+        public Storage? IPCStorage { get; private set; }
 
         [Resolved]
-        protected IAPIProvider API { get; private set; }
+        protected IAPIProvider API { get; private set; } = null!;
 
         [Resolved]
-        protected IRulesetStore Rulesets { get; private set; }
+        protected IRulesetStore Rulesets { get; private set; } = null!;
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         [Resolved]
-        private LadderInfo ladder { get; set; }
+        private LadderInfo ladder { get; set; } = null!;
 
         [Resolved]
-        private StableInfo stableInfo { get; set; }
+        private StableInfo stableInfo { get; set; } = null!;
 
         private int lastBeatmapId;
-        private ScheduledDelegate scheduled;
-        private GetBeatmapRequest beatmapLookupRequest;
+        private ScheduledDelegate? scheduled;
+        private GetBeatmapRequest? beatmapLookupRequest;
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            string stablePath = stableInfo.StablePath ?? findStablePath();
+            string? stablePath = stableInfo.StablePath ?? findStablePath();
             initialiseIPCStorage(stablePath);
         }
 
-        [CanBeNull]
-        private Storage initialiseIPCStorage(string path)
+        private Storage? initialiseIPCStorage(string? path)
         {
             scheduled?.Cancel();
 
@@ -89,9 +85,9 @@ namespace osu.Game.Tournament.IPC
 
                                     lastBeatmapId = beatmapId;
 
-                                    var existing = ladder.CurrentMatch.Value?.Round.Value?.Beatmaps.FirstOrDefault(b => b.ID == beatmapId && b.Beatmap != null);
+                                    var existing = ladder.CurrentMatch.Value?.Round.Value?.Beatmaps.FirstOrDefault(b => b.ID == beatmapId);
 
-                                    if (existing != null)
+                                    if (existing?.Beatmap != null)
                                         Beatmap.Value = existing.Beatmap;
                                     else
                                     {
@@ -114,7 +110,7 @@ namespace osu.Game.Tournament.IPC
                             using (var stream = IPCStorage.GetStream(file_ipc_channel_filename))
                             using (var sr = new StreamReader(stream))
                             {
-                                ChatChannel.Value = sr.ReadLine();
+                                ChatChannel.Value = sr.ReadLine().AsNonNull();
                             }
                         }
                         catch (Exception)
@@ -140,8 +136,8 @@ namespace osu.Game.Tournament.IPC
                             using (var stream = IPCStorage.GetStream(file_ipc_scores_filename))
                             using (var sr = new StreamReader(stream))
                             {
-                                Score1.Value = int.Parse(sr.ReadLine());
-                                Score2.Value = int.Parse(sr.ReadLine());
+                                Score1.Value = int.Parse(sr.ReadLine().AsNonNull());
+                                Score2.Value = int.Parse(sr.ReadLine().AsNonNull());
                             }
                         }
                         catch (Exception)
@@ -164,7 +160,7 @@ namespace osu.Game.Tournament.IPC
         /// </summary>
         /// <param name="path">Path to the IPC directory</param>
         /// <returns>Whether the supplied path was a valid IPC directory.</returns>
-        public bool SetIPCLocation(string path)
+        public bool SetIPCLocation(string? path)
         {
             if (path == null || !ipcFileExistsInDirectory(path))
                 return false;
@@ -184,29 +180,28 @@ namespace osu.Game.Tournament.IPC
         /// <returns>Whether an IPC directory was successfully auto-detected.</returns>
         public bool AutoDetectIPCLocation() => SetIPCLocation(findStablePath());
 
-        private static bool ipcFileExistsInDirectory(string p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
+        private static bool ipcFileExistsInDirectory(string? p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
 
-        [CanBeNull]
-        private string findStablePath()
+        private string? findStablePath()
         {
-            string stableInstallPath = findFromEnvVar() ??
-                                       findFromRegistry() ??
-                                       findFromLocalAppData() ??
-                                       findFromDotFolder();
+            string? stableInstallPath = findFromEnvVar() ??
+                                        findFromRegistry() ??
+                                        findFromLocalAppData() ??
+                                        findFromDotFolder();
 
             Logger.Log($"Stable path for tourney usage: {stableInstallPath}");
             return stableInstallPath;
         }
 
-        private string findFromEnvVar()
+        private string? findFromEnvVar()
         {
             try
             {
                 Logger.Log("Trying to find stable with environment variables");
-                string stableInstallPath = Environment.GetEnvironmentVariable("OSU_STABLE_PATH");
+                string? stableInstallPath = Environment.GetEnvironmentVariable("OSU_STABLE_PATH");
 
                 if (ipcFileExistsInDirectory(stableInstallPath))
-                    return stableInstallPath;
+                    return stableInstallPath!;
             }
             catch
             {
@@ -215,7 +210,7 @@ namespace osu.Game.Tournament.IPC
             return null;
         }
 
-        private string findFromLocalAppData()
+        private string? findFromLocalAppData()
         {
             Logger.Log("Trying to find stable in %LOCALAPPDATA%");
             string stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"osu!");
@@ -226,7 +221,7 @@ namespace osu.Game.Tournament.IPC
             return null;
         }
 
-        private string findFromDotFolder()
+        private string? findFromDotFolder()
         {
             Logger.Log("Trying to find stable in dotfolders");
             string stableInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".osu");
@@ -237,16 +232,16 @@ namespace osu.Game.Tournament.IPC
             return null;
         }
 
-        private string findFromRegistry()
+        private string? findFromRegistry()
         {
             Logger.Log("Trying to find stable in registry");
 
             try
             {
-                string stableInstallPath;
+                string? stableInstallPath;
 
 #pragma warning disable CA1416
-                using (RegistryKey key = Registry.ClassesRoot.OpenSubKey("osu"))
+                using (RegistryKey? key = Registry.ClassesRoot.OpenSubKey("osu"))
                     stableInstallPath = key?.OpenSubKey(@"shell\open\command")?.GetValue(string.Empty)?.ToString()?.Split('"')[1].Replace("osu!.exe", "");
 #pragma warning restore CA1416
 

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -87,12 +87,13 @@ namespace osu.Game.Tournament.IPC
 
                                     var existing = ladder.CurrentMatch.Value?.Round.Value?.Beatmaps.FirstOrDefault(b => b.ID == beatmapId);
 
-                                    if (existing?.Beatmap != null)
+                                    if (existing != null)
                                         Beatmap.Value = existing.Beatmap;
                                     else
                                     {
                                         beatmapLookupRequest = new GetBeatmapRequest(new APIBeatmap { OnlineID = beatmapId });
                                         beatmapLookupRequest.Success += b => Beatmap.Value = new TournamentBeatmap(b);
+                                        beatmapLookupRequest.Failure += _ => Beatmap.Value = null;
                                         API.Queue(beatmapLookupRequest);
                                     }
                                 }

--- a/osu.Game.Tournament/IPC/FileBasedIPC.cs
+++ b/osu.Game.Tournament/IPC/FileBasedIPC.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Microsoft.Win32;
@@ -180,7 +181,7 @@ namespace osu.Game.Tournament.IPC
         /// <returns>Whether an IPC directory was successfully auto-detected.</returns>
         public bool AutoDetectIPCLocation() => SetIPCLocation(findStablePath());
 
-        private static bool ipcFileExistsInDirectory(string? p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
+        private static bool ipcFileExistsInDirectory([NotNullWhen(true)] string? p) => p != null && File.Exists(Path.Combine(p, "ipc.txt"));
 
         private string? findStablePath()
         {
@@ -201,7 +202,7 @@ namespace osu.Game.Tournament.IPC
                 string? stableInstallPath = Environment.GetEnvironmentVariable("OSU_STABLE_PATH");
 
                 if (ipcFileExistsInDirectory(stableInstallPath))
-                    return stableInstallPath!;
+                    return stableInstallPath;
             }
             catch
             {

--- a/osu.Game.Tournament/IPC/MatchIPCInfo.cs
+++ b/osu.Game.Tournament/IPC/MatchIPCInfo.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Tournament.IPC
 {
     public partial class MatchIPCInfo : Component
     {
-        public Bindable<TournamentBeatmap> Beatmap { get; } = new Bindable<TournamentBeatmap>();
+        public Bindable<TournamentBeatmap?> Beatmap { get; } = new Bindable<TournamentBeatmap?>();
         public Bindable<LegacyMods> Mods { get; } = new Bindable<LegacyMods>();
         public Bindable<TourneyState> State { get; } = new Bindable<TourneyState>();
         public Bindable<string> ChatChannel { get; } = new Bindable<string>();

--- a/osu.Game.Tournament/JsonPointConverter.cs
+++ b/osu.Game.Tournament/JsonPointConverter.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Drawing;
@@ -28,7 +26,7 @@ namespace osu.Game.Tournament
             if (reader.TokenType != JsonToken.StartObject)
             {
                 // if there's no object present then this is using string representation (System.Drawing.Point serializes to "x,y")
-                string str = (string)reader.Value;
+                string? str = (string?)reader.Value;
 
                 Debug.Assert(str != null);
 
@@ -45,8 +43,11 @@ namespace osu.Game.Tournament
 
                 if (reader.TokenType == JsonToken.PropertyName)
                 {
-                    string name = reader.Value?.ToString();
+                    string? name = reader.Value?.ToString();
                     int? val = reader.ReadAsInt32();
+
+                    if (name == null)
+                        continue;
 
                     if (val == null)
                         continue;

--- a/osu.Game.Tournament/Models/LadderInfo.cs
+++ b/osu.Game.Tournament/Models/LadderInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -17,7 +15,7 @@ namespace osu.Game.Tournament.Models
     [Serializable]
     public class LadderInfo
     {
-        public Bindable<RulesetInfo> Ruleset = new Bindable<RulesetInfo>();
+        public Bindable<RulesetInfo?> Ruleset = new Bindable<RulesetInfo?>();
 
         public BindableList<TournamentMatch> Matches = new BindableList<TournamentMatch>();
         public BindableList<TournamentRound> Rounds = new BindableList<TournamentRound>();
@@ -27,7 +25,7 @@ namespace osu.Game.Tournament.Models
         public List<TournamentProgression> Progressions = new List<TournamentProgression>();
 
         [JsonIgnore] // updated manually in TournamentGameBase
-        public Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
+        public Bindable<TournamentMatch?> CurrentMatch = new Bindable<TournamentMatch?>();
 
         public Bindable<int> ChromaKeyWidth = new BindableInt(1024)
         {

--- a/osu.Game.Tournament/Models/RoundBeatmap.cs
+++ b/osu.Game.Tournament/Models/RoundBeatmap.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Tournament.Models
     public class RoundBeatmap
     {
         public int ID;
-
         public string Mods = string.Empty;
 
         [JsonProperty("BeatmapInfo")]

--- a/osu.Game.Tournament/Models/StableInfo.cs
+++ b/osu.Game.Tournament/Models/StableInfo.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using Newtonsoft.Json;
@@ -20,12 +18,12 @@ namespace osu.Game.Tournament.Models
         /// <summary>
         /// Path to the IPC directory used by the stable (cutting-edge) install.
         /// </summary>
-        public string StablePath { get; set; }
+        public string? StablePath { get; set; }
 
         /// <summary>
         /// Fired whenever stable info is successfully saved to file.
         /// </summary>
-        public event Action OnStableInfoSaved;
+        public event Action? OnStableInfoSaved;
 
         private const string config_path = "stable.json";
 

--- a/osu.Game.Tournament/Models/TournamentMatch.cs
+++ b/osu.Game.Tournament/Models/TournamentMatch.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -33,16 +31,16 @@ namespace osu.Game.Tournament.Models
         }
 
         [JsonIgnore]
-        public readonly Bindable<TournamentTeam> Team1 = new Bindable<TournamentTeam>();
+        public readonly Bindable<TournamentTeam?> Team1 = new Bindable<TournamentTeam?>();
 
-        public string Team1Acronym;
+        public string? Team1Acronym;
 
         public readonly Bindable<int?> Team1Score = new Bindable<int?>();
 
         [JsonIgnore]
-        public readonly Bindable<TournamentTeam> Team2 = new Bindable<TournamentTeam>();
+        public readonly Bindable<TournamentTeam?> Team2 = new Bindable<TournamentTeam?>();
 
-        public string Team2Acronym;
+        public string? Team2Acronym;
 
         public readonly Bindable<int?> Team2Score = new Bindable<int?>();
 
@@ -53,13 +51,13 @@ namespace osu.Game.Tournament.Models
         public readonly ObservableCollection<BeatmapChoice> PicksBans = new ObservableCollection<BeatmapChoice>();
 
         [JsonIgnore]
-        public readonly Bindable<TournamentRound> Round = new Bindable<TournamentRound>();
+        public readonly Bindable<TournamentRound?> Round = new Bindable<TournamentRound?>();
 
         [JsonIgnore]
-        public readonly Bindable<TournamentMatch> Progression = new Bindable<TournamentMatch>();
+        public readonly Bindable<TournamentMatch?> Progression = new Bindable<TournamentMatch?>();
 
         [JsonIgnore]
-        public readonly Bindable<TournamentMatch> LosersProgression = new Bindable<TournamentMatch>();
+        public readonly Bindable<TournamentMatch?> LosersProgression = new Bindable<TournamentMatch?>();
 
         /// <summary>
         /// Should not be set directly. Use LadderInfo.CurrentMatch.Value = this instead.
@@ -79,7 +77,7 @@ namespace osu.Game.Tournament.Models
             Team2.BindValueChanged(t => Team2Acronym = t.NewValue?.Acronym.Value, true);
         }
 
-        public TournamentMatch(TournamentTeam team1 = null, TournamentTeam team2 = null)
+        public TournamentMatch(TournamentTeam? team1 = null, TournamentTeam? team2 = null)
             : this()
         {
             Team1.Value = team1;
@@ -87,10 +85,10 @@ namespace osu.Game.Tournament.Models
         }
 
         [JsonIgnore]
-        public TournamentTeam Winner => !Completed.Value ? null : Team1Score.Value > Team2Score.Value ? Team1.Value : Team2.Value;
+        public TournamentTeam? Winner => !Completed.Value ? null : Team1Score.Value > Team2Score.Value ? Team1.Value : Team2.Value;
 
         [JsonIgnore]
-        public TournamentTeam Loser => !Completed.Value ? null : Team1Score.Value > Team2Score.Value ? Team2.Value : Team1.Value;
+        public TournamentTeam? Loser => !Completed.Value ? null : Team1Score.Value > Team2Score.Value ? Team2.Value : Team1.Value;
 
         public TeamColour WinnerColour => Winner == Team1.Value ? TeamColour.Red : TeamColour.Blue;
 

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tournament.Models
             {
                 int[] ranks = Players.Select(p => p.Rank)
                                      .Where(i => i.HasValue)
-                                     .Cast<int>()
+                                     .Select(i => i!.Value)
                                      .ToArray();
 
                 if (ranks.Length == 0)

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 
 namespace osu.Game.Tournament.Models
 {
@@ -39,7 +38,7 @@ namespace osu.Game.Tournament.Models
             {
                 int[] ranks = Players.Select(p => p.Rank)
                                      .Where(i => i.HasValue)
-                                     .Select(i => i.Value)
+                                     .Select(i => i.AsNonNull().Value)
                                      .ToArray();
 
                 if (ranks.Length == 0)
@@ -66,14 +65,14 @@ namespace osu.Game.Tournament.Models
             {
                 // use a sane default flag name based on acronym.
                 if (val.OldValue.StartsWith(FlagName.Value, StringComparison.InvariantCultureIgnoreCase))
-                    FlagName.Value = val.NewValue.Length >= 2 ? val.NewValue?.Substring(0, 2).ToUpperInvariant() : string.Empty;
+                    FlagName.Value = val.NewValue?.Length >= 2 ? val.NewValue.Substring(0, 2).ToUpperInvariant() : string.Empty;
             };
 
             FullName.ValueChanged += val =>
             {
                 // use a sane acronym based on full name.
                 if (val.OldValue.StartsWith(Acronym.Value, StringComparison.InvariantCultureIgnoreCase))
-                    Acronym.Value = val.NewValue.Length >= 3 ? val.NewValue?.Substring(0, 3).ToUpperInvariant() : string.Empty;
+                    Acronym.Value = val.NewValue?.Length >= 3 ? val.NewValue.Substring(0, 3).ToUpperInvariant() : string.Empty;
             };
         }
 

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 
 namespace osu.Game.Tournament.Models
 {

--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tournament.Models
             {
                 int[] ranks = Players.Select(p => p.Rank)
                                      .Where(i => i.HasValue)
-                                     .Select(i => i.AsNonNull().Value)
+                                     .Cast<int>()
                                      .ToArray();
 
                 if (ranks.Length == 0)

--- a/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
+++ b/osu.Game.Tournament/Screens/BeatmapInfoScreen.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Tournament.Screens
             SongBar.Mods = mods.NewValue;
         }
 
-        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap> beatmap)
+        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap?> beatmap)
         {
             SongBar.FadeInFromZero(300, Easing.OutQuint);
             SongBar.Beatmap = beatmap.NewValue;

--- a/osu.Game.Tournament/Screens/Drawings/Components/Group.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/Group.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
         public bool ContainsTeam(string fullName)
         {
-            return allTeams.Any(t => t.Team.FullName.Value == fullName);
+            return allTeams.Any(t => t.Team?.FullName.Value == fullName);
         }
 
         public bool RemoveTeam(TournamentTeam team)
@@ -112,7 +112,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
         {
             StringBuilder sb = new StringBuilder();
             foreach (GroupTeam gt in allTeams)
-                sb.AppendLine(gt.Team.FullName.Value);
+                sb.AppendLine(gt.Team?.FullName.Value);
             return sb.ToString();
         }
     }

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -136,11 +136,11 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
                             closest = stc;
                     }
 
-                    Trace.Assert(closest != null, "closest != null");
+                    Debug.Assert(closest != null, "closest != null");
 
-                    offset += DrawWidth / 2f - (closest.AsNonNull().Position.X + closest.AsNonNull().DrawWidth / 2f);
+                    offset += DrawWidth / 2f - (closest.Position.X + closest.DrawWidth / 2f);
 
-                    ScrollingTeam st = closest.AsNonNull();
+                    ScrollingTeam st = closest;
 
                     availableTeams.RemoveAll(at => at == st.Team);
 

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -22,8 +21,8 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 {
     public partial class ScrollingTeamContainer : Container
     {
-        public event Action OnScrollStarted;
-        public event Action<TournamentTeam> OnSelected;
+        public event Action? OnScrollStarted;
+        public event Action<TournamentTeam>? OnSelected;
 
         private readonly List<TournamentTeam> availableTeams = new List<TournamentTeam>();
 
@@ -42,7 +41,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
         private double lastTime;
 
-        private ScheduledDelegate delayedStateChangeDelegate;
+        private ScheduledDelegate? delayedStateChangeDelegate;
 
         public ScrollingTeamContainer()
         {
@@ -117,7 +116,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
                     if (!Children.Any())
                         break;
 
-                    ScrollingTeam closest = null;
+                    ScrollingTeam? closest = null;
 
                     foreach (var c in Children)
                     {
@@ -139,15 +138,14 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
                     Trace.Assert(closest != null, "closest != null");
 
-                    // ReSharper disable once PossibleNullReferenceException
-                    offset += DrawWidth / 2f - (closest.Position.X + closest.DrawWidth / 2f);
+                    offset += DrawWidth / 2f - (closest.AsNonNull().Position.X + closest.AsNonNull().DrawWidth / 2f);
 
-                    ScrollingTeam st = closest;
+                    ScrollingTeam st = closest.AsNonNull();
 
                     availableTeams.RemoveAll(at => at == st.Team);
 
                     st.Selected = true;
-                    OnSelected?.Invoke(st.Team);
+                    OnSelected?.Invoke(st.Team.AsNonNull());
 
                     delayedStateChangeDelegate = Scheduler.AddDelayed(() => setScrollState(ScrollState.Idle), 10000);
                     break;
@@ -174,7 +172,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
             setScrollState(ScrollState.Idle);
         }
 
-        public void AddTeams(IEnumerable<TournamentTeam> teams)
+        public void AddTeams(IEnumerable<TournamentTeam>? teams)
         {
             if (teams == null)
                 return;
@@ -190,8 +188,11 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
             setScrollState(ScrollState.Idle);
         }
 
-        public void RemoveTeam(TournamentTeam team)
+        public void RemoveTeam(TournamentTeam? team)
         {
+            if (team == null)
+                return;
+
             availableTeams.Remove(team);
 
             foreach (var c in Children)
@@ -311,6 +312,8 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
         public partial class ScrollingTeam : DrawableTournamentTeam
         {
+            public new TournamentTeam Team => base.Team.AsNonNull();
+
             public const float WIDTH = 58;
             public const float HEIGHT = 44;
 

--- a/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/ScrollingTeamContainer.cs
@@ -188,11 +188,8 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
             setScrollState(ScrollState.Idle);
         }
 
-        public void RemoveTeam(TournamentTeam? team)
+        public void RemoveTeam(TournamentTeam team)
         {
-            if (team == null)
-                return;
-
             availableTeams.Remove(team);
 
             foreach (var c in Children)

--- a/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/StorageBackedTeamList.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -39,7 +37,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
                     {
                         while (sr.Peek() != -1)
                         {
-                            string line = sr.ReadLine()?.Trim();
+                            string? line = sr.ReadLine()?.Trim();
 
                             if (string.IsNullOrEmpty(line))
                                 continue;
@@ -56,7 +54,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
                             teams.Add(new TournamentTeam
                             {
                                 FullName = { Value = split[1], },
-                                Acronym = { Value = split.Length >= 3 ? split[2] : null, },
+                                Acronym = { Value = split.Length >= 3 ? split[2] : string.Empty, },
                                 FlagName = { Value = split[0] }
                             });
                         }

--- a/osu.Game.Tournament/Screens/Drawings/Components/VisualiserContainer.cs
+++ b/osu.Game.Tournament/Screens/Drawings/Components/VisualiserContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -72,7 +70,7 @@ namespace osu.Game.Tournament.Screens.Drawings.Components
 
             private float leftPos => -(float)((Time.Current + Offset) / CycleTime) + expiredCount;
 
-            private Texture texture;
+            private Texture texture = null!;
 
             private int expiredCount;
 

--- a/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
+++ b/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tournament.Screens.Drawings
 
         private Storage storage = null!;
 
-        public ITeamList? TeamList;
+        public ITeamList TeamList = null!;
 
         [BackgroundDependencyLoader]
         private void load(Storage storage)
@@ -48,7 +48,8 @@ namespace osu.Game.Tournament.Screens.Drawings
 
             RelativeSizeAxes = Axes.Both;
 
-            TeamList ??= new StorageBackedTeamList(storage);
+            if (TeamList.IsNull())
+                TeamList = new StorageBackedTeamList(storage);
 
             if (!TeamList.Teams.Any())
             {
@@ -223,7 +224,7 @@ namespace osu.Game.Tournament.Screens.Drawings
             teamsContainer.ClearTeams();
             allTeams.Clear();
 
-            foreach (TournamentTeam t in TeamList.AsNonNull().Teams)
+            foreach (TournamentTeam t in TeamList.Teams)
             {
                 if (groupsContainer.ContainsTeam(t.FullName.Value))
                     continue;

--- a/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
+++ b/osu.Game.Tournament/Screens/Drawings/DrawingsScreen.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -28,26 +27,26 @@ namespace osu.Game.Tournament.Screens.Drawings
     {
         private const string results_filename = "drawings_results.txt";
 
-        private ScrollingTeamContainer teamsContainer;
-        private GroupContainer groupsContainer;
-        private TournamentSpriteText fullTeamNameText;
+        private ScrollingTeamContainer teamsContainer = null!;
+        private GroupContainer groupsContainer = null!;
+        private TournamentSpriteText fullTeamNameText = null!;
 
         private readonly List<TournamentTeam> allTeams = new List<TournamentTeam>();
 
-        private DrawingsConfigManager drawingsConfig;
+        private DrawingsConfigManager drawingsConfig = null!;
 
-        private Task writeOp;
+        private Task? writeOp;
 
-        private Storage storage;
+        private Storage storage = null!;
 
-        public ITeamList TeamList;
+        public ITeamList? TeamList;
 
         [BackgroundDependencyLoader]
         private void load(Storage storage)
         {
-            RelativeSizeAxes = Axes.Both;
-
             this.storage = storage;
+
+            RelativeSizeAxes = Axes.Both;
 
             TeamList ??= new StorageBackedTeamList(storage);
 
@@ -224,7 +223,7 @@ namespace osu.Game.Tournament.Screens.Drawings
             teamsContainer.ClearTeams();
             allTeams.Clear();
 
-            foreach (TournamentTeam t in TeamList.Teams)
+            foreach (TournamentTeam t in TeamList.AsNonNull().Teams)
             {
                 if (groupsContainer.ContainsTeam(t.FullName.Value))
                     continue;
@@ -251,7 +250,7 @@ namespace osu.Game.Tournament.Screens.Drawings
                     using (Stream stream = storage.GetStream(results_filename, FileAccess.Read, FileMode.Open))
                     using (StreamReader sr = new StreamReader(stream))
                     {
-                        string line;
+                        string? line;
 
                         while ((line = sr.ReadLine()?.Trim()) != null)
                         {
@@ -261,8 +260,7 @@ namespace osu.Game.Tournament.Screens.Drawings
                             if (line.ToUpperInvariant().StartsWith("GROUP", StringComparison.Ordinal))
                                 continue;
 
-                            // ReSharper disable once AccessToModifiedClosure
-                            TournamentTeam teamToAdd = allTeams.FirstOrDefault(t => t.FullName.Value == line);
+                            TournamentTeam? teamToAdd = allTeams.FirstOrDefault(t => t.FullName.Value == line);
 
                             if (teamToAdd == null)
                                 continue;

--- a/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tournament.Screens.Editors
 
         private RectangularPositionSnapGrid grid = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private IDialogOverlay? dialogOverlay { get; set; }
 
         protected override bool DrawLoserPaths => true;

--- a/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/LadderEditorScreen.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Drawing;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -35,13 +32,12 @@ namespace osu.Game.Tournament.Screens.Editors
         [Cached]
         private LadderEditorInfo editorInfo = new LadderEditorInfo();
 
-        private WarningBox rightClickMessage;
+        private WarningBox rightClickMessage = null!;
 
-        private RectangularPositionSnapGrid grid;
+        private RectangularPositionSnapGrid grid = null!;
 
         [Resolved(canBeNull: true)]
-        [CanBeNull]
-        private IDialogOverlay dialogOverlay { get; set; }
+        private IDialogOverlay? dialogOverlay { get; set; }
 
         protected override bool DrawLoserPaths => true;
 
@@ -94,36 +90,28 @@ namespace osu.Game.Tournament.Screens.Editors
             ScrollContent.Add(new JoinVisualiser(MatchesContainer, match, losers, UpdateLayout));
         }
 
-        public MenuItem[] ContextMenuItems
-        {
-            get
+        public MenuItem[] ContextMenuItems =>
+            new MenuItem[]
             {
-                if (editorInfo == null)
-                    return Array.Empty<MenuItem>();
-
-                return new MenuItem[]
+                new OsuMenuItem("Create new match", MenuItemType.Highlighted, () =>
                 {
-                    new OsuMenuItem("Create new match", MenuItemType.Highlighted, () =>
+                    Vector2 pos = MatchesContainer.Count == 0 ? Vector2.Zero : lastMatchesContainerMouseDownPosition;
+
+                    TournamentMatch newMatch = new TournamentMatch { Position = { Value = new Point((int)pos.X, (int)pos.Y) } };
+
+                    LadderInfo.Matches.Add(newMatch);
+
+                    editorInfo.Selected.Value = newMatch;
+                }),
+                new OsuMenuItem("Reset teams", MenuItemType.Destructive, () =>
+                {
+                    dialogOverlay?.Push(new LadderResetTeamsDialog(() =>
                     {
-                        Vector2 pos = MatchesContainer.Count == 0 ? Vector2.Zero : lastMatchesContainerMouseDownPosition;
-
-                        TournamentMatch newMatch = new TournamentMatch { Position = { Value = new Point((int)pos.X, (int)pos.Y) } };
-
-                        LadderInfo.Matches.Add(newMatch);
-
-                        editorInfo.Selected.Value = newMatch;
-                    }),
-                    new OsuMenuItem("Reset teams", MenuItemType.Destructive, () =>
-                    {
-                        dialogOverlay?.Push(new LadderResetTeamsDialog(() =>
-                        {
-                            foreach (var p in MatchesContainer)
-                                p.Match.Reset();
-                        }));
-                    })
-                };
-            }
-        }
+                        foreach (var p in MatchesContainer)
+                            p.Match.Reset();
+                    }));
+                })
+            };
 
         public void Remove(TournamentMatch match)
         {
@@ -135,11 +123,11 @@ namespace osu.Game.Tournament.Screens.Editors
             private readonly Container<DrawableTournamentMatch> matchesContainer;
             public readonly TournamentMatch Source;
             private readonly bool losers;
-            private readonly Action complete;
+            private readonly Action? complete;
 
-            private ProgressionPath path;
+            private ProgressionPath? path;
 
-            public JoinVisualiser(Container<DrawableTournamentMatch> matchesContainer, TournamentMatch source, bool losers, Action complete)
+            public JoinVisualiser(Container<DrawableTournamentMatch> matchesContainer, TournamentMatch source, bool losers, Action? complete)
             {
                 this.matchesContainer = matchesContainer;
                 RelativeSizeAxes = Axes.Both;
@@ -153,7 +141,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     Source.Progression.Value = null;
             }
 
-            private DrawableTournamentMatch findTarget(InputState state)
+            private DrawableTournamentMatch? findTarget(InputState state)
             {
                 return matchesContainer.FirstOrDefault(d => d.ReceivePositionalInputAt(state.Mouse.Position));
             }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/MatchHeader.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,9 +12,9 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 {
     public partial class MatchHeader : Container
     {
-        private TeamScoreDisplay teamDisplay1;
-        private TeamScoreDisplay teamDisplay2;
-        private DrawableTournamentHeaderLogo logo;
+        private TeamScoreDisplay teamDisplay1 = null!;
+        private TeamScoreDisplay teamDisplay2 = null!;
+        private DrawableTournamentHeaderLogo logo = null!;
 
         private bool showScores = true;
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamDisplay.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             }
         }
 
-        public TeamDisplay(TournamentTeam team, TeamColour colour, Bindable<int?> currentTeamScore, int pointsToWin)
+        public TeamDisplay(TournamentTeam? team, TeamColour colour, Bindable<int?> currentTeamScore, int pointsToWin)
             : base(team)
         {
             AutoSizeAxes = Axes.Both;

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TeamScoreDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -17,16 +15,22 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
     {
         private readonly TeamColour teamColour;
 
-        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
-        private readonly Bindable<TournamentTeam> currentTeam = new Bindable<TournamentTeam>();
+        private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
+        private readonly Bindable<TournamentTeam?> currentTeam = new Bindable<TournamentTeam?>();
         private readonly Bindable<int?> currentTeamScore = new Bindable<int?>();
 
-        private TeamDisplay teamDisplay;
+        private TeamDisplay? teamDisplay;
 
         public bool ShowScore
         {
-            get => teamDisplay.ShowScore;
-            set => teamDisplay.ShowScore = value;
+            get => teamDisplay?.ShowScore ?? false;
+            set
+            {
+                if (teamDisplay != null)
+                {
+                    teamDisplay.ShowScore = value;
+                }
+            }
         }
 
         public TeamScoreDisplay(TeamColour teamColour)
@@ -48,7 +52,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             updateMatch();
         }
 
-        private void matchChanged(ValueChangedEvent<TournamentMatch> match)
+        private void matchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             currentTeamScore.UnbindBindings();
             currentTeam.UnbindBindings();
@@ -78,7 +82,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             switch (e.Button)
             {
                 case MouseButton.Left:
-                    if (currentTeamScore.Value < currentMatch.Value.PointsToWin)
+                    if (currentTeamScore.Value < currentMatch.Value?.PointsToWin)
                         currentTeamScore.Value++;
                     return true;
 
@@ -91,7 +95,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
             return base.OnMouseDown(e);
         }
 
-        private void teamChanged(ValueChangedEvent<TournamentTeam> team)
+        private void teamChanged(ValueChangedEvent<TournamentTeam?> team)
         {
             bool wasShowingScores = teamDisplay?.ShowScore ?? false;
 

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -146,7 +144,7 @@ namespace osu.Game.Tournament.Screens.Gameplay.Components
 
         private partial class MatchScoreCounter : CommaSeparatedScoreCounter
         {
-            private OsuSpriteText displayedSpriteText;
+            private OsuSpriteText displayedSpriteText = null!;
 
             public MatchScoreCounter()
             {

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -26,16 +24,16 @@ namespace osu.Game.Tournament.Screens.Gameplay
         private readonly BindableBool warmup = new BindableBool();
 
         public readonly Bindable<TourneyState> State = new Bindable<TourneyState>();
-        private OsuButton warmupButton;
-        private MatchIPCInfo ipc;
+        private OsuButton warmupButton = null!;
+        private MatchIPCInfo ipc = null!;
 
         [Resolved(canBeNull: true)]
-        private TournamentSceneManager sceneManager { get; set; }
+        private TournamentSceneManager? sceneManager { get; set; }
 
         [Resolved]
-        private TournamentMatchChatDisplay chat { get; set; }
+        private TournamentMatchChatDisplay chat { get; set; } = null!;
 
-        private Drawable chroma;
+        private Drawable chroma = null!;
 
         [BackgroundDependencyLoader]
         private void load(LadderInfo ladder, MatchIPCInfo ipc)
@@ -142,7 +140,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
             State.BindValueChanged(_ => updateState(), true);
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             base.CurrentMatchChanged(match);
 
@@ -153,29 +151,35 @@ namespace osu.Game.Tournament.Screens.Gameplay
             scheduledScreenChange?.Cancel();
         }
 
-        private ScheduledDelegate scheduledScreenChange;
-        private ScheduledDelegate scheduledContract;
+        private ScheduledDelegate? scheduledScreenChange;
+        private ScheduledDelegate? scheduledContract;
 
-        private TournamentMatchScoreDisplay scoreDisplay;
+        private TournamentMatchScoreDisplay scoreDisplay = null!;
 
         private TourneyState lastState;
-        private MatchHeader header;
+        private MatchHeader header = null!;
 
         private void contract()
         {
+            if (!IsLoaded)
+                return;
+
             scheduledContract?.Cancel();
 
             SongBar.Expanded = false;
             scoreDisplay.FadeOut(100);
-            using (chat?.BeginDelayedSequence(500))
-                chat?.Expand();
+            using (chat.BeginDelayedSequence(500))
+                chat.Expand();
         }
 
         private void expand()
         {
+            if (!IsLoaded)
+                return;
+
             scheduledContract?.Cancel();
 
-            chat?.Contract();
+            chat.Contract();
 
             using (BeginDelayedSequence(300))
             {
@@ -252,7 +256,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
         private partial class ChromaArea : CompositeDrawable
         {
             [Resolved]
-            private LadderInfo ladder { get; set; }
+            private LadderInfo ladder { get; set; } = null!;
 
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/GameplayScreen.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tournament.Screens.Gameplay
         private OsuButton warmupButton = null!;
         private MatchIPCInfo ipc = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private TournamentSceneManager? sceneManager { get; set; }
 
         [Resolved]

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         private readonly Func<bool>? isWinner;
         private LadderEditorScreen ladderEditor = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private LadderInfo? ladderInfo { get; set; }
 
         private void setCurrent()
@@ -53,7 +53,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             ladderInfo.CurrentMatch.Value.Current.Value = true;
         }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         private LadderEditorInfo? editorInfo { get; set; }
 
         public DrawableMatchTeam(TournamentTeam? team, TournamentMatch match, bool losers)

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableMatchTeam.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -28,20 +26,20 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
     {
         private readonly TournamentMatch match;
         private readonly bool losers;
-        private TournamentSpriteText scoreText;
-        private Box background;
-        private Box backgroundRight;
+        private TournamentSpriteText scoreText = null!;
+        private Box background = null!;
+        private Box backgroundRight = null!;
 
         private readonly Bindable<int?> score = new Bindable<int?>();
         private readonly BindableBool completed = new BindableBool();
 
         private Color4 colourWinner;
 
-        private readonly Func<bool> isWinner;
-        private LadderEditorScreen ladderEditor;
+        private readonly Func<bool>? isWinner;
+        private LadderEditorScreen ladderEditor = null!;
 
         [Resolved(canBeNull: true)]
-        private LadderInfo ladderInfo { get; set; }
+        private LadderInfo? ladderInfo { get; set; }
 
         private void setCurrent()
         {
@@ -56,9 +54,9 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         }
 
         [Resolved(CanBeNull = true)]
-        private LadderEditorInfo editorInfo { get; set; }
+        private LadderEditorInfo? editorInfo { get; set; }
 
-        public DrawableMatchTeam(TournamentTeam team, TournamentMatch match, bool losers)
+        public DrawableMatchTeam(TournamentTeam? team, TournamentMatch match, bool losers)
             : base(team)
         {
             this.match = match;
@@ -72,14 +70,11 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             AcronymText.Padding = new MarginPadding { Left = 50 };
             AcronymText.Font = OsuFont.Torus.With(size: 22, weight: FontWeight.Bold);
 
-            if (match != null)
-            {
-                isWinner = () => match.Winner == Team;
+            isWinner = () => match.Winner == Team;
 
-                completed.BindTo(match.Completed);
-                if (team != null)
-                    score.BindTo(team == match.Team1.Value ? match.Team1Score : match.Team2Score);
-            }
+            completed.BindTo(match.Completed);
+            if (team != null)
+                score.BindTo(team == match.Team1.Value ? match.Team1Score : match.Team2Score);
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -28,10 +28,10 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         private readonly Drawable currentMatchSelectionBox;
         private Bindable<TournamentMatch>? globalSelection;
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         private LadderEditorInfo? editorInfo { get; set; }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved]
         private LadderInfo? ladderInfo { get; set; }
 
         public DrawableTournamentMatch(TournamentMatch match, bool editor = false)

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentMatch.cs
@@ -1,10 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -27,13 +26,13 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         protected readonly FillFlowContainer<DrawableMatchTeam> Flow;
         private readonly Drawable selectionBox;
         private readonly Drawable currentMatchSelectionBox;
-        private Bindable<TournamentMatch> globalSelection;
+        private Bindable<TournamentMatch>? globalSelection;
 
         [Resolved(CanBeNull = true)]
-        private LadderEditorInfo editorInfo { get; set; }
+        private LadderEditorInfo? editorInfo { get; set; }
 
         [Resolved(CanBeNull = true)]
-        private LadderInfo ladderInfo { get; set; }
+        private LadderInfo? ladderInfo { get; set; }
 
         public DrawableTournamentMatch(TournamentMatch match, bool editor = false)
         {
@@ -129,7 +128,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         /// <summary>
         /// Fired when something changed that requires a ladder redraw.
         /// </summary>
-        public Action Changed;
+        public Action? Changed;
 
         private readonly List<IUnbindable> refBindables = new List<IUnbindable>();
 
@@ -201,20 +200,22 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             }
             else
             {
-                transferProgression(Match.Progression?.Value, Match.Winner);
-                transferProgression(Match.LosersProgression?.Value, Match.Loser);
+                Debug.Assert(Match.Winner != null);
+                transferProgression(Match.Progression.Value, Match.Winner);
+                Debug.Assert(Match.Loser != null);
+                transferProgression(Match.LosersProgression.Value, Match.Loser);
             }
 
             Changed?.Invoke();
         }
 
-        private void transferProgression(TournamentMatch destination, TournamentTeam team)
+        private void transferProgression(TournamentMatch? destination, TournamentTeam team)
         {
             if (destination == null) return;
 
             bool progressionAbove = destination.ID < Match.ID;
 
-            Bindable<TournamentTeam> destinationTeam;
+            Bindable<TournamentTeam?> destinationTeam;
 
             // check for the case where we have already transferred out value
             if (destination.Team1.Value == team)
@@ -268,8 +269,8 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             {
                 foreach (var conditional in Match.ConditionalMatches)
                 {
-                    bool team1Match = conditional.Acronyms.Contains(Match.Team1Acronym);
-                    bool team2Match = conditional.Acronyms.Contains(Match.Team2Acronym);
+                    bool team1Match = Match.Team1Acronym != null && conditional.Acronyms.Contains(Match.Team1Acronym);
+                    bool team2Match = Match.Team2Acronym != null && conditional.Acronyms.Contains(Match.Team2Acronym);
 
                     if (team1Match && team2Match)
                         Match.Date.Value = conditional.Date.Value;
@@ -343,6 +344,9 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             Selected = false;
             Match.Progression.Value = null;
             Match.LosersProgression.Value = null;
+
+            if (ladderInfo == null)
+                return;
 
             ladderInfo.Matches.Remove(Match);
 

--- a/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/DrawableTournamentRound.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -52,7 +50,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             name.BindValueChanged(_ => textName.Text = ((losers ? "Losers " : "") + round.Name).ToUpperInvariant(), true);
 
             description = round.Description.GetBoundCopy();
-            description.BindValueChanged(_ => textDescription.Text = round.Description.Value?.ToUpperInvariant(), true);
+            description.BindValueChanged(_ => textDescription.Text = round.Description.Value?.ToUpperInvariant() ?? string.Empty, true);
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/LadderEditorSettings.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -23,17 +21,17 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
 {
     public partial class LadderEditorSettings : CompositeDrawable
     {
-        private SettingsDropdown<TournamentRound> roundDropdown;
-        private PlayerCheckbox losersCheckbox;
-        private DateTextBox dateTimeBox;
-        private SettingsTeamDropdown team1Dropdown;
-        private SettingsTeamDropdown team2Dropdown;
+        private SettingsDropdown<TournamentRound?> roundDropdown = null!;
+        private PlayerCheckbox losersCheckbox = null!;
+        private DateTextBox dateTimeBox = null!;
+        private SettingsTeamDropdown team1Dropdown = null!;
+        private SettingsTeamDropdown team2Dropdown = null!;
 
         [Resolved]
-        private LadderEditorInfo editorInfo { get; set; }
+        private LadderEditorInfo editorInfo { get; set; } = null!;
 
         [Resolved]
-        private LadderInfo ladderInfo { get; set; }
+        private LadderInfo ladderInfo { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -77,7 +75,7 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
             };
         }
 
-        private void roundDropdownChanged(ValueChangedEvent<TournamentRound> round)
+        private void roundDropdownChanged(ValueChangedEvent<TournamentRound?> round)
         {
             if (editorInfo.Selected.Value?.Date.Value < round.NewValue?.StartDate.Value)
             {
@@ -101,11 +99,11 @@ namespace osu.Game.Tournament.Screens.Ladder.Components
         {
         }
 
-        private partial class SettingsRoundDropdown : SettingsDropdown<TournamentRound>
+        private partial class SettingsRoundDropdown : SettingsDropdown<TournamentRound?>
         {
             public SettingsRoundDropdown(BindableList<TournamentRound> rounds)
             {
-                Current = new Bindable<TournamentRound>();
+                Current = new Bindable<TournamentRound?>();
 
                 foreach (var r in rounds.Prepend(new TournamentRound()))
                     add(r);

--- a/osu.Game.Tournament/Screens/Ladder/Components/SettingsTeamDropdown.cs
+++ b/osu.Game.Tournament/Screens/Ladder/Components/SettingsTeamDropdown.cs
@@ -12,7 +12,7 @@ using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Screens.Ladder.Components
 {
-    public partial class SettingsTeamDropdown : SettingsDropdown<TournamentTeam>
+    public partial class SettingsTeamDropdown : SettingsDropdown<TournamentTeam?>
     {
         public SettingsTeamDropdown(BindableList<TournamentTeam> teams)
         {

--- a/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
+++ b/osu.Game.Tournament/Screens/Ladder/LadderScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
@@ -22,13 +20,13 @@ namespace osu.Game.Tournament.Screens.Ladder
 {
     public partial class LadderScreen : TournamentScreen
     {
-        protected Container<DrawableTournamentMatch> MatchesContainer;
-        private Container<Path> paths;
-        private Container headings;
+        protected Container<DrawableTournamentMatch> MatchesContainer = null!;
+        private Container<Path> paths = null!;
+        private Container headings = null!;
 
-        protected LadderDragContainer ScrollContent;
+        protected LadderDragContainer ScrollContent = null!;
 
-        protected Container Content;
+        protected Container Content = null!;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -252,9 +252,6 @@ namespace osu.Game.Tournament.Screens.MapPool
 
                 foreach (var b in CurrentMatch.Value.Round.Value.Beatmaps)
                 {
-                    if (b.Beatmap == null)
-                        continue;
-
                     if (currentFlow == null || (LadderInfo.SplitMapPoolByMods.Value && currentMods != b.Mods))
                     {
                         mapFlows.Add(currentFlow = new FillFlowContainer<TournamentBeatmapPanel>

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -121,13 +121,13 @@ namespace osu.Game.Tournament.Screens.MapPool
             splitMapPoolByMods.BindValueChanged(_ => updateDisplay());
         }
 
-        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap> beatmap)
+        private void beatmapChanged(ValueChangedEvent<TournamentBeatmap?> beatmap)
         {
             if (CurrentMatch.Value == null || CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) < 2)
                 return;
 
             // if bans have already been placed, beatmap changes result in a selection being made autoamtically
-            if (beatmap.NewValue.OnlineID > 0)
+            if (beatmap.NewValue?.OnlineID > 0)
                 addForBeatmap(beatmap.NewValue.OnlineID);
         }
 

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tournament.Screens.MapPool
     {
         private FillFlowContainer<FillFlowContainer<TournamentBeatmapPanel>> mapFlows = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private TournamentSceneManager? sceneManager { get; set; }
 
         private TeamColour pickColour;

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -24,20 +22,20 @@ namespace osu.Game.Tournament.Screens.MapPool
 {
     public partial class MapPoolScreen : TournamentMatchScreen
     {
-        private FillFlowContainer<FillFlowContainer<TournamentBeatmapPanel>> mapFlows;
+        private FillFlowContainer<FillFlowContainer<TournamentBeatmapPanel>> mapFlows = null!;
 
         [Resolved(canBeNull: true)]
-        private TournamentSceneManager sceneManager { get; set; }
+        private TournamentSceneManager? sceneManager { get; set; }
 
         private TeamColour pickColour;
         private ChoiceType pickType;
 
-        private OsuButton buttonRedBan;
-        private OsuButton buttonBlueBan;
-        private OsuButton buttonRedPick;
-        private OsuButton buttonBluePick;
+        private OsuButton buttonRedBan = null!;
+        private OsuButton buttonBlueBan = null!;
+        private OsuButton buttonRedPick = null!;
+        private OsuButton buttonBluePick = null!;
 
-        private ScheduledDelegate scheduledScreenChange;
+        private ScheduledDelegate? scheduledScreenChange;
 
         [BackgroundDependencyLoader]
         private void load(MatchIPCInfo ipc)
@@ -113,7 +111,7 @@ namespace osu.Game.Tournament.Screens.MapPool
             ipc.Beatmap.BindValueChanged(beatmapChanged);
         }
 
-        private Bindable<bool> splitMapPoolByMods;
+        private Bindable<bool>? splitMapPoolByMods;
 
         protected override void LoadComplete()
         {
@@ -148,6 +146,9 @@ namespace osu.Game.Tournament.Screens.MapPool
 
         private void setNextMode()
         {
+            if (CurrentMatch.Value == null)
+                return;
+
             const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
 
             var nextColour = (CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
@@ -169,11 +170,11 @@ namespace osu.Game.Tournament.Screens.MapPool
                     addForBeatmap(map.Beatmap.OnlineID);
                 else
                 {
-                    var existing = CurrentMatch.Value.PicksBans.FirstOrDefault(p => p.BeatmapID == map.Beatmap?.OnlineID);
+                    var existing = CurrentMatch.Value?.PicksBans.FirstOrDefault(p => p.BeatmapID == map.Beatmap?.OnlineID);
 
                     if (existing != null)
                     {
-                        CurrentMatch.Value.PicksBans.Remove(existing);
+                        CurrentMatch.Value?.PicksBans.Remove(existing);
                         setNextMode();
                     }
                 }
@@ -186,13 +187,13 @@ namespace osu.Game.Tournament.Screens.MapPool
 
         private void reset()
         {
-            CurrentMatch.Value.PicksBans.Clear();
+            CurrentMatch.Value?.PicksBans.Clear();
             setNextMode();
         }
 
         private void addForBeatmap(int beatmapId)
         {
-            if (CurrentMatch.Value == null)
+            if (CurrentMatch.Value?.Round.Value == null)
                 return;
 
             if (CurrentMatch.Value.Round.Value.Beatmaps.All(b => b.Beatmap?.OnlineID != beatmapId))
@@ -228,7 +229,7 @@ namespace osu.Game.Tournament.Screens.MapPool
             base.Hide();
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             base.CurrentMatchChanged(match);
             updateDisplay();
@@ -245,12 +246,15 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             if (CurrentMatch.Value.Round.Value != null)
             {
-                FillFlowContainer<TournamentBeatmapPanel> currentFlow = null;
-                string currentMods = null;
+                FillFlowContainer<TournamentBeatmapPanel>? currentFlow = null;
+                string? currentMods = null;
                 int flowCount = 0;
 
                 foreach (var b in CurrentMatch.Value.Round.Value.Beatmaps)
                 {
+                    if (b.Beatmap == null)
+                        continue;
+
                     if (currentFlow == null || (LadderInfo.SplitMapPoolByMods.Value && currentMods != b.Mods))
                     {
                         mapFlows.Add(currentFlow = new FillFlowContainer<TournamentBeatmapPanel>

--- a/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
+++ b/osu.Game.Tournament/Screens/Schedule/ScheduleScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -21,9 +19,9 @@ namespace osu.Game.Tournament.Screens.Schedule
 {
     public partial class ScheduleScreen : TournamentScreen
     {
-        private readonly Bindable<TournamentMatch> currentMatch = new Bindable<TournamentMatch>();
-        private Container mainContainer;
-        private LadderInfo ladder;
+        private readonly Bindable<TournamentMatch?> currentMatch = new Bindable<TournamentMatch?>();
+        private Container mainContainer = null!;
+        private LadderInfo ladder = null!;
 
         [BackgroundDependencyLoader]
         private void load(LadderInfo ladder)
@@ -107,7 +105,7 @@ namespace osu.Game.Tournament.Screens.Schedule
             currentMatch.BindValueChanged(matchChanged, true);
         }
 
-        private void matchChanged(ValueChangedEvent<TournamentMatch> match)
+        private void matchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             var upcoming = ladder.Matches.Where(p => !p.Completed.Value && p.Team1.Value != null && p.Team2.Value != null && Math.Abs(p.Date.Value.DayOfYear - DateTimeOffset.UtcNow.DayOfYear) < 4);
             var conditionals = ladder

--- a/osu.Game.Tournament/Screens/Setup/ResolutionSelector.cs
+++ b/osu.Game.Tournament/Screens/Setup/ResolutionSelector.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -14,9 +12,9 @@ namespace osu.Game.Tournament.Screens.Setup
         private const int minimum_window_height = 480;
         private const int maximum_window_height = 2160;
 
-        public new Action<int> Action;
+        public new Action<int>? Action;
 
-        private OsuNumberBox numberBox;
+        private OsuNumberBox? numberBox;
 
         protected override Drawable CreateComponent()
         {

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Drawing;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -24,27 +22,27 @@ namespace osu.Game.Tournament.Screens.Setup
 {
     public partial class SetupScreen : TournamentScreen
     {
-        private FillFlowContainer fillFlow;
+        private FillFlowContainer fillFlow = null!;
 
-        private LoginOverlay loginOverlay;
-        private ResolutionSelector resolution;
-
-        [Resolved]
-        private MatchIPCInfo ipc { get; set; }
+        private LoginOverlay? loginOverlay;
+        private ResolutionSelector resolution = null!;
 
         [Resolved]
-        private StableInfo stableInfo { get; set; }
+        private MatchIPCInfo ipc { get; set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private StableInfo stableInfo { get; set; } = null!;
 
         [Resolved]
-        private RulesetStore rulesets { get; set; }
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
 
         [Resolved(canBeNull: true)]
-        private TournamentSceneManager sceneManager { get; set; }
+        private TournamentSceneManager? sceneManager { get; set; }
 
-        private Bindable<Size> windowSize;
+        private Bindable<Size> windowSize = null!;
 
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager frameworkConfig)
@@ -115,7 +113,7 @@ namespace osu.Game.Tournament.Screens.Setup
                     Failing = api.IsLoggedIn != true,
                     Description = "In order to access the API and display metadata, signing in is required."
                 },
-                new LabelledDropdown<RulesetInfo>
+                new LabelledDropdown<RulesetInfo?>
                 {
                     Label = "Ruleset",
                     Description = "Decides what stats are displayed and which ranks are retrieved for players. This requires a restart to reload data for an existing bracket.",

--- a/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/SetupScreen.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tournament.Screens.Setup
         [Resolved]
         private RulesetStore rulesets { get; set; } = null!;
 
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private TournamentSceneManager? sceneManager { get; set; }
 
         private Bindable<Size> windowSize = null!;

--- a/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tournament.Screens.Setup
 {
     public partial class StablePathSelectScreen : TournamentScreen
     {
-        [Resolved(canBeNull: true)]
+        [Resolved]
         private TournamentSceneManager? sceneManager { get; set; }
 
         [Resolved]

--- a/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -24,19 +22,19 @@ namespace osu.Game.Tournament.Screens.Setup
     public partial class StablePathSelectScreen : TournamentScreen
     {
         [Resolved(canBeNull: true)]
-        private TournamentSceneManager sceneManager { get; set; }
+        private TournamentSceneManager? sceneManager { get; set; }
 
         [Resolved]
-        private MatchIPCInfo ipc { get; set; }
+        private MatchIPCInfo ipc { get; set; } = null!;
 
-        private OsuDirectorySelector directorySelector;
-        private DialogOverlay overlay;
+        private OsuDirectorySelector directorySelector = null!;
+        private DialogOverlay? overlay;
 
         [BackgroundDependencyLoader(true)]
         private void load(Storage storage, OsuColour colours)
         {
             var initialStorage = (ipc as FileBasedIPC)?.IPCStorage ?? storage;
-            string initialPath = new DirectoryInfo(initialStorage.GetFullPath(string.Empty)).Parent?.FullName;
+            string? initialPath = new DirectoryInfo(initialStorage.GetFullPath(string.Empty)).Parent?.FullName;
 
             AddRangeInternal(new Drawable[]
             {

--- a/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
+++ b/osu.Game.Tournament/Screens/Setup/TournamentSwitcher.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -13,12 +11,12 @@ namespace osu.Game.Tournament.Screens.Setup
 {
     internal partial class TournamentSwitcher : ActionableInfo
     {
-        private OsuDropdown<string> dropdown;
-        private OsuButton folderButton;
-        private OsuButton reloadTournamentsButton;
+        private OsuDropdown<string> dropdown = null!;
+        private OsuButton folderButton = null!;
+        private OsuButton reloadTournamentsButton = null!;
 
         [Resolved]
-        private TournamentGameBase game { get; set; }
+        private TournamentGameBase game { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(TournamentStorage storage)

--- a/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
+++ b/osu.Game.Tournament/Screens/Showcase/ShowcaseScreen.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Tournament.Screens.Showcase
             });
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             // showcase screen doesn't care about a match being selected.
             // base call intentionally omitted to not show match warning.

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -22,12 +20,12 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 {
     public partial class SeedingScreen : TournamentMatchScreen
     {
-        private Container mainContainer;
+        private Container mainContainer = null!;
 
-        private readonly Bindable<TournamentTeam> currentTeam = new Bindable<TournamentTeam>();
+        private readonly Bindable<TournamentTeam?> currentTeam = new Bindable<TournamentTeam?>();
 
-        private TourneyButton showFirstTeamButton;
-        private TourneyButton showSecondTeamButton;
+        private TourneyButton showFirstTeamButton = null!;
+        private TourneyButton showSecondTeamButton = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -53,13 +51,13 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             RelativeSizeAxes = Axes.X,
                             Text = "Show first team",
-                            Action = () => currentTeam.Value = CurrentMatch.Value.Team1.Value,
+                            Action = () => currentTeam.Value = CurrentMatch.Value?.Team1.Value,
                         },
                         showSecondTeamButton = new TourneyButton
                         {
                             RelativeSizeAxes = Axes.X,
                             Text = "Show second team",
-                            Action = () => currentTeam.Value = CurrentMatch.Value.Team2.Value,
+                            Action = () => currentTeam.Value = CurrentMatch.Value?.Team2.Value,
                         },
                         new SettingsTeamDropdown(LadderInfo.Teams)
                         {
@@ -73,7 +71,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
             currentTeam.BindValueChanged(teamChanged, true);
         }
 
-        private void teamChanged(ValueChangedEvent<TournamentTeam> team) => updateTeamDisplay();
+        private void teamChanged(ValueChangedEvent<TournamentTeam?> team) => updateTeamDisplay();
 
         public override void Show()
         {
@@ -84,7 +82,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
             updateTeamDisplay();
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             base.CurrentMatchChanged(match);
 
@@ -256,7 +254,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
         private partial class LeftInfo : CompositeDrawable
         {
-            public LeftInfo(TournamentTeam team)
+            public LeftInfo(TournamentTeam? team)
             {
                 FillFlowContainer fill;
 
@@ -315,7 +313,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 
             private partial class TeamDisplay : DrawableTournamentTeam
             {
-                public TeamDisplay(TournamentTeam team)
+                public TeamDisplay(TournamentTeam? team)
                     : base(team)
                 {
                     AutoSizeAxes = Axes.Both;

--- a/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/TeamIntroScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -15,7 +13,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
 {
     public partial class TeamIntroScreen : TournamentMatchScreen
     {
-        private Container mainContainer;
+        private Container mainContainer = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -36,7 +34,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
             };
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             base.CurrentMatchChanged(match);
 

--- a/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamWin/TeamWinScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,12 +14,12 @@ namespace osu.Game.Tournament.Screens.TeamWin
 {
     public partial class TeamWinScreen : TournamentMatchScreen
     {
-        private Container mainContainer;
+        private Container mainContainer = null!;
 
         private readonly Bindable<bool> currentCompleted = new Bindable<bool>();
 
-        private TourneyVideo blueWinVideo;
-        private TourneyVideo redWinVideo;
+        private TourneyVideo blueWinVideo = null!;
+        private TourneyVideo redWinVideo = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -51,7 +49,7 @@ namespace osu.Game.Tournament.Screens.TeamWin
             currentCompleted.BindValueChanged(_ => update());
         }
 
-        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected override void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             base.CurrentMatchChanged(match);
 
@@ -70,7 +68,7 @@ namespace osu.Game.Tournament.Screens.TeamWin
         {
             var match = CurrentMatch.Value;
 
-            if (match.Winner == null)
+            if (match?.Winner == null)
             {
                 mainContainer.Clear();
                 return;

--- a/osu.Game.Tournament/Screens/TournamentMatchScreen.cs
+++ b/osu.Game.Tournament/Screens/TournamentMatchScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Game.Tournament.Models;
 
@@ -10,8 +8,8 @@ namespace osu.Game.Tournament.Screens
 {
     public abstract partial class TournamentMatchScreen : TournamentScreen
     {
-        protected readonly Bindable<TournamentMatch> CurrentMatch = new Bindable<TournamentMatch>();
-        private WarningBox noMatchWarning;
+        protected readonly Bindable<TournamentMatch?> CurrentMatch = new Bindable<TournamentMatch?>();
+        private WarningBox? noMatchWarning;
 
         protected override void LoadComplete()
         {
@@ -21,7 +19,7 @@ namespace osu.Game.Tournament.Screens
             CurrentMatch.BindValueChanged(CurrentMatchChanged, true);
         }
 
-        protected virtual void CurrentMatchChanged(ValueChangedEvent<TournamentMatch> match)
+        protected virtual void CurrentMatchChanged(ValueChangedEvent<TournamentMatch?> match)
         {
             if (match.NewValue == null)
             {

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Drawing;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -35,12 +33,12 @@ namespace osu.Game.Tournament
         public static readonly Color4 ELEMENT_FOREGROUND_COLOUR = Color4Extensions.FromHex("#000");
 
         public static readonly Color4 TEXT_COLOUR = Color4Extensions.FromHex("#fff");
-        private Drawable heightWarning;
+        private Drawable heightWarning = null!;
 
-        private Bindable<WindowMode> windowMode;
+        private Bindable<WindowMode> windowMode = null!;
         private readonly BindableSize windowSize = new BindableSize();
 
-        private LoadingSpinner loadingSpinner;
+        private LoadingSpinner loadingSpinner = null!;
 
         [Cached(typeof(IDialogOverlay))]
         private readonly DialogOverlay dialogOverlay = new DialogOverlay();

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -1,14 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
@@ -31,11 +30,11 @@ namespace osu.Game.Tournament
     public partial class TournamentGameBase : OsuGameBase
     {
         public const string BRACKET_FILENAME = @"bracket.json";
-        private LadderInfo ladder;
-        private TournamentStorage storage;
-        private DependencyContainer dependencies;
-        private FileBasedIPC ipc;
-        private BeatmapLookupCache beatmapCache;
+        private LadderInfo ladder = null!;
+        private TournamentStorage storage = null!;
+        private DependencyContainer dependencies = null!;
+        private FileBasedIPC ipc = null!;
+        private BeatmapLookupCache beatmapCache = null!;
 
         protected Task BracketLoadTask => bracketLoadTaskCompletionSource.Task;
 
@@ -54,7 +53,7 @@ namespace osu.Game.Tournament
             return new ProductionEndpointConfiguration();
         }
 
-        private TournamentSpriteText initialisationText;
+        private TournamentSpriteText initialisationText = null!;
 
         [BackgroundDependencyLoader]
         private void load(Storage baseStorage)
@@ -78,6 +77,8 @@ namespace osu.Game.Tournament
             dependencies.CacheAs(new StableInfo(storage));
 
             beatmapCache = dependencies.Get<BeatmapLookupCache>();
+
+            ladder = new LadderInfo();
         }
 
         protected override void LoadComplete()
@@ -100,10 +101,10 @@ namespace osu.Game.Tournament
                 {
                     using (Stream stream = storage.GetStream(BRACKET_FILENAME, FileAccess.Read, FileMode.Open))
                     using (var sr = new StreamReader(stream))
-                        ladder = JsonConvert.DeserializeObject<LadderInfo>(await sr.ReadToEndAsync().ConfigureAwait(false), new JsonPointConverter());
+                    {
+                        ladder = JsonConvert.DeserializeObject<LadderInfo>(await sr.ReadToEndAsync().ConfigureAwait(false), new JsonPointConverter()) ?? ladder;
+                    }
                 }
-
-                ladder ??= new LadderInfo();
 
                 var resolvedRuleset = ladder.Ruleset.Value != null
                     ? RulesetStore.GetRuleset(ladder.Ruleset.Value.ShortName)
@@ -283,7 +284,7 @@ namespace osu.Game.Tournament
 
         private void updateLoadProgressMessage(string s) => Schedule(() => initialisationText.Text = s);
 
-        public void PopulatePlayer(TournamentUser user, Action success = null, Action failure = null, bool immediate = false)
+        public void PopulatePlayer(TournamentUser user, Action? success = null, Action? failure = null, bool immediate = false)
         {
             var req = new GetUserRequest(user.OnlineID, ladder.Ruleset.Value);
 
@@ -348,8 +349,8 @@ namespace osu.Game.Tournament
             foreach (var r in ladder.Rounds)
                 r.Matches = ladder.Matches.Where(p => p.Round.Value == r).Select(p => p.ID).ToList();
 
-            ladder.Progressions = ladder.Matches.Where(p => p.Progression.Value != null).Select(p => new TournamentProgression(p.ID, p.Progression.Value.ID)).Concat(
-                                            ladder.Matches.Where(p => p.LosersProgression.Value != null).Select(p => new TournamentProgression(p.ID, p.LosersProgression.Value.ID, true)))
+            ladder.Progressions = ladder.Matches.Where(p => p.Progression.Value != null).Select(p => new TournamentProgression(p.ID, p.Progression.Value.AsNonNull().ID)).Concat(
+                                            ladder.Matches.Where(p => p.LosersProgression.Value != null).Select(p => new TournamentProgression(p.ID, p.LosersProgression.Value.AsNonNull().ID, true)))
                                         .ToList();
 
             return JsonConvert.SerializeObject(ladder,

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tournament
     public partial class TournamentGameBase : OsuGameBase
     {
         public const string BRACKET_FILENAME = @"bracket.json";
-        private LadderInfo ladder = null!;
+        private LadderInfo ladder = new LadderInfo();
         private TournamentStorage storage = null!;
         private DependencyContainer dependencies = null!;
         private FileBasedIPC ipc = null!;
@@ -77,8 +77,6 @@ namespace osu.Game.Tournament
             dependencies.CacheAs(new StableInfo(storage));
 
             beatmapCache = dependencies.Get<BeatmapLookupCache>();
-
-            ladder = new LadderInfo();
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Tournament/TournamentSceneManager.cs
+++ b/osu.Game.Tournament/TournamentSceneManager.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -35,8 +33,8 @@ namespace osu.Game.Tournament
     [Cached]
     public partial class TournamentSceneManager : CompositeDrawable
     {
-        private Container screens;
-        private TourneyVideo video;
+        private Container screens = null!;
+        private TourneyVideo video = null!;
 
         public const int CONTROL_AREA_WIDTH = 200;
 
@@ -50,8 +48,8 @@ namespace osu.Game.Tournament
         [Cached]
         private TournamentMatchChatDisplay chat = new TournamentMatchChatDisplay();
 
-        private Container chatContainer;
-        private FillFlowContainer buttons;
+        private Container chatContainer = null!;
+        private FillFlowContainer buttons = null!;
 
         public TournamentSceneManager()
         {
@@ -166,10 +164,10 @@ namespace osu.Game.Tournament
 
         private float depth;
 
-        private Drawable currentScreen;
-        private ScheduledDelegate scheduledHide;
+        private Drawable? currentScreen;
+        private ScheduledDelegate? scheduledHide;
 
-        private Drawable temporaryScreen;
+        private Drawable? temporaryScreen;
 
         public void SetScreen(Drawable screen)
         {
@@ -284,7 +282,7 @@ namespace osu.Game.Tournament
                                 Y = -2,
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Text = shortcutKey.ToString(),
+                                Text = shortcutKey.Value.ToString(),
                             }
                         }
                     });
@@ -304,7 +302,7 @@ namespace osu.Game.Tournament
 
             private bool isSelected;
 
-            public Action<Type> RequestSelection;
+            public Action<Type>? RequestSelection;
 
             public bool IsSelected
             {


### PR DESCRIPTION
Most of the important thing should be in the model, which is how much content in bracket.json can be empty.

The following content is my own reasoning based on the code:
`Ruleset` and `CurrentMatch` in `LadderInfo` can be null.
`Beatmap` in `RoundBeatmap` can be null because https://github.com/ppy/osu/blob/master/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs#L251-L255
`Beatmap` in `SeedingBeatmap` can be null because https://github.com/ppy/osu/blob/master/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs#L246-L250
`Team1Acronym` and `Team2Acronym` in `TournamentMatch` can be null because https://github.com/ppy/osu/blob/master/osu.Game.Tournament/Models/TournamentMatch.cs#L29C10-L29C10

I'm not too sure about the test coverage, but so far I haven't encountered any bugs