### PR TITLE
Rename "dummy" local user to something more descriptive

### DIFF
--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Online.API
 
         public Bindable<APIUser> LocalUser { get; } = new Bindable<APIUser>(new APIUser
         {
-            Username = @"Dummy",
+            Username = @"Local user",
             Id = DUMMY_USER_ID,
         });
 


### PR DESCRIPTION
This created weird cases in logs which are very hard to understand. The one which really got me was this:

```
[runtime] 2023-08-13 07:48:27 [verbose]: Invalidating working beatmap cache for unknown artist - unknown title (Dummy)
```

Which looks like a dummy working beatmap was invalidated, but it turns out that's just the local user which was populated when creating a new local beatmap.
