### PR TITLE
Fix circle scale not matching stable due to missing multiplier

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450);
 
-            Scale = (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 2;
+            Scale = IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize);
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;

--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
@@ -151,7 +152,7 @@ namespace osu.Game.Rulesets.Catch.Objects
 
             TimePreempt = (float)IBeatmapDifficultyInfo.DifficultyRange(difficulty.ApproachRate, 1800, 1200, 450);
 
-            Scale = IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize);
+            Scale = LegacyRulesetExtensions.CalculateScaleFromCircleSize(difficulty.CircleSize);
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Objects.Drawables;
 using osu.Game.Rulesets.Catch.Skinning;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -469,7 +470,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Calculates the scale of the catcher based off the provided beatmap difficulty.
         /// </summary>
-        private static Vector2 calculateScale(IBeatmapDifficultyInfo difficulty) => new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize) * 2);
+        private static Vector2 calculateScale(IBeatmapDifficultyInfo difficulty) => new Vector2(LegacyRulesetExtensions.CalculateScaleFromCircleSize(difficulty.CircleSize) * 2);
 
         private enum DroppedObjectAnimation
         {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Size = new Vector2(BASE_SIZE);
 
             if (difficulty != null)
-                Scale = new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize));
+                Scale = calculateScale(difficulty);
 
             CatchWidth = CalculateCatchWidth(Scale);
 
@@ -192,7 +192,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="difficulty">The beatmap difficulty.</param>
-        public static float CalculateCatchWidth(IBeatmapDifficultyInfo difficulty) => CalculateCatchWidth(new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize)));
+        public static float CalculateCatchWidth(IBeatmapDifficultyInfo difficulty) => CalculateCatchWidth(calculateScale(difficulty));
 
         /// <summary>
         /// Determine if this catcher can catch a <see cref="CatchHitObject"/> in the current position.
@@ -465,6 +465,11 @@ namespace osu.Game.Rulesets.Catch.UI
             d.LifetimeStart = Clock.CurrentTime;
             d.Expire();
         }
+
+        /// <summary>
+        /// Calculates the scale of the catcher based off the provided beatmap difficulty.
+        /// </summary>
+        private static Vector2 calculateScale(IBeatmapDifficultyInfo difficulty) => new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize) * 2);
 
         private enum DroppedObjectAnimation
         {

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Size = new Vector2(BASE_SIZE);
 
             if (difficulty != null)
-                Scale = calculateScale(difficulty);
+                Scale = new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize));
 
             CatchWidth = CalculateCatchWidth(Scale);
 
@@ -183,11 +183,6 @@ namespace osu.Game.Rulesets.Catch.UI
         public Drawable CreateProxiedContent() => caughtObjectContainer.CreateProxy();
 
         /// <summary>
-        /// Calculates the scale of the catcher based off the provided beatmap difficulty.
-        /// </summary>
-        private static Vector2 calculateScale(IBeatmapDifficultyInfo difficulty) => new Vector2(1.0f - 0.7f * (difficulty.CircleSize - 5) / 5);
-
-        /// <summary>
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="scale">The scale of the catcher.</param>
@@ -197,7 +192,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// Calculates the width of the area used for attempting catches in gameplay.
         /// </summary>
         /// <param name="difficulty">The beatmap difficulty.</param>
-        public static float CalculateCatchWidth(IBeatmapDifficultyInfo difficulty) => CalculateCatchWidth(calculateScale(difficulty));
+        public static float CalculateCatchWidth(IBeatmapDifficultyInfo difficulty) => CalculateCatchWidth(new Vector2(IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize)));
 
         /// <summary>
         /// Determine if this catcher can catch a <see cref="CatchHitObject"/> in the current position.

--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -15,22 +15,22 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu";
 
-        [TestCase(6.7115569159190587d, 206, "diffcalc-test")]
-        [TestCase(1.4391311903612753d, 45, "zero-length-sliders")]
+        [TestCase(6.710442985146793d, 206, "diffcalc-test")]
+        [TestCase(1.4386882251130073d, 45, "zero-length-sliders")]
         [TestCase(0.42506480230838789d, 2, "very-fast-slider")]
         [TestCase(0.14102693012101306d, 1, "nan-slider")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(8.9757300665532966d, 206, "diffcalc-test")]
+        [TestCase(8.9742952703071666d, 206, "diffcalc-test")]
         [TestCase(0.55071082800473514d, 2, "very-fast-slider")]
