### PR TITLE
Update classic scoring formula to closer match stable score V1

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(ScoringMode.Standardised, HitResult.Meh, 116_667)]
         [TestCase(ScoringMode.Standardised, HitResult.Ok, 233_338)]
         [TestCase(ScoringMode.Standardised, HitResult.Great, 1_000_000)]
-        [TestCase(ScoringMode.Classic, HitResult.Meh, 0)]
-        [TestCase(ScoringMode.Classic, HitResult.Ok, 2)]
-        [TestCase(ScoringMode.Classic, HitResult.Great, 36)]
+        [TestCase(ScoringMode.Classic, HitResult.Meh, 11_670)]
+        [TestCase(ScoringMode.Classic, HitResult.Ok, 23_341)]
+        [TestCase(ScoringMode.Classic, HitResult.Great, 100_033)]
         public void TestSingleOsuHit(ScoringMode scoringMode, HitResult hitResult, int expectedScore)
         {
             scoreProcessor.ApplyBeatmap(beatmap);
@@ -84,17 +84,17 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(ScoringMode.Standardised, HitResult.SmallBonus, HitResult.SmallBonus, 1_000_030)]
         [TestCase(ScoringMode.Standardised, HitResult.LargeBonus, HitResult.LargeBonus, 1_000_150)]
         [TestCase(ScoringMode.Classic, HitResult.Miss, HitResult.Great, 0)]
-        [TestCase(ScoringMode.Classic, HitResult.Meh, HitResult.Great, 4)]
-        [TestCase(ScoringMode.Classic, HitResult.Ok, HitResult.Great, 15)]
-        [TestCase(ScoringMode.Classic, HitResult.Good, HitResult.Perfect, 53)]
-        [TestCase(ScoringMode.Classic, HitResult.Great, HitResult.Great, 140)]
-        [TestCase(ScoringMode.Classic, HitResult.Perfect, HitResult.Perfect, 140)]
+        [TestCase(ScoringMode.Classic, HitResult.Meh, HitResult.Great, 7_975)]
+        [TestCase(ScoringMode.Classic, HitResult.Ok, HitResult.Great, 15_949)]
+        [TestCase(ScoringMode.Classic, HitResult.Good, HitResult.Perfect, 30_398)]
+        [TestCase(ScoringMode.Classic, HitResult.Great, HitResult.Great, 49_546)]
+        [TestCase(ScoringMode.Classic, HitResult.Perfect, HitResult.Perfect, 49_546)]
         [TestCase(ScoringMode.Classic, HitResult.SmallTickMiss, HitResult.SmallTickHit, 0)]
-        [TestCase(ScoringMode.Classic, HitResult.SmallTickHit, HitResult.SmallTickHit, 11)]
+        [TestCase(ScoringMode.Classic, HitResult.SmallTickHit, HitResult.SmallTickHit, 54_189)]
         [TestCase(ScoringMode.Classic, HitResult.LargeTickMiss, HitResult.LargeTickHit, 0)]
-        [TestCase(ScoringMode.Classic, HitResult.LargeTickHit, HitResult.LargeTickHit, 9)]
-        [TestCase(ScoringMode.Classic, HitResult.SmallBonus, HitResult.SmallBonus, 36)]
-        [TestCase(ScoringMode.Classic, HitResult.LargeBonus, HitResult.LargeBonus, 36)]
+        [TestCase(ScoringMode.Classic, HitResult.LargeTickHit, HitResult.LargeTickHit, 49_289)]
+        [TestCase(ScoringMode.Classic, HitResult.SmallBonus, HitResult.SmallBonus, 100_003)]
+        [TestCase(ScoringMode.Classic, HitResult.LargeBonus, HitResult.LargeBonus, 100_015)]
         public void TestFourVariousResultsOneMiss(ScoringMode scoringMode, HitResult hitResult, HitResult maxResult, int expectedScore)
         {
             var minResult = new TestJudgement(hitResult).MinResult;

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -27,44 +27,37 @@ namespace osu.Game.Scoring.Legacy
                                      .DefaultIfEmpty(0)
                                      .Sum();
 
-            // This gives a similar feeling to osu!stable scoring (ScoreV1) while keeping classic scoring as only a constant multiple of standardised scoring.
-            // The invariant is important to ensure that scores don't get re-ordered on leaderboards between the two scoring modes.
-            double scaledRawScore = score / ScoreProcessor.MAX_SCORE;
-
-            return (long)Math.Round(Math.Pow(scaledRawScore * Math.Max(1, maxBasicJudgements), 2) * getStandardisedToClassicMultiplier(rulesetId));
+            return convertStandardisedToClassic(rulesetId, score, maxBasicJudgements);
         }
 
         /// <summary>
