### PR TITLE
osu!standard Performance Calc: Small circle size adjustment

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -152,11 +152,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             // We will scale distances by this factor, so we can assume a uniform CircleSize among beatmaps.
             float scalingFactor = NORMALISED_RADIUS / (float)BaseObject.Radius;
 
+	    // We add a small circle bonus for objects with radius less than 30
             if (BaseObject.Radius < 30)
-            {
-                float smallCircleBonus = Math.Min(30 - (float)BaseObject.Radius, 5) / 50;
-                scalingFactor *= 1 + smallCircleBonus;
-            }
+	    {
+		float smallCircleBonus = (float)Math.Pow(1.35, 7.27 / (float)BaseObject.Radius ) ;
+		scalingFactor *= smallCircleBonus;
+	    }
+	
 
             Vector2 lastCursorPosition = getEndCursorPosition(lastObject);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 	    // We add a small circle bonus for objects with radius less than 30
             if (BaseObject.Radius < 30)
 	    {
-		float smallCircleBonus = (float)Math.Pow(1.35, 7.27 / (float)BaseObject.Radius ) ;
+		float smallCircleBonus = (float)Math.Pow(1.35, 7 / (float)BaseObject.Radius ) ;
 		scalingFactor *= smallCircleBonus;
 	    }
 	

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -159,7 +159,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 		scalingFactor *= smallCircleBonus;
 	    }
 	
-
             Vector2 lastCursorPosition = getEndCursorPosition(lastObject);
 
             LazyJumpDistance = (BaseObject.StackedPosition * scalingFactor - lastCursorPosition * scalingFactor).Length;

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
 	    // We add a small circle bonus for objects with radius less than 30
             if (BaseObject.Radius < 30)
 	    {
-		float smallCircleBonus = (float)Math.Pow(1.35, 7 / (float)BaseObject.Radius ) ;
+		float smallCircleBonus = (float)Math.Pow(1.4, 20 / (float)BaseObject.Radius - 0.5 ) ;
 		scalingFactor *= smallCircleBonus;
 	    }
 	


### PR DESCRIPTION
Hello there!

I rewrote the smallCircleSizeBonus with Math.Pow and adjusted the values to align with generically observed player sentiment. This is an explicit buff for circles with radius less than 30 (cs 6.5).

I cross checked scores with both the main tree and with the proposed Xexxar length bonus removal and aim buff, and the values look good, if not better. 

Please let me know if I missed something or need to do some adjustments to tests to confirm everything works right.

Thanks!

### Comments

This should help account for future possibilities like scaling cs above 10 and increasing the bonus as the object radius nears 0. I have no idea how to use desmos correctly, but the formula is simple enough to plug into any calculator. Comparing to current bonus, this buffs cs6.5 specifically as well as very high cs, while keeping the pp values within reason.

Heres a quick graph I put together just to show the actual value of the smallCircleBonus with the proposed change, which is in black.

![image](https://github.com/ppy/osu/assets/18505898/8701b6f7-f269-48ea-809f-0548ec9a9e69)



