### PR TITLE
Fix issues after storyboard resource lookup refactor

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -142,14 +142,32 @@ namespace osu.Game.Storyboards.Drawables
             public void Dispose() =>
                 realmFileStore.Dispose();
 
-            public byte[] Get(string name) =>
-                realmFileStore.Get(storyboard.GetStoragePathFromStoryboardPath(name));
+            public byte[] Get(string name)
+            {
+                string? storagePath = storyboard.GetStoragePathFromStoryboardPath(name);
 
-            public Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken()) =>
-                realmFileStore.GetAsync(storyboard.GetStoragePathFromStoryboardPath(name), cancellationToken);
+                return string.IsNullOrEmpty(storagePath)
+                    ? null!
+                    : realmFileStore.Get(storagePath);
+            }
 
-            public Stream GetStream(string name) =>
-                realmFileStore.GetStream(storyboard.GetStoragePathFromStoryboardPath(name));
+            public Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+            {
+                string? storagePath = storyboard.GetStoragePathFromStoryboardPath(name);
+
+                return string.IsNullOrEmpty(storagePath)
+                    ? Task.FromResult<byte[]>(null!)
+                    : realmFileStore.GetAsync(storagePath, cancellationToken);
+            }
+
+            public Stream? GetStream(string name)
+            {
+                string? storagePath = storyboard.GetStoragePathFromStoryboardPath(name);
+
+                return string.IsNullOrEmpty(storagePath)
+                    ? null
+                    : realmFileStore.GetStream(storagePath);
+            }
 
             public IEnumerable<string> GetAvailableResources() =>
                 realmFileStore.GetAvailableResources();

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -29,12 +29,7 @@ namespace osu.Game.Storyboards.Drawables
         [BackgroundDependencyLoader(true)]
         private void load(IBindable<WorkingBeatmap> beatmap, TextureStore textureStore)
         {
-            string? path = beatmap.Value.BeatmapSetInfo?.GetPathForFile(Video.Path);
-
-            if (path == null)
-                return;
-
-            var stream = textureStore.GetStream(path);
+            var stream = textureStore.GetStream(Video.Path);
 
             if (stream == null)
                 return;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24862

Two regressions from https://github.com/ppy/osu/pull/24809:

## [Fix `StoryboardResourceLookupStore` dying on failure to unmap path](https://github.com/ppy/osu/commit/ba518e1da8442d8aaf17a235d227a394f077689e)

Before the introduction of `StoryboardResourceLookupStore`, missing files would softly fail by use of null fallbacks:

https://github.com/ppy/osu/blob/4a7d7c6ed96a1208841d9dea928078e424b71c40/osu.Game/Storyboards/Storyboard.cs#L116-L119

After the aforementioned class was added, however, the fallbacks would not work anymore if for whatever reason `GetStoragePathFromStoryboardPath()` failed to unmap the storyboard asset name to a storage path.

While that helped unearth the _other_ regression (more about that in a second) by making it more loud, it's probably not something we want around due to reliability reasons.

## [Fix `DrawableStoryboardVideo` attempting to unmap path once too much](https://github.com/ppy/osu/commit/641e651bf282aeeb11050756e63e3a98cc136bf9)

The `StoryboardResourceLookupStore` cached at storyboard level is supposed to already be handling that; no need for local logic anymore.

This is a baffling oversight on my part since the OP of the original PR mentioned the weird `DrawableStoryboardVideo` logic _explicitly_, but then I failed to spot that the PR was nto touching that class at all. Or test storyboards with videos. (I did test storyboards, but _only_ ones without videos.........)