### PR TITLE
Fix game crashing when entering skin editor in multiplayer spectator

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -356,7 +356,7 @@ namespace osu.Game.Overlays.SkinEditor
                     {
                         new SettingsDropdown<SkinComponentsContainerLookup?>
                         {
-                            Items = availableTargets.Select(t => t.Lookup),
+                            Items = availableTargets.Select(t => t.Lookup).Distinct(),
                             Current = selectedTarget,
                         }
                     }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23886. Cherry-picked from my upcoming multiplayer spectator changes since I noticed it had its own tracking issue.