### PR TITLE
Always notify `EditorBeatmap` for editor change handling

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 
             AddMouseMoveStep(-100, 100);
             addVertexCheckStep(3, 1, times[0], positions[0]);
+            addDragEndStep();
         }
 
         [Test]
@@ -100,6 +101,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddMouseMoveStep(times[2] - 50, positions[2] - 50);
             addVertexCheckStep(4, 1, times[1] - 50, positions[1] - 50);
             addVertexCheckStep(4, 2, times[2] - 50, positions[2] - 50);
+            addDragEndStep();
         }
 
         [Test]
@@ -113,6 +115,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             addDragStartStep(times[1], positions[1]);
             AddMouseMoveStep(times[1], 400);
             AddAssert("slider velocity changed", () => !hitObject.SliderVelocityBindable.IsDefault);
+            addDragEndStep();
         }
 
         [Test]
@@ -129,6 +132,8 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddStep("scroll playfield", () => manualClock.CurrentTime += 200);
             AddMouseMoveStep(times[1] + 200, positions[1] + 100);
             addVertexCheckStep(2, 1, times[1] + 200, positions[1] + 100);
+
+            addDragEndStep();
         }
 
         [Test]

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
         private Vector2 dragStartPosition;
 
         [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
+        private EditorBeatmap? editorBeatmap { get; set; }
 
         public SelectionEditablePath(Func<float, double> positionToTime)
             : base(positionToTime)
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             for (int i = 0; i < VertexCount; i++)
                 VertexStates[i].VertexBeforeChange = Vertices[i];
 
-            changeHandler?.BeginChange();
+            editorBeatmap?.BeginChange();
             return true;
         }
 
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         protected override void OnDragEnd(DragEndEvent e)
         {
-            changeHandler?.EndChange();
+            editorBeatmap?.EndChange();
         }
 
         private int getMouseTargetVertex(Vector2 screenSpacePosition)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -49,6 +49,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         [Resolved(CanBeNull = true)]
         private IDistanceSnapProvider snapProvider { get; set; }
 
+        [Resolved(CanBeNull = true)]
+        private EditorBeatmap editorBeatmap { get; set; }
+
         public PathControlPointVisualiser(T hitObject, bool allowSelection)
         {
             this.hitObject = hitObject;
@@ -95,9 +98,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (toRemove.Count == 0)
                 return false;
 
-            changeHandler?.BeginChange();
+            editorBeatmap?.BeginChange();
             RemoveControlPointsRequested?.Invoke(toRemove);
-            changeHandler?.EndChange();
+            editorBeatmap?.EndChange();
 
             // Since pieces are re-used, they will not point to the deleted control points while remaining selected
             foreach (var piece in Pieces)
@@ -114,9 +117,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             if (controlPointsToSplitAt.Count == 0)
                 return false;
 
-            changeHandler?.BeginChange();
+            editorBeatmap?.BeginChange();
             SplitControlPointsRequested?.Invoke(controlPointsToSplitAt);
-            changeHandler?.EndChange();
+            editorBeatmap?.EndChange();
 
             // Since pieces are re-used, they will not point to the deleted control points while remaining selected
             foreach (var piece in Pieces)
@@ -257,9 +260,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             piece.ControlPoint.Type = type;
         }
 
-        [Resolved(CanBeNull = true)]
-        private IEditorChangeHandler changeHandler { get; set; }
-
         #region Drag handling
 
         private Vector2[] dragStartPositions;
@@ -276,7 +276,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             Debug.Assert(draggedControlPointIndex >= 0);
 
-            changeHandler?.BeginChange();
+            editorBeatmap?.BeginChange();
         }
 
         private void dragInProgress(DragEvent e)
@@ -341,7 +341,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 hitObject.Path.ControlPoints[i].Type = dragPathTypes[i];
         }
 
-        private void dragEnded() => changeHandler?.EndChange();
+        private void dragEnded() => editorBeatmap?.EndChange();
 
         #endregion
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -49,9 +49,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private EditorBeatmap editorBeatmap { get; set; }
 
         [Resolved(CanBeNull = true)]
-        private IEditorChangeHandler changeHandler { get; set; }
-
-        [Resolved(CanBeNull = true)]
         private BindableBeatDivisor beatDivisor { get; set; }
 
         public override Quad SelectionQuad => BodyPiece.ScreenSpaceDrawQuad;
@@ -173,7 +170,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 case MouseButton.Left:
                     if (e.ControlPressed && IsSelected)
                     {
-                        changeHandler?.BeginChange();
+                        editorBeatmap?.BeginChange();
                         placementControlPoint = addControlPoint(e.MousePosition);
                         ControlPointVisualiser?.SetSelectionTo(placementControlPoint);
                         return true; // Stop input from being handled and modifying the selection
@@ -204,7 +201,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (placementControlPoint != null)
             {
                 placementControlPoint = null;
-                changeHandler?.EndChange();
+                editorBeatmap?.EndChange();
             }
         }
 
@@ -354,7 +351,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             var timingPoint = editorBeatmap.ControlPointInfo.TimingPointAt(HitObject.StartTime);
             double streamSpacing = timingPoint.BeatLength / beatDivisor.Value;
 
-            changeHandler?.BeginChange();
+            editorBeatmap.BeginChange();
 
             int i = 0;
             double time = HitObject.StartTime;
@@ -385,7 +382,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             editorBeatmap.Remove(HitObject);
 
-            changeHandler?.EndChange();
+            editorBeatmap.EndChange();
         }
 
         public override MenuItem[] ContextMenuItems => new MenuItem[]

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -323,6 +323,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 HitObject.StartTime += split_gap;
 
                 editorBeatmap.Add(newSlider);
+                editorBeatmap.ForceUpdateState();
 
                 HitObject.NewCombo = false;
                 HitObject.Path.ExpectedDistance.Value -= newSlider.Path.CalculatedDistance;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -340,6 +340,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             foreach (var c in controlPoints)
                 c.Position -= first;
             HitObject.Position += first;
