### PR TITLE
Enforce minimum gameplay sample volume of 5%

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNote.cs
@@ -108,7 +108,11 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                     RelativeSizeAxes = Axes.X
                 },
                 tailContainer = new Container<DrawableHoldNoteTail> { RelativeSizeAxes = Axes.Both },
-                slidingSample = new PausableSkinnableSound { Looping = true }
+                slidingSample = new PausableSkinnableSound
+                {
+                    Looping = true,
+                    MinimumSampleVolume = MINIMUM_SAMPLE_VOLUME,
+                }
             });
 
             maskedContents.AddRange(new[]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -107,7 +107,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 headContainer = new Container<DrawableSliderHead> { RelativeSizeAxes = Axes.Both },
                 OverlayElementContainer = new Container { RelativeSizeAxes = Axes.Both, },
                 Ball,
-                slidingSample = new PausableSkinnableSound { Looping = true }
+                slidingSample = new PausableSkinnableSound
+                {
+                    Looping = true,
+                    MinimumSampleVolume = MINIMUM_SAMPLE_VOLUME,
+                }
             });
 
             PositionBindable.BindValueChanged(_ => Position = HitObject.StackedPosition);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -99,6 +99,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 spinningSample = new PausableSkinnableSound
                 {
                     Volume = { Value = 0 },
+                    MinimumSampleVolume = MINIMUM_SAMPLE_VOLUME,
                     Looping = true,
                     Frequency = { Value = spinning_sample_initial_frequency }
                 }

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -160,6 +160,26 @@ namespace osu.Game.Rulesets.Objects.Drawables
         internal bool IsInitialized;
 
         /// <summary>
+        /// The minimum allowable volume for sample playback.
+        /// <see cref="Samples"/> quieter than that will be forcibly played at this volume instead.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Drawable hitobjects adding their own custom samples, or other sample playback sources
+        /// (i.e. <see cref="GameplaySampleTriggerSource"/>) must enforce this themselves.
+        /// </para>
+        /// <para>
+        /// This sample volume floor is present in stable, although it is set at 8% rather than 5%.
+        /// See: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Audio/AudioEngine.cs#L1070,
+        /// https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Audio/AudioEngine.cs#L1404-L1405.
+        /// The reason why it is 5% here is that the 8% cap was enforced in a silent manner
+        /// (i.e. the minimum selectable volume in the editor was 5%, but it would be played at 8% anyways),
+        /// which is confusing and arbitrary, so we're just doing 5% here at the cost of sacrificing strict parity.
+        /// </para>
+        /// </remarks>
+        public const int MINIMUM_SAMPLE_VOLUME = 5;
+
+        /// <summary>
         /// Creates a new <see cref="DrawableHitObject"/>.
         /// </summary>
         /// <param name="initialHitObject">
@@ -181,7 +201,10 @@ namespace osu.Game.Rulesets.Objects.Drawables
             comboColourBrightness.BindTo(gameplaySettings.ComboColourNormalisationAmount);
 
             // Explicit non-virtual function call in case a DrawableHitObject overrides AddInternal.
-            base.AddInternal(Samples = new PausableSkinnableSound());
+            base.AddInternal(Samples = new PausableSkinnableSound
+            {
+                MinimumSampleVolume = MINIMUM_SAMPLE_VOLUME
+            });
 
             CurrentSkin = skinSource;
             CurrentSkin.SourceChanged += skinSourceChanged;

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
@@ -45,7 +46,10 @@ namespace osu.Game.Rulesets.UI
                 Child = hitSounds = new Container<SkinnableSound>
                 {
                     Name = "concurrent sample pool",
-                    ChildrenEnumerable = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new PausableSkinnableSound())
+                    ChildrenEnumerable = Enumerable.Range(0, max_concurrent_hitsounds).Select(_ => new PausableSkinnableSound
+                    {
+                        MinimumSampleVolume = DrawableHitObject.MINIMUM_SAMPLE_VOLUME
+                    })
                 }
             };
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -16,6 +16,7 @@ using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Screens.Edit.Timing;
 using osuTK;
 using osuTK.Graphics;
