### PR TITLE
Add debug output for skin configuration lookups

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/ManiaSkinConfigurationLookup.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/ManiaSkinConfigurationLookup.cs
@@ -30,5 +30,7 @@ namespace osu.Game.Rulesets.Mania.Skinning
             Lookup = lookup;
             ColumnIndex = columnIndex;
         }
+
+        public override string ToString() => $"[{nameof(ManiaSkinConfigurationLookup)} lookup:{Lookup} col:{ColumnIndex}]";
     }
 }

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -219,15 +219,20 @@ namespace osu.Game.Skinning
                     switch (global)
                     {
                         case GlobalSkinColours.ComboColours:
+                        {
+                            LogLookupDebug(this, lookup, LookupDebugType.Hit);
                             return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>?>(Configuration.ComboColours));
+                        }
                     }
 
                     break;
 
                 case SkinComboColourLookup comboColour:
+                    LogLookupDebug(this, lookup, LookupDebugType.Hit);
                     return SkinUtils.As<TValue>(new Bindable<Color4>(getComboColour(Configuration, comboColour.ColourIndex)));
             }
 
+            LogLookupDebug(this, lookup, LookupDebugType.Miss);
             return null;
         }
 

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -72,6 +72,8 @@ namespace osu.Game.Skinning
                     // If it is decided that we need this due to beatmaps somehow using it, the default (1.0 specified in LegacySkinDecoder.CreateTemplateObject)
                     // needs to be removed else it will cause incorrect skin behaviours. This is due to the config lookup having no context of which skin
                     // it should be returning the version for.
+
+                    Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Miss);
                     return null;
             }
 

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Skinning
             Lookup = lookup;
             ColumnIndex = columnIndex;
         }
+
+        public override string ToString() => $"[{nameof(LegacyManiaSkinConfigurationLookup)} lookup:{Lookup} col:{ColumnIndex} totalcols:{TotalColumns}]";
     }
 
     public enum LegacyManiaSkinConfigurationLookups

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
@@ -82,9 +83,9 @@ namespace osu.Game.Skinning
             }
         }
 
+        [SuppressMessage("ReSharper", "RedundantAssignment")] // for `wasHit` assignments used in `finally` debug logic
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
         {
-            // ReSharper disable once RedundantAssignment (used in `finally` debug logic)
             bool wasHit = true;
 
             try

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -84,48 +84,58 @@ namespace osu.Game.Skinning
 
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
         {
-            switch (lookup)
+            bool wasHit = true;
+
+            try
             {
-                case GlobalSkinColours colour:
-                    switch (colour)
-                    {
-                        case GlobalSkinColours.ComboColours:
-                            var comboColours = Configuration.ComboColours;
-                            if (comboColours != null)
-                                return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(comboColours));
+                switch (lookup)
+                {
+                    case GlobalSkinColours colour:
+                        switch (colour)
+                        {
+                            case GlobalSkinColours.ComboColours:
+                                var comboColours = Configuration.ComboColours;
+                                if (comboColours != null)
+                                    return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(comboColours));
 
-                            break;
+                                break;
 
-                        default:
-                            return SkinUtils.As<TValue>(getCustomColour(Configuration, colour.ToString()));
-                    }
+                            default:
+                                return SkinUtils.As<TValue>(getCustomColour(Configuration, colour.ToString()));
+                        }
 
-                    break;
-
-                case SkinComboColourLookup comboColour:
-                    return SkinUtils.As<TValue>(GetComboColour(Configuration, comboColour.ColourIndex, comboColour.Combo));
-
-                case SkinCustomColourLookup customColour:
-                    return SkinUtils.As<TValue>(getCustomColour(Configuration, customColour.Lookup.ToString() ?? string.Empty));
-
-                case LegacyManiaSkinConfigurationLookup maniaLookup:
-                    if (!AllowManiaSkin)
                         break;
 
-                    var result = lookupForMania<TValue>(maniaLookup);
-                    if (result != null)
-                        return result;
+                    case SkinComboColourLookup comboColour:
+                        return SkinUtils.As<TValue>(GetComboColour(Configuration, comboColour.ColourIndex, comboColour.Combo));
 
-                    break;
+                    case SkinCustomColourLookup customColour:
+                        return SkinUtils.As<TValue>(getCustomColour(Configuration, customColour.Lookup.ToString() ?? string.Empty));
 
-                case SkinConfiguration.LegacySetting legacy:
-                    return legacySettingLookup<TValue>(legacy);
+                    case LegacyManiaSkinConfigurationLookup maniaLookup:
+                        if (!AllowManiaSkin)
+                            break;
 
-                default:
-                    return genericLookup<TLookup, TValue>(lookup);
+                        var result = lookupForMania<TValue>(maniaLookup);
+                        if (result != null)
+                            return result;
+
+                        break;
+
+                    case SkinConfiguration.LegacySetting legacy:
+                        return legacySettingLookup<TValue>(legacy);
+
+                    default:
+                        return genericLookup<TLookup, TValue>(lookup);
+                }
+
+                wasHit = false;
+                return null;
             }