+
+            editorBeatmap.Update(HitObject);
         }
 
         private void convertToStream()

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -320,20 +320,18 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 };
 
                 // Increase the start time of the slider before adding the new slider so the new slider is immediately inserted at the correct index and internal state remains valid.
-                HitObject.StartTime += split_gap;
-
-                editorBeatmap.Add(newSlider);
-                editorBeatmap.ForceUpdateState();
-
+                // We can't use newSlider.SpanDuration because it will only be calculated after EditorBeatmap updated the slider.
+                HitObject.StartTime += newSlider.Path.Distance / HitObject.Path.Distance * HitObject.Duration + split_gap;
+                HitObject.Path.ExpectedDistance.Value -= newSlider.Path.Distance;
                 HitObject.NewCombo = false;
-                HitObject.Path.ExpectedDistance.Value -= newSlider.Path.CalculatedDistance;
-                HitObject.StartTime += newSlider.SpanDuration;
 
                 // In case the remainder of the slider has no length left over, give it length anyways so we don't get a 0 length slider.
                 if (HitObject.Path.ExpectedDistance.Value <= Precision.DOUBLE_EPSILON)
                 {
                     HitObject.Path.ExpectedDistance.Value = null;
                 }
+
+                editorBeatmap.Add(newSlider);
             }
 
             // Once all required pieces have been split off, the original slider has the final split.

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Rulesets.Osu.Edit
             SelectionBox.CanReverse = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
         }
 
