### PR TITLE
Fix dangerous buttons using different shades of pink

### DIFF
--- a/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TournamentEditorScreen.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Tournament.Screens.Editors
                         new TourneyButton
                         {
                             RelativeSizeAxes = Axes.X,
-                            BackgroundColour = colours.Pink3,
+                            BackgroundColour = colours.DangerousButtonColour,
                             Text = "Clear all",
                             Action = () =>
                             {

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -397,5 +397,7 @@ namespace osu.Game.Graphics
 
         public Color4 SpotlightColour => Green2;
         public Color4 FeaturedArtistColour => Blue2;
+
+        public Color4 DangerousButtonColour => Pink3;
     }
 }

--- a/osu.Game/Graphics/UserInterface/DangerousRoundedButton.cs
+++ b/osu.Game/Graphics/UserInterface/DangerousRoundedButton.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            BackgroundColour = colours.PinkDark;
+            BackgroundColour = colours.DangerousButtonColour;
         }
     }
 }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Overlays.FirstRunSetup
                             {
                                 Anchor = Anchor.TopRight,
                                 Origin = Anchor.TopRight,
-                                BackgroundColour = colours.Pink3,
+                                BackgroundColour = colours.DangerousButtonColour,
                                 Text = FirstRunSetupOverlayStrings.ClassicDefaults,
                                 RelativeSizeAxes = Axes.X,
                                 Action = applyClassic

--- a/osu.Game/Overlays/Settings/DangerousSettingsButton.cs
+++ b/osu.Game/Overlays/Settings/DangerousSettingsButton.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Overlays.Settings
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            BackgroundColour = colours.Pink3;
+            BackgroundColour = colours.DangerousButtonColour;
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingConflictPopover.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingConflictPopover.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             applyNewButton = new HoverableRoundedButton
                             {
                                 Text = InputSettingsStrings.ApplyNewBinding,
-                                BackgroundColour = colours.Pink3,
+                                BackgroundColour = colours.DangerousButtonColour,
                                 RelativeSizeAxes = Axes.X,
                                 Width = 0.48f,
                                 Anchor = Anchor.CentreRight,


### PR DESCRIPTION
Noticed in passing. Doesn't look intentional.

For the future, made an alias for the "dangerous" colour in `OsuColour` for reuse.

| before | after |
| :-: | :-: |
| ![1697195848](https://github.com/ppy/osu/assets/20418176/f6fe03be-b6e5-4b16-b454-7d46a7484957) | ![1697195890](https://github.com/ppy/osu/assets/20418176/8a4ef5b3-1666-4b28-a737-eb6d3f21c0c2) |