### PR TITLE
Refactor key binding panel for easier usage

### DIFF
--- a/osu.Game.Tests/Input/RealmKeyBindingTest.cs
+++ b/osu.Game.Tests/Input/RealmKeyBindingTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Testing;
+using osu.Game.Input.Bindings;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Input
+{
+    [HeadlessTest]
+    public partial class RealmKeyBindingTest : OsuTestScene
+    {
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        [Test]
+        public void TestUnmapGlobalAction()
+        {
+            var keyBinding = new RealmKeyBinding(GlobalAction.ToggleReplaySettings, KeyCombination.FromKey(Key.Z));
+
+            AddAssert("action is integer", () => keyBinding.Action, () => Is.EqualTo((int)GlobalAction.ToggleReplaySettings));
+            AddAssert("action unmaps correctly", () => keyBinding.GetAction(rulesets), () => Is.EqualTo(GlobalAction.ToggleReplaySettings));
+        }
+
+        [TestCase(typeof(OsuRuleset), OsuAction.Smoke, null)]
+        [TestCase(typeof(TaikoRuleset), TaikoAction.LeftCentre, null)]
+        [TestCase(typeof(CatchRuleset), CatchAction.MoveRight, null)]
+        [TestCase(typeof(ManiaRuleset), ManiaAction.Key7, 7)]
+        public void TestUnmapRulesetActions(Type rulesetType, object action, int? variant)
+        {
+            string rulesetName = ((Ruleset)Activator.CreateInstance(rulesetType)!).ShortName;
+            var keyBinding = new RealmKeyBinding(action, KeyCombination.FromKey(Key.Z), rulesetName, variant);
+
+            AddAssert("action is integer", () => keyBinding.Action, () => Is.EqualTo((int)action));
+            AddAssert("action unmaps correctly", () => keyBinding.GetAction(rulesets), () => Is.EqualTo(action));
+        }
+    }
+}

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input;
@@ -37,7 +38,7 @@ namespace osu.Game.Input.Bindings
                                                                        // based on such usages potentially requiring a lot more key bindings that may be "shared" with global ones.
                                                                        .Concat(OverlayKeyBindings);
 
-        public IEnumerable<KeyBinding> GlobalKeyBindings => new[]
+        public static IEnumerable<KeyBinding> GlobalKeyBindings => new[]
         {
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
@@ -67,7 +68,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
         };
 
-        public IEnumerable<KeyBinding> OverlayKeyBindings => new[]
+        public static IEnumerable<KeyBinding> OverlayKeyBindings => new[]
         {
             new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
             new KeyBinding(InputKey.F6, GlobalAction.ToggleNowPlaying),
@@ -77,7 +78,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.N }, GlobalAction.ToggleNotifications),
         };
 
-        public IEnumerable<KeyBinding> EditorKeyBindings => new[]
+        public static IEnumerable<KeyBinding> EditorKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.F1 }, GlobalAction.EditorComposeMode),
             new KeyBinding(new[] { InputKey.F2 }, GlobalAction.EditorDesignMode),
@@ -101,7 +102,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.R }, GlobalAction.EditorToggleRotateControl),
         };
 
-        public IEnumerable<KeyBinding> InGameKeyBindings => new[]
+        public static IEnumerable<KeyBinding> InGameKeyBindings => new[]
         {
             new KeyBinding(InputKey.Space, GlobalAction.SkipCutscene),
             new KeyBinding(InputKey.ExtraMouseButton2, GlobalAction.SkipCutscene),
@@ -118,7 +119,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F2, GlobalAction.ExportReplay),
         };
 
-        public IEnumerable<KeyBinding> ReplayKeyBindings => new[]
+        public static IEnumerable<KeyBinding> ReplayKeyBindings => new[]
         {
             new KeyBinding(InputKey.Space, GlobalAction.TogglePauseReplay),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.TogglePauseReplay),
@@ -127,7 +128,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
         };
 