-        protected override void OnOperationEnded()
+        protected override void EndChange()
         {
-            base.OnOperationEnded();
+            base.EndChange();
             referencePathTypes = null;
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
@@ -19,14 +19,14 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public partial class OsuSelectionRotationHandler : SelectionRotationHandler
     {
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
+        private EditorBeatmap editorBeatmap = null!;
 
         private BindableList<HitObject> selectedItems { get; } = new BindableList<HitObject>();
 
         [BackgroundDependencyLoader]
         private void load(EditorBeatmap editorBeatmap)
         {
+            this.editorBeatmap = editorBeatmap;
             selectedItems.BindTo(editorBeatmap.SelectedHitObjects);
         }
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (objectsInRotation != null)
                 throw new InvalidOperationException($"Cannot {nameof(Begin)} a rotate operation while another is in progress!");
 
-            changeHandler?.BeginChange();
+            editorBeatmap.BeginChange();
 
             objectsInRotation = selectedMovableObjects.ToArray();
             defaultOrigin = GeometryUtils.GetSurroundingQuad(objectsInRotation).Centre;
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (objectsInRotation == null)
                 throw new InvalidOperationException($"Cannot {nameof(Commit)} a rotate operation without calling {nameof(Begin)} first!");
 
-            changeHandler?.EndChange();
+            editorBeatmap.EndChange();
 
             objectsInRotation = null;
             originalPositions = null;

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
@@ -93,6 +93,12 @@ namespace osu.Game.Rulesets.Osu.Edit
             if (objectsInRotation == null)
                 throw new InvalidOperationException($"Cannot {nameof(Commit)} a rotate operation without calling {nameof(Begin)} first!");
 
+            // EditorSelectionHandler.EndChange() is not called in the rotation operation, so we need to call it here.
+            foreach (var hitObject in objectsInRotation)
+            {
+                editorBeatmap.Update(hitObject);
+            }
+
             editorBeatmap.EndChange();
 
             objectsInRotation = null;

--- a/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprintContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Skinning;
 using osuTK;
@@ -25,6 +26,9 @@ namespace osu.Game.Overlays.SkinEditor
         [Resolved]
         private SkinEditor editor { get; set; } = null!;
 
+        [Resolved(CanBeNull = true)]
+        private IEditorChangeHandler? changeHandler { get; set; }
+
         public SkinBlueprintContainer(ISerialisableDrawableContainer targetContainer)
         {
             this.targetContainer = targetContainer;
@@ -40,6 +44,16 @@ namespace osu.Game.Overlays.SkinEditor
             bindableList.BindCollectionChanged(componentsChanged, true);
 
             targetComponents.Add(bindableList);
+        }
+
+        protected override void BeginChange()
+        {
+            changeHandler?.BeginChange();
+        }
+
+        protected override void EndChange()
+        {
+            changeHandler?.EndChange();
         }
 
         private void componentsChanged(object? sender, NotifyCollectionChangedEventArgs e) => Schedule(() =>

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -229,7 +229,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void applyOrigins(Anchor origin)
         {
-            OnOperationBegan();
+            BeginChange();
 
             foreach (var item in SelectedItems)
             {
@@ -246,7 +246,7 @@ namespace osu.Game.Overlays.SkinEditor
                 ApplyClosestAnchor(drawable);
             }
 
-            OnOperationEnded();
+            EndChange();
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void applyFixedAnchors(Anchor anchor)
         {
-            OnOperationBegan();
+            BeginChange();
 
             foreach (var item in SelectedItems)
             {
@@ -268,12 +268,12 @@ namespace osu.Game.Overlays.SkinEditor
                 applyAnchor(drawable, anchor);
             }
 
-            OnOperationEnded();
+            EndChange();
         }
 
         private void applyClosestAnchors()
         {
-            OnOperationBegan();
+            BeginChange();
 
             foreach (var item in SelectedItems)
             {
@@ -281,7 +281,7 @@ namespace osu.Game.Overlays.SkinEditor
                 ApplyClosestAnchor((Drawable)item);
             }
 
-            OnOperationEnded();
+            EndChange();
         }
 
         private static Anchor getClosestAnchor(Drawable drawable)

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -13,6 +13,7 @@ using osu.Framework.Utils;
 using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Skinning;
@@ -25,6 +26,19 @@ namespace osu.Game.Overlays.SkinEditor
     {
         [Resolved]
         private SkinEditor skinEditor { get; set; } = null!;
+
+        [Resolved(CanBeNull = true)]
+        private IEditorChangeHandler? changeHandler { get; set; }
+
+        protected override void BeginChange()
+        {
+            changeHandler?.BeginChange();
+        }
+
+        protected override void EndChange()
+        {
+            changeHandler?.EndChange();
+        }
 
         public override SelectionRotationHandler CreateRotationHandler() => new SkinSelectionRotationHandler
         {

--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Edit
         private readonly DrawableRuleset<TObject> drawableRuleset;
 
         [Resolved]
-        private EditorBeatmap beatmap { get; set; } = null!;
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
 
         public DrawableEditorRulesetWrapper(DrawableRuleset<TObject> drawableRuleset)
         {
@@ -42,24 +42,21 @@ namespace osu.Game.Rulesets.Edit
             Playfield.DisplayJudgements.Value = false;
         }
 
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            beatmap.HitObjectAdded += addHitObject;
-            beatmap.HitObjectRemoved += removeHitObject;
+            editorBeatmap.HitObjectAdded += addHitObject;
+            editorBeatmap.HitObjectRemoved += removeHitObject;
 
-            if (changeHandler != null)
+            if (editorBeatmap.CanSave)
             {
                 // for now only regenerate replay on a finalised state change, not HitObjectUpdated.
-                changeHandler.OnStateChange += () => Scheduler.AddOnce(regenerateAutoplay);
+                editorBeatmap.OnStateChange += () => Scheduler.AddOnce(regenerateAutoplay);
             }
             else
             {
-                beatmap.HitObjectUpdated += _ => Scheduler.AddOnce(regenerateAutoplay);
+                editorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(regenerateAutoplay);
             }
 
             Scheduler.AddOnce(regenerateAutoplay);
@@ -93,10 +90,10 @@ namespace osu.Game.Rulesets.Edit
         {
             base.Dispose(isDisposing);
 
-            if (beatmap.IsNotNull())
+            if (editorBeatmap.IsNotNull())
             {
-                beatmap.HitObjectAdded -= addHitObject;
-                beatmap.HitObjectRemoved -= removeHitObject;
+                editorBeatmap.HitObjectAdded -= addHitObject;
+                editorBeatmap.HitObjectRemoved -= removeHitObject;
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -95,6 +95,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             });
         }
 
+        protected virtual void BeginChange()
+        {
+            changeHandler?.BeginChange();
+        }
+
+        protected virtual void EndChange()
+        {
+            changeHandler?.EndChange();
+        }
+
         protected virtual Container<SelectionBlueprint<T>> CreateSelectionBlueprintContainer() => new Container<SelectionBlueprint<T>> { RelativeSizeAxes = Axes.Both };
 
         /// <summary>
@@ -190,7 +200,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (movementBlueprints != null)
             {
                 isDraggingBlueprint = true;
-                changeHandler?.BeginChange();
+                BeginChange();
                 return true;
             }
 
@@ -213,7 +223,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (isDraggingBlueprint)
             {
                 DragOperationCompleted();
-                changeHandler?.EndChange();
+                EndChange();
             }
 
             DragBox.Hide();

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -41,9 +41,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [Resolved(canBeNull: true)]
         private IPositionSnapProvider snapProvider { get; set; }
 
-        [Resolved(CanBeNull = true)]
-        private IEditorChangeHandler changeHandler { get; set; }
-
         protected readonly BindableList<T> SelectedItems = new BindableList<T>();
 
         protected BlueprintContainer()
@@ -95,15 +92,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
             });
         }
 
-        protected virtual void BeginChange()
-        {
-            changeHandler?.BeginChange();
-        }
+        protected virtual void BeginChange() { }
 
-        protected virtual void EndChange()
-        {
-            changeHandler?.EndChange();
-        }
+        protected virtual void EndChange() { }
 
         protected virtual Container<SelectionBlueprint<T>> CreateSelectionBlueprintContainer() => new Container<SelectionBlueprint<T>> { RelativeSizeAxes = Axes.Both };
 

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.LoadComplete();
 
-            Beatmap.HitObjectAdded += hitObjectAdded;
+            EditorBeatmap.HitObjectAdded += hitObjectAdded;
 
             // updates to selected are handled for us by SelectionHandler.
             NewCombo.BindTo(SelectionHandler.SelectionNewComboState);
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (nudgeMovementActive && !e.ControlPressed)
             {
-                Beatmap.EndChange();
+                EditorBeatmap.EndChange();
                 nudgeMovementActive = false;
             }
         }
@@ -144,7 +144,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (!nudgeMovementActive)
             {
                 nudgeMovementActive = true;
-                Beatmap.BeginChange();
+                EditorBeatmap.BeginChange();
             }
 
             var firstBlueprint = SelectionHandler.SelectedBlueprints.FirstOrDefault();
@@ -294,7 +294,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             var snapResult = Composer.FindSnappedPositionAndTime(InputManager.CurrentState.Mouse.Position);
 
             // if no time was found from positional snapping, we should still quantize to the beat.
-            snapResult.Time ??= Beatmap.SnapTime(EditorClock.CurrentTime, null);
+            snapResult.Time ??= EditorBeatmap.SnapTime(EditorClock.CurrentTime, null);
 
             CurrentPlacement.UpdateTimeAndPosition(snapResult);
         }
@@ -346,7 +346,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             refreshTool();
 
             // on successful placement, the new combo button should be reset as this is the most common user interaction.
-            if (Beatmap.SelectedHitObjects.Count == 0)
+            if (EditorBeatmap.SelectedHitObjects.Count == 0)
                 NewCombo.Value = TernaryState.False;
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected EditorClock EditorClock { get; private set; }
 
         [Resolved]
-        protected EditorBeatmap Beatmap { get; private set; }
+        protected EditorBeatmap EditorBeatmap { get; private set; }
 
         protected readonly HitObjectComposer Composer;
 
@@ -39,7 +39,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            SelectedItems.BindTo(Beatmap.SelectedHitObjects);
+            SelectedItems.BindTo(EditorBeatmap.SelectedHitObjects);
         }
 
         protected override void LoadComplete()
@@ -48,8 +48,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             InputManager = GetContainingInputManager();
 
