### PR TITLE
Fix legacy score calculators using incorrect mod multipliers

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -214,6 +215,59 @@ namespace osu.Game.Rulesets.Catch
         public int LegacyID => 2;
 
         public ILegacyScoreSimulator CreateLegacyScoreSimulator() => new CatchLegacyScoreSimulator();
+
+        public double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty)
+        {
+            bool scoreV2 = mods.Any(m => m is ModScoreV2);
+
+            double multiplier = 1.0;
+
+            foreach (var mod in mods)
+            {
+                switch (mod)
+                {
+                    case CatchModNoFail:
+                        multiplier *= scoreV2 ? 1.0 : 0.5;
+                        break;
+
+                    case CatchModEasy:
+                        multiplier *= 0.5;
+                        break;
+
+                    case CatchModHalfTime:
+                    case CatchModDaycore:
+                        multiplier *= 0.3;
+                        break;
+
+                    case CatchModHidden:
+                        multiplier *= scoreV2 ? 1.0 : 1.06;
+                        break;
+
+                    case CatchModHardRock:
+                        multiplier *= scoreV2 ? 1.0 : 1.12;
+                        break;
+
+                    case CatchModDoubleTime:
+                    case CatchModNightcore:
+                        multiplier *= scoreV2 ? 1.0 : 1.06;
+                        break;
+
+                    case CatchModFlashlight:
+                        multiplier *= 1.12;
+                        break;
+
+                    // case CatchModSpunOut:
+                    //     multiplier *= 0.9;
+                    //     break;
+
+                    // case CatchModAutopilot:
+                    case CatchModRelax:
+                        return 0;
+                }
+            }
+
+            return multiplier;
+        }
 
         public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new CatchReplayFrame();
 

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -256,11 +256,6 @@ namespace osu.Game.Rulesets.Catch
                         multiplier *= 1.12;
                         break;
 
-                    // case CatchModSpunOut:
-                    //     multiplier *= 0.9;
-                    //     break;
-
-                    // case CatchModAutopilot:
                     case CatchModRelax:
                         return 0;
                 }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -244,12 +244,12 @@ namespace osu.Game.Rulesets.Catch
                         break;
 
                     case CatchModHardRock:
-                        multiplier *= scoreV2 ? 1.0 : 1.12;
+                        multiplier *= 1.12;
                         break;
 
                     case CatchModDoubleTime:
                     case CatchModNightcore:
-                        multiplier *= scoreV2 ? 1.0 : 1.06;
+                        multiplier *= 1.06;
                         break;
 
                     case CatchModFlashlight:

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 {
     internal class CatchLegacyScoreSimulator : ILegacyScoreSimulator
     {
-        public int AccuracyScore { get; private set; }
+        public long AccuracyScore { get; private set; }
 
-        public int ComboScore { get; private set; }
+        public long ComboScore { get; private set; }
 
         public double BonusScoreRatio => legacyBonusScore == 0 ? 0 : (double)modernBonusScore / legacyBonusScore;
 
-        private int legacyBonusScore;
-        private int modernBonusScore;
+        private long legacyBonusScore;
+        private long modernBonusScore;
         private int combo;
 
         private double scoreMultiplier;

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -70,7 +70,14 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                  + baseBeatmap.Difficulty.CircleSize
                  + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
 
-            scoreMultiplier = difficultyPeppyStars * mods.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier);
+            scoreMultiplier = difficultyPeppyStars * new CatchRuleset().GetLegacyScoreMultiplier(mods, new LegacyBeatmapConversionDifficultyInfo
+            {
+                IsForTargetRuleset = baseBeatmap.BeatmapInfo.Ruleset.OnlineID == 2,
+                CircleSize = baseBeatmap.Difficulty.CircleSize,
+                OverallDifficulty = baseBeatmap.Difficulty.OverallDifficulty,
+                CircleCount = countNormal,
+                TotalObjectCount = objectCount
+            });
 
             foreach (var obj in playableBeatmap.HitObjects)
                 simulateHit(obj);

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -44,38 +44,41 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         {
             IsForCurrentRuleset = beatmap.BeatmapInfo.Ruleset.Equals(ruleset.RulesetInfo);
 
-            double roundedCircleSize = Math.Round(beatmap.Difficulty.CircleSize);
-            double roundedOverallDifficulty = Math.Round(beatmap.Difficulty.OverallDifficulty);
+            TargetColumns = GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmap(beatmap));
 
-            if (IsForCurrentRuleset)
+            if (IsForCurrentRuleset && TargetColumns > ManiaRuleset.MAX_STAGE_KEYS)
             {
-                TargetColumns = GetColumnCountForNonConvert(beatmap.BeatmapInfo);
-
-                if (TargetColumns > ManiaRuleset.MAX_STAGE_KEYS)
-                {
-                    TargetColumns /= 2;
-                    Dual = true;
-                }
-            }
-            else
-            {
-                float percentSliderOrSpinner = (float)beatmap.HitObjects.Count(h => h is IHasDuration) / beatmap.HitObjects.Count;
-                if (percentSliderOrSpinner < 0.2)
-                    TargetColumns = 7;
-                else if (percentSliderOrSpinner < 0.3 || roundedCircleSize >= 5)
-                    TargetColumns = roundedOverallDifficulty > 5 ? 7 : 6;
-                else if (percentSliderOrSpinner > 0.6)
-                    TargetColumns = roundedOverallDifficulty > 4 ? 5 : 4;
-                else
-                    TargetColumns = Math.Max(4, Math.Min((int)roundedOverallDifficulty + 1, 7));
+                TargetColumns /= 2;
+                Dual = true;
             }
 
             originalTargetColumns = TargetColumns;
         }
 
