### PR TITLE
Fix incorrect access to realm object in beatmap editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -92,25 +92,6 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        [FlakyTest]
-        /*
-         * Fail rate around 1.2%.
-         *
-         * Failing with realm refetch occasionally being null.
-         * My only guess is that the WorkingBeatmap at SetupScreen is dummy instead of the true one.
-         * If it's something else, we have larger issues with realm, but I don't think that's the case.
-         *
-         * at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2)
-         * at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
-         * at System.Diagnostics.TraceInternal.TraceProvider.Fail(String message, String detailMessage)
-         * at System.Diagnostics.Debug.Fail(String message, String detailMessage)
-         * at osu.Game.Database.ModelManager`1.<>c__DisplayClass8_0.<performFileOperation>b__0(Realm realm) ModelManager.cs:line 50
-         * at osu.Game.Database.RealmExtensions.Write(Realm realm, Action`1 function) RealmExtensions.cs:line 14
-         * at osu.Game.Database.ModelManager`1.performFileOperation(TModel item, Action`1 operation) ModelManager.cs:line 47
-         * at osu.Game.Database.ModelManager`1.AddFile(TModel item, Stream contents, String filename) ModelManager.cs:line 37
-         * at osu.Game.Screens.Edit.Setup.ResourcesSection.ChangeAudioTrack(FileInfo source) ResourcesSection.cs:line 115
-         * at osu.Game.Tests.Visual.Editing.TestSceneEditorBeatmapCreation.<TestAddAudioTrack>b__11_0() TestSceneEditorBeatmapCreation.cs:line 101
-         */
         public void TestAddAudioTrack()
         {
             AddAssert("track is virtual", () => Beatmap.Value.Track is TrackVirtual);

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using osu.Framework.Platform;

--- a/osu.Game/Database/ModelManager.cs
+++ b/osu.Game/Database/ModelManager.cs
@@ -48,16 +48,13 @@ namespace osu.Game.Database
             // This method should be removed as soon as all the surrounding pieces support non-detached operations.
             if (!item.IsManaged)
             {
-                // Importantly, begin the realm write *before* re-fetching, else the update realm may not be in a consistent state
-                // (ie. if an async import finished very recently).
-                Realm.Realm.Write(realm =>
+                // We use RealmLive here as it handled re-retrieval and refreshing of realm if required.
+                new RealmLive<TModel>(item.ID, Realm).PerformWrite(i =>
                 {
-                    var managed = realm.Find<TModel>(item.ID);
-                    Debug.Assert(managed != null);
-                    operation(managed);
+                    operation(i);
 
                     item.Files.Clear();
-                    item.Files.AddRange(managed.Files.Detach());
+                    item.Files.AddRange(i.Files.Detach());
                 });
             }
             else

--- a/osu.Game/Database/RealmExtensions.cs
+++ b/osu.Game/Database/RealmExtensions.cs
@@ -13,10 +13,13 @@ namespace osu.Game.Database
         /// If a match was not found, a <see cref="Realm.Refresh"/> is performed before trying a second time.
         /// This ensures that an instance is found even if the realm requested against was not in a consistent state.
         /// </summary>
-        /// <param name="realm"></param>
-        /// <param name="id"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
+        /// <param name="realm">The realm to operate on.</param>
+        /// <param name="id">The ID of the entity to find in the realm.</param>
+        /// <typeparam name="T">The type of the entity to find in the realm.</typeparam>
+        /// <returns>
+        /// The retrieved entity of type <typeparamref name="T"/>.
+        /// Can be <see langword="null"/> if the entity is still not found by <paramref name="id"/> even after a refresh.
+        /// </returns>
         public static T? FindWithRefresh<T>(this Realm realm, Guid id) where T : IRealmObject
         {
             var found = realm.Find<T>(id);
@@ -24,7 +27,7 @@ namespace osu.Game.Database
             if (found == null)
             {
                 // It may be that we access this from the update thread before a refresh has taken place.
-                // To ensure that behaviour matches what we'd expect (the object *is* available), force
+                // To ensure that behaviour matches what we'd expect (the object generally *should be* available), force
                 // a refresh to bring in any off-thread changes immediately.
                 realm.Refresh();
                 found = realm.Find<T>(id);

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Database
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
-        /// <param name="data">The realm data. Must be managed (see <see cref="IRealmObject.IsManaged"/>).</param>
+        /// <param name="data">The realm data. Must be managed (see <see cref="IRealmObjectBase.IsManaged"/>).</param>
         /// <param name="realm">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
         public RealmLive(T data, RealmAccess realm)
             : base(data.ID)

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -30,12 +30,30 @@ namespace osu.Game.Database
         /// <summary>
         /// Construct a new instance of live realm data.
         /// </summary>
-        /// <param name="data">The realm data.</param>
+        /// <param name="data">The realm data. Must be managed (see <see cref="IRealmObject.IsManaged"/>).</param>
         /// <param name="realm">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
         public RealmLive(T data, RealmAccess realm)
             : base(data.ID)
         {
             this.data = data;
+            this.realm = realm;
+
+            dataIsFromUpdateThread = ThreadSafety.IsUpdateThread;
+        }
+
+        /// <summary>
+        /// Construct a new instance of live realm data from an ID.
+        /// </summary>
+        /// <param name="id">The ID of an already-persisting realm instance.</param>
+        /// <param name="realm">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
+        public RealmLive(Guid id, RealmAccess realm)
+            : base(id)
+        {
+            data = retrieveFromID(realm.Realm);
+
+            if (data.IsNull())
+                throw new ArgumentException("Realm instance for provided ID could not be found.", nameof(id));
+
             this.realm = realm;
 
             dataIsFromUpdateThread = ThreadSafety.IsUpdateThread;

--- a/osu.Game/Database/RealmLive.cs
+++ b/osu.Game/Database/RealmLive.cs
@@ -42,24 +42,6 @@ namespace osu.Game.Database
         }
 
         /// <summary>
-        /// Construct a new instance of live realm data from an ID.
-        /// </summary>
-        /// <param name="id">The ID of an already-persisting realm instance.</param>
-        /// <param name="realm">The realm factory the data was sourced from. May be null for an unmanaged object.</param>
-        public RealmLive(Guid id, RealmAccess realm)
-            : base(id)
-        {
-            data = retrieveFromID(realm.Realm);
-
-            if (data.IsNull())
-                throw new ArgumentException("Realm instance for provided ID could not be found.", nameof(id));
-
-            this.realm = realm;
-
-            dataIsFromUpdateThread = ThreadSafety.IsUpdateThread;
-        }
-
-        /// <summary>
         /// Perform a read operation on this live object.
         /// </summary>
         /// <param name="perform">The action to perform.</param>
@@ -80,7 +62,7 @@ namespace osu.Game.Database
                     return;
                 }
 
-                perform(retrieveFromID(r));
+                perform(r.FindWithRefresh<T>(ID)!);
                 RealmLiveStatistics.USAGE_ASYNC.Value++;
             });
         }
