### PR TITLE
Fix global beatmap clock potentially getting into bad state

### DIFF
--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Beatmaps
         {
             base.Update();
 
-            if (Source != null && Source is not IAdjustableClock && Source.CurrentTime < decoupledClock.CurrentTime)
+            if (Source != null && Source is not IAdjustableClock && Source.CurrentTime < decoupledClock.CurrentTime - 100)
             {
                 // InterpolatingFramedClock won't interpolate backwards unless its source has an ElapsedFrameTime.
                 // See https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Timing/InterpolatingFramedClock.cs#L91-L93


### PR DESCRIPTION
This is likely responsible for offset drift some users have reported. As a result of this bug, interpolation of audio is being bypassed by per-frame seeks when things enter a bad state.

See https://github.com/ppy/osu/issues/24447 for a better look at what's happening. For me, on startup, the `Seek` call in this workaround is unexpectedly executing every frame, cancelling any interpolation by seeking the interpolated clock to the source clock's current time.

I'm fixing this in a jank way, but my intention is to drop everything and revisit clocks in general to put an end to this nonsense in the near future.

When testing this, the important thing to check is that the workaround `Seek` call should only ever be called once, and only when a rewind happens. Generally, this is when the global beatmap is changed and the new beatmap is at an earlier location than the previous, time-wise.

- Closes https://github.com/ppy/osu/issues/24447
- Closes (maybe) https://github.com/ppy/osu/issues/23992 (needs testing, because that could be a different issue)
- Addresses some of these: https://github.com/ppy/osu/discussions/23965, https://github.com/ppy/osu/discussions/14628, https://github.com/ppy/osu/discussions/15234
- Probably improves stuttering performance, especially on devices where audio reporting is not great (android maybe?)