### PR TITLE
Don't completely fade FPS counter out when running at full FPS

### DIFF
--- a/osu.Game/Graphics/UserInterface/FPSCounter.cs
+++ b/osu.Game/Graphics/UserInterface/FPSCounter.cs
@@ -213,7 +213,7 @@ namespace osu.Game.Graphics.UserInterface
                 requestDisplay();
             else if (isDisplayed && Time.Current - lastDisplayRequiredTime > 2000 && !IsHovered)
             {
-                mainContent.FadeTo(0, 300, Easing.OutQuint);
+                mainContent.FadeTo(0.7f, 300, Easing.OutQuint);
                 isDisplayed = false;
             }
         }


### PR DESCRIPTION
I've heard multiple times from uses that this is distracting or confusing.

It now fades, but doesn't fully disappear.
