### PR TITLE
Add pooling for mania barlines

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
@@ -117,18 +117,16 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         private void createBarLine(bool major)
         {
-            foreach (var stage in stages)
+            var obj = new BarLine
             {
-                var obj = new BarLine
-                {
-                    StartTime = Time.Current + 2000,
-                    Major = major,
-                };
+                StartTime = Time.Current + 2000,
+                Major = major,
+            };
 
-                obj.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            obj.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
+            foreach (var stage in stages)
                 stage.Add(obj);
-            }
         }
 
         private ScrollingTestContainer createStage(ScrollingDirection direction, ManiaAction action)

--- a/osu.Game.Rulesets.Mania/ManiaSkinComponentLookup.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSkinComponentLookup.cs
@@ -33,5 +33,6 @@ namespace osu.Game.Rulesets.Mania
         HitExplosion,
         StageBackground,
         StageForeground,
+        BarLine
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/BarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/BarLine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 
@@ -8,7 +9,15 @@ namespace osu.Game.Rulesets.Mania.Objects
 {
     public class BarLine : ManiaHitObject, IBarLine
     {
-        public bool Major { get; set; }
+        private HitObjectProperty<bool> major;
+
+        public Bindable<bool> MajorBindable => major.Bindable;
+
+        public bool Major
+        {
+            get => major.Value;
+            set => major.Value = value;
+        }
 
         public override Judgement CreateJudgement() => new IgnoreJudgement();
     }

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableBarLine.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Shapes;
-using osuTK;
+using osu.Game.Rulesets.Mania.Skinning.Default;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Mania.Objects.Drawables
 {
@@ -13,45 +15,41 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// </summary>
     public partial class DrawableBarLine : DrawableManiaHitObject<BarLine>
     {
+        public readonly Bindable<bool> Major = new Bindable<bool>();
+
+        public DrawableBarLine()
+            : this(null!)
+        {
+        }
+
         public DrawableBarLine(BarLine barLine)
             : base(barLine)
         {
             RelativeSizeAxes = Axes.X;
-            Height = barLine.Major ? 1.7f : 1.2f;
+        }
 
-            AddInternal(new Box
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.BarLine), _ => new DefaultBarLine())
             {
-                Name = "Bar line",
-                Anchor = Anchor.BottomCentre,
-                Origin = Anchor.BottomCentre,
-                RelativeSizeAxes = Axes.Both,
-                Alpha = barLine.Major ? 0.5f : 0.2f
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
             });
 
-            if (barLine.Major)
-            {
-                Vector2 size = new Vector2(22, 6);
-                const float line_offset = 4;
+            Major.BindValueChanged(major => Height = major.NewValue ? 1.7f : 1.2f, true);
+        }
 
-                AddInternal(new Circle
-                {
-                    Name = "Left line",
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreRight,
+        protected override void OnApply()
+        {
+            base.OnApply();
+            Major.BindTo(HitObject.MajorBindable);
+        }
 
-                    Size = size,
-                    X = -line_offset,
-                });
-
-                AddInternal(new Circle
-                {
-                    Name = "Right line",
-                    Anchor = Anchor.CentreRight,
-                    Origin = Anchor.CentreLeft,
-                    Size = size,
-                    X = line_offset,
-                });
-            }
+        protected override void OnFree()
+        {
+            base.OnFree();
+            Major.UnbindFrom(HitObject.MajorBindable);
         }
 
         protected override void UpdateStartTimeStateTransforms() => this.FadeOut(150);

--- a/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Mania.Skinning.Default
+{
+    public partial class DefaultBarLine : CompositeDrawable
+    {
+        private Bindable<bool> major = null!;
+
+        private Drawable mainLine = null!;
+        private Drawable leftAnchor = null!;
+        private Drawable rightAnchor = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(DrawableHitObject drawableHitObject)
+        {
+            RelativeSizeAxes = Axes.Both;
+
+            AddInternal(mainLine = new Box
+            {
+                Name = "Bar line",
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.Both,
+            });
+
+            Vector2 size = new Vector2(22, 6);
+            const float line_offset = 4;
+
+            AddInternal(leftAnchor = new Circle
+            {
+                Name = "Left anchor",
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreRight,
+                Size = size,
+                X = -line_offset,
+            });
+
+            AddInternal(rightAnchor = new Circle
+            {
+                Name = "Right anchor",
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreLeft,
+                Size = size,
+                X = line_offset,
+            });
+
+            major = ((DrawableBarLine)drawableHitObject).Major.GetBoundCopy();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            major.BindValueChanged(updateMajor, true);
+        }
+
+        private void updateMajor(ValueChangedEvent<bool> major)
+        {
+            mainLine.Alpha = major.NewValue ? 0.5f : 0.2f;
+            leftAnchor.Alpha = rightAnchor.Alpha = major.NewValue ? 1 : 0;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -119,6 +119,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                         case ManiaSkinComponents.StageForeground:
                             return new LegacyStageForeground();
 
+                        case ManiaSkinComponents.BarLine:
+                            return null; // Not yet implemented.
+
                         default:
                             throw new UnsupportedSkinComponentException(lookup);
                     }

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -136,6 +136,8 @@ namespace osu.Game.Rulesets.Mania.UI
                 columnFlow.SetContentForColumn(i, column);
                 AddNested(column);
             }
+
+            RegisterPool<BarLine, DrawableBarLine>(50, 200);
         }
 
         private ISkinSource currentSkin;
@@ -186,7 +188,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public override bool Remove(DrawableHitObject h) => Columns.ElementAt(((ManiaHitObject)h.HitObject).Column - firstColumnIndex).Remove(h);
 
-        public void Add(BarLine barLine) => base.Add(new DrawableBarLine(barLine));
+        public void Add(BarLine barLine) => base.Add(barLine);
 
         internal void OnNewResult(DrawableHitObject judgedObject, JudgementResult result)
         {


### PR DESCRIPTION
At COE, it was brought up to me that this map wasn't loading: https://osu.ppy.sh/beatmapsets/501530#mania/1073952 Turns out that it is loading, just very slowly.

The primary reason is that it creates some 200k drawables, which this PR directly addresses. The implementation here is similar to the taiko one.

The second reason, which is not addressed in this PR, and likely doesn't need to be addressed, appears to be some inefficiency in HitObjectContainer resulting in what looks to be worst case sort complexity:

![image](https://github.com/ppy/osu/assets/1329837/5799f083-c226-40fc-ae8e-eeca56453530)

i.e. every object added to the HOC causes the HOC to immediately be re-sorted:

https://github.com/ppy/osu/blob/01eceea72f15d673141bb651031e5f944fe25d3e/osu.Game/Rulesets/UI/HitObjectContainer.cs#L153-L164