### PR TITLE
Add the ability for mod icons to show extended information

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -1,10 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.UI;
@@ -24,6 +28,54 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Direction = FillDirection.Full,
                     ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods().Select(m => new ModIcon(m)),
                 };
+            });
+
+            AddStep("toggle selected", () =>
+            {
+                foreach (var icon in this.ChildrenOfType<ModIcon>())
+                    icon.Selected.Toggle();
+            });
+        }
+
+        [Test]
+        public void TestShowRateAdjusts()
+        {
+            AddStep("create mod icons", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Full,
+                    ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods()
+                                                .OfType<ModRateAdjust>()
+                                                .SelectMany((m) =>
+                                                {
+                                                    List<ModIcon> icons = new List<ModIcon> { new ModIcon(m) };
+
+                                                    for (double i = m.SpeedChange.MinValue; i < m.SpeedChange.MaxValue; i += m.SpeedChange.Precision * 10)
+                                                    {
+                                                        m = (ModRateAdjust)m.DeepClone();
+                                                        m.SpeedChange.Value = i;
+                                                        icons.Add(new ModIcon(m));
+                                                    }
+
+                                                    return icons;
+                                                }),
+                };
+            });
+
+            AddStep("adjust rates", () =>
+            {
+                foreach (var icon in this.ChildrenOfType<ModIcon>())
+                {
+                    if (icon.Mod is ModRateAdjust rateAdjust)
+                    {
+                        if (RNG.NextDouble() > 0.9)
+                            rateAdjust.SpeedChange.Value = rateAdjust.SpeedChange.Default;
+                        else
+                            rateAdjust.SpeedChange.Value = RNG.NextDouble(rateAdjust.SpeedChange.MinValue, rateAdjust.SpeedChange.MaxValue);
+                    }
+                }
             });
         }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModIcon.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Direction = FillDirection.Full,
                     ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods()
                                                 .OfType<ModRateAdjust>()
-                                                .SelectMany((m) =>
+                                                .SelectMany(m =>
                                                 {
                                                     List<ModIcon> icons = new List<ModIcon> { new ModIcon(m) };
 
@@ -70,10 +70,9 @@ namespace osu.Game.Tests.Visual.UserInterface
                 {
                     if (icon.Mod is ModRateAdjust rateAdjust)
                     {
-                        if (RNG.NextDouble() > 0.9)
-                            rateAdjust.SpeedChange.Value = rateAdjust.SpeedChange.Default;
-                        else
-                            rateAdjust.SpeedChange.Value = RNG.NextDouble(rateAdjust.SpeedChange.MinValue, rateAdjust.SpeedChange.MaxValue);
+                        rateAdjust.SpeedChange.Value = RNG.NextDouble() > 0.9
+                            ? rateAdjust.SpeedChange.Default
+                            : RNG.NextDouble(rateAdjust.SpeedChange.MinValue, rateAdjust.SpeedChange.MaxValue);
                     }
                 }
             });

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -89,6 +89,8 @@ namespace osu.Game.Graphics
         public static IconUsage ModSpunOut => Get(0xe046);
         public static IconUsage ModSuddenDeath => Get(0xe047);
         public static IconUsage ModTarget => Get(0xe048);
-        public static IconUsage ModBg => Get(0xe04a);
+
+        // Use "Icons/BeatmapDetails/mod-icon" instead
+        // public static IconUsage ModBg => Get(0xe04a);
     }
 }

