### PR TITLE
Make Adaptive Speed more fun

### DIFF
--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -264,7 +264,7 @@ namespace osu.Game.Rulesets.Mods
                 return rate_change_on_miss;
 
             double prevEndTime = precedingEndTimes[result.HitObject];
-            var rateChange = (result.HitObject.GetEndTime() - prevEndTime) / (result.TimeAbsolute - prevEndTime);
+            double rateChange = (result.HitObject.GetEndTime() - prevEndTime) / (result.TimeAbsolute - prevEndTime);
 
             if (Math.Abs(rateChange - 1.0) < rate_change_threshold) // Reward well-timed results with a speed up.
                 return rate_change_on_hit;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => MinimumRate.Value;
+        public override double ScoreMultiplier => minAllowableRate;
 
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Mods
         };
 
         [SettingSource("Minimum rate", "The minimum speed of the track")]
-        public BindableNumber<double> MinimumRate { get; } = new BindableDouble(0.5)
+        public BindableNumber<double> MinimumRate { get; } = new BindableDouble(1)
         {
             MinValue = 0.5,
             MaxValue = 4,

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -71,8 +71,8 @@ namespace osu.Game.Rulesets.Mods
         // The two properties below denote the maximum allowable range of rates that `SpeedChange` can take.
         // The range is purposefully wider than the range of values that `InitialRate` allows
         // in order to give some leeway for change even when extreme initial rates are chosen.
-        private double MinAllowableRate => MinimumRate.Value - 0.4d;
-        private double MaxAllowableRate => MaximumRate.Value + 0.5d;
+        private double minAllowableRate => MinimumRate.Value - 0.4d;
+        private double maxAllowableRate => MaximumRate.Value + 0.5d;
 
         // The two constants below denote the maximum allowable change in rate caused by a single hit
         // This prevents sudden jolts caused by a badly-timed hit.
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Mods
                 ratesForRewinding.Add(result.HitObject, recentRates[0]);
                 recentRates.RemoveAt(0);
 
-                recentRates.Add(Math.Clamp(getRelativeRateChange(result) * SpeedChange.Value, MinAllowableRate, MaxAllowableRate));
+                recentRates.Add(Math.Clamp(getRelativeRateChange(result) * SpeedChange.Value, minAllowableRate, maxAllowableRate));
 
                 updateTargetRate();
             };

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -79,11 +79,14 @@ namespace osu.Game.Rulesets.Mods
         private const double min_allowable_rate_change = 0.9d;
         private const double max_allowable_rate_change = 1.11d;
 
+        // The rate multiplier used on hits and misses.
+        private const double rate_change_multiplier = 0.95;
+
         // Apply a fixed rate change when missing, allowing the player to catch up when the rate is too fast.
-        private const double rate_change_on_miss = min_allowable_rate_change / 0.95;
+        private const double rate_change_on_miss = min_allowable_rate_change / rate_change_multiplier;
 
         // Apply a fixed rate change when accurately hitting notes, to counteract overcorrection stagnating or even slowing down an accurate but unstable human player.
-        private const double rate_change_on_hit = max_allowable_rate_change * 0.95;
+        private const double rate_change_on_hit = max_allowable_rate_change * rate_change_multiplier;
 
         // The threshold below which we'll reward the player's high accuracy with a speed up.
         private const double rate_change_threshold = 0.05;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -188,7 +188,11 @@ namespace osu.Game.Rulesets.Mods
 
         public void Update(Playfield playfield)
         {
-            SpeedChange.Value = Interpolation.DampContinuously(SpeedChange.Value, targetRate, 50, playfield.Clock.ElapsedFrameTime);
+            // Use the absolute clock time so that we always move towards targetRate, not away from it (as is the case when rewinding).
+            // This prevents TrackBass from throwing an exception as the tempo approaches the lower bound (when AdjustPitch is set to false).
+            double elapsedTime = Math.Abs(playfield.Clock.ElapsedFrameTime);
+
+            SpeedChange.Value = Interpolation.DampContinuously(SpeedChange.Value, targetRate, 50, elapsedTime);
         }
 
         public double ApplyToRate(double time, double rate = 1) => rate * InitialRate.Value;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Mods
         private const double max_allowable_rate_change = 1.11d;
 
         // Apply a fixed rate change when missing, allowing the player to catch up when the rate is too fast.
-        private const double rate_change_on_miss = 0.95d;
+        private const double rate_change_on_miss = min_allowable_rate_change / 0.95;
 
         // Apply a fixed rate change when accurately hitting notes, to counteract overcorrection stagnating or even slowing down an accurate but unstable human player.
         private const double rate_change_on_hit = max_allowable_rate_change * 0.95;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -60,10 +60,10 @@ namespace osu.Game.Rulesets.Mods
         };
 
         [SettingSource("Rate multiplier", "How much hits and misses affect tempo")]
