### PR TITLE
Fix broken automatic beatmap download setting migration

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -64,6 +64,12 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.Username, string.Empty);
             SetDefault(OsuSetting.Token, string.Empty);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+            // this default set MUST remain despite the setting being deprecated, because `SetDefault()` calls are implicitly used to declare the type returned for the lookup.
+            // if this is removed, the setting will be interpreted as a string, and `Migrate()` will fail due to cast failure.
+            // can be removed 20240618
+            SetDefault(OsuSetting.AutomaticallyDownloadWhenSpectating, false);
+#pragma warning restore CS0618 // Type or member is obsolete
             SetDefault(OsuSetting.AutomaticallyDownloadMissingBeatmaps, false);
 
             SetDefault(OsuSetting.SavePassword, false).ValueChanged += enabled =>
@@ -218,7 +224,7 @@ namespace osu.Game.Configuration
             if (combined < 20230918)
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                SetValue(OsuSetting.AutomaticallyDownloadMissingBeatmaps, Get<OsuSetting>(OsuSetting.AutomaticallyDownloadWhenSpectating)); // can be removed 20240618
+                SetValue(OsuSetting.AutomaticallyDownloadMissingBeatmaps, Get<bool>(OsuSetting.AutomaticallyDownloadWhenSpectating)); // can be removed 20240618
 #pragma warning restore CS0618 // Type or member is obsolete
             }
         }


### PR DESCRIPTION
Reported via pp server.

Note to self: test obvious logic, especially if it's migration logic.

Can be tested by setting `Version = 2023.917.0` in development config. (Or by running in release config, but don't.)