-        public IEnumerable<KeyBinding> SongSelectKeyBindings => new[]
+        public static IEnumerable<KeyBinding> SongSelectKeyBindings => new[]
         {
             new KeyBinding(InputKey.F1, GlobalAction.ToggleModSelection),
             new KeyBinding(InputKey.F2, GlobalAction.SelectNextRandom),
@@ -136,7 +137,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.BackSpace, GlobalAction.DeselectAllMods),
         };
 
-        public IEnumerable<KeyBinding> AudioControlKeyBindings => new[]
+        public static IEnumerable<KeyBinding> AudioControlKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.Alt, InputKey.Up }, GlobalAction.IncreaseVolume),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Down }, GlobalAction.DecreaseVolume),
@@ -153,6 +154,39 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.PlayPause, GlobalAction.MusicPlay),
             new KeyBinding(InputKey.F3, GlobalAction.MusicPlay)
         };
+
+        public static IEnumerable<KeyBinding> GetDefaultBindingsFor(GlobalActionCategory category)
+        {
+            switch (category)
+            {
+                case GlobalActionCategory.General:
+                    return GlobalKeyBindings;
+
+                case GlobalActionCategory.Editor:
+                    return EditorKeyBindings;
+
+                case GlobalActionCategory.InGame:
+                    return InGameKeyBindings;
+
+                case GlobalActionCategory.Replay:
+                    return ReplayKeyBindings;
+
+                case GlobalActionCategory.SongSelect:
+                    return SongSelectKeyBindings;
+
+                case GlobalActionCategory.AudioControl:
+                    return AudioControlKeyBindings;
+
+                case GlobalActionCategory.Overlays:
+                    return OverlayKeyBindings;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(category), category, $"Unexpected {nameof(GlobalActionCategory)}");
+            }
+        }
+
+        public static IEnumerable<GlobalAction> GetGlobalActionsFor(GlobalActionCategory category)
+            => GetDefaultBindingsFor(category).Select(binding => binding.Action).Cast<GlobalAction>().Distinct();
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e) => handler?.OnPressed(e) == true;
 
@@ -364,5 +398,16 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorToggleRotateControl))]
         EditorToggleRotateControl,
