### PR TITLE
Update overlay pop-in/pop-out sample usage

### DIFF
--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Collections
 
         private AudioFilter lowPassFilter = null!;
 
+        protected override string PopInSampleName => @"UI/overlay-big-pop-in";
+        protected override string PopOutSampleName => @"UI/overlay-big-pop-out";
+
         public ManageCollectionsDialog()
         {
             Anchor = Anchor.Centre;

--- a/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Graphics.Containers
         private Sample samplePopOut;
         protected virtual string PopInSampleName => "UI/overlay-pop-in";
         protected virtual string PopOutSampleName => "UI/overlay-pop-out";
+        protected virtual double PopInOutSampleBalance => 0;
 
         protected override bool BlockNonPositionalInput => true;
 
@@ -133,15 +134,21 @@ namespace osu.Game.Graphics.Containers
                         return;
                     }
 
-                    if (didChange)
-                        samplePopIn?.Play();
+                    if (didChange && samplePopIn != null)
+                    {
+                        samplePopIn.Balance.Value = PopInOutSampleBalance;
+                        samplePopIn.Play();
+                    }
 
                     if (BlockScreenWideMouse && DimMainContent) overlayManager?.ShowBlockingOverlay(this);
                     break;
 
                 case Visibility.Hidden:
-                    if (didChange)
-                        samplePopOut?.Play();
+                    if (didChange && samplePopOut != null)
+                    {
+                        samplePopOut.Balance.Value = PopInOutSampleBalance;
+                        samplePopOut.Play();
+                    }
 
                     if (BlockScreenWideMouse) overlayManager?.HideBlockingOverlay(this);
                     break;

--- a/osu.Game/Graphics/Containers/WaveContainer.cs
+++ b/osu.Game/Graphics/Containers/WaveContainer.cs
@@ -40,7 +40,8 @@ namespace osu.Game.Graphics.Containers
         protected virtual string PopInSampleName => "UI/wave-pop-in";
         protected virtual string PopOutSampleName => "UI/overlay-big-pop-out";
 
