### PR TITLE
Ensure health displays don't pile up transforms when off-screen

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -142,18 +142,8 @@ namespace osu.Game.Screens.Play.HUD
 
             Current.BindValueChanged(v =>
             {
-                Scheduler.AddOnce(() =>
-                {
-                    if (v.NewValue >= GlowBarValue)
-                        finishMissDisplay();
-
-                    double time = v.NewValue > GlowBarValue ? 500 : 250;
-
-                    // TODO: this should probably use interpolation in update.
-                    this.TransformTo(nameof(HealthBarValue), v.NewValue, time, Easing.OutQuint);
-                    if (resetMissBarDelegate == null)
-                        this.TransformTo(nameof(GlowBarValue), v.NewValue, time, Easing.OutQuint);
-                });
+                // For some reason making the delegate inline here doesn't work correctly.
+                Scheduler.AddOnce(updateCurrent);
             }, true);
 
             BarLength.BindValueChanged(l => Width = l.NewValue, true);
@@ -167,6 +157,17 @@ namespace osu.Game.Screens.Play.HUD
                 updatePath();
 
             return base.OnInvalidate(invalidation, source);
+        }
+
+        private void updateCurrent()
+        {
+            if (Current.Value >= GlowBarValue) finishMissDisplay();
+
+            double time = Current.Value > GlowBarValue ? 500 : 250;
+
+            // TODO: this should probably use interpolation in update.
+            this.TransformTo(nameof(HealthBarValue), Current.Value, time, Easing.OutQuint);
+            if (resetMissBarDelegate == null) this.TransformTo(nameof(GlowBarValue), Current.Value, time, Easing.OutQuint);
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Play.HUD
                     return;
 
                 glowBarValue = value;
-                updatePathVertices();
+                Scheduler.AddOnce(updatePathVertices);
             }
         }
 
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Play.HUD
                     return;
 
                 healthBarValue = value;
-                updatePathVertices();
+                Scheduler.AddOnce(updatePathVertices);
             }
         }
 

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -139,11 +139,7 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            Current.BindValueChanged(v =>
-            {
-                // For some reason making the delegate inline here doesn't work correctly.
-                Scheduler.AddOnce(updateCurrent);
-            }, true);
+            Current.BindValueChanged(_ => Scheduler.AddOnce(updateCurrent), true);
 
             BarLength.BindValueChanged(l => Width = l.NewValue, true);
             BarHeight.BindValueChanged(_ => updatePath());

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -16,7 +16,6 @@ using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
@@ -178,9 +177,9 @@ namespace osu.Game.Screens.Play.HUD
             glowBar.Alpha = (float)Interpolation.DampContinuously(glowBar.Alpha, GlowBarValue > 0 ? 1 : 0, 40, Time.Elapsed);
         }
 
-        protected override void Flash(JudgementResult result)
+        protected override void Flash()
         {
-            base.Flash(result);
+            base.Flash();
 
             mainBar.TransformTo(nameof(BarPath.GlowColour), main_bar_glow_colour.Opacity(0.8f))
                    .TransformTo(nameof(BarPath.GlowColour), main_bar_glow_colour, 300, Easing.OutQuint);
@@ -196,9 +195,9 @@ namespace osu.Game.Screens.Play.HUD
             }
         }
 