@@ -102,7 +84,7 @@ namespace osu.Game.Database
 
             return realm.Run(r =>
             {
-                var returnData = perform(retrieveFromID(r));
+                var returnData = perform(r.FindWithRefresh<T>(ID)!);
                 RealmLiveStatistics.USAGE_ASYNC.Value++;
 
                 if (returnData is RealmObjectBase realmObject && realmObject.IsManaged)
@@ -159,24 +141,9 @@ namespace osu.Game.Database
             }
 
             dataIsFromUpdateThread = true;
-            data = retrieveFromID(realm.Realm);
+            data = realm.Realm.FindWithRefresh<T>(ID)!;
+
             RealmLiveStatistics.USAGE_UPDATE_REFETCH.Value++;
-        }
-
-        private T retrieveFromID(Realm realm)
-        {
-            var found = realm.Find<T>(ID);
-
-            if (found == null)
-            {
-                // It may be that we access this from the update thread before a refresh has taken place.
-                // To ensure that behaviour matches what we'd expect (the object *is* available), force
-                // a refresh to bring in any off-thread changes immediately.
-                realm.Refresh();
-                found = realm.Find<T>(ID)!;
-            }
-
-            return found;
         }
     }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -199,6 +199,8 @@ namespace osu.Game.Screens.Edit
 
             if (loadableBeatmap is DummyWorkingBeatmap)
             {
+                Logger.Log("Editor was loaded without a valid beatmap; creating a new beatmap.");
+
                 isNewBeatmap = true;
 
                 loadableBeatmap = beatmapManager.CreateNew(Ruleset.Value, api.LocalUser.Value);


### PR DESCRIPTION
Fix `ModelManager` not correctly re-retrieving realm objects before performing operations

Falls into the age-old trap of attempting to retrieve an item from realm without first ensuring that realm is in an up-to-date state.

Consider this scenario:

- Editor is entered from main menu, causing it to create a new beatmap from its async `load()` method.
- Editor opens correctly, then main thread performs a file operations on the same beatmap.
- Main thread is potentially not refreshed yet, and will result in `null` instance when performing the re-fetch in `performFileOperation`.

I've fixed this by using the safe implementation inside `RealmLive<T>`.  Feels like we want this is one place which is always used as the correct method.

On a quick search, there are 10-20 other usages of `Realm.Find<T>` which could also have similar issues, but it'll be a bit of a pain to go through and fix each of these. In 99.9% of cases, the accesses are on instances which couldn't have just been created (or the usage of recently-imported/created is blocked by realm subscription flows, ie.  baetmap import) so I'm not touching them for now.

Something to keep in mind when working with realm going forward though.

This fixes a flaky test which has still been pinging in recent times (https://teamcity.ppy.sh/buildConfiguration/Osu_Build/42448?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true).
