### PR TITLE
Adjust argon health bar to fit with existing layout

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
@@ -21,6 +22,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached(typeof(HealthProcessor))]
         private HealthProcessor healthProcessor = new DrainingHealthProcessor(0);
 
+        private ArgonHealthDisplay healthDisplay = null!;
+
         [SetUpSteps]
         public void SetUpSteps()
         {
@@ -36,12 +39,24 @@ namespace osu.Game.Tests.Visual.Gameplay
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.Gray,
                     },
-                    new ArgonHealthDisplay
+                    healthDisplay = new ArgonHealthDisplay
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     },
                 };
+            });
+
+            AddSliderStep("Width", 0, 1f, 1f, val =>
+            {
+                if (healthDisplay.IsNotNull())
+                    healthDisplay.BarLength.Value = val;
+            });
+
+            AddSliderStep("Height", 0, 64, 0, val =>
+            {
+                if (healthDisplay.IsNotNull())
+                    healthDisplay.BarHeight.Value = val;
             });
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -12,7 +12,6 @@ using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play.HUD;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -41,7 +40,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Scale = new Vector2(2f),
                     },
                 };
             });

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -145,9 +145,11 @@ namespace osu.Game.Screens.Play.HUD
                 if (v.NewValue >= GlowBarValue)
                     finishMissDisplay();
 
-                this.TransformTo(nameof(HealthBarValue), v.NewValue, 300, Easing.OutQuint);
+                double time = v.NewValue > GlowBarValue ? 500 : 250;
+
+                this.TransformTo(nameof(HealthBarValue), v.NewValue, time, Easing.OutQuint);
                 if (resetMissBarDelegate == null)
-                    this.TransformTo(nameof(GlowBarValue), v.NewValue, 300, Easing.OutQuint);
+                    this.TransformTo(nameof(GlowBarValue), v.NewValue, time, Easing.OutQuint);
             }, true);
 
             BarLength.BindValueChanged(l => Width = l.NewValue, true);

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
@@ -96,7 +95,7 @@ namespace osu.Game.Screens.Play.HUD
             }
         }
 
-        private const float left_line_width = 50f;
+        private const float main_path_radius = 10f;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -104,51 +103,37 @@ namespace osu.Game.Screens.Play.HUD
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            InternalChild = new FillFlowContainer
+            InternalChild = new Container
             {
                 AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(4f, 0f),
                 Children = new Drawable[]
                 {
-                    new Circle
+                    background = new BackgroundPath
                     {
-                        Margin = new MarginPadding { Top = 8.5f, Left = -2 },
-                        Size = new Vector2(left_line_width, 3f),
+                        PathRadius = main_path_radius,
                     },
-                    new Container
+                    glowBar = new BarPath
                     {
-                        AutoSizeAxes = Axes.Both,
-                        Children = new Drawable[]
-                        {
-                            background = new BackgroundPath
-                            {
-                                PathRadius = 10f,
-                            },
-                            glowBar = new BarPath
-                            {
-                                BarColour = Color4.White,
-                                GlowColour = OsuColour.Gray(0.5f),
-                                Blending = BlendingParameters.Additive,
-                                Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.8f), Color4.White),
-                                PathRadius = 40f,
-                                // Kinda hacky, but results in correct positioning with increased path radius.
-                                Margin = new MarginPadding(-30f),
-                                GlowPortion = 0.9f,
-                            },
-                            mainBar = new BarPath
-                            {
-                                AutoSizeAxes = Axes.None,
-                                RelativeSizeAxes = Axes.Both,
-                                Blending = BlendingParameters.Additive,
-                                BarColour = main_bar_colour,
-                                GlowColour = main_bar_glow_colour,
-                                PathRadius = 10f,
-                                GlowPortion = 0.6f,
-                            },
-                        }
-                    }
-                },
+                        BarColour = Color4.White,
+                        GlowColour = OsuColour.Gray(0.5f),
+                        Blending = BlendingParameters.Additive,
+                        Colour = ColourInfo.GradientHorizontal(Color4.White.Opacity(0.8f), Color4.White),
+                        PathRadius = 40f,
+                        // Kinda hacky, but results in correct positioning with increased path radius.
+                        Margin = new MarginPadding(-30f),
+                        GlowPortion = 0.9f,
+                    },
+                    mainBar = new BarPath
+                    {
+                        AutoSizeAxes = Axes.None,
+                        RelativeSizeAxes = Axes.Both,
+                        Blending = BlendingParameters.Additive,
+                        BarColour = main_bar_colour,
+                        GlowColour = main_bar_glow_colour,
+                        PathRadius = main_path_radius,
+                        GlowPortion = 0.6f,
+                    },
+                }
             };
         }
 
@@ -247,7 +232,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updatePath()
         {
-            float barLength = DrawWidth - left_line_width - 24;
+            float barLength = DrawWidth - main_path_radius * 2;
             float curveStart = barLength - 70;
             float curveEnd = barLength - 40;
 

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -30,16 +30,15 @@ namespace osu.Game.Screens.Play.HUD
         public bool UsesFixedAnchor { get; set; }
 
         [SettingSource("Bar height")]
-        public BindableFloat BarHeight { get; } = new BindableFloat
+        public BindableFloat BarHeight { get; } = new BindableFloat(20)
         {
-            Default = 32,
             MinValue = 0,
             MaxValue = 64,
             Precision = 1
         };
 
         [SettingSource("Bar length")]
-        public BindableFloat BarLength { get; } = new BindableFloat(1)
+        public BindableFloat BarLength { get; } = new BindableFloat(0.98f)
         {
             MinValue = 0.2f,
             MaxValue = 1,

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Skinning
                         case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
                             var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
                             {
+                                var health = container.OfType<ArgonHealthDisplay>().FirstOrDefault();
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();
                                 var combo = container.OfType<DefaultComboCounter>().FirstOrDefault();
@@ -127,6 +128,13 @@ namespace osu.Game.Skinning
                                     const float horizontal_padding = 20;
 
                                     score.Position = new Vector2(0, vertical_offset);
+
+                                    if (health != null)
+                                    {
+                                        health.Origin = Anchor.TopCentre;
+                                        health.Anchor = Anchor.TopCentre;
+                                        health.Y = 5;
+                                    }
 
                                     if (ppCounter != null)
                                     {
@@ -191,7 +199,7 @@ namespace osu.Game.Skinning
                                     new DefaultComboCounter(),
                                     new DefaultScoreCounter(),
                                     new DefaultAccuracyCounter(),
-                                    new DefaultHealthDisplay(),
+                                    new ArgonHealthDisplay(),
                                     new ArgonSongProgress(),
                                     new ArgonKeyCounterDisplay(),
                                     new BarHitErrorMeter(),


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25014

To make things fit so we can show this off in the next release, I've made some changes and added some configurability.

### The health bar is now relative sized

This is to make it work with the fullscreen layout. The final layout needs it to be non-relative-sized. We'll deal with that when we need to. I'm still figuring out how that can work in my head.

### The white bar at the left is no longer contained within it

This allows the bar to be used more flexibly by users in their own skins, IMO. The white bars in the argon skin design should be a very simple skinnable component (that exposes a colour and corner radius or similar) which is not attached directly to the elements.

https://github.com/ppy/osu/assets/191335/0f0f71c9-bdd0-448a-8ad6-a4d63b9ba209