--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -210,7 +210,7 @@ namespace osu.Game.Online.Leaderboards
                     Spacing = new Vector2(2f, 0f),
                     Children = new Drawable[]
                     {
-                        new ModIcon(mod, showTooltip: false).With(icon =>
+                        new ModIcon(mod, showTooltip: false, showExtendedInformation: false).With(icon =>
                         {
                             icon.Origin = Anchor.CentreLeft;
                             icon.Anchor = Anchor.CentreLeft;

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -20,8 +20,9 @@ namespace osu.Game.Rulesets.Mods
         string Name { get; }
 
         /// <summary>
-        /// Short import information to display on the mod icon. For example, a rate adjust mod's rate
+        /// Short important information to display on the mod icon. For example, a rate adjust mod's rate
         /// or similarly important setting.
+        /// Use <see cref="string.Empty"/> if the icon should not display any additional info.
         /// </summary>
         string ExtendedIconInformation { get; }
 

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Rulesets.Mods
         string Name { get; }
 
         /// <summary>
+        /// Short import information to display on the mod icon. For example, a rate adjust mod's rate
+        /// or similarly important setting.
+        /// </summary>
+        string ExtendedIconInformation { get; }
+
+        /// <summary>
         /// The user readable description of this mod.
         /// </summary>
         LocalisableString Description { get; }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -28,6 +28,9 @@ namespace osu.Game.Rulesets.Mods
         public abstract string Acronym { get; }
 
         [JsonIgnore]
+        public virtual string ExtendedIconInformation => string.Empty;
+
+        [JsonIgnore]
         public virtual IconUsage? Icon => null;
 
         [JsonIgnore]

--- a/osu.Game/Rulesets/Mods/ModRateAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModRateAdjust.cs
@@ -28,5 +28,7 @@ namespace osu.Game.Rulesets.Mods
         public override Type[] IncompatibleMods => new[] { typeof(ModTimeRamp), typeof(ModAdaptiveSpeed), typeof(ModRateAdjust) };
 
         public override string SettingDescription => SpeedChange.IsDefault ? string.Empty : $"{SpeedChange.Value:N2}x";
+
+        public override string ExtendedIconInformation => SettingDescription;
     }
 }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -38,7 +38,9 @@ namespace osu.Game.Rulesets.UI
         public virtual LocalisableString TooltipText => showTooltip ? ((mod as Mod)?.IconTooltip ?? mod.Name) : null;
 
         private IMod mod;
+
         private readonly bool showTooltip;
+        private readonly bool showExtendedInformation;
 
         public IMod Mod
         {
@@ -73,13 +75,15 @@ namespace osu.Game.Rulesets.UI
         /// </summary>
         /// <param name="mod">The mod to be displayed</param>
         /// <param name="showTooltip">Whether a tooltip describing the mod should display on hover.</param>
-        public ModIcon(IMod mod, bool showTooltip = true)
+        /// <param name="showExtendedInformation">Whether to display a mod's extended information, if available.</param>
+        public ModIcon(IMod mod, bool showTooltip = true, bool showExtendedInformation = true)
         {
             AutoSizeAxes = Axes.X;
             Height = size;
 
             this.mod = mod ?? throw new ArgumentNullException(nameof(mod));
             this.showTooltip = showTooltip;
+            this.showExtendedInformation = showExtendedInformation;
         }
 
         [BackgroundDependencyLoader]
@@ -187,9 +191,9 @@ namespace osu.Game.Rulesets.UI
             backgroundColour = colours.ForModType(value.Type);
             updateColour();
 
-            bool hasExtended = !string.IsNullOrEmpty(mod.ExtendedIconInformation);
+            bool showExtended = showExtendedInformation && !string.IsNullOrEmpty(mod.ExtendedIconInformation);
 
-            extendedContent.Alpha = hasExtended ? 1 : 0;
+            extendedContent.Alpha = showExtended ? 1 : 0;
 
             extendedText.Text = mod.ExtendedIconInformation;
         }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Rulesets.UI
                         },
                         extendedText = new OsuSpriteText
                         {
-                            Font = OsuFont.Default.With(size: 30f, weight: FontWeight.Bold),
+                            Font = OsuFont.Default.With(size: 34f, weight: FontWeight.Bold),
                             UseFullGlyphHeight = false,
                             Text = mod.ExtendedIconInformation,
                             X = 5,

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
@@ -29,13 +27,13 @@ namespace osu.Game.Rulesets.UI
     {
         public readonly BindableBool Selected = new BindableBool();
 
-        private SpriteIcon modIcon;
-        private SpriteText modAcronym;
-        private SpriteIcon background;
+        private SpriteIcon modIcon = null!;
+        private SpriteText modAcronym = null!;
+        private SpriteIcon background = null!;
 
         private const float size = 80;
 
-        public virtual LocalisableString TooltipText => showTooltip ? ((mod as Mod)?.IconTooltip ?? mod.Name) : null;
+        public virtual LocalisableString TooltipText => showTooltip ? ((mod as Mod)?.IconTooltip ?? mod.Name) : string.Empty;
 
         private IMod mod;
 
@@ -58,17 +56,17 @@ namespace osu.Game.Rulesets.UI
         }
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         private Color4 backgroundColour;
 
-        private Sprite extendedBackground;
+        private Sprite extendedBackground = null!;
 
-        private OsuSpriteText extendedText;
+        private OsuSpriteText extendedText = null!;
 
-        private Container extendedContent;
+        private Container extendedContent = null!;
 
-        private ModSettingChangeTracker modSettingsChangeTracker;
+        private ModSettingChangeTracker? modSettingsChangeTracker;
 
         /// <summary>
         /// Construct a new instance.

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -106,7 +106,6 @@ namespace osu.Game.Rulesets.UI
                             Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            //Scale = SHADOW_FUDGE
                         },
                         extendedText = new OsuSpriteText
                         {

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.UI
             if (value is Mod actualMod)
             {
                 modSettingsChangeTracker = new ModSettingChangeTracker(new[] { actualMod });
-                modSettingsChangeTracker.SettingChanged = _ => updateMod(actualMod);
+                modSettingsChangeTracker.SettingChanged = _ => updateExtendedInformation();
             }
 
             modAcronym.Text = value.Acronym;
@@ -193,10 +193,14 @@ namespace osu.Game.Rulesets.UI
             backgroundColour = colours.ForModType(value.Type);
             updateColour();
 
+            updateExtendedInformation();
+        }
+
+        private void updateExtendedInformation()
+        {
             bool showExtended = showExtendedInformation && !string.IsNullOrEmpty(mod.ExtendedIconInformation);
 
             extendedContent.Alpha = showExtended ? 1 : 0;
-
             extendedText.Text = mod.ExtendedIconInformation;
         }
 

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -18,6 +18,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -44,6 +45,9 @@ namespace osu.Game.Rulesets.UI
             get => mod;
             set
             {
+                if (mod == value)
+                    return;
+
                 mod = value;
 
                 if (IsLoaded)
@@ -61,6 +65,8 @@ namespace osu.Game.Rulesets.UI
         private OsuSpriteText extendedText;
 
         private Container extendedContent;
+
+        private ModSettingChangeTracker modSettingsChangeTracker;
 
         /// <summary>
         /// Construct a new instance.
@@ -123,7 +129,7 @@ namespace osu.Game.Rulesets.UI
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Size = new Vector2(120, 55),
-                    X = size - 23,
+                    X = size - 22,
                     Children = new Drawable[]
                     {
                         extendedBackground = new Sprite
@@ -156,6 +162,14 @@ namespace osu.Game.Rulesets.UI
 
         private void updateMod(IMod value)
         {
+            modSettingsChangeTracker?.Dispose();
+
+            if (value is Mod actualMod)
+            {
+                modSettingsChangeTracker = new ModSettingChangeTracker(new[] { actualMod });
+                modSettingsChangeTracker.SettingChanged = _ => updateMod(actualMod);
+            }
+
             modAcronym.Text = value.Acronym;
             modIcon.Icon = value.Icon ?? FontAwesome.Solid.Question;
 
@@ -184,6 +198,12 @@ namespace osu.Game.Rulesets.UI
         {
             extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
             extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            modSettingsChangeTracker?.Dispose();
         }
     }
 }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Mods;
 using osuTK;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.UI
@@ -27,9 +28,9 @@ namespace osu.Game.Rulesets.UI
     {
         public readonly BindableBool Selected = new BindableBool();
 
-        private readonly SpriteIcon modIcon;
-        private readonly SpriteText modAcronym;
-        private readonly SpriteIcon background;
+        private SpriteIcon modIcon;
+        private SpriteText modAcronym;
+        private SpriteIcon background;
 
         private const float size = 80;
 
@@ -55,6 +56,10 @@ namespace osu.Game.Rulesets.UI
 
         private Color4 backgroundColour;
 
+        private Sprite extendedBackground;
+
+        private OsuSpriteText extendedText;
+
         /// <summary>
         /// Construct a new instance.
         /// </summary>
@@ -64,8 +69,12 @@ namespace osu.Game.Rulesets.UI
         {
             this.mod = mod ?? throw new ArgumentNullException(nameof(mod));
             this.showTooltip = showTooltip;
+        }
 
-            Size = new Vector2(size);
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            AutoSizeAxes = Axes.Both;
 
             Children = new Drawable[]
             {
@@ -76,6 +85,23 @@ namespace osu.Game.Rulesets.UI
                     Size = new Vector2(size),
                     Icon = OsuIcon.ModBg,
                     Shadow = true,
+                },
+                extendedBackground = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
+                    X = size - 3,
+                    Size = new Vector2(120, 55),
+                },
+                extendedText = new OsuSpriteText
+                {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
+                    Font = OsuFont.Default.With(size: 30f, weight: FontWeight.Bold),
+                    UseFullGlyphHeight = false,
+                    X = size,
+                    Text = mod.ExtendedIconInformation,
                 },
                 modAcronym = new OsuSpriteText
                 {
@@ -129,7 +155,8 @@ namespace osu.Game.Rulesets.UI
 
         private void updateColour()
         {
-            background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
+            extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
+            extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);
         }
     }
 }

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -60,6 +60,8 @@ namespace osu.Game.Rulesets.UI
 
         private OsuSpriteText extendedText;
 
