### PR TITLE
Implement beatmap options popover

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFooterV2.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFooterV2.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -37,10 +38,10 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             Children = new Drawable[]
             {
-                footer = new FooterV2
+                new PopoverContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
+                    RelativeSizeAxes = Axes.Both,
+                    Child = footer = new FooterV2(),
                 },
                 overlay = new DummyOverlay()
             };

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFooterV2.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFooterV2.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Testing;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Select.FooterV2;
 using osuTK.Input;
 
@@ -56,6 +57,24 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             overlay.Hide();
         });
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("set beatmap", () => Beatmap.Value = CreateWorkingBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo)));
+        }
+
+        [Test]
+        public void TestShowOptions()
+        {
+            AddStep("enable options", () =>
+            {
+                var optionsButton = this.ChildrenOfType<FooterButtonV2>().Last();
+
+                optionsButton.Enabled.Value = true;
+                optionsButton.TriggerClick();
+            });
+        }
 
         [Test]
         public void TestState()

--- a/osu.Game/Localisation/CommonStrings.cs
+++ b/osu.Game/Localisation/CommonStrings.cs
@@ -169,6 +169,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString RevertToDefault => new TranslatableString(getKey(@"revert_to_default"), @"Revert to default");
 
+        /// <summary>
+        /// "General"
+        /// </summary>
+        public static LocalisableString General => new TranslatableString(getKey(@"general"), @"General");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/DebugSettingsStrings.cs
+++ b/osu.Game/Localisation/DebugSettingsStrings.cs
@@ -15,11 +15,6 @@ namespace osu.Game.Localisation
         public static LocalisableString DebugSectionHeader => new TranslatableString(getKey(@"debug_section_header"), @"Debug");
 
         /// <summary>
-        /// "General"
-        /// </summary>
-        public static LocalisableString GeneralHeader => new TranslatableString(getKey(@"general_header"), @"General");
-
-        /// <summary>
         /// "Show log overlay"
         /// </summary>
         public static LocalisableString ShowLogOverlay => new TranslatableString(getKey(@"show_log_overlay"), @"Show log overlay");

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -20,11 +20,6 @@ namespace osu.Game.Localisation
         public static LocalisableString BeatmapHeader => new TranslatableString(getKey(@"beatmap_header"), @"Beatmap");
 
         /// <summary>
-        /// "General"
-        /// </summary>
-        public static LocalisableString GeneralHeader => new TranslatableString(getKey(@"general_header"), @"General");
-
-        /// <summary>
         /// "Audio"
         /// </summary>
         public static LocalisableString AudioHeader => new TranslatableString(getKey(@"audio"), @"Audio");

--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -10,11 +10,6 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.GeneralSettings";
 
         /// <summary>
-        /// "General"
-        /// </summary>
-        public static LocalisableString GeneralSectionHeader => new TranslatableString(getKey(@"general_section_header"), @"General");
-
-        /// <summary>
         /// "Language"
         /// </summary>
         public static LocalisableString LanguageHeader => new TranslatableString(getKey(@"language_header"), @"Language");

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -20,11 +20,6 @@ namespace osu.Game.Localisation
         public static LocalisableString LocallyModifiedTooltip => new TranslatableString(getKey(@"locally_modified_tooltip"), @"Has been locally modified");
 
         /// <summary>
-        /// "General"
-        /// </summary>
-        public static LocalisableString General => new TranslatableString(getKey(@"general"), @"General");
-
-        /// <summary>
         /// "Manage collections"
         /// </summary>
         public static LocalisableString ManageCollections => new TranslatableString(getKey(@"manage_collections"), @"Manage collections");

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -19,6 +19,46 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString LocallyModifiedTooltip => new TranslatableString(getKey(@"locally_modified_tooltip"), @"Has been locally modified");
 
