### PR TITLE
Fix object dim being applied to approach circles

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -33,6 +34,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public SkinnableDrawable ApproachCircle { get; private set; }
         public HitReceptor HitArea { get; private set; }
         public SkinnableDrawable CirclePiece { get; private set; }
+
+        protected override IEnumerable<Drawable> DimmablePieces => new[]
+        {
+            CirclePiece,
+        };
 
         Drawable IHasApproachCircle.ApproachCircle => ApproachCircle;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -71,20 +73,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             ScaleBindable.UnbindFrom(HitObject.ScaleBindable);
         }
 
+        protected virtual IEnumerable<Drawable> DimmablePieces => Enumerable.Empty<Drawable>();
+
         protected override void UpdateInitialTransforms()
         {
             base.UpdateInitialTransforms();
 
-            // Dim should only be applied at a top level, as it will be implicitly applied to nested objects.
-            if (ParentHitObject == null)
+            foreach (var piece in DimmablePieces)
             {
-                // Of note, no one noticed this was missing for years, but it definitely feels like it should still exist.
-                // For now this is applied across all skins, and matches stable.
-                // For simplicity, dim colour is applied to the DrawableHitObject itself.
-                // We may need to make a nested container setup if this even causes a usage conflict (ie. with a mod).
-                this.FadeColour(new Color4(195, 195, 195, 255));
-                using (BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
-                    this.FadeColour(Color4.White, 100);
+                piece.FadeColour(new Color4(195, 195, 195, 255));
+                using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
+                    piece.FadeColour(Color4.White, 100);
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -34,6 +35,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public SkinnableDrawable Body { get; private set; }
 
         private ShakeContainer shakeContainer;
+
+        protected override IEnumerable<Drawable> DimmablePieces => new Drawable[]
+        {
+            HeadCircle,
+            TailCircle,
+            Body,
+        };
 
         /// <summary>
         /// A target container which can be used to add top level elements to the slider's display.


### PR DESCRIPTION
Arguably closes https://github.com/ppy/osu/issues/24956. I think this will satisfy most users and we should only address the numbers if there's outcry over it.

The number portion is nested deeply and with reason - depending on skin setting it changes the visual order. I'm not sure how to fix that one, but I also think it's weird behaviour and if people don't complain, I'd rather dim the number for consistency.

That said, the approach circle is an important one to ensure it matches 1:1, so I've fixed that here.

| Before | After |
| :---: | :---: |
| ![osu Game Rulesets Osu Tests 2023-09-29 at 09 28 08](https://github.com/ppy/osu/assets/191335/18455581-c935-4098-97dc-637095fc91b4) | ![osu Game Rulesets Osu Tests 2023-09-29 at 09 27 35](https://github.com/ppy/osu/assets/191335/9b777bc5-ad4f-488e-8f0d-66b1595f2085) |