### PR TITLE
Fix osu!mania legacy skin configurations not working when notes are not skinned

### DIFF
--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning
 {
     public class LegacyBeatmapSkin : LegacySkin
     {
-        protected override bool AllowManiaSkin => false;
+        protected override bool AllowManiaConfigLookups => false;
         protected override bool UseCustomSampleBanks => true;
 
         /// <summary>

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -29,13 +29,7 @@ namespace osu.Game.Skinning
 {
     public class LegacySkin : Skin
     {
-        /// <summary>
-        /// Whether texture for the keys exists.
-        /// Used to determine if the mania ruleset is skinned.
-        /// </summary>
-        private readonly Lazy<bool> hasKeyTexture;
-
-        protected virtual bool AllowManiaSkin => hasKeyTexture.Value;
+        protected virtual bool AllowManiaConfigLookups => true;
 
         /// <summary>
         /// Whether this skin can use samples with a custom bank (custom sample set in stable terminology).
@@ -61,10 +55,6 @@ namespace osu.Game.Skinning
         protected LegacySkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage, string configurationFilename = @"skin.ini")
             : base(skin, resources, storage, configurationFilename)
         {
-            // todo: this shouldn't really be duplicated here (from ManiaLegacySkinTransformer). we need to come up with a better solution.
-            hasKeyTexture = new Lazy<bool>(() => this.GetAnimation(
-                lookupForMania<string>(new LegacyManiaSkinConfigurationLookup(4, LegacyManiaSkinConfigurationLookups.KeyImage, 0))?.Value ?? "mania-key1", true,
-                true) != null);
         }
 
         protected override void ParseConfigurationStream(Stream stream)
@@ -114,7 +104,7 @@ namespace osu.Game.Skinning
                         return SkinUtils.As<TValue>(getCustomColour(Configuration, customColour.Lookup.ToString() ?? string.Empty));
 
                     case LegacyManiaSkinConfigurationLookup maniaLookup:
-                        if (!AllowManiaSkin)
+                        if (!AllowManiaConfigLookups)
                             break;
 
                         var result = lookupForMania<TValue>(maniaLookup);


### PR DESCRIPTION
Originally disabled via https://github.com/ppy/osu/pull/8535, but *as far as I can tell* this does not look required anymore (we have much better classic fallback support these days).

Closes https://github.com/ppy/osu/issues/24693 (and can be tested with skin that issue).

- [x] Depends on https://github.com/ppy/osu/pull/24726 for conflict avoidance