### PR TITLE
Add B-Spline slider curve type

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -102,6 +102,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("Catmull Slider 1 Repeat", () => SetContents(_ => testCatmull(1)));
             AddStep("Catmull Slider 2 Repeats", () => SetContents(_ => testCatmull(2)));
 
+            AddStep("B-Spline Slider", () => SetContents(_ => testBSpline()));
+            AddStep("B-Spline Slider 1 Repeat", () => SetContents(_ => testBSpline(1)));
+            AddStep("B-Spline Slider 2 Repeats", () => SetContents(_ => testBSpline(2)));
+
             AddStep("Big Single, Large StackOffset", () => SetContents(_ => testSimpleBigLargeStackOffset()));
             AddStep("Big 1 Repeat, Large StackOffset", () => SetContents(_ => testSimpleBigLargeStackOffset(1)));
 
@@ -331,6 +335,8 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private Drawable testCatmull(int repeats = 0) => createCatmull(repeats);
 
+        private Drawable testBSpline(int repeats = 0) => createBSpline(repeats);
+
         private Drawable createCatmull(int repeats = 0)
         {
             var repeatSamples = new List<IList<HitSampleInfo>>();
@@ -353,6 +359,26 @@ namespace osu.Game.Rulesets.Osu.Tests
             };
 
             return createDrawable(slider, 3, 1);
+        }
+
+        private Drawable createBSpline(int repeats = 0)
+        {
+            var slider = new Slider
+            {
+                StartTime = Time.Current + time_offset,
+                Position = new Vector2(-max_length / 2, 0),
+                Path = new SliderPath(PathType.BSpline, new[]
+                {
+                    Vector2.Zero,
+                    new Vector2(max_length * 0.375f, max_length * 0.18f),
+                    new Vector2(max_length / 2, max_length / 4),
+                    new Vector2(max_length * 0.75f, -max_length / 2),
+                    new Vector2(max_length, 0)
+                }),
+                RepeatCount = repeats,
+            };
+
+            return createDrawable(slider, 2, 3);
         }
 
         private Drawable createDrawable(Slider slider, float circleSize, double speedMultiplier)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -270,6 +270,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 case PathType.PerfectCurve:
                     return colours.PurpleDark;
 
+                case PathType.BSpline:
+                    return colours.GreenLight;
+
                 default:
                     return colours.Red;
             }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -271,7 +271,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     return colours.PurpleDark;
 
                 case PathType.BSpline:
-                    return colours.GreenLight;
+                    return colours.BlueDarker;
 
                 default:
                     return colours.Red;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -371,6 +371,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 curveTypeItems.Add(createMenuItemForPathType(PathType.PerfectCurve));
                 curveTypeItems.Add(createMenuItemForPathType(PathType.Bezier));
                 curveTypeItems.Add(createMenuItemForPathType(PathType.Catmull));
