### PR TITLE
Update spectator server development endpoint URLs

### DIFF
--- a/osu.Game/Online/DevelopmentEndpointConfiguration.cs
+++ b/osu.Game/Online/DevelopmentEndpointConfiguration.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Online
             WebsiteRootUrl = APIEndpointUrl = @"https://dev.ppy.sh";
             APIClientSecret = @"3LP2mhUrV89xxzD1YKNndXHEhWWCRLPNKioZ9ymT";
             APIClientID = "5";
-            SpectatorEndpointUrl = $"{APIEndpointUrl}/spectator";
-            MultiplayerEndpointUrl = $"{APIEndpointUrl}/multiplayer";
-            MetadataEndpointUrl = $"{APIEndpointUrl}/metadata";
+            SpectatorEndpointUrl = $@"{APIEndpointUrl}/signalr/spectator";
+            MultiplayerEndpointUrl = $@"{APIEndpointUrl}/signalr/multiplayer";
+            MetadataEndpointUrl = $@"{APIEndpointUrl}/signalr/metadata";
         }
     }
 }


### PR DESCRIPTION
With the way `dev.ppy.sh` was previously configured, the `osu-web` `/multiplayer` routes and `osu-server-spectator` `/multiplayer` routes would conflict with each other, with the `osu-server-spectator` route taking precedence. This would mean that some `osu-web` pages would just straight up not be available on dev.

To counteract this, the `osu-server-spectator` routes are now exposed under `https://dev.ppy.sh/signalr/`. This PR updates the client-side configuration to use these new routes.