### PR TITLE
Rename `SliderVelocity` to `SliderVelocityMultiplier` to distinguish from `Velocity`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamPlacementBlueprint.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddAssert("end time is correct", () => Precision.AlmostEquals(lastObject.EndTime, times[1]));
             AddAssert("start position is correct", () => Precision.AlmostEquals(lastObject.OriginalX, positions[0]));
             AddAssert("end position is correct", () => Precision.AlmostEquals(lastObject.EndX, positions[1]));
-            AddAssert("default slider velocity", () => lastObject.SliderVelocityBindable.IsDefault);
+            AddAssert("default slider velocity", () => lastObject.SliderVelocityMultiplierBindable.IsDefault);
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             addPlacementSteps(times, positions);
             addPathCheckStep(times, positions);
 
-            AddAssert("slider velocity changed", () => !lastObject.SliderVelocityBindable.IsDefault);
+            AddAssert("slider velocity changed", () => !lastObject.SliderVelocityMultiplierBindable.IsDefault);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -108,11 +108,11 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             double[] times = { 100, 300 };
             float[] positions = { 200, 300 };
             addBlueprintStep(times, positions);
-            AddAssert("default slider velocity", () => hitObject.SliderVelocityBindable.IsDefault);
+            AddAssert("default slider velocity", () => hitObject.SliderVelocityMultiplierBindable.IsDefault);
 
             addDragStartStep(times[1], positions[1]);
             AddMouseMoveStep(times[1], 400);
-            AddAssert("slider velocity changed", () => !hitObject.SliderVelocityBindable.IsDefault);
+            AddAssert("slider velocity changed", () => !hitObject.SliderVelocityMultiplierBindable.IsDefault);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapConverter.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Catch.Beatmaps
                         ComboOffset = comboData?.ComboOffset ?? 0,
                         LegacyLastTickOffset = (obj as IHasLegacyLastTickOffset)?.LegacyLastTickOffset ?? 0,
                         LegacyConvertedY = yPositionData?.Y ?? CatchHitObject.DEFAULT_LEGACY_CONVERT_Y,
-                        SliderVelocity = sliderVelocityData?.SliderVelocity ?? 1
+                        SliderVelocityMultiplier = sliderVelocityData?.SliderVelocityMultiplier ?? 1
                     }.Yield();
 
                 case IHasDuration endTime:

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
         public void UpdateHitObjectFromPath(JuiceStream hitObject)
         {
             // The SV setting may need to be changed for the current path.
-            var svBindable = hitObject.SliderVelocityBindable;
+            var svBindable = hitObject.SliderVelocityMultiplierBindable;
             double svToVelocityFactor = hitObject.Velocity / svBindable.Value;
             double requiredVelocity = path.ComputeRequiredVelocity();
 

--- a/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/JuiceStream.cs
@@ -28,17 +28,17 @@ namespace osu.Game.Rulesets.Catch.Objects
 
         public int RepeatCount { get; set; }
 
-        public BindableNumber<double> SliderVelocityBindable { get; } = new BindableDouble(1)
+        public BindableNumber<double> SliderVelocityMultiplierBindable { get; } = new BindableDouble(1)
         {
             Precision = 0.01,
             MinValue = 0.1,
             MaxValue = 10
         };
 
-        public double SliderVelocity
+        public double SliderVelocityMultiplier
         {
-            get => SliderVelocityBindable.Value;
-            set => SliderVelocityBindable.Value = value;
+            get => SliderVelocityMultiplierBindable.Value;
+            set => SliderVelocityMultiplierBindable.Value = value;
         }
 
         [JsonIgnore]
@@ -48,10 +48,10 @@ namespace osu.Game.Rulesets.Catch.Objects
         private double tickDistanceFactor;
 
         [JsonIgnore]
-        public double Velocity => velocityFactor * SliderVelocity;
+        public double Velocity => velocityFactor * SliderVelocityMultiplier;
 
         [JsonIgnore]
-        public double TickDistance => tickDistanceFactor * SliderVelocity;
+        public double TickDistance => tickDistanceFactor * SliderVelocityMultiplier;
 
         /// <summary>
         /// The length of one span of this <see cref="JuiceStream"/>.

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/DistanceObjectPatternGenerator.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
             if (hitObject.LegacyBpmMultiplier.HasValue)
                 beatLength = timingPoint.BeatLength * hitObject.LegacyBpmMultiplier.Value;
             else if (hitObject is IHasSliderVelocity hasSliderVelocity)
-                beatLength = timingPoint.BeatLength / hasSliderVelocity.SliderVelocity;
+                beatLength = timingPoint.BeatLength / hasSliderVelocity.SliderVelocityMultiplier;
             else
                 beatLength = timingPoint.BeatLength;
 

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                                 new PathControlPoint(new Vector2(0, 6.25f))
                             }),
                             RepeatCount = 1,