-
-            return null;
+            finally
+            {
+                LogLookupDebug(this, lookup, wasHit ? LookupDebugType.Hit : LookupDebugType.Miss);
+            }
         }
 
         private IBindable<TValue>? lookupForMania<TValue>(LegacyManiaSkinConfigurationLookup maniaLookup)

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Skinning
 
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
         {
+            // ReSharper disable once RedundantAssignment (used in `finally` debug logic)
             bool wasHit = true;
 
             try

--- a/osu.Game/Skinning/ResourceStoreBackedSkin.cs
+++ b/osu.Game/Skinning/ResourceStoreBackedSkin.cs
@@ -46,7 +46,10 @@ namespace osu.Game.Skinning
         public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
             where TLookup : notnull
             where TValue : notnull
-            => null;
+        {
+            Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Miss);
+            return null;
+        }
 
         public void Dispose()
         {

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Skinning
 
         #endregion
 
-        public override string ToString() => $"{GetType().ReadableName()}{{ Name: {Name} }}";
+        public override string ToString() => $"{GetType().ReadableName()} {{ Name: {Name} }}";
 
         private static readonly ThreadLocal<int> nested_level = new ThreadLocal<int>(() => 0);
 

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -6,10 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -54,6 +57,8 @@ namespace osu.Game.Skinning
 
         private readonly RealmBackedResourceStore<SkinInfo>? realmBackedStorage;
 
+        public string Name { get; }
+
         /// <summary>
         /// Construct a new skin.
         /// </summary>
@@ -63,6 +68,8 @@ namespace osu.Game.Skinning
         /// <param name="configurationFilename">An optional filename to read the skin configuration from. If not provided, the configuration will be retrieved from the storage using "skin.ini".</param>
         protected Skin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage = null, string configurationFilename = @"skin.ini")
         {
+            Name = skin.Name;
+
             if (resources != null)
             {
                 SkinInfo = skin.ToLive(resources.RealmAccess);
@@ -239,5 +246,50 @@ namespace osu.Game.Skinning
         }
 
         #endregion
+
+        public override string ToString() => $"{GetType().ReadableName()}{{ Name: {Name} }}";
+
+        private static readonly ThreadLocal<int> nested_level = new ThreadLocal<int>(() => 0);
+
+        [Conditional("SKIN_LOOKUP_DEBUG")]
+        internal static void LogLookupDebug(object callingClass, object lookup, LookupDebugType type, [CallerMemberName] string callerMethod = "")
+        {
+            string icon = string.Empty;
+            int level = nested_level.Value;
+
+            switch (type)
+            {
+                case LookupDebugType.Hit:
+                    icon = "🟢";
+                    break;
+
+                case LookupDebugType.Miss:
+                    icon = "🔴";
+                    break;
+
+                case LookupDebugType.Enter:
+                    nested_level.Value++;
+                    break;
+
+                case LookupDebugType.Exit:
+                    nested_level.Value--;
+                    if (nested_level.Value == 0)
+                        Logger.Log(string.Empty);
+                    return;
+            }
+
+            string lookupString = lookup.ToString() ?? string.Empty;
+            string callingClassString = callingClass.ToString() ?? string.Empty;
+
+            Logger.Log($"{string.Join(null, Enumerable.Repeat("|-", level))}{callingClassString}.{callerMethod}(lookup: {lookupString}) {icon}");
+        }
+
+        internal enum LookupDebugType
+        {
+            Hit,
+            Miss,
+            Enter,
+            Exit
+        }
     }
 }

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -260,11 +260,11 @@ namespace osu.Game.Skinning
             switch (type)
             {
                 case LookupDebugType.Hit:
-                    icon = "🟢";
+                    icon = "🟢 hit";
                     break;
 
                 case LookupDebugType.Miss:
-                    icon = "🔴";
+                    icon = "🔴 miss";
                     break;
 
                 case LookupDebugType.Enter:

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -261,13 +261,22 @@ namespace osu.Game.Skinning
         private T lookupWithFallback<T>(Func<ISkin, T> lookupFunction)
             where T : class
         {
-            foreach (var source in AllSources)
+            try
             {
-                if (lookupFunction(source) is T skinSourced)
-                    return skinSourced;
-            }
+                Skin.LogLookupDebug(this, lookupFunction, Skin.LookupDebugType.Enter);
 
-            return null;
+                foreach (var source in AllSources)
+                {
+                    if (lookupFunction(source) is T skinSourced)
+                        return skinSourced;
+                }
+
+                return null;
+            }
+            finally
+            {
+                Skin.LogLookupDebug(this, lookupFunction, Skin.LookupDebugType.Exit);
+            }
         }
 
         #region IResourceStorageProvider

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Skinning
                 }
             }
 
