### PR TITLE
Add instantaneous mode to `SliderWithTextBoxInput`

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneSliderWithTextBoxInput : OsuManualInputManagerTestScene
+    {
+        private SliderWithTextBoxInput<float> sliderWithTextBoxInput = null!;
+
+        private OsuSliderBar<float> slider => sliderWithTextBoxInput.ChildrenOfType<OsuSliderBar<float>>().Single();
+        private Nub nub => sliderWithTextBoxInput.ChildrenOfType<Nub>().Single();
+        private OsuTextBox textBox => sliderWithTextBoxInput.ChildrenOfType<OsuTextBox>().Single();
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create slider", () => Child = sliderWithTextBoxInput = new SliderWithTextBoxInput<float>("Test Slider")
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 0.5f,
+                Current = new BindableFloat
+                {
+                    MinValue = -5,
+                    MaxValue = 5,
+                    Precision = 0.2f
+                }
+            });
+        }
+
+        [Test]
+        public void TestNonInstantaneousMode()
+        {
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("change text", () => textBox.Text = "3");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.Zero);
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.Zero);
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("slider moved", () => slider.Current.Value, () => Is.EqualTo(3));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(nub));
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move mouse to minimum", () => InputManager.MoveMouseTo(sliderWithTextBoxInput.ScreenSpaceDrawQuad.BottomLeft));
+            AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("3"));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestNonInstantaneousMode()
         {
+            AddStep("set instantaneous to false", () => sliderWithTextBoxInput.Instantaneous = false);
+
             AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
             AddStep("change text", () => textBox.Text = "3");
             AddAssert("slider not moved", () => slider.Current.Value, () => Is.Zero);
@@ -63,6 +65,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestInstantaneousMode()
         {
+            AddStep("set instantaneous to true", () => sliderWithTextBoxInput.Instantaneous = true);
+
             AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
             AddStep("change text", () => textBox.Text = "3");
             AddAssert("slider moved", () => slider.Current.Value, () => Is.EqualTo(3));

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -59,5 +59,28 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
             AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
         }
+
+        [Test]
+        public void TestInstantaneousMode()
+        {
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("change text", () => textBox.Text = "3");
+            AddAssert("slider moved", () => slider.Current.Value, () => Is.EqualTo(3));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(3));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(nub));
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move mouse to minimum", () => InputManager.MoveMouseTo(sliderWithTextBoxInput.ScreenSpaceDrawQuad.BottomLeft));
+            AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -60,6 +60,26 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
             AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
             AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("set text to invalid", () => textBox.Text = "garbage");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("text restored", () => textBox.Text, () => Is.EqualTo("-5"));
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("set text to invalid", () => textBox.Text = "garbage");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("lose focus", () => InputManager.ChangeFocus(null));
+            AddAssert("text restored", () => textBox.Text, () => Is.EqualTo("-5"));
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
         }
 
         [Test]
@@ -84,6 +104,26 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
             AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("set text to invalid", () => textBox.Text = "garbage");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("text restored", () => textBox.Text, () => Is.EqualTo("-5"));
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("focus textbox", () => InputManager.ChangeFocus(textBox));
+            AddStep("set text to invalid", () => textBox.Text = "garbage");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("lose focus", () => InputManager.ChangeFocus(null));
+            AddAssert("text restored", () => textBox.Text, () => Is.EqualTo("-5"));
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
             AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
         }
     }

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -8,12 +8,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
 using osu.Game.Utils;
 using osuTK;
 
-namespace osu.Game.Screens.Edit.Timing
+namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class SliderWithTextBoxInput<T> : CompositeDrawable, IHasCurrentValue<T>
         where T : struct, IEquatable<T>, IComparable<T>, IConvertible

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -51,8 +51,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             textBox.OnCommit += (t, isNew) =>
             {
-                if (!isNew) return;
-
                 try
                 {
                     switch (slider.Current)


### PR DESCRIPTION
For use with https://github.com/ppy/osu/issues/12045. See tests for statement of desired behaviour.

Also includes moving the control out to a more general namespace. Combined with the rather hefty logic changes this diff looks like a reimplementation, which I apologise for, but it would have been rather messy anyways. Hence the testing, and per-commit reading may be more palatable.