-        [TestCase(1.7437232654020756d, 45, "zero-length-sliders")]
+        [TestCase(1.743180218215227d, 45, "zero-length-sliders")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModDoubleTime());
 
-        [TestCase(6.7115569159190587d, 239, "diffcalc-test")]
+        [TestCase(6.710442985146793d, 239, "diffcalc-test")]
         [TestCase(0.42506480230838789d, 4, "very-fast-slider")]
-        [TestCase(1.4391311903612753d, 54, "zero-length-sliders")]
+        [TestCase(1.4386882251130073d, 54, "zero-length-sliders")]
         public void TestClassicMod(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModClassic());
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
@@ -35,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             const double time_slider_start = 1000;
 
-            float circleRadius = OsuHitObject.OBJECT_RADIUS * IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(circleSize);
+            float circleRadius = OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(circleSize, true);
             float followCircleRadius = circleRadius * 1.2f;
 
             performTest(new Beatmap<OsuHitObject>

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderFollowCircleInput.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             const double time_slider_start = 1000;
 
-            float circleRadius = OsuHitObject.OBJECT_RADIUS * (1.0f - 0.7f * (circleSize - 5) / 5) / 2;
+            float circleRadius = OsuHitObject.OBJECT_RADIUS * IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(circleSize);
             float followCircleRadius = circleRadius * 1.2f;
 
             performTest(new Beatmap<OsuHitObject>

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -155,7 +155,17 @@ namespace osu.Game.Rulesets.Osu.Objects
             // This adjustment is necessary for AR>10, otherwise TimePreempt can become smaller leading to hitcircles not fully fading in.
             TimeFadeIn = 400 * Math.Min(1, TimePreempt / PREEMPT_MIN);
 
-            Scale = (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 2;
+            // The following comment is copied verbatim from osu-stable:
+            //
+            //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
+            //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
+            //   for all plays, but by an amount so small it should only be effective in replays.
+            //
+            // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
+            // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
+            const float broken_gamefield_rounding_allowance = 1.00041f;
+
+            Scale = (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 2 * broken_gamefield_rounding_allowance;
         }
 
         protected override HitWindows CreateHitWindows() => new OsuHitWindows();

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -155,17 +155,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             // This adjustment is necessary for AR>10, otherwise TimePreempt can become smaller leading to hitcircles not fully fading in.
             TimeFadeIn = 400 * Math.Min(1, TimePreempt / PREEMPT_MIN);
 
-            // The following comment is copied verbatim from osu-stable:
-            //
-            //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
-            //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
-            //   for all plays, but by an amount so small it should only be effective in replays.
-            //
-            // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
-            // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
-            const float broken_gamefield_rounding_allowance = 1.00041f;
-
-            Scale = (1.0f - 0.7f * (difficulty.CircleSize - 5) / 5) / 2 * broken_gamefield_rounding_allowance;
+            Scale = IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize);
         }
 
         protected override HitWindows CreateHitWindows() => new OsuHitWindows();

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
@@ -155,7 +156,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             // This adjustment is necessary for AR>10, otherwise TimePreempt can become smaller leading to hitcircles not fully fading in.
             TimeFadeIn = 400 * Math.Min(1, TimePreempt / PREEMPT_MIN);
 
-            Scale = IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(difficulty.CircleSize);
+            Scale = LegacyRulesetExtensions.CalculateScaleFromCircleSize(difficulty.CircleSize, true);
         }
 
         protected override HitWindows CreateHitWindows() => new OsuHitWindows();

--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -13,6 +13,7 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Scoring;
 using osuTK;
@@ -208,7 +209,7 @@ namespace osu.Game.Rulesets.Osu.Statistics
             if (score.HitEvents.Count == 0)
                 return;
 
