### PR TITLE
Fix OAuth refresh attempt when no network available causing full logout

### DIFF
--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -99,9 +99,14 @@ namespace osu.Game.Online.API
                     return true;
                 }
             }
+            catch (HttpRequestException)
+            {
+                // Network failure.
+                return false;
+            }
             catch
             {
-                //todo: potentially only kill the refresh token on certain exception types.
+                // Force a full re-reauthentication.
                 Token.Value = null;
                 return false;
             }


### PR DESCRIPTION
Would show "Missing password" because we don't store password, but this is due to incorrect handling of socket exceptions.

Closes #24890.

To test the network failure path:

```diff
diff --git a/osu.Game/Online/API/OAuth.cs b/osu.Game/Online/API/OAuth.cs
index 1f26ab5458..c12fbbaa61 100644
--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -120,13 +120,13 @@ internal bool AuthenticateWithRefresh(string refresh)
         private bool ensureAccessToken()
         {
             // if we already have a valid access token, let's use it.
-            if (accessTokenValid) return true;
+            // if (accessTokenValid) return true;
 
             // we want to ensure only a single authentication update is happening at once.
             lock (access_token_retrieval_lock)
             {
                 // re-check if valid, in case another request completed and revalidated our access.
-                if (accessTokenValid) return true;
+                // if (accessTokenValid) return true;
 
                 // if not, let's try using our refresh token to request a new access token.
                 if (!string.IsNullOrEmpty(Token.Value?.RefreshToken))

```


To test the authentication failure still clears the token:

```diff
diff --git a/osu.Game/Online/API/OAuth.cs b/osu.Game/Online/API/OAuth.cs
index 1f26ab5458..7c832be3ca 100644
--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -88,7 +88,7 @@ internal bool AuthenticateWithRefresh(string refresh)
                     Url = $@"{endpoint}/oauth/token",
                     Method = HttpMethod.Post,
                     ClientId = clientId,
-                    ClientSecret = clientSecret
+                    ClientSecret = clientSecret + "wang"
                 };
 
                 using (refreshRequest)
@@ -120,13 +120,13 @@ internal bool AuthenticateWithRefresh(string refresh)
         private bool ensureAccessToken()
         {
             // if we already have a valid access token, let's use it.
-            if (accessTokenValid) return true;
+            // if (accessTokenValid) return true;
 
             // we want to ensure only a single authentication update is happening at once.
             lock (access_token_retrieval_lock)
             {
                 // re-check if valid, in case another request completed and revalidated our access.
-                if (accessTokenValid) return true;
+                // if (accessTokenValid) return true;
 
                 // if not, let's try using our refresh token to request a new access token.
                 if (!string.IsNullOrEmpty(Token.Value?.RefreshToken))

```