-            Beatmap.HitObjectAdded += AddBlueprintFor;
-            Beatmap.HitObjectRemoved += RemoveBlueprintFor;
+            EditorBeatmap.HitObjectAdded += AddBlueprintFor;
+            EditorBeatmap.HitObjectRemoved += RemoveBlueprintFor;
 
             if (Composer != null)
             {
@@ -61,6 +61,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 usageEventBuffer.HitObjectUsageFinished += RemoveBlueprintFor;
                 usageEventBuffer.HitObjectUsageTransferred += TransferBlueprintFor;
             }
+        }
+
+        protected override void BeginChange()
+        {
+            // If the editor beatmap has a change handler then this will automatically call BeginChange() on it.
+            EditorBeatmap.BeginChange();
+        }
+
+        protected override void EndChange()
+        {
+            // If the editor beatmap has a change handler then this will automatically call EndChange() on it.
+            EditorBeatmap.EndChange();
         }
 
         protected override void Update()
@@ -84,10 +96,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 if (offset != 0)
                 {
-                    Beatmap.PerformOnSelection(obj =>
+                    EditorBeatmap.PerformOnSelection(obj =>
                     {
                         obj.StartTime += offset;
-                        Beatmap.Update(obj);
+                        EditorBeatmap.Update(obj);
                     });
                 }
             }
@@ -118,7 +130,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             // handle positional change etc.
             foreach (var blueprint in SelectionBlueprints)
-                Beatmap.Update(blueprint.Item);
+                EditorBeatmap.Update(blueprint.Item);
         }
 
         protected override bool OnDoubleClick(DoubleClickEvent e)
@@ -141,7 +153,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override void SelectAll()
         {
             Composer.Playfield.KeepAllAlive();
-            SelectedItems.AddRange(Beatmap.HitObjects.Except(SelectedItems).ToArray());
+            SelectedItems.AddRange(EditorBeatmap.HitObjects.Except(SelectedItems).ToArray());
         }
 
         protected override void OnBlueprintSelected(SelectionBlueprint<HitObject> blueprint)
@@ -162,10 +174,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.Dispose(isDisposing);
 
-            if (Beatmap != null)
+            if (EditorBeatmap != null)
             {
-                Beatmap.HitObjectAdded -= AddBlueprintFor;
-                Beatmap.HitObjectRemoved -= RemoveBlueprintFor;
+                EditorBeatmap.HitObjectAdded -= AddBlueprintFor;
+                EditorBeatmap.HitObjectRemoved -= RemoveBlueprintFor;
             }
 
             usageEventBuffer?.Dispose();

--- a/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs
@@ -65,13 +65,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void BeginChange()
         {
-            // If the editor beatmap has a change handler then this will automatically call BeginChange() on it.
             EditorBeatmap.BeginChange();
         }
 
         protected override void EndChange()
         {
-            // If the editor beatmap has a change handler then this will automatically call EndChange() on it.
             EditorBeatmap.EndChange();
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -39,6 +39,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
             SelectedItems.CollectionChanged += (_, _) => Scheduler.AddOnce(UpdateTernaryStates);
         }
 
+        protected override void BeginChange()
+        {
+            // If the editor beatmap has a change handler then this will automatically call BeginChange() on it.
+            EditorBeatmap.BeginChange();
+        }
+
+        protected override void EndChange()
+        {
+            // If the editor beatmap has a change handler then this will automatically call EndChange() on it.
+            EditorBeatmap.EndChange();
+        }
+
         protected override void DeleteItems(IEnumerable<HitObject> items) => EditorBeatmap.RemoveRange(items);
 
         #region Selection State

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -41,7 +41,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void BeginChange()
         {
-            // If the editor beatmap has a change handler then this will automatically call BeginChange() on it.
             EditorBeatmap.BeginChange();
         }
 
@@ -52,7 +51,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 EditorBeatmap.Update(hitObject);
             }
 
-            // If the editor beatmap has a change handler then this will automatically call EndChange() on it.
             EditorBeatmap.EndChange();
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -47,6 +47,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void EndChange()
         {
+            foreach (var hitObject in SelectedItems)
+            {
+                EditorBeatmap.Update(hitObject);
+            }
+
             // If the editor beatmap has a change handler then this will automatically call EndChange() on it.
             EditorBeatmap.EndChange();
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -30,7 +30,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public Func<Direction, bool, bool>? OnFlip;
         public Func<bool>? OnReverse;
 
+        /// <summary>
+        /// Fired when a drag operation begins from the selection box.
+        /// </summary>
         public Action? OperationStarted;
+
+        /// <summary>
+        /// Fired when a drag operation ends from the selection box.
+        /// </summary>
         public Action? OperationEnded;
 
         private SelectionBoxButton? reverseButton;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -90,26 +90,20 @@ namespace osu.Game.Screens.Edit.Compose.Components
         public SelectionBox CreateSelectionBox()
             => new SelectionBox
             {
-                OperationStarted = OnOperationBegan,
-                OperationEnded = OnOperationEnded,
+                OperationStarted = BeginChange,
+                OperationEnded = EndChange,
 
                 OnScale = HandleScale,
                 OnFlip = HandleFlip,
                 OnReverse = HandleReverse,
             };
 
-        /// <summary>
-        /// Fired when a drag operation ends from the selection box.
-        /// </summary>
-        protected virtual void OnOperationBegan()
+        protected virtual void BeginChange()
         {
             ChangeHandler?.BeginChange();
         }
 
-        /// <summary>
-        /// Fired when a drag operation begins from the selection box.
-        /// </summary>
-        protected virtual void OnOperationEnded()
+        protected virtual void EndChange()
         {
             ChangeHandler?.EndChange();
         }
@@ -181,16 +175,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (e.Action)
             {
                 case GlobalAction.EditorFlipHorizontally:
-                    ChangeHandler?.BeginChange();
+                    BeginChange();
                     handled = HandleFlip(Direction.Horizontal, true);
-                    ChangeHandler?.EndChange();
+                    EndChange();
 
                     return handled;
 
                 case GlobalAction.EditorFlipVertically:
-                    ChangeHandler?.BeginChange();
+                    BeginChange();
                     handled = HandleFlip(Direction.Vertical, true);
-                    ChangeHandler?.EndChange();
+                    EndChange();
 
                     return handled;
             }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -51,10 +51,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private readonly List<SelectionBlueprint<T>> selectedBlueprints;
 
         protected SelectionBox SelectionBox { get; private set; }
-
-        [Resolved(CanBeNull = true)]
-        protected IEditorChangeHandler ChangeHandler { get; private set; }
-
         protected SelectionRotationHandler RotationHandler { get; private set; }
 
         protected SelectionHandler()
@@ -98,15 +94,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 OnReverse = HandleReverse,
             };
 
