### PR TITLE
Fix issues switching to new beatmap in multiplayer spectator

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -79,6 +79,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         [Test]
+        public void TestMultipleStartRequests()
+        {
+            int[] userIds = getPlayerIds(2);
+
+            start(userIds);
+            loadSpectateScreen();
+
+            sendFrames(userIds, 1000);
+            AddWaitStep("wait a bit", 20);
+
+            start(userIds);
+        }
+
+        [Test]
         public void TestDelayedStart()
         {
             AddStep("start players silently", () =>

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -371,9 +371,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void onLoadRequested()
         {
-            if (BeatmapAvailability.Value.State != DownloadState.LocallyAvailable)
-                return;
-
             // In the case of spectating, IMultiplayerClient.LoadRequested can be fired while the game is still spectating a previous session.
             // For now, we want to game to switch to the new game so need to request exiting from the play screen.
             if (!ParentScreen.IsCurrentScreen())
@@ -389,6 +386,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             // even when it is not truly ready (i.e. the beatmap hasn't been selected by the client yet). For the time being, a simple fix to this is to ignore the callback.
             // Note that spectator will be entered automatically when the client is capable of doing so via beatmap availability callbacks (see: updateBeatmapAvailability()).
             if (client.LocalUser?.State == MultiplayerUserState.Spectating && (SelectedItem.Value == null || Beatmap.IsDefault))
+                return;
+
+            if (BeatmapAvailability.Value.State != DownloadState.LocallyAvailable)
                 return;
 
             StartPlay();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorScreen.cs
@@ -214,7 +214,20 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         }
 
         protected override void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState)
-            => instances.Single(i => i.UserId == userId).LoadScore(spectatorGameplayState.Score);
+        {
+            var playerArea = instances.Single(i => i.UserId == userId);
+
+            // The multiplayer spectator flow requires the client to return to a higher level screen
+            // (ie. StartGameplay should only be called once per player).
+            //
+            // Meanwhile, the solo spectator flow supports multiple `StartGameplay` calls.
+            // To ensure we don't crash out in an edge case where this is called more than once in multiplayer,
+            // guard against re-entry for the same player.
+            if (playerArea.Score != null)
+                return;
+
+            playerArea.LoadScore(spectatorGameplayState.Score);
+        }
 
         protected override void QuitGameplay(int userId)
         {


### PR DESCRIPTION
Fixes two separate issues (one hard crash, one flow break).

See individual commit messages for further details.

I've tested the case without unit test coverage on production multiple times using the following steps:

- Spectate
- Wait for beatmap to finish but don't have the next beatmap downloaded
- Wait for next beatmap to be started by room

Game should return to lobby with the fix.