### PR TITLE
Fix health bar animating when it shouldn't be

### DIFF
--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -78,22 +79,25 @@ namespace osu.Game.Screens.Play.HUD
             if (PlayInitialIncreaseAnimation)
                 startInitialAnimation();
             else
-                Current.Value = 1;
+                Current.Value = health.Value;
         }
 
         private void startInitialAnimation()
         {
+            if (Current.Value >= health.Value)
+                return;
+
             // TODO: this should run in gameplay time, including showing a larger increase when skipping.
             // TODO: it should also start increasing relative to the first hitobject.
             const double increase_delay = 150;
 
             initialIncrease = Scheduler.AddDelayed(() =>
             {
-                double newValue = Current.Value + 0.05f;
+                double newValue = Math.Min(Current.Value + 0.05f, health.Value);
                 this.TransformBindableTo(Current, newValue, increase_delay);
                 Scheduler.AddOnce(Flash);
 
-                if (newValue >= 1)
+                if (newValue >= health.Value)
                     finishInitialAnimation();
             }, increase_delay, true);
         }


### PR DESCRIPTION
It wasn't correctly checking the current underlying health, which could be zero in usages of `AccumulatingHealthProcessor`, for instance.

Closes #25046.