### PR TITLE
Update badge header background color in line with web

### DIFF
--- a/osu.Game/Overlays/Profile/Header/BadgeHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BadgeHeaderContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background5,
+                    Colour = colourProvider.Background4,
                 },
                 new Container // artificial shadow
                 {
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Profile.Header
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Spacing = new Vector2(10, 10),
-                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Top = 10 },
+                    Padding = new MarginPadding { Horizontal = WaveOverlayContainer.HORIZONTAL_PADDING, Vertical = 10 },
                 }
             };
         }

--- a/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/TopHeaderContainer.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Overlays.Profile.Header
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = colourProvider.Background4,
+                    Colour = colourProvider.Background3,
                 },
                 new FillFlowContainer
                 {


### PR DESCRIPTION
- To be in line with https://github.com/ppy/osu-web/pull/10469 and https://github.com/ppy/osu-web/pull/10504 (top header color changes)

Not worried about the other views (i.e. multiplayer) yet as it is not implemented.

| Before | After | Web |
| --- | --- | --- |
| ![osu!_XAeS0kEEXC](https://github.com/ppy/osu/assets/35318437/b6a37af0-3d58-4259-bc77-8407b603fa58) | ![UVZEs0iVlc](https://github.com/ppy/osu/assets/35318437/3e4e7228-c399-48d2-8339-fd4213854f22) | ![firefox_p6g6HEvWJs](https://github.com/ppy/osu/assets/35318437/09cfbb99-31d6-4c25-8fb5-f8dcf15db212) |