### PR TITLE
Remove slider velocity from `DrumRoll`

### DIFF
--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -139,7 +139,6 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                             StartTime = obj.StartTime,
                             Samples = obj.Samples,
                             Duration = taikoDuration,
-                            SliderVelocity = obj is IHasSliderVelocity velocityData ? velocityData.SliderVelocity : 1
                         };
                     }
 

--- a/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/DrumRoll.cs
@@ -3,7 +3,6 @@
 
 using osu.Game.Rulesets.Objects.Types;
 using System.Threading;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Formats;
@@ -14,7 +13,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects
 {
-    public class DrumRoll : TaikoStrongableHitObject, IHasPath, IHasSliderVelocity
+    public class DrumRoll : TaikoStrongableHitObject, IHasPath
     {
         /// <summary>
         /// Drum roll distance that results in a duration of 1 speed-adjusted beat length.
@@ -34,19 +33,6 @@ namespace osu.Game.Rulesets.Taiko.Objects
         /// </summary>
         public double Velocity { get; private set; }
 
-        public BindableNumber<double> SliderVelocityBindable { get; } = new BindableDouble(1)
-        {
-            Precision = 0.01,
-            MinValue = 0.1,
-            MaxValue = 10
-        };
-
-        public double SliderVelocity
-        {
-            get => SliderVelocityBindable.Value;
-            set => SliderVelocityBindable.Value = value;
-        }
-
         /// <summary>
         /// Numer of ticks per beat length.
         /// </summary>
@@ -63,8 +49,9 @@ namespace osu.Game.Rulesets.Taiko.Objects
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
+            EffectControlPoint effectPoint = controlPointInfo.EffectPointAt(StartTime);
 
-            double scoringDistance = base_distance * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = base_distance * difficulty.SliderMultiplier * effectPoint.ScrollSpeed;
             Velocity = scoringDistance / timingPoint.BeatLength;
 
             TickRate = difficulty.SliderTickRate == 3 ? 3 : 4;


### PR DESCRIPTION
Removed `ISliderVelocity` from `DrumRoll` because it doesnt need it and it created the ability to edit the SV in the editor which shouldn't be possible, because changing it only breaks the drum roll duration. 

If you change the SV of a drum roll in the editor, save, and come back. The duration will have changed by a factor equal to how much you changed the SV from the scroll speed.

The SV was being used to calculate the scroll speed of the drum roll and it just happened to always be the same as the `ScrollSpeed` because of how `LegacyBeatmapDecoder` works. Removing SV and using scroll speed directly makes the intention of the code a lot clearer.