### PR TITLE
Fix storyboard being see-through in some contexts

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -125,13 +125,13 @@ namespace osu.Game.Tests.Visual.Background
             createFakeStoryboard();
             AddStep("Enable Storyboard", () =>
             {
-                player.ReplacesBackground.Value = true;
+                player.StoryboardReplacesBackground.Value = true;
                 player.StoryboardEnabled.Value = true;
             });
-            AddUntilStep("Background is invisible, storyboard is visible", () => songSelect.IsBackgroundInvisible() && player.IsStoryboardVisible);
+            AddUntilStep("Background is black, storyboard is visible", () => songSelect.IsBackgroundVisible() && songSelect.IsBackgroundBlack() && player.IsStoryboardVisible);
             AddStep("Disable Storyboard", () =>
             {
-                player.ReplacesBackground.Value = false;
+                player.StoryboardReplacesBackground.Value = false;
                 player.StoryboardEnabled.Value = false;
             });
             AddUntilStep("Background is visible, storyboard is invisible", () => songSelect.IsBackgroundVisible() && !player.IsStoryboardVisible);
@@ -173,7 +173,7 @@ namespace osu.Game.Tests.Visual.Background
             createFakeStoryboard();
             AddStep("Enable Storyboard", () =>
             {
-                player.ReplacesBackground.Value = true;
+                player.StoryboardReplacesBackground.Value = true;
                 player.StoryboardEnabled.Value = true;
             });
             AddStep("Enable user dim", () => player.DimmableStoryboard.IgnoreUserSettings.Value = false);
@@ -188,7 +188,7 @@ namespace osu.Game.Tests.Visual.Background
         {
             performFullSetup();
             createFakeStoryboard();
-            AddStep("Enable replacing background", () => player.ReplacesBackground.Value = true);
+            AddStep("Enable replacing background", () => player.StoryboardReplacesBackground.Value = true);
 
             AddUntilStep("Storyboard is invisible", () => !player.IsStoryboardVisible);
             AddUntilStep("Background is visible", () => songSelect.IsBackgroundVisible());
@@ -199,11 +199,11 @@ namespace osu.Game.Tests.Visual.Background
                 player.DimmableStoryboard.IgnoreUserSettings.Value = true;
             });
             AddUntilStep("Storyboard is visible", () => player.IsStoryboardVisible);
-            AddUntilStep("Background is invisible", () => songSelect.IsBackgroundInvisible());
+            AddUntilStep("Background is dimmed", () => songSelect.IsBackgroundVisible() && songSelect.IsBackgroundBlack());
 
-            AddStep("Disable background replacement", () => player.ReplacesBackground.Value = false);
+            AddStep("Disable background replacement", () => player.StoryboardReplacesBackground.Value = false);
             AddUntilStep("Storyboard is visible", () => player.IsStoryboardVisible);
-            AddUntilStep("Background is visible", () => songSelect.IsBackgroundVisible());
+            AddUntilStep("Background is visible", () => songSelect.IsBackgroundVisible() && !songSelect.IsBackgroundBlack());
         }
 
         /// <summary>
