### PR TITLE
Fix OAuth refresh attempt when no network available causing full logout (part 2)

### DIFF
--- a/osu.Game/Online/API/OAuth.cs
+++ b/osu.Game/Online/API/OAuth.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Net.Sockets;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 
@@ -99,6 +100,11 @@ namespace osu.Game.Online.API
                     return true;
                 }
             }
+            catch (SocketException)
+            {
+                // Network failure.
+                return false;
+            }
             catch (HttpRequestException)
             {
                 // Network failure.
@@ -106,7 +112,7 @@ namespace osu.Game.Online.API
             }
             catch
             {
-                // Force a full re-reauthentication.
+                // Force a full re-authentication.
                 Token.Value = null;
                 return false;
             }


### PR DESCRIPTION
This time for `SocketException`s. I seem to recall looking at this and deciding there was a reason to not catch socket exceptions, but on revisiting it seems sane to do so.

This covers a fail case like reported:

```
2023-10-06 03:24:17 [verbose]: Request to https://lazer.ppy.sh/oauth/token failed with System.Net.Http.HttpRequestException: No such host is known. (lazer.ppy.sh:443)
2023-10-06 03:24:17 [verbose]: ---> System.Net.Sockets.SocketException (11001): No such host is known.
2023-10-06 03:24:17 [verbose]: at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
```

Closes https://github.com/ppy/osu/issues/24890 (again).