-        public static int GetColumnCountForNonConvert(BeatmapInfo beatmapInfo)
+        public static int GetColumnCount(LegacyBeatmapConversionDifficultyInfo difficulty)
         {
-            double roundedCircleSize = Math.Round(beatmapInfo.Difficulty.CircleSize);
+            if (difficulty.IsForTargetRuleset)
+                return GetColumnCountForNonConvert(difficulty);
+
+            double roundedCircleSize = Math.Round(difficulty.CircleSize);
+            double roundedOverallDifficulty = Math.Round(difficulty.OverallDifficulty);
+
+            int countSliderOrSpinner = difficulty.TotalObjectCount - difficulty.CircleCount;
+            float percentSpecialObjects = (float)countSliderOrSpinner / difficulty.TotalObjectCount;
+
+            if (percentSpecialObjects < 0.2)
+                return 7;
+            if (percentSpecialObjects < 0.3 || roundedCircleSize >= 5)
+                return roundedOverallDifficulty > 5 ? 7 : 6;
+            if (percentSpecialObjects > 0.6)
+                return roundedOverallDifficulty > 4 ? 5 : 4;
+
+            return Math.Max(4, Math.Min((int)roundedOverallDifficulty + 1, 7));
+        }
+
+        public static int GetColumnCountForNonConvert(IBeatmapDifficultyInfo difficulty)
+        {
+            double roundedCircleSize = Math.Round(difficulty.CircleSize);
             return (int)Math.Max(1, roundedCircleSize);
         }
 

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 {
     internal class ManiaLegacyScoreSimulator : ILegacyScoreSimulator
     {
-        public int AccuracyScore => 0;
-        public int ComboScore { get; private set; }
+        public long AccuracyScore => 0;
+        public long ComboScore { get; private set; }
         public double BonusScoreRatio => 0;
 
         public void Simulate(IWorkingBeatmap workingBeatmap, IBeatmap playableBeatmap, IReadOnlyList<Mod> mods)

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania
 
         public bool Matches(BeatmapInfo beatmapInfo)
         {
-            return !keys.HasFilter || (beatmapInfo.Ruleset.OnlineID == new ManiaRuleset().LegacyID && keys.IsInRange(ManiaBeatmapConverter.GetColumnCountForNonConvert(beatmapInfo)));
+            return !keys.HasFilter || (beatmapInfo.Ruleset.OnlineID == new ManiaRuleset().LegacyID && keys.IsInRange(ManiaBeatmapConverter.GetColumnCountForNonConvert(beatmapInfo.Difficulty)));
         }
 
         public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -335,12 +335,6 @@ namespace osu.Game.Rulesets.Mania
                     case ManiaModDaycore:
                         multiplier *= 0.5;
                         break;
-
-                    // case ManiaModSpunOut:
-                    // case ManiaModRelax:
-                    // case ManiaModAutopilot:
-                    //     multiplier *= 0;
-                    //     break;
                 }
             }
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
@@ -73,7 +73,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                  + baseBeatmap.Difficulty.CircleSize
                  + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
 
