### PR TITLE
Remove drag handles from manage collections dialog for now

### DIFF
--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -36,7 +36,13 @@ namespace osu.Game.Collections
         public DrawableCollectionListItem(Live<BeatmapCollection> item, bool isCreated)
             : base(item)
         {
-            ShowDragHandle.Value = item.IsManaged;
+            // For now we don't support rearranging and always use alphabetical sort.
+            // Change this to:
+            //
+            // ShowDragHandle.Value = item.IsManaged;
+            //
+            // if we want to support user sorting (but changes will need to be made to realm to persist).
+            ShowDragHandle.Value = false;
         }
 
         protected override Drawable CreateContent() => new ItemContent(Model);


### PR DESCRIPTION
The realm implementation doesn't support this. May come back at a future date, but this matches stable so it's not a huge deal.