### PR TITLE
Move playlist item download button to left

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -456,6 +456,7 @@ namespace osu.Game.Screens.OnlinePlay
 
         private IEnumerable<Drawable> createButtons() => new[]
         {
+            beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
             showResultsButton = new GrayButton(FontAwesome.Solid.ChartPie)
             {
                 Size = new Vector2(30, 30),
@@ -463,7 +464,6 @@ namespace osu.Game.Screens.OnlinePlay
                 Alpha = AllowShowingResults ? 1 : 0,
                 TooltipText = "View results"
             },
-            beatmap == null ? Empty() : new PlaylistDownloadButton(beatmap),
             editButton = new PlaylistEditButton
             {
                 Size = new Vector2(30, 30),


### PR DESCRIPTION
Felt really anti-user when you go to click the results button and the downloads button pops into its place.

Before:


https://github.com/ppy/osu/assets/191335/2c7c42de-85c9-45c6-9658-2969365f400d

After:

https://github.com/ppy/osu/assets/191335/8a6b28e2-ba50-4e75-99be-b23cfeeeebdf