-        protected virtual void BeginChange()
-        {
-            ChangeHandler?.BeginChange();
-        }
+        protected virtual void BeginChange() { }
 
-        protected virtual void EndChange()
-        {
-            ChangeHandler?.EndChange();
-        }
+        protected virtual void EndChange() { }
 
         #region User Input Handling
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             private IndeterminateSliderWithTextBoxInput<double> sliderVelocitySlider;
 
             [Resolved(canBeNull: true)]
-            private EditorBeatmap beatmap { get; set; }
+            private EditorBeatmap editorBeatmap { get; set; }
 
             public DifficultyEditPopover(HitObject hitObject)
             {
@@ -103,7 +103,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
-                var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).Where(o => o is IHasSliderVelocity).ToArray();
+                var relevantObjects = (editorBeatmap.SelectedHitObjects.Contains(hitObject) ? editorBeatmap.SelectedHitObjects : hitObject.Yield()).Where(o => o is IHasSliderVelocity).ToArray();
 
                 // even if there are multiple objects selected, we can still display a value if they all have the same value.
                 var selectedPointBindable = relevantObjects.Select(point => ((IHasSliderVelocity)point).SliderVelocity).Distinct().Count() == 1
@@ -123,15 +123,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     if (val.NewValue == null)
                         return;
 
-                    beatmap.BeginChange();
+                    editorBeatmap.BeginChange();
 
                     foreach (var h in relevantObjects)
                     {
                         ((IHasSliderVelocity)h).SliderVelocity = val.NewValue.Value;
-                        beatmap.Update(h);
+                        editorBeatmap.Update(h);
                     }
 
-                    beatmap.EndChange();
+                    editorBeatmap.EndChange();
                 });
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             private IndeterminateSliderWithTextBoxInput<int> volume = null!;
 
             [Resolved(canBeNull: true)]
-            private EditorBeatmap beatmap { get; set; } = null!;
+            private EditorBeatmap editorBeatmap { get; set; } = null!;
 
             public SampleEditPopover(HitObject hitObject)
             {
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 // if the piece belongs to a currently selected object, assume that the user wants to change all selected objects.
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
-                var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).ToArray();
+                var relevantObjects = (editorBeatmap.SelectedHitObjects.Contains(hitObject) ? editorBeatmap.SelectedHitObjects : hitObject.Yield()).ToArray();
                 var relevantSamples = relevantObjects.Select(h => h.Samples).ToArray();
 
                 // even if there are multiple objects selected, we can still display sample volume or bank if they all have the same value.
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 if (string.IsNullOrEmpty(newBank))
                     return;
 
-                beatmap.BeginChange();
+                editorBeatmap.BeginChange();
 
                 foreach (var h in objects)
                 {
@@ -161,10 +161,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         h.Samples[i] = h.Samples[i].With(newBank: newBank);
                     }
 
-                    beatmap.Update(h);
+                    editorBeatmap.Update(h);
                 }
 
-                beatmap.EndChange();
+                editorBeatmap.EndChange();
             }
 
             private void updateBankPlaceholderText(IEnumerable<HitObject> objects)
@@ -178,7 +178,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 if (newVolume == null)
                     return;
 
-                beatmap.BeginChange();
+                editorBeatmap.BeginChange();
 
                 foreach (var h in objects)
                 {
@@ -187,10 +187,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         h.Samples[i] = h.Samples[i].With(newVolume: newVolume.Value);
                     }
 
-                    beatmap.Update(h);
+                    editorBeatmap.Update(h);
                 }
 
-                beatmap.EndChange();
+                editorBeatmap.EndChange();
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.LoadComplete();
 
-            placement = Beatmap.PlacementObject.GetBoundCopy();
+            placement = EditorBeatmap.PlacementObject.GetBoundCopy();
             placement.ValueChanged += placementChanged;
         }
 
@@ -172,7 +172,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             SelectedItems.RemoveAll(hitObject => !shouldBeSelected(hitObject));
 
-            foreach (var hitObject in Beatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected))
+            foreach (var hitObject in EditorBeatmap.HitObjects.Except(SelectedItems).Where(shouldBeSelected))
             {
                 Composer.Playfield.SetKeepAlive(hitObject, true);
                 SelectedItems.Add(hitObject);

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -281,16 +281,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             private readonly HitObject? hitObject;
 
             [Resolved]
-            private EditorBeatmap beatmap { get; set; } = null!;
+            private EditorBeatmap editorBeatmap { get; set; } = null!;
 
             [Resolved]
             private IBeatSnapProvider beatSnapProvider { get; set; } = null!;
 
             [Resolved]
             private Timeline timeline { get; set; } = null!;
-
-            [Resolved]
-            private IEditorChangeHandler? changeHandler { get; set; }
 
             private ScheduledDelegate? dragOperation;
 
@@ -371,7 +368,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             protected override bool OnDragStart(DragStartEvent e)
             {
-                changeHandler?.BeginChange();
+                editorBeatmap.BeginChange();
                 return true;
             }
 
@@ -401,7 +398,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                         return;
 
                                     hasSliderVelocity.SliderVelocity = newVelocity;
-                                    beatmap.Update(hitObject);
+                                    editorBeatmap.Update(hitObject);
                                 }
                                 else
                                 {
@@ -413,7 +410,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                         return;
 
                                     repeatHitObject.RepeatCount = proposedCount;
-                                    beatmap.Update(hitObject);
+                                    editorBeatmap.Update(hitObject);
                                 }
 
                                 break;
