### PR TITLE
Split out individual difficulties when using difficulty sort at song select

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
@@ -16,6 +17,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.GameplayTest;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
 
@@ -201,6 +203,33 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("wait for music playing", () => Game.MusicController.IsPlaying);
             AddStep("user request stop", () => Game.MusicController.Stop(requestedByUser: true));
             AddUntilStep("wait for music stopped", () => !Game.MusicController.IsPlaying);
+        }
+
+        [TestCase(SortMode.Title)]
+        [TestCase(SortMode.Difficulty)]
+        public void TestSelectionRetainedOnExit(SortMode sortMode)
+        {
+            BeatmapSetInfo beatmapSet = null!;
+
+            AddStep("import test beatmap", () => Game.BeatmapManager.Import(TestResources.GetTestBeatmapForImport()).WaitSafely());
+            AddStep("retrieve beatmap", () => beatmapSet = Game.BeatmapManager.QueryBeatmapSet(set => !set.Protected).AsNonNull().Value.Detach());
+
+            AddStep($"set sort mode to {sortMode}", () => Game.LocalConfig.SetValue(OsuSetting.SongSelectSortingMode, sortMode));
+            AddStep("present beatmap", () => Game.PresentBeatmap(beatmapSet));
+            AddUntilStep("wait for song select",
+                () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
+                      && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
+                      && songSelect.IsLoaded);
+
+            AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));
+            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
+
+            AddStep("exit editor", () => InputManager.Key(Key.Escape));
+            AddUntilStep("wait for editor exit", () => Game.ScreenStack.CurrentScreen is not Editor);
+
+            AddUntilStep("selection retained on song select",
+                () => Game.Beatmap.Value.BeatmapInfo.ID,
+                () => Is.EqualTo(beatmapSet.Beatmaps.First(b => b.Ruleset.OnlineID == 0).ID));
         }
 
         private EditorBeatmap getEditorBeatmap() => getEditor().ChildrenOfType<EditorBeatmap>().Single();

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -1016,7 +1016,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             List<BeatmapSetInfo> manySets = new List<BeatmapSetInfo>();
 