+    }
+
+    public enum GlobalActionCategory
+    {
+        General,
+        Editor,
+        InGame,
+        Replay,
+        SongSelect,
+        AudioControl,
+        Overlays
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Input.Bindings
 {
     public partial class GlobalActionContainer : DatabasedKeyBindingContainer<GlobalAction>, IHandleGlobalKeyboardInput, IKeyBindingHandler<GlobalAction>
     {
+        protected override bool Prioritised => true;
+
         private readonly IKeyBindingHandler<GlobalAction>? handler;
 
         public GlobalActionContainer(OsuGameBase? game)
@@ -23,22 +25,62 @@ namespace osu.Game.Input.Bindings
                 handler = h;
         }
 
-        protected override bool Prioritised => true;
-
-        // IMPORTANT: Take care when changing order of the items in the enumerable.
-        // It is used to decide the order of precedence, with the earlier items having higher precedence.
-        public override IEnumerable<IKeyBinding> DefaultKeyBindings => GlobalKeyBindings
-                                                                       .Concat(EditorKeyBindings)
-                                                                       .Concat(InGameKeyBindings)
-                                                                       .Concat(ReplayKeyBindings)
-                                                                       .Concat(SongSelectKeyBindings)
-                                                                       .Concat(AudioControlKeyBindings)
+        /// <summary>
+        /// All default key bindings across all categories, ordered with highest priority first.
+        /// </summary>
+        /// <remarks>
+        /// IMPORTANT: Take care when changing order of the items in the enumerable.
+        /// It is used to decide the order of precedence, with the earlier items having higher precedence.
+        /// </remarks>
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => globalKeyBindings
+                                                                       .Concat(editorKeyBindings)
+                                                                       .Concat(inGameKeyBindings)
+                                                                       .Concat(replayKeyBindings)
+                                                                       .Concat(songSelectKeyBindings)
+                                                                       .Concat(audioControlKeyBindings)
                                                                        // Overlay bindings may conflict with more local cases like the editor so they are checked last.
                                                                        // It has generally been agreed on that local screens like the editor should have priority,
                                                                        // based on such usages potentially requiring a lot more key bindings that may be "shared" with global ones.
-                                                                       .Concat(OverlayKeyBindings);
+                                                                       .Concat(overlayKeyBindings);
 
-        public static IEnumerable<KeyBinding> GlobalKeyBindings => new[]
+        public static IEnumerable<KeyBinding> GetDefaultBindingsFor(GlobalActionCategory category)
+        {
+            switch (category)
+            {
+                case GlobalActionCategory.General:
+                    return globalKeyBindings;
+
+                case GlobalActionCategory.Editor:
+                    return editorKeyBindings;
+
+                case GlobalActionCategory.InGame:
+                    return inGameKeyBindings;
+
+                case GlobalActionCategory.Replay:
+                    return replayKeyBindings;
+
+                case GlobalActionCategory.SongSelect:
+                    return songSelectKeyBindings;
+
+                case GlobalActionCategory.AudioControl:
+                    return audioControlKeyBindings;
+
+                case GlobalActionCategory.Overlays:
+                    return overlayKeyBindings;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(category), category, $"Unexpected {nameof(GlobalActionCategory)}");
+            }
+        }
+
+        public static IEnumerable<GlobalAction> GetGlobalActionsFor(GlobalActionCategory category)
+            => GetDefaultBindingsFor(category).Select(binding => binding.Action).Cast<GlobalAction>().Distinct();
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e) => handler?.OnPressed(e) == true;
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e) => handler?.OnReleased(e);
+
+        private static IEnumerable<KeyBinding> globalKeyBindings => new[]
         {
             new KeyBinding(InputKey.Up, GlobalAction.SelectPrevious),
             new KeyBinding(InputKey.Down, GlobalAction.SelectNext),
@@ -68,7 +110,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F12, GlobalAction.TakeScreenshot),
         };
 
-        public static IEnumerable<KeyBinding> OverlayKeyBindings => new[]
+        private static IEnumerable<KeyBinding> overlayKeyBindings => new[]
         {
             new KeyBinding(InputKey.F8, GlobalAction.ToggleChat),
             new KeyBinding(InputKey.F6, GlobalAction.ToggleNowPlaying),
@@ -78,7 +120,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.N }, GlobalAction.ToggleNotifications),
         };
 
-        public static IEnumerable<KeyBinding> EditorKeyBindings => new[]
+        private static IEnumerable<KeyBinding> editorKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.F1 }, GlobalAction.EditorComposeMode),
             new KeyBinding(new[] { InputKey.F2 }, GlobalAction.EditorDesignMode),
@@ -102,7 +144,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.R }, GlobalAction.EditorToggleRotateControl),
         };
 
-        public static IEnumerable<KeyBinding> InGameKeyBindings => new[]
+        private static IEnumerable<KeyBinding> inGameKeyBindings => new[]
         {
             new KeyBinding(InputKey.Space, GlobalAction.SkipCutscene),
             new KeyBinding(InputKey.ExtraMouseButton2, GlobalAction.SkipCutscene),
@@ -119,7 +161,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.F2, GlobalAction.ExportReplay),
         };
 
-        public static IEnumerable<KeyBinding> ReplayKeyBindings => new[]
+        private static IEnumerable<KeyBinding> replayKeyBindings => new[]
         {
             new KeyBinding(InputKey.Space, GlobalAction.TogglePauseReplay),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.TogglePauseReplay),
@@ -128,7 +170,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
         };
 
-        public static IEnumerable<KeyBinding> SongSelectKeyBindings => new[]
+        private static IEnumerable<KeyBinding> songSelectKeyBindings => new[]
         {
             new KeyBinding(InputKey.F1, GlobalAction.ToggleModSelection),
             new KeyBinding(InputKey.F2, GlobalAction.SelectNextRandom),
@@ -137,7 +179,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.BackSpace, GlobalAction.DeselectAllMods),
         };
 