@@ -425,7 +422,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                     return;
 
                                 endTimeHitObject.Duration = snappedTime - hitObject.StartTime;
-                                beatmap.Update(hitObject);
+                                editorBeatmap.Update(hitObject);
                                 break;
                         }
                     }
@@ -439,7 +436,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 dragOperation?.Cancel();
                 dragOperation = null;
 
-                changeHandler?.EndChange();
+                editorBeatmap.EndChange();
                 OnDragHandled?.Invoke(null);
             }
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -19,16 +19,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
     public partial class TimelineTickDisplay : TimelinePart<PointVisualisation>
     {
         [Resolved]
-        private EditorBeatmap beatmap { get; set; } = null!;
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
 
         [Resolved]
         private Bindable<WorkingBeatmap> working { get; set; } = null!;
 
         [Resolved]
         private BindableBeatDivisor beatDivisor { get; set; } = null!;
-
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -45,9 +42,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             beatDivisor.BindValueChanged(_ => invalidateTicks());
 
-            if (changeHandler != null)
-                // currently this is the best way to handle any kind of timing changes.
-                changeHandler.OnStateChange += invalidateTicks;
+            // currently this is the best way to handle any kind of timing changes.
+            editorBeatmap.OnStateChange += invalidateTicks;
         }
 
         private void invalidateTicks()
@@ -103,10 +99,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             nextMinTick = null;
             nextMaxTick = null;
 
-            for (int i = 0; i < beatmap.ControlPointInfo.TimingPoints.Count; i++)
+            for (int i = 0; i < editorBeatmap.ControlPointInfo.TimingPoints.Count; i++)
             {
-                var point = beatmap.ControlPointInfo.TimingPoints[i];
-                double until = i + 1 < beatmap.ControlPointInfo.TimingPoints.Count ? beatmap.ControlPointInfo.TimingPoints[i + 1].Time : working.Value.Track.Length;
+                var point = editorBeatmap.ControlPointInfo.TimingPoints[i];
+                double until = i + 1 < editorBeatmap.ControlPointInfo.TimingPoints.Count ? editorBeatmap.ControlPointInfo.TimingPoints[i + 1].Time : working.Value.Track.Length;
 
                 int beat = 0;
 
@@ -192,8 +188,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.Dispose(isDisposing);
 
-            if (changeHandler != null)
-                changeHandler.OnStateChange -= invalidateTicks;
+            editorBeatmap.OnStateChange -= invalidateTicks;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Edit
                 if (!canSave)
                     return false;
 
-                return lastSavedHash != changeHandler?.CurrentStateHash;
+                return lastSavedHash != editorBeatmap.CurrentStateHash;
             }
         }
 
@@ -148,9 +148,6 @@ namespace osu.Game.Screens.Edit
         private EditorBeatmap editorBeatmap;
 
         private BottomBar bottomBar;
-
-        [CanBeNull] // Should be non-null once it can support custom rulesets.
-        private EditorChangeHandler changeHandler;
 
         private DependencyContainer dependencies;
 
@@ -250,12 +247,6 @@ namespace osu.Game.Screens.Edit
             editorBeatmap.UpdateInProgress.BindValueChanged(_ => updateSampleDisabledState());
 
             canSave = editorBeatmap.BeatmapInfo.Ruleset.CreateInstance() is ILegacyRuleset;
-
-            if (canSave)
-            {
-                changeHandler = new BeatmapEditorChangeHandler(editorBeatmap);
-                dependencies.CacheAs<IEditorChangeHandler>(changeHandler);
-            }
 
             beatDivisor.Value = editorBeatmap.BeatmapInfo.BeatDivisor;
             beatDivisor.BindValueChanged(divisor => editorBeatmap.BeatmapInfo.BeatDivisor = divisor.NewValue);
@@ -367,8 +358,8 @@ namespace osu.Game.Screens.Edit
                     bottomBar = new BottomBar(),
                 }
             });
-            changeHandler?.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);
-            changeHandler?.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
+            editorBeatmap.CanUndo.BindValueChanged(v => undoMenuItem.Action.Disabled = !v.NewValue, true);
+            editorBeatmap.CanRedo.BindValueChanged(v => redoMenuItem.Action.Disabled = !v.NewValue, true);
 
             editorBackgroundDim.BindValueChanged(_ => dimBackground());
         }
@@ -846,9 +837,9 @@ namespace osu.Game.Screens.Edit
 
         #endregion
 
-        protected void Undo() => changeHandler?.RestoreState(-1);
+        protected void Undo() => editorBeatmap.RestoreState(-1);
 
-        protected void Redo() => changeHandler?.RestoreState(1);
+        protected void Redo() => editorBeatmap.RestoreState(1);
 
         protected void SetPreviewPointToCurrentTime()
         {
@@ -993,7 +984,7 @@ namespace osu.Game.Screens.Edit
 
         private void updateLastSavedHash()
         {
-            lastSavedHash = changeHandler?.CurrentStateHash;
+            lastSavedHash = editorBeatmap.CurrentStateHash;
         }
 
         private List<MenuItem> createFileMenuItems() => new List<MenuItem>

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -96,6 +96,8 @@ namespace osu.Game.Screens.Edit
         [CanBeNull] // Should be non-null once it can support custom rulesets.
         private readonly BeatmapEditorChangeHandler changeHandler;
 
+        public bool CanSave { get; }
+
         public EditorBeatmap(IBeatmap playableBeatmap, ISkin beatmapSkin = null, BeatmapInfo beatmapInfo = null)
         {
             PlayableBeatmap = playableBeatmap;
@@ -122,7 +124,9 @@ namespace osu.Game.Screens.Edit
                 EndChange();
             });
 