-                            SliderVelocity = 10
+                            SliderVelocityMultiplier = 10
                         }
                     }
                 },

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                     {
                         StartTime = time_slider_start,
                         Position = new Vector2(0, 0),
-                        SliderVelocity = velocity,
+                        SliderVelocityMultiplier = velocity,
                         Path = new SliderPath(PathType.Linear, new[]
                         {
                             Vector2.Zero,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -349,7 +349,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                         {
                             StartTime = time_slider_start,
                             Position = new Vector2(0, 0),
-                            SliderVelocity = 0.1f,
+                            SliderVelocityMultiplier = 0.1f,
                             Path = new SliderPath(PathType.PerfectCurve, new[]
                             {
                                 Vector2.Zero,

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -451,7 +451,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             public TestSlider()
             {
-                SliderVelocity = 0.1f;
+                SliderVelocityMultiplier = 0.1f;
 
                 DefaultsApplied += _ =>
                 {

--- a/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Beatmaps
                         // this results in more (or less) ticks being generated in <v8 maps for the same time duration.
                         TickDistanceMultiplier = beatmap.BeatmapInfo.BeatmapVersion < 8 ? 1f / ((LegacyControlPointInfo)beatmap.ControlPointInfo).DifficultyPointAt(original.StartTime).SliderVelocity : 1,
                         GenerateTicks = generateTicksData?.GenerateTicks ?? true,
-                        SliderVelocity = sliderVelocityData?.SliderVelocity ?? 1,
+                        SliderVelocityMultiplier = sliderVelocityData?.SliderVelocityMultiplier ?? 1,
                     }.Yield();
 
                 case IHasDuration endTimeData:

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -85,9 +85,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     BeginPlacement();
 
                     double? nearestSliderVelocity = (editorBeatmap.HitObjects
-                                                                  .LastOrDefault(h => h is Slider && h.GetEndTime() < HitObject.StartTime) as Slider)?.SliderVelocity;
+                                                                  .LastOrDefault(h => h is Slider && h.GetEndTime() < HitObject.StartTime) as Slider)?.SliderVelocityMultiplier;
 
-                    HitObject.SliderVelocity = nearestSliderVelocity ?? 1;
+                    HitObject.SliderVelocityMultiplier = nearestSliderVelocity ?? 1;
                     HitObject.Position = ToLocalSpace(result.ScreenSpacePosition);
 
                     // Replacing the DifficultyControlPoint above doesn't trigger any kind of invalidation.

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 ComboOffset = original.ComboOffset;
                 LegacyLastTickOffset = original.LegacyLastTickOffset;
                 TickDistanceMultiplier = original.TickDistanceMultiplier;
-                SliderVelocity = original.SliderVelocity;
+                SliderVelocityMultiplier = original.SliderVelocityMultiplier;
             }
 
             protected override void CreateNestedHitObjects(CancellationToken cancellationToken)

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -134,17 +134,17 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         public bool OnlyJudgeNestedObjects = true;
 
-        public BindableNumber<double> SliderVelocityBindable { get; } = new BindableDouble(1)
+        public BindableNumber<double> SliderVelocityMultiplierBindable { get; } = new BindableDouble(1)
         {
             Precision = 0.01,
             MinValue = 0.1,
             MaxValue = 10
         };
 
-        public double SliderVelocity
+        public double SliderVelocityMultiplier
         {
-            get => SliderVelocityBindable.Value;
-            set => SliderVelocityBindable.Value = value;
+            get => SliderVelocityMultiplierBindable.Value;
+            set => SliderVelocityMultiplierBindable.Value = value;
         }
 
         public bool GenerateTicks { get; set; } = true;
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = BASE_SCORING_DISTANCE * difficulty.SliderMultiplier * SliderVelocityMultiplier;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
             TickDistance = GenerateTicks ? (scoringDistance / difficulty.SliderTickRate * TickDistanceMultiplier) : double.PositiveInfinity;

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double SpanDuration => Duration / this.SpanCount();
 
         /// <summary>
-        /// Velocity of this <see cref="Slider"/>.
+        /// The computed velocity of this <see cref="Slider"/>. This is the amount of path distance travelled in 1 ms.
         /// </summary>
         public double Velocity { get; private set; }
 

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                 {
                     if (hitObject is not IHasSliderVelocity hasSliderVelocity) continue;
 
-                    double nextScrollSpeed = hasSliderVelocity.SliderVelocity;
+                    double nextScrollSpeed = hasSliderVelocity.SliderVelocityMultiplier;
                     EffectControlPoint currentEffectPoint = converted.ControlPointInfo.EffectPointAt(hitObject.StartTime);
 
                     if (!Precision.AlmostEquals(lastScrollSpeed, nextScrollSpeed, acceptableDifference: currentEffectPoint.ScrollSpeedBindable.Precision))
@@ -189,7 +189,7 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
             if (obj.LegacyBpmMultiplier.HasValue)
                 beatLength = timingPoint.BeatLength * obj.LegacyBpmMultiplier.Value;
             else if (obj is IHasSliderVelocity hasSliderVelocity)
-                beatLength = timingPoint.BeatLength / hasSliderVelocity.SliderVelocity;
+                beatLength = timingPoint.BeatLength / hasSliderVelocity.SliderVelocityMultiplier;
             else
                 beatLength = timingPoint.BeatLength;
 

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Editing
         {
             assertSnapDistance(100, new Slider
             {
-                SliderVelocity = multiplier
+                SliderVelocityMultiplier = multiplier
             }, false);
         }
 
@@ -88,7 +88,7 @@ namespace osu.Game.Tests.Editing
         {
             assertSnapDistance(100 * multiplier, new Slider
             {
-                SliderVelocity = multiplier
+                SliderVelocityMultiplier = multiplier
             }, true);
         }
 
@@ -112,7 +112,7 @@ namespace osu.Game.Tests.Editing
 
             var referenceObject = new Slider
             {
-                SliderVelocity = slider_velocity
+                SliderVelocityMultiplier = slider_velocity
             };
 
             assertSnapDistance(base_distance * slider_velocity, referenceObject, true);

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Visual.Editing
                             new PathControlPoint(new Vector2(100, 0))
                         }
                     },
-                    SliderVelocity = 2
+                    SliderVelocityMultiplier = 2
                 });
             });
         }