-        public static IEnumerable<KeyBinding> AudioControlKeyBindings => new[]
+        private static IEnumerable<KeyBinding> audioControlKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.Alt, InputKey.Up }, GlobalAction.IncreaseVolume),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Down }, GlobalAction.DecreaseVolume),
@@ -154,43 +196,6 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.PlayPause, GlobalAction.MusicPlay),
             new KeyBinding(InputKey.F3, GlobalAction.MusicPlay)
         };
-
-        public static IEnumerable<KeyBinding> GetDefaultBindingsFor(GlobalActionCategory category)
-        {
-            switch (category)
-            {
-                case GlobalActionCategory.General:
-                    return GlobalKeyBindings;
-
-                case GlobalActionCategory.Editor:
-                    return EditorKeyBindings;
-
-                case GlobalActionCategory.InGame:
-                    return InGameKeyBindings;
-
-                case GlobalActionCategory.Replay:
-                    return ReplayKeyBindings;
-
-                case GlobalActionCategory.SongSelect:
-                    return SongSelectKeyBindings;
-
-                case GlobalActionCategory.AudioControl:
-                    return AudioControlKeyBindings;
-
-                case GlobalActionCategory.Overlays:
-                    return OverlayKeyBindings;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(category), category, $"Unexpected {nameof(GlobalActionCategory)}");
-            }
-        }
-
-        public static IEnumerable<GlobalAction> GetGlobalActionsFor(GlobalActionCategory category)
-            => GetDefaultBindingsFor(category).Select(binding => binding.Action).Cast<GlobalAction>().Distinct();
-
-        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e) => handler?.OnPressed(e) == true;
-
-        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e) => handler?.OnReleased(e);
     }
 
     public enum GlobalAction

--- a/osu.Game/Input/Bindings/RealmKeyBinding.cs
+++ b/osu.Game/Input/Bindings/RealmKeyBinding.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Input.Bindings;
 using osu.Game.Database;
+using osu.Game.Rulesets;
 using Realms;
 
 namespace osu.Game.Input.Bindings
@@ -26,6 +28,13 @@ namespace osu.Game.Input.Bindings
             set => KeyCombinationString = value.ToString();
         }
 
