### PR TITLE
Show results immediately if user hits "back" key after finishing gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("disable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, false));
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
-            AddAssert("player exited", () => Stack.CurrentScreen == null);
+            AddUntilStep("reached results screen", () => Stack.CurrentScreen is ResultsScreen);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -72,12 +72,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestStoryboardExitDuringOutroStillExits()
+        public void TestStoryboardExitDuringOutroProgressesToResults()
         {
             CreateTest();
             AddUntilStep("completion set by processor", () => Player.ScoreProcessor.HasCompleted.Value);
             AddStep("exit via pause", () => Player.ExitViaPause());
-            AddAssert("player exited", () => !Player.IsCurrentScreen() && Player.GetChildScreen() == null);
+            AddUntilStep("reached results screen", () => Stack.CurrentScreen is ResultsScreen);
         }
 
         [TestCase(false)]

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -601,8 +601,13 @@ namespace osu.Game.Screens.Play
                 }
             }
 
-            // if an exit has been requested, cancel any pending completion (the user has shown intention to exit).
-            resultsDisplayDelegate?.Cancel();
+            // Matching osu!stable behaviour, if the results screen is pending and the user requests an exit,
+            // show the results instead.
+            if (resultsDisplayDelegate != null)
+            {
+                progressToResults(false);
+                return;
+            }
 
             // import current score if possible.
             prepareAndImportScoreAsync();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -671,6 +671,7 @@ namespace osu.Game.Screens.Play
         /// <remarks>This can be called from a child screen in order to trigger the restart process.</remarks>
         /// </summary>
         /// <param name="quickRestart">Whether a quick restart was requested (skipping intro etc.).</param>
+        /// <returns>Whether this call resulted in a restart.</returns>
         public bool Restart(bool quickRestart = false)
         {
             if (!Configuration.AllowRestart)

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -596,7 +596,7 @@ namespace osu.Game.Screens.Play
 
             // Matching osu!stable behaviour, if the results screen is pending and the user requests an exit,
             // show the results instead.
-            if (resultsDisplayDelegate != null && !isRestarting)
+            if (GameplayState.HasPassed && !isRestarting)
             {
                 progressToResults(false);
                 return false;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -279,8 +279,10 @@ namespace osu.Game.Screens.Play
                     {
                         if (!this.IsCurrentScreen()) return;
 
-                        fadeOut(true);
-                        PerformExit(false);
+                        if (PerformExit(false))
+                            // The hotkey overlay dims the screen.
+                            // If the operation succeeds, we want to make sure we stay dimmed to keep continuity.
+                            fadeOut(true);
                     },
                 },
             });
@@ -298,8 +300,10 @@ namespace osu.Game.Screens.Play
                         {
                             if (!this.IsCurrentScreen()) return;
 
-                            fadeOut(true);
-                            Restart(true);
+                            if (Restart(true))
+                                // The hotkey overlay dims the screen.
+                                // If the operation succeeds, we want to make sure we stay dimmed to keep continuity.
+                                fadeOut(true);
                         },
                     },
                 });
@@ -565,7 +569,8 @@ namespace osu.Game.Screens.Play
         /// Whether the pause or fail dialog should be shown before performing an exit.
         /// If <see langword="true"/> and a dialog is not yet displayed, the exit will be blocked and the relevant dialog will display instead.
         /// </param>
-        protected void PerformExit(bool showDialogFirst)
+        /// <returns>Whether this call resulted in a final exit.</returns>
+        protected bool PerformExit(bool showDialogFirst)
         {
             // there is a chance that an exit request occurs after the transition to results has already started.
             // even in such a case, the user has shown intent, so forcefully return to this screen (to proceed with the upwards exit process).
@@ -576,7 +581,7 @@ namespace osu.Game.Screens.Play
                 // in the potential case that this instance has already been exited, this is required to avoid a crash.
                 if (this.GetChildScreen() != null)
                     this.MakeCurrent();
-                return;
+                return true;
             }
 
             bool pauseOrFailDialogVisible =
@@ -588,7 +593,7 @@ namespace osu.Game.Screens.Play
                 if (ValidForResume && GameplayState.HasFailed)
                 {
                     failAnimationContainer.FinishTransforms(true);
-                    return;
+                    return false;
                 }
 
                 // even if this call has requested a dialog, there is a chance the current player mode doesn't support pausing.
@@ -597,16 +602,16 @@ namespace osu.Game.Screens.Play
                     // in the case a dialog needs to be shown, attempt to pause and show it.
                     // this may fail (see internal checks in Pause()) but the fail cases are temporary, so don't fall through to Exit().
                     Pause();
-                    return;
+                    return false;
                 }
             }
 
             // Matching osu!stable behaviour, if the results screen is pending and the user requests an exit,
             // show the results instead.
-            if (resultsDisplayDelegate != null)
+            if (resultsDisplayDelegate != null && !isRestarting)
             {
                 progressToResults(false);
-                return;
+                return false;
             }
 
             // import current score if possible.
@@ -617,6 +622,7 @@ namespace osu.Game.Screens.Play
             // - the pause / fail dialog was requested but is already displayed (user showing intention to exit).
             // - the pause / fail dialog was requested but couldn't be displayed due to the type or state of this Player instance.
             this.Exit();
+            return true;
         }
 
         private void performUserRequestedSkip()
@@ -665,10 +671,10 @@ namespace osu.Game.Screens.Play
         /// <remarks>This can be called from a child screen in order to trigger the restart process.</remarks>
         /// </summary>
         /// <param name="quickRestart">Whether a quick restart was requested (skipping intro etc.).</param>
-        public void Restart(bool quickRestart = false)
+        public bool Restart(bool quickRestart = false)
         {
             if (!Configuration.AllowRestart)
-                return;
+                return false;
 
             isRestarting = true;
 
@@ -678,7 +684,7 @@ namespace osu.Game.Screens.Play
 
             RestartRequested?.Invoke(quickRestart);
 
-            PerformExit(false);
+            return PerformExit(false);
         }
 
         /// <summary>
@@ -1205,8 +1211,11 @@ namespace osu.Game.Screens.Play
             float fadeOutDuration = instant ? 0 : 250;
             this.FadeOut(fadeOutDuration);
 
-            ApplyToBackground(b => b.IgnoreUserSettings.Value = true);
-            storyboardReplacesBackground.Value = false;
+            if (this.IsCurrentScreen())
+            {
+                ApplyToBackground(b => b.IgnoreUserSettings.Value = true);
+                storyboardReplacesBackground.Value = false;
+            }
         }
 
         #endregion

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -414,6 +414,8 @@ namespace osu.Game.Screens.Play
             quickRestart = quickRestartRequested;
             hideOverlays = true;
             ValidForResume = true;
+
+            this.MakeCurrent();
         }
 
         private void contentIn()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/18089.

I've gone ahead and matched the osu!stable behaviour for this, as it seems like it's what people are used to and they will settle for no less.