-            float radius = OsuHitObject.OBJECT_RADIUS * IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(playableBeatmap.Difficulty.CircleSize);
+            float radius = OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(playableBeatmap.Difficulty.CircleSize, true);
 
             foreach (var e in score.HitEvents.Where(e => e.HitObject is HitCircle && !(e.HitObject is SliderTailCircle)))
             {

--- a/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
+++ b/osu.Game.Rulesets.Osu/Statistics/AccuracyHeatmap.cs
@@ -208,8 +208,7 @@ namespace osu.Game.Rulesets.Osu.Statistics
             if (score.HitEvents.Count == 0)
                 return;
 
-            // Todo: This should probably not be done like this.
-            float radius = OsuHitObject.OBJECT_RADIUS * (1.0f - 0.7f * (playableBeatmap.Difficulty.CircleSize - 5) / 5) / 2;
+            float radius = OsuHitObject.OBJECT_RADIUS * IBeatmapDifficultyInfo.CalculateScaleFromCircleSize(playableBeatmap.Difficulty.CircleSize);
 
             foreach (var e in score.HitEvents.Where(e => e.HitObject is HitCircle && !(e.HitObject is SliderTailCircle)))
             {

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -44,21 +44,6 @@ namespace osu.Game.Beatmaps
         /// </summary>
         double SliderTickRate { get; }
 
-        static float CalculateScaleFromCircleSize(float circleSize)
-        {
-            // The following comment is copied verbatim from osu-stable:
-            //
-            //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
-            //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
-            //   for all plays, but by an amount so small it should only be effective in replays.
-            //
-            // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
-            // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
-            const float broken_gamefield_rounding_allowance = 1.00041f;
-
-            return (float)(1.0f - 0.7f * DifficultyRange(circleSize)) / 2 * broken_gamefield_rounding_allowance;
-        }
-
         /// <summary>
         /// Maps a difficulty value [0, 10] to a two-piece linear range of values.
         /// </summary>

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -44,6 +44,21 @@ namespace osu.Game.Beatmaps
         /// </summary>
         double SliderTickRate { get; }
 
+        static float CalculateScaleFromCircleSize(float circleSize)
+        {
+            // The following comment is copied verbatim from osu-stable:
+            //
+            //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
+            //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
+            //   for all plays, but by an amount so small it should only be effective in replays.
+            //
+            // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
+            // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
+            const float broken_gamefield_rounding_allowance = 1.00041f;
+
+            return (float)(1.0f - 0.7f * DifficultyRange(circleSize)) / 2 * broken_gamefield_rounding_allowance;
+        }
+
         /// <summary>
         /// Maps a difficulty value [0, 10] to a two-piece linear range of values.
         /// </summary>
@@ -55,12 +70,19 @@ namespace osu.Game.Beatmaps
         static double DifficultyRange(double difficulty, double min, double mid, double max)
         {
             if (difficulty > 5)
-                return mid + (max - mid) * (difficulty - 5) / 5;
+                return mid + (max - mid) * DifficultyRange(difficulty);
             if (difficulty < 5)
                 return mid - (mid - min) * (5 - difficulty) / 5;
 
             return mid;
         }
+
+        /// <summary>
+        /// Maps a difficulty value [0, 10] to a linear range of [-1, 1].
+        /// </summary>
+        /// <param name="difficulty">The difficulty value to be mapped.</param>
+        /// <returns>Value to which the difficulty value maps in the specified range.</returns>
+        static double DifficultyRange(double difficulty) => (difficulty - 5) / 5;
 
         /// <summary>
         /// Maps a difficulty value [0, 10] to a two-piece linear range of values.

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Beatmaps
             if (difficulty > 5)
                 return mid + (max - mid) * DifficultyRange(difficulty);
             if (difficulty < 5)
-                return mid - (mid - min) * (5 - difficulty) / 5;
+                return mid + (mid - min) * DifficultyRange(difficulty);
 
             return mid;
         }

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
             const float broken_gamefield_rounding_allowance = 1.00041f;
 
-            return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * broken_gamefield_rounding_allowance;
+            return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1);
         }
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects.Types;
 
@@ -37,6 +38,24 @@ namespace osu.Game.Rulesets.Objects.Legacy
             }
 
             return timingControlPoint.BeatLength * bpmMultiplier;
+        }
+
+        /// <summary>
+        /// Calculates scale from a CS value, with an optional fudge that was historically applied to the osu! ruleset.
+        /// </summary>
+        public static float CalculateScaleFromCircleSize(float circleSize, bool applyFudge = false)
+        {
+            // The following comment is copied verbatim from osu-stable:
+            //
+            //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
+            //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
+            //   for all plays, but by an amount so small it should only be effective in replays.
+            //
+            // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
+            // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
+            const float broken_gamefield_rounding_allowance = 1.00041f;
+
+            return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * broken_gamefield_rounding_allowance;
         }
     }
 }


### PR DESCRIPTION
This multiplier has to exist. I'm not sure how we missed it until now.

Closes https://github.com/ppy/osu/issues/25162. Tested to fix the linked replay.

Note that I unfortunately found something very unfortunate this is likely going to cause us nightmares for eternity, but I don't know if we can aim to fix it. Stable applies mod multipliers at a very low level, as part of the `double` math. Note the remaining discrepancies:

