### PR TITLE
Remove remaining usages of `LargeTick{Hit,Miss}` in mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/Judgements/ManiaJudgement.cs
@@ -12,12 +12,6 @@ namespace osu.Game.Rulesets.Mania.Judgements
         {
             switch (result)
             {
-                case HitResult.LargeTickHit:
-                    return DEFAULT_MAX_HEALTH_INCREASE * 0.1;
-
-                case HitResult.LargeTickMiss:
-                    return -DEFAULT_MAX_HEALTH_INCREASE * 0.1;
-
                 case HitResult.Meh:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -385,20 +385,7 @@ namespace osu.Game.Rulesets.Mania
                 HitResult.Good,
                 HitResult.Ok,
                 HitResult.Meh,
-
-                HitResult.LargeTickHit,
             };
-        }
-
-        public override LocalisableString GetDisplayNameForHitResult(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.LargeTickHit:
-                    return "hold tick";
-            }
-
-            return base.GetDisplayNameForHitResult(result);
         }
 
         public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
@@ -11,8 +11,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play.HUD.JudgementCounter;
@@ -57,7 +57,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             };
         });
 
-        protected override Ruleset CreateRuleset() => new ManiaRuleset();
+        protected override Ruleset CreateRuleset() => new OsuRuleset();
 
         private void applyOneJudgement(HitResult result)
         {


### PR DESCRIPTION
A few minor stragglers from https://github.com/ppy/osu/pull/25062. Noticed when reviewing https://github.com/ppy/osu/pull/25096.

Of particular note, removal of `LargeTickHit` from `GetValidHitResults()` means that it will stop showing up in several places that deal with judgement counts and so on. One such place is the results screen, which would actually continue to show tick counts on results for old scores prior to the aforementioned pull, but not on scores set after it.

Another is the skinnable judgement counter display, wherein deleting `LargeTickHit` caused... test failures, as the test scene was using mania for ruleset, and using `LargeTickHit` specifically for counts, which would not be shown after the aforementioned removal. That was switched to use osu! instead.