### PR TITLE
SFX tweaks

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Graphics.UserInterface
 
             Placeholder.Colour = colourProvider?.Foreground1 ?? new Color4(180, 180, 180, 255);
 
+            // Note that `KeyBindingRow` uses similar logic for input feedback, so remember to update there if changing here.
             var textAddedSamples = new Sample?[4];
             for (int i = 0; i < textAddedSamples.Length; i++)
                 textAddedSamples[i] = audio.Samples.Get($@"Keyboard/key-press-{1 + i}");

--- a/osu.Game/Overlays/LoginOverlay.cs
+++ b/osu.Game/Overlays/LoginOverlay.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays
 
         private const float transition_time = 400;
 
-        protected override double PopInOutSampleBalance => OsuGameBase.SFX_STEREO_STRENGTH;
+        protected override double PopInOutSampleBalance => OsuGameBase.SFX_STEREO_STRENGTH * 0.75f;
 
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);

--- a/osu.Game/Overlays/News/NewsCard.cs
+++ b/osu.Game/Overlays/News/NewsCard.cs
@@ -14,6 +14,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Overlays.News
@@ -28,6 +29,7 @@ namespace osu.Game.Overlays.News
         private TextFlowContainer main = null!;
 
         public NewsCard(APINewsPost post)
+            : base(HoverSampleSet.Button)
         {
             this.post = post;
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -55,8 +55,7 @@ namespace osu.Game.Overlays
         private Container playerContainer = null!;
         private Container playlistContainer = null!;
 
-        protected override string PopInSampleName => "UI/now-playing-pop-in";
-        protected override string PopOutSampleName => "UI/now-playing-pop-out";
+        protected override double PopInOutSampleBalance => OsuGameBase.SFX_STEREO_STRENGTH * 0.75f;
 
         [Resolved]
         private MusicController musicController { get; set; } = null!;

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -13,7 +13,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osuTK;
 
@@ -54,11 +53,6 @@ namespace osu.Game.Overlays
                 if (IsLoaded)
                     UpdateState();
             }
-        }
-
-        public RevertToDefaultButton()
-            : base(HoverSampleSet.Button)
-        {
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -17,6 +19,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Framework.Utils;
 using osu.Game.Database;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -96,6 +99,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private KeyButton? bindTarget;
 
+        private Sample?[]? keypressSamples;
+
         private const float transition_time = 150;
         private const float height = 20;
         private const float padding = 5;
@@ -118,7 +123,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, AudioManager audioManager)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -202,6 +207,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 Scheduler.AddOnce(updateButtons);
                 updateIsDefaultValue();
             }, true);
+
+            keypressSamples = new Sample[4];
+            for (int i = 0; i < keypressSamples.Length; i++)
+                keypressSamples[i] = audioManager.Samples.Get($@"Keyboard/key-press-{1 + i}");
         }
 
         public void RestoreDefaults()
@@ -300,6 +309,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 return false;
 
             Debug.Assert(bindTarget != null);
+
+            keypressSamples?[RNG.Next(0, keypressSamples.Length)]?.Play();
 
             bindTarget.UpdateKeyCombination(KeyCombination.FromInputState(e.CurrentState), KeyCombination.FromKey(e.Key));
             if (!isModifier(e.Key)) finalise();

--- a/osu.Game/Overlays/Settings/SidebarButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarButton.cs
@@ -14,8 +14,8 @@ namespace osu.Game.Overlays.Settings
         [Resolved]
         protected OverlayColourProvider ColourProvider { get; private set; } = null!;
 
-        protected SidebarButton()
-            : base(HoverSampleSet.ButtonSidebar)
+        protected SidebarButton(HoverSampleSet? hoverSounds = HoverSampleSet.ButtonSidebar)
+            : base(hoverSounds)
         {
         }
 

--- a/osu.Game/Overlays/SettingsSubPanel.cs
+++ b/osu.Game/Overlays/SettingsSubPanel.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
 using osuTK;
 
@@ -37,6 +38,11 @@ namespace osu.Game.Overlays
         public partial class BackButton : SidebarButton
         {
             private Container content;
+
+            public BackButton()
+                : base(HoverSampleSet.Default)
+            {
+            }
 
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Rulesets;
 using osuTK.Graphics;
@@ -38,6 +39,8 @@ namespace osu.Game.Overlays.Toolbar
 
         private partial class RulesetButton : ToolbarButton
         {
+            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(HoverSampleSet.Button);
+
             public bool Active
             {
                 set

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Toolbar
 
         private partial class RulesetButton : ToolbarButton
         {
-            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds(HoverSampleSet.Button);
+            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
 
             public bool Active
             {


### PR DESCRIPTION
A bunch of little fixes grouped together:
- Fixes toolbar ruleset buttons not having hover sounds
- Replaces `NowPlayingOverlay` pop-in/pop-out sounds with newer generic overlay pop-in/pop-out ones
- Changes `NewsCard` select samples from `Default` sample set to `Button`
- Reduces `LoginOverlay` sample panning to match `NowPlayingOverlay`
- Changes back button sample set (in `KeyBindingPanel`) from `ButtonSidebar` to `Default`
- Adds keypress feedback/sound when binding keys (in `KeyBindingPanel`)
- Changes `RevertToDefaultButton` from `Button` sample set to `Default`