### PR TITLE
Fix score importer looking up guest user by username online

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -15,6 +15,9 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -26,6 +29,7 @@ using osu.Game.Screens;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Resources;
+using osu.Game.Users;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -148,6 +152,40 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
             AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+        }
+
+        [Test]
+        public void TestGuestScoreIsStoredAsGuest()
+        {
+            AddStep("set up API", () => ((DummyAPIAccess)API).HandleRequest = req =>
+            {
+                switch (req)
+                {
+                    case GetUserRequest userRequest:
+                        userRequest.TriggerSuccess(new APIUser
+                        {
+                            Username = "Guest",
+                            CountryCode = CountryCode.JP,
+                            Id = 1234
+                        });
+                        return true;
+
+                    default:
+                        return false;
+                }
+            });
+
+            AddStep("log out", () => API.Logout());
+            CreateTest();
+
+            AddUntilStep("wait for track to start running", () => Beatmap.Value.Track.IsRunning);
+            AddStep("log back in", () => API.Login("username", "password"));
+
+            AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
+
+            AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
+            AddUntilStep("score in database", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID) != null));
+            AddAssert("score is not associated with online user", () => Realm.Run(r => r.Find<ScoreInfo>(Player.Score.ScoreInfo.ID))!.UserID == APIUser.SYSTEM_USER_ID);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLocalScoreImport.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             DateTimeOffset? getLastPlayed() => Realm.Run(r => r.Find<BeatmapInfo>(Beatmap.Value.BeatmapInfo.ID)?.LastPlayed);
 
+            AddStep("reset last played", () => Realm.Write(r => r.Find<BeatmapInfo>(Beatmap.Value.BeatmapInfo.ID)!.LastPlayed = null));
             AddAssert("last played is null", () => getLastPlayed() == null);
 
             CreateTest();

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -190,6 +190,9 @@ namespace osu.Game.Scoring
         /// </summary>
         private void populateUserDetails(ScoreInfo model)
         {
+            if (model.RealmUser.OnlineID == APIUser.SYSTEM_USER_ID)
+                return;
+
             string username = model.RealmUser.Username;
 
             if (usernameLookupCache.TryGetValue(username, out var existing))


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25039.

w h o o p s

The report was wrong, there's no "submission" happening here, it's just the "unmap user to online user by username" logic running when it shouldn't.

Notably the default `UserID` is 1:

https://github.com/ppy/osu/blob/6b3860001085d1e168aa72ba31f6c555ee2251be/osu.Game/Models/RealmUser.cs#L14

which means that checking against `SYSTEM_USER_ID` shouldn't break anything.