### PR TITLE
Fix crash when loading player instance without exiting previous instance

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneAllRulesetPlayers.cs
@@ -67,6 +67,11 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private Player loadPlayerFor(RulesetInfo rulesetInfo)
         {
+            // if a player screen is present already, we must exit that before loading another one,
+            // otherwise it'll crash on SpectatorClient.BeginPlaying being called while client is in "playing" state already.
+            if (Stack.CurrentScreen is Player)
+                Stack.Exit();
+
             Ruleset.Value = rulesetInfo;
             var ruleset = rulesetInfo.CreateInstance();
 

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -12,6 +12,7 @@ using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual
 {
@@ -79,6 +80,11 @@ namespace osu.Game.Tests.Visual
 
         protected void LoadPlayer(Mod[] mods)
         {
+            // if a player screen is present already, we must exit that before loading another one,
+            // otherwise it'll crash on SpectatorClient.BeginPlaying being called while client is in "playing" state already.
+            if (Stack.CurrentScreen is Player)
+                Stack.Exit();
+
             var ruleset = CreatePlayerRuleset();
             Ruleset.Value = ruleset.RulesetInfo;
 


### PR DESCRIPTION
I tend to reload player by only clicking on the "load player" step, but that crashes with the following:
```
System.InvalidOperationException: Cannot invoke BeginPlaying when already playing
   at osu.Game.Online.Spectator.SpectatorClient.<>c__DisplayClass41_0.<BeginPlaying>b__0() in /Users/salman/Projects/osu/osu.Game/Online/Spectator/SpectatorClient.cs:line 183
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
```

That got annoying over time so decided it must be better to at least let the load step automatically quit the previous player instance so that `EndPlaying` is called before loading another player instance.