### PR TITLE
Fix legacy beatmap exporter not converting beatmap between decode and re-encode

### DIFF
--- a/osu.Desktop/LegacyIpc/LegacyTcpIpcProvider.cs
+++ b/osu.Desktop/LegacyIpc/LegacyTcpIpcProvider.cs
@@ -75,7 +75,7 @@ namespace osu.Desktop.LegacyIpc
                 case LegacyIpcDifficultyCalculationRequest req:
                     try
                     {
-                        WorkingBeatmap beatmap = new FlatFileWorkingBeatmap(req.BeatmapFile);
+                        WorkingBeatmap beatmap = new FlatWorkingBeatmap(req.BeatmapFile);
                         var ruleset = beatmap.BeatmapInfo.Ruleset.CreateInstance();
                         Mod[] mods = ruleset.ConvertFromLegacyMods((LegacyMods)req.Mods).ToArray();
 

--- a/osu.Game/Beatmaps/FlatWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/FlatWorkingBeatmap.cs
@@ -12,25 +12,26 @@ using osu.Game.Skinning;
 namespace osu.Game.Beatmaps
 {
     /// <summary>
-    /// A <see cref="WorkingBeatmap"/> which can be constructed directly from a .osu file, providing an implementation for
+    /// A <see cref="WorkingBeatmap"/> which can be constructed directly from an .osu file (via <see cref="FlatWorkingBeatmap(string, int?)"/>)
+    /// or an <see cref="IBeatmap"/> instance (via <see cref="FlatWorkingBeatmap(IBeatmap)"/>,
+    /// providing an implementation for
     /// <see cref="WorkingBeatmap.GetPlayableBeatmap(osu.Game.Rulesets.IRulesetInfo,System.Collections.Generic.IReadOnlyList{osu.Game.Rulesets.Mods.Mod})"/>.
     /// </summary>
-    public class FlatFileWorkingBeatmap : WorkingBeatmap
+    public class FlatWorkingBeatmap : WorkingBeatmap
     {
-        private readonly Beatmap beatmap;
+        private readonly IBeatmap beatmap;
 
-        public FlatFileWorkingBeatmap(string file, int? beatmapId = null)
-            : this(readFromFile(file), beatmapId)
+        public FlatWorkingBeatmap(string file, int? beatmapId = null)
+            : this(readFromFile(file))
         {
+            if (beatmapId.HasValue)
+                beatmap.BeatmapInfo.OnlineID = beatmapId.Value;
         }
 
-        private FlatFileWorkingBeatmap(Beatmap beatmap, int? beatmapId = null)
+        public FlatWorkingBeatmap(IBeatmap beatmap)
             : base(beatmap.BeatmapInfo, null)
         {
             this.beatmap = beatmap;
-
-            if (beatmapId.HasValue)
-                beatmap.BeatmapInfo.OnlineID = beatmapId.Value;
         }
 
         private static Beatmap readFromFile(string filename)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24504.

`LegacyBeatmapExporter` was playing _juuust_ a bit too fast and loose with the beatmap manipulation. In particular, it was not converting the beatmap to the target ruleset via `WorkingBeatmap.GetPlayableBeatmap()`, which led to the linked failure, as `Catch.ConvertSpinner` does not implement `IHasPosition`, but `BananaShower` does (via `CatchHitObject`):

https://github.com/ppy/osu/blob/896cbb0ba074474858e222253a34b449a7869bea/osu.Game/Rulesets/Objects/Legacy/Catch/ConvertSpinner.cs#L11
https://github.com/ppy/osu/blob/896cbb0ba074474858e222253a34b449a7869bea/osu.Game.Rulesets.Catch/Objects/BananaShower.cs#L12
https://github.com/ppy/osu/blob/896cbb0ba074474858e222253a34b449a7869bea/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs#L17

You could ask "why not make `Catch.ConvertSpinner` implement `IHasPosition`, then". Well, general established practice [elsewhere](https://github.com/ppy/osu/blob/896cbb0ba074474858e222253a34b449a7869bea/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs#L196-L218) involves conversion, and decode-encode stability tests don't exercise the paths that skip conversion. So in a way this is me playing it safe.