### PR TITLE
Switch download requests to new API endpoint

### DIFF
--- a/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
+++ b/osu.Game/Online/API/Requests/DownloadReplayRequest.cs
@@ -14,6 +14,6 @@ namespace osu.Game.Online.API.Requests
 
         protected override string FileExtension => ".osr";
 
-        protected override string Target => $@"scores/{Model.Ruleset.ShortName}/{Model.OnlineID}/download";
+        protected override string Target => $@"scores/{Model.OnlineID}/download";
     }
 }


### PR DESCRIPTION
- Continuation of work on https://github.com/ppy/osu/issues/24229
- [x] Hard-depends on `osu-web` **deployment** with https://github.com/ppy/osu-web/pull/10492
- [x] Soft-depends on on `osu-web` **deployment** with https://github.com/ppy/osu-web/pull/10495 for correct operation

This API endpoint is intended for usage with the entire `solo_scores` machinery and ID schema, rather than the legacy `*_scores_high` ID schema. It also supports automagically falling back to downloading legacy replays if a stable-imported score is requested for download (internally this happens via `legacy_score_id` in the `data` json).

This change will allow replays to be downloaded, but it will still not yield 100% correct behaviour, as there is further work to be done in that respect. The download tracker is expecting score hashes to arrive from web to verify the integrity of the incoming download, but the API does not expose such a facility right now:

https://github.com/ppy/osu/blob/d70df88fa007c7a3f5b4e3e2d600e7fa634ee2f5/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs#L192

we will have to decide as to whether we want to add one web-side, or whether we want to disable the checking client-side.

---

This can be tested locally. For lazer replays, it is sufficient to follow the local full stack guide, especially [the recently-added parts about replay upload](https://github.com/ppy/osu/wiki/Testing-web---server-full-stack-with-osu!#replays). It is also helpful to have `osu-queue-score-statistics` running locally in `queue watch` mode so that scores can be processed onto leaderboards, and as such be accessible from within the client that way.

As for stable-imported replays, that is a bit difficult, but you can get close enough with some manual sql tinkering. What I basically did is I set a lazer score and then I hijacked it to do some sql-side shenanigans:

```sql
INSERT INTO osu_scores_high
    (`beatmap_id`, `user_id`, `score`, `maxcombo`, `rank`, `count50`, `count100`, `count300`, `countmiss`, `countgeki`, `countkatu`, `perfect`, `enabled_mods`, `date`, `pp`, `replay`, `hidden`, `country_acronym`)
SELECT
    beatmap_id,
    user_id,
    JSON_EXTRACT(data, '$.total_score') AS `score`,
    JSON_EXTRACT(data, '$.max_combo') AS `maxcombo`,
    'A' AS `rank`, -- mysql doesn't like selecting from json because of enum type disparities or whatever i don't really care
    JSON_EXTRACT(data, '$.statistics.meh') AS `count50`,
    JSON_EXTRACT(data, '$.statistics.ok') AS `count100`,
    JSON_EXTRACT(data, '$.statistics.great') AS `count300`,
    JSON_EXTRACT(data, '$.statistics.miss') AS `countmiss`,
    0 AS `countgeki`, -- don't care
    0 AS `countkatu`, -- don't care
    0 AS `perfect`, -- don't care
    0 AS `enabled_mods`, -- don't care
    created_at AS `date`,
    NULL AS `pp`, -- don't care
    1 AS `replay`,
    0 AS `hidden`,
    'JP' AS `country_acronym` -- don't care
FROM solo_scores
ORDER BY id DESC
LIMIT 1;

UPDATE solo_scores SET `data` = JSON_INSERT(`data`, '$.legacy_score_id', 201) where id = 136;
```

(ids obviously need changing). The replay itself will be a bit garbage (no frames inside) and I haven't entirely figured out why that is, but just for testing that `osu-web` pathway, it is sufficient.