### PR TITLE
Fix closest anchor for rotated/flipped selections in skin editor

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -291,7 +291,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (parent == null)
                 return drawable.Anchor;
 
-            var screenPosition = getScreenPosition();
+            var screenPosition = drawable.ToScreenSpace(drawable.OriginPosition);
 
             var absolutePosition = parent.ToLocalSpace(screenPosition);
             var factor = parent.RelativeToAbsoluteFactor;
@@ -313,26 +313,6 @@ namespace osu.Game.Overlays.SkinEditor
             result |= getAnchorFromPosition(absolutePosition.Y / factor.Y, Anchor.y0, Anchor.y1, Anchor.y2);
 
             return result;
-
-            Vector2 getScreenPosition()
-            {
-                var quad = drawable.ScreenSpaceDrawQuad;
-                var origin = drawable.Origin;
-
-                var pos = quad.TopLeft;
-
-                if (origin.HasFlagFast(Anchor.x2))
-                    pos.X += quad.Width;
-                else if (origin.HasFlagFast(Anchor.x1))
-                    pos.X += quad.Width / 2f;
-
-                if (origin.HasFlagFast(Anchor.y2))
-                    pos.Y += quad.Height;
-                else if (origin.HasFlagFast(Anchor.y1))
-                    pos.Y += quad.Height / 2f;
-
-                return pos;
-            }
         }
 
         private static void applyAnchor(Drawable drawable, Anchor anchor)


### PR DESCRIPTION
Resolves ppy/osu#24677.


https://github.com/ppy/osu/assets/34943251/19c75a10-d71a-466c-98ce-8a05ffa86366