### PR TITLE
Clean up `KeyBindingRow` and related classes

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneChangeAndUseGameplayBindings.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private KeyBindingsSubsection osuBindingSubsection => keyBindingPanel
                                                               .ChildrenOfType<VariantBindingsSubsection>()
-                                                              .FirstOrDefault(s => s.Ruleset.ShortName == "osu");
+                                                              .FirstOrDefault(s => s.Ruleset!.ShortName == "osu");
 
         private OsuButton configureBindingsButton => Game.Settings
                                                          .ChildrenOfType<BindingSettings>().SingleOrDefault()?

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -39,14 +39,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// </summary>
         public Action<KeyBindingRow> BindingUpdated { get; set; }
 
-        private readonly object action;
-        private readonly IEnumerable<RealmKeyBinding> bindings;
+        public bool AllowMainMouseButtons;
 
-        private const float transition_time = 150;
+        public IEnumerable<KeyCombination> Defaults;
 
-        private const float height = 20;
-
-        private const float padding = 5;
+        #region IFilterable
 
         private bool matchingFilter;
 
@@ -60,23 +57,39 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             }
         }
 
-        private Container content;
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
-            content.ReceivePositionalInputAt(screenSpacePos);
-
         public bool FilteringActive { get; set; }
+
+        public IEnumerable<LocalisableString> FilterTerms => bindings.Select(b => (LocalisableString)keyCombinationProvider.GetReadableString(b.KeyCombination)).Prepend(text.Text);
+
+        #endregion
+
+        private readonly object action;
+        private readonly IEnumerable<RealmKeyBinding> bindings;
+
+        private Bindable<bool> isDefault { get; } = new BindableBool(true);
 
         [Resolved]
         private ReadableKeyCombinationProvider keyCombinationProvider { get; set; }
+
+        [Resolved]
+        private RealmAccess realm { get; set; }
+
+        private Container content;
 
         private OsuSpriteText text;
         private FillFlowContainer cancelAndClearButtons;
         private FillFlowContainer<KeyButton> buttons;
 
-        private Bindable<bool> isDefault { get; } = new BindableBool(true);
+        private KeyButton bindTarget;
 
-        public IEnumerable<LocalisableString> FilterTerms => bindings.Select(b => (LocalisableString)keyCombinationProvider.GetReadableString(b.KeyCombination)).Prepend(text.Text);
+        private const float transition_time = 150;
+        private const float height = 20;
+        private const float padding = 5;
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            content.ReceivePositionalInputAt(screenSpacePos);
+
+        public override bool AcceptsFocus => bindTarget == null;
 
         public KeyBindingRow(object action, List<RealmKeyBinding> bindings)
         {
@@ -86,9 +99,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
         }
-
-        [Resolved]
-        private RealmAccess realm { get; set; }
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -204,14 +214,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             base.OnHoverLost(e);
         }
-
-        public override bool AcceptsFocus => bindTarget == null;
-
-        private KeyButton bindTarget;
-
-        public bool AllowMainMouseButtons;
-
-        public IEnumerable<KeyCombination> Defaults;
 
         private bool isModifier(Key k) => k < Key.F1;
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -37,11 +37,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// <summary>
         /// Invoked when the binding of this row is updated with a change being written.
         /// </summary>
-        public Action<KeyBindingRow> BindingUpdated { get; set; }
+        public Action<KeyBindingRow> BindingUpdated { get; init; }
 
-        public bool AllowMainMouseButtons;
+        public bool AllowMainMouseButtons { get; init; }
 
-        public IEnumerable<KeyCombination> Defaults;
+        public IEnumerable<KeyCombination> Defaults { get; init; }
 
         #region IFilterable
 

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -39,8 +39,14 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// </summary>
         public Action<KeyBindingRow> BindingUpdated { get; init; }
 
+        /// <summary>
+        /// Whether left and right mouse button clicks should be included in the edited bindings.
+        /// </summary>
         public bool AllowMainMouseButtons { get; init; }
 
+        /// <summary>
+        /// The default key bindings for this row.
+        /// </summary>
         public IEnumerable<KeyCombination> Defaults { get; init; }
 
         #region IFilterable
@@ -91,6 +97,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public override bool AcceptsFocus => bindTarget == null;
 
+        /// <summary>
+        /// Creates a new <see cref="KeyBindingRow"/>.
+        /// </summary>
+        /// <param name="action">The action that this row contains bindings for.</param>
+        /// <param name="bindings">The keybindings to display in this row.</param>
         public KeyBindingRow(object action, List<RealmKeyBinding> bindings)
         {
             this.action = action;

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -1,13 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
 using osu.Game.Database;
 using osu.Game.Input.Bindings;
@@ -25,9 +25,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// </summary>
         protected virtual bool AutoAdvanceTarget => false;
 
-        protected IEnumerable<Framework.Input.Bindings.KeyBinding> Defaults { get; init; }
+        protected IEnumerable<KeyBinding> Defaults { get; init; } = Array.Empty<KeyBinding>();
 
-        public RulesetInfo Ruleset { get; protected set; }
+        public RulesetInfo? Ruleset { get; protected set; }
 
         private readonly int? variant;
 
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         [BackgroundDependencyLoader]
         private void load(RealmAccess realm)
         {
-            string rulesetName = Ruleset?.ShortName;
+            string? rulesetName = Ruleset?.ShortName;
 
             var bindings = realm.Run(r => r.All<RealmKeyBinding>()
                                            .Where(b => b.RulesetName == rulesetName && b.Variant == variant)

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// </summary>
         protected virtual bool AutoAdvanceTarget => false;
 
-        protected IEnumerable<Framework.Input.Bindings.KeyBinding> Defaults;
+        protected IEnumerable<Framework.Input.Bindings.KeyBinding> Defaults { get; init; }
 
         public RulesetInfo Ruleset { get; protected set; }
 


### PR DESCRIPTION
This is just a bit of cleanup I did before further work on disallowing binding multiple bindings to one key ([see preview on discord](https://discord.com/channels/188630481301012481/188630652340404224/1161658683395145828)). I didn't end up using this cleanup _that_ much, but hey, if it's done...

Includes:

- cleaning up member orders
- making some pretty unsafe properties init-only
- xmldoc
- NRT pass

There should be no behavioural changes here, unless I messed up. Recommend reading commit by commit.