### PR TITLE
Fix game crash when using "Bubbles" mod on a beatmap with no hit circles

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
@@ -61,11 +61,11 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
+            OsuHitObject firstObject = drawableRuleset.Beatmap.HitObjects.Where(o => o is Spinner || o is Slider || o is HitCircle).First();
             // Multiplying by 2 results in an initial size that is too large, hence 1.90 has been chosen
             // Also avoids the HitObject bleeding around the edges of the bubble drawable at minimum size
-            bubbleSize = (float)(drawableRuleset.Beatmap.HitObjects.OfType<HitCircle>().First().Radius * 1.90f);
-            bubbleFade = drawableRuleset.Beatmap.HitObjects.OfType<HitCircle>().First().TimePreempt * 2;
-
+            bubbleSize = (float)firstObject.Radius * 1.90f;
+            bubbleFade = firstObject.TimePreempt * 2;
             // We want to hide the judgements since they are obscured by the BubbleDrawable (due to layering)
             drawableRuleset.Playfield.DisplayJudgements.Value = false;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBubbles.cs
@@ -61,11 +61,13 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            OsuHitObject firstObject = drawableRuleset.Beatmap.HitObjects.Where(o => o is Spinner || o is Slider || o is HitCircle).First();
+            OsuHitObject firstObject = drawableRuleset.Beatmap.HitObjects.First();
+
             // Multiplying by 2 results in an initial size that is too large, hence 1.90 has been chosen
             // Also avoids the HitObject bleeding around the edges of the bubble drawable at minimum size
             bubbleSize = (float)firstObject.Radius * 1.90f;
             bubbleFade = firstObject.TimePreempt * 2;
+
             // We want to hide the judgements since they are obscured by the BubbleDrawable (due to layering)
             drawableRuleset.Playfield.DisplayJudgements.Value = false;
 


### PR DESCRIPTION
Fixes bubbles mod crashing when no HitCircle is placed in a map like in Issue #24444

First PR tell me if you want me to change anything