-            public override string ToString() => $"{GetType().ReadableName()}{{ skin: {skin} }}";
+            public override string ToString() => $"{GetType().ReadableName()} {{ Skin: {skin} }}";
         }
     }
 }

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
@@ -161,17 +162,26 @@ namespace osu.Game.Skinning
             where TLookup : notnull
             where TValue : notnull
         {
-            foreach (var (_, lookupWrapper) in skinSources)
+            try
             {
-                IBindable<TValue>? bindable;
-                if ((bindable = lookupWrapper.GetConfig<TLookup, TValue>(lookup)) != null)
-                    return bindable;
+                Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Enter);
+
+                foreach (var (_, lookupWrapper) in skinSources)
+                {
+                    IBindable<TValue>? bindable;
+                    if ((bindable = lookupWrapper.GetConfig<TLookup, TValue>(lookup)) != null)
+                        return bindable;
+                }
+
+                if (!AllowFallingBackToParent)
+                    return null;
+
+                return ParentSource?.GetConfig<TLookup, TValue>(lookup);
             }
-
-            if (!AllowFallingBackToParent)
-                return null;
-
-            return ParentSource?.GetConfig<TLookup, TValue>(lookup);
+            finally
+            {
+                Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Exit);
+            }
         }
 
         /// <summary>
@@ -271,25 +281,36 @@ namespace osu.Game.Skinning
                 where TLookup : notnull
                 where TValue : notnull
             {
-                switch (lookup)
+                try
                 {
-                    case GlobalSkinColours:
-                    case SkinComboColourLookup:
-                    case SkinCustomColourLookup:
-                        if (provider.AllowColourLookup)
-                            return skin.GetConfig<TLookup, TValue>(lookup);
+                    Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Enter);
 
-                        break;
+                    switch (lookup)
+                    {
+                        case GlobalSkinColours:
+                        case SkinComboColourLookup:
+                        case SkinCustomColourLookup:
+                            if (provider.AllowColourLookup)
+                                return skin.GetConfig<TLookup, TValue>(lookup);
 
-                    default:
-                        if (provider.AllowConfigurationLookup)
-                            return skin.GetConfig<TLookup, TValue>(lookup);
+                            break;
 
-                        break;
+                        default:
+                            if (provider.AllowConfigurationLookup)
+                                return skin.GetConfig<TLookup, TValue>(lookup);
+
+                            break;
+                    }
+
+                    return null;
                 }
-
-                return null;
+                finally
+                {
+                    Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Exit);
+                }
             }
+
+            public override string ToString() => $"{GetType().ReadableName()}{{ skin: {skin} }}";
         }
     }
 }

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -34,6 +34,19 @@ namespace osu.Game.Skinning
 
         public virtual ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
 
-        public virtual IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull => Skin.GetConfig<TLookup, TValue>(lookup);
+        public virtual IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup) where TLookup : notnull where TValue : notnull
+        {
+            try
+            {
+                Skinning.Skin.LogLookupDebug(this, lookup, Skinning.Skin.LookupDebugType.Enter);
+                return Skin.GetConfig<TLookup, TValue>(lookup);
+            }
+            finally
+            {
+                Skinning.Skin.LogLookupDebug(this, lookup, Skinning.Skin.LookupDebugType.Exit);
+            }
+        }
+
+        public override string ToString() => $"{nameof(SkinTransformer)}{{ Skin: {Skin} }}";
     }
 }

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -47,6 +47,6 @@ namespace osu.Game.Skinning
             }
         }
 
-        public override string ToString() => $"{nameof(SkinTransformer)}{{ Skin: {Skin} }}";
+        public override string ToString() => $"{nameof(SkinTransformer)} {{ Skin: {Skin} }}";
     }
 }

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -190,15 +190,20 @@ namespace osu.Game.Skinning
                     switch (global)
                     {
                         case GlobalSkinColours.ComboColours:
+                        {
+                            LogLookupDebug(this, lookup, LookupDebugType.Hit);
                             return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>?>(Configuration.ComboColours));
+                        }
                     }
 
                     break;
 
                 case SkinComboColourLookup comboColour:
