### PR TITLE
Set correct date added value when importing stable beatmapsets

### DIFF
--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Platform;
@@ -74,7 +75,7 @@ namespace osu.Game.Tests.Database
                     var stableStorage = new StableStorage(tmpStorage.GetFullPath(""), host);
                     var songsStorage = stableStorage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);
 
-                    System.IO.Compression.ZipFile.ExtractToDirectory(TestResources.GetQuickTestBeatmapForImport(), songsStorage.GetFullPath("renatus"));
+                    ZipFile.ExtractToDirectory(TestResources.GetQuickTestBeatmapForImport(), songsStorage.GetFullPath("renatus"));
 
                     string[] beatmaps = Directory.GetFiles(songsStorage.GetFullPath("renatus"), "*.osu", SearchOption.TopDirectoryOnly);
 
@@ -82,10 +83,10 @@ namespace osu.Game.Tests.Database
 
                     await new LegacyBeatmapImporter(new BeatmapImporter(storage, realm)).ImportFromStableAsync(stableStorage);
 
-                    var beatmapset = realm.Realm.All<BeatmapSetInfo>().First();
+                    var importedSet = realm.Realm.All<BeatmapSetInfo>().Single();
 
-                    Assert.NotNull(beatmapset);
-                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), beatmapset.DateAdded);
+                    Assert.NotNull(importedSet);
+                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), importedSet.DateAdded);
                 }
             });
         }

--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -1,19 +1,22 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
+using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Database
 {
     [TestFixture]
-    public class LegacyBeatmapImporterTest
+    public class LegacyBeatmapImporterTest : RealmTest
     {
         private readonly TestLegacyBeatmapImporter importer = new TestLegacyBeatmapImporter();
 
@@ -58,6 +61,32 @@ namespace osu.Game.Tests.Database
                 using (var stream = storage.CreateFileSafely(path))
                     stream.WriteByte(0);
             }
+        }
+
+        [Test]
+        public void TestStableDateAddedApplied()
+        {
+            RunTestWithRealmAsync(async (realm, storage) =>
+            {
+                using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+                using (var tmpStorage = new TemporaryNativeStorage("stable-songs-folder"))
+                {
+                    var stableStorage = new StableStorage(tmpStorage.GetFullPath(""), host);
+                    var songsStorage = stableStorage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);
+
+                    System.IO.Compression.ZipFile.ExtractToDirectory(TestResources.GetQuickTestBeatmapForImport(), songsStorage.GetFullPath("renatus"));
+
+                    string[] beatmaps = Directory.GetFiles(songsStorage.GetFullPath("renatus"), "*.osu", SearchOption.TopDirectoryOnly);
+
+                    File.SetLastWriteTimeUtc(beatmaps[beatmaps.Length / 2], new DateTime(2000, 1, 1, 12, 0, 0));
+
+                    await new LegacyBeatmapImporter(new BeatmapImporter(storage, realm)).ImportFromStableAsync(stableStorage);
+
+                    var set = realm.Realm.All<BeatmapSetInfo>();
+
+                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), set.First().DateAdded);
+                }
+            });
         }
 
         private class TestLegacyBeatmapImporter : LegacyBeatmapImporter

--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -82,9 +82,10 @@ namespace osu.Game.Tests.Database
 
                     await new LegacyBeatmapImporter(new BeatmapImporter(storage, realm)).ImportFromStableAsync(stableStorage);
 
-                    var set = realm.Realm.All<BeatmapSetInfo>();
+                    var beatmapset = realm.Realm.All<BeatmapSetInfo>().First();
 
-                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), set.First().DateAdded);
+                    Assert.NotNull(beatmapset);
+                    Assert.AreEqual(new DateTimeOffset(new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc)), beatmapset.DateAdded);
                 }
             });
         }

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -323,11 +323,11 @@ namespace osu.Game.Beatmaps
             {
                 var beatmaps = reader.Filenames.Where(f => f.EndsWith(".osu", StringComparison.OrdinalIgnoreCase));
 
-                dateAdded = File.GetLastWriteTimeUtc(legacyReader.GetPath(beatmaps.First()));
+                dateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmaps.First()));
 
                 foreach (string beatmapName in beatmaps)
                 {
-                    var currentDateAdded = File.GetLastWriteTimeUtc(legacyReader.GetPath(beatmapName));
+                    var currentDateAdded = File.GetLastWriteTimeUtc(legacyReader.GetFullPath(beatmapName));
 
                     if (currentDateAdded < dateAdded)
                         dateAdded = currentDateAdded;

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -314,7 +314,6 @@ namespace osu.Game.Beatmaps
             return new BeatmapSetInfo
             {
                 OnlineID = beatmap.BeatmapInfo.BeatmapSet?.OnlineID ?? -1,
-                // Metadata = beatmap.Metadata,
                 DateAdded = dateAdded
             };
         }

--- a/osu.Game/IO/Archives/LegacyDirectoryArchiveReader.cs
+++ b/osu.Game/IO/Archives/LegacyDirectoryArchiveReader.cs
@@ -21,7 +21,9 @@ namespace osu.Game.IO.Archives
             this.path = Path.GetFullPath(path);
         }
 
-        public override Stream GetStream(string name) => File.OpenRead(Path.Combine(path, name));
+        public override Stream GetStream(string name) => File.OpenRead(GetPath(name));
+
+        public string GetPath(string name) => Path.Combine(path, name);
 
         public override void Dispose()
         {

--- a/osu.Game/IO/Archives/LegacyDirectoryArchiveReader.cs
+++ b/osu.Game/IO/Archives/LegacyDirectoryArchiveReader.cs
@@ -21,9 +21,9 @@ namespace osu.Game.IO.Archives
             this.path = Path.GetFullPath(path);
         }
 
-        public override Stream GetStream(string name) => File.OpenRead(GetPath(name));
+        public override Stream GetStream(string name) => File.OpenRead(GetFullPath(name));
 
-        public string GetPath(string name) => Path.Combine(path, name);
+        public string GetFullPath(string filename) => Path.Combine(path, filename);
 
         public override void Dispose()
         {


### PR DESCRIPTION
Resolves #13717.

I'm not sure if it's the right idea to put this code inside the regular `BeatmapImporter`, but I couldn't find any other reasonable way of doing this - the legacy importers are just firing the regular importers, and don't have any way to later influence them, and I didn't want to make this into a larger refactor.

