### PR TITLE
Disable redundant verbatim string prefix inspections

### DIFF
--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -170,7 +170,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantStringInterpolation/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantVerbatimPrefix/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantVerbatimStringPrefix/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantVerbatimStringPrefix/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveRedundantOrStatement_002EFalse/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveRedundantOrStatement_002ETrue/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RemoveToList_002E1/@EntryIndexedValue">WARNING</s:String>


### PR DESCRIPTION
For some reason this started flaring up recently all over for me and showing inspections all over:

![1693219650](https://github.com/ppy/osu/assets/20418176/3c8257ea-e72a-4459-9058-198a5854a7c2)

which are _technically_ valid, but interfere with our convention of using verbatim string prefixes to denote non-localisable strings. This, as a result, led to circular inspections (addressing the r# inspection results in getting the `osu-localisation-analyser` one, addresssing that one results in getting the r# inspection back, etc. ad nauseam).