+                curveTypeItems.Add(createMenuItemForPathType(PathType.BSpline));
 
                 var menuItems = new List<MenuItem>
                 {

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -403,7 +403,14 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             int totalCount = Pieces.Count(p => p.IsSelected.Value);
             int countOfState = Pieces.Where(p => p.IsSelected.Value).Count(p => p.ControlPoint.Type == type);
 
-            var item = new TernaryStateRadioMenuItem(type == null ? "Inherit" : type.ToString().Humanize(), MenuItemType.Standard, _ =>
+            string name = type switch
+            {
+                null => "Inherit",
+                PathType.BSpline => "B-Spline",
+                _ => type.ToString().Humanize()
+            };
+
+            var item = new TernaryStateRadioMenuItem(name, MenuItemType.Standard, _ =>
             {
                 foreach (var p in Pieces.Where(p => p.IsSelected.Value))
                     updatePathType(p, type);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBezierConverter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBezierConverter.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [TestCase(PathType.Bezier)]
         [TestCase(PathType.Catmull)]
         [TestCase(PathType.PerfectCurve)]
+        [TestCase(PathType.BSpline)]
         public void TestSingleSegment(PathType type)
             => AddStep("create path", () => path.ControlPoints.AddRange(createSegment(type, Vector2.Zero, new Vector2(0, 100), new Vector2(100))));
 
@@ -125,6 +126,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [TestCase(PathType.Bezier)]
         [TestCase(PathType.Catmull)]
         [TestCase(PathType.PerfectCurve)]
+        [TestCase(PathType.BSpline)]
         public void TestMultipleSegment(PathType type)
         {
             AddStep("create path", () =>

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBezierConverter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBezierConverter.cs
@@ -182,6 +182,27 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
+        [TestCase(PathType.Linear)]
+        [TestCase(PathType.Bezier)]
+        [TestCase(PathType.Catmull)]
+        [TestCase(PathType.PerfectCurve)]
+        [TestCase(PathType.BSpline)]
+        public void TestLongSegment(PathType type)
+        {
+            AddStep("create path", () =>
+            {
+                path.ControlPoints.AddRange(createSegment(type,
+                        Enumerable.Range(0, 10).Select(i =>
+                            new Vector2(
+                                (i >> 1) * 100,
+                                (i + 1) % 4 < 2 ? 0 : 100
+                            )
+                        ).ToArray()
+                    )
+                );
+            });
+        }
+
         private List<PathControlPoint> createSegment(PathType type, params Vector2[] controlPoints)
         {
             var points = controlPoints.Select(p => new PathControlPoint { Position = p }).ToList();

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -474,6 +474,10 @@ namespace osu.Game.Beatmaps.Formats
                             case PathType.Linear:
                                 writer.Write("L|");
                                 break;
+
+                            case PathType.BSpline:
+                                writer.Write("S|");
+                                break;
                         }
 
                         lastType = point.Type;

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -67,7 +67,12 @@ namespace osu.Game.Database
 
                 hitObject.StartTime = Math.Floor(hitObject.StartTime);
 
-                if (hitObject is not IHasPath hasPath || BezierConverter.CountSegments(hasPath.Path.ControlPoints) <= 1) continue;
+                if (hitObject is not IHasPath hasPath) continue;
+
+                int segmentCount = BezierConverter.CountSegments(hasPath.Path.ControlPoints);
+
+                if (segmentCount == 0 || (segmentCount == 1 && hasPath.Path.ControlPoints[0].Type != PathType.BSpline))
+                    continue;
 
                 var newControlPoints = BezierConverter.ConvertToModernBezier(hasPath.Path.ControlPoints);
 

--- a/osu.Game/Rulesets/Objects/BezierConverter.cs
+++ b/osu.Game/Rulesets/Objects/BezierConverter.cs
@@ -34,17 +34,9 @@ namespace osu.Game.Rulesets.Objects
             new CircleBezierPreset(3.1385246920140215,
                 new[] { new Vector2d(1, 0), new Vector2d(1, 0.87084764f), new Vector2d(0.002304826f, 1.5033062f), new Vector2d(-0.9973236f, 0.8739115f), new Vector2d(-0.9999953f, 0.0030679568f) }),
             new CircleBezierPreset(5.69720464620727,
-                new[]
-                {
-                    new Vector2d(1, 0), new Vector2d(1, 1.4137783f), new Vector2d(-1.4305235f, 2.0779421f), new Vector2d(-2.3410065f, -0.94017583f), new Vector2d(0.05132711f, -1.7309346f),
-                    new Vector2d(0.8331702f, -0.5530167f)
-                }),
+                new[] { new Vector2d(1, 0), new Vector2d(1, 1.4137783f), new Vector2d(-1.4305235f, 2.0779421f), new Vector2d(-2.3410065f, -0.94017583f), new Vector2d(0.05132711f, -1.7309346f), new Vector2d(0.8331702f, -0.5530167f) }),
             new CircleBezierPreset(2 * Math.PI,
-                new[]
-                {
-                    new Vector2d(1, 0), new Vector2d(1, 1.2447058f), new Vector2d(-0.8526471f, 2.118367f), new Vector2d(-2.6211002f, 7.854936e-06f), new Vector2d(-0.8526448f, -2.118357f),
-                    new Vector2d(1, -1.2447058f), new Vector2d(1, 0)
-                })
+                new[] { new Vector2d(1, 0), new Vector2d(1, 1.2447058f), new Vector2d(-0.8526471f, 2.118367f), new Vector2d(-2.6211002f, 7.854936e-06f), new Vector2d(-0.8526448f, -2.118357f), new Vector2d(1, -1.2447058f), new Vector2d(1, 0) })
         };
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -229,6 +229,9 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
                 case 'P':
                     return PathType.PerfectCurve;
+
+                case 'S':
+                    return PathType.BSpline;
             }
         }
 

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -282,7 +282,7 @@ namespace osu.Game.Rulesets.Objects
                     return PathApproximator.ApproximateCatmull(subControlPoints);
 
                 case PathType.BSpline:
-                    return PathApproximator.ApproximateBSpline(subControlPoints, 2);
+                    return PathApproximator.ApproximateBSpline(subControlPoints, 3);
             }
 
             return PathApproximator.ApproximateBezier(subControlPoints);

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -280,6 +280,9 @@ namespace osu.Game.Rulesets.Objects
 
                 case PathType.Catmull:
                     return PathApproximator.ApproximateCatmull(subControlPoints);