+        /// <summary>
+        /// The resultant action which is triggered by this binding.
+        /// </summary>
+        /// <remarks>
+        /// This implementation always returns an integer.
+        /// If wanting to get the actual enum-typed value, use <see cref="GetAction"/>.
+        /// </remarks>
         [Ignored]
         public object Action
         {
@@ -52,6 +61,21 @@ namespace osu.Game.Input.Bindings
         [UsedImplicitly] // Realm
         private RealmKeyBinding()
         {
+        }
+
+        public object GetAction(RulesetStore rulesets)
+        {
+            if (string.IsNullOrEmpty(RulesetName))
+                return (GlobalAction)ActionInt;
+
+            var ruleset = rulesets.GetRuleset(RulesetName);
+            var actionType = ruleset!.CreateInstance()
+                                     .GetDefaultKeyBindings(Variant ?? 0)
+                                     .First() // let's just assume nobody does something stupid like mix multiple types...
+                                     .Action
+                                     .GetType();
+
+            return Enum.ToObject(actionType, ActionInt);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -18,92 +19,19 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public override LocalisableString Header => InputSettingsStrings.GlobalKeyBindingHeader;
 
-        public GlobalKeyBindingsSection(GlobalActionContainer manager)
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            Add(new DefaultBindingsSubsection(manager));
-            Add(new OverlayBindingsSubsection(manager));
-            Add(new AudioControlKeyBindingsSubsection(manager));
-            Add(new SongSelectKeyBindingSubsection(manager));
-            Add(new InGameKeyBindingsSubsection(manager));
-            Add(new ReplayKeyBindingsSubsection(manager));
-            Add(new EditorKeyBindingsSubsection(manager));
-        }
-
-        private partial class DefaultBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => string.Empty;
-
-            public DefaultBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
+            AddRange(new[]
             {
-                Defaults = GlobalActionContainer.GlobalKeyBindings;
-            }
-        }
-
-        private partial class OverlayBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.OverlaysSection;
-
-            public OverlayBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.OverlayKeyBindings;
-            }
-        }
-
-        private partial class SongSelectKeyBindingSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.SongSelectSection;
-
-            public SongSelectKeyBindingSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.SongSelectKeyBindings;
-            }
-        }
-
-        private partial class InGameKeyBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.InGameSection;
-
-            public InGameKeyBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.InGameKeyBindings;
-            }
-        }
-
-        private partial class ReplayKeyBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.ReplaySection;
-
-            public ReplayKeyBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.ReplayKeyBindings;
-            }
-        }
-
-        private partial class AudioControlKeyBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.AudioSection;
-
-            public AudioControlKeyBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.AudioControlKeyBindings;
-            }
-        }
-
-        private partial class EditorKeyBindingsSubsection : KeyBindingsSubsection
-        {
-            protected override LocalisableString Header => InputSettingsStrings.EditorSection;
-
-            public EditorKeyBindingsSubsection(GlobalActionContainer manager)
-                : base(null)
-            {
-                Defaults = GlobalActionContainer.EditorKeyBindings;
-            }
+                new GlobalKeyBindingsSubsection(string.Empty, GlobalActionCategory.General),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.OverlaysSection, GlobalActionCategory.Overlays),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.AudioSection, GlobalActionCategory.AudioControl),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.SongSelectSection, GlobalActionCategory.SongSelect),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.InGameSection, GlobalActionCategory.InGame),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.ReplaySection, GlobalActionCategory.Replay),
+                new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorSection, GlobalActionCategory.Editor),
+            });
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public DefaultBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.GlobalKeyBindings;
+                Defaults = GlobalActionContainer.GlobalKeyBindings;
             }
         }
 
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public OverlayBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.OverlayKeyBindings;
+                Defaults = GlobalActionContainer.OverlayKeyBindings;
             }
         }
 
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public SongSelectKeyBindingSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.SongSelectKeyBindings;
+                Defaults = GlobalActionContainer.SongSelectKeyBindings;
             }
         }
 
@@ -69,7 +69,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public InGameKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.InGameKeyBindings;
+                Defaults = GlobalActionContainer.InGameKeyBindings;
             }
         }
 
@@ -80,7 +80,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public ReplayKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.ReplayKeyBindings;
+                Defaults = GlobalActionContainer.ReplayKeyBindings;
             }
         }
 
