### PR TITLE
Fix Floating Fruits not flipping playfield properly

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModFloatingFruits.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Mods
+{
+    public partial class TestSceneCatchModFloatingFruits : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        [Test]
+        public void TestFloating() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModFloatingFruits(),
+            PassCondition = () => true
+        });
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFloatingFruits.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Catch.Objects;
@@ -21,10 +20,8 @@ namespace osu.Game.Rulesets.Catch.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<CatchHitObject> drawableRuleset)
         {
-            drawableRuleset.PlayfieldAdjustmentContainer.Anchor = Anchor.Centre;
-            drawableRuleset.PlayfieldAdjustmentContainer.Origin = Anchor.Centre;
-
             drawableRuleset.PlayfieldAdjustmentContainer.Scale = new Vector2(1, -1);
+            drawableRuleset.PlayfieldAdjustmentContainer.Y = 1 - drawableRuleset.PlayfieldAdjustmentContainer.Y;
         }
     }
 }


### PR DESCRIPTION
Regressed by https://github.com/ppy/osu/pull/25070.

| 0ca05d986deebc263b4acedb2dadb91fb3867f35 | master | this PR |
| :-: | :-: | :-: |
| ![osu_2023-10-19_19-50-47](https://github.com/ppy/osu/assets/20418176/bfe80d95-617a-4ec4-9826-31941d92cbf1) | ![osu_2023-10-19_19-49-23](https://github.com/ppy/osu/assets/20418176/63fb9b22-633e-40d7-91e6-e163328b07ac) | ![osu_2023-10-19_19-44-19](https://github.com/ppy/osu/assets/20418176/c28a28c3-08a7-48bd-86cc-28269d3ab36f) |

Test coverage is purely visual because how do you even check this.