@@ -101,7 +102,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             },
                             volume = new IndeterminateSliderWithTextBoxInput<int>("Volume", new BindableInt(100)
                             {
-                                MinValue = 0,
+                                MinValue = DrawableHitObject.MINIMUM_SAMPLE_VOLUME,
                                 MaxValue = 100,
                             })
                         }

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -20,6 +20,12 @@ namespace osu.Game.Skinning
     /// </summary>
     public partial class SkinnableSound : SkinReloadableDrawable, IAdjustableAudioComponent
     {
+        /// <summary>
+        /// The minimum allowable volume for <see cref="Samples"/>.
+        /// <see cref="Samples"/> that specify a lower <see cref="ISampleInfo.Volume"/> will be forcibly pulled up to this volume.
+        /// </summary>
+        public int MinimumSampleVolume { get; set; }
+
         public override bool RemoveWhenNotAlive => false;
         public override bool RemoveCompletedTransforms => false;
 
@@ -156,7 +162,7 @@ namespace osu.Game.Skinning
             {
                 var sample = samplePool?.GetPooledSample(s) ?? new PoolableSkinnableSample(s);
                 sample.Looping = Looping;
-                sample.Volume.Value = s.Volume / 100.0;
+                sample.Volume.Value = Math.Max(s.Volume, MinimumSampleVolume) / 100.0;
 
                 samplesContainer.Add(sample);
             }


### PR DESCRIPTION
RFC. Addresses https://github.com/ppy/osu/issues/25165#issuecomment-1768204286

As per [my comment there](https://github.com/ppy/osu/issues/25165#issuecomment-1772266455), stable's sample volume floor is actually 8%, but it is enforced in what seem to be completely stupid ways (in the UI it's 5%, but actual playback takes place at minimum 8%). Since that seems weird and bad, and basically nobody seems to know about it (source: a brief discussion I had with the NAT today), and it seems there should be no harm in actually having the cap be 5% without weird gymnastics or lying to the users, that's what I ended up doing.

## Testing resources

[VolumeTesting.zip](https://github.com/ppy/osu/files/13055229/VolumeTesting.zip) contains 3 beatmaps:

- `HitCircleVolume` contains 25 hitcircles with 1 sec spacing, with volume ranging from 0 to 24
- `HitCircleSlider` contains 15 sliders with 3 sec spacing, with volume ranging from 0 to 14
- `HitCircleSpinner` contains 15 spinners with 3 sec spacing, with volume ranging from 0 to 14

taiko was also tested on `HitCircleVolume` to cover the `GameplaySampleTriggerSource` part of this diff.

## Test results

Recordings obtained from playing back the beatmaps as WAV files are available here:

- [circles.zip](https://github.com/ppy/osu/files/13055261/circles.zip)
- [sliders.zip](https://github.com/ppy/osu/files/13055265/sliders.zip)
- [spinners.zip](https://github.com/ppy/osu/files/13055267/spinners.zip)
- [taiko.zip](https://github.com/ppy/osu/files/13055270/taiko.zip)

Recordings were captured via 'stereo mix' input on my windows box. Visual waveform comparison, for convenience:

| test case | result |
| :-: | :-: |
| circles | ![circles_comparison](https://github.com/ppy/osu/assets/20418176/b0bded34-81f0-472b-9742-7b2e4216d116) |
| sliders | ![sliders_comparison](https://github.com/ppy/osu/assets/20418176/b833c16f-4d48-4b65-87ef-b0605530fcf0) |
| spinners | ![spinners_comparison](https://github.com/ppy/osu/assets/20418176/e8bead04-d62d-4710-92a7-9e6166d033ef) |
| taiko | ![taiko_comparison](https://github.com/ppy/osu/assets/20418176/70fd4b53-5f41-4f03-a799-7b8993ce0754) |

Please disregard the weird tick spam on the `spinners` case. I'm not sure where that's coming from but it's pretty clearly not broken by this PR. ~~I'll investigate the cause of this in more detail later.~~ This is fixed by https://github.com/ppy/osu/pull/25216.