+        private Container extendedContent;
+
         /// <summary>
         /// Construct a new instance.
         /// </summary>
@@ -67,6 +69,9 @@ namespace osu.Game.Rulesets.UI
         /// <param name="showTooltip">Whether a tooltip describing the mod should display on hover.</param>
         public ModIcon(IMod mod, bool showTooltip = true)
         {
+            AutoSizeAxes = Axes.X;
+            Height = size;
+
             this.mod = mod ?? throw new ArgumentNullException(nameof(mod));
             this.showTooltip = showTooltip;
         }
@@ -74,52 +79,68 @@ namespace osu.Game.Rulesets.UI
         [BackgroundDependencyLoader]
         private void load(TextureStore textures)
         {
-            AutoSizeAxes = Axes.Both;
-
             Children = new Drawable[]
             {
-                background = new SpriteIcon
+                new Container
                 {
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Name = "main content",
                     Size = new Vector2(size),
-                    Icon = OsuIcon.ModBg,
-                    Shadow = true,
+                    Children = new Drawable[]
+                    {
+                        background = new SpriteIcon
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Size = new Vector2(size),
+                            Icon = OsuIcon.ModBg,
+                            Shadow = true,
+                        },
+                        modAcronym = new OsuSpriteText
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Colour = OsuColour.Gray(84),
+                            Alpha = 0,
+                            Font = OsuFont.Numeric.With(null, 22f),
+                            UseFullGlyphHeight = false,
+                            Text = mod.Acronym
+                        },
+                        modIcon = new SpriteIcon
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Colour = OsuColour.Gray(84),
+                            Size = new Vector2(45),
+                            Icon = FontAwesome.Solid.Question
+                        },
+                    }
                 },
