### PR TITLE
Fix crash in tournament client when pick/ban is activated

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Tournament.Tests.Components
     public partial class TestSceneSongBar : TournamentTestScene
     {
         private SongBar songBar = null!;
+        private TournamentBeatmap ladderBeatmap = null!;
 
         [SetUpSteps]
         public override void SetUpSteps()
@@ -22,9 +23,10 @@ namespace osu.Game.Tournament.Tests.Components
 
             AddStep("setup picks bans", () =>
             {
+                ladderBeatmap = CreateSampleBeatmap();
                 Ladder.CurrentMatch.Value!.PicksBans.Add(new BeatmapChoice
                 {
-                    BeatmapID = CreateSampleBeatmap().OnlineID,
+                    BeatmapID = ladderBeatmap.OnlineID,
                     Team = TeamColour.Red,
                     Type = ChoiceType.Pick,
                 });
@@ -52,7 +54,7 @@ namespace osu.Game.Tournament.Tests.Components
                 beatmap.StarRating = 4.56f;
                 beatmap.Length = 123456;
                 beatmap.BPM = 133;
-                beatmap.OnlineID = CreateSampleBeatmap().OnlineID;
+                beatmap.OnlineID = ladderBeatmap.OnlineID;
 
                 songBar.Beatmap = new TournamentBeatmap(beatmap);
             });

--- a/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneSongBar.cs
@@ -2,27 +2,34 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.Legacy;
-using osu.Game.Tests.Visual;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 
 namespace osu.Game.Tournament.Tests.Components
 {
     [TestFixture]
-    public partial class TestSceneSongBar : OsuTestScene
+    public partial class TestSceneSongBar : TournamentTestScene
     {
-        [Cached]
-        private readonly LadderInfo ladder = new LadderInfo();
-
         private SongBar songBar = null!;
 
         [SetUpSteps]
-        public void SetUpSteps()
+        public override void SetUpSteps()
         {
+            base.SetUpSteps();
+
+            AddStep("setup picks bans", () =>
+            {
+                Ladder.CurrentMatch.Value!.PicksBans.Add(new BeatmapChoice
+                {
+                    BeatmapID = CreateSampleBeatmap().OnlineID,
+                    Team = TeamColour.Red,
+                    Type = ChoiceType.Pick,
+                });
+            });
+
             AddStep("create bar", () => Child = songBar = new SongBar
             {
                 RelativeSizeAxes = Axes.X,
@@ -38,12 +45,14 @@ namespace osu.Game.Tournament.Tests.Components
             AddStep("set beatmap", () =>
             {
                 var beatmap = CreateAPIBeatmap(Ruleset.Value);
+
                 beatmap.CircleSize = 3.4f;
                 beatmap.ApproachRate = 6.8f;
                 beatmap.OverallDifficulty = 5.5f;
                 beatmap.StarRating = 4.56f;
                 beatmap.Length = 123456;
                 beatmap.BPM = 133;
+                beatmap.OnlineID = CreateSampleBeatmap().OnlineID;
 
                 songBar.Beatmap = new TournamentBeatmap(beatmap);
             });

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -234,7 +234,7 @@ namespace osu.Game.Tournament.Components
                         }
                     }
                 },
-                new UnmaskedTournamentBeatmapPanel(beatmap)
+                new TournamentBeatmapPanel(beatmap)
                 {
                     RelativeSizeAxes = Axes.X,
                     Width = 0.5f,
@@ -275,20 +275,6 @@ namespace osu.Game.Tournament.Components
                     AddText(new TournamentSpriteText { Text = content }, s => cp(s, true));
                 }
             }
-        }
-    }
-
-    internal partial class UnmaskedTournamentBeatmapPanel : TournamentBeatmapPanel
-    {
-        public UnmaskedTournamentBeatmapPanel(IBeatmapInfo? beatmap, string mod = "")
-            : base(beatmap, mod)
-        {
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            Masking = false;
         }
     }
 }


### PR DESCRIPTION
Turns out the masking I added breaks when a border style is applied for picks/bans, and it wasn't doing much for visuals anyway ( was mostly there for the rounded corners which are not even featured in the tournament client yet.

Closes https://github.com/ppy/osu/issues/24589.