-            scoreMultiplier = difficultyPeppyStars * mods.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier);
+            scoreMultiplier = difficultyPeppyStars * new OsuRuleset().GetLegacyScoreMultiplier(mods, new LegacyBeatmapConversionDifficultyInfo
+            {
+                IsForTargetRuleset = baseBeatmap.BeatmapInfo.Ruleset.OnlineID == 0,
+                CircleSize = baseBeatmap.Difficulty.CircleSize,
+                OverallDifficulty = baseBeatmap.Difficulty.OverallDifficulty,
+                CircleCount = countNormal,
+                TotalObjectCount = objectCount
+            });
 
             foreach (var obj in playableBeatmap.HitObjects)
                 simulateHit(obj);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     internal class OsuLegacyScoreSimulator : ILegacyScoreSimulator
     {
-        public int AccuracyScore { get; private set; }
+        public long AccuracyScore { get; private set; }
 
-        public int ComboScore { get; private set; }
+        public long ComboScore { get; private set; }
 
         public double BonusScoreRatio => legacyBonusScore == 0 ? 0 : (double)modernBonusScore / legacyBonusScore;
 
-        private int legacyBonusScore;
-        private int modernBonusScore;
+        private long legacyBonusScore;
+        private long modernBonusScore;
         private int combo;
 
         private double scoreMultiplier;

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -259,6 +259,59 @@ namespace osu.Game.Rulesets.Osu
 
         public ILegacyScoreSimulator CreateLegacyScoreSimulator() => new OsuLegacyScoreSimulator();
 
+        public double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty)
+        {
+            bool scoreV2 = mods.Any(m => m is ModScoreV2);
+
+            double multiplier = 1.0;
+
+            foreach (var mod in mods)
+            {
+                switch (mod)
+                {
+                    case OsuModNoFail:
+                        multiplier *= scoreV2 ? 1.0 : 0.5;
+                        break;
+
+                    case OsuModEasy:
+                        multiplier *= 0.5;
+                        break;
+
+                    case OsuModHalfTime:
+                    case OsuModDaycore:
+                        multiplier *= 0.3;
+                        break;
+
+                    case OsuModHidden:
+                        multiplier *= 1.06;
+                        break;
+
+                    case OsuModHardRock:
+                        multiplier *= scoreV2 ? 1.10 : 1.06;
+                        break;
+
+                    case OsuModDoubleTime:
+                    case OsuModNightcore:
+                        multiplier *= scoreV2 ? 1.20 : 1.12;
+                        break;
+
+                    case OsuModFlashlight:
+                        multiplier *= 1.12;
+                        break;
+
+                    case OsuModSpunOut:
+                        multiplier *= 0.9;
+                        break;
+
+                    case OsuModRelax:
+                    case OsuModAutopilot:
+                        return 0;
+                }
+            }
+
+            return multiplier;
+        }
+
         public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new OsuReplayFrame();
 
         public override IRulesetConfigManager CreateConfig(SettingsStore? settings) => new OsuRulesetConfigManager(settings, RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -76,7 +76,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                  + baseBeatmap.Difficulty.CircleSize
                  + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
 
-            modMultiplier = mods.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier);
+            modMultiplier = new TaikoRuleset().GetLegacyScoreMultiplier(mods, new LegacyBeatmapConversionDifficultyInfo
+            {
+                IsForTargetRuleset = baseBeatmap.BeatmapInfo.Ruleset.OnlineID == 1,
+                CircleSize = baseBeatmap.Difficulty.CircleSize,
+                OverallDifficulty = baseBeatmap.Difficulty.OverallDifficulty,
+                CircleCount = countNormal,
+                TotalObjectCount = objectCount
+            });
 
             foreach (var obj in playableBeatmap.HitObjects)
                 simulateHit(obj);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 {
     internal class TaikoLegacyScoreSimulator : ILegacyScoreSimulator
     {
-        public int AccuracyScore { get; private set; }
+        public long AccuracyScore { get; private set; }
 
-        public int ComboScore { get; private set; }
+        public long ComboScore { get; private set; }
 
         public double BonusScoreRatio => legacyBonusScore == 0 ? 0 : (double)modernBonusScore / legacyBonusScore;
 
-        private int legacyBonusScore;
-        private int modernBonusScore;
+        private long legacyBonusScore;
+        private long modernBonusScore;
         private int combo;
 
         private double modMultiplier;

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -245,11 +245,6 @@ namespace osu.Game.Rulesets.Taiko
                         multiplier *= 1.06;
                         break;
 
-                    // case TaikoModSpunOut:
-                    //     multiplier *= 0.9;
-                    //     break;
-
-                    // case TaikoModAutopilot:
                     case TaikoModRelax:
                         return 0;
                 }

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -208,6 +208,56 @@ namespace osu.Game.Rulesets.Taiko
 
         public ILegacyScoreSimulator CreateLegacyScoreSimulator() => new TaikoLegacyScoreSimulator();
 
+        public double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty)
+        {
+            bool scoreV2 = mods.Any(m => m is ModScoreV2);
+
+            double multiplier = 1.0;
+
+            foreach (var mod in mods)
+            {
+                switch (mod)
+                {
+                    case TaikoModNoFail:
+                        multiplier *= scoreV2 ? 1.0 : 0.5;
+                        break;
+
+                    case TaikoModEasy:
+                        multiplier *= 0.5;
+                        break;
+
+                    case TaikoModHalfTime:
+                    case TaikoModDaycore:
+                        multiplier *= 0.3;
+                        break;
+
+                    case TaikoModHidden:
+                        multiplier *= 1.06;
+                        break;
+
+                    case TaikoModHardRock:
+                    case TaikoModFlashlight:
+                        multiplier *= 1.12;
+                        break;
+
+                    case TaikoModDoubleTime:
+                    case TaikoModNightcore:
+                        multiplier *= 1.06;
+                        break;
+
+                    // case TaikoModSpunOut:
+                    //     multiplier *= 0.9;
+                    //     break;
+
+                    // case TaikoModAutopilot:
+                    case TaikoModRelax:
+                        return 0;
+                }
+            }
+
+            return multiplier;
+        }
+
         public override IConvertibleReplayFrame CreateConvertibleReplayFrame() => new TaikoReplayFrame();
 
         public override IRulesetConfigManager CreateConfig(SettingsStore? settings) => new TaikoRulesetConfigManager(settings, RulesetInfo);

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -232,17 +232,14 @@ namespace osu.Game.Rulesets.Taiko
                         break;
 
                     case TaikoModHidden:
