### PR TITLE
Block input to objects lying under already-hit slider heads before slider is fully judged when classic note lock is active

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -506,7 +506,6 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
-        [Ignore("Currently broken, first attempt at fixing broke even harder. See https://github.com/ppy/osu/issues/24743.")]
         public void TestInputDoesNotFallThroughOverlappingSliders()
         {
             const double time_first_slider = 1000;
@@ -550,6 +549,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
             addJudgementAssert(hitObjects[1], HitResult.Miss);
             // the slider head of the first slider prevents the second slider's head from being hit, so the judgement offset should be very late.
+            // this is not strictly done by the hit policy implementation itself (see `OsuModClassic.blockInputToObjectsUnderSliderHead()`),
+            // but we're testing this here anyways to just keep everything related to input handling and note lock in one place.
             addJudgementOffsetAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, referenceHitWindows.WindowFor(HitResult.Meh));
             addClickActionAssert(0, ClickAction.Hit);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -556,7 +556,96 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
-        public void TestOverlappingObjectsDontBlockEachOtherWhenFullyFadedOut()
+        public void TestOverlappingSlidersDontBlockEachOtherWhenFullyJudged()
+        {
+            const double time_first_slider = 1000;
+            const double time_second_slider = 1600;
+            Vector2 positionFirstSlider = new Vector2(100, 50);
+            Vector2 positionSecondSlider = new Vector2(100, 80);
+            var midpoint = (positionFirstSlider + positionSecondSlider) / 2;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new Slider
+                {
+                    StartTime = time_first_slider,
+                    Position = positionFirstSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                },
+                new Slider
+                {
+                    StartTime = time_second_slider,
+                    Position = positionSecondSlider,
+                    Path = new SliderPath(PathType.Linear, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(25, 0),
+                    })
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_slider, Position = midpoint, Actions = { OsuAction.RightButton } },
+                new OsuReplayFrame { Time = time_first_slider + 25, Position = midpoint },
+                // this frame doesn't do anything on lazer, but is REQUIRED for correct playback on stable,
+                // because stable during replay playback only updates game state _when it encounters a replay frame_
+                new OsuReplayFrame { Time = 1250, Position = midpoint },
+                new OsuReplayFrame { Time = time_second_slider + 50, Position = midpoint, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_second_slider + 75, Position = midpoint },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Ok);
+            addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
+            addJudgementAssert(hitObjects[1], HitResult.Ok);
+            addJudgementOffsetAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, 50);
+            addClickActionAssert(0, ClickAction.Hit);
+            addClickActionAssert(1, ClickAction.Hit);
+        }
+
+        [Test]
+        public void TestOverlappingHitCirclesDontBlockEachOtherWhenBothVisible()
+        {
+            const double time_first_circle = 1000;
+            const double time_second_circle = 1200;
+            Vector2 positionFirstCircle = new Vector2(100);
+            Vector2 positionSecondCircle = new Vector2(120);
+            var midpoint = (positionFirstCircle + positionSecondCircle) / 2;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new HitCircle
+                {
+                    StartTime = time_first_circle,
+                    Position = positionFirstCircle,
+                },
+                new HitCircle
+                {
+                    StartTime = time_second_circle,
+                    Position = positionSecondCircle,
+                },
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_first_circle, Position = midpoint, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_first_circle + 25, Position = midpoint },
+                new OsuReplayFrame { Time = time_first_circle + 50, Position = midpoint, Actions = { OsuAction.RightButton } },
+            });
+
+            addJudgementAssert(hitObjects[0], HitResult.Great);
+            addJudgementOffsetAssert(hitObjects[0], 0);
+
+            addJudgementAssert(hitObjects[1], HitResult.Meh);
+            addJudgementOffsetAssert(hitObjects[1], -150);
+        }
+
+        [Test]
+        public void TestOverlappingHitCirclesDontBlockEachOtherWhenFullyFadedOut()
         {
             const double time_first_circle = 1000;
             const double time_second_circle = 1200;
@@ -587,8 +676,10 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 new OsuReplayFrame { Time = time_first_circle, Position = positionFirstCircle, Actions = { OsuAction.LeftButton } },
                 new OsuReplayFrame { Time = time_first_circle + 50, Position = positionFirstCircle },
+                new OsuReplayFrame { Time = time_second_circle - 50, Position = positionSecondCircle },
                 new OsuReplayFrame { Time = time_second_circle, Position = positionSecondCircle, Actions = { OsuAction.LeftButton } },
                 new OsuReplayFrame { Time = time_second_circle + 50, Position = positionSecondCircle },
+                new OsuReplayFrame { Time = time_third_circle - 50, Position = positionFirstCircle },
                 new OsuReplayFrame { Time = time_third_circle, Position = positionFirstCircle, Actions = { OsuAction.LeftButton } },
                 new OsuReplayFrame { Time = time_third_circle + 50, Position = positionFirstCircle },
             });

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -74,6 +74,10 @@ namespace osu.Game.Rulesets.Osu.Mods
                     head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                     if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(head);