@@ -257,7 +257,7 @@ namespace osu.Game.Tests.Visual.Background
         private void createFakeStoryboard() => AddStep("Create storyboard", () =>
         {
             player.StoryboardEnabled.Value = false;
-            player.ReplacesBackground.Value = false;
+            player.StoryboardReplacesBackground.Value = false;
             player.DimmableStoryboard.Add(new OsuSpriteText
             {
                 Size = new Vector2(500, 50),
@@ -323,6 +323,8 @@ namespace osu.Game.Tests.Visual.Background
                 config.BindWith(OsuSetting.BlurLevel, BlurLevel);
             }
 
+            public bool IsBackgroundBlack() => background.CurrentColour == OsuColour.Gray(0);
+
             public bool IsBackgroundDimmed() => background.CurrentColour == OsuColour.Gray(1f - background.CurrentDim);
 
             public bool IsBackgroundUndimmed() => background.CurrentColour == Color4.White;
@@ -330,8 +332,6 @@ namespace osu.Game.Tests.Visual.Background
             public bool IsUserBlurApplied() => Precision.AlmostEquals(background.CurrentBlur, new Vector2((float)BlurLevel.Value * BackgroundScreenBeatmap.USER_BLUR_FACTOR), 0.1f);
 
             public bool IsUserBlurDisabled() => background.CurrentBlur == new Vector2(0);
-
-            public bool IsBackgroundInvisible() => background.CurrentAlpha == 0;
 
             public bool IsBackgroundVisible() => background.CurrentAlpha == 1;
 
@@ -367,7 +367,7 @@ namespace osu.Game.Tests.Visual.Background
             {
                 base.OnEntering(e);
 
-                ApplyToBackground(b => ReplacesBackground.BindTo(b.StoryboardReplacesBackground));
+                ApplyToBackground(b => StoryboardReplacesBackground.BindTo(b.StoryboardReplacesBackground));
             }
 
             public new DimmableStoryboard DimmableStoryboard => base.DimmableStoryboard;
@@ -376,7 +376,7 @@ namespace osu.Game.Tests.Visual.Background
             public bool BlockLoad;
 
             public Bindable<bool> StoryboardEnabled;
-            public readonly Bindable<bool> ReplacesBackground = new Bindable<bool>();
+            public readonly Bindable<bool> StoryboardReplacesBackground = new Bindable<bool>();
             public readonly Bindable<bool> IsPaused = new Bindable<bool>();
 
             public LoadBlockingTestPlayer(bool allowPause = true)

--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -24,8 +24,11 @@ namespace osu.Game.Graphics.Containers
         public const double BACKGROUND_FADE_DURATION = 800;
 
         /// <summary>
-        /// Whether or not user-configured settings relating to brightness of elements should be ignored
+        /// Whether or not user-configured settings relating to brightness of elements should be ignored.
         /// </summary>
+        /// <remarks>
+        /// For best or worst, this also bypasses storyboard disable. Not sure this is correct but leaving it as to not break anything.
+        /// </remarks>
         public readonly Bindable<bool> IgnoreUserSettings = new Bindable<bool>();
 
         /// <summary>
@@ -52,7 +55,7 @@ namespace osu.Game.Graphics.Containers
 
         private float breakLightening => LightenDuringBreaks.Value && IsBreakTime.Value ? BREAK_LIGHTEN_AMOUNT : 0;
 
-        protected float DimLevel => Math.Max(!IgnoreUserSettings.Value ? (float)UserDimLevel.Value - breakLightening : DimWhenUserSettingsIgnored.Value, 0);
+        protected virtual float DimLevel => Math.Max(!IgnoreUserSettings.Value ? (float)UserDimLevel.Value - breakLightening : DimWhenUserSettingsIgnored.Value, 0);
 
         protected override Container<Drawable> Content => dimContent;
 

--- a/osu.Game/Graphics/Containers/UserDimContainer.cs
+++ b/osu.Game/Graphics/Containers/UserDimContainer.cs
@@ -29,11 +29,6 @@ namespace osu.Game.Graphics.Containers
         public readonly Bindable<bool> IgnoreUserSettings = new Bindable<bool>();
 
         /// <summary>
-        /// Whether or not the storyboard loaded should completely hide the background behind it.
-        /// </summary>
-        public readonly Bindable<bool> StoryboardReplacesBackground = new Bindable<bool>();
-
-        /// <summary>
         /// Whether player is in break time.
         /// Must be bound to <see cref="BreakTracker.IsBreakTime"/> to allow for dim adjustments in gameplay.
         /// </summary>
@@ -83,7 +78,6 @@ namespace osu.Game.Graphics.Containers
             LightenDuringBreaks.ValueChanged += _ => UpdateVisuals();
             IsBreakTime.ValueChanged += _ => UpdateVisuals();
             ShowStoryboard.ValueChanged += _ => UpdateVisuals();
-            StoryboardReplacesBackground.ValueChanged += _ => UpdateVisuals();
             IgnoreUserSettings.ValueChanged += _ => UpdateVisuals();
         }
 

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Screens.Backgrounds
         /// </remarks>
         public readonly Bindable<bool> IgnoreUserSettings = new Bindable<bool>(true);
 
+        /// <summary>
+        /// Whether or not the storyboard loaded should completely hide the background behind it.
+        /// </summary>
         public readonly Bindable<bool> StoryboardReplacesBackground = new Bindable<bool>();
 
         /// <summary>
@@ -60,12 +63,11 @@ namespace osu.Game.Screens.Backgrounds
 
             InternalChild = dimmable = CreateFadeContainer();
 
+            dimmable.StoryboardReplacesBackground.BindTo(StoryboardReplacesBackground);
             dimmable.IgnoreUserSettings.BindTo(IgnoreUserSettings);
             dimmable.IsBreakTime.BindTo(IsBreakTime);
             dimmable.BlurAmount.BindTo(BlurAmount);
             dimmable.DimWhenUserSettingsIgnored.BindTo(DimWhenUserSettingsIgnored);
-
-            StoryboardReplacesBackground.BindTo(dimmable.StoryboardReplacesBackground);
         }
 
         [BackgroundDependencyLoader]
@@ -144,6 +146,8 @@ namespace osu.Game.Screens.Backgrounds
             /// </remarks>
             public readonly Bindable<float> BlurAmount = new BindableFloat();
 
+            public readonly Bindable<bool> StoryboardReplacesBackground = new Bindable<bool>();
+
             public Background Background
             {
                 get => background;
@@ -187,6 +191,7 @@ namespace osu.Game.Screens.Backgrounds
 
                 userBlurLevel.ValueChanged += _ => UpdateVisuals();
                 BlurAmount.ValueChanged += _ => UpdateVisuals();
+                StoryboardReplacesBackground.ValueChanged += _ => UpdateVisuals();
             }
 
             protected override bool ShowDimContent

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -194,9 +194,16 @@ namespace osu.Game.Screens.Backgrounds
                 StoryboardReplacesBackground.ValueChanged += _ => UpdateVisuals();
             }
 
