### PR TITLE
Add precise rotation control to osu! editor

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.815.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.817.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuDistanceSnapGrid.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
@@ -70,12 +71,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             base.Content.Children = new Drawable[]
             {
                 editorClock = new EditorClock(editorBeatmap),
-                snapProvider,
+                new PopoverContainer { Child = snapProvider },
                 Content
             };
         }
 
-        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+        protected override Container<Drawable> Content { get; } = new PopoverContainer { RelativeSizeAxes = Axes.Both };
 
         [SetUp]
         public void Setup() => Schedule(() =>

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePreciseRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePreciseRotation.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Edit;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit.Components.RadioButtons;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public partial class TestScenePreciseRotation : TestSceneOsuEditor
+    {
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset);
+
+        [Test]
+        public void TestHotkeyHandling()
+        {
+            AddStep("select single circle", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.OfType<HitCircle>().First()));
+            AddStep("press rotate hotkey", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddUntilStep("no popover present", () => this.ChildrenOfType<PreciseRotationPopover>().Count(), () => Is.Zero);
+
+            AddStep("select first three objects", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.Clear();
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects.Take(3));
+            });
+            AddStep("press rotate hotkey", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddUntilStep("popover present", () => this.ChildrenOfType<PreciseRotationPopover>().Count(), () => Is.EqualTo(1));
+            AddStep("press rotate hotkey", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddUntilStep("no popover present", () => this.ChildrenOfType<PreciseRotationPopover>().Count(), () => Is.Zero);
+        }
+
+        [Test]
+        public void TestRotateCorrectness()
+        {
+            AddStep("replace objects", () =>
+            {
+                EditorBeatmap.Clear();
+                EditorBeatmap.AddRange(new HitObject[]
+                {
+                    new HitCircle { Position = new Vector2(100) },
+                    new HitCircle { Position = new Vector2(200) },
+                });
+            });
+            AddStep("select both circles", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            AddStep("press rotate hotkey", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddUntilStep("popover present", getPopover, () => Is.Not.Null);
+
+            AddStep("rotate by 180deg", () => getPopover().ChildrenOfType<TextBox>().Single().Current.Value = "180");
+            AddAssert("first object rotated 180deg around playfield centre",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(OsuPlayfield.BASE_SIZE - new Vector2(100)));
+            AddAssert("second object rotated 180deg around playfield centre",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
+                () => Is.EqualTo(OsuPlayfield.BASE_SIZE - new Vector2(200)));
+
+            AddStep("change rotation origin", () => getPopover().ChildrenOfType<EditorRadioButton>().ElementAt(1).TriggerClick());
+            AddAssert("first object rotated 90deg around selection centre",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position, () => Is.EqualTo(new Vector2(200, 200)));
+            AddAssert("second object rotated 90deg around selection centre",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position, () => Is.EqualTo(new Vector2(100, 100)));
+
+            PreciseRotationPopover? getPopover() => this.ChildrenOfType<PreciseRotationPopover>().SingleOrDefault();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -85,6 +85,11 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             // we may be entering the screen with a selection already active
             updateDistanceSnapGrid();
+
+            RightToolbox.Add(new TransformToolboxGroup
+            {
+                RotationHandler = BlueprintContainer.SelectionHandler.RotationHandler
+            });
         }
 
         protected override ComposeBlueprintContainer CreateBlueprintContainer()

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit.Components.RadioButtons;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class PreciseRotationPopover : OsuPopover
+    {
+        private readonly SelectionRotationHandler rotationHandler;
+
+        private readonly Bindable<PreciseRotationInfo> rotationInfo = new Bindable<PreciseRotationInfo>(new PreciseRotationInfo(0, RotationOrigin.PlayfieldCentre));
+
+        private SliderWithTextBoxInput<float> angleInput = null!;
+        private EditorRadioButtonCollection rotationOrigin = null!;
+
+        public PreciseRotationPopover(SelectionRotationHandler rotationHandler)
+        {
+            this.rotationHandler = rotationHandler;
+
+            AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new FillFlowContainer
+            {
+                Width = 220,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(20),
+                Children = new Drawable[]
+                {
+                    angleInput = new SliderWithTextBoxInput<float>("Angle (degrees):")
+                    {
+                        Current = new BindableNumber<float>
+                        {
+                            MinValue = -180,
+                            MaxValue = 180,
+                            Precision = 1
+                        },
+                        Instantaneous = true
+                    },
+                    rotationOrigin = new EditorRadioButtonCollection
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Items = new[]
+                        {
+                            new RadioButton("Playfield centre",
+                                () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.PlayfieldCentre },
+                                () => new SpriteIcon { Icon = FontAwesome.Regular.Square }),
+                            new RadioButton("Selection centre",
+                                () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.SelectionCentre },
+                                () => new SpriteIcon { Icon = FontAwesome.Solid.ObjectGroup })
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ScheduleAfterChildren(() => angleInput.TakeFocus());
+            angleInput.Current.BindValueChanged(angle => rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue });
+            rotationOrigin.Items.First().Select();
+
+            rotationInfo.BindValueChanged(rotation =>
+            {
+                rotationHandler.Update(rotation.NewValue.Degrees, rotation.NewValue.Origin == RotationOrigin.PlayfieldCentre ? OsuPlayfield.BASE_SIZE / 2 : null);
+            });
+        }
+
+        protected override void PopIn()
+        {
+            base.PopIn();
+            rotationHandler.Begin();
+        }
+
+        protected override void PopOut()
+        {
+            base.PopOut();
+
+            if (IsLoaded)
+                rotationHandler.Commit();
+        }
+    }
+
+    public enum RotationOrigin
+    {
+        PlayfieldCentre,
+        SelectionCentre
+    }
+
+    public record PreciseRotationInfo(float Degrees, RotationOrigin Origin);
+}

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                     {
                         Current = new BindableNumber<float>
                         {
-                            MinValue = -180,
-                            MaxValue = 180,
+                            MinValue = -360,
+                            MaxValue = 360,
                             Precision = 1
                         },
                         Instantaneous = true

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                                 () => new SpriteIcon { Icon = FontAwesome.Regular.Square }),
                             new RadioButton("Selection centre",
                                 () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.SelectionCentre },
-                                () => new SpriteIcon { Icon = FontAwesome.Solid.ObjectGroup })
+                                () => new SpriteIcon { Icon = FontAwesome.Solid.VectorSquare })
                         }
                     }
                 }

