### PR TITLE
Fix `MemoryStreamArchiveReader.GetStream()` failing in some cases

### DIFF
--- a/osu.Game/IO/Archives/MemoryStreamArchiveReader.cs
+++ b/osu.Game/IO/Archives/MemoryStreamArchiveReader.cs
@@ -19,7 +19,7 @@ namespace osu.Game.IO.Archives
             this.stream = stream;
         }
 
-        public override Stream GetStream(string name) => new MemoryStream(stream.GetBuffer(), 0, (int)stream.Length);
+        public override Stream GetStream(string name) => new MemoryStream(stream.ToArray(), 0, (int)stream.Length);
 
         public override void Dispose()
         {


### PR DESCRIPTION
`MemoryStreamArchiveReader` introduced in 0657b551964986fc5504a202eaa5e699d1c72f00 would previously use `MemoryStream.GetBuffer()` to retrieve the underlying byte buffer with stream data. However, this is not generally the method you would want, for two reasons:

1. It can fail if the stream wasn't created in the way that supports it.
2. As per [docs](https://learn.microsoft.com/en-us/dotnet/api/system.io.memorystream.getbuffer?view=net-7.0#system-io-memorystream-getbuffer), it will return the _raw_ contents of the buffer, including potentially unused bytes.

To fix, use `MemoryStream.ToArray()` instead, which avoids both pitfalls. Notably, `ToArray()` always returns the full contents of the buffer, regardless of `Position`, [as per documentation](https://learn.microsoft.com/en-us/dotnet/api/system.io.memorystream.toarray?view=net-7.0#system-io-memorystream-toarray).