### PR TITLE
Add score difference display to multiplayer spectator

### DIFF
--- a/osu.Game.Tournament/IPC/MatchIPCInfo.cs
+++ b/osu.Game.Tournament/IPC/MatchIPCInfo.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tournament.IPC
         public Bindable<LegacyMods> Mods { get; } = new Bindable<LegacyMods>();
         public Bindable<TourneyState> State { get; } = new Bindable<TourneyState>();
         public Bindable<string> ChatChannel { get; } = new Bindable<string>();
-        public BindableInt Score1 { get; } = new BindableInt();
-        public BindableInt Score2 { get; } = new BindableInt();
+        public BindableLong Score1 { get; } = new BindableLong();
+        public BindableLong Score2 { get; } = new BindableLong();
     }
 }

--- a/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
+++ b/osu.Game.Tournament/Screens/Gameplay/Components/TournamentMatchScoreDisplay.cs
@@ -1,181 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Tournament.IPC;
-using osuTK;
 
 namespace osu.Game.Tournament.Screens.Gameplay.Components
 {
-    // TODO: Update to derive from osu-side class?
-    public partial class TournamentMatchScoreDisplay : CompositeDrawable
+    public partial class TournamentMatchScoreDisplay : MatchScoreDisplay
     {
-        private const float bar_height = 18;
-
-        private readonly BindableInt score1 = new BindableInt();
-        private readonly BindableInt score2 = new BindableInt();
-
-        private readonly MatchScoreCounter score1Text;
-        private readonly MatchScoreCounter score2Text;
-
-        private readonly MatchScoreDiffCounter scoreDiffText;
-
-        private readonly Drawable score1Bar;
-        private readonly Drawable score2Bar;
-
-        public TournamentMatchScoreDisplay()
-        {
-            RelativeSizeAxes = Axes.X;
-            AutoSizeAxes = Axes.Y;
-
-            InternalChildren = new[]
-            {
-                new Box
-                {
-                    Name = "top bar red (static)",
-                    RelativeSizeAxes = Axes.X,
-                    Height = bar_height / 4,
-                    Width = 0.5f,
-                    Colour = TournamentGame.COLOUR_RED,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopRight
-                },
-                new Box
-                {
-                    Name = "top bar blue (static)",
-                    RelativeSizeAxes = Axes.X,
-                    Height = bar_height / 4,
-                    Width = 0.5f,
-                    Colour = TournamentGame.COLOUR_BLUE,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopLeft
-                },
-                score1Bar = new Box
-                {
-                    Name = "top bar red",
-                    RelativeSizeAxes = Axes.X,
-                    Height = bar_height,
-                    Width = 0,
-                    Colour = TournamentGame.COLOUR_RED,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopRight
-                },
-                score1Text = new MatchScoreCounter
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre
-                },
-                score2Bar = new Box
-                {
-                    Name = "top bar blue",
-                    RelativeSizeAxes = Axes.X,
-                    Height = bar_height,
-                    Width = 0,
-                    Colour = TournamentGame.COLOUR_BLUE,
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopLeft
-                },
-                score2Text = new MatchScoreCounter
-                {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre
-                },
-                scoreDiffText = new MatchScoreDiffCounter
-                {
-                    Anchor = Anchor.TopCentre,
-                    Margin = new MarginPadding
-                    {
-                        Top = bar_height / 4,
-                        Horizontal = 8
-                    },
-                    Alpha = 0
-                }
-            };
-        }
-
         [BackgroundDependencyLoader]
         private void load(MatchIPCInfo ipc)
         {
-            score1.BindValueChanged(_ => updateScores());
-            score1.BindTo(ipc.Score1);
-
-            score2.BindValueChanged(_ => updateScores());
-            score2.BindTo(ipc.Score2);
-        }
-
-        private void updateScores()
-        {
-            score1Text.Current.Value = score1.Value;
-            score2Text.Current.Value = score2.Value;
-
-            var winningText = score1.Value > score2.Value ? score1Text : score2Text;
-            var losingText = score1.Value <= score2.Value ? score1Text : score2Text;
-
-            winningText.Winning = true;
-            losingText.Winning = false;
-
-            var winningBar = score1.Value > score2.Value ? score1Bar : score2Bar;
-            var losingBar = score1.Value <= score2.Value ? score1Bar : score2Bar;
-
-            int diff = Math.Max(score1.Value, score2.Value) - Math.Min(score1.Value, score2.Value);
-
-            losingBar.ResizeWidthTo(0, 400, Easing.OutQuint);
-            winningBar.ResizeWidthTo(Math.Min(0.4f, MathF.Pow(diff / 1500000f, 0.5f) / 2), 400, Easing.OutQuint);
-
-            scoreDiffText.Alpha = diff != 0 ? 1 : 0;
-            scoreDiffText.Current.Value = -diff;
-            scoreDiffText.Origin = score1.Value > score2.Value ? Anchor.TopLeft : Anchor.TopRight;
-        }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
-            score1Text.X = -Math.Max(5 + score1Text.DrawWidth / 2, score1Bar.DrawWidth);
-            score2Text.X = Math.Max(5 + score2Text.DrawWidth / 2, score2Bar.DrawWidth);
-        }
-
-        private partial class MatchScoreCounter : CommaSeparatedScoreCounter
-        {
-            private OsuSpriteText displayedSpriteText = null!;
-
-            public MatchScoreCounter()
-            {
-                Margin = new MarginPadding { Top = bar_height, Horizontal = 10 };
-            }
-
-            public bool Winning
-            {
-                set => updateFont(value);
-            }
-
-            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
-            {
-                displayedSpriteText = s;
-                displayedSpriteText.Spacing = new Vector2(-6);
-                updateFont(false);
-            });
-
-            private void updateFont(bool winning)
-                => displayedSpriteText.Font = winning
-                    ? OsuFont.Torus.With(weight: FontWeight.Bold, size: 50, fixedWidth: true)
-                    : OsuFont.Torus.With(weight: FontWeight.Regular, size: 40, fixedWidth: true);
-        }
-
-        private partial class MatchScoreDiffCounter : CommaSeparatedScoreCounter
-        {
-            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
-            {
-                s.Spacing = new Vector2(-2);
-                s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: bar_height, fixedWidth: true);
-            });
+            Team1Score.BindTo(ipc.Score1);
+            Team2Score.BindTo(ipc.Score2);
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -24,13 +22,13 @@ namespace osu.Game.Screens.Play.HUD
         public BindableLong Team1Score = new BindableLong();
         public BindableLong Team2Score = new BindableLong();
 
