### PR TITLE
Adjust beatmap card thumbnail dim state to match web better

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 {
     public abstract partial class BeatmapCard : OsuClickableContainer, IHasContextMenu
     {
-        public const float TRANSITION_DURATION = 400;
+        public const float TRANSITION_DURATION = 340;
         public const float CORNER_RADIUS = 10;
 
         protected const float WIDTH = 430;

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -3,15 +3,15 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps.Drawables.Cards.Buttons;
-using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Framework.Graphics.UserInterface;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.Drawables.Cards
 {
@@ -25,7 +25,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             set => foreground.Padding = value;
         }
 
-        private readonly UpdateableOnlineBeatmapSetCover cover;
+        private readonly Box background;
         private readonly Container foreground;
         private readonly PlayButton playButton;
         private readonly CircularProgress progress;
@@ -33,14 +33,21 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         protected override Container<Drawable> Content => content;
 
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
         public BeatmapCardThumbnail(APIBeatmapSet beatmapSetInfo)
         {
             InternalChildren = new Drawable[]
             {
-                cover = new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
+                new UpdateableOnlineBeatmapSetCover(BeatmapSetCoverType.List)
                 {
                     RelativeSizeAxes = Axes.Both,
                     OnlineInfo = beatmapSetInfo
+                },
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
                 },
                 foreground = new Container
                 {
@@ -68,7 +75,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load()
         {
             progress.Colour = colourProvider.Highlight1;
         }
@@ -89,7 +96,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             bool shouldDim = Dimmed.Value || playButton.Playing.Value;
 
             playButton.FadeTo(shouldDim ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
-            cover.FadeColour(shouldDim ? OsuColour.Gray(0.2f) : Color4.White, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            background.FadeColour(colourProvider.Background6.Opacity(shouldDim ? 0.8f : 0f), BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
         }
     }
 }


### PR DESCRIPTION
As discussed on stream.

| before | after |
| :-: | :-: |
| ![before](https://github.com/ppy/osu/assets/20418176/e04b2b5d-4cf9-43e3-825c-fa2cfbb8503a) | ![after](https://github.com/ppy/osu/assets/20418176/8e31280b-2d70-4848-a576-5d1d647bd7d1) |

Relevant web-side css rule: https://github.com/ppy/osu-web/blob/7904e96e734382f9e1daf47684cb6f3093195f3d/resources/css/bem/beatmapset-panel.less#L9