### PR TITLE
Move mod overlay difficulty multiplier display to bottom of screen

### DIFF
--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -72,6 +72,7 @@ namespace osu.Game.Overlays.Mods
             const float shear = ShearedOverlayContainer.SHEAR;
 
             AutoSizeAxes = Axes.Both;
+
             InternalChild = content = new Container
             {
                 Origin = Anchor.BottomRight,
@@ -145,22 +146,10 @@ namespace osu.Game.Overlays.Mods
                                 Direction = FillDirection.Horizontal,
                                 Children = new[]
                                 {
-                                    circleSizeDisplay = new VerticalAttributeDisplay("CS")
-                                    {
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                    },
-                                    drainRateDisplay = new VerticalAttributeDisplay("HP")
-                                    {
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                    },
-                                    approachRateDisplay = new VerticalAttributeDisplay("AR")
-                                    {
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                    },
-                                    overallDifficultyDisplay = new VerticalAttributeDisplay("OD")
-                                    {
-                                        Shear = new Vector2(-ShearedOverlayContainer.SHEAR, 0),
-                                    },
+                                    circleSizeDisplay = new VerticalAttributeDisplay("CS") { Shear = new Vector2(-shear, 0), },
+                                    drainRateDisplay = new VerticalAttributeDisplay("HP") { Shear = new Vector2(-shear, 0), },
+                                    approachRateDisplay = new VerticalAttributeDisplay("AR") { Shear = new Vector2(-shear, 0), },
+                                    overallDifficultyDisplay = new VerticalAttributeDisplay("OD") { Shear = new Vector2(-shear, 0), },
                                 }
                             }
                         }

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Overlays.Mods
         {
             Current.Default = 1d;
             Current.Value = 1d;
+
             Add(new SpriteIcon
             {
                 Anchor = Anchor.CentreLeft,

--- a/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/DifficultyMultiplierDisplay.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osuTK;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Mods
@@ -13,21 +10,12 @@ namespace osu.Game.Overlays.Mods
     {
         protected override LocalisableString Label => DifficultyMultiplierDisplayStrings.DifficultyMultiplier;
 
-        protected override string CounterFormat => @"N2";
+        protected override string CounterFormat => @"0.0x";
 
         public DifficultyMultiplierDisplay()
         {
             Current.Default = 1d;
             Current.Value = 1d;
-
-            Add(new SpriteIcon
-            {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                Icon = FontAwesome.Solid.Times,
-                Size = new Vector2(7),
-                Margin = new MarginPadding { Top = 1 }
-            });
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Overlays/Mods/ModCounterDisplay.cs
+++ b/osu.Game/Overlays/Mods/ModCounterDisplay.cs
@@ -49,8 +49,6 @@ namespace osu.Game.Overlays.Mods
         /// </summary>
         protected abstract LocalisableString Label { get; }
 
-        protected virtual float ValueAreaWidth => 56;
-
         protected virtual string CounterFormat => @"N0";
 
         protected override Container<Drawable> Content => content;
@@ -59,7 +57,7 @@ namespace osu.Game.Overlays.Mods
 
         protected ModCounterDisplay()
         {
-            Height = HEIGHT;
+            Height = ShearedButton.HEIGHT;
             AutoSizeAxes = Axes.X;
 
             InternalChild = new InputBlockingContainer
@@ -75,8 +73,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         Anchor = Anchor.CentreRight,
                         Origin = Anchor.CentreRight,
-                        RelativeSizeAxes = Axes.Y,
-                        Width = ValueAreaWidth + ModSelectPanel.CORNER_RADIUS
+                        RelativeSizeAxes = Axes.Both,
                     },
                     new GridContainer
                     {
@@ -85,7 +82,7 @@ namespace osu.Game.Overlays.Mods
                         ColumnDimensions = new[]
                         {
                             new Dimension(GridSizeMode.AutoSize),
-                            new Dimension(GridSizeMode.Absolute, ValueAreaWidth)
+                            new Dimension(GridSizeMode.Absolute, 56)
                         },
                         Content = new[]
                         {

--- a/osu.Game/Overlays/Mods/ModCounterDisplay.cs
+++ b/osu.Game/Overlays/Mods/ModCounterDisplay.cs
@@ -67,6 +67,8 @@ namespace osu.Game.Overlays.Mods
                 Masking = true,
                 CornerRadius = ModSelectPanel.CORNER_RADIUS,
                 Shear = new Vector2(ShearedOverlayContainer.SHEAR, 0),
+                Anchor = Anchor.BottomRight,
+                Origin = Anchor.BottomRight,
                 Children = new Drawable[]
                 {
                     contentBackground = new Box

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -356,9 +356,9 @@ namespace osu.Game.Overlays.Mods
 
                 // this is cheating a bit; the 640 value is hardcoded based on how wide the expanded panel _generally_ is.
                 // due to the transition applied, the raw screenspace quad of the panel cannot be used, as it will trigger an ugly feedback cycle of expanding and collapsing.
-                float projectedLeftEdgeOfExpandedModEffectPreviewPanel = footerButtonFlow.ToScreenSpace(footerButtonFlow.DrawSize - new Vector2(640, 0)).X;
+                float projectedLeftEdgeOfExpandedBeatmapAttributesDisplay = footerButtonFlow.ToScreenSpace(footerButtonFlow.DrawSize - new Vector2(640, 0)).X;
 
-                bool screenIsntWideEnough = rightEdgeOfLastButton > projectedLeftEdgeOfExpandedModEffectPreviewPanel;
+                bool screenIsntWideEnough = rightEdgeOfLastButton > projectedLeftEdgeOfExpandedBeatmapAttributesDisplay;
 
                 // only update preview panel's collapsed state after we are fully visible, to ensure all the buttons are where we expect them to be.
                 if (Alpha == 1)

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -266,16 +266,16 @@ namespace osu.Game.Overlays.Mods
                     },
                     Children = new Drawable[]
                     {
-                        beatmapAttributesDisplay = new BeatmapAttributesDisplay
-                        {
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            BeatmapInfo = { Value = beatmap?.BeatmapInfo }
-                        },
                         multiplierDisplay = new DifficultyMultiplierDisplay
                         {
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight
+                        },
+                        beatmapAttributesDisplay = new BeatmapAttributesDisplay
+                        {
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+                            BeatmapInfo = { Value = beatmap?.BeatmapInfo }
                         },
                     }
                 });
@@ -350,8 +350,7 @@ namespace osu.Game.Overlays.Mods
 
             SearchTextBox.PlaceholderText = SearchTextBox.HasFocus ? Resources.Localisation.Web.CommonStrings.InputSearch : ModSelectOverlayStrings.TabToSearch;
 
-            // only update preview panel's collapsed state after we are fully visible, to ensure all the buttons are where we expect them to be.
-            if (beatmapAttributesDisplay != null && Alpha == 1)
+            if (beatmapAttributesDisplay != null)
             {
                 float rightEdgeOfLastButton = footerButtonFlow.Last().ScreenSpaceDrawQuad.TopRight.X;
 
@@ -361,12 +360,13 @@ namespace osu.Game.Overlays.Mods
 
                 bool screenIsntWideEnough = rightEdgeOfLastButton > projectedLeftEdgeOfExpandedModEffectPreviewPanel;
 
-                beatmapAttributesDisplay.Collapsed.Value = screenIsntWideEnough;
-                footerContentFlow.Direction = screenIsntWideEnough ? FillDirection.Vertical : FillDirection.Horizontal;
+                // only update preview panel's collapsed state after we are fully visible, to ensure all the buttons are where we expect them to be.
+                if (Alpha == 1)
+                    beatmapAttributesDisplay.Collapsed.Value = screenIsntWideEnough;
 
-                int layout = screenIsntWideEnough ? -1 : 1;
-                if (footerContentFlow.GetLayoutPosition(beatmapAttributesDisplay) != layout)
-                    footerContentFlow.SetLayoutPosition(beatmapAttributesDisplay, layout);
+                footerContentFlow.LayoutDuration = 200;
+                footerContentFlow.LayoutEasing = Easing.OutQuint;
+                footerContentFlow.Direction = screenIsntWideEnough ? FillDirection.Vertical : FillDirection.Horizontal;
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -355,9 +355,9 @@ namespace osu.Game.Overlays.Mods
             {
                 float rightEdgeOfLastButton = footerButtonFlow.Last().ScreenSpaceDrawQuad.TopRight.X;
 
-                // this is cheating a bit; the 375 value is hardcoded based on how wide the expanded panel _generally_ is.
+                // this is cheating a bit; the 640 value is hardcoded based on how wide the expanded panel _generally_ is.
                 // due to the transition applied, the raw screenspace quad of the panel cannot be used, as it will trigger an ugly feedback cycle of expanding and collapsing.
-                float projectedLeftEdgeOfExpandedModEffectPreviewPanel = footerButtonFlow.ToScreenSpace(footerButtonFlow.DrawSize - new Vector2(375 + 70, 0)).X;
+                float projectedLeftEdgeOfExpandedModEffectPreviewPanel = footerButtonFlow.ToScreenSpace(footerButtonFlow.DrawSize - new Vector2(640, 0)).X;
 
                 bool screenIsntWideEnough = rightEdgeOfLastButton > projectedLeftEdgeOfExpandedModEffectPreviewPanel;
 


### PR DESCRIPTION
In order to aid the user in knowing how their mod customisation is affecting the score multiplier, this needs to be displayed at the bottom of the screen.

This comes with a few layout change considerations. Applied in this PR:

- The flow of information now becomes vertical when it can't fit on the bottom line.

In upcoming PRs:

- The difficulty multiplier display's visuals will be updated to match the beatmap attribute display. This is a large-ish refactor, so will be a separate PR.
- ~~The mod search textbox feels like it could be merged with the header, rather than taking up a full line. Needs further investigation.~~ Dropping this for now. The design in figma doesn't match what we have at all, and attempting to get the search control to fit in the header is fruitless.

Addresses part of the usability concern in https://github.com/ppy/osu/issues/24674.

https://github.com/ppy/osu/assets/191335/b90ed481-6810-44d0-8d35-e7a0060256de

(video was taken with partial visual changes applied which are not in this PR)