### PR TITLE
Use current date as default value for tournament date text boxes

### DIFF
--- a/osu.Game.Tournament/Components/DateTextBox.cs
+++ b/osu.Game.Tournament/Components/DateTextBox.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Tournament.Components
 {
     public partial class DateTextBox : SettingsTextBox
     {
-        private readonly BindableWithCurrent<DateTimeOffset> current = new BindableWithCurrent<DateTimeOffset>();
+        private readonly BindableWithCurrent<DateTimeOffset> current = new BindableWithCurrent<DateTimeOffset>(DateTimeOffset.Now);
 
         public new Bindable<DateTimeOffset>? Current
         {


### PR DESCRIPTION
Previous default value (zero everything) was causing test failures on my local machine due to my system following a different calendar format that doesn't support date ranges outside of the year 1900 and 2077.

<img width="802" alt="CleanShot 2023-10-26 at 10 46 50@2x" src="https://github.com/ppy/osu/assets/22781491/3b097577-eded-44fa-aa70-72954909983f">

([source](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.umalquracalendar?view=net-7.0#remarks), ~~I'm definitely looking forward to the year 2078~~)