### PR TITLE
Fix multiplayer not correctly pausing the track on initialisation

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -11,6 +11,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
@@ -28,6 +29,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Beatmap.Value = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
             });
 
+            AddStep("Start track playing", () =>
+            {
+                Beatmap.Value.Track.Start();
+            });
+
             AddStep("initialise gameplay", () =>
             {
                 Stack.Push(player = new MultiplayerPlayer(MultiplayerClient.ServerAPIRoom, new PlaylistItem(Beatmap.Value.BeatmapInfo)
@@ -37,7 +43,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
 
             AddUntilStep("wait for player to be current", () => player.IsCurrentScreen() && player.IsLoaded);
+
+            AddAssert("gameplay clock is paused", () => player.ChildrenOfType<GameplayClockContainer>().Single().IsPaused.Value);
+            AddAssert("gameplay clock is not running", () => !player.ChildrenOfType<GameplayClockContainer>().Single().IsRunning);
+
             AddStep("start gameplay", () => ((IMultiplayerClient)MultiplayerClient).GameplayStarted());
+
+            AddUntilStep("gameplay clock is not paused", () => !player.ChildrenOfType<GameplayClockContainer>().Single().IsPaused.Value);
+            AddAssert("gameplay clock is running", () => player.ChildrenOfType<GameplayClockContainer>().Single().IsRunning);
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -148,6 +148,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 loadingDisplay.Show();
                 client.ChangeState(MultiplayerUserState.ReadyForGameplay);
             }
+
+            // This will pause the clock, pending the gameplay started callback from the server.
+            GameplayClockContainer.Reset();
         }
 
         private void failAndBail(string message = null)

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -138,7 +138,8 @@ namespace osu.Game.Screens.Play
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.
         /// </summary>
         /// <param name="time">The time to seek to on resetting. If <c>null</c>, the existing <see cref="StartTime"/> will be used.</param>
-        /// <param name="startClock">Whether to start the clock immediately. If <c>false</c>, the clock will remain stopped after this call.</param>
+        /// <param name="startClock">Whether to start the clock immediately. If <c>false</c> and the clock was already paused, the clock will remain paused after this call.
+        /// </param>
         public void Reset(double? time = null, bool startClock = false)
         {
             bool wasPaused = isPaused.Value;

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -138,12 +138,15 @@ namespace osu.Game.Screens.Play
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.
         /// </summary>
         /// <param name="time">The time to seek to on resetting. If <c>null</c>, the existing <see cref="StartTime"/> will be used.</param>
-        /// <param name="startClock">Whether to start the clock immediately, if not already started.</param>
+        /// <param name="startClock">Whether to start the clock immediately. If <c>false</c>, the clock will remain stopped after this call.</param>
         public void Reset(double? time = null, bool startClock = false)
         {
             bool wasPaused = isPaused.Value;
 
-            Stop();
+            // The intention of the Reset method is to get things into a known sane state.
+            // As such, we intentionally stop the underlying clock directly here, bypassing Stop/StopGameplayClock.
+            // This is to avoid any kind of isPaused state checks and frequency ramping (as provided by MasterGameplayClockContainer).
+            GameplayClock.Stop();
 
             if (time != null)
                 StartTime = time.Value;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1078,7 +1078,7 @@ namespace osu.Game.Screens.Play
         protected virtual void StartGameplay()
         {
             if (GameplayClockContainer.IsRunning)
-                throw new InvalidOperationException($"{nameof(StartGameplay)} should not be called when the gameplay clock is already running");
+                Logger.Error(new InvalidOperationException($"{nameof(StartGameplay)} should not be called when the gameplay clock is already running"), "Clock failure");
 
             GameplayClockContainer.Reset(startClock: true);
 


### PR DESCRIPTION
This resolves crashes experience in the last release (before the hotfix):

https://sentry.ppy.sh/share/issue/34bf79ed73c043b58b09369f45835cd7/
https://sentry.ppy.sh/share/issue/8b4161417ef8438b984c6577b031195e/
https://sentry.ppy.sh/share/issue/506cd43cd7f646ea95ceb3a79eff6c33/

The title says this only affects multiplayer, but it also does have a small chance of affecting solo play (resolved by f0bd97539379ad11f54dbdf354f0adca7565044a).

Please see individual commit messages for further notes.

Closes https://github.com/ppy/osu/issues/25048.