-        public BindableNumber<double> RateMultiplier { get; } = new BindableDouble(0.95)
+        public BindableNumber<double> RateMultiplier { get; } = new BindableDouble(0.51)
         {
             MinValue = 0,
-            MaxValue = 2,
+            MaxValue = 8,
             Precision = 0.01
         };
 
@@ -88,10 +88,10 @@ namespace osu.Game.Rulesets.Mods
         private const double max_allowable_rate_change = 1.11d;
 
         // Apply a fixed rate change when missing, allowing the player to catch up when the rate is too fast.
-        private double rateChangeOnMiss => Math.Min(1.0, min_allowable_rate_change / RateMultiplier.Value);
+        private double rateChangeOnMiss => Math.Pow(min_allowable_rate_change, RateMultiplier.Value);
 
         // Apply a fixed rate change when accurately hitting notes, to counteract overcorrection stagnating or even slowing down an accurate but unstable human player.
-        private double rateChangeOnHit => Math.Max(1.0, max_allowable_rate_change * RateMultiplier.Value);
+        private double rateChangeOnHit => Math.Pow(max_allowable_rate_change, RateMultiplier.Value);
 
         // The threshold below which we'll reward the player's high accuracy with a speed up.
         private const double rate_change_threshold = 0.05;

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -28,7 +28,22 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.Fun;
 
-        public override double ScoreMultiplier => minAllowableRate;
+        public override double ScoreMultiplier
+        {
+            get
+            {
+                // Round to the nearest multiple of 0.1.
+                double value = (int)(minAllowableRate * 10) / 10.0;
+
+                // Offset back to 0.
+                value -= 1;
+
+                if (minAllowableRate > 1.0)
+                    value /= 5; // Each 0.1 multiple changes score multiplier by 0.02.
+
+                return 1 + value;
+            }
+        }
 
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;


### PR DESCRIPTION
* Fixes pathological cases that would occur way too often for me to ignore: accurately full combo a map, yet the speed would stagnate, or much worse, slow down to a crawl, due to overcorrection/lack of reward for high accuracy.

The thresholded accuracy reward lets the mod perfectly adapt to the player's real abilities: no longer does the target rate go below 1.0 on easy maps due to unstable notes, and the rate change is responsive enough to match one's speed limit to be able to complete songs.

Here's a diff play, with the target rate debug log on the left terminal.

New behaviour (video):

[![osu as mod new replay](https://i.ytimg.com/vi/xTTAwGJdDms/maxresdefault.jpg)](https://youtu.be/xTTAwGJdDms)

Old behaviour (video; playing back the same new replay from above):

[![osu as mod old replay](https://i.ytimg.com/vi/RVW7ua_TB1w/maxresdefault.jpg)](https://youtu.be/RVW7ua_TB1w)

0.63x on a full combo. This isn't a prank. Here's the entire diff against the master branch:

```diff
diff --git a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
index e7127abcf0..c4f95050c2 100644
--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -16,6 +16,8 @@
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 
+using osu.Framework.Logging;
+
 namespace osu.Game.Rulesets.Mods
 {
     public class ModAdaptiveSpeed : Mod, IApplicableToRate, IApplicableToDrawableHitObject, IApplicableToBeatmap, IUpdatableByPlayfield
@@ -257,6 +259,8 @@ private void updateTargetRate()
 
             // Scale the rate adjustment based on consistency
             targetRate = Interpolation.Lerp(targetRate, recentRates.Average(), Math.Abs(consistency) / (recent_rate_count - 1d));
+
+            Logger.Log($"[AS mod] Target rate: {targetRate:0.00} (recent rates: {string.Join(", ", recentRates.Select(r => r.ToString("0.00")))})");
         }
     }
 }
```

TL;DR:

```csharp
var rateChange = (result.HitObject.GetEndTime() - prevEndTime) / (result.TimeAbsolute - prevEndTime);

if (Math.Abs(rateChange - 1.0) < rate_change_threshold) // Reward well-timed results with a speed up.
    return rate_change_on_hit;
```

A couple new constants are introduced, and I wondered for a bit whether we should expose them to users to customise further, but they feel just about right !

```csharp
// Apply a fixed rate change when accurately hitting notes, to counteract overcorrection stagnating or even slowing down an accurate but unstable human player.
private const double rate_change_on_hit = max_allowable_rate_change * 0.95;

// The threshold below which we'll reward the player's high accuracy with a speed up.
private const double rate_change_threshold = 0.05;
```

Shall we expose these options as well ?

* Expose min/max speed options, and increase the max speed's range to expand playable maps for high level players.

* Set the score multiplier to the min speed, since this is now dynamic.

<video src="https://github.com/ppy/osu/assets/15223353/2924b160-9f2f-4c1c-9bcf-dcc3d60f6d94">
</video>