-            protected override bool ShowDimContent
-                // The background needs to be hidden in the case of it being replaced by the storyboard
-                => (!ShowStoryboard.Value && !IgnoreUserSettings.Value) || !StoryboardReplacesBackground.Value;
+            protected override float DimLevel
+            {
+                get
+                {
+                    if ((IgnoreUserSettings.Value || ShowStoryboard.Value) && StoryboardReplacesBackground.Value)
+                        return 1;
+
+                    return base.DimLevel;
+                }
+            }
 
             protected override void UpdateVisuals()
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1049,8 +1049,6 @@ namespace osu.Game.Screens.Play
 
             DimmableStoryboard.IsBreakTime.BindTo(breakTracker.IsBreakTime);
 
-            DimmableStoryboard.StoryboardReplacesBackground.BindTo(storyboardReplacesBackground);
-
             storyboardReplacesBackground.Value = Beatmap.Value.Storyboard.ReplacesBackground && Beatmap.Value.Storyboard.HasDrawable;
 
             foreach (var mod in GameplayState.Mods.OfType<IApplicableToPlayer>())


### PR DESCRIPTION
Failing cases:

- Multiplayer spectator
- Anywhere, when screen scaling is applied and menu background is set to be visible

| Before | After |
| :---: | :---: |
| ![osu! 2023-08-02 at 06 51 22](https://github.com/ppy/osu/assets/191335/01967755-e3b4-4cdb-af5e-34fb56b2e10b) | ![osu! 2023-08-02 at 06 49 48](https://github.com/ppy/osu/assets/191335/586e88b7-e7a7-4419-af0b-03bc1293bf3b) |

I decided to implement this in the simplest way possible. Rendering a background texture might be slightly more expensive than a black box, but at least performance will be consistent across multiple display cases. Correctness comes before performance anyway, so I'm not even testing performance of this change for now.

Please review each commit individually. The first commit is a tidy-up which moves a bindable from being in a weird place and will be confusing if looking at the full PR diff at once.

---

- Closes https://github.com/ppy/osu/issues/24432
- Supersedes and closes https://github.com/ppy/osu/pull/22035