### PR TITLE
Disable IPC binding in tournament client to allow running concurrently

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -85,7 +85,7 @@ namespace osu.Desktop
                 }
             }
 
-            using (DesktopGameHost host = Host.GetSuitableDesktopHost(gameName, new HostOptions { BindIPC = true }))
+            using (DesktopGameHost host = Host.GetSuitableDesktopHost(gameName, new HostOptions { BindIPC = !tournamentClient }))
             {
                 if (!host.IsPrimaryInstance)
                 {


### PR DESCRIPTION
Was brought up (and hacked around) during COE. This allows starting the tournament client when osu! is already running, which can be useful for some scenarios. At COE it was used to allow streaming gameplay from the multiplayer spectator interface while still using the tournament client for bracket display (with manual updating on the side).

The tournament client doesn't support any IPC operations so this should have no negative effect.