### PR TITLE
Add `GetDisplayScore()` extension for `SoloScoreInfo`

### DIFF
--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Scoring.Legacy
@@ -15,6 +16,9 @@ namespace osu.Game.Scoring.Legacy
 
         public static long GetDisplayScore(this ScoreInfo scoreInfo, ScoringMode mode)
             => getDisplayScore(scoreInfo.Ruleset.OnlineID, scoreInfo.TotalScore, mode, scoreInfo.MaximumStatistics);
+
+        public static long GetDisplayScore(this SoloScoreInfo soloScoreInfo, ScoringMode mode)
+            => getDisplayScore(soloScoreInfo.RulesetID, soloScoreInfo.TotalScore, mode, soloScoreInfo.MaximumStatistics);
 
         private static long getDisplayScore(int rulesetId, long score, ScoringMode mode, IReadOnlyDictionary<HitResult, int> maximumStatistics)
         {


### PR DESCRIPTION
To be used server-side for ppy/osu-queue-score-statistics#134.

Saves figuring out how to convert to `ScoreInfo` (which is not trivial server-side) to only _then_ be able to call `GetDisplayScore()`, since all the required data is already there in `SoloScoreInfo`.