-                        multiplier *= 1.06;
-                        break;
-
                     case TaikoModHardRock:
-                    case TaikoModFlashlight:
-                        multiplier *= 1.12;
+                        multiplier *= 1.06;
                         break;
 
                     case TaikoModDoubleTime:
                     case TaikoModNightcore:
-                        multiplier *= 1.06;
+                    case TaikoModFlashlight:
+                        multiplier *= 1.12;
                         break;
 
                     case TaikoModRelax:

--- a/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
@@ -127,8 +127,9 @@ namespace osu.Game.Tests.Database
             });
         }
 
-        [Test]
-        public void TestScoreUpgradeSuccess()
+        [TestCase(30000002)]
+        [TestCase(30000003)]
+        public void TestScoreUpgradeSuccess(int scoreVersion)
         {
             ScoreInfo scoreInfo = null!;
 
@@ -138,7 +139,7 @@ namespace osu.Game.Tests.Database
                 {
                     r.Add(scoreInfo = new ScoreInfo(ruleset: r.All<RulesetInfo>().First(), beatmap: r.All<BeatmapInfo>().First())
                     {
-                        TotalScoreVersion = 30000002,
+                        TotalScoreVersion = scoreVersion,
                         LegacyTotalScore = 123456,
                         IsLegacyScore = true,
                     });

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -235,7 +235,9 @@ namespace osu.Game
             Logger.Log("Querying for scores that need total score conversion...");
 
             HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(r.All<ScoreInfo>()
-                                                                             .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null && s.TotalScoreVersion == 30000002)
+                                                                             .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null
+                                                                                                                         && (s.TotalScoreVersion == 30000002
+                                                                                                                             || s.TotalScoreVersion == 30000003))
                                                                              .AsEnumerable().Select(s => s.ID)));
 
             Logger.Log($"Found {scoreIds.Count} scores which require total score conversion.");

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -248,13 +248,13 @@ namespace osu.Game.Database
 
             Debug.Assert(score.LegacyTotalScore != null);
 
-            int maximumLegacyAccuracyScore = attributes.LegacyAccuracyScore;
-            int maximumLegacyComboScore = attributes.LegacyComboScore;
+            long maximumLegacyAccuracyScore = attributes.LegacyAccuracyScore;
+            long maximumLegacyComboScore = attributes.LegacyComboScore;
             double maximumLegacyBonusRatio = attributes.LegacyBonusScoreRatio;
             double modMultiplier = score.Mods.Select(m => m.ScoreMultiplier).Aggregate(1.0, (c, n) => c * n);
 
             // The part of total score that doesn't include bonus.
