### PR TITLE
Fix inflation amount being added to the box

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -137,13 +137,22 @@ namespace osu.Game.Overlays.SkinEditor
             base.Update();
 
             drawableQuad = drawable.ToScreenSpace(
-                drawable.DrawRectangle
-                        .Inflate(SkinSelectionHandler.INFLATE_SIZE));
+                drawable.DrawRectangle);
 
             var localSpaceQuad = ToLocalSpace(drawableQuad);
 
-            box.Position = localSpaceQuad.TopLeft;
-            box.Size = localSpaceQuad.Size;
+            float cos = MathF.Cos(MathUtils.DegreesToRadians(drawable.Rotation));
+            float sin = MathF.Sin(MathUtils.DegreesToRadians(drawable.Rotation));
+
+            float offsetX = drawable.Scale.X > 0 ? -SkinSelectionHandler.INFLATE_SIZE : SkinSelectionHandler.INFLATE_SIZE;
+            float offsetY = drawable.Scale.Y > 0 ? -SkinSelectionHandler.INFLATE_SIZE : SkinSelectionHandler.INFLATE_SIZE;
+
+            float rotatedX = cos * offsetX - sin * offsetY;
+            float rotatedY = sin * offsetX + cos * offsetY;
+
+            box.Position = new Vector2(localSpaceQuad.TopLeft[0] + rotatedX, localSpaceQuad.TopLeft[1] + rotatedY);
+            box.Size = new Vector2(localSpaceQuad.Width + MathF.Abs(SkinSelectionHandler.INFLATE_SIZE) * 2,
+                localSpaceQuad.Height + MathF.Abs(SkinSelectionHandler.INFLATE_SIZE) * 2);
             box.Rotation = drawable.Rotation;
             box.Scale = new Vector2(MathF.Sign(drawable.Scale.X), MathF.Sign(drawable.Scale.Y));
         }


### PR DESCRIPTION
Resolving #25049 

Bug that's occurring in the current 'master' branch of osu: 
!['pink box bug'](https://res.cloudinary.com/dclcbz6dx/image/upload/v1697673915/current_osu_bug_scxwv4.gif)

After my fix: 
!['fix pink box bug'](https://res.cloudinary.com/dclcbz6dx/image/upload/v1697673922/fix_osu_bug_hb2xvy.gif)

Hotreload:
['hotreload gif'](https://res.cloudinary.com/dclcbz6dx/image/upload/v1697690283/hr_osu_bug_cswxw0.gif)

My thought process: 
Based on my understanding of the intended behavior, we want the pink box to be inflated by a constant value of `SkinSelectionHandler.INFLATE_SIZE`. However, it seems the amount of inflation increases as we scale the element to a larger size.

In my attempt to address this issue, I initially tried to look for a way to perform the inflation operation in screen space rather than local space (as [@bdach](https://github.com/ppy/osu/pull/25069#issuecomment-1753745757) suggested). However, I encountered a problem: the `inflate` function only works for `RectangleF` (and `RectangleI`) class objects. After converting the rectangle to a Quad using `ToScreenSpace`, there are no `ToSpace` operation in Drawable that can convert it back to a rectangle.

I decided to take a different approach by using [rotation matrix](https://en.wikipedia.org/wiki/Rotation_matrix) after offsetting the initial position by `SkinSelectionHandler.INFLATE_SIZE`. This approach helps us obtain the new `box.position` value. 

With my current code, the pink box is slightly larger than the element by a small, constant value and it doesn't get relatively larger when scaled. In my eyes, this is an appropriate fix to meet the intended behavior.

Let me know if there are any issues with my approach to solving this problem.