### PR TITLE
Adjust gameplay element maximum size limits for backwards compatibility

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyBananaPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyBananaPiece.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 {
     public partial class LegacyBananaPiece : LegacyCatchHitObjectPiece
     {
-        private static readonly Vector2 banana_max_size = new Vector2(128);
+        private static readonly Vector2 banana_max_size = new Vector2(160);
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyDropletPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyDropletPiece.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 {
     public partial class LegacyDropletPiece : LegacyCatchHitObjectPiece
     {
-        private static readonly Vector2 droplet_max_size = new Vector2(82, 103);
+        private static readonly Vector2 droplet_max_size = new Vector2(160);
 
         public LegacyDropletPiece()
         {

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyFruitPiece.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 {
     internal partial class LegacyFruitPiece : LegacyCatchHitObjectPiece
     {
-        private static readonly Vector2 fruit_max_size = new Vector2(128);
+        private static readonly Vector2 fruit_max_size = new Vector2(160);
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             // expected behaviour in this scenario is not showing the overlay, rather than using hitcircleoverlay.png.
             InternalChildren = new[]
             {
-                CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName)?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS) })
+                CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName)?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d, maxSize: OsuHitObject.OBJECT_DIMENSIONS))
+                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => skin.GetAnimation(@$"{circleName}overlay", true, true, frameLength: 1000 / 2d, maxSize: OsuHitObject.OBJECT_DIMENSIONS * 2))
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             var skin = skinSource.FindProvider(s => s.GetTexture(lookupName) != null);
 
-            InternalChild = arrow = (skin?.GetAnimation(lookupName, true, true, maxSize: OsuHitObject.OBJECT_DIMENSIONS) ?? Empty()).With(d =>
+            InternalChild = arrow = (skin?.GetAnimation(lookupName, true, true, maxSize: OsuHitObject.OBJECT_DIMENSIONS * 2) ?? Empty()).With(d =>
             {
                 d.Anchor = Anchor.Centre;
                 d.Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS),
+                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2),
                     Colour = new Color4(5, 5, 5, 255),
                 },
                 LegacyColourCompatibility.ApplyWithDoubledAlpha(animationContent.With(d =>
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS),
+                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2),
                     Blending = BlendingParameters.Additive,
                 },
             };

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
 using osuTK.Graphics;
@@ -47,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2),
+                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE),
                     Colour = new Color4(5, 5, 5, 255),
                 },
                 LegacyColourCompatibility.ApplyWithDoubledAlpha(animationContent.With(d =>
@@ -59,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2),
+                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE),
                     Blending = BlendingParameters.Additive,
                 },
             };

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -42,14 +42,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         return this.GetAnimation("sliderscorepoint", false, false);
 
                     case OsuSkinComponents.SliderFollowCircle:
-                        var followCircleContent = this.GetAnimation("sliderfollowcircle", true, true, true, maxSize: new Vector2(308f));
+                        var followCircleContent = this.GetAnimation("sliderfollowcircle", true, true, true, maxSize: OsuHitObject.OBJECT_DIMENSIONS * 3);
                         if (followCircleContent != null)
                             return new LegacyFollowCircle(followCircleContent);
 
                         return null;
 
                     case OsuSkinComponents.SliderBall:
-                        var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "", maxSize: OsuHitObject.OBJECT_DIMENSIONS);
+                        var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "", maxSize: OsuHitObject.OBJECT_DIMENSIONS * 2);
 
                         // todo: slider ball has a custom frame delay based on velocity
                         // Math.Max((150 / Velocity) * GameBase.SIXTY_FRAME_TIME, GameBase.SIXTY_FRAME_TIME);
@@ -139,7 +139,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         if (!this.HasFont(LegacyFont.HitCircle))
                             return null;
 
-                        return new LegacySpriteText(LegacyFont.HitCircle, OsuHitObject.OBJECT_DIMENSIONS)
+                        return new LegacySpriteText(LegacyFont.HitCircle, OsuHitObject.OBJECT_DIMENSIONS * 2)
                         {
                             // stable applies a blanket 0.8x scale to hitcircle fonts
                             Scale = new Vector2(0.8f),

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -23,6 +23,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         /// </summary>
         public const float LEGACY_CIRCLE_RADIUS = OsuHitObject.OBJECT_RADIUS - 5;
 
+        /// <summary>
+        /// The maximum allowed size of sprites that reside in the follow circle area of a slider.
+        /// </summary>
+        /// <remarks>
+        /// The reason this is extracted out to a constant, rather than be inlined in the follow circle sprite retrieval,
+        /// is that some skins will use `sliderb` elements to emulate a slider follow circle with slightly different visual effects applied
+        /// (`sliderb` is always shown and doesn't pulsate; `sliderfollowcircle` isn't always shown and pulsates).
+        /// </remarks>
+        public static readonly Vector2 MAX_FOLLOW_CIRCLE_AREA_SIZE = OsuHitObject.OBJECT_DIMENSIONS * 3;
+
         public OsuLegacySkinTransformer(ISkin skin)
             : base(skin)
         {
@@ -42,14 +52,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         return this.GetAnimation("sliderscorepoint", false, false);
 
                     case OsuSkinComponents.SliderFollowCircle:
-                        var followCircleContent = this.GetAnimation("sliderfollowcircle", true, true, true, maxSize: OsuHitObject.OBJECT_DIMENSIONS * 3);
+                        var followCircleContent = this.GetAnimation("sliderfollowcircle", true, true, true, maxSize: MAX_FOLLOW_CIRCLE_AREA_SIZE);
                         if (followCircleContent != null)
                             return new LegacyFollowCircle(followCircleContent);
 
                         return null;
 
                     case OsuSkinComponents.SliderBall:
-                        var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "", maxSize: OsuHitObject.OBJECT_DIMENSIONS * 2);
+                        var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "", maxSize: MAX_FOLLOW_CIRCLE_AREA_SIZE);
 
                         // todo: slider ball has a custom frame delay based on velocity
                         // Math.Max((150 / Velocity) * GameBase.SIXTY_FRAME_TIME, GameBase.SIXTY_FRAME_TIME);