--- a/osu.Game.Rulesets.Osu/Edit/TransformToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/TransformToolboxGroup.cs
@@ -1,0 +1,80 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Input.Bindings;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Screens.Edit.Components;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class TransformToolboxGroup : EditorToolboxGroup, IKeyBindingHandler<GlobalAction>
+    {
+        private readonly Bindable<bool> canRotate = new BindableBool();
+
+        private EditorToolButton rotateButton = null!;
+
+        public SelectionRotationHandler RotationHandler { get; init; } = null!;
+
+        public TransformToolboxGroup()
+            : base("transform")
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(5),
+                Children = new Drawable[]
+                {
+                    rotateButton = new EditorToolButton("Rotate",
+                        () => new SpriteIcon { Icon = FontAwesome.Solid.Undo },
+                        () => new PreciseRotationPopover(RotationHandler)),
+                    // TODO: scale
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // bindings to `Enabled` on the buttons are decoupled on purpose
+            // due to the weird `OsuButton` behaviour of resetting `Enabled` to `false` when `Action` is set.
+            canRotate.BindTo(RotationHandler.CanRotate);
+            canRotate.BindValueChanged(_ => rotateButton.Enabled.Value = canRotate.Value, true);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat) return false;
+
+            switch (e.Action)
+            {
+                case GlobalAction.EditorToggleRotateControl:
+                {
+                    rotateButton.TriggerClick();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -257,7 +257,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 texture.Bind();
 
                 for (int i = 0; i < points.Count; i++)
-                    drawPointQuad(points[i], textureRect, i + firstVisiblePointIndex);
+                    drawPointQuad(renderer, points[i], textureRect, i + firstVisiblePointIndex);
 
                 UnbindTextureShader(renderer);
                 renderer.PopLocalMatrix();
@@ -325,7 +325,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             private float getRotation(int index) => max_rotation * (StatelessRNG.NextSingle(rotationSeed, index) * 2 - 1);
 
-            private void drawPointQuad(SmokePoint point, RectangleF textureRect, int index)
+            private void drawPointQuad(IRenderer renderer, SmokePoint point, RectangleF textureRect, int index)
             {
                 Debug.Assert(quadBatch != null);
 
@@ -347,25 +347,25 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 var localBotLeft = point.Position + ortho - dir;
                 var localBotRight = point.Position + ortho + dir;
 
-                quadBatch.Add(new TexturedVertex2D
+                quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localTopLeft,
                     TexturePosition = textureRect.TopLeft,
                     Colour = Color4Extensions.Multiply(ColourAtPosition(localTopLeft), colour),
                 });
-                quadBatch.Add(new TexturedVertex2D
+                quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localTopRight,
                     TexturePosition = textureRect.TopRight,
                     Colour = Color4Extensions.Multiply(ColourAtPosition(localTopRight), colour),
                 });
-                quadBatch.Add(new TexturedVertex2D
+                quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localBotRight,
                     TexturePosition = textureRect.BottomRight,
                     Colour = Color4Extensions.Multiply(ColourAtPosition(localBotRight), colour),
                 });
-                quadBatch.Add(new TexturedVertex2D
+                quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localBotLeft,
                     TexturePosition = textureRect.BottomLeft,

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
@@ -29,7 +30,7 @@ namespace osu.Game.Tests.Editing
         [Cached(typeof(IBeatSnapProvider))]
         private readonly EditorBeatmap editorBeatmap;
 
-        protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
+        protected override Container<Drawable> Content { get; } = new PopoverContainer { RelativeSizeAxes = Axes.Both };
 
         public TestSceneHitObjectComposerDistanceSnapping()
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectComposer.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -178,7 +178,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("distance spacing increased by 0.5", () => editorBeatmap.BeatmapInfo.DistanceSpacing == originalSpacing + 0.5);
         }
 
-        public partial class EditorBeatmapContainer : Container
+        public partial class EditorBeatmapContainer : PopoverContainer
         {
             private readonly IWorkingBeatmap working;
 

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public string Text
         {
+            get => Component.Text;
             set => Component.Text = value;
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             Current.BindValueChanged(updateTextBoxFromSlider, true);
         }
 
+        public bool TakeFocus() => GetContainingInputManager().ChangeFocus(textBox);
+
         private bool updatingFromTextBox;
 
         private void textChanged(ValueChangedEvent<string> change)

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -105,6 +105,7 @@ namespace osu.Game.Input.Bindings
             // See https://github.com/ppy/osu-framework/blob/master/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs#L37-L38.
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelRight }, GlobalAction.EditorCyclePreviousBeatSnapDivisor),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.MouseWheelLeft }, GlobalAction.EditorCycleNextBeatSnapDivisor),
+            new KeyBinding(new[] { InputKey.Control, InputKey.R }, GlobalAction.EditorToggleRotateControl),
         };
 
         public IEnumerable<KeyBinding> InGameKeyBindings => new[]
