### PR TITLE
Allow judging at most one swell tick per frame

### DIFF
--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
+using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -269,6 +270,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 ProxyContent();
             else
                 UnproxyContent();
+
+            if ((Clock as IGameplayClock)?.IsRewinding == true)
+                lastPressHandleTime = null;
         }
 
         private bool? lastWasCentre;

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private readonly CircularContainer targetRing;
         private readonly CircularContainer expandingRing;
 
+        private double? lastPressHandleTime;
+
         public override bool DisplayResult => false;
 
         public DrawableSwell()
@@ -140,6 +142,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             UnproxyContent();
 
             lastWasCentre = null;
+            lastPressHandleTime = null;
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)
@@ -285,7 +288,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             if (lastWasCentre == isCentre)
                 return false;
 
+            // If we've already successfully judged a tick this frame, do not judge more.
+            // Note that the ordering is important here - this is intentionally placed after the alternating check.
+            // That is done to prevent accidental double inputs blocking simultaneous but legitimate hits from registering.
+            if (lastPressHandleTime == Time.Current)
+                return true;
+
             lastWasCentre = isCentre;
+            lastPressHandleTime = Time.Current;
 
             UpdateResult(true);
 


### PR DESCRIPTION
Addresses part of #24780.

This PR changes swell input handling such that only one swell tick can be judged in a given update frame. This is supposed to curtail cases wherein a user binds (either in-game, or via external tools) all four taiko actions to one key, to knock out four hits at a time with one key.

Note that this is supposed to be a starting point rather than a complete solution. As per https://github.com/ppy/osu/issues/24780#issuecomment-1746842162, this change is actually quite lenient in comparison to stable, in two respects:

- In stable, if in one frame you hit a key that is not properly alternated and another key that *is* properly alternated, then the not-alternated press blocks the alternated press. In other words, the following sequence of hits:

   ```
   left rim
   left rim + right center
   ```
   will cause just one swell tick to be judged, even though the right center hit _could_ have been considered valid. The implementation in this PR assumes good faith, and will count the right center hit as valid. The reason I did this is that I can see perfectly reasonable cases wherein you may e.g. have a chattering key that will cause an input to be repeated and as such unfairly eat a valid press with stable's implementation.
- Also, as per [the code snippet here](https://github.com/ppy/osu/issues/24780#issuecomment-1746842162) - as long as score V2 is off - stable enforces a cooldown duration of 30ms between subsequent hits on a swell. I'm not sure what to do with that given it's dependent on score V2 for whatever reason, so I decided not to implement it for now.

If you wish to test stable, then [SwellTest.zip](https://github.com/ppy/osu/files/12806922/SwellTest.zip) contains a beatmap with one swell on it, as well as a replay on said map wherein all 4 keys are pressed in a single frame 7 times.

- On lazer master this clears the swell;
- with this PR, it gets the swell halfway to clear;
- on stable, due to the pessimistic treatment of inputs, the replay registers just one hit. (The 30ms thing is largely irrelevant in this context.)