### PR TITLE
Enable sentry "global mode" as per recommendation

### DIFF
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Utils
 
                 options.AutoSessionTracking = true;
                 options.IsEnvironmentUser = false;
+                options.IsGlobalModeEnabled = true;
                 // The reported release needs to match version as reported to Sentry in .github/workflows/sentry-release.yml
                 options.Release = $"osu@{game.Version.Replace($@"-{OsuGameBase.BUILD_SUFFIX}", string.Empty)}";
             });


### PR DESCRIPTION
Sentry documentation suggests this should be on for a client-facing app.

We haven't run into issues without it until now, but might as well set it correctly?
