### PR TITLE
Mark "Score V2" mod as not user-playable

### DIFF
--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -16,5 +16,6 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.System;
         public override LocalisableString Description => "Score set on earlier osu! versions with the V2 scoring algorithm active.";
         public override double ScoreMultiplier => 1;
+        public override bool UserPlayable => false;
     }
 }


### PR DESCRIPTION
The mod generally will only be present on scores imported from stable. As such, it's probably ok to mark it as such.

The primary reason for this change is to address #24436 (Score V2 being visible on beatmap overlay leaderboard mod selector).

There is one possibly-unintended consequence of this change, namely that the results screen uses `UserPlayable` to determine as to whether animations should be played back, with the intention of turning off the animation playback for autoplay scores specifically. Therefore, turning off this flag will mean that the results screen animations will not play out for Score V2 scores - but I tend to consider this as either largely unimportant, or something that should be fixed in some other way (possibly by checking against the autoplay mod directly).

Other usages of `UserPlayable` are either innocuous, or straight-up good safeties going forward in the context of Score V2 (guards against selection in mod select overlays, against score submission with the mod).