### PR TITLE
Allow "Last year's placing" in the tournament seeding to show "N/A" for new teams

### DIFF
--- a/osu.Game.Tournament/Models/TournamentTeam.cs
+++ b/osu.Game.Tournament/Models/TournamentTeam.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Tournament.Models
 
         public Bindable<int> LastYearPlacing = new BindableInt
         {
-            MinValue = 1,
+            MinValue = 0,
             MaxValue = 256
         };
 

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -10,7 +10,9 @@ using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osu.Game.Tournament.Models;
@@ -128,7 +130,7 @@ namespace osu.Game.Tournament.Screens.Editors
                                 Width = 0.2f,
                                 Current = Model.Seed
                             },
-                            new SettingsSlider<int>
+                            new SettingsSlider<int, LastYearPlacementSlider>
                             {
                                 LabelText = "Last Year Placement",
                                 Width = 0.33f,
@@ -173,6 +175,11 @@ namespace osu.Game.Tournament.Screens.Editors
                         }
                     },
                 };
+            }
+
+            private partial class LastYearPlacementSlider : RoundedSliderBar<int>
+            {
+                public override LocalisableString TooltipText => Current.Value == 0 ? "N/A" : base.TooltipText;
             }
 
             public partial class PlayerEditor : CompositeDrawable

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -274,7 +274,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                             new TeamDisplay(team) { Margin = new MarginPadding { Bottom = 30 } },
                             new RowDisplay("Average Rank:", $"#{team.AverageRank:#,0}"),
                             new RowDisplay("Seed:", team.Seed.Value),
-                            new RowDisplay("Last year's placing:", team.LastYearPlacing.Value > 0 ? $"#{team.LastYearPlacing:#,0}" : "0"),
+                            new RowDisplay("Last year's placing:", team.LastYearPlacing.Value > 0 ? $"#{team.LastYearPlacing:#,0}" : "N/A"),
                             new Container { Margin = new MarginPadding { Bottom = 30 } },
                         }
                     },


### PR DESCRIPTION
Currently, there is no proper way to represent a team that did not place in the last year's tournament (e. g. new teams) in the seeding screen. The way I've seen this be handled is either setting it to some (arbitrary?) high value (e.g. https://www.twitch.tv/videos/1770154093?t=00h06m37s, new teams are shown as `#64`) or sometimes by just leaving it as `#1` (non-official and/or one-off tournaments).

This change increases the range of the corresponding `BindableInt` to include zero (`1-256` -> `0-256`) , which also makes zero the default value for newly created teams (in the team editor).
The value zero represents "no placement/placing in the last year's tournament", and is represented in the UI as "Last year's placing: N/A".