### PR TITLE
Add application category type to enable game mode on new macOS versions

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -34,9 +34,9 @@
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>We don&apos;t really use the camera.</string>
+	<string>We don't really use the camera.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>We don&apos;t really use the microphone.</string>
+	<string>We don't really use the microphone.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeRight</string>
@@ -130,5 +130,7 @@
 			<string>Editor</string>
 		</dict>
 	</array>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music-games</string>
 </dict>
 </plist>


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/discussions/24557#discussioncomment-6787057.

