### PR TITLE
Display mod icons using stable (consistent, not osu!stable) ordering

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -31,6 +31,7 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Game.Online.API;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Utils;
 
 namespace osu.Game.Online.Leaderboards
@@ -242,7 +243,7 @@ namespace osu.Game.Online.Leaderboards
                                     Origin = Anchor.BottomRight,
                                     AutoSizeAxes = Axes.Both,
                                     Direction = FillDirection.Horizontal,
-                                    ChildrenEnumerable = Score.Mods.Select(mod => new ModIcon(mod) { Scale = new Vector2(0.375f) })
+                                    ChildrenEnumerable = Score.Mods.AsOrdered().Select(mod => new ModIcon(mod) { Scale = new Vector2(0.375f) })
                                 },
                             },
                         },

--- a/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScoreTooltip.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Online.Leaderboards
             topScoreStatistics.Clear();
             bottomScoreStatistics.Clear();
 
-            foreach (var mod in score.Mods)
+            foreach (var mod in score.Mods.AsOrdered())
             {
                 modStatistics.Add(new ModCell(mod));
             }

--- a/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/ScoreTable.cs
@@ -24,6 +24,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics.Cursor;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring.Drawables;
 
 namespace osu.Game.Overlays.BeatmapSet.Scores
@@ -195,7 +196,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 Direction = FillDirection.Horizontal,
                 AutoSizeAxes = Axes.Both,
                 Spacing = new Vector2(1),
-                ChildrenEnumerable = score.Mods.Select(m => new ModIcon(m)
+                ChildrenEnumerable = score.Mods.AsOrdered().Select(m => new ModIcon(m)
                 {
                     AutoSizeAxes = Axes.Both,
                     Scale = new Vector2(0.3f)

--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 set
                 {
                     modsContainer.Clear();
-                    modsContainer.Children = value.Select(mod => new ModIcon(mod)
+                    modsContainer.Children = value.AsOrdered().Select(mod => new ModIcon(mod)
                     {
                         AutoSizeAxes = Axes.Both,
                         Scale = new Vector2(0.25f),

--- a/osu.Game/Overlays/Mods/EditPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/EditPresetPopover.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateState()
         {
-            scrollContent.ChildrenEnumerable = saveableMods.Select(mod => new ModPresetRow(mod));
+            scrollContent.ChildrenEnumerable = saveableMods.AsOrdered().Select(mod => new ModPresetRow(mod));
             useCurrentModsButton.Enabled.Value = checkSelectedModsDiffersFromSaved();
         }
 

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Overlays.Mods
                 return;
 
             lastPreset = preset;
-            Content.ChildrenEnumerable = preset.Mods.Select(mod => new ModPresetRow(mod));
+            Content.ChildrenEnumerable = preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod));
         }
 
         protected override void PopIn() => this.FadeIn(transition_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Overlays.Mods
         {
             modSettingsFlow.Clear();
 
-            foreach (var mod in SelectedMods.Value.OrderBy(mod => mod.Type).ThenBy(mod => mod.Acronym))
+            foreach (var mod in SelectedMods.Value.AsOrdered())
             {
                 var settings = mod.CreateSettingsControls().ToList();
 

--- a/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
+++ b/osu.Game/Overlays/Profile/Sections/Ranks/DrawableProfileScore.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Leaderboards;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring.Drawables;
 using osu.Game.Utils;
@@ -48,6 +49,8 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
         {
+            var ruleset = rulesets.GetRuleset(Score.RulesetID)?.CreateInstance() ?? throw new InvalidOperationException($"Ruleset with ID of {Score.RulesetID} not found locally");
+
             AddInternal(new ProfileItemContainer
             {
                 Children = new Drawable[]
@@ -132,14 +135,9 @@ namespace osu.Game.Overlays.Profile.Sections.Ranks
                                         Origin = Anchor.CentreRight,
                                         Direction = FillDirection.Horizontal,
                                         Spacing = new Vector2(2),
-                                        Children = Score.Mods.Select(mod =>
+                                        Children = Score.Mods.Select(m => m.ToMod(ruleset)).AsOrdered().Select(mod => new ModIcon(mod)
                                         {
-                                            var ruleset = rulesets.GetRuleset(Score.RulesetID) ?? throw new InvalidOperationException($"Ruleset with ID of {Score.RulesetID} not found locally");
-
-                                            return new ModIcon(mod.ToMod(ruleset.CreateInstance()))
-                                            {
-                                                Scale = new Vector2(0.35f)
-                                            };
+                                            Scale = new Vector2(0.35f)
                                         }).ToList(),
                                     }
                                 }

--- a/osu.Game/Rulesets/Mods/ModExtensions.cs
+++ b/osu.Game/Rulesets/Mods/ModExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Scoring;
@@ -28,5 +29,9 @@ namespace osu.Game.Rulesets.Mods
                 }
             };
         }
+
+        public static IEnumerable<Mod> AsOrdered(this IEnumerable<Mod> mods) => mods
+                                                                                .OrderBy(m => m.Type)
+                                                                                .ThenBy(m => m.Acronym);
     }
 }

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Play.HUD
         {
             iconsContainer.Clear();
 
-            foreach (Mod mod in mods.NewValue)
+            foreach (Mod mod in mods.NewValue.AsOrdered())
                 iconsContainer.Add(new ModIcon(mod) { Scale = new Vector2(0.6f) });
 
             appearTransform();

--- a/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModFlowDisplay.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Screens.Play.HUD
 
             Spacing = new Vector2(0, -12 * iconScale);
 
-            foreach (Mod mod in current.Value)
+            foreach (Mod mod in current.Value.AsOrdered())
             {
                 Add(new ModIcon(mod)
                 {


### PR DESCRIPTION
In discussion with nanaya, we likely want this now that we're adding the ability for some icons to be extended. Historically mod icons have been displayed in a stable but arbitrary order (based on their position in the `Mods` enum).

This change aims to make them stable across lazer scores (where they are stored based on .. the order the user selected them).

I was originally planning to show mods with extended information (see https://github.com/ppy/osu/pull/24954) at the end to ensure the overall alignment of mod icons would be consistent, but it turns out that this looks bad – when a mod has default settings it will not be extended, causing display to be misordered:

![osu! 2023-09-28 at 07 55 07](https://github.com/ppy/osu/assets/191335/3a2e6e7f-c4fe-4112-8c20-8b1c4860fcb6)

If the order is agreed upon, this change would also be applied to osu-web.