+        /// <summary>
+        /// "General"
+        /// </summary>
+        public static LocalisableString General => new TranslatableString(getKey(@"general"), @"General");
+
+        /// <summary>
+        /// "Manage collections"
+        /// </summary>
+        public static LocalisableString ManageCollections => new TranslatableString(getKey(@"manage_collections"), @"Manage collections");
+
+        /// <summary>
+        /// "For all difficulties"
+        /// </summary>
+        public static LocalisableString ForAllDifficulties => new TranslatableString(getKey(@"for_all_difficulties"), @"For all difficulties");
+
+        /// <summary>
+        /// "Delete beatmap"
+        /// </summary>
+        public static LocalisableString DeleteBeatmap => new TranslatableString(getKey(@"delete_beatmap"), @"Delete beatmap");
+
+        /// <summary>
+        /// "For selected difficulty"
+        /// </summary>
+        public static LocalisableString ForSelectedDifficulty => new TranslatableString(getKey(@"for_selected_difficulty"), @"For selected difficulty");
+
+        /// <summary>
+        /// "Mark as played"
+        /// </summary>
+        public static LocalisableString MarkAsPlayed => new TranslatableString(getKey(@"mark_as_played"), @"Mark as played");
+
+        /// <summary>
+        /// "Clear all local scores"
+        /// </summary>
+        public static LocalisableString ClearAllLocalScores => new TranslatableString(getKey(@"clear_all_local_scores"), @"Clear all local scores");
+
+        /// <summary>
+        /// "Edit beatmap"
+        /// </summary>
+        public static LocalisableString EditBeatmap => new TranslatableString(getKey(@"edit_beatmap"), @"Edit beatmap");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -15,11 +15,6 @@ namespace osu.Game.Localisation
         public static LocalisableString UserInterfaceSectionHeader => new TranslatableString(getKey(@"user_interface_section_header"), @"User Interface");
 
         /// <summary>
-        /// "General"
-        /// </summary>
-        public static LocalisableString GeneralHeader => new TranslatableString(getKey(@"general_header"), @"General");
-
-        /// <summary>
         /// "Rotate cursor when dragging"
         /// </summary>
         public static LocalisableString CursorRotation => new TranslatableString(getKey(@"cursor_rotation"), @"Rotate cursor when dragging");

