### PR TITLE
Fix dummy beatmap showing AR 5 on song select

### DIFF
--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -36,9 +36,10 @@ namespace osu.Game.Beatmaps
                 BeatmapSet = new BeatmapSetInfo(),
                 Difficulty = new BeatmapDifficulty
                 {
-                    DrainRate = 0,
                     CircleSize = 0,
+                    DrainRate = 0,
                     OverallDifficulty = 0,
+                    ApproachRate = 0,
                 },
                 Ruleset = new DummyRuleset().RulesetInfo
             }, audio)


### PR DESCRIPTION
Noticed when trying to make difficulty settings modular (already have it working, just need to clean up some code before PRing):

https://github.com/ppy/osu/blob/1ae8665a08854d7e34ba217cc2b5569a443be98b/osu.Game/Screens/Select/Details/AdvancedStats.cs#L132-L133

![osu!_nYQolbTtma](https://github.com/ppy/osu/assets/35318437/80355a86-4f5e-4855-b58b-890c159092f4)