### PR TITLE
Use existing localisations for some missed strings

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -15,6 +15,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
@@ -188,7 +189,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddUntilStep($"displayed bpm is {target}", () =>
             {
-                var label = infoWedge.DisplayedContent.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == "BPM");
+                var label = infoWedge.DisplayedContent.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == BeatmapsetsStrings.ShowStatsBpm);
                 return label.Statistic.Content == target;
             });
         }

--- a/osu.Game/Graphics/Containers/LinkFlowContainer.cs
+++ b/osu.Game/Graphics/Containers/LinkFlowContainer.cs
@@ -15,6 +15,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Online;
 using osu.Game.Users;
+using osu.Game.Localisation;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -74,7 +75,7 @@ namespace osu.Game.Graphics.Containers
         }
 
         public void AddUserLink(IUser user, Action<SpriteText> creationParameters = null)
-            => createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user), "view profile");
+            => createLink(CreateChunkFor(user.Username, true, CreateSpriteText, creationParameters), new LinkDetails(LinkAction.OpenUserProfile, user), ContextMenuStrings.ViewProfile);
 
         private void createLink(ITextPart textPart, LinkDetails link, LocalisableString tooltipText, Action action = null)
         {

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -30,6 +30,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Graphics.Containers;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Screens.Select
 {
@@ -371,7 +372,7 @@ namespace osu.Game.Screens.Select
                     {
                         new InfoLabel(new BeatmapStatistic
                         {
-                            Name = $"Length (Drain: {playableBeatmap.CalculateDrainLength().ToFormattedDuration().ToString()})",
+                            Name = BeatmapsetsStrings.ShowStatsTotalLength(playableBeatmap.CalculateDrainLength().ToFormattedDuration()),
                             CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
                             Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
                         }),
@@ -415,7 +416,7 @@ namespace osu.Game.Screens.Select
 
                 bpmLabelContainer.Child = new InfoLabel(new BeatmapStatistic
                 {
-                    Name = "BPM",
+                    Name = BeatmapsetsStrings.ShowStatsBpm,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Bpm),
                     Content = labelText
                 });

--- a/osu.Game/Users/Drawables/ClickableAvatar.cs
+++ b/osu.Game/Users/Drawables/ClickableAvatar.cs
@@ -6,14 +6,13 @@ using osu.Framework.Allocation;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
+using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
 {
     public partial class ClickableAvatar : OsuClickableContainer
     {
-        private const string default_tooltip_text = "view profile";
-
         public override LocalisableString TooltipText
         {
             get
@@ -21,7 +20,7 @@ namespace osu.Game.Users.Drawables
                 if (!Enabled.Value)
                     return string.Empty;
 
-                return ShowUsernameTooltip ? (user?.Username ?? string.Empty) : default_tooltip_text;
+                return ShowUsernameTooltip ? (user?.Username ?? string.Empty) : ContextMenuStrings.ViewProfile;
             }
             set => throw new NotSupportedException();
         }


### PR DESCRIPTION
Remaining unlocalised strings for [`BeatmapInfoWedge`](https://github.com/ppy/osu/blob/ac3d7327df713f3cc1a7ef7c23fc941f9be212ad/osu.Game/Screens/Select/BeatmapInfoWedge.cs) should be added to `osu.Game.Resources.Localisation.Web`.

https://github.com/ppy/osu/blob/ac3d7327df713f3cc1a7ef7c23fc941f9be212ad/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L412-L414 https://github.com/ppy/osu/blob/ac3d7327df713f3cc1a7ef7c23fc941f9be212ad/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L386 `GetStatistics()` is missing localisation for everything besides `Circle Count` and `Slider Count`.

---
Localisation for [`"mapped by {0}"`](https://github.com/ppy/osu-resources/blob/c5ce7c61de51ce680b6ad6cb21d57655c9140ffd/osu.Game.Resources/Localisation/Web/BeatmapsetsStrings.cs#L170) exists, but the string is split between `d.AddUserLink` and `d.AddUserLink`. https://github.com/ppy/osu/blob/ac3d7327df713f3cc1a7ef7c23fc941f9be212ad/osu.Game/Screens/Select/BeatmapInfoWedge.cs#L435-L436