### PR TITLE
Reduce delay before loading beatmap after selection change at song select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -312,7 +312,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             createSongSelect();
 
-            addRulesetImportStep(0);
+            // We need to use one real beatmap to trigger the "same-track-transfer" logic that we're looking to test here.
+            // See `SongSelect.ensurePlayingSelected` and `WorkingBeatmap.TryTransferTrack`.
+            AddStep("import test beatmap", () => manager.Import(new ImportTask(TestResources.GetTestBeatmapForImport())).WaitSafely());
             addRulesetImportStep(0);
 
             checkMusicPlaying(true);
@@ -321,6 +323,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("manual pause", () => music.TogglePause());
             checkMusicPlaying(false);
+
+            // Track should not have changed, so music should still not be playing.
             AddStep("select next difficulty", () => songSelect!.Carousel.SelectNext(skipDifficulties: false));
             checkMusicPlaying(false);
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -525,7 +525,11 @@ namespace osu.Game.Screens.Select
             if (beatmapInfoNoDebounce == null)
                 run();
             else
-                selectionChangedDebounce = Scheduler.AddDelayed(run, 200);
+            {
+                // Intentionally slightly higher than repeat_tick_rate to avoid loading songs when holding left / right arrows.
+                // See https://github.com/ppy/osu-framework/blob/master/osu.Framework/Input/InputManager.cs#L44
+                selectionChangedDebounce = Scheduler.AddDelayed(run, 80);
+            }
 
             if (beatmap?.Equals(beatmapInfoPrevious) != true)
             {


### PR DESCRIPTION
This was originally set high because of performance concerns. We have since improved things quite drastically. Even with a very low debounce my song select is amazingly smooth.

This is about as low as we can got unless we want chaos when key repeating left/right arrows (it's not as bad as you think, maybe worth testing during review and see if it feels more expected?).

Of note, stable has key repeat disabled on left/right arrows and zero debounce.

Addresses concerns in https://github.com/ppy/osu/discussions/24916.