### PR TITLE
Fix spinner requirements being susceptible to FP precision

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -70,8 +70,11 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             double secondsDuration = Duration / 1000;
 
-            SpinsRequired = (int)(minRps * secondsDuration);
-            MaximumBonusSpins = Math.Max(0, (int)(maxRps * secondsDuration) - SpinsRequired - bonus_spins_gap);
+            // Allow a 0.1ms floating point precision error in the calculation of the duration.
+            const double duration_error = 0.0001;
+
+            SpinsRequired = (int)(minRps * secondsDuration + duration_error);
+            MaximumBonusSpins = Math.Max(0, (int)(maxRps * secondsDuration + duration_error) - SpinsRequired - bonus_spins_gap);
         }
 
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)


### PR DESCRIPTION
See: https://github.com/ppy/osu/runs/17361055215#r0s0

This should be enough to fix the test and be imperceptible in gameplay.

I'm choosing this method instead of rounding, as we do want to tend towards an upper bound rather than a lower bound. To show this, I've charted up truncation vs rounding https://docs.google.com/spreadsheets/d/1c1rE9Svq2_Ix4L4pUPX6EBtnp1iytL0IbaGRBPUI-HQ/edit?usp=sharing - notice how a spinner with 3 ticks would require 300RPM vs the stated 250RPM using the rounding method, which scales linearly to 430RPM requiring 480RPM to complete.