### PR TITLE
Fix multiplayer match screen being exited from when not current

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -265,7 +265,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave this multiplayer match?", () =>
                     {
                         exitConfirmed = true;
-                        this.Exit();
+                        if (this.IsCurrentScreen())
+                            this.Exit();
                     }));
                 }
 


### PR DESCRIPTION
This was supposed to be fixed by #24255, but [has popped up as a regression on Sentry since](https://sentry.ppy.sh/organizations/ppy/issues/22749/?project=2&referrer=regression_activity-email).

On a fifteen-minute check I cannot figure out how to reproduce, so rather than spending further brain cycles on this, just apply the same explicit guard that like [fifteen other places do](https://github.com/search?q=repo%3Appy%2Fosu%20%22if%20(this.IsCurrentScreen())%22&type=code).