-        protected override void Miss(JudgementResult result)
+        protected override void Miss()
         {
-            base.Miss(result);
+            base.Miss();
 
             if (resetMissBarDelegate != null)
             {

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -149,6 +149,7 @@ namespace osu.Game.Screens.Play.HUD
 
                     double time = v.NewValue > GlowBarValue ? 500 : 250;
 
+                    // TODO: this should probably use interpolation in update.
                     this.TransformTo(nameof(HealthBarValue), v.NewValue, time, Easing.OutQuint);
                     if (resetMissBarDelegate == null)
                         this.TransformTo(nameof(GlowBarValue), v.NewValue, time, Easing.OutQuint);

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -142,14 +142,17 @@ namespace osu.Game.Screens.Play.HUD
 
             Current.BindValueChanged(v =>
             {
-                if (v.NewValue >= GlowBarValue)
-                    finishMissDisplay();
+                Scheduler.AddOnce(() =>
+                {
+                    if (v.NewValue >= GlowBarValue)
+                        finishMissDisplay();
 
-                double time = v.NewValue > GlowBarValue ? 500 : 250;
+                    double time = v.NewValue > GlowBarValue ? 500 : 250;
 
-                this.TransformTo(nameof(HealthBarValue), v.NewValue, time, Easing.OutQuint);
-                if (resetMissBarDelegate == null)
-                    this.TransformTo(nameof(GlowBarValue), v.NewValue, time, Easing.OutQuint);
+                    this.TransformTo(nameof(HealthBarValue), v.NewValue, time, Easing.OutQuint);
+                    if (resetMissBarDelegate == null)
+                        this.TransformTo(nameof(GlowBarValue), v.NewValue, time, Easing.OutQuint);
+                });
             }, true);
 
             BarLength.BindValueChanged(l => Width = l.NewValue, true);

--- a/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
@@ -112,20 +112,18 @@ namespace osu.Game.Screens.Play.HUD
             };
         }
 
+        protected override void Flash(JudgementResult result)
+        {
+            fill.FadeEdgeEffectTo(Math.Min(1, fill.EdgeEffect.Colour.Linear.A + (1f - base_glow_opacity) / glow_max_hits), 50, Easing.OutQuint)
+                .Delay(glow_fade_delay)
+                .FadeEdgeEffectTo(base_glow_opacity, glow_fade_time, Easing.OutQuint);
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             AccentColour = colours.BlueLighter;
             GlowColour = colours.BlueDarker;
-        }
-
-        protected override void Flash(JudgementResult result) => Scheduler.AddOnce(flash);
-
-        private void flash()
-        {
-            fill.FadeEdgeEffectTo(Math.Min(1, fill.EdgeEffect.Colour.Linear.A + (1f - base_glow_opacity) / glow_max_hits), 50, Easing.OutQuint)
-                .Delay(glow_fade_delay)
-                .FadeEdgeEffectTo(base_glow_opacity, glow_fade_time, Easing.OutQuint);
         }
 
         protected override void Update()

--- a/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultHealthDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Judgements;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -112,7 +111,7 @@ namespace osu.Game.Screens.Play.HUD
             };
         }
 