+                    LogLookupDebug(this, lookup, LookupDebugType.Hit);
                     return SkinUtils.As<TValue>(new Bindable<Color4>(getComboColour(Configuration, comboColour.ColourIndex)));
             }
 
+            LogLookupDebug(this, lookup, LookupDebugType.Miss);
             return null;
         }
 


### PR DESCRIPTION
We've struggle with debugging these over the years so I think this was worth a couple of hours of work.

Example of osu! lookups:

```log
[runtime] 2023-09-06 08:38:30 [verbose]: BeatmapSkinProvidingContainer.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacyBeatmapSkin{ Name: Vickeblanka - Lucky Ending (TV Size) (tears_) [Normal] } } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-RulesetSkinProvidingContainer.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-|-LegacySkin{ Name: Test Skin [test-skin] }.GetConfig(lookup: SpinnerFrequencyModulate) 🟢
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-|-DefaultLegacySkin{ Name: osu! "classic" (2013) }.GetConfig(lookup: SpinnerFrequencyModulate) 🟢
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: osu.Game.Skinning.ResourceStoreBackedSkin }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-osu.Game.Skinning.ResourceStoreBackedSkin.GetConfig(lookup: SpinnerFrequencyModulate) 🔴
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: TrianglesSkin{ Name: osu! "triangles" (2017) } }.GetConfig(lookup: SpinnerFrequencyModulate)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-TrianglesSkin{ Name: osu! "triangles" (2017) }.GetConfig(lookup: SpinnerFrequencyModulate) 🔴
[runtime] 2023-09-06 08:38:30 [verbose]:
[runtime] 2023-09-06 08:38:30 [verbose]: BeatmapSkinProvidingContainer.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacyBeatmapSkin{ Name: Vickeblanka - Lucky Ending (TV Size) (tears_) [Normal] } } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-RulesetSkinProvidingContainer.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-|-LegacySkin{ Name: Test Skin [test-skin] }.GetConfig(lookup: ScorePrefix) 🟢
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-|-DefaultLegacySkin{ Name: osu! "classic" (2013) }.GetConfig(lookup: ScorePrefix) 🟢
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: osu.Game.Skinning.ResourceStoreBackedSkin }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-osu.Game.Skinning.ResourceStoreBackedSkin.GetConfig(lookup: ScorePrefix) 🔴
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: TrianglesSkin{ Name: osu! "triangles" (2017) } }.GetConfig(lookup: ScorePrefix)
[runtime] 2023-09-06 08:38:30 [verbose]: |-|-|-TrianglesSkin{ Name: osu! "triangles" (2017) }.GetConfig(lookup: ScorePrefix) 🔴
```

Example of osu!mania lookups:

```log
[runtime] 2023-09-06 08:28:34 [verbose]: |-RulesetSkinProvidingContainer.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnWidth col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } } }.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnWidth col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnWidth col:0 totalcols:4])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-|-LegacySkin{ Name: Test Skin [test-skin] }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnWidth col:0 totalcols:4]) 🔴
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } } }.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnWidth col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnWidth col:0 totalcols:4])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-|-DefaultLegacySkin{ Name: osu! "classic" (2013) }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnWidth col:0 totalcols:4]) 🟢
[runtime] 2023-09-06 08:28:34 [verbose]:
[runtime] 2023-09-06 08:28:34 [verbose]: BeatmapSkinProvidingContainer.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnSpacing col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacyBeatmapSkin{ Name: antiPLUR - Runengon (Raveille) [Easy] } } }.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnSpacing col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-RulesetSkinProvidingContainer.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnSpacing col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } } }.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnSpacing col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-SkinTransformer{ Skin: LegacySkin{ Name: Test Skin [test-skin] } }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnSpacing col:0 totalcols:4])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-|-LegacySkin{ Name: Test Skin [test-skin] }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnSpacing col:0 totalcols:4]) 🔴
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-SkinProvidingContainer+DisableableSkinSource{ skin: SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } } }.GetConfig(lookup: [ManiaSkinConfigurationLookup lookup:ColumnSpacing col:0])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-SkinTransformer{ Skin: DefaultLegacySkin{ Name: osu! "classic" (2013) } }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnSpacing col:0 totalcols:4])
[runtime] 2023-09-06 08:28:34 [verbose]: |-|-|-|-DefaultLegacySkin{ Name: osu! "classic" (2013) }.GetConfig(lookup: [LegacyManiaSkinConfigurationLookup lookup:ColumnSpacing col:0 totalcols:4]) 🟢
[runtime] 2023-09-06 08:28:34 [verbose]:

```

Confirmed useful by using the output to debug the source of failure for https://github.com/ppy/osu/issues/24693.