@@ -378,5 +379,8 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleInGameLeaderboard))]
         ToggleInGameLeaderboard,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorToggleRotateControl))]
+        EditorToggleRotateControl,
     }
 }

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -344,6 +344,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ExportReplay => new TranslatableString(getKey(@"export_replay"), @"Export replay");
 
+        /// <summary>
+        /// "Toggle rotate control"
+        /// </summary>
+        public static LocalisableString EditorToggleRotateControl => new TranslatableString(getKey(@"editor_toggle_rotate_control"), @"Toggle rotate control");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Edit/Components/EditorToolButton.cs
+++ b/osu.Game/Screens/Edit/Components/EditorToolButton.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Edit.Components
+{
+    public partial class EditorToolButton : OsuButton, IHasPopover
+    {
+        public BindableBool Selected { get; } = new BindableBool();
+
+        private readonly Func<Drawable> createIcon;
+        private readonly Func<Popover?> createPopover;
+
+        private Color4 defaultBackgroundColour;
+        private Color4 defaultIconColour;
+        private Color4 selectedBackgroundColour;
+        private Color4 selectedIconColour;
+
+        private Drawable icon = null!;
+
+        public EditorToolButton(LocalisableString text, Func<Drawable> createIcon, Func<Popover?> createPopover)
+        {
+            Text = text;
+            this.createIcon = createIcon;
+            this.createPopover = createPopover;
+
+            RelativeSizeAxes = Axes.X;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            defaultBackgroundColour = colourProvider.Background3;
+            selectedBackgroundColour = colourProvider.Background1;
+
+            defaultIconColour = defaultBackgroundColour.Darken(0.5f);
+            selectedIconColour = selectedBackgroundColour.Lighten(0.5f);
+
+            Add(icon = createIcon().With(b =>
+            {
+                b.Blending = BlendingParameters.Additive;
+                b.Anchor = Anchor.CentreLeft;
+                b.Origin = Anchor.CentreLeft;
+                b.Size = new Vector2(20);
+                b.X = 10;
+            }));
+
+            Action = Selected.Toggle;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Selected.BindValueChanged(_ => updateSelectionState(), true);
+        }
+
+        private void updateSelectionState()
+        {
+            if (!IsLoaded)
+                return;
+
+            BackgroundColour = Selected.Value ? selectedBackgroundColour : defaultBackgroundColour;
+            icon.Colour = Selected.Value ? selectedIconColour : defaultIconColour;
+
+            if (Selected.Value)
+                this.ShowPopover();
+            else
+                this.HidePopover();
+        }
+
+        protected override SpriteText CreateText() => new OsuSpriteText
+        {
+            Depth = -1,
+            Origin = Anchor.CentreLeft,
+            Anchor = Anchor.CentreLeft,
+            X = 40f
+        };
+
+        public Popover? GetPopover() => Enabled.Value
+            ? createPopover()?.With(p =>
+            {
+                p.State.BindValueChanged(state =>
+                {
+                    if (state.NewValue == Visibility.Hidden)
+                        Selected.Value = false;
+                });
+            })
+            : null;
+    }
+}

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public Container<SelectionBlueprint<T>> SelectionBlueprints { get; private set; }
 
