### PR TITLE
Apply velocity into legacy slider ball animation rate

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
@@ -49,8 +50,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 150 / stableSliderVelocity * LegacySkinExtensions.SIXTY_FRAME_TIME,
                 LegacySkinExtensions.SIXTY_FRAME_TIME);
 
-            ball = skin.GetAnimation("sliderb", true, true, animationSeparator: "", frameLength: ballAnimationRate,
-                maxSize: OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE).AsNonNull();
+            Vector2 maxSize = OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE;
 
             InternalChildren = new[]
             {
@@ -58,19 +58,20 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE),
+                    Texture = skin.GetTexture("sliderb-nd")?.WithMaximumSize(maxSize),
                     Colour = new Color4(5, 5, 5, 255),
                 },
-                LegacyColourCompatibility.ApplyWithDoubledAlpha(ball.With(d =>
+                ball = skin.GetAnimation("sliderb", true, true, animationSeparator: "", frameLength: ballAnimationRate, maxSize: maxSize).AsNonNull().With(d =>
                 {
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;
-                }), ballColour),
+                    d.Colour = ballColour;
+                }),
                 layerSpec = new Sprite
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE),
+                    Texture = skin.GetTexture("sliderb-spec")?.WithMaximumSize(maxSize),
                     Blending = BlendingParameters.Additive,
                 },
             };

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -37,18 +37,23 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader]
-        private void load(DrawableHitObject drawableHitObject)
+        private void load()
         {
             var ballColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBall)?.Value ?? Color4.White;
 
-            DrawableSlider drawableSlider = (DrawableSlider)drawableHitObject;
+            double? ballAnimationRate = null;
 
-            // stable apparently calculates slider velocity in units of seconds rather than milliseconds.
-            double stableSliderVelocity = drawableSlider.HitObject.Velocity * 1000;
+            if (parentObject != null)
+            {
+                DrawableSlider drawableSlider = (DrawableSlider)parentObject;
 
-            double ballAnimationRate = Math.Max(
-                150 / stableSliderVelocity * LegacySkinExtensions.SIXTY_FRAME_TIME,
-                LegacySkinExtensions.SIXTY_FRAME_TIME);
+                // stable apparently calculates slider velocity in units of seconds rather than milliseconds.
+                double stableSliderVelocity = drawableSlider.HitObject.Velocity * 1000;
+
+                ballAnimationRate = Math.Max(
+                    150 / stableSliderVelocity * LegacySkinExtensions.SIXTY_FRAME_TIME,
+                    LegacySkinExtensions.SIXTY_FRAME_TIME);
+            }
 
             Vector2 maxSize = OsuLegacySkinTransformer.MAX_FOLLOW_CIRCLE_AREA_SIZE;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -109,11 +109,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private void onHitObjectApplied(DrawableHitObject? drawableObject = null)
         {
-            if (drawableObject != null && drawableObject is not DrawableSlider)
-                return;
-
-            ballAnimation.ClearFrames();
-
             double frameDelay;
 
             if (drawableObject?.HitObject != null)
@@ -127,6 +122,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             else
                 frameDelay = LegacySkinExtensions.SIXTY_FRAME_TIME;
 
+            ballAnimation.ClearFrames();
             foreach (var texture in ballTextures)
                 ballAnimation.AddFrame(texture, frameDelay);
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBall.cs
@@ -120,11 +120,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             {
                 DrawableSlider drawableSlider = (DrawableSlider)drawableObject;
 
-                // stable apparently calculates slider velocity in units of seconds rather than milliseconds.
-                double stableSliderVelocity = drawableSlider.HitObject.Velocity * 1000;
-
                 frameDelay = Math.Max(
-                    150 / stableSliderVelocity * LegacySkinExtensions.SIXTY_FRAME_TIME,
+                    0.15 / drawableSlider.HitObject.Velocity * LegacySkinExtensions.SIXTY_FRAME_TIME,
                     LegacySkinExtensions.SIXTY_FRAME_TIME);
             }
             else

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -59,13 +59,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         return null;
 
                     case OsuSkinComponents.SliderBall:
-                        var sliderBallContent = this.GetAnimation("sliderb", true, true, animationSeparator: "", maxSize: MAX_FOLLOW_CIRCLE_AREA_SIZE);
-
-                        // todo: slider ball has a custom frame delay based on velocity
-                        // Math.Max((150 / Velocity) * GameBase.SIXTY_FRAME_TIME, GameBase.SIXTY_FRAME_TIME);
-
-                        if (sliderBallContent != null)
-                            return new LegacySliderBall(sliderBallContent, this);
+                        if (GetTexture("sliderb") != null || GetTexture("sliderb0") != null)
+                            return new LegacySliderBall(this);
 
                         return null;
 

--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -200,7 +200,11 @@ namespace osu.Game.Skinning
             }
         }
 
-        private const double default_frame_time = 1000 / 60d;
+        /// <summary>
+        /// The frame length of each frame at a 60 FPS rate.
+        /// Default frame rate for legacy skin animations.
+        /// </summary>
+        public const double SIXTY_FRAME_TIME = 1000 / 60d;
 
         private static double getFrameLength(ISkin source, bool applyConfigFrameRate, Texture[] textures)
         {
@@ -214,7 +218,7 @@ namespace osu.Game.Skinning
                 return 1000f / textures.Length;
             }
 
-            return default_frame_time;
+            return SIXTY_FRAME_TIME;
         }
     }
 }


### PR DESCRIPTION
- Continuation of #25190 

https://github.com/ppy/osu/assets/22781491/f9fc515b-5673-417d-85d3-b74fc1abf285

While at it, I've removed unnecessary usage of `ApplyWithDoubledAlpha` on the ball animation content, since the colour is fetched from `SliderBall`, which cannot have non-opaque colours, since it's disabled at a decoder level (`allowAlpha: false`):
https://github.com/ppy/osu/blob/b34a36f6cec639d1ac8d987002dd0a893214c9cd/osu.Game/Beatmaps/Formats/LegacyDecoder.cs#L81-L83 

It may be set to a combo colour when tint is enabled, but that also cannot have alpha<1.