### PR TITLE
Add setting to keep gameplay leaderboard expanded

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -137,6 +137,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.KeyOverlay, false);
             SetDefault(OsuSetting.ReplaySettingsOverlay, true);
             SetDefault(OsuSetting.GameplayLeaderboard, true);
+            SetDefault(OsuSetting.ExpandGameplayLeaderboard, false);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
             SetDefault(OsuSetting.FloatingComments, false);
@@ -322,6 +323,7 @@ namespace osu.Game.Configuration
         ShowStoryboard,
         KeyOverlay,
         GameplayLeaderboard,
+        ExpandGameplayLeaderboard,
         PositionalHitsoundsLevel,
         AlwaysPlayFirstComboBreak,
         FloatingComments,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -85,6 +85,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysShowGameplayLeaderboard => new TranslatableString(getKey(@"gameplay_leaderboard"), @"Always show gameplay leaderboard");
 
         /// <summary>
+        /// "Keep gameplay leaderboard expanded"
+        /// </summary>
+        public static LocalisableString KeepGameplayLeaderboardExpanded => new TranslatableString(getKey(@"expand_gameplay_leaderboard"), @"Keep gameplay leaderboard expanded");
+
+        /// <summary>
         /// "Always play first combo break sound"
         /// </summary>
         public static LocalisableString AlwaysPlayFirstComboBreak => new TranslatableString(getKey(@"always_play_first_combo_break"), @"Always play first combo break sound");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -42,6 +42,12 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = GameplaySettingsStrings.KeepGameplayLeaderboardExpanded,
+                    Current = config.GetBindable<bool>(OsuSetting.ExpandGameplayLeaderboard),
+                    Keywords = new[] { "opened" },
+                },
+                new SettingsCheckbox
+                {
                     ClassicDefault = false,
                     LabelText = GameplaySettingsStrings.ShowHealthDisplayWhenCantFail,
                     Current = config.GetBindable<bool>(OsuSetting.ShowHealthDisplayWhenCantFail),

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Screens.Play
         private bool isRestarting;
 
         private Bindable<bool> mouseWheelDisabled;
+        private Bindable<bool> expandGameplayLeaderboard;
 
         private readonly Bindable<bool> storyboardReplacesBackground = new Bindable<bool>();
 
@@ -211,6 +212,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
+            expandGameplayLeaderboard = config.GetBindable<bool>(OsuSetting.ExpandGameplayLeaderboard);
 
             if (game != null)
                 gameActive.BindTo(game.IsActive);
@@ -856,7 +858,8 @@ namespace osu.Game.Screens.Play
         private void loadLeaderboard()
         {
             HUDOverlay.HoldingForHUD.BindValueChanged(_ => updateLeaderboardExpandedState());
-            LocalUserPlaying.BindValueChanged(_ => updateLeaderboardExpandedState(), true);
+            LocalUserPlaying.BindValueChanged(_ => updateLeaderboardExpandedState());
+            expandGameplayLeaderboard.BindValueChanged(_ => updateLeaderboardExpandedState(), true);
 
             var gameplayLeaderboard = CreateGameplayLeaderboard();
 
@@ -880,7 +883,7 @@ namespace osu.Game.Screens.Play
         protected virtual void AddLeaderboardToHUD(GameplayLeaderboard leaderboard) => HUDOverlay.LeaderboardFlow.Add(leaderboard);
 
         private void updateLeaderboardExpandedState() =>
-            LeaderboardExpandedState.Value = !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value;
+            LeaderboardExpandedState.Value = !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value || expandGameplayLeaderboard.Value;
 
         #endregion
 


### PR DESCRIPTION
This is a small change that creates a setting to keep the gameplay leaderboard expanded.

This is my favorite part of stable, and while I enjoy lazer's elegant new UX of the leaderboard, I think it's good to have an option to have it remain expanded.