### PR TITLE
Parse only supported schemes as URIs

### DIFF
--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -32,8 +32,17 @@ namespace osu.Game.Tests.Chat
             Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a gopher://really-old-protocol we don't support." });
 
             Assert.AreEqual(result.Content, result.DisplayContent);
-            Assert.AreEqual(1, result.Links.Count);
-            Assert.AreEqual("gopher://really-old-protocol", result.Links[0].Url);
+            Assert.AreEqual(0, result.Links.Count);
+        }
+
+        [Test]
+        public void TestSupportedProtocolLinkParsing()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "forgotspacehttps://dev.ppy.sh joinmyosump://12345 jointheosu://chan/#english" });
+
+            Assert.AreEqual("https://dev.ppy.sh", result.Links[0].Url);
+            Assert.AreEqual("osump://12345", result.Links[1].Url);
+            Assert.AreEqual("osu://chan/#english", result.Links[2].Url);
         }
 
         [Test]

--- a/osu.Game.Tests/Chat/MessageFormatterTests.cs
+++ b/osu.Game.Tests/Chat/MessageFormatterTests.cs
@@ -36,6 +36,15 @@ namespace osu.Game.Tests.Chat
         }
 
         [Test]
+        public void TestFakeProtocolLink()
+        {
+            Message result = MessageFormatter.FormatMessage(new Message { Content = "This is a osunotarealprotocol://completely-made-up-protocol we don't support." });
+
+            Assert.AreEqual(result.Content, result.DisplayContent);
+            Assert.AreEqual(0, result.Links.Count);
+        }
+
+        [Test]
         public void TestSupportedProtocolLinkParsing()
         {
             Message result = MessageFormatter.FormatMessage(new Message { Content = "forgotspacehttps://dev.ppy.sh joinmyosump://12345 jointheosu://chan/#english" });

--- a/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatLink.cs
@@ -64,6 +64,9 @@ namespace osu.Game.Tests.Visual.Online
             addMessageWithChecks("test!");
             addMessageWithChecks("dev.ppy.sh!");
             addMessageWithChecks("https://dev.ppy.sh!", 1, expectedActions: LinkAction.External);
+            addMessageWithChecks("http://dev.ppy.sh!", 1, expectedActions: LinkAction.External);
+            addMessageWithChecks("forgothttps://dev.ppy.sh!", 1, expectedActions: LinkAction.External);
+            addMessageWithChecks("forgothttp://dev.ppy.sh!", 1, expectedActions: LinkAction.External);
             addMessageWithChecks("00:12:345 (1,2) - Test?", 1, expectedActions: LinkAction.OpenEditorTimestamp);
             addMessageWithChecks("Wiki link for tasty [[Performance Points]]", 1, expectedActions: LinkAction.OpenWiki);
             addMessageWithChecks("(osu forums)[https://dev.ppy.sh/forum] (old link format)", 1, expectedActions: LinkAction.External);
@@ -84,9 +87,11 @@ namespace osu.Game.Tests.Visual.Online
             addMessageWithChecks("feels important", 0, true, true);
             addMessageWithChecks("likes to post this [https://dev.ppy.sh/home link].", 1, true, true, expectedActions: LinkAction.External);
             addMessageWithChecks("Join my multiplayer game osump://12346.", 1, expectedActions: LinkAction.JoinMultiplayerMatch);
+            addMessageWithChecks("Join my multiplayer gameosump://12346.", 1, expectedActions: LinkAction.JoinMultiplayerMatch);
             addMessageWithChecks("Join my [multiplayer game](osump://12346).", 1, expectedActions: LinkAction.JoinMultiplayerMatch);
             addMessageWithChecks($"Join my [#english]({OsuGameBase.OSU_PROTOCOL}chan/#english).", 1, expectedActions: LinkAction.OpenChannel);
             addMessageWithChecks($"Join my {OsuGameBase.OSU_PROTOCOL}chan/#english.", 1, expectedActions: LinkAction.OpenChannel);
+            addMessageWithChecks($"Join my{OsuGameBase.OSU_PROTOCOL}chan/#english.", 1, expectedActions: LinkAction.OpenChannel);
             addMessageWithChecks("Join my #english or #japanese channels.", 2, expectedActions: new[] { LinkAction.OpenChannel, LinkAction.OpenChannel });
             addMessageWithChecks("Join my #english or #nonexistent #hashtag channels.", 1, expectedActions: LinkAction.OpenChannel);
             addMessageWithChecks("Hello world\uD83D\uDE12(<--This is an emoji). There are more:\uD83D\uDE10\uD83D\uDE00,\uD83D\uDE20");

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Online.Chat
         //      http[s]://<domain>.<tld>[:port][/path][?query][#fragment]
         private static readonly Regex advanced_link_regex = new Regex(
             // protocol
-            @"(?<link>(https?|osu)[a-z]*?://" +
+            @"(?<link>(https?|osu)[a-z]*?:\/\/" +
             // domain + tld
             @"(?<domain>(?:[a-z0-9]\.|[a-z0-9][a-z0-9-]*[a-z0-9]\.)*[a-z0-9-]*[a-z0-9]" +
             // port (optional)

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Online.Chat
         //      http[s]://<domain>.<tld>[:port][/path][?query][#fragment]
         private static readonly Regex advanced_link_regex = new Regex(
             // protocol
-            @"(?<link>[a-z]*?:\/\/" +
+            @"(?<link>(https?|osu)[a-z]*?://" +
             // domain + tld
             @"(?<domain>(?:[a-z0-9]\.|[a-z0-9][a-z0-9-]*[a-z0-9]\.)*[a-z0-9-]*[a-z0-9]" +
             // port (optional)

--- a/osu.Game/Online/Chat/MessageFormatter.cs
+++ b/osu.Game/Online/Chat/MessageFormatter.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Online.Chat
         //      http[s]://<domain>.<tld>[:port][/path][?query][#fragment]
         private static readonly Regex advanced_link_regex = new Regex(
             // protocol
-            @"(?<link>(https?|osu)[a-z]*?:\/\/" +
+            @"(?<link>(https?|osu(mp)?):\/\/" +
             // domain + tld
             @"(?<domain>(?:[a-z0-9]\.|[a-z0-9][a-z0-9-]*[a-z0-9]\.)*[a-z0-9-]*[a-z0-9]" +
             // port (optional)


### PR DESCRIPTION
Fixes #22952 

Before:
![image](https://github.com/ppy/osu/assets/48604271/a2f733c9-5109-40e1-b568-4bb02b3308b5)
![image](https://github.com/ppy/osu/assets/48604271/2d35d06a-acd9-474c-8357-a517e4c8bb26)

After:
![image](https://github.com/ppy/osu/assets/48604271/b1084a5b-e73d-47f6-ac8b-1b1b4830958d)
![image](https://github.com/ppy/osu/assets/48604271/82058b4f-6673-4b85-9ff3-052104c4c3b2)
