### PR TITLE
Add extended info support to tiny mod switches

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSwitchTiny.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSwitchTiny.cs
@@ -2,16 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.UI;
@@ -34,6 +37,49 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestMania() => createSwitchTestFor(new ManiaRuleset());
 
+        [Test]
+        public void TestShowRateAdjusts()
+        {
+            AddStep("create mod icons", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Full,
+                    ChildrenEnumerable = Ruleset.Value.CreateInstance().CreateAllMods()
+                                                .OfType<ModRateAdjust>()
+                                                .SelectMany(m =>
+                                                {
+                                                    List<TestModSwitchTiny> icons = new List<TestModSwitchTiny> { new TestModSwitchTiny(m) };
+
+                                                    for (double i = m.SpeedChange.MinValue; i < m.SpeedChange.MaxValue; i += m.SpeedChange.Precision * 10)
+                                                    {
+                                                        m = (ModRateAdjust)m.DeepClone();
+                                                        m.SpeedChange.Value = i;
+                                                        icons.Add(new TestModSwitchTiny(m, true));
+                                                    }
+
+                                                    return icons;
+                                                }),
+                };
+            });
+
+            AddStep("adjust rates", () =>
+            {
+                foreach (var icon in this.ChildrenOfType<TestModSwitchTiny>())
+                {
+                    if (icon.Mod is ModRateAdjust rateAdjust)
+                    {
+                        rateAdjust.SpeedChange.Value = RNG.NextDouble() > 0.9
+                            ? rateAdjust.SpeedChange.Default
+                            : RNG.NextDouble(rateAdjust.SpeedChange.MinValue, rateAdjust.SpeedChange.MaxValue);
+                    }
+                }
+            });
+
+            AddToggleStep("toggle active", active => this.ChildrenOfType<TestModSwitchTiny>().ForEach(s => s.Active.Value = active));
+        }
+
         private void createSwitchTestFor(Ruleset ruleset)
         {
             AddStep("no colour scheme", () => Child = createContent(ruleset, null));
@@ -43,7 +89,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 AddStep($"{scheme} colour scheme", () => Child = createContent(ruleset, scheme));
             }
 
-            AddToggleStep("toggle active", active => this.ChildrenOfType<ModSwitchTiny>().ForEach(s => s.Active.Value = active));
+            AddToggleStep("toggle active", active => this.ChildrenOfType<TestModSwitchTiny>().ForEach(s => s.Active.Value = active));
         }
 
         private static Drawable createContent(Ruleset ruleset, OverlayColourScheme? colourScheme)
@@ -62,7 +108,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                                                 AutoSizeAxes = Axes.Y,
                                                 Direction = FillDirection.Full,
                                                 Spacing = new Vector2(5),
-                                                ChildrenEnumerable = group.Select(mod => new ModSwitchTiny(mod))
+                                                ChildrenEnumerable = group.Select(mod => new TestModSwitchTiny(mod))
                                             })
             };
 
@@ -80,6 +126,16 @@ namespace osu.Game.Tests.Visual.UserInterface
             }
 
             return switchFlow;
+        }
+
+        private partial class TestModSwitchTiny : ModSwitchTiny
+        {
+            public new IMod Mod => base.Mod;
+
+            public TestModSwitchTiny(IMod mod, bool showExtendedInformation = false)
+                : base(mod, showExtendedInformation)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
- Needed for https://github.com/ppy/osu/pull/22237

Mostly copied from `ModIcon`, but:
- `ModSwitchTiny.Mod` is immutable so kept it that way
- `showExtendedInformation` defaults to false as current usages don't need it
- little tweak to font size

https://github.com/ppy/osu/assets/35318437/ddda6117-e557-4f90-96f7-f885a6c52afd

