### PR TITLE
Add `color` search keyword for `colour` settings

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Rulesets.Mania
                 },
                 new SettingsCheckbox
                 {
+                    Keywords = new[] { "color" },
                     LabelText = RulesetSettingsStrings.TimingBasedColouring,
                     Current = config.GetBindable<bool>(ManiaRulesetSetting.TimingBasedNoteColouring),
                 }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/BeatmapSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/BeatmapSettings.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
-                    Keywords = new[] { "combo", "override" },
+                    Keywords = new[] { "combo", "override", "color" },
                     LabelText = SkinSettingsStrings.BeatmapColours,
                     Current = config.GetBindable<bool>(OsuSetting.BeatmapColours)
                 },
@@ -47,6 +47,7 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsSlider<float>
                 {
+                    Keywords = new[] { "color" },
                     LabelText = GraphicsSettingsStrings.ComboColourNormalisation,
                     Current = comboColourNormalisation,
                     DisplayAsPercentage = true,


### PR DESCRIPTION
# Changes done

Added a keyword for colour settings.

Solves a minor annoyance of mine as I toggle the beatmap color option a lot when editing/playing beatmaps, but I always forget I have to search for colour instead.