@@ -110,7 +110,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("unify slider velocity", () =>
             {
                 foreach (var h in EditorBeatmap.HitObjects.OfType<IHasSliderVelocity>())
-                    h.SliderVelocity = 1.5;
+                    h.SliderVelocityMultiplier = 1.5;
             });
 
             AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
@@ -194,7 +194,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void hitObjectHasVelocity(int objectIndex, double velocity) => AddAssert($"{objectIndex.ToOrdinalWords()} has velocity {velocity}", () =>
         {
             var h = EditorBeatmap.HitObjects.ElementAt(objectIndex);
-            return h is IHasSliderVelocity hasSliderVelocity && hasSliderVelocity.SliderVelocity == velocity;
+            return h is IHasSliderVelocity hasSliderVelocity && hasSliderVelocity.SliderVelocityMultiplier == velocity;
         });
     }
 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Beatmaps.Formats
             }
 
             if (hitObject is IHasSliderVelocity hasSliderVelocity)
-                hasSliderVelocity.SliderVelocity = difficultyControlPoint.SliderVelocity;
+                hasSliderVelocity.SliderVelocityMultiplier = difficultyControlPoint.SliderVelocity;
 
             hitObject.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -269,7 +269,7 @@ namespace osu.Game.Beatmaps.Formats
                 foreach (var hitObject in hitObjects)
                 {
                     if (hitObject is IHasSliderVelocity hasSliderVelocity)
-                        yield return new DifficultyControlPoint { Time = hitObject.StartTime, SliderVelocity = hasSliderVelocity.SliderVelocity };
+                        yield return new DifficultyControlPoint { Time = hitObject.StartTime, SliderVelocity = hasSliderVelocity.SliderVelocityMultiplier };
                 }
             }
 

--- a/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/DistancedHitObjectComposer.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Rulesets.Edit
 
         public virtual float GetBeatSnapDistanceAt(HitObject referenceObject, bool useReferenceSliderVelocity = true)
         {
-            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocity : 1) * EditorBeatmap.Difficulty.SliderMultiplier * 1
+            return (float)(100 * (useReferenceSliderVelocity && referenceObject is IHasSliderVelocity hasSliderVelocity ? hasSliderVelocity.SliderVelocityMultiplier : 1) * EditorBeatmap.Difficulty.SliderMultiplier * 1
                            / BeatSnapProvider.BeatDivisor);
         }
 

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertSlider.cs
@@ -41,12 +41,12 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
         public double Velocity = 1;
 
-        public BindableNumber<double> SliderVelocityBindable { get; } = new BindableDouble(1);
+        public BindableNumber<double> SliderVelocityMultiplierBindable { get; } = new BindableDouble(1);
 
-        public double SliderVelocity
+        public double SliderVelocityMultiplier
         {
-            get => SliderVelocityBindable.Value;
-            set => SliderVelocityBindable.Value = value;
+            get => SliderVelocityMultiplierBindable.Value;
+            set => SliderVelocityMultiplierBindable.Value = value;
         }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             TimingControlPoint timingPoint = controlPointInfo.TimingPointAt(StartTime);
 
-            double scoringDistance = base_scoring_distance * difficulty.SliderMultiplier * SliderVelocity;
+            double scoringDistance = base_scoring_distance * difficulty.SliderMultiplier * SliderVelocityMultiplier;
 
             Velocity = scoringDistance / timingPoint.BeatLength;
         }

