### PR TITLE
Link new song select wedge title and artist to search text box

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -141,9 +141,9 @@ namespace osu.Game.Screens.Select
                                                     LayoutEasing = Easing.OutQuad,
                                                     Children = new[]
                                                     {
-                                                        description = new MetadataSectionDescription(searchOnSongSelect),
-                                                        source = new MetadataSectionSource(searchOnSongSelect),
-                                                        tags = new MetadataSectionTags(searchOnSongSelect),
+                                                        description = new MetadataSectionDescription(query => songSelect?.Search(query)),
+                                                        source = new MetadataSectionSource(query => songSelect?.Search(query)),
+                                                        tags = new MetadataSectionTags(query => songSelect?.Search(query)),
                                                     },
                                                 },
                                             },
@@ -176,12 +176,6 @@ namespace osu.Game.Screens.Select
                 },
                 loading = new LoadingLayer(true)
             };
-
-            void searchOnSongSelect(string text)
-            {
-                if (songSelect != null)
-                    songSelect.FilterControl.CurrentTextSearch.Value = text;
-            }
         }
 
         private void updateStatistics()

--- a/osu.Game/Screens/Select/BeatmapInfoWedgeV2.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedgeV2.cs
@@ -319,6 +319,8 @@ namespace osu.Game.Screens.Select
             {
                 base.UpdateAfterChildren();
 
+                // best effort to confine the auto-sized text to wedge bounds
+                // the artist label doesn't have an extra text_margin as it doesn't touch the right metadata
                 TitleLabel.MaxWidth = DrawWidth - text_margin * 2 - shear_width;
                 ArtistLabel.MaxWidth = DrawWidth - text_margin - shear_width;
             }

--- a/osu.Game/Screens/Select/BeatmapInfoWedgeV2.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedgeV2.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
 
@@ -270,37 +271,56 @@ namespace osu.Game.Screens.Select
             }
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(SongSelect? songSelect, LocalisationManager localisation)
             {
                 var metadata = working.Metadata;
+
+                var titleText = new RomanisableString(metadata.TitleUnicode, metadata.Title);
+                var artistText = new RomanisableString(metadata.ArtistUnicode, metadata.Artist);
 
                 Child = new FillFlowContainer
                 {
                     Name = "Top-left aligned metadata",
                     Direction = FillDirection.Vertical,
-                    Padding = new MarginPadding { Left = text_margin, Right = text_margin + shear_width, Top = 12 },
+                    Padding = new MarginPadding { Left = text_margin, Top = 12 },
                     AutoSizeAxes = Axes.Y,
                     RelativeSizeAxes = Axes.X,
                     Children = new Drawable[]
                     {
-                        TitleLabel = new TruncatingSpriteText
+                        new OsuHoverContainer
                         {
-                            Shadow = true,
-                            Text = new RomanisableString(metadata.TitleUnicode, metadata.Title),
-                            Font = OsuFont.TorusAlternate.With(size: 40, weight: FontWeight.SemiBold),
-                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Both,
+                            Action = () => songSelect?.Search(titleText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript)),
+                            Child = TitleLabel = new TruncatingSpriteText
+                            {
+                                Shadow = true,
+                                Text = titleText,
+                                Font = OsuFont.TorusAlternate.With(size: 40, weight: FontWeight.SemiBold),
+                            },
                         },
-                        ArtistLabel = new TruncatingSpriteText
+                        new OsuHoverContainer
                         {
-                            // TODO : figma design has a diffused shadow, instead of the solid one present here, not possible currently as far as i'm aware.
-                            Shadow = true,
-                            Text = new RomanisableString(metadata.ArtistUnicode, metadata.Artist),
-                            // Not sure if this should be semi bold or medium
-                            Font = OsuFont.Torus.With(size: 20, weight: FontWeight.SemiBold),
-                            RelativeSizeAxes = Axes.X,
-                        }
+                            AutoSizeAxes = Axes.Both,
+                            Action = () => songSelect?.Search(artistText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript)),
+                            Child = ArtistLabel = new TruncatingSpriteText
+                            {
+                                // TODO : figma design has a diffused shadow, instead of the solid one present here, not possible currently as far as i'm aware.
+                                Shadow = true,
+                                Text = artistText,
+                                // Not sure if this should be semi bold or medium
+                                Font = OsuFont.Torus.With(size: 20, weight: FontWeight.SemiBold),
+                            },
+                        },
                     }
                 };
+            }
+
+            protected override void UpdateAfterChildren()
+            {
+                base.UpdateAfterChildren();
+
+                TitleLabel.MaxWidth = DrawWidth - text_margin * 2 - shear_width;
+                ArtistLabel.MaxWidth = DrawWidth - text_margin - shear_width;
             }
         }
     }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -391,6 +391,15 @@ namespace osu.Game.Screens.Select
         }
 
         /// <summary>
+        /// Set the query to the search text box.
+        /// </summary>
+        /// <param name="query">The string to search.</param>
+        public void Search(string query)
+        {
+            FilterControl.CurrentTextSearch.Value = query;
+        }
+
+        /// <summary>
         /// Call to make a selection and perform the default action for this SongSelect.
         /// </summary>
         /// <param name="beatmapInfo">An optional beatmap to override the current carousel selection.</param>


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/22332

I had this implemented on the old design, but the wedge redesign PR was still open so I didn't want to improve the old thing and left it stashed. Can be backported, but I'm really dedicated to finishing the redesign this year.

I did composition instead of making a new class because I would have to forward all the sprite text properties to the hover container and they only need two lines to work (autosize and action).

![osu Game Tests_IW8ZLEZMZn](https://github.com/ppy/osu/assets/35318437/b2638b13-87f1-458b-b6ef-ec86d0756bd8)