### PR TITLE
Allow saving changes in tournament system using `Ctrl`+`S`

### DIFF
--- a/osu.Game.Tournament/SaveChangesOverlay.cs
+++ b/osu.Game.Tournament/SaveChangesOverlay.cs
@@ -7,13 +7,16 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Online.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Tournament
 {
-    internal partial class SaveChangesOverlay : CompositeDrawable
+    internal partial class SaveChangesOverlay : CompositeDrawable, IKeyBindingHandler<PlatformAction>
     {
         [Resolved]
         private TournamentGame tournamentGame { get; set; } = null!;
@@ -76,6 +79,21 @@ namespace osu.Game.Tournament
             }
 
             scheduleNextCheck();
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+        {
+            if (e.Action == PlatformAction.Save && !e.Repeat)
+            {
+                saveChangesButton.TriggerClick();
+                return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)
+        {
         }
 
         private void scheduleNextCheck() => Scheduler.AddDelayed(() => checkForChanges().FireAndForget(), 1000);


### PR DESCRIPTION
Low hanging fruit. As proposed in https://github.com/ppy/osu/discussions/24658.