--- a/osu.Game/Rulesets/Objects/Types/IHasSliderVelocity.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasSliderVelocity.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Objects.Types
         /// <summary>
         /// The slider velocity multiplier.
         /// </summary>
-        double SliderVelocity { get; set; }
+        double SliderVelocityMultiplier { get; set; }
 
-        BindableNumber<double> SliderVelocityBindable { get; }
+        BindableNumber<double> SliderVelocityMultiplierBindable { get; }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                     if (selected is IHasSliderVelocity sliderVelocity)
                     {
                         AddHeader("Slider Velocity");
-                        AddValue($"{sliderVelocity.SliderVelocity:#,0.00}x ({sliderVelocity.SliderVelocity * EditorBeatmap.Difficulty.SliderMultiplier:#,0.00}x)");
+                        AddValue($"{sliderVelocity.SliderVelocityMultiplier:#,0.00}x ({sliderVelocity.SliderVelocityMultiplier * EditorBeatmap.Difficulty.SliderMultiplier:#,0.00}x)");
                     }
 
                     if (selected is IHasRepeats repeats)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             HitObject = hitObject;
 
-            speedMultiplier = (hitObject as IHasSliderVelocity)?.SliderVelocityBindable.GetBoundCopy();
+            speedMultiplier = (hitObject as IHasSliderVelocity)?.SliderVelocityMultiplierBindable.GetBoundCopy();
         }
 
         protected override Color4 GetRepresentingColour(OsuColour colours) => colours.Lime1;
@@ -106,8 +106,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).Where(o => o is IHasSliderVelocity).ToArray();
 
                 // even if there are multiple objects selected, we can still display a value if they all have the same value.
-                var selectedPointBindable = relevantObjects.Select(point => ((IHasSliderVelocity)point).SliderVelocity).Distinct().Count() == 1
-                    ? ((IHasSliderVelocity)relevantObjects.First()).SliderVelocityBindable
+                var selectedPointBindable = relevantObjects.Select(point => ((IHasSliderVelocity)point).SliderVelocityMultiplier).Distinct().Count() == 1
+                    ? ((IHasSliderVelocity)relevantObjects.First()).SliderVelocityMultiplierBindable
                     : null;
 
                 if (selectedPointBindable != null)
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     foreach (var h in relevantObjects)
                     {
-                        ((IHasSliderVelocity)h).SliderVelocity = val.NewValue.Value;
+                        ((IHasSliderVelocity)h).SliderVelocityMultiplier = val.NewValue.Value;
                         beatmap.Update(h);
                     }
 
@@ -169,7 +169,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             InspectorText.Clear();
 
-            double[] sliderVelocities = EditorBeatmap.HitObjects.OfType<IHasSliderVelocity>().Select(sv => sv.SliderVelocity).OrderBy(v => v).ToArray();
+            double[] sliderVelocities = EditorBeatmap.HitObjects.OfType<IHasSliderVelocity>().Select(sv => sv.SliderVelocityMultiplier).OrderBy(v => v).ToArray();
 
             AddHeader("Base velocity (from beatmap setup)");
             AddValue($"{beatmapVelocity:#,0.00}x");

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -395,12 +395,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                                 if (e.CurrentState.Keyboard.ShiftPressed && hitObject is IHasSliderVelocity hasSliderVelocity)
                                 {
-                                    double newVelocity = hasSliderVelocity.SliderVelocity * (repeatHitObject.Duration / proposedDuration);
+                                    double newVelocity = hasSliderVelocity.SliderVelocityMultiplier * (repeatHitObject.Duration / proposedDuration);
 
-                                    if (Precision.AlmostEquals(newVelocity, hasSliderVelocity.SliderVelocity))
+                                    if (Precision.AlmostEquals(newVelocity, hasSliderVelocity.SliderVelocityMultiplier))
                                         return;
 
-                                    hasSliderVelocity.SliderVelocity = newVelocity;
+                                    hasSliderVelocity.SliderVelocityMultiplier = newVelocity;
                                     beatmap.Update(hitObject);
                                 }
                                 else

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Edit
                     continue;
 
                 if (oldObject is IHasSliderVelocity oldWithVelocity && newObject is IHasSliderVelocity newWithVelocity)
-                    oldWithVelocity.SliderVelocity = newWithVelocity.SliderVelocity;
+                    oldWithVelocity.SliderVelocityMultiplier = newWithVelocity.SliderVelocityMultiplier;
 
                 oldObject.Samples = newObject.Samples;
 


### PR DESCRIPTION
Because having both `Slider.Velocity` and `Slider.SliderVelocity` existing is a violation of sensibility.

Also adds better xmldoc for `Slider.Velocity`.
