### PR TITLE
Fix and use score user's `IsBot` property in results screen animation

### DIFF
--- a/osu.Game/Rulesets/Mods/ModExtensions.cs
+++ b/osu.Game/Rulesets/Mods/ModExtensions.cs
@@ -21,8 +21,10 @@ namespace osu.Game.Rulesets.Mods
                 {
                     User = new APIUser
                     {
-                        Id = APIUser.SYSTEM_USER_ID,
+                        // TODO: Some fields weren't copied from replayData.User (namely IsBot and Id). Should ModCreatedUser inherit from APIUser so we could pass it verbatim to avoid future mistakes ?
+                        Id = replayData.User.OnlineID,
                         Username = replayData.User.Username,
+                        IsBot = replayData.User.IsBot,
                     }
                 }
             };

--- a/osu.Game/Rulesets/Mods/ModExtensions.cs
+++ b/osu.Game/Rulesets/Mods/ModExtensions.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Mods
                 {
                     User = new APIUser
                     {
-                        // TODO: Some fields weren't copied from replayData.User (namely IsBot and Id). Should ModCreatedUser inherit from APIUser so we could pass it verbatim to avoid future mistakes ?
                         Id = replayData.User.OnlineID,
                         Username = replayData.User.Username,
                         IsBot = replayData.User.IsBot,

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -156,7 +156,7 @@ namespace osu.Game.Screens.Ranking
             if (Score != null)
             {
                 // only show flair / animation when arriving after watching a play that isn't autoplay.
-                bool shouldFlair = player != null && Score.Mods.All(m => m.UserPlayable);
+                bool shouldFlair = player != null && !Score.User.IsBot;
 
                 ScorePanelList.AddScore(Score, shouldFlair);
             }


### PR DESCRIPTION
While a mod-created replay did flag itself as performed by a bot, the extension method converting it into a Score did not copy all the generated properties.

As noted, it might be preferable for ModCreatedUser to inherit APIUser and forward it as-is to the Score instance.

Related to PR #24675