-                extendedBackground = new Sprite
+                extendedContent = new Container
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
-                    X = size - 3,
+                    Name = "extended content",
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
                     Size = new Vector2(120, 55),
-                },
-                extendedText = new OsuSpriteText
-                {
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
-                    Font = OsuFont.Default.With(size: 30f, weight: FontWeight.Bold),
-                    UseFullGlyphHeight = false,
-                    X = size,
-                    Text = mod.ExtendedIconInformation,
-                },
-                modAcronym = new OsuSpriteText
-                {
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
-                    Colour = OsuColour.Gray(84),
-                    Alpha = 0,
-                    Font = OsuFont.Numeric.With(null, 22f),
-                    UseFullGlyphHeight = false,
-                    Text = mod.Acronym
-                },
-                modIcon = new SpriteIcon
-                {
-                    Origin = Anchor.Centre,
-                    Anchor = Anchor.Centre,
-                    Colour = OsuColour.Gray(84),
-                    Size = new Vector2(45),
-                    Icon = FontAwesome.Solid.Question
+                    X = size - 23,
+                    Children = new Drawable[]
+                    {
+                        extendedBackground = new Sprite
+                        {
+                            Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
+                            Size = new Vector2(120, 55),
+                        },
+                        extendedText = new OsuSpriteText
+                        {
+                            Font = OsuFont.Default.With(size: 30f, weight: FontWeight.Bold),
+                            UseFullGlyphHeight = false,
+                            Text = mod.ExtendedIconInformation,
+                            X = 5,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
                 },
             };
         }