-            int maximumLegacyBaseScore = maximumLegacyAccuracyScore + maximumLegacyComboScore;
+            long maximumLegacyBaseScore = maximumLegacyAccuracyScore + maximumLegacyComboScore;
 
             // The combo proportion is calculated as a proportion of maximumLegacyBaseScore.
             double comboProportion = Math.Min(1, (double)score.LegacyTotalScore / maximumLegacyBaseScore);

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -51,12 +51,12 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// The accuracy portion of the legacy (ScoreV1) total score.
         /// </summary>
-        public int LegacyAccuracyScore { get; set; }
+        public long LegacyAccuracyScore { get; set; }
 
         /// <summary>
         /// The combo-multiplied portion of the legacy (ScoreV1) total score.
         /// </summary>
-        public int LegacyComboScore { get; set; }
+        public long LegacyComboScore { get; set; }
 
         /// <summary>
         /// A ratio of <c>new_bonus_score / old_bonus_score</c> for converting the bonus score of legacy scores to the new scoring.
@@ -106,8 +106,8 @@ namespace osu.Game.Rulesets.Difficulty
             MaxCombo = (int)values[ATTRIB_ID_MAX_COMBO];
 
             // Temporarily allow these attributes to not exist so as to not block releases of server-side components while these attributes aren't populated/used yet.
-            LegacyAccuracyScore = (int)values.GetValueOrDefault(ATTRIB_ID_LEGACY_ACCURACY_SCORE);
-            LegacyComboScore = (int)values.GetValueOrDefault(ATTRIB_ID_LEGACY_COMBO_SCORE);
+            LegacyAccuracyScore = (long)values.GetValueOrDefault(ATTRIB_ID_LEGACY_ACCURACY_SCORE);
+            LegacyComboScore = (long)values.GetValueOrDefault(ATTRIB_ID_LEGACY_COMBO_SCORE);
             LegacyBonusScoreRatio = values.GetValueOrDefault(ATTRIB_ID_LEGACY_BONUS_SCORE_RATIO);
         }
     }

--- a/osu.Game/Rulesets/ILegacyRuleset.cs
+++ b/osu.Game/Rulesets/ILegacyRuleset.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets
@@ -14,6 +16,17 @@ namespace osu.Game.Rulesets
         /// </summary>
         int LegacyID { get; }
 
+        /// <summary>
+        /// Creates an object that is able to simulate the maximum legacy scoring values possible on a beatmap.
+        /// </summary>
         ILegacyScoreSimulator CreateLegacyScoreSimulator();
+
+        /// <summary>
+        /// Returns the legacy score multiplier for the mods. This is only used during legacy score conversion.
+        /// </summary>
+        /// <param name="mods">The mods.</param>
+        /// <param name="difficulty">Extra difficulty parameters.</param>
+        /// <returns>The legacy multiplier.</returns>
+        double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty);
     }
 }