@@ -139,10 +149,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         if (!this.HasFont(LegacyFont.HitCircle))
                             return null;
 
-                        return new LegacySpriteText(LegacyFont.HitCircle, OsuHitObject.OBJECT_DIMENSIONS * 2)
+                        const float hitcircle_text_scale = 0.8f;
+                        return new LegacySpriteText(LegacyFont.HitCircle, OsuHitObject.OBJECT_DIMENSIONS * 2 / hitcircle_text_scale)
                         {
                             // stable applies a blanket 0.8x scale to hitcircle fonts
-                            Scale = new Vector2(0.8f),
+                            Scale = new Vector2(hitcircle_text_scale),
                         };
 
                     case OsuSkinComponents.SpinnerBody:

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyCirclePiece.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     public partial class LegacyCirclePiece : CompositeDrawable, IHasAccentColour
     {
         private static readonly Vector2 circle_piece_size = new Vector2(128);
+        private static readonly Vector2 max_circle_sprite_size = new Vector2(160);
 
         private Drawable backgroundLayer = null!;
         private Drawable? foregroundLayer;
@@ -54,9 +55,9 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
                 string prefix = ((drawableHitObject.HitObject as TaikoStrongableHitObject)?.IsStrong ?? false) ? big_hit : normal_hit;
 
-                return skin.GetAnimation($"{prefix}{lookup}", true, false, maxSize: circle_piece_size) ??
+                return skin.GetAnimation($"{prefix}{lookup}", true, false, maxSize: max_circle_sprite_size) ??
                        // fallback to regular size if "big" version doesn't exist.
-                       skin.GetAnimation($"{normal_hit}{lookup}", true, false, maxSize: circle_piece_size);
+                       skin.GetAnimation($"{normal_hit}{lookup}", true, false, maxSize: max_circle_sprite_size);
             }
 
             // backgroundLayer is guaranteed to exist due to the pre-check in TaikoLegacySkinTransformer.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24973

This PR adjusts the maximum allowable element sizes enforced in https://github.com/ppy/osu/pull/24706 such that they affect a significantly smaller number of user skins.

The new limits were chosen by sampling across over 4000 skins, using [data graciously provided](https://github.com/ppy/osu/issues/24973#issuecomment-1747956285) by @RockRoller01. The methodology for doing so is described in [this gist](https://gist.github.com/bdach/6228ba41d128b23d1f89142f404108a3).

The nominal goals were:
- Keep the ratio of broken skins under 5%
- In osu!, I've heard several voices that people don't really care about skins blowing up the sprite sizes, since it wasn't really exploitable. So I was more than fine generally even doubling the max allowed size to keep the percentage of broken skins low.
- In taiko and catch, as there were numerous complaints and questions about putting a hard limit on gameplay element sizes to curb abuse, and thus I was a lot more stringent and generally only allowed up to about 25% slack (with the exception of droplets, which were generally the odd one out anyways, and so I've allowed them to be as large as a normal fruit).

The table below contains the full breakdown:

| element | previous maximum | % of skins broken before | new maximum | % of skins broken after |
| :- | :-: | -: | :-: | -: |
| `hitcircle` | 128x128 | 12.26% | 256x256 | 0.14% |
| `sliderstartcircle` | 128x128 | 13.56% | 256x256 | 0.90% |
| `sliderendcircle` | 128x128 | 5.34% | 256x256 | 1.73% |
| `hitcircleoverlay` | 128x128 | 15.96% | 256x256 | 0.13% |
| `sliderstartcircleoverlay` | 128x128 | 15.51% | 256x256 | 0.26% |
| `sliderendcircleoverlay` | 128x128 | 4.90% | 256x256 | 0.72% |
| `reversearrow` | 128x128 | 36.47% | 256x256 | 0.19% |
| `sliderb` | 128x128 | 40.89% | 384x384 | 0.53% |
| `sliderb-nd` | 128x128 | 3.57% | 384x384 | 3.57% |
| `sliderb-spec` | 128x128 | 0.00% | 384x384 | 0.00% |
| `sliderfollowcircle` | 308x308 | 4.04% | 384x384 | 1.52% |
| `default-N` | 128x128 | 13.33% | 320x320 | 0.03% |
| `taikohitcircle` | 128x128 | 8.61% | 160x160 | 3.84% |
| `taikobigcircle` | 128x128 | 9.22% | 160x160 | 2.99% |
| `taikohitcircleoverlay` | 128x128 | 9.60% | 160x160 | 2.71% |
| `taikobigcircleoverlay` | 128x128 | 11.11% | 160x160 | 3.24% |
| `fruit-{bananas,pear,grapes,apple,orange}` | 128x128 | 7.59% | 160x160 | 3.04% |
| `fruit-{bananas,pear,grapes,apple,orange}-overlay` | 128x128 | 6.48% | 160x160 | 3.15% |
| `fruit-drop` | 82x103 | 34.45% | 160x160 | 1.49% |
| `fruit-drop-overlay` | 82x103 | 40.87% | 160x160 | 1.62% |

All dimensions are `@1x`. `@2x` elements are still allowed to be twice as big as limits above.