### PR TITLE
Reduce approach circle's final opacity to match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             CirclePiece.FadeInFromZero(HitObject.TimeFadeIn);
 
-            ApproachCircle.FadeIn(Math.Min(HitObject.TimeFadeIn * 2, HitObject.TimePreempt));
+            ApproachCircle.FadeTo(0.9f, Math.Min(HitObject.TimeFadeIn * 2, HitObject.TimePreempt));
             ApproachCircle.ScaleTo(1f, HitObject.TimePreempt);
             ApproachCircle.Expire(true);
         }


### PR DESCRIPTION
Closes #24941.

---

Turns out that approach circles were more visible on lazer until now. So let's bring them back in line with stable expectations.

| Before | After |
| :---: | :---: |
| ![osu! 2023-09-29 at 03 50 28](https://github.com/ppy/osu/assets/191335/6a4ed88c-785a-4e94-95ab-2651083ced8d) | ![osu! 2023-09-29 at 03 50 01](https://github.com/ppy/osu/assets/191335/d12beb7f-ef7b-4cf1-95c2-8aa6605ed80d) |