@@ -91,7 +91,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public AudioControlKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.AudioControlKeyBindings;
+                Defaults = GlobalActionContainer.AudioControlKeyBindings;
             }
         }
 
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             public EditorKeyBindingsSubsection(GlobalActionContainer manager)
                 : base(null)
             {
-                Defaults = manager.EditorKeyBindings;
+                Defaults = GlobalActionContainer.EditorKeyBindings;
             }
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSubsection.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Localisation;
+using osu.Game.Database;
+using osu.Game.Input.Bindings;
+using Realms;
+
+namespace osu.Game.Overlays.Settings.Sections.Input
+{
+    public partial class GlobalKeyBindingsSubsection : KeyBindingsSubsection
+    {
+        protected override LocalisableString Header { get; }
+
+        private readonly GlobalActionCategory category;
+
+        public GlobalKeyBindingsSubsection(LocalisableString header, GlobalActionCategory category)
+        {
+            Header = header;
+            this.category = category;
+            Defaults = GlobalActionContainer.GetDefaultBindingsFor(category);
+        }
+
+        protected override IEnumerable<RealmKeyBinding> GetKeyBindings(Realm realm)
+        {
+            var bindings = realm.All<RealmKeyBinding>()
+                                .Where(b => b.RulesetName == null && b.Variant == null)
+                                .Detach();
+
+            var actionsInSection = GlobalActionContainer.GetGlobalActionsFor(category).Cast<int>().ToHashSet();
+            return bindings.Where(kb => actionsInSection.Contains(kb.ActionInt));
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Rulesets;
 
@@ -14,9 +13,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         protected override Drawable CreateHeader() => new SettingsHeader(InputSettingsStrings.KeyBindingPanelHeader, InputSettingsStrings.KeyBindingPanelDescription);
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(RulesetStore rulesets, GlobalActionContainer global)
+        private void load(RulesetStore rulesets)
         {
-            AddSection(new GlobalKeyBindingsSection(global));
+            AddSection(new GlobalKeyBindingsSection());
 
             foreach (var ruleset in rulesets.AvailableRulesets)
                 AddSection(new RulesetBindingsSection(ruleset));

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         /// <summary>
         /// Invoked when the binding of this row is updated with a change being written.
         /// </summary>
-        public Action<KeyBindingRow>? BindingUpdated { get; init; }
+        public Action<KeyBindingRow>? BindingUpdated { get; set; }
 
         /// <summary>
         /// Whether left and right mouse button clicks should be included in the edited bindings.

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets;
@@ -18,7 +19,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         public RulesetBindingsSection(RulesetInfo ruleset)
         {
             this.ruleset = ruleset;
+        }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             var r = ruleset.CreateInstance();
 
             foreach (int variant in r.AvailableVariants)

--- a/osu.Game/Overlays/Settings/Sections/Input/VariantBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/VariantBindingsSubsection.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets;
+using Realms;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
@@ -12,15 +17,33 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         protected override LocalisableString Header { get; }
 
+        public RulesetInfo Ruleset { get; }
+        private readonly int variant;
+
         public VariantBindingsSubsection(RulesetInfo ruleset, int variant)
-            : base(variant)
         {
             Ruleset = ruleset;
+            this.variant = variant;
 
             var rulesetInstance = ruleset.CreateInstance();
 
             Header = rulesetInstance.GetVariantName(variant);
             Defaults = rulesetInstance.GetDefaultKeyBindings(variant);
         }
+
+        protected override IEnumerable<RealmKeyBinding> GetKeyBindings(Realm realm)
+        {
+            string rulesetName = Ruleset.ShortName;
+
+            return realm.All<RealmKeyBinding>()
+                        .Where(b => b.RulesetName == rulesetName && b.Variant == variant);
+        }
+
+        protected override KeyBindingRow CreateKeyBindingRow(object action, IEnumerable<RealmKeyBinding> keyBindings, IEnumerable<KeyBinding> defaults)
+            => new KeyBindingRow(action, keyBindings.ToList())
+            {
+                AllowMainMouseButtons = true,
+                Defaults = defaults.Select(d => d.KeyCombination),
+            };
     }
 }


### PR DESCRIPTION
There are 2 issues I want to tackle with this pull:

- `RealmKeyBinding.Action` is an integer, always. This makes it very difficult to use it in UI, since for UI display, you'd want to be calling `GetLocalisableDescription()` on a strongly-typed enum instance rather than an integer; calling it on an integer doesn't return the binding name, it just returns the number.

  https://github.com/ppy/osu/commit/2a0e4c364d11c681b4a8ada723f56b0f1687666d is intended for this. It adds a helper method to always unconditionally unmap `Action` to a strongly-typed object.
- `GlobalAction` has no notion of sections. I want to disallow reusing one key across multiple bindings in a section. This makes retrieval of the set of key bindings to check for conflicts tricky. Previous code would kind of bodge it using the default key bindings, but all the pieces are _right there_ and making this API just a bit nicer is not much work. So I did that in https://github.com/ppy/osu/commit/1c784c9abec3ca18a566b2bff1be2fd2fa7467aa - `GlobalActionCategory` corresponds 1:1 to the key binding setting sections.

  This in turn enables https://github.com/ppy/osu/commit/c2e92cbb704aa79f0c8b6ab04ad675ccd45f3075, which while tangential to my future plans, feels pretty nice and gets rid of a bunch of boilerplate.