-        /// Returns a ballpark multiplier which gives a similar "feel" for how large scores should get when displayed in "classic" mode.
+        /// Returns a ballpark "classic" score which gives a similar "feel" to stable.
         /// This is different per ruleset to match the different algorithms used in the scoring implementation.
         /// </summary>
-        private static double getStandardisedToClassicMultiplier(int rulesetId)
+        /// <remarks>
+        /// The coefficients chosen here were determined by a least-squares fit performed over all beatmaps
+        /// with the goal of minimising the relative error of maximum possible base score (without bonus).
+        /// The constant coefficients (100000, 1 / 10d) - while being detrimental to the least-squares fit - are forced,
+        /// so that every 10 points in standardised mode converts to at least 1 point in classic mode.
+        /// This is done to account for bonus judgements in a way that does not reorder scores.
+        /// </remarks>
+        private static long convertStandardisedToClassic(int rulesetId, long standardisedTotalScore, int objectCount)
         {
-            double multiplier;
-
             switch (rulesetId)
             {
-                // For non-legacy rulesets, just go with the same as the osu! ruleset.
-                // This is arbitrary, but at least allows the setting to do something to the score.
-                default:
                 case 0:
-                    multiplier = 36;
-                    break;
+                    return (long)Math.Round((objectCount * objectCount * 32.57 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
 
                 case 1:
-                    multiplier = 22;
-                    break;
+                    return (long)Math.Round((objectCount * 1109 + 100000) * standardisedTotalScore / ScoreProcessor.MAX_SCORE);
 
                 case 2:
-                    multiplier = 28;
-                    break;
+                    return (long)Math.Round(Math.Pow(standardisedTotalScore / ScoreProcessor.MAX_SCORE * objectCount, 2) * 21.62 + standardisedTotalScore / 10d);
 
                 case 3:
-                    multiplier = 16;
-                    break;
+                default:
+                    return standardisedTotalScore;
             }
-
-            return multiplier;
         }
 
         public static int? GetCountGeki(this ScoreInfo scoreInfo)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23763
- Closes https://github.com/ppy/osu/issues/17011

The goal of this PR is to adjust the classic scoring algorithm to match score V1 closer in several (but not all) aspects. I will attempt to summarise _somewhat_ briefly what this means below, but this will be a long opening post nevertheless, for the code changes here are 1% of the work that was put in to arrive at these changes.

First, let me explain that _this PR's intention is not to port stable score V1 across literally_. That is infeasible due to several constraints placed upon the scoring algorithms; some are negotiable, some are not. This PR only improves _some_ aspects of classic score. I will attempt to explain this exhaustively but briefly in the sections below.

## What is supposed to match closer?

### osu!mania

mania is a bit of a black sheep in this diff, so let's get it out of the way first.

stable score V1 for mania is basically linear, and capped to 1 million anyways. Thus, the concept of "classic" score doesn't really make much sense; VSRG people are generally used to the 1M cap, and having score blow up like it did doesn't seem to benefit anybody. So this diff makes the "classic" setting do absolutely nothing for mania - as in, mania classic and standardised score are the same value. Period.

Now, standardised score is not actually the same as stable score V1, but bringing that across is generally not feasible due to other constraints. But it will do well enough - the rate of change and magnitude both match, and that's all I care about for the purposes of this diff.

If you only care about mania, you don't need to read the rest of this. Everything else is for the other rulesets.

### Bonus is (slightly) less susceptible to being worthless at the start of a map

I'll be brief; the root issue at hand is mostly described already in https://github.com/ppy/osu/issues/17011#issuecomment-1053557056. What this PR does about it, is that it ensures that if standardised score rises by 10 points, classic score will rise by at least 1 point.

#### How was this achieved?

When fitting the new formulae to total score values on existing beatmaps, I forced a constant 100k score component on the formulae; multiplying the normalised standardised score ($\frac{\texttt{standardised}}{1000000}$) by 100k makes it so that every 10 standardised points correspond to at least 1 classic point.

This could be possibly considered a little ridiculous on short maps, as I'm sure you'll be able to tell by the test case changes, but I guess if it's any consolation, then it's not really that much worse than what standardised score does on short maps.

### Magnitude of classic total score on perfect and near-perfect plays

The general ballpark of how high classic score for perfect plays should now be closer to stable. This will wildly vary per map for reasons I am yet to explain here, but the hope is that generally the fit will improve.

#### How was this achieved?

Using lazer's score V1 simulators, intended to be used for conversion to standardised score, I simulated the maximum base score (without bonus) for every beatmap from the data.ppy.sh data dumps for osu!, taiko, and catch (including converts). Using this data, I then fit an at-most-quadratic factor dependent on total basic object count for each ruleset, with the 100k constant factor described previously forced; the optimisation criterion was the minimisation of relative error when compared to stable.

The code used to generate the data to fit against, the generated data, and the fitting process have been described in [this gist](https://gist.github.com/bdach/bdedd2443a925bc590d8a948761e825d).

Note that the data extraction process already included changes from https://github.com/ppy/osu/pull/24779 - although since I was fitting to maximum _base_ score without bonus, changes therein should not generally have any meaningful impact, I don't think.

For reproduction, if required:

1. Apply [this diff](https://gist.github.com/bdach/bdedd2443a925bc590d8a948761e825d#file-01-patch-to-apply-onto-24779-diff) onto https://github.com/ppy/osu/pull/24779
2. Run [this program](https://gist.github.com/bdach/bdedd2443a925bc590d8a948761e825d#file-02-total-score-simulation-cs) against beatmap dumps from data.ppy.sh
3. You should get a CSV [like so](https://gist.github.com/bdach/bdedd2443a925bc590d8a948761e825d#file-03-extracted-total-score-data-csv)
4. This [jupyter notebook](https://gist.github.com/bdach/bdedd2443a925bc590d8a948761e825d#file-04-new-classic-scoring-ipynb) describes the rest.

### The general rate of ascent of classic score

The rates of ascent of score V1 and V2 _on a perfect score_ on stable are - as far as I can tell - as follows:

| ruleset | score V1 | score V2 |
| :- | :-: | :-: |
| osu! | $O(n^2)$ | $O(n^2)$
| osu!taiko | $O(n)$ | $O(n \log n)$ (until 400 combo) / $O(n)$ (over 400 combo) |
| osu!catch | $O(n^2)$ | $O(n \log n)$ (until 200 combo) / $O(n)$ (over 200 combo) |

The table above uses the [big O notation](https://en.wikipedia.org/wiki/Big_O_notation) for representing asymptotic boundedness of the scoring functions. $n$ is the number of objects in each case.

The previous rescale used was still assuming we were using old standardised (which was linear, $O(n)$). This no longer holds, which means that squaring osu! score, which previously made sense, now does not.

#### How was this achieved?

For both osu! and osu!taiko, since the asymptotic bound for both scoring algorithms is the same, classic score is now essentially a linear rescale of standardised score.

The scoring test scenes that I recently added also aim to illustrate that this matches better. See screenshots below:

| ruleset | before | after |
| :- | :-: | :-: |
| osu! | ![before-osu](https://github.com/ppy/osu/assets/20418176/a7b9b1c6-8dd8-4d7f-b838-2ee848ea9874) | ![after-osu](https://github.com/ppy/osu/assets/20418176/628d51a5-3c2e-455b-be70-ce293347ae76) |
| osu!taiko | ![before-taiko](https://github.com/ppy/osu/assets/20418176/6bd9ad02-913f-405d-a80c-226fa8794518) | ![after-taiko](https://github.com/ppy/osu/assets/20418176/27a201da-b66f-4926-8f32-f0496addf530) |
| osu!catch | ![before-catch](https://github.com/ppy/osu/assets/20418176/9d30c33d-be09-43c0-904f-b872712af9ff) | ![after-catch](https://github.com/ppy/osu/assets/20418176/b1b05e0f-0d81-4d7b-9f15-b5ac7eebea98) |
| osu!mania | ![before-mania](https://github.com/ppy/osu/assets/20418176/5605cf5d-1e37-4412-b284-7b96755b5462) | ![after-mania](https://github.com/ppy/osu/assets/20418176/e404c07b-8df4-4c84-8cd7-54cd5e1be8df) |

When reading the diff, note that catch is the odd one out here. Going fully linear with catch actually presents in a _worse_ estimate of the rate of ascent; therefore, the normalised standardised score for catch is still a quadratic factor.

## What will not match closer? Why?

### Scores cannot be reordered, and the corollaries

Since we've already established that we're not permitting scores to be reordered between classic and standardised scoring, this limits the possibilities for implementation of classic quite considerably. In general, for reorders to be impossible, classic must be a _strictly monotonic_ function of standardised (in math terms, this means that if standardised score increases, classic score must also increase).

This has the following side-effects:

#### Classic score is still not monotonic with respect to misses (aside from catch)

If you miss with Score V1 on stable, you do not lose score; if you miss with Score V2, you _do_ lose score, since the accuracy portion goes down. (The edge case is catch, wherein Score V2 _is_ actually monotonic. I'm discarding it from further deliberations in this subsection.)

Since classic score _has_ to be a monotonic function of standardised, and on standardised you lose score on missing, you still lose score on missing in classic, too.

#### Accounting for bonus score is best-effort

We generally cannot subtract bonus from the user's score, apply rescaling, and then add the bonus back again, as this action may reorder scores. This is why - despite actually _ruining_ fits - the 100k factor is added like it is, to attempt to compensate for bonus.

#### osu!catch mod multipliers are essentially squared in classic scoring mode

Since classic scoring mode receives the standardised score *post*-application of mod multipliers to rescale (as it *must*, in order to avoid reordering scores), this means that in catch, if the multiplier is not 1, then its effect is actually squared.

This can be fixed, but at the cost of sacrificing catch's rate of ascent (it would have to be linear rather than quadratic).

### Classic score still has no concept of a "score multiplier"

For osu!, taiko, and catch, score V1 is also a byproduct of a map-dependent "score multiplier", which depends on: drain rate, overall difficulty, circle size, object count and drain length.This does not exist for classic scoring yet. It potentially _could_, with _generally_ minor difficulty - because it's a map-dependent value, it actually is a separate concern from all of the score reordering issues, and we could bring it back if we think the complexity is worth it. I generally didn't want to do that yet, though.

## Custom rulesets

As a footnote, when touching this code and noticing how score implementations diverge, I decided that making classic score do anything for custom rulesets doesn't really make much sense, so I did what I did for mania and just made classic score do nothing for other rulesets. This is up for further discussion, although it has to be said, that with how divergent the score conversion is for particular rulesets, setting forth any algorithm at this point would be as arbitrary as just having classic score not work. Maybe that's something for ruleset API in the future.

---

@WitherFlower this is one for you to look over - interested to see if you've got any feedback on this since I considerably altered your original proposals.