### PR TITLE
Remove tournament client minimum window size

### DIFF
--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Drawing;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;

--- a/osu.Game.Tournament/TournamentGame.cs
+++ b/osu.Game.Tournament/TournamentGame.cs
@@ -48,8 +48,6 @@ namespace osu.Game.Tournament
         {
             frameworkConfig.BindWith(FrameworkSetting.WindowedSize, windowSize);
 
-            windowSize.MinValue = new Size(TournamentSceneManager.REQUIRED_WIDTH, TournamentSceneManager.STREAM_AREA_HEIGHT);
-
             windowMode = frameworkConfig.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
 
             Add(loadingSpinner = new LoadingSpinner(true, true)


### PR DESCRIPTION
This seemed like a good idea but people were using it with smaller resolutions, do let's just not do it.

Addresses https://github.com/ppy/osu/discussions/24670.
