### PR TITLE
Fix tracking on empty control point groups

### DIFF
--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -147,6 +147,10 @@ namespace osu.Game.Screens.Edit.Timing
                 trackedType = null;
             else
             {
+                // If the selected group has no control points, clear the tracked type.
+                // Otherwise the user will be unable to select a group with no control points.
+                if (selectedGroup.Value.ControlPoints.Count == 0)
+                    trackedType = null;
                 // If the selected group only has one control point, update the tracking type.
                 if (selectedGroup.Value.ControlPoints.Count == 1)
                     trackedType = selectedGroup.Value?.ControlPoints.Single().GetType();

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -147,17 +147,25 @@ namespace osu.Game.Screens.Edit.Timing
                 trackedType = null;
             else
             {
-                // If the selected group has no control points, clear the tracked type.
-                // Otherwise the user will be unable to select a group with no control points.
-                if (selectedGroup.Value.ControlPoints.Count == 0)
-                    trackedType = null;
-                // If the selected group only has one control point, update the tracking type.
-                if (selectedGroup.Value.ControlPoints.Count == 1)
-                    trackedType = selectedGroup.Value?.ControlPoints.Single().GetType();
-                // If the selected group has more than one control point, choose the first as the tracking type
-                // if we don't already have a singular tracked type.
-                else if (trackedType == null)
-                    trackedType = selectedGroup.Value?.ControlPoints.FirstOrDefault()?.GetType();
+                switch (selectedGroup.Value.ControlPoints.Count)
+                {
+                    // If the selected group has no control points, clear the tracked type.
+                    // Otherwise the user will be unable to select a group with no control points.
+                    case 0:
+                        trackedType = null;
+                        break;
+
+                    // If the selected group only has one control point, update the tracking type.
+                    case 1:
+                        trackedType = selectedGroup.Value?.ControlPoints.Single().GetType();
+                        break;
+
+                    // If the selected group has more than one control point, choose the first as the tracking type
+                    // if we don't already have a singular tracked type.
+                    default:
+                        trackedType ??= selectedGroup.Value?.ControlPoints.FirstOrDefault()?.GetType();
+                        break;
+                }
             }
 
             if (trackedType != null)


### PR DESCRIPTION
Small issue I noticed. When adding a control point you might at some point have a control point group with no control points in it. This could happen because you for instance deselect the 'effects' section and then select the 'timing' section. However the moment you deselect the 'effects' section and there are no sections active, your selection gets moved to the previous effect control point group because of tracking. The control point group with no control points is very hard to select because the game remembers the tracked type and tries to select those types of control point groups.

This PR fixes the issue.

One unintended behaviour of this change is that when a control point group with no control points is selected, tracking is disabled, so it will not automatically move to the next control point group. I think this is fine though since the area of effect of this control point group with no control points is undefined so technically there is no "next group" which overrides the effect.