-        protected SelectionHandler<T> SelectionHandler { get; private set; }
+        public SelectionHandler<T> SelectionHandler { get; private set; }
 
         private readonly Dictionary<T, SelectionBlueprint<T>> blueprintMap = new Dictionary<T, SelectionBlueprint<T>>();
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [Resolved(CanBeNull = true)]
         protected IEditorChangeHandler ChangeHandler { get; private set; }
 
-        protected SelectionRotationHandler RotationHandler { get; private set; }
+        public SelectionRotationHandler RotationHandler { get; private set; }
 
         protected SelectionHandler()
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="11.1.2" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.815.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.817.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.719.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -23,6 +23,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.815.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.817.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/12045
- [x] Depends on https://github.com/ppy/osu-framework/pull/5967
- [x] Depends on framework package w/ the above
- [x] Depends on https://github.com/ppy/osu/pull/24431

https://github.com/ppy/osu/assets/20418176/2939201e-5e5e-4e88-b5d4-8eed7a98dd58

A few notes:

- Rotation is clamped to [-180deg, 180deg] range. Textbox inputs above that will be clamped to the range on focus loss/commit (not shown on above video)
- Stable also has a direction toggle (clockwise/counterclockwise). I didn't add it back as it seemed pointless and led to ambiguity (180deg CCW = -180deg CW)
- The hotkey is <kbd>Ctrl</kbd>-<kbd>R</kbd> to avoid clash with the global "random skin" binding.