-            AddStep("Populuate beatmap sets", () =>
+            AddStep("Populate beatmap sets", () =>
             {
                 manySets.Clear();
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestScrollPositionMaintainedOnAdd()
         {
-            loadBeatmaps(count: 1, randomDifficulties: false);
+            loadBeatmaps(setCount: 1);
 
             for (int i = 0; i < 10; i++)
             {
@@ -125,7 +125,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestDeletion()
         {
-            loadBeatmaps(count: 5, randomDifficulties: true);
+            loadBeatmaps(setCount: 5, randomDifficulties: true);
 
             AddStep("remove first set", () => carousel.RemoveBeatmapSet(carousel.Items.Select(item => item.Item).OfType<CarouselBeatmapSet>().First().BeatmapSet));
             AddUntilStep("4 beatmap sets visible", () => this.ChildrenOfType<DrawableCarouselBeatmapSet>().Count(set => set.Alpha > 0) == 4);
@@ -134,7 +134,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestScrollPositionMaintainedOnDelete()
         {
-            loadBeatmaps(count: 50, randomDifficulties: false);
+            loadBeatmaps(setCount: 50);
 
             for (int i = 0; i < 10; i++)
             {
@@ -151,7 +151,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestManyPanels()
         {
-            loadBeatmaps(count: 5000, randomDifficulties: true);
+            loadBeatmaps(setCount: 5000, randomDifficulties: true);
         }
 
         [Test]
@@ -505,31 +505,34 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestAddRemoveDifficultySort()
         {
-            loadBeatmaps();
+            const int local_set_count = 1;
+            const int local_diff_count = 1;
+
+            loadBeatmaps(setCount: local_set_count, diffCount: local_diff_count);
 
             AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
 
-            checkVisibleItemCount(false, set_count * diff_count);
+            checkVisibleItemCount(false, local_set_count * local_diff_count);
 
-            var firstAdded = TestResources.CreateTestBeatmapSetInfo(diff_count);
-            var secondAdded = TestResources.CreateTestBeatmapSetInfo(diff_count);
+            var firstAdded = TestResources.CreateTestBeatmapSetInfo(local_diff_count);
+            var secondAdded = TestResources.CreateTestBeatmapSetInfo(local_diff_count);
 
             AddStep("Add new set", () => carousel.UpdateBeatmapSet(firstAdded));
             AddStep("Add new set", () => carousel.UpdateBeatmapSet(secondAdded));
 
-            checkVisibleItemCount(false, (set_count + 2) * diff_count);
+            checkVisibleItemCount(false, (local_set_count + 2) * local_diff_count);
 
             AddStep("Remove set", () => carousel.RemoveBeatmapSet(firstAdded));
 
-            checkVisibleItemCount(false, (set_count + 1) * diff_count);
+            checkVisibleItemCount(false, (local_set_count + 1) * local_diff_count);
 
-            setSelected(set_count + 1, 1);
+            setSelected(local_set_count + 1, 1);
 
             AddStep("Remove set", () => carousel.RemoveBeatmapSet(secondAdded));
 
-            checkVisibleItemCount(false, (set_count) * diff_count);
+            checkVisibleItemCount(false, (local_set_count) * local_diff_count);
 
-            waitForSelection(set_count);
+            waitForSelection(local_set_count);
         }
 
         [Test]
@@ -1171,8 +1174,8 @@ namespace osu.Game.Tests.Visual.SongSelect
             }
         }
 
-        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null, int? count = null,
-                                  bool randomDifficulties = false)
+        private void loadBeatmaps(List<BeatmapSetInfo> beatmapSets = null, Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null,
+                                  int? setCount = null, int? diffCount = null, bool randomDifficulties = false)
         {
             bool changed = false;
 
@@ -1180,11 +1183,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 beatmapSets = new List<BeatmapSetInfo>();
 
-                for (int i = 1; i <= (count ?? set_count); i++)
+                for (int i = 1; i <= (setCount ?? set_count); i++)
                 {
                     beatmapSets.Add(randomDifficulties
                         ? TestResources.CreateTestBeatmapSetInfo()
-                        : TestResources.CreateTestBeatmapSetInfo(diff_count));
+                        : TestResources.CreateTestBeatmapSetInfo(diffCount ?? diff_count));
                 }
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -758,7 +758,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
-        public void TestSortingWithFiltered()
+        public void TestSortingWithDifficultyFiltered()
         {
             List<BeatmapSetInfo> sets = new List<BeatmapSetInfo>();
 
@@ -777,13 +777,32 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
+            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+
+            checkVisibleItemCount(false, 9);
+            checkVisibleItemCount(true, 1);
+
             AddStep("Filter to normal", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Normal" }, false));
-            AddAssert("Check first set at end", () => carousel.BeatmapSets.First().Equals(sets.Last()));
-            AddAssert("Check last set at start", () => carousel.BeatmapSets.Last().Equals(sets.First()));
+            checkVisibleItemCount(false, 3);
+            checkVisibleItemCount(true, 1);
+
+            AddUntilStep("Check all visible sets have one normal", () =>
+            {
+                return carousel.Items.OfType<DrawableCarouselBeatmapSet>()
+                               .Where(p => p.IsPresent)
+                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Normal", StringComparison.Ordinal)) == 3;
+            });
 
             AddStep("Filter to insane", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Insane" }, false));
-            AddAssert("Check first set at start", () => carousel.BeatmapSets.First().Equals(sets.First()));
-            AddAssert("Check last set at end", () => carousel.BeatmapSets.Last().Equals(sets.Last()));
+            checkVisibleItemCount(false, 3);
+            checkVisibleItemCount(true, 1);
+
+            AddUntilStep("Check all visible sets have one insane", () =>
+            {
+                return carousel.Items.OfType<DrawableCarouselBeatmapSet>()
+                               .Where(p => p.IsPresent)
+                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Insane", StringComparison.Ordinal)) == 3;
+            });
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -505,8 +505,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestAddRemoveDifficultySort()
         {
-            const int local_set_count = 1;
-            const int local_diff_count = 1;
+            const int local_set_count = 2;
+            const int local_diff_count = 2;
 
             loadBeatmaps(setCount: local_set_count, diffCount: local_diff_count);
 
@@ -515,22 +515,16 @@ namespace osu.Game.Tests.Visual.SongSelect
             checkVisibleItemCount(false, local_set_count * local_diff_count);
 
             var firstAdded = TestResources.CreateTestBeatmapSetInfo(local_diff_count);
-            var secondAdded = TestResources.CreateTestBeatmapSetInfo(local_diff_count);
 
             AddStep("Add new set", () => carousel.UpdateBeatmapSet(firstAdded));
-            AddStep("Add new set", () => carousel.UpdateBeatmapSet(secondAdded));
-
-            checkVisibleItemCount(false, (local_set_count + 2) * local_diff_count);
-
-            AddStep("Remove set", () => carousel.RemoveBeatmapSet(firstAdded));
 
             checkVisibleItemCount(false, (local_set_count + 1) * local_diff_count);
 
-            setSelected(local_set_count + 1, 1);
-
-            AddStep("Remove set", () => carousel.RemoveBeatmapSet(secondAdded));
+            AddStep("Remove set", () => carousel.RemoveBeatmapSet(firstAdded));
 
             checkVisibleItemCount(false, (local_set_count) * local_diff_count);
+
+            setSelected(local_set_count, 1);
 
             waitForSelection(local_set_count);
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         private BeatmapInfo currentSelection => carousel.SelectedBeatmapInfo;
 
         private const int set_count = 5;
+        private const int diff_count = 3;
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
@@ -502,6 +503,36 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestAddRemoveDifficultySort()
+        {
+            loadBeatmaps();
+
+            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+
+            checkVisibleItemCount(false, set_count * diff_count);
+
+            var firstAdded = TestResources.CreateTestBeatmapSetInfo(diff_count);
+            var secondAdded = TestResources.CreateTestBeatmapSetInfo(diff_count);
+
+            AddStep("Add new set", () => carousel.UpdateBeatmapSet(firstAdded));
+            AddStep("Add new set", () => carousel.UpdateBeatmapSet(secondAdded));
+
+            checkVisibleItemCount(false, (set_count + 2) * diff_count);
+
+            AddStep("Remove set", () => carousel.RemoveBeatmapSet(firstAdded));
+
+            checkVisibleItemCount(false, (set_count + 1) * diff_count);
+
+            setSelected(set_count + 1, 1);
+
+            AddStep("Remove set", () => carousel.RemoveBeatmapSet(secondAdded));
+
+            checkVisibleItemCount(false, (set_count) * diff_count);
+
+            waitForSelection(set_count);
+        }
+
+        [Test]
         public void TestSelectionEnteringFromEmptyRuleset()
         {
             var sets = new List<BeatmapSetInfo>();
@@ -662,7 +693,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 for (int i = 0; i < 3; i++)
                 {
-                    var set = TestResources.CreateTestBeatmapSetInfo(3);
+                    var set = TestResources.CreateTestBeatmapSetInfo(diff_count);
 
                     // only need to set the first as they are a shared reference.
                     var beatmap = set.Beatmaps.First();
@@ -709,7 +740,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 for (int i = 0; i < 3; i++)
                 {
-                    var set = TestResources.CreateTestBeatmapSetInfo(3);
+                    var set = TestResources.CreateTestBeatmapSetInfo(diff_count);
 
                     // only need to set the first as they are a shared reference.
                     var beatmap = set.Beatmaps.First();
@@ -768,7 +799,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 for (int i = 0; i < 3; i++)
                 {
-                    var set = TestResources.CreateTestBeatmapSetInfo(3);
+                    var set = TestResources.CreateTestBeatmapSetInfo(diff_count);
                     set.Beatmaps[0].StarRating = 3 - i;
                     set.Beatmaps[2].StarRating = 6 + i;
                     sets.Add(set);
@@ -857,7 +888,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("create hidden set", () =>
             {
-                hidingSet = TestResources.CreateTestBeatmapSetInfo(3);
+                hidingSet = TestResources.CreateTestBeatmapSetInfo(diff_count);
                 hidingSet.Beatmaps[1].Hidden = true;
 
                 hiddenList.Clear();
@@ -904,7 +935,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("add mixed ruleset beatmapset", () =>
             {
-                testMixed = TestResources.CreateTestBeatmapSetInfo(3);
+                testMixed = TestResources.CreateTestBeatmapSetInfo(diff_count);
 
                 for (int i = 0; i <= 2; i++)
                 {
@@ -926,7 +957,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             BeatmapSetInfo testSingle = null;
             AddStep("add single ruleset beatmapset", () =>
             {
-                testSingle = TestResources.CreateTestBeatmapSetInfo(3);
+                testSingle = TestResources.CreateTestBeatmapSetInfo(diff_count);
                 testSingle.Beatmaps.ForEach(b =>
                 {
                     b.Ruleset = rulesets.AvailableRulesets.ElementAt(1);
@@ -949,7 +980,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 manySets.Clear();
 
                 for (int i = 1; i <= 50; i++)
-                    manySets.Add(TestResources.CreateTestBeatmapSetInfo(3));
+                    manySets.Add(TestResources.CreateTestBeatmapSetInfo(diff_count));
             });
 
             loadBeatmaps(manySets);
@@ -1113,7 +1144,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 {
                     beatmapSets.Add(randomDifficulties
                         ? TestResources.CreateTestBeatmapSetInfo()
-                        : TestResources.CreateTestBeatmapSetInfo(3));
+                        : TestResources.CreateTestBeatmapSetInfo(diff_count));
                 }
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -1006,6 +1006,43 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        public void TestCarouselRemembersSelectionDifficultySort()
+        {
+            List<BeatmapSetInfo> manySets = new List<BeatmapSetInfo>();
+
+            AddStep("Populuate beatmap sets", () =>
+            {
+                manySets.Clear();
+
+                for (int i = 1; i <= 50; i++)
+                    manySets.Add(TestResources.CreateTestBeatmapSetInfo(diff_count));
+            });
+
+            loadBeatmaps(manySets);
+
+            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+
+            advanceSelection(direction: 1, diff: false);
+
+            for (int i = 0; i < 5; i++)
+            {
+                AddStep("Toggle non-matching filter", () =>
+                {
+                    carousel.Filter(new FilterCriteria { SearchText = Guid.NewGuid().ToString() }, false);
+                });
+
+                AddStep("Restore no filter", () =>
+                {
+                    carousel.Filter(new FilterCriteria(), false);
+                    eagerSelectedIDs.Add(carousel.SelectedBeatmapSet!.ID);
+                });
+            }
+
+            // always returns to same selection as long as it's available.
+            AddAssert("Selection was remembered", () => eagerSelectedIDs.Count == 1);
+        }
+
+        [Test]
         public void TestFilteringByUserStarDifficulty()
         {
             BeatmapSetInfo set = null;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -791,17 +791,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         [Test]
         public void TestSortingWithDifficultyFiltered()
         {
+            const int local_diff_count = 3;
+            const int local_set_count = 2;
+
             List<BeatmapSetInfo> sets = new List<BeatmapSetInfo>();
 
             AddStep("Populuate beatmap sets", () =>
             {
                 sets.Clear();
 
-                for (int i = 0; i < 3; i++)
+                for (int i = 0; i < local_set_count; i++)
                 {
-                    var set = TestResources.CreateTestBeatmapSetInfo(diff_count);
+                    var set = TestResources.CreateTestBeatmapSetInfo(local_diff_count);
                     set.Beatmaps[0].StarRating = 3 - i;
-                    set.Beatmaps[2].StarRating = 6 + i;
+                    set.Beatmaps[1].StarRating = 6 + i;
                     sets.Add(set);
                 }
             });
@@ -810,29 +813,29 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
 
-            checkVisibleItemCount(false, 9);
+            checkVisibleItemCount(false, local_set_count * local_diff_count);
             checkVisibleItemCount(true, 1);
 
             AddStep("Filter to normal", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Normal" }, false));
-            checkVisibleItemCount(false, 3);
+            checkVisibleItemCount(false, local_set_count);
             checkVisibleItemCount(true, 1);
 
             AddUntilStep("Check all visible sets have one normal", () =>
             {
                 return carousel.Items.OfType<DrawableCarouselBeatmapSet>()
                                .Where(p => p.IsPresent)
-                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Normal", StringComparison.Ordinal)) == 3;
+                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Normal", StringComparison.Ordinal)) == local_set_count;
             });
 
             AddStep("Filter to insane", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Insane" }, false));
-            checkVisibleItemCount(false, 3);
+            checkVisibleItemCount(false, local_set_count);
             checkVisibleItemCount(true, 1);
 
             AddUntilStep("Check all visible sets have one insane", () =>
             {
                 return carousel.Items.OfType<DrawableCarouselBeatmapSet>()
                                .Where(p => p.IsPresent)
-                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Insane", StringComparison.Ordinal)) == 3;
+                               .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Insane", StringComparison.Ordinal)) == local_set_count;
             });
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -15,6 +15,7 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
+using osu.Game.Screens.Select.Filter;
 using osu.Game.Tests.Online;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
@@ -190,6 +191,57 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("update started", () => beatmapDownloader.GetExistingDownload(testBeatmapSetInfo) != null);
             AddStep("release mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
+        }
+
+        [Test]
+        public void TestSplitDisplay()
+        {
+            ArchiveDownloadRequest<IBeatmapSetInfo>? downloadRequest = null;
+
+            AddStep("set difficulty sort mode", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }));
+            AddStep("update online hash", () =>
+            {
+                testBeatmapSetInfo.Beatmaps.First().OnlineMD5Hash = "different hash";
+                testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
+
+                carousel.UpdateBeatmapSet(testBeatmapSetInfo);
+            });
+
+            AddUntilStep("multiple \"sets\" visible", () => carousel.ChildrenOfType<DrawableCarouselBeatmapSet>().Count(), () => Is.GreaterThan(1));
+            AddUntilStep("update button visible", getUpdateButton, () => Is.Not.Null);
+
+            AddStep("click button", () => getUpdateButton()?.TriggerClick());
+
+            AddUntilStep("wait for download started", () =>
+            {
+                downloadRequest = beatmapDownloader.GetExistingDownload(testBeatmapSetInfo);
+                return downloadRequest != null;
+            });
+
+            AddUntilStep("wait for button disabled", () => getUpdateButton()?.Enabled.Value == false);
+
+            AddUntilStep("progress download to completion", () =>
+            {
+                if (downloadRequest is TestSceneOnlinePlayBeatmapAvailabilityTracker.TestDownloadRequest testRequest)
+                {
+                    testRequest.SetProgress(testRequest.Progress + 0.1f);
+
+                    if (testRequest.Progress >= 1)
+                    {
+                        testRequest.TriggerSuccess();
+
+                        // usually this would be done by the import process.
+                        testBeatmapSetInfo.Beatmaps.First().MD5Hash = "different hash";
+                        testBeatmapSetInfo.Beatmaps.First().LastOnlineUpdate = DateTimeOffset.Now;
+
+                        // usually this would be done by a realm subscription.
+                        carousel.UpdateBeatmapSet(testBeatmapSetInfo);
+                        return true;
+                    }
+                }
+
+                return false;
+            });
         }
 
         private BeatmapCarousel createCarousel()

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -251,7 +251,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 RelativeSizeAxes = Axes.Both,
                 BeatmapSets = new List<BeatmapSetInfo>
                 {
-                    (testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo()),
+                    (testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo(5)),
                 }
             };
         }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -419,6 +419,8 @@ namespace osu.Game.Screens.Select
 
             if (beatmapsSplitOut)
             {
+                var newSets = new List<CarouselBeatmapSet>();
+
                 foreach (var beatmap in beatmapSet.Beatmaps)
                 {
                     var newSet = createCarouselSet(new BeatmapSetInfo(new[] { beatmap })
@@ -429,12 +431,17 @@ namespace osu.Game.Screens.Select
 
                     if (newSet != null)
                     {
+                        newSets.Add(newSet);
                         root.AddItem(newSet);
-
-                        // check if we can/need to maintain our current selection.
-                        if (previouslySelectedID != null)
-                            select((CarouselItem?)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
                     }
+                }
+
+                // check if we can/need to maintain our current selection.
+                if (previouslySelectedID != null)
+                {
+                    var toSelect = newSets.FirstOrDefault(s => s.Beatmaps.Any(b => b.BeatmapInfo.ID == previouslySelectedID))
+                                   ?? newSets.FirstOrDefault();
+                    select(toSelect);
                 }
             }
             else

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -137,8 +137,10 @@ namespace osu.Game.Screens.Select
             {
                 var carouselBeatmapSets = originalBeatmapSetsDetached.SelectMany(s => s.Beatmaps).Select(b =>
                 {
-                    var set = new BeatmapSetInfo(new[] { b });
-                    return createCarouselSet(set);
+                    return createCarouselSet(new BeatmapSetInfo(new[] { b })
+                    {
+                        ID = b.BeatmapSet!.ID,
+                    });
                 }).OfType<CarouselBeatmapSet>();
 
                 newRoot.AddItems(carouselBeatmapSets);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Screens.Select
                     return createCarouselSet(new BeatmapSetInfo(new[] { b })
                     {
                         ID = b.BeatmapSet!.ID,
+                        OnlineID = b.BeatmapSet!.OnlineID
                     });
                 }).OfType<CarouselBeatmapSet>();
 
@@ -422,7 +423,8 @@ namespace osu.Game.Screens.Select
                 {
                     var newSet = createCarouselSet(new BeatmapSetInfo(new[] { beatmap })
                     {
-                        ID = beatmapSet.ID
+                        ID = beatmapSet.ID,
+                        OnlineID = beatmapSet.OnlineID
                     });
 
                     if (newSet != null)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -134,8 +134,7 @@ namespace osu.Game.Screens.Select
             if (selectedBeatmapSet != null && !originalBeatmapSetsDetached.Contains(selectedBeatmapSet.BeatmapSet))
                 selectedBeatmapSet = null;
 
-            var selectedSetBefore = selectedBeatmapSet;
-            var selectedBeatmapBefore = selectedBeatmap;
+            var selectedBeatmapBefore = selectedBeatmap?.BeatmapInfo;
 
             CarouselRoot newRoot = new CarouselRoot(this);
 
@@ -170,9 +169,9 @@ namespace osu.Game.Screens.Select
                 signalBeatmapsLoaded();
 
             // Restore selection
-            if (selectedBeatmapBefore != null && selectedSetBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedSetBefore.BeatmapSet.ID, out var newSelectionCandidates))
+            if (selectedBeatmapBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedBeatmapBefore.BeatmapSet!.ID, out var newSelectionCandidates))
             {
-                CarouselBeatmap? found = newSelectionCandidates.SelectMany(s => s.Beatmaps).SingleOrDefault(b => b.BeatmapInfo.ID == selectedBeatmapBefore.BeatmapInfo.ID);
+                CarouselBeatmap? found = newSelectionCandidates.SelectMany(s => s.Beatmaps).SingleOrDefault(b => b.BeatmapInfo.ID == selectedBeatmapBefore.ID);
 
                 if (found != null)
                     found.State.Value = CarouselItemState.Selected;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -405,7 +405,7 @@ namespace osu.Game.Screens.Select
             if (selectedBeatmapSet?.BeatmapSet.ID == beatmapSet.ID)
                 previouslySelectedID = selectedBeatmap?.BeatmapInfo.ID;
 
-            var removedSets = root.RemoveChild(beatmapSet.ID);
+            var removedSets = root.RemoveItemsByID(beatmapSet.ID);
 
             foreach (var removedSet in removedSets)
             {
@@ -1147,7 +1147,7 @@ namespace osu.Game.Screens.Select
                 base.AddItem(i);
             }
 
-            public IEnumerable<CarouselBeatmapSet> RemoveChild(Guid beatmapSetID)
+            public IEnumerable<CarouselBeatmapSet> RemoveItemsByID(Guid beatmapSetID)
             {
                 if (BeatmapSetsByID.TryGetValue(beatmapSetID, out var carouselBeatmapSets))
                 {

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.Select
 
         private CarouselBeatmapSet? selectedBeatmapSet;
 
-        private IEnumerable<BeatmapSetInfo> originalBeatmapSetsDetached = Enumerable.Empty<BeatmapSetInfo>();
+        private List<BeatmapSetInfo> originalBeatmapSetsDetached = new List<BeatmapSetInfo>();
 
         /// <summary>
         /// Raised when the <see cref="SelectedBeatmapInfo"/> is changed.
@@ -381,6 +381,8 @@ namespace osu.Game.Screens.Select
             if (!root.BeatmapSetsByID.TryGetValue(beatmapSetID, out var existingSets))
                 return;
 
+            originalBeatmapSetsDetached.RemoveAll(set => set.ID == beatmapSetID);
+
             foreach (var set in existingSets)
             {
                 foreach (var beatmap in set.Beatmaps)
@@ -401,6 +403,9 @@ namespace osu.Game.Screens.Select
         public void UpdateBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
         {
             Guid? previouslySelectedID = null;
+
+            originalBeatmapSetsDetached.RemoveAll(set => set.ID == beatmapSet.ID);
+            originalBeatmapSetsDetached.Add(beatmapSet.Detach());
 
             // If the selected beatmap is about to be removed, store its ID so it can be re-selected if required
             if (selectedBeatmapSet?.BeatmapSet.ID == beatmapSet.ID)

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -393,7 +393,6 @@ namespace osu.Game.Screens.Select
             if (selectedBeatmapSet?.BeatmapSet.ID == beatmapSet.ID)
                 previouslySelectedID = selectedBeatmap?.BeatmapInfo.ID;
 
-            var newSet = createCarouselSet(beatmapSet);
             var removedSets = root.RemoveChild(beatmapSet.ID);
 
             foreach (var removedSet in removedSets)
@@ -405,13 +404,37 @@ namespace osu.Game.Screens.Select
                     expirePanelImmediately(removedDrawable);
             }
 
-            if (newSet != null)
+            if (beatmapsSplitOut)
             {
-                root.AddItem(newSet);
+                foreach (var beatmap in beatmapSet.Beatmaps)
+                {
+                    var newSet = createCarouselSet(new BeatmapSetInfo(new[] { beatmap })
+                    {
+                        ID = beatmapSet.ID
+                    });
 
-                // check if we can/need to maintain our current selection.
-                if (previouslySelectedID != null)
-                    select((CarouselItem?)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
+                    if (newSet != null)
+                    {
+                        root.AddItem(newSet);
+
+                        // check if we can/need to maintain our current selection.
+                        if (previouslySelectedID != null)
+                            select((CarouselItem?)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
+                    }
+                }
+            }
+            else
+            {
+                var newSet = createCarouselSet(beatmapSet);
+
+                if (newSet != null)
+                {
+                    root.AddItem(newSet);
+
+                    // check if we can/need to maintain our current selection.
+                    if (previouslySelectedID != null)
+                        select((CarouselItem?)newSet.Beatmaps.FirstOrDefault(b => b.BeatmapInfo.ID == previouslySelectedID) ?? newSet);
+                }
             }
 
             itemsCache.Invalidate();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -131,6 +131,12 @@ namespace osu.Game.Screens.Select
         {
             originalBeatmapSetsDetached = beatmapSets.Detach();
 
+            if (selectedBeatmapSet != null && !originalBeatmapSetsDetached.Contains(selectedBeatmapSet.BeatmapSet))
+                selectedBeatmapSet = null;
+
+            var selectedSetBefore = selectedBeatmapSet;
+            var selectedBetmapBefore = selectedBeatmap;
+
             CarouselRoot newRoot = new CarouselRoot(this);
 
             if (beatmapsSplitOut)
@@ -148,13 +154,11 @@ namespace osu.Game.Screens.Select
             else
             {
                 var carouselBeatmapSets = originalBeatmapSetsDetached.Select(createCarouselSet).OfType<CarouselBeatmapSet>();
+
                 newRoot.AddItems(carouselBeatmapSets);
             }
 
             root = newRoot;
-
-            if (selectedBeatmapSet != null && !originalBeatmapSetsDetached.Contains(selectedBeatmapSet.BeatmapSet))
-                selectedBeatmapSet = null;
 
             Scroll.Clear(false);
             itemsCache.Invalidate();
@@ -164,6 +168,15 @@ namespace osu.Game.Screens.Select
 
             if (loadedTestBeatmaps)
                 signalBeatmapsLoaded();
+
+            // Restore selection
+            if (selectedBetmapBefore != null && selectedSetBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedSetBefore.BeatmapSet.ID, out var newSelectionCandidates))
+            {
+                CarouselBeatmap? found = newSelectionCandidates.SelectMany(s => s.Beatmaps).SingleOrDefault(b => b.BeatmapInfo.ID == selectedBetmapBefore.BeatmapInfo.ID);
+
+                if (found != null)
+                    found.State.Value = CarouselItemState.Selected;
+            }
         }
 
         private readonly List<CarouselItem> visibleItems = new List<CarouselItem>();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Select
                 selectedBeatmapSet = null;
 
             var selectedSetBefore = selectedBeatmapSet;
-            var selectedBetmapBefore = selectedBeatmap;
+            var selectedBeatmapBefore = selectedBeatmap;
 
             CarouselRoot newRoot = new CarouselRoot(this);
 
@@ -170,9 +170,9 @@ namespace osu.Game.Screens.Select
                 signalBeatmapsLoaded();
 
             // Restore selection
-            if (selectedBetmapBefore != null && selectedSetBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedSetBefore.BeatmapSet.ID, out var newSelectionCandidates))
+            if (selectedBeatmapBefore != null && selectedSetBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedSetBefore.BeatmapSet.ID, out var newSelectionCandidates))
             {
-                CarouselBeatmap? found = newSelectionCandidates.SelectMany(s => s.Beatmaps).SingleOrDefault(b => b.BeatmapInfo.ID == selectedBetmapBefore.BeatmapInfo.ID);
+                CarouselBeatmap? found = newSelectionCandidates.SelectMany(s => s.Beatmaps).SingleOrDefault(b => b.BeatmapInfo.ID == selectedBeatmapBefore.BeatmapInfo.ID);
 
                 if (found != null)
                     found.State.Value = CarouselItemState.Selected;

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -19,6 +19,11 @@ namespace osu.Game.Screens.Select
         public GroupMode Group;
         public SortMode Sort;
 
+        /// <summary>
+        /// Whether the display of beatmap sets should be split apart per-difficulty for the current criteria.
+        /// </summary>
+        public bool SplitOutDifficulties => Sort == SortMode.Difficulty;
+
         public BeatmapSetInfo? SelectedBeatmapSet;
 
         public OptionalRange<double> StarDifficulty;


### PR DESCRIPTION
Probably the number one feature request for song select. I found a way to implement this without refactoring and rewriting everything, so here's a RFC.

Note that one test is currently broken (pretty obvious why). But everything else seems to work quite well.

Closes https://github.com/ppy/osu/issues/2547 (I guess, until redesign / refactor).