-            if (BeatmapInfo.Ruleset.CreateInstance() is not ILegacyRuleset) return;
+            CanSave = BeatmapInfo.Ruleset.CreateInstance() is ILegacyRuleset;
+
+            if (!CanSave) return;
 
             changeHandler = new BeatmapEditorChangeHandler(this);
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -337,6 +337,11 @@ namespace osu.Game.Screens.Edit
             hasTiming.Value = !ReferenceEquals(ControlPointInfo.TimingPointAt(editorClock.CurrentTime), TimingControlPoint.DEFAULT);
         }
 
+        /// <summary>
+        /// Force an update of the editor state. This is useful for when an operation requires the updated state mid-operation.
+        /// </summary>
+        public void ForceUpdateState() => UpdateState();
+
         protected override void UpdateState()
         {
             if (batchPendingUpdates.Count == 0 && batchPendingDeletes.Count == 0 && batchPendingInserts.Count == 0)

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -373,11 +373,6 @@ namespace osu.Game.Screens.Edit
             hasTiming.Value = !ReferenceEquals(ControlPointInfo.TimingPointAt(editorClock.CurrentTime), TimingControlPoint.DEFAULT);
         }
 
-        /// <summary>
-        /// Force an update of the editor state. This is useful for when an operation requires the updated state mid-operation.
-        /// </summary>
-        public void ForceUpdateState() => UpdateState();
-
         protected override void UpdateState()
         {
             if (batchPendingUpdates.Count == 0 && batchPendingDeletes.Count == 0 && batchPendingInserts.Count == 0)

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -14,13 +14,14 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Edit
 {
-    public partial class EditorBeatmap : TransactionalCommitComponent, IBeatmap, IBeatSnapProvider
+    public partial class EditorBeatmap : TransactionalCommitComponent, IBeatmap, IBeatSnapProvider, IEditorChangeHandler
     {
         /// <summary>
         /// Will become <c>true</c> when a new update is queued, and <c>false</c> when all updates have been applied.
@@ -92,6 +93,9 @@ namespace osu.Game.Screens.Edit
 
         private readonly Dictionary<HitObject, Bindable<double>> startTimeBindables = new Dictionary<HitObject, Bindable<double>>();
 
+        [CanBeNull] // Should be non-null once it can support custom rulesets.
+        private readonly BeatmapEditorChangeHandler changeHandler;
+
         public EditorBeatmap(IBeatmap playableBeatmap, ISkin beatmapSkin = null, BeatmapInfo beatmapInfo = null)
         {
             PlayableBeatmap = playableBeatmap;
@@ -117,7 +121,35 @@ namespace osu.Game.Screens.Edit
                 BeatmapInfo.Metadata.PreviewTime = s.NewValue;
                 EndChange();
             });
+
+            if (BeatmapInfo.Ruleset.CreateInstance() is not ILegacyRuleset) return;
+
+            changeHandler = new BeatmapEditorChangeHandler(this);
+
+            CanUndo.BindTo(changeHandler.CanUndo);
+            CanRedo.BindTo(changeHandler.CanRedo);
+            changeHandler.OnStateChange += () => OnStateChange?.Invoke();
         }
+
+        #region change handler
+
+        public readonly Bindable<bool> CanUndo = new Bindable<bool>();
+        public readonly Bindable<bool> CanRedo = new Bindable<bool>();
+
+        public event Action OnStateChange;
+
+        /// <summary>
+        /// A SHA-2 hash representing the current visible editor state.
+        /// </summary>
+        public string CurrentStateHash => changeHandler?.CurrentStateHash;
+
+        /// <summary>
+        /// Restores an older or newer state.
+        /// </summary>
+        /// <param name="direction">The direction to restore in. If less than 0, an older state will be used. If greater than 0, a newer state will be used.</param>
+        public void RestoreState(int direction) => changeHandler?.RestoreState(direction);
+
+        #endregion
 
         /// <summary>
         /// Converts a <see cref="ControlPointInfo"/> such that the resultant <see cref="ControlPointInfo"/> is non-legacy.

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -31,13 +31,10 @@ namespace osu.Game.Screens.Edit.Timing
         private EditorClock clock { get; set; } = null!;
 
         [Resolved]
-        protected EditorBeatmap Beatmap { get; private set; } = null!;
+        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
 
         [Resolved]
         private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
-
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -106,11 +103,11 @@ namespace osu.Game.Screens.Edit.Timing
                     : "+ Add at current time";
             }, true);
 
