### PR TITLE
Add toggle in unstable rate counter skin element to convert unstable rate calculation based on rate change

### DIFF
--- a/osu.Game/Localisation/HUD/UnstableRateCounterStrings.cs
+++ b/osu.Game/Localisation/HUD/UnstableRateCounterStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation.HUD
+{
+    public static class UnstableRateCounterStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.HUD.UnstableRateCounterStrings";
+
+        /// <summary>
+        /// "Convert unstable rate"
+        /// </summary>
+        public static LocalisableString ConvertUnstableRate => new TranslatableString(getKey(@"convert_unstable_rate"), "Convert unstable rate");
+
+        /// <summary>
+        /// "Converts unstable rate according to rate changes"
+        /// </summary>
+        public static LocalisableString ConvertUnstableRateDescription => new TranslatableString(getKey(@"convert_unstable_rate_description"), "Converts unstable rate according to rate changes");
+
+        private static string getKey(string key) => $"{prefix}:{key}";
+    }
+}


### PR DESCRIPTION
Added toggle for unstable rate counter to be calculated according to rate changes from mods, instead of always being calculated based on the realtime standard deviation.
Here's some examples of how the toggle shows for the user, and it's effect in gameplay.
For the example I'll have both a unstable rate counter on the left with the toggle disabled (should work as it did before the implementation) and a counter on the right with the toggle enabled

https://github.com/ppy/osu/assets/41023844/33495622-2d90-4f7b-959c-3cec97fef010


https://github.com/ppy/osu/assets/41023844/89322de1-4ab1-4906-87df-b53a4ce0a6e1


https://github.com/ppy/osu/assets/41023844/df5be053-480d-4801-940c-d4066888be28


Currently both in stable and in lazer unstable rate calculations are made according to the realtime deviation (which is what is supposed to), but most people prefer to calculate that deviation according do the rate change from mods like DoubleTime, as seen in most scoreposts of DoubleTime scores, with some examples at the end.
https://www.reddit.com/r/osugame/comments/y61apq/mrekk_kasai_harcores_cycle_hit_home_run_hddt/ https://www.reddit.com/r/osugame/comments/14li1dn/sytho_07th_expansion_rogunlimitation_angelhoney/ 
It's probably something most future lazer streamers would prefere, as most people already convert unstable rate when talking about DT, and will probably become more complicated (and thus request something of the sort) with rate changes now not being limited to 0.75x or 1.5x.