### PR TITLE
Fix `TestFriendScore` intermittently failing due to randomness 

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -6,7 +6,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.PolygonExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -161,10 +160,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             int playerNumber = 1;
 
             AddRepeatStep("add 3 other players", () => createRandomScore(new APIUser { Username = $"Player {playerNumber++}" }), 3);
-            AddUntilStep("there are no pink color score", () => leaderboard.ChildrenOfType<Box>().All(b => b.Colour != Color4Extensions.FromHex("ff549a")));
+            AddUntilStep("no pink color scores",
+                () => leaderboard.ChildrenOfType<Box>().Select(b => ((Colour4)b.Colour).ToHex()),
+                () => Does.Not.Contain("#FF549A"));
 
             AddRepeatStep("add 3 friend score", () => createRandomScore(friend), 3);
-            AddUntilStep("there are pink color for friend score", () => leaderboard.GetScoreByUsername("my friend").ChildrenOfType<Box>().Any(b => b.Colour == Color4Extensions.FromHex("ff549a")));
+            AddUntilStep("friend score is pink",
+                () => leaderboard.GetScoreByUsername("my friend").ChildrenOfType<Box>().Select(b => ((Colour4)b.Colour).ToHex()),
+                () => Does.Contain("#FF549A"));
         }
 
         private void addLocalPlayer()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayLeaderboard.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
@@ -165,8 +166,10 @@ namespace osu.Game.Tests.Visual.Gameplay
                 () => Does.Not.Contain("#FF549A"));
 
             AddRepeatStep("add 3 friend score", () => createRandomScore(friend), 3);
-            AddUntilStep("friend score is pink",
-                () => leaderboard.GetScoreByUsername("my friend").ChildrenOfType<Box>().Select(b => ((Colour4)b.Colour).ToHex()),
+            AddUntilStep("at least one friend score is pink",
+                () => leaderboard.GetAllScoresForUsername("my friend")
+                                 .SelectMany(score => score.ChildrenOfType<Box>())
+                                 .Select(b => ((Colour4)b.Colour).ToHex()),
                 () => Does.Contain("#FF549A"));
         }
 
@@ -211,10 +214,8 @@ namespace osu.Game.Tests.Visual.Gameplay
                 return scoreItem != null && scoreItem.ScorePosition == expectedPosition;
             }
 
-            public GameplayLeaderboardScore GetScoreByUsername(string username)
-            {
-                return Flow.FirstOrDefault(i => i.User?.Username == username);
-            }
+            public IEnumerable<GameplayLeaderboardScore> GetAllScoresForUsername(string username)
+                => Flow.Where(i => i.User?.Username == username);
         }
     }
 }


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/6264424208/job/17011092348#step:5:24

## [Rewrite `TestFriendScore` assertions to constraint model](https://github.com/ppy/osu/commit/9301a1907abdc0f97bc5f7486fb55aea20e61e3a)

Allows to clearly see what the failure is:

	TearDown : System.TimeoutException : "friend score is pink" timed out: Expected: some item equal to "#FF549A"
	  But was:  < "#FFFFFF", "#7FCC33", "#444444" >

The `#7FCC33` colour is used for the first score on the leaderboard.

## [Fix `TestFriendScore` intermittently failing due to randomness](https://github.com/ppy/osu/commit/e45d45632421c1091a93428b824f65f06a943cbc)

If `createRandomScore()` happened to randomly pick the highest total score when called with `friend` as the sole argument, that particular scoreboard panel would not be pink.

`GetScoreByUsername()` would arbitrarily pick the first scoreboard panel for the user, so in this particular case where a friend had the number 1 score, the test would wrongly fail.

Fix by checking whether any of the 3 added friend scoreboard panels have received the pink colour. Because there is more than 1 friend score in the test, doing so ensures that at least one of those should eventually become pink (because, obviously, you can't have two scores at number 1).

---

@cdwcgt Please read this PR description, understand the failure, and make sure to draw your conclusions from it for future contributions.