### PR TITLE
Enable AOT on android release builds

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -12,6 +12,11 @@
   <ItemGroup>
     <PackageReference Include="ppy.osu.Framework.Android" Version="2023.801.0" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- On release configurations, we use AOT compiler for optimal performance, along with Mono Interpreter as a fallback for libraries such as AutoMapper. -->
+    <EnableLLVM>true</EnableLLVM>
+    <AotAssemblies>true</AotAssemblies>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.
          Since Realm objects are not declared directly in Android projects, simply disable Fody. -->

--- a/osu.Android/osu.Android.csproj
+++ b/osu.Android/osu.Android.csproj
@@ -6,8 +6,6 @@
     <RootNamespace>osu.Android</RootNamespace>
     <AssemblyName>osu.Android</AssemblyName>
     <UseMauiEssentials>true</UseMauiEssentials>
-    <!-- This currently causes random lockups during gameplay. https://github.com/mono/mono/issues/18973 -->
-    <EnableLLVM>false</EnableLLVM>
     <Version>0.0.0</Version>
     <ApplicationVersion Condition=" '$(ApplicationVersion)' == '' ">1</ApplicationVersion>
     <ApplicationDisplayVersion Condition=" '$(ApplicationDisplayVersion)' == '' ">$(Version)</ApplicationDisplayVersion>


### PR DESCRIPTION
Not sure about interpreter fallback, will need to test with some users.