### PR TITLE
Fix flaky editor beatmap creation test

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddAssert("track is not virtual", () => Beatmap.Value.Track is not TrackVirtual);
-            AddAssert("track length changed", () => Beatmap.Value.Track.Length > 60000);
+            AddUntilStep("track length changed", () => Beatmap.Value.Track.Length > 60000);
 
             AddStep("test play", () => Editor.TestGameplay());
 


### PR DESCRIPTION
Came up as a failure when locally running tests for ppy/osu-framework#6001 - but the test is actually a previously-known flaky that I couldn't reproduce the failure of until testing the aforementioned PR.

This appears to be a simple race; the test scene queries the track length from update thread, but the length is actually set [on the audio thread](https://github.com/ppy/osu-framework/blob/242268266bd3c7dc091c1febe0bedb0a5a3737d0/osu.Framework/Audio/Track/TrackBass.cs#L113). So it's not unreasonable that given unlucky timing, the length will not be set by `TrackBass` before it is queried.

To fix, switch assert to until step. I'm generally not really willing to give this more time of day until this change is proven insufficient.