### PR TITLE
Reduce black fill of song bar in tournament UI back to reasonable levels

### DIFF
--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Tournament.Components
                 {
                     Colour = colours.Gray3,
                     RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.4f,
                 },
                 flow = new FillFlowContainer
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24993.

https://github.com/ppy/osu/assets/191335/fb04e805-65ba-41dc-ba62-8af00d118537

