### PR TITLE
Refactor scoring test scene for ruleset extensibility (and move existing instance to osu! ruleset project)

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneScoring.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneScoring.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Beatmaps;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Scoring;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Tests.Visual.Gameplay;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    [TestFixture]
+    public partial class TestSceneScoring : ScoringTestScene
+    {
+        protected override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor();
+
+        protected override IBeatmap CreateBeatmap(int maxCombo)
+        {
+            var beatmap = new OsuBeatmap();
+            for (int i = 0; i < maxCombo; i++)
+                beatmap.HitObjects.Add(new HitCircle());
+            return beatmap;
+        }
+
+        protected override JudgementResult CreatePerfectJudgementResult() => new OsuJudgementResult(new HitCircle(), new OsuJudgement()) { Type = HitResult.Great };
+        protected override JudgementResult CreateNonPerfectJudgementResult() => new OsuJudgementResult(new HitCircle(), new OsuJudgement()) { Type = HitResult.Ok };
+        protected override JudgementResult CreateMissJudgementResult() => new OsuJudgementResult(new HitCircle(), new OsuJudgement()) { Type = HitResult.Miss };
+    }
+}

--- a/osu.Game/Tests/Visual/Gameplay/ScoringTestScene.cs
+++ b/osu.Game/Tests/Visual/Gameplay/ScoringTestScene.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -13,6 +12,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -36,6 +36,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         protected abstract IScoringAlgorithm CreateScoreV2(int maxCombo);
         protected abstract ProcessorBasedScoringAlgorithm CreateScoreAlgorithm(IBeatmap beatmap, ScoringMode mode);
 
+        protected Bindable<int> MaxCombo => sliderMaxCombo.Current;
+        protected BindableList<double> NonPerfectLocations => graphs.NonPerfectLocations;
+        protected BindableList<double> MissLocations => graphs.MissLocations;
+
         private GraphContainer graphs = null!;
         private SettingsSlider<int> sliderMaxCombo = null!;
         private SettingsCheckbox scaleToMax = null!;
@@ -50,8 +54,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        [Test]
-        public void TestBasic()
+        [SetUpSteps]
+        public void SetUpSteps()
         {
             AddStep("setup tests", () =>
             {
@@ -130,24 +134,24 @@ namespace osu.Game.Tests.Visual.Gameplay
                     }
                 };
 
-                sliderMaxCombo.Current.BindValueChanged(_ => rerun());
-                scaleToMax.Current.BindValueChanged(_ => rerun());
+                sliderMaxCombo.Current.BindValueChanged(_ => Rerun());
+                scaleToMax.Current.BindValueChanged(_ => Rerun());
 
                 standardisedVisible.BindValueChanged(_ => rescalePlots());
                 classicVisible.BindValueChanged(_ => rescalePlots());
                 scoreV1Visible.BindValueChanged(_ => rescalePlots());
                 scoreV2Visible.BindValueChanged(_ => rescalePlots());
 
-                graphs.MissLocations.BindCollectionChanged((_, __) => rerun());
-                graphs.NonPerfectLocations.BindCollectionChanged((_, __) => rerun());
+                graphs.MissLocations.BindCollectionChanged((_, __) => Rerun());
+                graphs.NonPerfectLocations.BindCollectionChanged((_, __) => Rerun());
 
                 graphs.MaxCombo.BindTo(sliderMaxCombo.Current);
 
-                rerun();
+                Rerun();
             });
         }
 
-        private void rerun()
+        protected void Rerun()
         {
             graphs.Clear();
             legend.Clear();


### PR DESCRIPTION
Continuation of preparation for https://github.com/ppy/osu/issues/23763

To work with the classic scoring algorithm, I want to get all rulesets under test coverage similar to the one we already had in `TestSceneScoring`. As it turns out after some checking I did on Wednesday, rulesets do wildly diverge in scoring behaviour, so I do believe that this wasn't a fruitless endeavour.

To prepare for the above, this PR refactors a base class for the scoring tests that shall live in `osu.Game`, and moves the existing instance from `osu.Game.Tests` to `osu.Game.Rulesets.Osu.Tests` (since it was really ever testing osu!-the-ruleset scoring anyways).

In the end I decided to implement each score calculation independently and not reuse `LegacyScoreSimulator`s. That is mostly because the two have different goals and different levels of detail; the simulators are mostly concerned with perfect scores only, but handle all object types, while the scoring-test-local implementatons are concerned with non-perfect scoring too, but generally only handle the main object types (osu! hitcircle / taiko hit / catch fruit / mania note). That's because I don't think accurate replication there matters; classic scoring isn't going to match score V1 anyhow because of the constraints we placed on it (must be derived from standardised and not reorder scores), so the goal is to get the ballpark roughly correct.

Aside from the refactoring, this also adds some extra bells & whistles, such as being able to set particular scenarios via test steps, as well as adjust the `SliderMultiplier` constant on-the-fly (previously hardcoded to convenient value).

![1694776822](https://github.com/ppy/osu/assets/20418176/37afb4a7-10f9-4379-98c7-9d4358756d81)

Apologies for the LoC here, but this should make it much easier to review subsequent changes.

## Testing resources

[osu-scoring-resources.zip](https://github.com/ppy/osu/files/12618703/osu-scoring-resources.zip) contains a bunch of files, namely:

- `.osu` files that are beatmaps with particular test cases (all containing 100 objects)
- `.osr` files that correspond to replays set on beatmaps with the same name
- `.txt` files containing extracts of stable total score after each judgement to cross-check.

Six different test cases are provided:

- perfect score:
  - `ScoreV1Perfect`
  - `ScoreV2Perfect`
- score with misses:
  - `ScoreV1MissesAt25And50`
  - `ScoreV2MissesAt25And50`
- score with misses and 100s:
  - `ScoreV1MissesAnd100s`
  - `ScoreV2MissesAnd100s`

which correspond to the test steps added to the scene. For cross-referencing, set `ScoreMultiplier = 3` in the test.

Stable code for reference:

- Score V1: https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameModes/Play/Rulesets/Ruleset.cs#L1117-L1119
- Score V2: https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/GameplayElements/Scoring/Processors/ScoreProcessorOsu.cs