### PR TITLE
Fix multiplayer spectator potentially taking too long to start

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 using osu.Game.Screens.Play;
 
@@ -59,6 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         public bool Seek(double position)
         {
+            Logger.Log($"{nameof(SpectatorPlayerClock)} seeked to {position}");
             CurrentTime = position;
             return true;
         }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Screens.Play
             // - Gameplay doesn't start when it should (until a timeout occurs because nothing is happening for 10+ seconds)
             //
             // In addition, we use `CurrentTime` for this seek instead of `StartTime` as the above seek may have applied inherent
-            // offsets which need to be accounted for (ie. FramedBeatmapClock.TotalApliedOffset).
+            // offsets which need to be accounted for (ie. FramedBeatmapClock.TotalAppliedOffset).
             //
             // See https://github.com/ppy/osu/pull/24451/files/87fee001c786b29db34063ef3350e9a9f024d3ab#diff-28ca02979641e2d98a15fe5d5e806f56acf60ac100258a059fa72503b6cc54e8.
             (SourceClock as IAdjustableClock)?.Seek(CurrentTime);

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -160,6 +160,13 @@ namespace osu.Game.Screens.Play
 
             Seek(StartTime);
 
+            // This is a workaround for the fact that DecoupleableInterpolatingFramedClock doesn't seek the source
+            // if the source is not IsRunning. (see https://github.com/ppy/osu-framework/blob/2102638056dfcf85d21b4d85266d53b5dd018767/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs#L209-L210)
+            //
+            // This breaks in multiplayer spectator.
+            // I hope to remove this once we knock some sense into clocks in general.
+            (SourceClock as IAdjustableClock)?.Seek(StartTime);
+
             if (!wasPaused || startClock)
                 Start();
         }

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -162,10 +162,18 @@ namespace osu.Game.Screens.Play
 
             // This is a workaround for the fact that DecoupleableInterpolatingFramedClock doesn't seek the source
             // if the source is not IsRunning. (see https://github.com/ppy/osu-framework/blob/2102638056dfcf85d21b4d85266d53b5dd018767/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs#L209-L210)
-            //
-            // This breaks in multiplayer spectator.
             // I hope to remove this once we knock some sense into clocks in general.
-            (SourceClock as IAdjustableClock)?.Seek(StartTime);
+            //
+            // Without this seek, the multiplayer spectator start sequence breaks:
+            // - Individual clients' clocks are never updated to their expected time
+            // - The sync manager thinks they are running behind
+            // - Gameplay doesn't start when it should (until a timeout occurs because nothing is happening for 10+ seconds)
+            //
+            // In addition, we use `CurrentTime` for this seek instead of `StartTime` as the above seek may have applied inherent
+            // offsets which need to be accounted for (ie. FramedBeatmapClock.TotalApliedOffset).
+            //
+            // See https://github.com/ppy/osu/pull/24451/files/87fee001c786b29db34063ef3350e9a9f024d3ab#diff-28ca02979641e2d98a15fe5d5e806f56acf60ac100258a059fa72503b6cc54e8.
+            (SourceClock as IAdjustableClock)?.Seek(CurrentTime);
 
             if (!wasPaused || startClock)
                 Start();


### PR DESCRIPTION
When watching from the middle of gameplay, due to a series of failures, `SpectatorClock` would not get seeked to the current time, causing all clients to look like they were out of sync.

This is a hotfix for the issue. A better fix will require framework changes or considerable restructuring.

I'd recommend testing this works in practice and agreeing that while it is a hack, it's likely not going to cause issues and is something we want to see fixed sooner rather than later.

Closes #22091.