### PR TITLE
Use new `generic-error` sample in appropriate places

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingConflictPopover.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingConflictPopover.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private readonly KeyBindingRow.KeyBindingConflictInfo conflictInfo;
 
+        protected override string PopInSampleName => @"UI/generic-error";
+
         public KeyBindingConflictPopover(KeyBindingRow.KeyBindingConflictInfo conflictInfo)
         {
             this.conflictInfo = conflictInfo;

--- a/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/DrawableLoungeRoom.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
                     }
                 };
 
-                sampleJoinFail = audio.Samples.Get(@"UI/password-fail");
+                sampleJoinFail = audio.Samples.Get(@"UI/generic-error");
 
                 joinButton.Action = performJoin;
             }

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.1012.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1003.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1014.0" />
     <PackageReference Include="Sentry" Version="3.40.0" />
     <PackageReference Include="SharpCompress" Version="0.34.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Used by the duplicate keybinding popup and also replaces `password-fail` (incorrect room password popup)

- [x] Depends on ppy/osu-resources#288