### PR TITLE
Update osu! spinner ticks calculation method to better match with osu!(stable)

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private static readonly int score_per_tick = new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxNumericResult;
 
-        private int currentSpins;
+        private int completedFullSpins;
 
         private void updateBonusScore()
         {
@@ -295,14 +295,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             int spins = (int)(Result.RateAdjustedRotation / 360);
 
-            if (spins < currentSpins)
+            if (spins < completedFullSpins)
             {
                 // rewinding, silently handle
-                currentSpins = spins;
+                completedFullSpins = spins;
                 return;
             }
 
-            while (currentSpins != spins)
+            while (completedFullSpins != spins)
             {
                 var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
 
@@ -315,7 +315,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                         gainedBonus.Value = score_per_tick * (spins - HitObject.SpinsRequired);
                 }
 
-                currentSpins++;
+                completedFullSpins++;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private static readonly int score_per_tick = new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxNumericResult;
 
-        private int wholeSpins;
+        private int currentSpins;
 
         private void updateBonusScore()
         {
@@ -295,14 +295,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             int spins = (int)(Result.RateAdjustedRotation / 360);
 
-            if (spins < wholeSpins)
+            if (spins < currentSpins)
             {
                 // rewinding, silently handle
-                wholeSpins = spins;
+                currentSpins = spins;
                 return;
             }
 
-            while (wholeSpins != spins)
+            while (currentSpins != spins)
             {
                 var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
 
@@ -315,7 +315,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                         gainedBonus.Value = score_per_tick * (spins - HitObject.SpinsRequired);
                 }
 
-                wholeSpins++;
+                currentSpins++;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -42,15 +42,10 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             base.ApplyDefaultsToSelf(controlPointInfo, difficulty);
 
-            // spinning doesn't match 1:1 with stable, so let's fudge them easier for the time being.
-            const double stable_matching_fudge = 0.6;
-
-            // close to 477rpm
-            const double maximum_rotations_per_second = 8;
+            const double maximum_rotations_per_second = 477f / 60f;
 
             double secondsDuration = Duration / 1000;
-
-            double minimumRotationsPerSecond = stable_matching_fudge * IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, 3, 5, 7.5);
+            double minimumRotationsPerSecond = IBeatmapDifficultyInfo.DifficultyRange(difficulty.OverallDifficulty, 1.5, 2.5, 3.75);
 
             SpinsRequired = (int)(secondsDuration * minimumRotationsPerSecond);
             MaximumBonusSpins = (int)((maximum_rotations_per_second - minimumRotationsPerSecond) * secondsDuration);


### PR DESCRIPTION
- One step towards https://github.com/ppy/osu/issues/23732

osu!(stable) calculate spins requirement for completion in "half spins" unit, meanwhile lazer tries to do roughly the same but applies a 0.6x factor to "convert" into full spins. This PR updates the logic to calculate as full spins directly.