### PR TITLE
Fix nullability inspection in `NowPlayingOverlay`

### DIFF
--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        private Bindable<bool> allowTrackControl;
+        private Bindable<bool> allowTrackControl = null!;
 
         public NowPlayingOverlay()
         {


### PR DESCRIPTION
Made it to master due to a force merge fail caused by an underlying "silent merge conflict" between https://github.com/ppy/osu/pull/24361 (added new field) and https://github.com/ppy/osu/pull/24418 (enabled NRT).