@@ -151,6 +172,12 @@ namespace osu.Game.Rulesets.UI
 
             backgroundColour = colours.ForModType(value.Type);
             updateColour();
+
+            bool hasExtended = !string.IsNullOrEmpty(mod.ExtendedIconInformation);
+
+            extendedContent.Alpha = hasExtended ? 1 : 0;
+
+            extendedText.Text = mod.ExtendedIconInformation;
         }
 
         private void updateColour()

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Rulesets.UI
                             Font = OsuFont.Default.With(size: 34f, weight: FontWeight.Bold),
                             UseFullGlyphHeight = false,
                             Text = mod.ExtendedIconInformation,
-                            X = 5,
+                            X = 6,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -2,21 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK.Graphics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osuTK;
-using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Graphics.Textures;
-using osu.Framework.Localisation;
-using osu.Game.Configuration;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -29,9 +29,9 @@ namespace osu.Game.Rulesets.UI
 
         private SpriteIcon modIcon = null!;
         private SpriteText modAcronym = null!;
-        private SpriteIcon background = null!;
+        private Sprite background = null!;
 
-        private const float size = 80;
+        public static readonly Vector2 MOD_ICON_SIZE = new Vector2(80);
 
         public virtual LocalisableString TooltipText => showTooltip ? ((mod as Mod)?.IconTooltip ?? mod.Name) : string.Empty;
 
