### PR TITLE
Fix incorrect json property name for `HasReplay` field in `SoloScoreInfo`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("pp")]
         public double? PP { get; set; }
 
-        [JsonProperty("has_replay")]
+        [JsonProperty("replay")]
         public bool HasReplay { get; set; }
 
         // These properties are calculated or not relevant to any external usage.


### PR DESCRIPTION
See https://github.com/ppy/osu/issues/24229#issuecomment-1636768384 and subsequent conversation.

This won't actually fix the entire issue, there seems to be [at least one further issue somewhere else](https://github.com/ppy/osu/issues/24229#issuecomment-1692109217). Right now what this diff achieves is only unblocking the download button on online results screens.