### PR TITLE
Fix centred player not animating correctly

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiSpectatorScreen.cs
@@ -67,6 +67,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         [TestCase(1)]
         [TestCase(4)]
+        [TestCase(9)]
         public void TestGeneral(int count)
         {
             int[] userIds = getPlayerIds(count);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/PlayerGrid_Cell.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 );
 
                 // If we don't track the animating state, the animation will also occur when resizing the window.
-                isAnimating &= !Precision.AlmostEquals(Position, targetPos, 0.01f);
+                isAnimating &= !Precision.AlmostEquals(Size, targetSize, 0.5f);
             }
 
             /// <summary>


### PR DESCRIPTION
In a layout where one screen is perfectly centred, the target position will not change. This would in turn bypass the animation completely. Oops.