| CS,HR | stable | lazer(master) | lazer(pr) | circleguard |
| --- | --- | --- | --- | --- |
| 0,1 | 0.8503485 | -0.00034844875 | - | - |
| 0.1,1 | 0.8433456 | -0.00034558773 | - | - |
| 0.2,1 | 0.8363427 | -0.0003426671 | - | - |
| 0.3,1 | 0.82933986 | -0.00033986568 | - | - |
| 0.4,1 | 0.822337 | -0.00033700466 | - | - |
| 0.5,1 | 0.81533414 | -0.00033414364 | - | - |
| 0.6,1 | 0.8083312 | -0.000331223 | - | - |
| 0.70000005,1 | 0.80132836 | -0.000328362 | - | - |
| 0.8000001,1 | 0.7943255 | -0.00032550097 | - | - |
| 0.9000001,1 | 0.78732264 | -0.00032263994 | - | - |
| 1.0000001,1 | 0.78031975 | -0.00031977892 | - | - |
| 1.1000001,1 | 0.7733169 | -0.0003169179 | - | - |
| 1.2000002,1 | 0.766314 | -0.00031405687 | - | - |
| 1.3000002,1 | 0.75931114 | -0.00031113625 | - | - |
| 1.4000002,1 | 0.75230825 | -0.00030827522 | - | - |
| 1.5000002,1 | 0.7453054 | -0.0003054142 | - | - |
| 1.6000003,1 | 0.7383025 | -0.00030255318 | - | - |
| 1.7000003,1 | 0.73129964 | -0.00029969215 | - | - |
| 1.8000003,1 | 0.7242968 | -0.00029683113 | - | - |
| 1.9000003,1 | 0.7172939 | -0.0002939105 | - | - |
| 2.0000002,1 | 0.710291 | -0.00029104948 | - | - |
| 2.1000001,1 | 0.7032882 | -0.00028818846 | - | - |
| 2.2,1 | 0.6962853 | -0.00028532743 | - | - |
| 2.3,1 | 0.6892825 | -0.0002824664 | - | - |
| 2.3999999,1 | 0.6822796 | -0.00027954578 | - | - |
| 2.4999998,1 | 0.67527676 | -0.00027674437 | - | - |
| 2.5999997,1 | 0.6682739 | -0.00027394295 | - | - |
| 2.6999996,1 | 0.661271 | -0.00027096272 | - | - |
| 2.7999995,1 | 0.65426815 | -0.0002681017 | - | - |
| 2.8999994,1 | 0.64726526 | -0.00026518106 | - | - |
| 2.9999993,1 | 0.6402624 | -0.00026237965 | - | - |
| 3.0999992,1 | 0.6332596 | -0.00025957823 | - | - |
| 3.199999,1 | 0.6262567 | -0.0002566576 | - | - |
| 3.299999,1 | 0.6192538 | -0.00025373697 | - | - |
| 3.399999,1 | 0.6122509 | -0.00025087595 | - | - |
| 3.4999988,1 | 0.6052481 | -0.00024801493 | - | - |
| 3.5999987,1 | 0.59824526 | -0.0002451539 | - | - |
| 3.6999986,1 | 0.5912424 | -0.00024229288 | - | - |
| 3.7999985,1 | 0.58423954 | -0.00023943186 | - | - |
| 3.8999984,1 | 0.57723665 | -0.00023651123 | - | - |
| 3.9999983,1 | 0.57023376 | -0.00023365021 | - | - |
| 4.0999985,1 | 0.5632309 | -0.00023078918 | - | - |
| 4.1999984,1 | 0.55622804 | -0.00022792816 | - | - |
| 4.2999983,1 | 0.5492252 | -0.00022506714 | - | - |
| 4.399998,1 | 0.5422223 | -0.00022220612 | - | - |
| 4.499998,1 | 0.5352195 | -0.0002193451 | - | - |
| 4.599998,1 | 0.5282166 | -0.00021648407 | - | - |
| 4.699998,1 | 0.5212137 | -0.00021356344 | - | - |
| 4.799998,1 | 0.5142109 | -0.00021070242 | - | - |
| 4.8999977,1 | 0.507208 | -0.0002078414 | - | - |
| 4.9999976,1 | 0.50020516 | -0.00020498037 | - | - |
| 5.0999975,1 | 0.4932023 | -0.00020211935 | - | - |
| 5.1999974,1 | 0.4861994 | -0.00019922853 | - | - |
| 5.2999973,1 | 0.47919655 | -0.0001963675 | - | - |
| 5.399997,1 | 0.4721937 | -0.00019350648 | - | - |
| 5.499997,1 | 0.46519086 | -0.00019064546 | - | - |
| 5.599997,1 | 0.45818797 | -0.00018775463 | - | - |
| 5.699997,1 | 0.4511851 | -0.00018489361 | - | - |
| 5.799997,1 | 0.44418225 | -0.00018203259 | - | - |
| 5.8999968,1 | 0.43717936 | -0.00017914176 | - | - |
| 5.9999967,1 | 0.43017653 | -0.00017628074 | - | - |
| 6.0999966,1 | 0.42317367 | -0.00017341971 | - | - |
| 6.1999965,1 | 0.41617078 | -0.00017052889 | - | - |
| 6.2999964,1 | 0.40916792 | -0.00016766787 | - | - |
| 6.3999963,1 | 0.40216506 | -0.00016480684 | - | - |
| 6.499996,1 | 0.39516222 | -0.00016194582 | - | - |
| 6.599996,1 | 0.38815933 | -0.000159055 | - | - |
| 6.699996,1 | 0.38115647 | -0.00015619397 | - | - |
| 6.799996,1 | 0.3741536 | -0.00015333295 | - | - |
| 6.899996,1 | 0.36715072 | -0.00015044212 | - | - |
| 6.9999957,1 | 0.3601479 | -0.0001475811 | - | - |
| 7.0999956,1 | 0.35314503 | -0.00014472008 | - | - |
| 7.1999955,1 | 0.34614217 | -0.00014185905 | - | - |
| 7.2999954,1 | 0.33913928 | -0.00013896823 | - | - |
| 7.3999953,1 | 0.33213642 | -0.0001361072 | - | - |
| 7.499995,1 | 0.3251336 | -0.00013324618 | - | - |
| 7.599995,1 | 0.3181307 | -0.00013035536 | - | - |
| 7.699995,1 | 0.31112784 | -0.00012749434 | - | - |
| 7.799995,1 | 0.30412498 | -0.00012463331 | - | - |
| 7.899995,1 | 0.29712215 | -0.00012180209 | - | - |
| 7.9999948,1 | 0.29011926 | -0.000118881464 | - | - |
| 8.099995,1 | 0.2831164 | -0.00011602044 | - | - |
| 8.199995,1 | 0.2761135 | -0.00011315942 | - | - |
| 8.299995,1 | 0.2691106 | -0.00011026859 | - | - |
| 8.399996,1 | 0.2621077 | -0.00010740757 | - | - |
| 8.499996,1 | 0.2551048 | -0.000104516745 | - | - |
| 8.599997,1 | 0.24810192 | -0.000101685524 | - | - |
| 8.699997,1 | 0.24109901 | -9.87798E-05 | - | - |
| 8.799997,1 | 0.23409612 | -9.594858E-05 | - | - |
| 8.899998,1 | 0.22709322 | -9.304285E-05 | - | - |
| 8.999998,1 | 0.22009033 | -9.018183E-05 | - | - |
| 9.099998,1 | 0.21308744 | -8.7320805E-05 | - | - |
| 9.199999,1 | 0.20608453 | -8.444488E-05 | - | - |
| 9.299999,1 | 0.19908164 | -8.158386E-05 | - | - |
| 9.4,1 | 0.19207874 | -7.870793E-05 | - | - |
| 9.5,1 | 0.18507585 | -7.584691E-05 | - | - |
| 9.6,1 | 0.17807294 | -7.297099E-05 | - | - |
| 9.700001,1 | 0.17107007 | -7.0124865E-05 | - | - |
| 9.800001,1 | 0.16406716 | -6.724894E-05 | - | - |
| 9.900002,1 | 0.15706426 | -6.4373016E-05 | - | - |
| 0,1.3 | 0.8503485 | -0.00034844875 | - | - |
| 0.1,1.3 | 0.84124476 | -0.00034475327 | - | - |
| 0.2,1.3 | 0.832141 | -0.00034099817 | - | - |
| 0.3,1.3 | 0.82303727 | -0.00033724308 | - | - |
| 0.4,1.3 | 0.81393355 | -0.0003335476 | - | - |
| 0.5,1.3 | 0.8048298 | -0.0003297925 | - | - |
| 0.6,1.3 | 0.79572606 | -0.000326097 | - | - |
| 0.70000005,1.3 | 0.78662235 | -0.00032234192 | - | - |
| 0.8000001,1.3 | 0.77751863 | -0.00031864643 | - | - |
| 0.9000001,1.3 | 0.76841486 | -0.00031483173 | - | - |
| 1.0000001,1.3 | 0.75931114 | -0.00031113625 | - | - |
| 1.1000001,1.3 | 0.7502074 | -0.00030744076 | - | - |
| 1.2000002,1.3 | 0.74110365 | -0.00030368567 | - | - |
| 1.3000002,1.3 | 0.732 | -0.00029999018 | - | - |
| 1.4000002,1.3 | 0.7228962 | -0.00029623508 | - | - |
| 1.5000002,1.3 | 0.71379244 | -0.00029248 | - | - |
| 1.6000003,1.3 | 0.7046887 | -0.0002887249 | 5.9604645E-08 | 5.9604645E-08 |
| 1.7000003,1.3 | 0.695585 | -0.0002850294 | - | - |
| 1.8000003,1.3 | 0.6864813 | -0.00028133392 | - | - |
| 1.9000003,1.3 | 0.6773775 | -0.00027757883 | 5.9604645E-08 | 5.9604645E-08 |
| 2.0000002,1.3 | 0.66827387 | -0.00027388334 | - | - |
| 2.1000001,1.3 | 0.6591701 | -0.00027006865 | 5.9604645E-08 | 5.9604645E-08 |
| 2.2,1.3 | 0.6500664 | -0.00026637316 | - | - |
| 2.3,1.3 | 0.64096266 | -0.00026267767 | 5.9604645E-08 | 5.9604645E-08 |
| 2.3999999,1.3 | 0.63185894 | -0.00025892258 | - | - |
| 2.4999998,1.3 | 0.6227552 | -0.0002552271 | - | - |
| 2.5999997,1.3 | 0.6136515 | -0.000251472 | - | - |
| 2.6999996,1.3 | 0.60454774 | -0.0002477169 | - | - |
| 2.7999995,1.3 | 0.5954441 | -0.00024402142 | - | - |
| 2.8999994,1.3 | 0.5863403 | -0.00024026632 | - | - |
| 2.9999993,1.3 | 0.57723665 | -0.00023657084 | - | - |
| 3.0999992,1.3 | 0.5681329 | -0.00023281574 | - | - |
| 3.199999,1.3 | 0.55902916 | -0.00022906065 | - | - |
| 3.299999,1.3 | 0.54992545 | -0.00022536516 | - | - |
| 3.399999,1.3 | 0.54082173 | -0.00022161007 | - | - |
| 3.4999988,1.3 | 0.531718 | -0.00021791458 | - | - |
| 3.5999987,1.3 | 0.5226143 | -0.00021415949 | - | - |
| 3.6999986,1.3 | 0.5135105 | -0.0002104044 | - | - |
| 3.7999985,1.3 | 0.50440687 | -0.00020670891 | - | - |
| 3.8999984,1.3 | 0.49530312 | -0.00020298362 | - | - |
| 3.9999983,1.3 | 0.48619938 | -0.00019919872 | 2.9802322E-08 | 2.9802322E-08 |
| 4.0999985,1.3 | 0.47709563 | -0.00019550323 | - | - |
| 4.1999984,1.3 | 0.46799192 | -0.00019174814 | 2.9802322E-08 | 2.9802322E-08 |
| 4.2999983,1.3 | 0.4588882 | -0.00018805265 | - | - |
| 4.399998,1.3 | 0.4497845 | -0.00018429756 | 2.9802322E-08 | 2.9802322E-08 |
| 4.499998,1.3 | 0.44068077 | -0.00018060207 | - | - |
| 4.599998,1.3 | 0.43157703 | -0.00017684698 | 2.9802322E-08 | 2.9802322E-08 |
| 4.699998,1.3 | 0.4224733 | -0.00017312169 | - | - |
| 4.799998,1.3 | 0.4133696 | -0.0001693964 | 2.9802322E-08 | 2.9802322E-08 |
| 4.8999977,1.3 | 0.40426588 | -0.00016567111 | - | - |
| 4.9999976,1.3 | 0.39516217 | -0.00016194582 | 2.9802322E-08 | 2.9802322E-08 |
| 5.0999975,1.3 | 0.38605842 | -0.00015816092 | 2.9802322E-08 | 2.9802322E-08 |
| 5.1999974,1.3 | 0.3769547 | -0.00015446544 | - | - |
| 5.2999973,1.3 | 0.367851 | -0.00015071034 | 2.9802322E-08 | 2.9802322E-08 |
| 5.399997,1.3 | 0.35874727 | -0.00014701486 | - | - |
| 5.499997,1.3 | 0.34964356 | -0.00014325976 | 2.9802322E-08 | 2.9802322E-08 |
| 5.599997,1.3 | 0.34053984 | -0.00013956428 | - | - |
| 5.699997,1.3 | 0.3314361 | -0.00013577938 | 2.9802322E-08 | 2.9802322E-08 |
| 5.799997,1.3 | 0.32233238 | -0.0001320839 | - | - |
| 5.8999968,1.3 | 0.31322867 | -0.0001283288 | 2.9802322E-08 | 2.9802322E-08 |
| 5.9999967,1.3 | 0.30412495 | -0.00012463331 | - | - |
| 6.0999966,1.3 | 0.29502124 | -0.00012087822 | 2.9802322E-08 | 2.9802322E-08 |
| 6.1999965,1.3 | 0.2859175 | -0.000117093325 | 2.9802322E-08 | 2.9802322E-08 |
| 6.2999964,1.3 | 0.27681378 | -0.00011339784 | 2.9802322E-08 | 2.9802322E-08 |
| 6.3999963,1.3 | 0.26771003 | -0.00010967255 | 2.9802322E-08 | 2.9802322E-08 |
| 6.499996,1.3 | 0.2586063 | -0.000105947256 | - | - |
| 6.599996,1.3 | 0.24950261 | -0.000102207065 | 4.4703484E-08 | 4.4703484E-08 |
| 6.699996,1.3 | 0.24039888 | -9.8496675E-05 | 2.9802322E-08 | 2.9802322E-08 |
| 6.799996,1.3 | 0.23129517 | -9.4771385E-05 | 1.4901161E-08 | 1.4901161E-08 |
| 6.899996,1.3 | 0.22219144 | -9.1060996E-05 | - | - |
| 6.9999957,1.3 | 0.21308772 | -8.72761E-05 | 4.4703484E-08 | 4.4703484E-08 |
| 7.0999956,1.3 | 0.20398399 | -8.356571E-05 | 4.4703484E-08 | 4.4703484E-08 |
| 7.1999955,1.3 | 0.19488026 | -7.982552E-05 | 2.9802322E-08 | 2.9802322E-08 |
| 7.2999954,1.3 | 0.18577655 | -7.613003E-05 | - | - |
| 7.3999953,1.3 | 0.17667283 | -7.234514E-05 | 5.9604645E-08 | 5.9604645E-08 |
| 7.499995,1.3 | 0.1675691 | -6.863475E-05 | 2.9802322E-08 | 2.9802322E-08 |
| 7.599995,1.3 | 0.15846539 | -6.490946E-05 | 1.4901161E-08 | 1.4901161E-08 |
| 7.699995,1.3 | 0.14936167 | -6.121397E-05 | - | - |
| 7.799995,1.3 | 0.14025794 | -5.7414174E-05 | 4.4703484E-08 | 4.4703484E-08 |
| 7.899995,1.3 | 0.13115422 | -5.3718686E-05 | 2.9802322E-08 | 2.9802322E-08 |
| 7.9999948,1.3 | 0.1220505 | -4.9985945E-05 | 1.4901161E-08 | 1.4901161E-08 |
| 8.099995,1.3 | 0.11294678 | -4.6283007E-05 | - | - |
| 8.199995,1.3 | 0.10384302 | -4.2542815E-05 | 2.2351742E-08 | 2.2351742E-08 |
| 8.299995,1.3 | 0.09473925 | -3.876537E-05 | 5.2154064E-08 | 5.2154064E-08 |
| 8.399996,1.3 | 0.08563548 | -3.504753E-05 | 1.4901161E-08 | 1.4901161E-08 |
| 8.499996,1.3 | 0.076531716 | -3.129989E-05 | 3.7252903E-08 | 3.7252903E-08 |
| 8.599997,1.3 | 0.067427956 | -2.7649105E-05 | - | - |
| 8.699997,1.3 | 0.058324188 | -2.387166E-05 | 2.6077032E-08 | 2.6077032E-08 |
| 8.799997,1.3 | 0.04922042 | -2.0124018E-05 | 5.2154064E-08 | 5.2154064E-08 |
| 8.899998,1.3 | 0.040116657 | -1.6409904E-05 | 1.1175871E-08 | 1.1175871E-08 |
| 8.999998,1.3 | 0.03101289 | -1.2664124E-05 | 3.9115548E-08 | 3.9115548E-08 |
| 9.099998,1.3 | 0.021909125 | -9.007752E-06 | - | - |
| 9.199999,1.3 | 0.01280536 | -5.2331015E-06 | 2.7008355E-08 | 2.7008355E-08 |
| 9.299999,1.3 | 0.0037015947 | -1.4873222E-06 | 5.3551048E-08 | 5.3551048E-08 |
| 9.4,1.3 | -0.0054021706 | 2.2281893E-06 | 1.3504177E-08 | 1.3504177E-08 |
| 9.5,1.3 | -0.014505936 | 5.973503E-06 | 4.004687E-08 | 4.004687E-08 |
| 9.6,1.3 | -0.0236097 | 9.71742E-06 | - | - |
| 9.700001,1.3 | -0.03271347 | 1.3466924E-05 | 2.9802322E-08 | 2.9802322E-08 |
| 9.800001,1.3 | -0.041817233 | 1.7210841E-05 | 5.5879354E-08 | 5.5879354E-08 |
| 9.900002,1.3 | -0.050920993 | 2.0891428E-05 | 1.1175871E-08 | 1.1175871E-08 |