--- a/osu.Game/Overlays/OSD/CopyUrlToast.cs
+++ b/osu.Game/Overlays/OSD/CopyUrlToast.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Overlays.OSD
     public partial class CopyUrlToast : Toast
     {
         public CopyUrlToast()
-            : base(UserInterfaceStrings.GeneralHeader, ToastStrings.UrlCopied, "")
+            : base(CommonStrings.General, ToastStrings.UrlCopied, "")
         {
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public partial class GeneralSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => DebugSettingsStrings.GeneralHeader;
+        protected override LocalisableString Header => CommonStrings.General;
 
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig, IPerformFromScreenRunner? performer)

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
 {
     public partial class GeneralSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => GameplaySettingsStrings.GeneralHeader;
+        protected override LocalisableString Header => CommonStrings.General;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GeneralSection.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings.Sections
         [Resolved(CanBeNull = true)]
         private OsuGame? game { get; set; }
 
-        public override LocalisableString Header => GeneralSettingsStrings.GeneralSectionHeader;
+        public override LocalisableString Header => CommonStrings.General;
 
         public override Drawable CreateIcon() => new SpriteIcon
         {

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/GeneralSettings.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
 {
     public partial class GeneralSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => UserInterfaceStrings.GeneralHeader;
+        protected override LocalisableString Header => CommonStrings.General;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -97,7 +97,6 @@ namespace osu.Game.Screens.Select.FooterV2
 
                 Add(new SpriteIcon
                 {
-                    Blending = BlendingParameters.Additive,
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Size = new Vector2(17),

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -31,13 +31,16 @@ namespace osu.Game.Screens.Select.FooterV2
 
         private WorkingBeatmap beatmapWhenOpening = null!;
 
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
         public BeatmapOptionsPopover(FooterButtonOptionsV2 footerButton)
         {
             this.footerButton = footerButton;
         }
 
         [BackgroundDependencyLoader]
-        private void load(ManageCollectionsDialog? manageCollectionsDialog, SongSelect? songSelect, OsuColour colours, IBindable<WorkingBeatmap> beatmap)
+        private void load(ManageCollectionsDialog? manageCollectionsDialog, SongSelect? songSelect, OsuColour colours)
         {
             Content.Padding = new MarginPadding(5);
 
@@ -71,6 +74,8 @@ namespace osu.Game.Screens.Select.FooterV2
             base.LoadComplete();
 
             ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(this));
+
+            beatmap.BindValueChanged(_ => Hide());
         }
 
         [Resolved]

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -1,0 +1,148 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Collections;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Screens.Select.FooterV2
+{
+    public partial class BeatmapOptionsPopover : OsuPopover
+    {
+        private FillFlowContainer<OptionButton> buttonFlow = null!;
+        private readonly FooterButtonOptionsV2 footerButton;
+
+        public BeatmapOptionsPopover(FooterButtonOptionsV2 footerButton)
+        {
+            this.footerButton = footerButton;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ManageCollectionsDialog? manageCollectionsDialog, SongSelect? songSelect, OsuColour colours)
+        {
+            Content.Padding = new MarginPadding(5);
+
+            Child = buttonFlow = new FillFlowContainer<OptionButton>
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(3),
+            };
+
+            addButton(@"Manage collections", FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
+            addButton(@"Delete all difficulties", FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(), colours.Red);
+            addButton(@"Remove from unplayed", FontAwesome.Regular.TimesCircle, null);
+            addButton(@"Clear local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores());
+
+            if (songSelect != null && songSelect.AllowEditing)
+                addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit());
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            ScheduleAfterChildren(() => GetContainingInputManager().ChangeFocus(this));
+        }
+
+        private void addButton(LocalisableString text, IconUsage icon, Action? action, Color4? colour = null)
+        {
+            var button = new OptionButton
+            {
+                Text = text,
+                Icon = icon,
+                TextColour = colour,
+                Action = () =>
+                {
+                    Hide();
+                    action?.Invoke();
+                },
+            };
+
+            buttonFlow.Add(button);
+        }
+
+        private partial class OptionButton : OsuButton
+        {
+            public IconUsage Icon { get; init; }
+            public Color4? TextColour { get; init; }
+
+            public OptionButton()
+            {
+                Size = new Vector2(265, 50);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                BackgroundColour = colourProvider.Background3;
+
+                SpriteText.Colour = TextColour ?? Color4.White;
+                Content.CornerRadius = 10;
+
+                Add(new SpriteIcon
+                {
+                    Blending = BlendingParameters.Additive,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Size = new Vector2(17),
+                    X = 15,
+                    Icon = Icon,
+                    Colour = TextColour ?? Color4.White,
+                });
+            }
+
+            protected override SpriteText CreateText() => new OsuSpriteText
+            {
+                Depth = -1,
+                Origin = Anchor.CentreLeft,
+                Anchor = Anchor.CentreLeft,
+                X = 40
+            };
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            // don't absorb control as ToolbarRulesetSelector uses control + number to navigate
+            if (e.ControlPressed) return false;
+
+            if (!e.Repeat && e.Key >= Key.Number1 && e.Key <= Key.Number9)
+            {
+                int requested = e.Key - Key.Number1;
+
+                OptionButton? found = buttonFlow.Children.ElementAtOrDefault(requested);
+
+                if (found != null)
+                {
+                    found.TriggerClick();
+                    return true;
+                }
+            }
+
+            return base.OnKeyDown(e);
+        }
+
+        protected override void UpdateState(ValueChangedEvent<Visibility> state)
+        {
+            base.UpdateState(state);
+
+            if (state.NewValue == Visibility.Hidden)
+                footerButton.IsActive.Value = false;
+        }
+    }
+}

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Screens.Select.FooterV2
         }
 
         [BackgroundDependencyLoader]
-        private void load(ManageCollectionsDialog? manageCollectionsDialog, SongSelect? songSelect, OsuColour colours)
+        private void load(ManageCollectionsDialog? manageCollectionsDialog, SongSelect? songSelect, OsuColour colours, BeatmapManager? beatmapManager)
         {
             Content.Padding = new MarginPadding(5);
 
@@ -65,11 +65,12 @@ namespace osu.Game.Screens.Select.FooterV2
             addHeader(SongSelectStrings.ForSelectedDifficulty, beatmapWhenOpening.BeatmapInfo.DifficultyName);
             // TODO: make work, and make show "unplayed" or "played" based on status.
             addButton(SongSelectStrings.MarkAsPlayed, FontAwesome.Regular.TimesCircle, null);
-            addButton(CommonStrings.ButtonsHide.ToSentence(), FontAwesome.Solid.Magic, null);
             addButton(SongSelectStrings.ClearAllLocalScores, FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(beatmapWhenOpening.BeatmapInfo), colours.Red1);
 
             if (songSelect != null && songSelect.AllowEditing)
                 addButton(SongSelectStrings.EditBeatmap, FontAwesome.Solid.PencilAlt, () => songSelect.Edit(beatmapWhenOpening.BeatmapInfo));
+
+            addButton(CommonStrings.ButtonsHide.ToSentence(), FontAwesome.Solid.Magic, () => beatmapManager?.Hide(beatmapWhenOpening.BeatmapInfo));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -54,13 +54,13 @@ namespace osu.Game.Screens.Select.FooterV2
             addButton(@"Manage collections", FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
 
             addHeader("For all difficulties", beatmapWhenOpening.BeatmapSetInfo.ToString());
-            addButton(@"Delete beatmap", FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(), colours.Red1);
+            addButton(@"Delete beatmap", FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(beatmapWhenOpening.BeatmapSetInfo), colours.Red1);
 
             addHeader("For selected difficulty", beatmapWhenOpening.BeatmapInfo.DifficultyName);
             // TODO: make work, and make show "unplayed" or "played" based on status.
             addButton(@"Mark as played", FontAwesome.Regular.TimesCircle, null);
             addButton(@"Hide", FontAwesome.Solid.Magic, null);
-            addButton(@"Clear all local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(), colours.Red1);
+            addButton(@"Clear all local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(beatmapWhenOpening.BeatmapInfo), colours.Red1);
 
             if (songSelect != null && songSelect.AllowEditing)
                 addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit());

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Select.FooterV2
                 TextColour = colour,
                 Action = () =>
                 {
-                    Hide();
+                    Scheduler.AddDelayed(Hide, 50);
                     action?.Invoke();
                 },
             };

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Screens.Select.FooterV2
             addButton(@"Clear all local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(beatmapWhenOpening.BeatmapInfo), colours.Red1);
 
             if (songSelect != null && songSelect.AllowEditing)
-                addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit());
+                addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit(beatmapWhenOpening.BeatmapInfo));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -50,24 +50,20 @@ namespace osu.Game.Screens.Select.FooterV2
 
             beatmapWhenOpening = beatmap.Value;
 
-            addHeader("For all difficulties", beatmapWhenOpening.BeatmapSetInfo.ToString());
+            addHeader("General");
+            addButton(@"Manage collections", FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
 
+            addHeader("For all difficulties", beatmapWhenOpening.BeatmapSetInfo.ToString());
             addButton(@"Delete beatmap", FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(), colours.Red1);
 
             addHeader("For selected difficulty", beatmapWhenOpening.BeatmapInfo.DifficultyName);
-
             // TODO: make work, and make show "unplayed" or "played" based on status.
             addButton(@"Mark as played", FontAwesome.Regular.TimesCircle, null);
-
             addButton(@"Hide", FontAwesome.Solid.Magic, null);
             addButton(@"Clear all local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(), colours.Red1);
 
             if (songSelect != null && songSelect.AllowEditing)
                 addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit());
-
-            addHeader("General");
-
-            addButton(@"Manage collections", FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -21,6 +22,8 @@ using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using osu.Game.Localisation;
+using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Select.FooterV2
 {
@@ -53,20 +56,20 @@ namespace osu.Game.Screens.Select.FooterV2
 
             beatmapWhenOpening = beatmap.Value;
 
-            addHeader("General");
-            addButton(@"Manage collections", FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
+            addHeader(SongSelectStrings.General);
+            addButton(SongSelectStrings.ManageCollections, FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
 
-            addHeader("For all difficulties", beatmapWhenOpening.BeatmapSetInfo.ToString());
-            addButton(@"Delete beatmap", FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(beatmapWhenOpening.BeatmapSetInfo), colours.Red1);
+            addHeader(SongSelectStrings.ForAllDifficulties, beatmapWhenOpening.BeatmapSetInfo.ToString());
+            addButton(SongSelectStrings.DeleteBeatmap, FontAwesome.Solid.Trash, () => songSelect?.DeleteBeatmap(beatmapWhenOpening.BeatmapSetInfo), colours.Red1);
 
-            addHeader("For selected difficulty", beatmapWhenOpening.BeatmapInfo.DifficultyName);
+            addHeader(SongSelectStrings.ForSelectedDifficulty, beatmapWhenOpening.BeatmapInfo.DifficultyName);
             // TODO: make work, and make show "unplayed" or "played" based on status.
-            addButton(@"Mark as played", FontAwesome.Regular.TimesCircle, null);
-            addButton(@"Hide", FontAwesome.Solid.Magic, null);
-            addButton(@"Clear all local scores", FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(beatmapWhenOpening.BeatmapInfo), colours.Red1);
+            addButton(SongSelectStrings.MarkAsPlayed, FontAwesome.Regular.TimesCircle, null);
+            addButton(CommonStrings.ButtonsHide.ToSentence(), FontAwesome.Solid.Magic, null);
+            addButton(SongSelectStrings.ClearAllLocalScores, FontAwesome.Solid.Eraser, () => songSelect?.ClearScores(beatmapWhenOpening.BeatmapInfo), colours.Red1);
 
             if (songSelect != null && songSelect.AllowEditing)
-                addButton(@"Edit beatmap", FontAwesome.Solid.PencilAlt, () => songSelect.Edit(beatmapWhenOpening.BeatmapInfo));
+                addButton(SongSelectStrings.EditBeatmap, FontAwesome.Solid.PencilAlt, () => songSelect.Edit(beatmapWhenOpening.BeatmapInfo));
         }
 
         protected override void LoadComplete()
@@ -81,7 +84,7 @@ namespace osu.Game.Screens.Select.FooterV2
         [Resolved]
         private OverlayColourProvider overlayColourProvider { get; set; } = null!;
 
-        private void addHeader(string text, string? context = null)
+        private void addHeader(LocalisableString text, string? context = null)
         {
             var textFlow = new OsuTextFlowContainer
             {

--- a/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
+++ b/osu.Game/Screens/Select/FooterV2/BeatmapOptionsPopover.cs
@@ -18,12 +18,12 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
-using osu.Game.Localisation;
-using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
+using WebCommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Select.FooterV2
 {
@@ -56,7 +56,7 @@ namespace osu.Game.Screens.Select.FooterV2
 
             beatmapWhenOpening = beatmap.Value;
 
-            addHeader(SongSelectStrings.General);
+            addHeader(CommonStrings.General);
             addButton(SongSelectStrings.ManageCollections, FontAwesome.Solid.Book, () => manageCollectionsDialog?.Show());
 
             addHeader(SongSelectStrings.ForAllDifficulties, beatmapWhenOpening.BeatmapSetInfo.ToString());
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.Select.FooterV2
             if (songSelect != null && songSelect.AllowEditing)
                 addButton(SongSelectStrings.EditBeatmap, FontAwesome.Solid.PencilAlt, () => songSelect.Edit(beatmapWhenOpening.BeatmapInfo));
 
-            addButton(CommonStrings.ButtonsHide.ToSentence(), FontAwesome.Solid.Magic, () => beatmapManager?.Hide(beatmapWhenOpening.BeatmapInfo));
+            addButton(WebCommonStrings.ButtonsHide.ToSentence(), FontAwesome.Solid.Magic, () => beatmapManager?.Hide(beatmapWhenOpening.BeatmapInfo));
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Select/FooterV2/FooterButtonOptionsV2.cs
+++ b/osu.Game/Screens/Select/FooterV2/FooterButtonOptionsV2.cs
@@ -2,14 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Input.Bindings;
 
 namespace osu.Game.Screens.Select.FooterV2
 {
-    public partial class FooterButtonOptionsV2 : FooterButtonV2
+    public partial class FooterButtonOptionsV2 : FooterButtonV2, IHasPopover
     {
+        public readonly BindableBool IsActive = new BindableBool();
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colour)
         {
@@ -17,6 +24,34 @@ namespace osu.Game.Screens.Select.FooterV2
             Icon = FontAwesome.Solid.Cog;
             AccentColour = colour.Purple1;
             Hotkey = GlobalAction.ToggleBeatmapOptions;
+
+            Action = () => IsActive.Toggle();
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            IsActive.BindValueChanged(active =>
+            {
+                OverlayState.Value = active.NewValue ? Visibility.Visible : Visibility.Hidden;
+            });
+
+            OverlayState.BindValueChanged(state =>
+            {
+                switch (state.NewValue)
+                {
+                    case Visibility.Hidden:
+                        this.HidePopover();
+                        break;
+
+                    case Visibility.Visible:
+                        this.ShowPopover();
+                        break;
+                }
+            });
+        }
+
+        public Popover GetPopover() => new BeatmapOptionsPopover(this);
     }
 }

--- a/osu.Game/Screens/Select/FooterV2/FooterV2.cs
+++ b/osu.Game/Screens/Select/FooterV2/FooterV2.cs
@@ -48,11 +48,17 @@ namespace osu.Game.Screens.Select.FooterV2
 
         private FillFlowContainer<FooterButtonV2> buttons = null!;
 
-        [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        public FooterV2()
         {
             RelativeSizeAxes = Axes.X;
             Height = height;
+            Anchor = Anchor.BottomLeft;
+            Origin = Anchor.BottomLeft;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
             InternalChildren = new Drawable[]
             {
                 new Box

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -916,6 +916,9 @@ namespace osu.Game.Screens.Select
             return true;
         }
 
+        /// <summary>
+        /// Request to delete the current beatmap.
+        /// </summary>
         public void DeleteBeatmap()
         {
             if (Beatmap.Value.BeatmapSetInfo == null) return;
@@ -923,6 +926,9 @@ namespace osu.Game.Screens.Select
             dialogOverlay?.Push(new BeatmapDeleteDialog(Beatmap.Value.BeatmapSetInfo));
         }
 
+        /// <summary>
+        /// Request to clear the scores of the current beatmap.
+        /// </summary>
         public void ClearScores()
         {
             if (Beatmap.Value.BeatmapInfo == null) return;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -311,9 +311,9 @@ namespace osu.Game.Screens.Select
                     Footer.AddButton(button, overlay);
 
                 BeatmapOptions.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, () => manageCollectionsDialog?.Show());
-                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => delete(Beatmap.Value.BeatmapSetInfo));
+                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, DeleteBeatmap);
                 BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
-                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => clearScores(Beatmap.Value.BeatmapInfo));
+                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, ClearScores);
             }
 
             sampleChangeDifficulty = audio.Samples.Get(@"SongSelect/select-difficulty");
@@ -916,18 +916,18 @@ namespace osu.Game.Screens.Select
             return true;
         }
 
-        private void delete(BeatmapSetInfo? beatmap)
+        public void DeleteBeatmap()
         {
-            if (beatmap == null) return;
+            if (Beatmap.Value.BeatmapSetInfo == null) return;
 
-            dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
+            dialogOverlay?.Push(new BeatmapDeleteDialog(Beatmap.Value.BeatmapSetInfo));
         }
 
-        private void clearScores(BeatmapInfo? beatmapInfo)
+        public void ClearScores()
         {
-            if (beatmapInfo == null) return;
+            if (Beatmap.Value.BeatmapInfo == null) return;
 
-            dialogOverlay?.Push(new BeatmapClearScoresDialog(beatmapInfo, () =>
+            dialogOverlay?.Push(new BeatmapClearScoresDialog(Beatmap.Value.BeatmapInfo, () =>
                 // schedule done here rather than inside the dialog as the dialog may fade out and never callback.
                 Schedule(() => BeatmapDetails.Refresh())));
         }
@@ -963,7 +963,7 @@ namespace osu.Game.Screens.Select
                     if (e.ShiftPressed)
                     {
                         if (!Beatmap.IsDefault)
-                            delete(Beatmap.Value.BeatmapSetInfo);
+                            DeleteBeatmap();
                         return true;
                     }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -311,9 +311,9 @@ namespace osu.Game.Screens.Select
                     Footer.AddButton(button, overlay);
 
                 BeatmapOptions.AddButton(@"Manage", @"collections", FontAwesome.Solid.Book, colours.Green, () => manageCollectionsDialog?.Show());
-                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, DeleteBeatmap);
+                BeatmapOptions.AddButton(@"Delete", @"all difficulties", FontAwesome.Solid.Trash, colours.Pink, () => DeleteBeatmap(Beatmap.Value.BeatmapSetInfo));
                 BeatmapOptions.AddButton(@"Remove", @"from unplayed", FontAwesome.Regular.TimesCircle, colours.Purple, null);
-                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, ClearScores);
+                BeatmapOptions.AddButton(@"Clear", @"local scores", FontAwesome.Solid.Eraser, colours.Purple, () => ClearScores(Beatmap.Value.BeatmapInfo));
             }
 
             sampleChangeDifficulty = audio.Samples.Get(@"SongSelect/select-difficulty");
@@ -917,23 +917,23 @@ namespace osu.Game.Screens.Select
         }
 
         /// <summary>
-        /// Request to delete the current beatmap.
+        /// Request to delete a specific beatmap.
         /// </summary>
-        public void DeleteBeatmap()
+        public void DeleteBeatmap(BeatmapSetInfo? beatmap)
         {
-            if (Beatmap.Value.BeatmapSetInfo == null) return;
+            if (beatmap == null) return;
 
-            dialogOverlay?.Push(new BeatmapDeleteDialog(Beatmap.Value.BeatmapSetInfo));
+            dialogOverlay?.Push(new BeatmapDeleteDialog(beatmap));
         }
 
         /// <summary>
-        /// Request to clear the scores of the current beatmap.
+        /// Request to clear the scores of a specific beatmap.
         /// </summary>
-        public void ClearScores()
+        public void ClearScores(BeatmapInfo? beatmapInfo)
         {
-            if (Beatmap.Value.BeatmapInfo == null) return;
+            if (beatmapInfo == null) return;
 
-            dialogOverlay?.Push(new BeatmapClearScoresDialog(Beatmap.Value.BeatmapInfo, () =>
+            dialogOverlay?.Push(new BeatmapClearScoresDialog(beatmapInfo, () =>
                 // schedule done here rather than inside the dialog as the dialog may fade out and never callback.
                 Schedule(() => BeatmapDetails.Refresh())));
         }
@@ -969,7 +969,7 @@ namespace osu.Game.Screens.Select
                     if (e.ShiftPressed)
                     {
                         if (!Beatmap.IsDefault)
-                            DeleteBeatmap();
+                            DeleteBeatmap(Beatmap.Value.BeatmapSetInfo);
                         return true;
                     }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24273
- Addresses https://github.com/ppy/osu/discussions/22767

![osu Game Tests_K92q8e3VK4](https://github.com/ppy/osu/assets/35318437/c95961f4-3f0d-460a-8a81-fe5f47f2d5a2)

Some differences to the [proposed design](https://github.com/ppy/osu/issues/24273#issuecomment-1650045823):
- no arrow (to make things simple/consistent as no other popover has it yet)
- there were inconsistent measurements so I did my best to find the average/best numbers
- button sorting hasn't changed because of keys being assigned by index (muscle memory)
- icons were unchanged from old design (i.e. trash) as the design claims that it is using the same icons the game currently uses (see top on figma)

I had to take a different approach to add the buttons to the popover content since popovers are reconstructed every time.

The old `BeatmapOptionsOverlay` had `SongSelect` adding the buttons, and if you wanted to make an isolated test scene, you would have to copy the adding logic. It is now local by using DI.

Here's a WIP branch for the footer integrated into the game: https://github.com/ppy/osu/compare/master...Joehuu:osu:footer-redesign