### PR TITLE
Remove slider head circle movement (and remove setting from "classic" mod)

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -34,16 +34,16 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private int depthIndex;
 
-        private readonly BindableBool snakingIn = new BindableBool();
-        private readonly BindableBool snakingOut = new BindableBool();
+        private readonly BindableBool snakingIn = new BindableBool(true);
+        private readonly BindableBool snakingOut = new BindableBool(true);
 
         [SetUpSteps]
         public void SetUpSteps()
         {
-            AddToggleStep("toggle snaking", v =>
+            AddToggleStep("disable snaking", v =>
             {
-                snakingIn.Value = v;
-                snakingOut.Value = v;
+                snakingIn.Value = !v;
+                snakingOut.Value = !v;
             });
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -19,7 +19,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps.Legacy;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Judgements;
@@ -206,7 +205,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 StackHeight = 10
             };
 
-            return createDrawable(slider, 2, 2);
+            return createDrawable(slider, 2);
         }
 
         private Drawable testSimpleMedium(int repeats = 0) => createSlider(5, repeats: repeats);
@@ -229,6 +228,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             var slider = new Slider
             {
+                SliderVelocityMultiplier = speedMultiplier,
                 StartTime = Time.Current + time_offset,
                 Position = new Vector2(0, -(distance / 2)),
                 Path = new SliderPath(PathType.PerfectCurve, new[]
@@ -240,7 +240,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 StackHeight = stackHeight
             };
 
-            return createDrawable(slider, circleSize, speedMultiplier);
+            return createDrawable(slider, circleSize);
         }
 
         private Drawable testPerfect(int repeats = 0)
@@ -258,7 +258,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 RepeatCount = repeats,
             };
 
-            return createDrawable(slider, 2, 3);
+            return createDrawable(slider, 2);
         }
 
         private Drawable testLinear(int repeats = 0) => createLinear(repeats);
@@ -281,7 +281,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 RepeatCount = repeats,
             };
 
-            return createDrawable(slider, 2, 3);
+            return createDrawable(slider, 2);
         }
 
         private Drawable testBezier(int repeats = 0) => createBezier(repeats);
@@ -303,7 +303,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 RepeatCount = repeats,
             };
 
-            return createDrawable(slider, 2, 3);
+            return createDrawable(slider, 2);
         }
 
         private Drawable testLinearOverlapping(int repeats = 0) => createOverlapping(repeats);
@@ -326,7 +326,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 RepeatCount = repeats,
             };
 
-            return createDrawable(slider, 2, 3);
+            return createDrawable(slider, 2);
         }
 
         private Drawable testCatmull(int repeats = 0) => createCatmull(repeats);
@@ -352,15 +352,12 @@ namespace osu.Game.Rulesets.Osu.Tests
                 NodeSamples = repeatSamples
             };
 
-            return createDrawable(slider, 3, 1);
+            return createDrawable(slider, 3);
         }
 
