### PR TITLE
Prevent snapping outside of track length

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -317,6 +317,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);
+            // prevent snapping outside of track length
+            time = Math.Min(time, editorClock.TrackLength);
             return new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(time));
         }
     }


### PR DESCRIPTION
Partially addresses #24950.

I have made a simple stopgap fix to fix only what the issue's title states: allowing HitObjects to be dragged past the end time in the Editor.

I have changed `Timeline.FindSnappedPositionAndTime()` to return the minimum between the calculated snapped time and the track's length. I think this is a reasonable fix, as it does not make sense to snap to times outside of the track's playback period.

However, it still allows part of a HitObject to be present outside of the track if it has a duration (e.g. Spinners, Sliders); check https://github.com/ppy/osu/issues/24950#issuecomment-1740735546.

As such, it does not address the performance/functionality issues of a Spinner/Slider/HitObject with duration ending after the track's end time, as you could simply make a Spinner then drag its start point to the end time.