-            controlPointGroups.BindTo(Beatmap.ControlPointInfo.Groups);
+            controlPointGroups.BindTo(EditorBeatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((_, _) =>
             {
                 table.ControlGroups = controlPointGroups;
-                changeHandler?.SaveState();
+                EditorBeatmap.SaveState();
             }, true);
 
             table.OnRowSelected += drawable => scroll.ScrollIntoView(drawable);
@@ -162,9 +159,9 @@ namespace osu.Game.Screens.Edit.Timing
                 // To improve the efficiency of this in the future, we should reconsider the overall structure of ControlPointInfo.
 
                 // Find the next group which has the same type as the selected one.
-                var found = Beatmap.ControlPointInfo.Groups
-                                   .Where(g => g.ControlPoints.Any(cp => cp.GetType() == trackedType))
-                                   .LastOrDefault(g => g.Time <= clock.CurrentTimeAccurate);
+                var found = EditorBeatmap.ControlPointInfo.Groups
+                                         .Where(g => g.ControlPoints.Any(cp => cp.GetType() == trackedType))
+                                         .LastOrDefault(g => g.Time <= clock.CurrentTimeAccurate);
 
                 if (found != null)
                     selectedGroup.Value = found;
@@ -176,16 +173,16 @@ namespace osu.Game.Screens.Edit.Timing
             if (selectedGroup.Value == null)
                 return;
 
-            Beatmap.ControlPointInfo.RemoveGroup(selectedGroup.Value);
+            EditorBeatmap.ControlPointInfo.RemoveGroup(selectedGroup.Value);
 
-            selectedGroup.Value = Beatmap.ControlPointInfo.Groups.FirstOrDefault(g => g.Time >= clock.CurrentTime);
+            selectedGroup.Value = EditorBeatmap.ControlPointInfo.Groups.FirstOrDefault(g => g.Time >= clock.CurrentTime);
         }
 
         private void addNew()
         {
-            bool isFirstControlPoint = !Beatmap.ControlPointInfo.TimingPoints.Any();
+            bool isFirstControlPoint = !EditorBeatmap.ControlPointInfo.TimingPoints.Any();
 
-            var group = Beatmap.ControlPointInfo.GroupAt(clock.CurrentTime, true);
+            var group = EditorBeatmap.ControlPointInfo.GroupAt(clock.CurrentTime, true);
 
             if (isFirstControlPoint)
                 group.Add(new TimingControlPoint());

--- a/osu.Game/Screens/Edit/Timing/EffectSection.cs
+++ b/osu.Game/Screens/Edit/Timing/EffectSection.cs
@@ -38,13 +38,13 @@ namespace osu.Game.Screens.Edit.Timing
             kiai.Current.BindValueChanged(_ => saveChanges());
             scrollSpeedSlider.Current.BindValueChanged(_ => saveChanges());
 
-            var drawableRuleset = Beatmap.BeatmapInfo.Ruleset.CreateInstance().CreateDrawableRulesetWith(Beatmap.PlayableBeatmap);
+            var drawableRuleset = EditorBeatmap.BeatmapInfo.Ruleset.CreateInstance().CreateDrawableRulesetWith(EditorBeatmap.PlayableBeatmap);
             if (drawableRuleset is not IDrawableScrollingRuleset scrollingRuleset || scrollingRuleset.VisualisationMethod == ScrollVisualisationMethod.Constant)
                 scrollSpeedSlider.Hide();
 
             void saveChanges()
             {
-                if (!isRebinding) ChangeHandler?.SaveState();
+                if (!isRebinding) EditorBeatmap.SaveState();
             }
         }
 
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override EffectControlPoint CreatePoint()
         {
-            var reference = Beatmap.ControlPointInfo.EffectPointAt(SelectedGroup.Value.Time);
+            var reference = EditorBeatmap.ControlPointInfo.EffectPointAt(SelectedGroup.Value.Time);
 
             return new EffectControlPoint
             {

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -23,13 +23,10 @@ namespace osu.Game.Screens.Edit.Timing
         protected Bindable<ControlPointGroup> SelectedGroup { get; private set; } = null!;
 
         [Resolved]
-        protected EditorBeatmap Beatmap { get; private set; } = null!;
+        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
 
         [Resolved]
         private EditorClock clock { get; set; } = null!;
-
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -102,19 +99,19 @@ namespace osu.Game.Screens.Edit.Timing
             if (SelectedGroup.Value == null || time == SelectedGroup.Value.Time)
                 return;
 
-            changeHandler?.BeginChange();
+            EditorBeatmap.BeginChange();
 
             var currentGroupItems = SelectedGroup.Value.ControlPoints.ToArray();
 
-            Beatmap.ControlPointInfo.RemoveGroup(SelectedGroup.Value);
+            EditorBeatmap.ControlPointInfo.RemoveGroup(SelectedGroup.Value);
 
             foreach (var cp in currentGroupItems)
-                Beatmap.ControlPointInfo.Add(time, cp);
+                EditorBeatmap.ControlPointInfo.Add(time, cp);
 
             // the control point might not necessarily exist yet, if currentGroupItems was empty.
-            SelectedGroup.Value = Beatmap.ControlPointInfo.GroupAt(time, true);
+            SelectedGroup.Value = EditorBeatmap.ControlPointInfo.GroupAt(time, true);
 
-            changeHandler?.EndChange();
+            EditorBeatmap.EndChange();
         }
     }
 }

--- a/osu.Game/Screens/Edit/Timing/Section.cs
+++ b/osu.Game/Screens/Edit/Timing/Section.cs
@@ -27,13 +27,10 @@ namespace osu.Game.Screens.Edit.Timing
         private const float header_height = 50;
 
         [Resolved]
-        protected EditorBeatmap Beatmap { get; private set; } = null!;
+        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
 
         [Resolved]
         protected Bindable<ControlPointGroup> SelectedGroup { get; private set; } = null!;
-
-        [Resolved]
-        protected IEditorChangeHandler? ChangeHandler { get; private set; }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             void saveChanges()
             {
-                if (!isRebinding) ChangeHandler?.SaveState();
+                if (!isRebinding) EditorBeatmap.SaveState();
             }
         }
 
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override TimingControlPoint CreatePoint()
         {
-            var reference = Beatmap.ControlPointInfo.TimingPointAt(SelectedGroup.Value.Time);
+            var reference = EditorBeatmap.ControlPointInfo.TimingPointAt(SelectedGroup.Value.Time);
 
             return new TimingControlPoint
             {


### PR DESCRIPTION
I noticed a lot of operations dont call `EditorBeatmap.BeginChange()` and instead only `BeatmapEditorChangeHandler.BeginChange()`. This is weird because it doesn't notify `EditorBeatmap` about any transactions on hit objects. 

By calling `EditorBeatmap.BeginChange()` we automatically call `BeatmapEditorChangeHandler.BeginChange()` as well because the `BeatmapEditorChangeHandler` listens for the events of `EditorBeatmap`, so calling `EditorBeatmap.BeginChange()` seems like the best options for any operations the `EditorBeatmap` should know about.

I've refactored the code so every transaction on the hit objects of a `EditorBeatmap` calls `EditorBeatmap.BeginChange()` instead of `BeatmapEditorChangeHandler.BeginChange()`.

Futher I noticed that the selection box operations didn't call `EditorBeatmap.Update()` on the hit objects that got changed. This made it so stacking would not get updated for any of these operations. I've included a video of the interaction after my fix.

https://github.com/ppy/osu/assets/17460441/34a116e9-27ff-4682-9d55-a69e62a6220f

closes #20040
