### PR TITLE
Adjust slider repeat transforms to closer match stable

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSlider.cs
@@ -27,6 +27,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Configuration;
+using osu.Game.Rulesets.Osu.Mods;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
@@ -49,6 +50,8 @@ namespace osu.Game.Rulesets.Osu.Tests
                 snakingIn.Value = !v;
                 snakingOut.Value = !v;
             });
+
+            AddToggleStep("toggle hidden", hiddenActive => SelectedMods.Value = hiddenActive ? new[] { new OsuModHidden() } : Array.Empty<Mod>());
 
             AddSliderStep("hit at", 0f, 1f, 0f, v =>
             {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -98,6 +98,9 @@ namespace osu.Game.Rulesets.Osu.Mods
                         // only apply to circle piece – reverse arrow is not affected by hidden.
                         sliderRepeat.CirclePiece.FadeOut(fadeDuration);
 
+                    using (drawableObject.BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
+                        sliderRepeat.FadeOut();
+
                     break;
 
                 case DrawableHitCircle circle:

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -118,11 +118,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
                 case ArmedState.Hit:
                     this.FadeOut(animDuration, Easing.Out);
-
-                    const float final_scale = 1.5f;
-
-                    Arrow.ScaleTo(Scale * final_scale, animDuration, Easing.Out);
-                    CirclePiece.ScaleTo(Scale * final_scale, animDuration, Easing.Out);
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osuTK;
 using osuTK.Graphics;
 
@@ -19,8 +21,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public partial class ArgonReverseArrow : CompositeDrawable
     {
-        [Resolved]
-        private DrawableHitObject drawableObject { get; set; } = null!;
+        private DrawableSliderRepeat drawableRepeat { get; set; } = null!;
 
         private Bindable<Color4> accentColour = null!;
 
@@ -29,8 +30,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         private Sprite side = null!;
 
         [BackgroundDependencyLoader]
-        private void load(TextureStore textures)
+        private void load(DrawableHitObject drawableObject, TextureStore textures)
         {
+            drawableRepeat = (DrawableSliderRepeat)drawableObject;
+
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
@@ -70,10 +73,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 }
             };
 
-            accentColour = drawableObject.AccentColour.GetBoundCopy();
+            accentColour = drawableRepeat.AccentColour.GetBoundCopy();
             accentColour.BindValueChanged(accent => icon.Colour = accent.NewValue.Darken(4), true);
 
-            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
+            drawableRepeat.ApplyCustomUpdateState += updateStateTransforms;
         }
 
         private void updateStateTransforms(DrawableHitObject hitObject, ArmedState state)
@@ -96,6 +99,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         .MoveToX(0, move_in_duration, Easing.Out)
                         .Loop(total - (move_in_duration + move_out_duration));
                     break;
+
+                case ArmedState.Hit:
+                    double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
+                    this.ScaleTo(1.5f, animDuration, Easing.Out);
+                    break;
             }
         }
 
@@ -103,8 +111,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         {
             base.Dispose(isDisposing);
 
-            if (drawableObject.IsNotNull())
-                drawableObject.ApplyCustomUpdateState -= updateStateTransforms;
+            if (drawableRepeat.IsNotNull())
+                drawableRepeat.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultReverseArrow.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -8,14 +9,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
     public partial class DefaultReverseArrow : CompositeDrawable
     {
-        [Resolved]
-        private DrawableHitObject drawableObject { get; set; } = null!;
+        private DrawableSliderRepeat drawableRepeat { get; set; } = null!;
 
         public DefaultReverseArrow()
         {
@@ -36,9 +37,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(DrawableHitObject drawableObject)
         {
-            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
+            drawableRepeat = (DrawableSliderRepeat)drawableObject;
+            drawableRepeat.ApplyCustomUpdateState += updateStateTransforms;
         }
 
         private void updateStateTransforms(DrawableHitObject hitObject, ArmedState state)
@@ -55,6 +57,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                                  .ScaleTo(1f, move_in_duration, Easing.Out)
                                  .Loop(total - (move_in_duration + move_out_duration));
                     break;
+
+                case ArmedState.Hit:
+                    double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
+                    InternalChild.ScaleTo(1.5f, animDuration, Easing.Out);
+                    break;
             }
         }
 
@@ -62,8 +69,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             base.Dispose(isDisposing);
 
-            if (drawableObject.IsNotNull())
-                drawableObject.ApplyCustomUpdateState -= updateStateTransforms;
+            if (drawableRepeat.IsNotNull())
+                drawableRepeat.ApplyCustomUpdateState -= updateStateTransforms;
         }
     }
 }


### PR DESCRIPTION
Before: https://drive.google.com/file/d/1b0G7HzZ9VT4QRdZVmZYppRp9v_lEfHhX/view?usp=sharing
After: https://drive.google.com/file/d/1I6NAwCWOB7AGNVdxm7VmBEU5ffRal4ad/view?usp=sharing

Sorry for the google drive links, sometimes big github embeds just fail for me and I don't know what is it.

Videos contain 2 clips: one normal gameplay, one with hidden, on legacy default skin. Left is stable, right is lazer.

This contains two disparate fixes.

## https://github.com/ppy/osu/commit/30e5f470073399be071a7e947f6331c8056d3770: Instantly fade out slider repeats when hidden is active

This closes https://github.com/ppy/osu/issues/24902.

Not much more to say, explanation and stable code for cross-reference is available in the issue thread.

## https://github.com/ppy/osu/commit/f3cda5847448fa037b8739cf28815ebda4be0c49: Fix legacy slider repeats becoming much too large on hit

They had scale transforms applied to them in two places: the actual legacy pieces themselves (esp. `LegacyHitCirclePiece`), and on the `DrawableSliderRepeat` level.

This change moves all of the scale transforms to the skinnable pieces. Argon and triangles have received a copy of the previous logic each, so behaviour on those skins should not change.

---

There is one remaining difference you can spot on the videos at the start: with these changes, there is a visible gap when a repeat arrow is under another repeat arrow; the second arrow does not fade in as quickly as stable. I'm not sure what to do about that one.

The stable code is here: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameplayElements/HitObjects/Osu/HitCircleSliderEnd.cs#L34-L38. Stable heavily relies on being able to handle things sprite-per-sprite here.

The fade-in durations forced by `DrawableSliderRepeat` make this difficult to replicate in lazer without moving the fade transforms into the skinnable pieces. I did it for the scale transforms, as those don't really impact gameplay all that much, but I'm not sure about doing that for the fades - that feels potentially more abusable. Opinions welcome.