-        protected override void Flash(JudgementResult result)
+        protected override void Flash()
         {
             fill.FadeEdgeEffectTo(Math.Min(1, fill.EdgeEffect.Colour.Linear.A + (1f - base_glow_opacity) / glow_max_hits), 50, Easing.OutQuint)
                 .Delay(glow_fade_delay)

--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 
@@ -41,8 +40,7 @@ namespace osu.Game.Screens.Play.HUD
         /// Triggered when a <see cref="Judgement"/> is a successful hit, signaling the health display to perform a flash animation (if designed to do so).
         /// Calls to this method are debounced.
         /// </summary>
-        /// <param name="result">The judgement result.</param>
-        protected virtual void Flash(JudgementResult result)
+        protected virtual void Flash()
         {
         }
 
@@ -50,8 +48,7 @@ namespace osu.Game.Screens.Play.HUD
         /// Triggered when a <see cref="Judgement"/> resulted in the player losing health.
         /// Calls to this method are debounced.
         /// </summary>
-        /// <param name="result">The judgement result.</param>
-        protected virtual void Miss(JudgementResult result)
+        protected virtual void Miss()
         {
         }
 
@@ -94,7 +91,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 double newValue = Current.Value + 0.05f;
                 this.TransformBindableTo(Current, newValue, increase_delay);
-                Scheduler.AddOnce(Flash, new JudgementResult(new HitObject(), new Judgement()));
+                Scheduler.AddOnce(Flash);
 
                 if (newValue >= 1)
                     finishInitialAnimation();
@@ -120,9 +117,9 @@ namespace osu.Game.Screens.Play.HUD
         private void onNewJudgement(JudgementResult judgement)
         {
             if (judgement.IsHit && judgement.Type != HitResult.IgnoreHit)
-                Scheduler.AddOnce(Flash, judgement);
+                Scheduler.AddOnce(Flash);
             else if (judgement.Judgement.HealthIncreaseFor(judgement) < 0)
-                Scheduler.AddOnce(Miss, judgement);
+                Scheduler.AddOnce(Miss);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.Play.HUD
 
         /// <summary>
         /// Triggered when a <see cref="Judgement"/> is a successful hit, signaling the health display to perform a flash animation (if designed to do so).
+        /// Calls to this method are debounced.
         /// </summary>
         /// <param name="result">The judgement result.</param>
         protected virtual void Flash(JudgementResult result)
@@ -47,6 +48,7 @@ namespace osu.Game.Screens.Play.HUD
 
         /// <summary>
         /// Triggered when a <see cref="Judgement"/> resulted in the player losing health.
+        /// Calls to this method are debounced.
         /// </summary>
         /// <param name="result">The judgement result.</param>
         protected virtual void Miss(JudgementResult result)
@@ -92,7 +94,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 double newValue = Current.Value + 0.05f;
                 this.TransformBindableTo(Current, newValue, increase_delay);
-                Flash(new JudgementResult(new HitObject(), new Judgement()));
+                Scheduler.AddOnce(Flash, new JudgementResult(new HitObject(), new Judgement()));
 
                 if (newValue >= 1)
                     finishInitialAnimation();
@@ -115,9 +117,9 @@ namespace osu.Game.Screens.Play.HUD
         private void onNewJudgement(JudgementResult judgement)
         {
             if (judgement.IsHit && judgement.Type != HitResult.IgnoreHit)
-                Flash(judgement);
+                Scheduler.AddOnce(Flash, judgement);
             else if (judgement.Judgement.HealthIncreaseFor(judgement) < 0)
-                Miss(judgement);
+                Scheduler.AddOnce(Miss, judgement);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -103,6 +103,9 @@ namespace osu.Game.Screens.Play.HUD
 
         private void finishInitialAnimation()
         {
+            if (initialIncrease == null)
+                return;
+
             initialIncrease?.Cancel();
             initialIncrease = null;
 

--- a/osu.Game/Skinning/LegacyHealthDisplay.cs
+++ b/osu.Game/Skinning/LegacyHealthDisplay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Utils;
 using osuTK;
@@ -80,7 +79,7 @@ namespace osu.Game.Skinning
             marker.Position = fill.Position + new Vector2(fill.DrawWidth, isNewStyle ? fill.DrawHeight / 2 : 0);
         }
 
-        protected override void Flash(JudgementResult result) => marker.Flash(result);
+        protected override void Flash() => marker.Flash();
 
         private static Texture getTexture(ISkin skin, string name) => skin?.GetTexture($"scorebar-{name}");
 
@@ -238,7 +237,7 @@ namespace osu.Game.Skinning
                 });
             }
 
-            public override void Flash(JudgementResult result)
+            public override void Flash()
             {
                 bulgeMain();
 
@@ -257,7 +256,7 @@ namespace osu.Game.Skinning
         {
             public Bindable<double> Current { get; } = new Bindable<double>();
 
-            public virtual void Flash(JudgementResult result)
+            public virtual void Flash()
             {
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25050.

I noticed theres some other HUD elements with similar issues, but they are far less prominent. Will get to those another time.

Can be tested with:

```diff
diff --git a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
index 7bad623d7f..dafc3921af 100644
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -7,6 +7,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Judgements;
@@ -58,6 +59,23 @@ public void SetUpSteps()
                 if (healthDisplay.IsNotNull())
                     healthDisplay.BarHeight.Value = val;
             });
+
+            AddStep("Move off screen", () =>
+            {
+                healthDisplay.X = -10000;
+            });
+            AddStep("Move on screen", () =>
+            {
+                healthDisplay.X = 0;
+            });
+
+            AddStep("do heaps of shit", () =>
+            {
+                for (int i = 0; i < 100000; i++)
+                {
+                    healthDisplay.Current.Value = RNG.NextDouble();
+                }
+            });
         }
 
         [Test]

```