I propose we ignore these.

<details>
<summary>code used for testing</summary>

```csharp
// See https://aka.ms/new-console-template for more information

using System.Diagnostics;

const float broken_gamefield_rounding_allowance = 1.00041f;

Console.WriteLine("| CS,HR | stable | lazer(master) | lazer(pr) | circleguard |");
Console.WriteLine("| --- | --- | --- | --- | --- |");

foreach (double hr in new[] { 1, 1.3 })
    for (float cs = 0; cs < 10; cs += 0.1f)
    {
        float stable = getForStable(cs, hr);
        float lazerMaster = getForLazerMaster(cs, hr);
        float lazerPR = getForLazerThisPR(cs, hr);
        float circleGuard = getForCircleguard(cs, hr);

        lazerMaster -= stable;
        lazerPR -= stable;
        circleGuard -= stable;

        Console.WriteLine($"| {cs},{hr} | {stable} | {(lazerMaster == 0 ? "-" : lazerMaster)} | {(lazerPR == 0 ? "-" : lazerPR)} | {(circleGuard == 0 ? "-" : circleGuard)} |");
    }

float getForStable(float circleSize, double hardRockAdjust)
{
    float SpriteDisplaySize = (float)(1f - 0.7f * AdjustDifficulty(circleSize));

    return SpriteDisplaySize / 2f * broken_gamefield_rounding_allowance;

    double AdjustDifficulty(double difficulty)
    {
        return (ApplyModsToDifficulty(difficulty, hardRockAdjust) - 5) / 5;
    }

    static double ApplyModsToDifficulty(double difficulty, double hardRockFactor) => difficulty * hardRockFactor;
}

float getForCircleguard(float circleSize, double hardRockAdjust)
{
    circleSize *= (float)hardRockAdjust;

    return (float)((1.0f - (float)0.7 * ((double)circleSize - 5) / 5) / 2) * broken_gamefield_rounding_allowance;
}

float getForLazerMaster(float circleSize, double hardRockAdjust)
{
    circleSize *= (float)hardRockAdjust;

    return (1.0f - 0.7f * (circleSize - 5) / 5) / 2;
}

float getForLazerThisPR(float circleSize, double hardRockAdjust)
{
    circleSize *= (float)hardRockAdjust;

    return CalculateScaleFromCircleSize(circleSize);

    static float CalculateScaleFromCircleSize(float circleSize)
    {
        // The following comment is copied verbatim from osu-stable:
        //
        //   Builds of osu! up to 2013-05-04 had the gamefield being rounded down, which caused incorrect radius calculations
        //   in widescreen cases. This ratio adjusts to allow for old replays to work post-fix, which in turn increases the lenience
        //   for all plays, but by an amount so small it should only be effective in replays.
        //
        // To match expectations of gameplay we need to apply this multiplier to circle scale. It's weird but is what it is.
        // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
        const float broken_gamefield_rounding_allowance = 1.00041f;

        return (float)(1.0f - 0.7f * DifficultyRange(circleSize)) / 2 * broken_gamefield_rounding_allowance;

        /// <summary>
        /// Maps a difficulty value [0, 10] to a linear range of [-1, 1].
        /// </summary>
        /// <param name="difficulty">The difficulty value to be mapped.</param>
        /// <returns>Value to which the difficulty value maps in the specified range.</returns>
        static double DifficultyRange(double difficulty) => (difficulty - 5) / 5;
    }
}

```
</details>