### PR TITLE
Use dimmed placeholder text instead of empty box on cleared bindings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow_KeyButton.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow_KeyButton.cs
@@ -12,11 +12,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
@@ -153,7 +155,20 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 Scheduler.AddOnce(updateText);
 
-                void updateText() => Text.Text = keyCombinationProvider.GetReadableString(KeyBinding.Value.KeyCombination);
+                void updateText()
+                {
+                    LocalisableString keyCombinationString = keyCombinationProvider.GetReadableString(KeyBinding.Value.KeyCombination);
+                    float alpha = 1;
+
+                    if (LocalisableString.IsNullOrEmpty(keyCombinationString))
+                    {
+                        keyCombinationString = InputSettingsStrings.ActionHasNoKeyBinding;
+                        alpha = 0.4f;
+                    }
+
+                    Text.Text = keyCombinationString;
+                    Text.Alpha = alpha;
+                }
             }
 
             protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/25105 (for the localisable string, mostly).

| before | after |
| :-: | :-: |
| ![osu_2023-10-12_22-03-40](https://github.com/ppy/osu/assets/20418176/917569b4-d5d1-4c3b-bc28-ce419fc75141) | ![osu_2023-10-12_22-04-12](https://github.com/ppy/osu/assets/20418176/08ee1782-a64e-480f-a037-37a50473b566) |

Subjectively feels nicer than an empty box. PRing separately since subjective.