-        protected MatchScoreCounter Score1Text;
-        protected MatchScoreCounter Score2Text;
+        protected MatchScoreCounter Score1Text = null!;
+        protected MatchScoreCounter Score2Text = null!;
 
-        private Drawable score1Bar;
-        private Drawable score2Bar;
+        private Drawable score1Bar = null!;
+        private Drawable score2Bar = null!;
 
-        private MatchScoreDiffCounter scoreDiffText;
+        private MatchScoreDiffCounter scoreDiffText = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -166,7 +164,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected partial class MatchScoreCounter : CommaSeparatedScoreCounter
         {
-            private OsuSpriteText displayedSpriteText;
+            private OsuSpriteText displayedSpriteText = null!;
 
             public MatchScoreCounter()
             {

--- a/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/MatchScoreDisplay.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Screens.Play.HUD
         private Drawable score1Bar;
         private Drawable score2Bar;
 
+        private MatchScoreDiffCounter scoreDiffText;
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -98,6 +100,16 @@ namespace osu.Game.Screens.Play.HUD
                         },
                     }
                 },
+                scoreDiffText = new MatchScoreDiffCounter
+                {
+                    Anchor = Anchor.TopCentre,
+                    Margin = new MarginPadding
+                    {
+                        Top = bar_height / 4,
+                        Horizontal = 8
+                    },
+                    Alpha = 0
+                }
             };
         }
 
@@ -139,6 +151,10 @@ namespace osu.Game.Screens.Play.HUD
 
             losingBar.ResizeWidthTo(0, 400, Easing.OutQuint);
             winningBar.ResizeWidthTo(Math.Min(0.4f, MathF.Pow(diff / 1500000f, 0.5f) / 2), 400, Easing.OutQuint);
+
+            scoreDiffText.Alpha = diff != 0 ? 1 : 0;
+            scoreDiffText.Current.Value = -diff;
+            scoreDiffText.Origin = Team1Score.Value > Team2Score.Value ? Anchor.TopLeft : Anchor.TopRight;
         }
 
         protected override void UpdateAfterChildren()
@@ -173,6 +189,15 @@ namespace osu.Game.Screens.Play.HUD
                 => displayedSpriteText.Font = winning
                     ? OsuFont.Torus.With(weight: FontWeight.Bold, size: font_size, fixedWidth: true)
                     : OsuFont.Torus.With(weight: FontWeight.Regular, size: font_size * 0.8f, fixedWidth: true);
+        }
+
+        private partial class MatchScoreDiffCounter : CommaSeparatedScoreCounter
+        {
+            protected override OsuSpriteText CreateSpriteText() => base.CreateSpriteText().With(s =>
+            {
+                s.Spacing = new Vector2(-2);
+                s.Font = OsuFont.Torus.With(weight: FontWeight.Regular, size: bar_height, fixedWidth: true);
+            });
         }
     }
 }


### PR DESCRIPTION
Also:

- Applies nullability to `MatchScoreDisplay`
- Update `TournamentMatchScoreDisplay` to share base implementation

---

This was recently added (https://github.com/ppy/osu/pull/24334) for the tournament client, but was not applied to the local implementation which is used in multiplayer.

