### PR TITLE
Fix playfield skinnable layer bounds being incorrectly calculated with multiple stages

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -30,15 +30,15 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             get
             {
-                if (Stages.Count == 1)
-                    return Stages.First().ScreenSpaceDrawQuad;
+                RectangleF totalArea = RectangleF.Empty;
 
-                RectangleF area = RectangleF.Empty;
+                for (int i = 0; i < Stages.Count; ++i)
+                {
+                    var stageArea = Stages[i].ScreenSpaceDrawQuad.AABBFloat;
+                    totalArea = i == 0 ? stageArea : RectangleF.Union(totalArea, stageArea);
+                }
 
-                foreach (var stage in Stages)
-                    area = RectangleF.Union(area, stage.ScreenSpaceDrawQuad.AABBFloat);
-
-                return area;
+                return totalArea;
             }
         }
 


### PR DESCRIPTION
Closes #24514.

The original PR was _supposed_ to be handling this, and had code that _looked_ like it would handle it, but was in fact subtly wrong, as the union of `RectangleF.Empty` (initial value of `area`) and an arbitrary other rectangle is _not_ the second rectangle, but rather a rectangle that contains _both_ the second rectangle and the point (0,0), thus leading to the bound calculation fail.

I believe I forgot testing this before merge. Womp womp.