### PR TITLE
Fix insufficient leniency when querying sample points

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -1080,5 +1080,18 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(controlPoints.DifficultyPointAt(3000).GenerateTicks, Is.True);
             }
         }
+
+        [Test]
+        public void TestSamplePointLeniency()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("sample-point-leniency.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var hitObject = decoder.Decode(stream).HitObjects.Single();
+                Assert.That(hitObject.Samples.Select(s => s.Volume), Has.All.EqualTo(70));
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Resources/sample-point-leniency.osu
+++ b/osu.Game.Tests/Resources/sample-point-leniency.osu
@@ -1,0 +1,10 @@
+osu file format v14
+
+# extracted from https://osu.ppy.sh/beatmapsets/1859679#osu/3823636
+
+[TimingPoints]
+39166,-117.647058823529,4,2,1,5,0,0
+39262,-117.647058823529,4,2,1,70,0,0
+
+[HitObjects]
+440,70,39260,1,10,0:2:0:0:

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -28,9 +28,12 @@ namespace osu.Game.Beatmaps.Formats
         public const int EARLY_VERSION_TIMING_OFFSET = 24;
 
         /// <summary>
-        /// A small adjustment to the start time of control points to account for rounding/precision errors.
+        /// A small adjustment to the start time of sample control points to account for rounding/precision errors.
         /// </summary>
-        private const double control_point_leniency = 1;
+        /// <remarks>
+        /// Compare: https://github.com/peppy/osu-stable-reference/blob/master/osu!/GameplayElements/HitObjects/HitObject.cs#L319
+        /// </remarks>
+        private const double control_point_leniency = 5;
 
         internal static RulesetStore? RulesetStore;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25165

Compare: https://github.com/peppy/osu-stable-reference/blob/master/osu!/GameplayElements/HitObjects/HitObject.cs#L319.

This fixes the linked case, but is only sorta-kinda correct in general. Only "normal" samples use the stable code path linked above, exceptions such as `sliderslide` do not, and they don't seem to be applying the 5ms leniency anywhere. With this change, lazer will apply the leniency to both, as `sliderslide` samples are constructed based on the "normal" ones. But that's probably fine...?

I'm not sure if we want to do the "8% minimum volume" thing on top of this, and if so, how. Maybe one for a separate issue? Or maybe we ignore until somebody complains?