### PR TITLE
Apply flashlight slider dim immediately to match osu!(stable)

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             public void OnSliderTrackingChange(ValueChangedEvent<bool> e)
             {
-                // If a slider is in a tracking state, a further dim should be applied to the (remaining) visible portion of the playfield over a brief duration.
+                // If a slider is in a tracking state, a further dim should be applied to the (remaining) visible portion of the playfield.
                 FlashlightDim = e.NewValue ? 0.8f : 0.0f;
             }
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             public void OnSliderTrackingChange(ValueChangedEvent<bool> e)
             {
                 // If a slider is in a tracking state, a further dim should be applied to the (remaining) visible portion of the playfield over a brief duration.
-                this.TransformTo(nameof(FlashlightDim), e.NewValue ? 0.8f : 0.0f, 50);
+                FlashlightDim = e.NewValue ? 0.8f : 0.0f;
             }
 
             protected override bool OnMouseMove(MouseMoveEvent e)


### PR DESCRIPTION
- Resolves #23797 

osu!(stable) applies flashlight dim immediately on slider tracking ([source](https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameModes/Play/Rulesets/Ruleset.cs#L510-L517)). For balancing purposes as specified in https://github.com/ppy/osu/issues/23797#issuecomment-1687761366 &  https://github.com/ppy/osu/issues/23797#issuecomment-1687769839, this PR changes the transition to apply immediately in order to match stable.

master:

https://github.com/ppy/osu/assets/22781491/8facc6aa-712b-4c50-9f55-69adf90c0935

PR:

https://github.com/ppy/osu/assets/22781491/6beedad8-181a-4bf0-b8d2-198573934682

osu!(stable):

https://github.com/ppy/osu/assets/22781491/a60f44da-d653-4d67-a727-97c19cb4819f