-        private bool wasShown = false;
+        // required due to LoadAsyncComplete() in `VisibilityContainer` calling PopOut() during load - similar workaround to `OsuDropdownMenu`
+        private bool wasShown;
 
         public Color4 FirstWaveColour
         {

--- a/osu.Game/Graphics/Containers/WaveContainer.cs
+++ b/osu.Game/Graphics/Containers/WaveContainer.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -32,6 +35,13 @@ namespace osu.Game.Graphics.Containers
 
         protected override bool StartHidden => true;
 
+        private Sample? samplePopIn;
+        private Sample? samplePopOut;
+        protected virtual string PopInSampleName => "UI/wave-pop-in";
+        protected virtual string PopOutSampleName => "UI/overlay-big-pop-out";
+
+        private bool wasShown = false;
+
         public Color4 FirstWaveColour
         {
             get => firstWave.Colour;
@@ -54,6 +64,13 @@ namespace osu.Game.Graphics.Containers
         {
             get => fourthWave.Colour;
             set => fourthWave.Colour = value;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(AudioManager audio)
+        {
+            samplePopIn = audio.Samples.Get(PopInSampleName);
+            samplePopOut = audio.Samples.Get(PopOutSampleName);
         }
 
         public WaveContainer()
@@ -110,6 +127,8 @@ namespace osu.Game.Graphics.Containers
                 w.Show();
 
             contentContainer.MoveToY(0, APPEAR_DURATION, Easing.OutQuint);
+            samplePopIn?.Play();
+            wasShown = true;
         }
 
         protected override void PopOut()
@@ -118,6 +137,9 @@ namespace osu.Game.Graphics.Containers
                 w.Hide();
 
             contentContainer.MoveToY(2, DISAPPEAR_DURATION, Easing.In);
+
+            if (wasShown)
+                samplePopOut?.Play();
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Graphics/Containers/WaveContainer.cs
+++ b/osu.Game/Graphics/Containers/WaveContainer.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Graphics.Containers
 
         private Sample? samplePopIn;
         private Sample? samplePopOut;
-        protected virtual string PopInSampleName => "UI/wave-pop-in";
-        protected virtual string PopOutSampleName => "UI/overlay-big-pop-out";
 
         // required due to LoadAsyncComplete() in `VisibilityContainer` calling PopOut() during load - similar workaround to `OsuDropdownMenu`
         private bool wasShown;
@@ -70,8 +68,8 @@ namespace osu.Game.Graphics.Containers
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio)
         {
-            samplePopIn = audio.Samples.Get(PopInSampleName);
-            samplePopOut = audio.Samples.Get(PopOutSampleName);
+            samplePopIn = audio.Samples.Get("UI/wave-pop-in");
+            samplePopOut = audio.Samples.Get("UI/overlay-big-pop-out");
         }
 
         public WaveContainer()

--- a/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuAnimatedButton.cs
@@ -46,8 +46,8 @@ namespace osu.Game.Graphics.UserInterface
         private readonly Container content;
         private readonly Box hover;
 
-        public OsuAnimatedButton()
-            : base(HoverSampleSet.Button)
+        public OsuAnimatedButton(HoverSampleSet sampleSet = HoverSampleSet.Button)
+            : base(sampleSet)
         {
             base.Content.Add(content = new Container
             {

--- a/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Graphics.UserInterface
         private Sample? sampleOff;
         private Sample? sampleOn;
 
+        protected virtual bool PlayClickSampleOnly => false;
+
         /// <summary>
         /// Whether this button is currently toggled to an active state.
         /// </summary>
@@ -67,6 +69,9 @@ namespace osu.Game.Graphics.UserInterface
         private void playSample()
         {
             sampleClick?.Play();
+
+            if (PlayClickSampleOnly)
+                return;
 
             if (Active.Value)
                 sampleOn?.Play();

--- a/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedToggleButton.cs
@@ -14,7 +14,11 @@ namespace osu.Game.Graphics.UserInterface
         private Sample? sampleOff;
         private Sample? sampleOn;
 
-        protected virtual bool PlayClickSampleOnly => false;
+        /// <summary>
+        /// Sheared toggle buttons by default play two samples when toggled: a click and a toggle (on/off).
+        /// Sometimes this might be too much. Setting this to <c>false</c> will silence the toggle sound.
+        /// </summary>
+        protected virtual bool PlayToggleSamples => true;
 
         /// <summary>
         /// Whether this button is currently toggled to an active state.
@@ -70,13 +74,13 @@ namespace osu.Game.Graphics.UserInterface
         {
             sampleClick?.Play();
 
-            if (PlayClickSampleOnly)
-                return;
-
-            if (Active.Value)
-                sampleOn?.Play();
-            else
-                sampleOff?.Play();
+            if (PlayToggleSamples)
+            {
+                if (Active.Value)
+                    sampleOn?.Play();
+                else
+                    sampleOff?.Play();
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         // required due to LoadAsyncComplete() calling PopOut() during load - similar workaround to `OsuDropdownMenu`
         private bool wasOpened;
 
-        protected virtual bool PlayPopInOutSamples => true;
-
         public OsuPopover(bool withPadding = true)
         {
             Content.Padding = withPadding ? new MarginPadding(20) : new MarginPadding();
@@ -64,11 +62,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             this.ScaleTo(1, scale_duration, Easing.OutElasticHalf);
             this.FadeIn(fade_duration, Easing.OutQuint);
 
-            if (PlayPopInOutSamples)
-            {
-                samplePopIn?.Play();
-                wasOpened = true;
-            }
+            samplePopIn?.Play();
+            wasOpened = true;
         }
 
         protected override void PopOut()
@@ -76,7 +71,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             this.ScaleTo(0.7f, scale_duration, Easing.OutQuint);
             this.FadeOut(fade_duration, Easing.OutQuint);
 
-            if (wasOpened && PlayPopInOutSamples)
+            if (wasOpened)
                 samplePopOut?.Play();
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         protected virtual string PopInSampleName => "UI/overlay-pop-in";
         protected virtual string PopOutSampleName => "UI/overlay-pop-out";
 
-        // required due to LoadAsyncComplete() calling PopOut() during load - similar workaround to `OsuDropdownMenu`
+        // required due to LoadAsyncComplete() in `VisibilityContainer` calling PopOut() during load - similar workaround to `OsuDropdownMenu`
         private bool wasOpened;
 
         public OsuPopover(bool withPadding = true)

--- a/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuPopover.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,6 +23,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private const float fade_duration = 250;
         private const double scale_duration = 500;
 
+        private Sample? samplePopIn;
+        private Sample? samplePopOut;
+        protected virtual string PopInSampleName => "UI/overlay-pop-in";
+        protected virtual string PopOutSampleName => "UI/overlay-pop-out";
+
+        // required due to LoadAsyncComplete() calling PopOut() during load - similar workaround to `OsuDropdownMenu`
+        private bool wasOpened;
+
+        protected virtual bool PlayPopInOutSamples => true;
+
         public OsuPopover(bool withPadding = true)
         {
             Content.Padding = withPadding ? new MarginPadding(20) : new MarginPadding();
@@ -38,9 +50,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OverlayColourProvider? colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider? colourProvider, OsuColour colours, AudioManager audio)
         {
             Background.Colour = Arrow.Colour = colourProvider?.Background4 ?? colours.GreySeaFoamDarker;
+            samplePopIn = audio.Samples.Get(PopInSampleName);
+            samplePopOut = audio.Samples.Get(PopOutSampleName);
         }
 
         protected override Drawable CreateArrow() => Empty();
@@ -49,12 +63,21 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             this.ScaleTo(1, scale_duration, Easing.OutElasticHalf);
             this.FadeIn(fade_duration, Easing.OutQuint);
+
+            if (PlayPopInOutSamples)
+            {
+                samplePopIn?.Play();
+                wasOpened = true;
+            }
         }
 
         protected override void PopOut()
         {
             this.ScaleTo(0.7f, scale_duration, Easing.OutQuint);
             this.FadeOut(fade_duration, Easing.OutQuint);
+
+            if (wasOpened && PlayPopInOutSamples)
+                samplePopOut?.Play();
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -55,6 +55,9 @@ namespace osu.Game.Overlays
         private const float side_bar_width = 190;
         private const float chat_bar_height = 60;
 
+        protected override string PopInSampleName => @"UI/overlay-big-pop-in";
+        protected override string PopOutSampleName => @"UI/overlay-big-pop-out";
+
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
 

--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Overlays
 
         private const float transition_time = 400;
 
+        protected override double PopInOutSampleBalance => OsuGameBase.SFX_STEREO_STRENGTH;
+
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Overlays.Mods
 {
     public partial class AddPresetButton : ShearedToggleButton, IHasPopover
     {
-        protected override bool PlayClickSampleOnly => true;
+        protected override bool PlayToggleSamples => false;
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;

--- a/osu.Game/Overlays/Mods/AddPresetButton.cs
+++ b/osu.Game/Overlays/Mods/AddPresetButton.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Overlays.Mods
 {
     public partial class AddPresetButton : ShearedToggleButton, IHasPopover
     {
+        protected override bool PlayClickSampleOnly => true;
+
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Overlays
         public LocalisableString Title => NotificationsStrings.HeaderTitle;
         public LocalisableString Description => NotificationsStrings.HeaderDescription;
 
+        protected override double PopInOutSampleBalance => OsuGameBase.SFX_STEREO_STRENGTH;
+
         public const float WIDTH = 320;
 
         public const float TRANSITION_LENGTH = 600;

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Overlays
         private SeekLimitedSearchTextBox searchTextBox;
 
         protected override string PopInSampleName => "UI/settings-pop-in";
+        protected override double PopInOutSampleBalance => -OsuGameBase.SFX_STEREO_STRENGTH;
 
         private readonly bool showSidebar;
 

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Overlays
         protected override bool StartHidden => true;
 
         protected override string PopInSampleName => "UI/wave-pop-in";
+        protected override string PopOutSampleName => "UI/overlay-big-pop-out";
 
         public const float HORIZONTAL_PADDING = 50;
 

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -19,8 +19,8 @@ namespace osu.Game.Overlays
         protected override bool StartHidden => true;
 
         // `WaveContainer` plays PopIn/PopOut samples, so we disable the overlay-level one as to not double-up sample playback.
-        protected override string PopInSampleName => "";
-        protected override string PopOutSampleName => "";
+        protected override string PopInSampleName => string.Empty;
+        protected override string PopOutSampleName => string.Empty;
 
         public const float HORIZONTAL_PADDING = 50;
 

--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -18,8 +18,9 @@ namespace osu.Game.Overlays
 
         protected override bool StartHidden => true;
 
-        protected override string PopInSampleName => "UI/wave-pop-in";
-        protected override string PopOutSampleName => "UI/overlay-big-pop-out";
+        // `WaveContainer` plays PopIn/PopOut samples, so we disable the overlay-level one as to not double-up sample playback.
+        protected override string PopInSampleName => "";
+        protected override string PopOutSampleName => "";
 
         public const float HORIZONTAL_PADDING = 50;
 

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -262,6 +262,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             private readonly OsuSpriteText divisorText;
 
             public DivisorDisplay()
+                : base(HoverSampleSet.Default)
             {
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;

--- a/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
@@ -114,6 +114,9 @@ namespace osu.Game.Screens.Edit.Setup
 
         private partial class FileChooserPopover : OsuPopover
         {
+            protected override string PopInSampleName => "UI/overlay-big-pop-in";
+            protected override string PopOutSampleName => "UI/overlay-big-pop-out";
+
             public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo?> currentFile, string? chooserPath)
             {
                 Child = new Container

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -170,7 +170,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             if (Room.HasPassword.Value)
             {
-                sampleJoin?.Play();
                 this.ShowPopover();
                 return true;
             }
@@ -190,10 +189,6 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
             public override bool HandleNonPositionalInput => true;
 
             protected override bool BlockNonPositionalInput => true;
-
-            // When a room is clicked, it already plays a click sound, which clashes pretty badly with the pop in sound.
-            // Dunno about this one. I'd probably remove the click sound from the panel in cases they are password protected and play these pop in / out sounds.
-            protected override bool PlayPopInOutSamples => false;
 
             public PasswordEntryPopover(Room room)
             {

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -191,6 +191,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             protected override bool BlockNonPositionalInput => true;
 
+            // When a room is clicked, it already plays a click sound, which clashes pretty badly with the pop in sound.
+            // Dunno about this one. I'd probably remove the click sound from the panel in cases they are password protected and play these pop in / out sounds.
             protected override bool PlayPopInOutSamples => false;
 
             public PasswordEntryPopover(Room room)

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -191,6 +191,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
 
             protected override bool BlockNonPositionalInput => true;
 
+            protected override bool PlayPopInOutSamples => false;
+
             public PasswordEntryPopover(Room room)
             {
                 this.room = room;

--- a/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
+++ b/osu.Game/Screens/Select/Options/BeatmapOptionsOverlay.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Screens.Select.Options
 
         public override bool BlockScreenWideMouse => false;
 
+        protected override string PopInSampleName => "SongSelect/options-pop-in";
+        protected override string PopOutSampleName => "SongSelect/options-pop-out";
+
         public BeatmapOptionsOverlay()
         {
             AutoSizeAxes = Axes.Y;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.1.2" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.815.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.719.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.817.0" />
     <PackageReference Include="Sentry" Version="3.28.1" />
     <PackageReference Include="SharpCompress" Version="0.32.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
An update to the pop-in/pop-out samples for various overlays. Also adds them to some overlays/popups that were previously missing them.

Updated/added samples for overlays:
- `ManageCollectionsDialog`, `ChatOverlay`, `FileChooserPopover`: new shared `overlay-big-x`
- `NotificationOverlay`, `OsuPopover` and children (report, mod presets, etc): updated shared `overlay-x`
- `SettingsPanel`: updated `settings-pop-in`
- `BeatmapOptionsOverlay` (aware there is a new design for this incoming, but I had created the samples prior to finding out, so PR'ing for use in the meantime anyway)
- `WaveOverlayContainer.cs`: updated `wave-pop-in` sample

Adds left/right panning to the pop-in/pop-out of:
- `LoginOverlay`
- `NotificationOverlay`
- `SettingsPanel`

Also tweaked on-click sample playback behaviour of some components that didn't work well with the overlay pop-in samples.

- [x] Depends on ppy/osu-resources#276