+
+                    if (ClassicNoteLock.Value)
+                        blockInputToObjectsUnderSliderHead(head);
+
                     break;
 
                 case DrawableSliderTail tail:
@@ -83,8 +87,25 @@ namespace osu.Game.Rulesets.Osu.Mods
                 case DrawableHitCircle circle:
                     if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(circle);
+
                     break;
             }
+        }
+
+        /// <summary>
+        /// On stable, slider heads that have already been hit block input from reaching objects that may be underneath them
+        /// until the sliders they're part of have been fully judged.
+        /// The purpose of this method is to restore that behaviour.
+        /// In order to avoid introducing yet another confusing config option, this behaviour is roped into the general notion of "note lock".
+        /// </summary>
+        private static void blockInputToObjectsUnderSliderHead(DrawableSliderHead slider)
+        {
+            var oldHitAction = slider.HitArea.Hit;
+            slider.HitArea.Hit = () =>
+            {
+                oldHitAction?.Invoke();
+                return !slider.DrawableSlider.AllJudged;
+            };
         }
 
         private void applyEarlyFading(DrawableHitCircle circle)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     case OsuAction.RightButton:
                         if (IsHovered && (Hit?.Invoke() ?? false))
                         {
-                            HitAction = e.Action;
+                            HitAction ??= e.Action;
                             return true;
                         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24626 (attempt no. 2).

(Attach expanding brain meme to description here)

The previous version was... [rather catastrophically wrong](https://github.com/ppy/osu/pull/24745). Upon closer investigation today I discovered that this was _even more_ specific of an edge case than I previously posited.

See, in [this method](https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameModes/Play/Rulesets/Ruleset.cs#L1466-L1497) on stable, `hitObject` can be one of three things: a hitcircle, a slider, or a spinner. If the object isn't yet hit, it absorbs the input. Now sliders become hit [only after they've been fully... slid](https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/HitObjects/Osu/SliderOsu.cs#L1687), which explains the reason why slider heads block input from reaching inputs underneath. But - as the new test cases, cross-checked against stable, are supposed to illustrate here - _normal hitcircles don't do this_. They become `IsHit` _immediately_. So it is _only_ slider heads that need this treatment, and they should _only_ block until they've been fully judged.

The following are the steps that have been taken to prevent https://github.com/ppy/osu/issues/24743 from happening again with this change:

- The test covering that regression added in https://github.com/ppy/osu/pull/24745 passes.
- Two other tests, covering various edge cases related to slider heads and hit circles, have been added to this pull, and cross-checked against stable by checking replays. (This is also how I learned that [stable relies on the presence of replay frames to run gameplay logic during replay playback](https://discord.com/channels/188630481301012481/188630652340404224/1149680732856389742).)
- Using a [replay dataset linked on osu!dev](https://discord.com/channels/188630481301012481/188630652340404224/1149655017960259685), I did a three-way (2023.908.0 vs 2023.908.1 vs this PR) check of 100 random replays using [this code](https://gist.github.com/bdach/b2c7277fae0cd1e68b10bdb33ebd15db), and have verified that with this branch, I get discrepancies that are no worse than 2023.908.1, i.e. post-revert. 2023.908.0 was, as could be expected, noticeably much worse than both. (You'd say that 100 replays is pitiful, but each 100 replay run took ~20 minutes to simulate on my pc. It was single-threaded, obviously, but still. Also note that I'm not saying that there are _no_ discrepancies because there are at least 2 other large issues we have to fix before we can even approach 100% correct.)
- The code no longer applies to normal hitcircles and only blocks input until the parenting slider is judged rather than unconditionally.
- Finally, I playtested this a bit using one map from [one of the user reports of this](https://github.com/ppy/osu/discussions/24744) and it seems fine. I'm trash though, so this shouldn't be taken for actual useful evidence.