### PR TITLE
Block input to objects lying under already-hit hitcircles when classic note lock is active

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircleLateFade.cs
@@ -142,6 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             drawableHitCircle.Scale = new Vector2(2f);
 
+            LoadComponent(drawableHitCircle);
             foreach (var mod in SelectedMods.Value.OfType<IApplicableToDrawableHitObject>())
                 mod.ApplyToDrawableHitObject(drawableHitCircle);
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -549,6 +549,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
             addJudgementAssert(hitObjects[1], HitResult.Miss);
             // the slider head of the first slider prevents the second slider's head from being hit, so the judgement offset should be very late.
+            // this is not strictly done by the hit policy implementation itself (see `OsuModClassic.blockInputToUnderlyingObjects()`),
+            // but we're testing this here anyways to just keep everything related to input handling and note lock in one place.
             addJudgementOffsetAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, referenceHitWindows.WindowFor(HitResult.Meh));
             addClickActionAssert(0, ClickAction.Hit);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -336,6 +336,52 @@ namespace osu.Game.Rulesets.Osu.Tests
             addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
         }
 
+        [Test]
+        public void TestInputFallsThroughJudgedSliders()
+        {
+            const double time_first_slider = 1000;
+            const double time_second_slider = 1250;
+            Vector2 positionFirstSlider = new Vector2(100, 50);
+            Vector2 positionSecondSlider = new Vector2(100, 80);
+            var midpoint = (positionFirstSlider + positionSecondSlider) / 2;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestSlider
+                {
+                    StartTime = time_first_slider,
+                    Position = positionFirstSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                },
+                new TestSlider
+                {
+                    StartTime = time_second_slider,
+                    Position = positionSecondSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_slider, Position = midpoint, Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_first_slider + 25, Position = midpoint, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_first_slider + 50, Position = midpoint },
+            });
+
+            addJudgementAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, HitResult.Great);
+            addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
+            addJudgementAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Great);
+            addJudgementOffsetAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, -200);
+        }
+
         private void addJudgementAssert(OsuHitObject hitObject, HitResult result)
         {
             AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judgement is {result}",
@@ -352,6 +398,12 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judged at {offset}",
                 () => Precision.AlmostEquals(judgementResults.Single(r => r.HitObject == hitObject).TimeOffset, offset, 100));
+        }
+
+        private void addJudgementOffsetAssert(string name, Func<OsuHitObject> hitObject, double offset)
+        {
+            AddAssert($"{name} @ judged at {offset}",
+                () => judgementResults.Single(r => r.HitObject == hitObject()).TimeOffset, () => Is.EqualTo(offset).Within(50));
         }
 
         private ScoreAccessibleReplayPlayer currentPlayer;

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -74,6 +74,10 @@ namespace osu.Game.Rulesets.Osu.Mods
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                     if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(head);
+
+                    if (ClassicNoteLock.Value)
+                        blockInputToUnderlyingObjects(head);
+
                     break;
 
                 case DrawableSliderTail tail:
@@ -83,8 +87,27 @@ namespace osu.Game.Rulesets.Osu.Mods
                 case DrawableHitCircle circle:
                     if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(circle);
+
+                    if (ClassicNoteLock.Value)
+                        blockInputToUnderlyingObjects(circle);
+
                     break;
             }
+        }
+
+        /// <summary>
+        /// On stable, hitcircles that have already been hit block input from reaching objects that may be underneath them.
+        /// The purpose of this method is to restore that behaviour.
+        /// In order to avoid introducing yet another confusing config option, this behaviour is roped into the general notion of "note lock".
+        /// </summary>
+        private static void blockInputToUnderlyingObjects(DrawableHitCircle circle)
+        {
+            var oldHitAction = circle.HitArea.Hit;
+            circle.HitArea.Hit = () =>
+            {
+                oldHitAction?.Invoke();
+                return true;
+            };
         }
 
         private void applyEarlyFading(DrawableHitCircle circle)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     case OsuAction.RightButton:
                         if (IsHovered && (Hit?.Invoke() ?? false))
                         {
-                            HitAction = e.Action;
+                            HitAction ??= e.Action;
                             return true;
                         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24626

In the [issue thread](https://github.com/ppy/osu/issues/24626#issuecomment-1691037926), I stated that this would be "fixed" by https://github.com/ppy/osu/pull/24280; as it turns out upon further investigation that was not the case, and the test cases I had only "worked" due to specific timings. *However*, as it _also_ turns out,  the API surface that permits hit circles to block input on objects underneath them already exists, and makes implementing this _relatively_ painless. So I'm PRing this as a RFC to see if this is something that would be considered acceptable.

The behaviour proposed by this PR is as follows:

- With classic mod disabled, already-judged circles allow input to reach other objects underneath them.
- With classic mod enabled (specifically, with the "classic note lock" option enabled), already-judged circles block input from reaching objects underneath them.

Test coverage for both behaviours above is included in 40d1196aea1871751f6094d8878a4457045854ad.

Videos for reference:

#### master

https://github.com/ppy/osu/assets/20418176/b7607bb6-6a3b-4415-bf44-550cdc011f44

#### this PR

https://github.com/ppy/osu/assets/20418176/9eb682c8-ef6f-4ca8-a9ae-02840fd9e10f

#### stable

https://github.com/ppy/osu/assets/20418176/cf9ab24a-861a-469e-ad97-e2010c49549e