### PR TITLE
Fix osu! logo suddenly disappearing during rapid exit

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -202,6 +203,9 @@ namespace osu.Game.Screens.Menu
                 dialogOverlay?.Push(new StorageErrorDialog(osuStorage, osuStorage.Error));
         }
 
+        [CanBeNull]
+        private Drawable proxiedLogo;
+
         protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
             base.LogoArriving(logo, resuming);
@@ -211,7 +215,7 @@ namespace osu.Game.Screens.Menu
             logo.FadeColour(Color4.White, 100, Easing.OutQuint);
             logo.FadeIn(100, Easing.OutQuint);
 
-            logo.ProxyToContainer(logoTarget);
+            proxiedLogo = logo.ProxyToContainer(logoTarget);
 
             if (resuming)
             {
@@ -250,10 +254,25 @@ namespace osu.Game.Screens.Menu
             var seq = logo.FadeOut(300, Easing.InSine)
                           .ScaleTo(0.2f, 300, Easing.InSine);
 
-            logo.ReturnProxy();
+            if (proxiedLogo != null)
+            {
+                logo.ReturnProxy();
+                proxiedLogo = null;
+            }
 
             seq.OnComplete(_ => Buttons.SetOsuLogo(null));
             seq.OnAbort(_ => Buttons.SetOsuLogo(null));
+        }
+
+        protected override void LogoExiting(OsuLogo logo)
+        {
+            base.LogoExiting(logo);
+
+            if (proxiedLogo != null)
+            {
+                logo.ReturnProxy();
+                proxiedLogo = null;
+            }
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)


### PR DESCRIPTION
master:

https://github.com/ppy/osu/assets/20418176/99260d9a-8560-48a5-81e9-ad5580a04cbe

this PR:

https://github.com/ppy/osu/assets/20418176/0ab48ad5-fd7c-4087-9158-db60a999cd3e

That particular part regressed in https://github.com/ppy/osu/pull/24208. tl;dr: `MainMenu` wasn't returning the proxy to game on exit. Note that reproduction requires that any screen under `MainMenu` is navigated to; exiting from `MainMenu` itself will look fine.

You might ask why this isn't a problem if you exit slowly, but only shows up when exiting quickly; I have no idea after several hours of staring at `ScreenStack`. I got about as far as determining that during a slow exit, main menu [will only be expired](https://github.com/ppy/osu-framework/blob/e40d447b168a7fefd29c416d037df374f32a2d3f/osu.Framework/Screens/ScreenStack.cs#L314-L318), but during a fast exit, it will be expired and _then_ [removed from hierarchy entirely](https://github.com/ppy/osu-framework/blob/e40d447b168a7fefd29c416d037df374f32a2d3f/osu.Framework/Screens/ScreenStack.cs#L380-L391). I don't know why.

I also don't know why [this rotation](https://github.com/ppy/osu/blob/a6343a669c84cf9d42f61be702bea9de47fd77be/osu.Game/Screens/Menu/IntroScreen.cs#L328) doesn't play out all of the time. The kiai fountain PR didn't break that so I'm cutting my losses there. There's probably something that should be fixed in `ScreenStack` or in the weird logo arriving-suspending-exiting management flow but I'm attempting to be pragmatic here. If reviewers think that this PR is too much of a shortcut, then this can be closed I guess. Help debugging these complex systems would certainly be appreciated because I give up right now.