--- a/osu.Game/Rulesets/LegacyBeatmapConversionDifficultyInfo.cs
+++ b/osu.Game/Rulesets/LegacyBeatmapConversionDifficultyInfo.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Game.Beatmaps;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Rulesets
+{
+    /// <summary>
+    /// A set of properties that are required to facilitate beatmap conversion between legacy rulesets.
+    /// </summary>
+    public class LegacyBeatmapConversionDifficultyInfo : IBeatmapDifficultyInfo
+    {
+        /// <summary>
+        /// Whether the beatmap is made for the target ruleset.
+        /// </summary>
+        public bool IsForTargetRuleset { get; set; }
+
+        /// <summary>
+        /// The beatmap circle size.
+        /// </summary>
+        /// <remarks>
+        /// Only used if <see cref="IsForTargetRuleset"/> is <c>false</c>.
+        /// </remarks>
+        public float CircleSize { get; set; }
+
+        /// <summary>
+        /// The beatmap overall difficulty.
+        /// </summary>
+        /// <remarks>
+        /// Only used if <see cref="IsForTargetRuleset"/> is <c>false</c>.
+        /// </remarks>
+        public float OverallDifficulty { get; set; }
+
+        /// <summary>
+        /// The count of hitcircles in the beatmap.
+        /// </summary>
+        /// <remarks>
+        /// Only used if <see cref="IsForTargetRuleset"/> is <c>false</c>.
+        /// <para>When converting from osu! ruleset beatmaps, this is equivalent to the sum of sliders and spinners in the beatmap.</para>
+        /// </remarks>
+        public int CircleCount { get; set; }
+
+        /// <summary>
+        /// The total count of hitobjects in the beatmap.
+        /// </summary>
+        /// <remarks>
+        /// Only used if <see cref="IsForTargetRuleset"/> is <c>false</c>.
+        /// </remarks>
+        public int TotalObjectCount { get; set; }
+
+        float IBeatmapDifficultyInfo.DrainRate => 0;
+        float IBeatmapDifficultyInfo.ApproachRate => 0;
+        double IBeatmapDifficultyInfo.SliderMultiplier => 0;
+        double IBeatmapDifficultyInfo.SliderTickRate => 0;
+
+        public static LegacyBeatmapConversionDifficultyInfo FromAPIBeatmap(APIBeatmap apiBeatmap) => new LegacyBeatmapConversionDifficultyInfo
+        {
+            IsForTargetRuleset = apiBeatmap.RulesetID == 3,
+            CircleSize = apiBeatmap.CircleSize,
+            OverallDifficulty = apiBeatmap.OverallDifficulty,
+            CircleCount = apiBeatmap.CircleCount,
+            TotalObjectCount = apiBeatmap.SliderCount + apiBeatmap.SpinnerCount + apiBeatmap.CircleCount
+        };
+
+        public static LegacyBeatmapConversionDifficultyInfo FromBeatmap(IBeatmap beatmap) => new LegacyBeatmapConversionDifficultyInfo
+        {
+            IsForTargetRuleset = beatmap.BeatmapInfo.Ruleset.OnlineID == 3,
+            CircleSize = beatmap.Difficulty.CircleSize,
+            OverallDifficulty = beatmap.Difficulty.OverallDifficulty,
+            CircleCount = beatmap.HitObjects.Count(h => h is not IHasDuration),
+            TotalObjectCount = beatmap.HitObjects.Count
+        };
+    }
+}

--- a/osu.Game/Rulesets/Scoring/ILegacyScoreSimulator.cs
+++ b/osu.Game/Rulesets/Scoring/ILegacyScoreSimulator.cs
@@ -15,12 +15,12 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The accuracy portion of the legacy (ScoreV1) total score.
         /// </summary>
-        int AccuracyScore { get; }
+        long AccuracyScore { get; }
 
         /// <summary>
         /// The combo-multiplied portion of the legacy (ScoreV1) total score.
         /// </summary>
-        int ComboScore { get; }
+        long ComboScore { get; }
 
         /// <summary>
         /// A ratio of <c>new_bonus_score / old_bonus_score</c> for converting the bonus score of legacy scores to the new scoring.

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -30,9 +30,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000001: Appends <see cref="LegacyReplaySoloScoreInfo"/> to the end of scores.</description></item>
         /// <item><description>30000002: Score stored to replay calculated using the Score V2 algorithm. Legacy scores on this version are candidate to Score V1 -> V2 conversion.</description></item>
         /// <item><description>30000003: First version after converting legacy total score to standardised.</description></item>
+        /// <item><description>30000004: Fixed mod multipliers during legacy score conversion. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000003;
+        public const int LATEST_VERSION = 30000004;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/24653

There's actually two fixes here:
1. Fixing the mod multipliers.
2. Fixing score overflow as a result of using `int`.

The reason why I've added a new `ILegacyRuleset` method for this, is because `osu-queue-score-statistics` also needs to be able to calculate the mod multipliers:

https://github.com/ppy/osu-queue-score-statistics/blob/44b92c4504e5f392592aedb426f368f72826040c/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/ImportHighScoresCommand.cs#L546-L551

For those that have access to it, you can refer to this method: https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/Scoring/ModManager.cs#L180-L194 in the osu-stable source.

There's no real good way to test this right now, except by manually setting `DifficultyCalculator.ComputeLegacyScoringValues` to `true` and then breakpointing in the SV1 calculation block. The reason is because score by itself is kind-of meaningless on its own unless you're drilling down into something specific/you know what you're looking for - in this case the calculated total legacy score, which isn't exposed yet (maybe an osu-tools command is a good fit).

As I said before - this isn't super useful on its own, but here's a spreadsheet comparing `master` vs this PR over the top-10000 users on data.ppy.sh: https://docs.google.com/spreadsheets/d/1KIpHRhIk0YN7mOCvS3EUcDrn7lp84bDuPlVEx9sllGw/edit