### PR TITLE
Adjust osu!mania "major" barlines to be less visually distracting

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
@@ -33,25 +34,28 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
                 RelativeSizeAxes = Axes.Both,
             });
 
-            Vector2 size = new Vector2(22, 6);
-            const float line_offset = 4;
+            const float major_extension = 10;
 
-            AddInternal(leftAnchor = new Circle
+            AddInternal(leftAnchor = new Box
             {
                 Name = "Left anchor",
+                Blending = BlendingParameters.Additive,
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreRight,
-                Size = size,
-                X = -line_offset,
+                Width = major_extension,
+                RelativeSizeAxes = Axes.Y,
+                Colour = ColourInfo.GradientHorizontal(Colour4.Transparent, Colour4.White),
             });
 
-            AddInternal(rightAnchor = new Circle
+            AddInternal(rightAnchor = new Box
             {
                 Name = "Right anchor",
+                Blending = BlendingParameters.Additive,
                 Anchor = Anchor.CentreRight,
                 Origin = Anchor.CentreLeft,
-                Size = size,
-                X = line_offset,
+                Width = major_extension,
+                RelativeSizeAxes = Axes.Y,
+                Colour = ColourInfo.GradientHorizontal(Colour4.White, Colour4.Transparent),
             });
 
             major = ((DrawableBarLine)drawableHitObject).Major.GetBoundCopy();
@@ -66,7 +70,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
         private void updateMajor(ValueChangedEvent<bool> major)
         {
             mainLine.Alpha = major.NewValue ? 0.5f : 0.2f;
-            leftAnchor.Alpha = rightAnchor.Alpha = major.NewValue ? 1 : 0;
+            leftAnchor.Alpha = rightAnchor.Alpha = major.NewValue ? mainLine.Alpha * 0.3f : 0;
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Default/DefaultBarLine.cs
@@ -26,9 +26,13 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
         {
             RelativeSizeAxes = Axes.Both;
 
+            // Avoid flickering due to no anti-aliasing of boxes by default.
+            var edgeSmoothness = new Vector2(0.3f);
+
             AddInternal(mainLine = new Box
             {
                 Name = "Bar line",
+                EdgeSmoothness = edgeSmoothness,
                 Anchor = Anchor.BottomCentre,
                 Origin = Anchor.BottomCentre,
                 RelativeSizeAxes = Axes.Both,
@@ -39,6 +43,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
             AddInternal(leftAnchor = new Box
             {
                 Name = "Left anchor",
+                EdgeSmoothness = edgeSmoothness,
                 Blending = BlendingParameters.Additive,
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreRight,
@@ -50,6 +55,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Default
             AddInternal(rightAnchor = new Box
             {
                 Name = "Right anchor",
+                EdgeSmoothness = edgeSmoothness,
                 Blending = BlendingParameters.Additive,
                 Anchor = Anchor.CentreRight,
                 Origin = Anchor.CentreLeft,


### PR DESCRIPTION
Was waiting for a design for this but never came, and the existing design is very ugly and will probably stop people from using the new skins, so let's make a temporary change.

---

Applies to both "triangles" and "argon" skins.

| Before | After |
| :---: | :---: |
| ![osu! 2023-09-26 at 07 59 07](https://github.com/ppy/osu/assets/191335/fe92ccc0-d7c4-4854-97d6-3bd1ceec665f) | ![osu! 2023-09-26 at 07 58 38](https://github.com/ppy/osu/assets/191335/0adbb9a4-60d6-47cd-999a-ca51d0456a60) |