-        private Drawable createDrawable(Slider slider, float circleSize, double speedMultiplier)
+        private Drawable createDrawable(Slider slider, float circleSize)
         {
-            var cpi = new LegacyControlPointInfo();
-            cpi.Add(0, new DifficultyControlPoint { SliderVelocity = speedMultiplier });
-
-            slider.ApplyDefaults(cpi, new BeatmapDifficulty
+            slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty
             {
                 CircleSize = circleSize,
                 SliderTickRate = 3

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
@@ -135,23 +135,14 @@ namespace osu.Game.Rulesets.Osu.Tests
         }
 
         [Test]
-        public void TestRepeatArrowDoesNotMoveWhenHit()
+        public void TestRepeatArrowDoesNotMove([Values] bool useAutoplay)
         {
-            AddStep("enable autoplay", () => autoplay = true);
+            AddStep($"set autoplay to {useAutoplay}", () => autoplay = useAutoplay);
             setSnaking(true);
             CreateTest();
             // repeat might have a chance to update its position depending on where in the frame its hit,
             // so some leniency is allowed here instead of checking strict equality
             addCheckPositionChangeSteps(() => 16600, getSliderRepeat, positionAlmostSame);
-        }
-
-        [Test]
-        public void TestRepeatArrowMovesWhenNotHit()
-        {
-            AddStep("disable autoplay", () => autoplay = false);
-            setSnaking(true);
-            CreateTest();
-            addCheckPositionChangeSteps(() => 16600, getSliderRepeat, positionDecreased);
         }
 
         private void retrieveSlider(int index)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderSnaking.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Tests
     public partial class TestSceneSliderSnaking : TestSceneOsuPlayer
     {
         [Resolved]
-        private AudioManager audioManager { get; set; }
+        private AudioManager audioManager { get; set; } = null!;
 
         protected override bool Autoplay => autoplay;
         private bool autoplay;
@@ -41,12 +39,12 @@ namespace osu.Game.Rulesets.Osu.Tests
         private readonly BindableBool snakingIn = new BindableBool();
         private readonly BindableBool snakingOut = new BindableBool();
 
-        private IBeatmap beatmap;
+        private IBeatmap beatmap = null!;
 
         private const double duration_of_span = 3605;
         private const double fade_in_modifier = -1200;
 
-        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard storyboard = null)
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
             => new ClockBackedTestWorkingBeatmap(this.beatmap = beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
 
         [BackgroundDependencyLoader]
@@ -57,15 +55,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             config.BindWith(OsuRulesetSetting.SnakingOutSliders, snakingOut);
         }
 
-        private Slider slider;
-        private DrawableSlider drawableSlider;
-
-        [SetUp]
-        public void Setup() => Schedule(() =>
-        {
-            slider = null;
-            drawableSlider = null;
-        });
+        private Slider slider = null!;
+        private DrawableSlider? drawableSlider;
 
         protected override bool HasCustomSteps => true;
 
@@ -150,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("retrieve slider at index", () => slider = (Slider)beatmap.HitObjects[index]);
             addSeekStep(() => slider.StartTime);
             AddUntilStep("retrieve drawable slider", () =>
-                (drawableSlider = (DrawableSlider)Player.DrawableRuleset.Playfield.AllHitObjects.SingleOrDefault(d => d.HitObject == slider)) != null);
+                (drawableSlider = (DrawableSlider?)Player.DrawableRuleset.Playfield.AllHitObjects.SingleOrDefault(d => d.HitObject == slider)) != null);
         }
 
         private void addEnsureSnakingInSteps(Func<double> startTime) => addCheckPositionChangeSteps(startTime, getSliderEnd, positionIncreased);
@@ -170,7 +161,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private Func<double> timeAtRepeat(Func<double> startTime, int repeatIndex) => () => startTime() + 100 + duration_of_span * repeatIndex;
         private Func<Vector2> positionAtRepeat(int repeatIndex) => repeatIndex % 2 == 0 ? getSliderStart : getSliderEnd;
 
-        private List<Vector2> getSliderCurve() => ((PlaySliderBody)drawableSlider.Body.Drawable).CurrentCurve;
+        private List<Vector2> getSliderCurve() => ((PlaySliderBody)drawableSlider!.Body.Drawable).CurrentCurve;
         private Vector2 getSliderStart() => getSliderCurve().First();
         private Vector2 getSliderEnd() => getSliderCurve().Last();
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -25,9 +25,6 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("No slider head accuracy requirement", "Scores sliders proportionally to the number of ticks hit.")]
         public Bindable<bool> NoSliderHeadAccuracy { get; } = new BindableBool(true);
 
-        [SettingSource("No slider head movement", "Pins slider heads at their starting position, regardless of time.")]
-        public Bindable<bool> NoSliderHeadMovement { get; } = new BindableBool(true);
-
         [SettingSource("Apply classic note lock", "Applies note lock to the full hit window.")]
         public Bindable<bool> ClassicNoteLock { get; } = new BindableBool(true);
 
