### PR TITLE
Make `HealthIncreaseFor(JudgementResult)` virtual

### DIFF
--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Judgements
         /// </summary>
         /// <param name="result">The <see cref="JudgementResult"/> to find the numeric health increase for.</param>
         /// <returns>The numeric health increase of <paramref name="result"/>.</returns>
-        public double HealthIncreaseFor(JudgementResult result) => HealthIncreaseFor(result.Type);
+        public virtual double HealthIncreaseFor(JudgementResult result) => HealthIncreaseFor(result.Type);
 
         public override string ToString() => $"MaxResult:{MaxResult} MaxScore:{MaxNumericResult}";
 


### PR DESCRIPTION
By making `Judgement.HealthIncreaseFor(JudgementResult)`, rulesets are able to implement different health penalties / rewards based on information encoded in JudgementResult.

Rush in particular only penalizes players when colliding with hitobjects, like in MuseDash, but this is achieved via workarounds in HealthProcessor([RushJudgement](https://github.com/Beamographic/rush/blob/master/osu.Game.Rulesets.Rush/Judgements/RushJudgement.cs#L26), [RushHealthProcessor](https://github.com/Beamographic/rush/blob/master/osu.Game.Rulesets.Rush/Scoring/RushHealthProcessor.cs#L21)). This doesn't play nice with the updated HealthDisplay, which uses `Judgement.HealthIncreaseFor(JudgementResult)` to determine whether the miss animation should happen.

An alternative would be to make `HealthProcessor.HealthIncreaseFor(JudgementResult)` public and let `HealthDisplay` use that to determine whether a miss occurred. 