### PR TITLE
Add ability to see when a player is choosing a beatmap in multiplayer

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -286,6 +286,27 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
         }
 
+        [Test]
+        [FlakyTest] // See above
+        public void TestMapChoosingState()
+        {
+            AddStep("add playlist item with no allowed mods", () =>
+            {
+                SelectedRoom.Value.Playlist.Add(new PlaylistItem(new TestBeatmap(new OsuRuleset().RulesetInfo).BeatmapInfo)
+                {
+                    RulesetID = new OsuRuleset().RulesetInfo.OnlineID,
+                });
+            });
+
+            ClickButtonWhenEnabled<MultiplayerMatchSettingsOverlay.CreateOrUpdateButton>();
+
+            AddUntilStep("wait for join", () => RoomJoined);
+
+            ClickButtonWhenEnabled<MultiplayerMatchSubScreen.AddItemButton>();
+
+            AddUntilStep("wait for state", () => MultiplayerClient.LocalUser?.State == MultiplayerUserState.ChoosingMap);
+        }
+
         private partial class TestMultiplayerMatchSubScreen : MultiplayerMatchSubScreen
         {
             [Resolved(canBeNull: true)]

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -342,6 +342,34 @@ namespace osu.Game.Online.Multiplayer
             }
         }
 
+        /// <summary>
+        /// Toggles the <see cref="LocalUser"/>'s map choosing state.
+        /// </summary>
+        public async Task ToggleChoosingMap()
+        {
+            var localUser = LocalUser;
+
+            if (localUser == null)
+                return;
+
+
+            Logger.Log($"User in State {localUser.State}");
+            switch (localUser.State)
+            {
+                case MultiplayerUserState.Idle:
+                case MultiplayerUserState.Ready:
+                    await ChangeState(MultiplayerUserState.ChoosingMap).ConfigureAwait(false);
+                    return;
+
+                case MultiplayerUserState.ChoosingMap:
+                    await ChangeState(MultiplayerUserState.Idle).ConfigureAwait(false);
+                    return;
+
+                default:
+                    throw new InvalidOperationException($"Cannot toggle choosing map when in {localUser.State}");
+            }
+        }
+
         public abstract Task TransferHost(int userId);
 
         public abstract Task KickUser(int userId);

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -353,7 +353,6 @@ namespace osu.Game.Online.Multiplayer
                 return;
 
 
-            Logger.Log($"User in State {localUser.State}");
             switch (localUser.State)
             {
                 case MultiplayerUserState.Idle:

--- a/osu.Game/Online/Multiplayer/MultiplayerUserState.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerUserState.cs
@@ -65,6 +65,11 @@ namespace osu.Game.Online.Multiplayer
         /// <summary>
         /// The user is currently spectating this room.
         /// </summary>
-        Spectating
+        Spectating,
+
+        /// <summary>
+        /// The user is currently choosing a map.
+        /// </summary>
+        ChoosingMap
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             base.LoadComplete();
 
+            client.ToggleChoosingMap().FireAndForget();
+
             operationInProgress.BindTo(operationTracker.InProgress);
             operationInProgress.BindValueChanged(_ => updateLoadingLayer(), true);
         }
@@ -108,6 +110,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                         Carousel.AllowSelection = true;
                     });
                 });
+                client.ToggleChoosingMap().FireAndForget();
             }
             else
             {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Participants/StateDisplay.cs
@@ -141,6 +141,12 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Participants
                     icon.Colour = colours.BlueLight;
                     break;
 
+                case MultiplayerUserState.ChoosingMap:
+                    text.Text = "choosing map";
+                    icon.Icon = FontAwesome.Solid.Music;
+                    icon.Colour = colours.PurpleLight;
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(state), state, null);
             }


### PR DESCRIPTION
Discussed in https://github.com/ppy/osu/discussions/24293

Adds a new status "Choosing Map".
Removes "Ready" state if it is set.
Does not remove "Spectating" state if it is set.

Currently [ModSelectOverview.updateFromExternalSelection()](https://github.com/ppy/osu/blob/ac3d7327df713f3cc1a7ef7c23fc941f9be212ad/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L484C15-L484C15) throws an error when the test enters the song selection. Not sure why or how to resolve, input would be highly appreciated. While developing I commented it out as that seemed out of scope for this PR.