@@ -71,7 +68,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (obj)
             {
                 case DrawableSliderHead head:
-                    head.TrackFollowCircle = !NoSliderHeadMovement.Value;
                     if (FadeHitCircleEarly.Value && !usingHiddenFading)
                         applyEarlyFading(head);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -228,7 +228,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             double completionProgress = Math.Clamp((Time.Current - HitObject.StartTime) / HitObject.Duration, 0, 1);
 
             Ball.UpdateProgress(completionProgress);
-            SliderBody?.UpdateProgress(completionProgress);
+            SliderBody?.UpdateProgress(HeadCircle.IsHit ? completionProgress : 0);
 
             foreach (DrawableHitObject hitObject in NestedHitObjects)
             {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -317,7 +317,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             switch (state)
             {
                 case ArmedState.Hit:
-                    if (SliderBody?.SnakingOut.Value == true)
+                    if (HeadCircle.IsHit && SliderBody?.SnakingOut.Value == true)
                         Body.FadeOut(40); // short fade to allow for any body colour to smoothly disappear.
                     break;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -3,11 +3,9 @@
 
 #nullable disable
 
-using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Scoring;
 
@@ -23,12 +21,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
         public override bool DisplayResult => HitObject?.JudgeAsNormalHitCircle ?? base.DisplayResult;
-
-        /// <summary>
-        /// Makes this <see cref="DrawableSliderHead"/> track the follow circle when the start time is reached.
-        /// If <c>false</c>, this <see cref="DrawableSliderHead"/> will be pinned to its initial position in the slider.
-        /// </summary>
-        public bool TrackFollowCircle = true;
 
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
@@ -62,23 +54,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             pathVersion.BindTo(DrawableSlider.PathVersion);
 
             CheckHittable = (d, t, r) => DrawableSlider.CheckHittable?.Invoke(d, t, r) ?? ClickAction.Hit;
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            Debug.Assert(Slider != null);
-            Debug.Assert(HitObject != null);
-
-            if (TrackFollowCircle)
-            {
-                double completionProgress = Math.Clamp((Time.Current - Slider.StartTime) / Slider.Duration, 0, 1);
-
-                //todo: we probably want to reconsider this before adding scoring, but it looks and feels nice.
-                if (!IsHit)
-                    Position = Slider.CurvePositionAt(completionProgress);
-            }
         }
 
         protected override HitResult ResultFor(double timeOffset)

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -46,22 +46,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             BorderSize = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderBorderSize)?.Value ?? 1;
             BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
-
-            drawableObject.HitObjectApplied += onHitObjectApplied;
-        }
-
-        private void onHitObjectApplied(DrawableHitObject obj)
-        {
-            var drawableSlider = (DrawableSlider)obj;
-            if (drawableSlider.HitObject == null)
-                return;
-
-            // When not tracking the follow circle, unbind from the config and forcefully disable snaking out - it looks better that way.
-            if (!drawableSlider.HeadCircle.TrackFollowCircle)
-            {
-                SnakingOut.UnbindFrom(configSnakingOut);
-                SnakingOut.Value = false;
-            }
         }
 
         protected virtual Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour) =>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24639.

I've gone with the most simple approach animation wise, which feels quite good to me: the snaking path will only begin snaking after the head circle is hit. I can see that others came to roughly the same consensus in the original discussion, so I don't think there will be too much contention over this change.

Things to note:

- I considered having the slider ball not appear until the head is hit, but I don't think a change like this would sit well as it would potentially reduce readability
- I intentionally made the snaking only happen on a successful hit. So if you miss the slider head completely, the outwards snaking will never complete. This could be a good visual cue.
- The original plan I had animation wise was to have the portion of path before the slider ball's current position fade out on slider head hit, but this would mean duplicating the slider path. And I don't think this is a good idea from a performance perspective for such an edge case.

Here's how it looks in slow motion:

https://github.com/ppy/osu/assets/191335/75931867-2890-47c7-b963-f553a0b6cc80

It's important to note that in the majority of cases, these kinds of sliders are so fast you can't even catch this visually. It's usually hidden under the head / tail. Even when it's not, it's hard to catch:

https://github.com/ppy/osu/assets/191335/82db9ea2-dd7a-485e-a4ae-45eaa959439b

Finally, here's what missing a slider head completely looks like:

https://github.com/ppy/osu/assets/191335/4bd0ffb4-bfa1-4cee-bd93-98e49c829762

(basically, as if snaking was not enabled)
