### PR TITLE
Use `@2x` variant of profile badges

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -134,14 +134,16 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     AwardedAt = DateTimeOffset.FromUnixTimeSeconds(1505741569),
                     Description = "Outstanding help by being a voluntary test subject.",
-                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor.jpg",
+                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor-new@2x.png",
+                    ImageUrlLowRes = "https://assets.ppy.sh/profile-badges/contributor-new.png",
                     Url = "https://osu.ppy.sh/wiki/en/People/Community_Contributors",
                 },
                 new Badge
                 {
                     AwardedAt = DateTimeOffset.FromUnixTimeSeconds(1505741569),
                     Description = "Badge without a url.",
-                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor.jpg",
+                    ImageUrl = "https://assets.ppy.sh/profile-badges/contributor@2x.png",
+                    ImageUrlLowRes = "https://assets.ppy.sh/profile-badges/contributor.png",
                 },
             },
             Title = "osu!volunteer",

--- a/osu.Game/Users/Badge.cs
+++ b/osu.Game/Users/Badge.cs
@@ -16,8 +16,11 @@ namespace osu.Game.Users
         [JsonProperty("description")]
         public string Description;
 
-        [JsonProperty("image_url")]
+        [JsonProperty("image@2x_url")]
         public string ImageUrl;
+
+        [JsonProperty("image_url")]
+        public string ImageUrlLowRes;
 
         [JsonProperty("url")]
         public string Url;


### PR DESCRIPTION
- Possible after https://github.com/ppy/osu-web/pull/10512
- [x] Depends on new web deploy

| Before | After |
| --- | --- |
| ![XHWvAJKvSw](https://github.com/ppy/osu/assets/35318437/9ce5aef3-41cb-4c62-836d-fed1cf380ffb) | ![osu!_EsTkFpHdzY](https://github.com/ppy/osu/assets/35318437/7b0cb026-d740-4621-a1fe-970873b5a77c) |