### PR TITLE
Reduce inflate effect when scaling an element in Skin Editor

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             drawableQuad = drawable.ToScreenSpace(
                 drawable.DrawRectangle
-                        .Inflate(SkinSelectionHandler.INFLATE_SIZE));
+                        .Inflate(SkinSelectionHandler.INFLATE_SIZE / 3));
 
             var localSpaceQuad = ToLocalSpace(drawableQuad);
 


### PR DESCRIPTION
Fixes #25049.

I am not happy with this proposal. The “problem” remains, but I am unsure which path to go with, considering peppy said that it was an intended effect. (See linked issue)
I was thinking of limiting the inflation after it reaches a maximum inflation (Say 1.2 from original size), and limit the container to that maximum.

Please, let me know what you would see fit best.