### PR TITLE
Fix invalid PR URL in diffcalc GitHub action

### DIFF
--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Add pull-request environment
         if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
         run: |
-          sed -i "s;^OSU_B=.*$;OSU_B=${{ github.event.issue.pull_request.url }};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
+          sed -i "s;^OSU_B=.*$;OSU_B=${{ github.event.issue.pull_request.html_url }};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
 
       - name: Add comment environment
         if: ${{ github.event_name == 'issue_comment' }}


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/6570346137/job/17847635703

Documentation: https://docs.github.com/en/rest/overview/issue-event-types?apiVersion=2022-11-28#properties-for-commented ([grep](https://grep.app/search?q=github.event.issue.pull_request.html_url))