### PR TITLE
Fix `TestReplayExport` intermittent failure

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -173,7 +174,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             string? filePath = null;
 
             // Files starting with _ are temporary, created by CreateFileSafely call.
-            AddUntilStep("wait for export file", () => filePath = LocalStorage.GetFiles("exports").SingleOrDefault(f => !f.StartsWith("_", StringComparison.Ordinal)), () => Is.Not.Null);
+            AddUntilStep("wait for export file", () => filePath = LocalStorage.GetFiles("exports").SingleOrDefault(f => !Path.GetFileName(f).StartsWith("_", StringComparison.Ordinal)), () => Is.Not.Null);
             AddAssert("filesize is non-zero", () =>
             {
                 using (var stream = LocalStorage.GetStream(filePath))


### PR DESCRIPTION
The previous fix was not working as it was checking the path for the prefix `_`, not the filename.

See https://github.com/ppy/osu/runs/17415814653#r0s2 which clearly shows this.