@@ -76,8 +76,9 @@ namespace osu.Game.Rulesets.UI
         /// <param name="showExtendedInformation">Whether to display a mod's extended information, if available.</param>
         public ModIcon(IMod mod, bool showTooltip = true, bool showExtendedInformation = true)
         {
+            // May expand due to expanded content, so autosize here.
             AutoSizeAxes = Axes.X;
-            Height = size;
+            Height = MOD_ICON_SIZE.Y;
 
             this.mod = mod ?? throw new ArgumentNullException(nameof(mod));
             this.showTooltip = showTooltip;
@@ -89,21 +90,50 @@ namespace osu.Game.Rulesets.UI
         {
             Children = new Drawable[]
             {
+                extendedContent = new Container
+                {
+                    Name = "extended content",
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Size = new Vector2(116, MOD_ICON_SIZE.Y),
+                    X = MOD_ICON_SIZE.X - 22,
+                    Children = new Drawable[]
+                    {
+                        extendedBackground = new Sprite
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            FillMode = FillMode.Fit,
+                            Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            //Scale = SHADOW_FUDGE
+                        },
+                        extendedText = new OsuSpriteText
+                        {
+                            Font = OsuFont.Default.With(size: 34f, weight: FontWeight.Bold),
+                            UseFullGlyphHeight = false,
+                            Text = mod.ExtendedIconInformation,
+                            X = 5,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                    }
+                },
                 new Container
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Name = "main content",
-                    Size = new Vector2(size),
+                    Size = MOD_ICON_SIZE,
                     Children = new Drawable[]
                     {
-                        background = new SpriteIcon
+                        background = new Sprite
                         {
-                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            FillMode = FillMode.Fit,
+                            Texture = textures.Get("Icons/BeatmapDetails/mod-icon"),
                             Anchor = Anchor.Centre,
-                            Size = new Vector2(size),
-                            Icon = OsuIcon.ModBg,
-                            Shadow = true,
+                            Origin = Anchor.Centre,
                         },
                         modAcronym = new OsuSpriteText
                         {
@@ -122,31 +152,6 @@ namespace osu.Game.Rulesets.UI
                             Colour = OsuColour.Gray(84),
                             Size = new Vector2(45),
                             Icon = FontAwesome.Solid.Question
-                        },
-                    }
-                },
-                extendedContent = new Container
-                {
-                    Name = "extended content",
-                    Anchor = Anchor.CentreLeft,
-                    Origin = Anchor.CentreLeft,
-                    Size = new Vector2(120, 55),
-                    X = size - 22,
-                    Children = new Drawable[]
-                    {
-                        extendedBackground = new Sprite
-                        {
-                            Texture = textures.Get("Icons/BeatmapDetails/mod-icon-extender"),
-                            Size = new Vector2(120, 55),
-                        },
-                        extendedText = new OsuSpriteText
-                        {
-                            Font = OsuFont.Default.With(size: 34f, weight: FontWeight.Bold),
-                            UseFullGlyphHeight = false,
-                            Text = mod.ExtendedIconInformation,
-                            X = 5,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
                         },
                     }
                 },

--- a/osu.Game/Rulesets/UI/ModSwitchSmall.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchSmall.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
@@ -23,8 +24,8 @@ namespace osu.Game.Rulesets.UI
 
         private readonly IMod mod;
 
-        private readonly SpriteIcon background;
-        private readonly SpriteIcon? modIcon;
+        private Drawable background = null!;
+        private SpriteIcon? modIcon;
 
         private Color4 activeForegroundColour;
         private Color4 inactiveForegroundColour;
@@ -36,19 +37,24 @@ namespace osu.Game.Rulesets.UI
         {
             this.mod = mod;
 
-            AutoSizeAxes = Axes.Both;
+            Size = new Vector2(DEFAULT_SIZE);
+        }
 
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures, OsuColour colours, OverlayColourProvider? colourProvider)
+        {
             FillFlowContainer contentFlow;
             ModSwitchTiny tinySwitch;
 
-            InternalChildren = new Drawable[]
+            InternalChildren = new[]
             {
-                background = new SpriteIcon
+                background = new Sprite
                 {
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fit,
+                    Texture = textures.Get("Icons/BeatmapDetails/mod-icon"),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(DEFAULT_SIZE),
-                    Icon = OsuIcon.ModBg
                 },
                 contentFlow = new FillFlowContainer
                 {
@@ -78,11 +84,7 @@ namespace osu.Game.Rulesets.UI
                 });
                 tinySwitch.Scale = new Vector2(0.3f);
             }
-        }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuColour colours, OverlayColourProvider? colourProvider)
-        {
             inactiveForegroundColour = colourProvider?.Background5 ?? colours.Gray3;
             activeForegroundColour = colours.ForModType(mod.Type);
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Screens.Play
 
             contentIn();
 
-            MetadataInfo.Delay(750).FadeIn(500);
+            MetadataInfo.Delay(750).FadeIn(500, Easing.OutQuint);
 
             // after an initial delay, start the debounced load check.
             // this will continue to execute even after resuming back on restart.
@@ -420,7 +420,7 @@ namespace osu.Game.Screens.Play
         {
             MetadataInfo.Loading = true;
 
-            content.FadeInFromZero(400);
+            content.FadeInFromZero(500, Easing.OutQuint);
             content.ScaleTo(1, 650, Easing.OutQuint).Then().Schedule(prepareNewPlayer);
 
             settingsScroll.FadeInFromZero(500, Easing.Out)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.922.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.914.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.928.0" />
     <PackageReference Include="Sentry" Version="3.39.1" />
     <PackageReference Include="SharpCompress" Version="0.33.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24674.

Please *do not* pixel peep at sizing differences. I'm not interested in matching any close than what is here. No doubt these mod icons will be redesigned again and I don't want to spend any more time than I have getting this right. That said, things match quite well.

- [x] Depends on https://github.com/ppy/osu-resources/pull/285

Note that I removed the gap which was proposed in the design because it doesn't look great, especially after adding the shadow.

---

A remaining usability concern was players adjusting the rate of DT/HT, but this information being hidden when perusing leaderboards. We've changed how mod icons look to allow exposing this information when required.

![osu! 2023-09-28 at 09 59 50](https://github.com/ppy/osu/assets/191335/87c9f781-f3c6-46bc-bdab-d3bb4de11fcc)
![osu! 2023-09-28 at 10 00 25](https://github.com/ppy/osu/assets/191335/15f85234-0cdc-4ce1-8219-47cc934cb66a)
![osu! 2023-09-28 at 10 00 49](https://github.com/ppy/osu/assets/191335/b775e306-ac25-4230-9dfd-7f7d334a8a55)
![osu! 2023-09-28 at 10 00 58](https://github.com/ppy/osu/assets/191335/e637a75e-4285-4772-95df-ad87d439accb)
![osu! 2023-09-28 at 10 01 23](https://github.com/ppy/osu/assets/191335/a460432f-6b07-4d7d-9898-910b1cc9dca3)