+
+                case PathType.BSpline:
+                    return PathApproximator.ApproximateBSpline(subControlPoints, 2);
             }
 
             return PathApproximator.ApproximateBezier(subControlPoints);

--- a/osu.Game/Rulesets/Objects/Types/PathType.cs
+++ b/osu.Game/Rulesets/Objects/Types/PathType.cs
@@ -8,6 +8,7 @@ namespace osu.Game.Rulesets.Objects.Types
         Catmull,
         Bezier,
         Linear,
-        PerfectCurve
+        PerfectCurve,
+        BSpline
     }
 }


### PR DESCRIPTION
## Summary

RFC. Added b-splines as a curve type for sliders.

## Changes made

- `SliderPath.cs`
  - Approximate b-spline curve segments
- `PathControlPiece.cs`
  - Added a custom color for displaying b-spline controlpoints in the editor
- `ControlPointVisualiser.cs`
  - Added a context menu entry to to change controlPoint type to b-spline
- `LegacyBeatmapEncoder.cs`
  - Add encoding for b-spline controlPoints
- `LegacyBeatmapExporter.cs`
  - When converting sliders to bezier, don't skip single-segment sliders if the path type is b-spline
- `BezierConverter.cs`
  - Add conversion logic to turn b-spline segments into bezier segments
- `ConvertHitObjectParser.cs`
  - Add b-spline path type to beatmap parsing
- `TestSceneSlider.cs`
  - Add test case for b-spline sliders
- `TestSceneBezierConverter.cs`
  - Add test cases for b-spline to bezier conversion

## Reasoning

B-spline curves combine some of the benefits of both bezier & catmull sliders. They follow the control points more strictly, similar to catmull sliders, while maintaining the aesthetics of bezier sliders. Since they follow the control points more closely, they are easier to work with for new mappers, compared to bezier sliders, where the generated curve can vary widely from the actual control points.

## Examples

![image](https://github.com/ppy/osu/assets/8039761/19528e99-0bf6-4789-aca9-270cd67e1a58)
![image](https://github.com/ppy/osu/assets/8039761/e8910652-721d-4967-9bb2-4f1dd6a530a6)
![image](https://github.com/ppy/osu/assets/8039761/66e410f0-cefe-477f-9710-af62445c8dd7)

Thanks to @OliBomby for helping me with this
