### PR TITLE
Fix `SliderPath.GetSegmentEnds`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
@@ -185,6 +185,34 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("shorten to -10 length", () => path.ExpectedDistance.Value = -10);
         }
 
+        [Test]
+        public void TestGetSegmentEnds()
+        {
+            var positions = new[]
+            {
+                Vector2.Zero,
+                new Vector2(100, 0),
+                new Vector2(100),
+                new Vector2(200, 100),
+            };
+            double[] distances = { 100d, 200d, 300d };
+
+            AddStep("create path", () => path.ControlPoints.AddRange(positions.Select(p => new PathControlPoint(p, PathType.Linear))));
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 300)));
+            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(positions.Skip(1)));
+            AddStep("lengthen last segment", () => path.ExpectedDistance.Value = 400);
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 400)));
+            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(positions.Skip(1)));
+            AddStep("shorten last segment", () => path.ExpectedDistance.Value = 150);
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 150)));
+            AddAssert("segment end positions not recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(new[]
+            {
+                positions[1],
+                new Vector2(100, 50),
+                new Vector2(100, 50),
+            }));
+        }
+
         private List<PathControlPoint> createSegment(PathType type, params Vector2[] controlPoints)
         {
             var points = controlPoints.Select(p => new PathControlPoint { Position = p }).ToList();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
@@ -207,6 +207,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("shorten last segment", () => path.ExpectedDistance.Value = 150);
             AddAssert("segment ends are correct", () => path.GetSegmentEnds(), () => Is.EqualTo(distances.Select(d => d / 150)));
+            // see remarks in `GetSegmentEnds()` xmldoc (`SliderPath.PositionAt()` clamps progress to [0,1]).
             AddAssert("segment end positions not recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)), () => Is.EqualTo(new[]
             {
                 positions[1],

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSliderPath.cs
@@ -198,14 +198,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             double[] distances = { 100d, 200d, 300d };
 
             AddStep("create path", () => path.ControlPoints.AddRange(positions.Select(p => new PathControlPoint(p, PathType.Linear))));
-            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 300)));
-            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(positions.Skip(1)));
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds(), () => Is.EqualTo(distances.Select(d => d / 300)));
+            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)), () => Is.EqualTo(positions.Skip(1)));
+
             AddStep("lengthen last segment", () => path.ExpectedDistance.Value = 400);
-            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 400)));
-            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(positions.Skip(1)));
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds(), () => Is.EqualTo(distances.Select(d => d / 400)));
+            AddAssert("segment end positions recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)), () => Is.EqualTo(positions.Skip(1)));
+
             AddStep("shorten last segment", () => path.ExpectedDistance.Value = 150);
-            AddAssert("segment ends are correct", () => path.GetSegmentEnds().SequenceEqual(distances.Select(d => d / 150)));
-            AddAssert("segment end positions not recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)).SequenceEqual(new[]
+            AddAssert("segment ends are correct", () => path.GetSegmentEnds(), () => Is.EqualTo(distances.Select(d => d / 150)));
+            AddAssert("segment end positions not recovered", () => path.GetSegmentEnds().Select(p => path.PositionAt(p)), () => Is.EqualTo(new[]
             {
                 positions[1],
                 new Vector2(100, 50),

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -198,8 +198,16 @@ namespace osu.Game.Rulesets.Objects
         }
 
         /// <summary>
-        /// Returns the progress values at which segments of the path end.
+        /// Returns the progress values at which (control point) segments of the path end.
+        /// Ranges from 0 (beginning of the path) to 1 (end of the path) to infinity (beyond the end of the path).
         /// </summary>
+        /// <example>In case <see cref="Distance"/> is less than <see cref="CalculatedDistance"/>,
+        /// the last segment ends after the end of the path, hence it returns a value greater than 1.
+        /// <para/>
+        /// In case <see cref="Distance"/> is greater than <see cref="CalculatedDistance"/>,
+        /// the last segment ends before the end of the path, hence it returns a value less than 1.</example>
+        /// <remarks><see cref="PositionAt"/> truncates the progression values to [0,1],
+        /// so you can't use this method to retrieve the positions of segment ends beyond the end of the path.</remarks>
         public IEnumerable<double> GetSegmentEnds()
         {
             ensureValid();

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -201,13 +201,20 @@ namespace osu.Game.Rulesets.Objects
         /// Returns the progress values at which (control point) segments of the path end.
         /// Ranges from 0 (beginning of the path) to 1 (end of the path) to infinity (beyond the end of the path).
         /// </summary>
-        /// <example>In case <see cref="Distance"/> is less than <see cref="CalculatedDistance"/>,
+        /// <remarks>
+        /// <see cref="PositionAt"/> truncates the progression values to [0,1],
+        /// so you can't use this method in conjunction with that one to retrieve the positions of segment ends beyond the end of the path.
+        /// </remarks>
+        /// <example>
+        /// <para>
+        /// In case <see cref="Distance"/> is less than <see cref="CalculatedDistance"/>,
         /// the last segment ends after the end of the path, hence it returns a value greater than 1.
-        /// <para/>
+        /// </para>
+        /// <para>
         /// In case <see cref="Distance"/> is greater than <see cref="CalculatedDistance"/>,
-        /// the last segment ends before the end of the path, hence it returns a value less than 1.</example>
-        /// <remarks><see cref="PositionAt"/> truncates the progression values to [0,1],
-        /// so you can't use this method to retrieve the positions of segment ends beyond the end of the path.</remarks>
+        /// the last segment ends before the end of the path, hence it returns a value less than 1.
+        /// </para>
+        /// </example>
         public IEnumerable<double> GetSegmentEnds()
         {
             ensureValid();

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -254,8 +254,10 @@ namespace osu.Game.Rulesets.Objects
                 }
 
                 if (i > 0)
+                {
                     // Remember the index of the segment end
                     segmentEnds.Add(calculatedPath.Count - 1);
+                }
 
                 // Start the new segment at the current vertex
                 start = i;


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/pull/24527#discussion_r1297822451 there are quite a few issues with `GetSegmentEnds`. 

This PR fixes the issues, makes sure the values returned are what you expect from the name and documentation, and added a test.