### PR TITLE
Making FreezeFrame mod incompatible with Transform

### DIFF
--- a/OsuModFreezeFrame.cs
+++ b/OsuModFreezeFrame.cs
@@ -1,0 +1,91 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModFreezeFrame : Mod, IApplicableToDrawableHitObject, IApplicableToBeatmap
+    {
+        public override string Name => "Freeze Frame";
+
+        public override string Acronym => "FR";
+
+        public override double ScoreMultiplier => 1;
+
+        public override LocalisableString Description => "Burn the notes into your memory.";
+
+        //Alters the transforms of the approach circles, breaking the effects of these mods.
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModApproachDifferent), typeof(OsuModTransform) }).ToArray(); 
+
+        public override ModType Type => ModType.Fun;
+
+        //mod breaks normal approach circle preempt
+        private double originalPreempt;
+
+        public void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            var firstHitObject = beatmap.HitObjects.OfType<OsuHitObject>().FirstOrDefault();
+            if (firstHitObject == null)
+                return;
+
+            double lastNewComboTime = 0;
+
+            originalPreempt = firstHitObject.TimePreempt;
+
+            foreach (var obj in beatmap.HitObjects.OfType<OsuHitObject>())
+            {
+                if (obj.NewCombo) { lastNewComboTime = obj.StartTime; }
+
+                applyFadeInAdjustment(obj);
+            }
+
+            void applyFadeInAdjustment(OsuHitObject osuObject)
+            {
+                osuObject.TimePreempt += osuObject.StartTime - lastNewComboTime;
+
+                foreach (var nested in osuObject.NestedHitObjects.OfType<OsuHitObject>())
+                {
+                    switch (nested)
+                    {
+                        //Freezing the SliderTicks doesnt play well with snaking sliders
+                        case SliderTick:
+                        //SliderRepeat wont layer correctly if preempt is changed.
+                        case SliderRepeat:
+                            break;
+
+                        default:
+                            applyFadeInAdjustment(nested);
+                            break;
+                    }
+                }
+            }
+        }
+
+        public void ApplyToDrawableHitObject(DrawableHitObject drawableObject)
+        {
+            drawableObject.ApplyCustomUpdateState += (drawableHitObject, _) =>
+            {
+                if (drawableHitObject is not DrawableHitCircle drawableHitCircle) return;
+
+                var hitCircle = drawableHitCircle.HitObject;
+                var approachCircle = drawableHitCircle.ApproachCircle;
+
+                // Reapply scale, ensuring the AR isn't changed due to the new preempt.
+                approachCircle.ClearTransforms(targetMember: nameof(approachCircle.Scale));
+                approachCircle.ScaleTo(4 * (float)(hitCircle.TimePreempt / originalPreempt));
+
+                using (drawableHitCircle.ApproachCircle.BeginAbsoluteSequence(hitCircle.StartTime - hitCircle.TimePreempt))
+                    approachCircle.ScaleTo(1, hitCircle.TimePreempt).Then().Expire();
+            };
+        }
+    }
+}

--- a/OsuModTransform.cs
+++ b/OsuModTransform.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    internal class OsuModTransform : ModWithVisibilityAdjustment
+    {
+        public override string Name => "Transform";
+        public override string Acronym => "TR";
+        public override IconUsage? Icon => FontAwesome.Solid.ArrowsAlt;
+        public override ModType Type => ModType.Fun;
+        public override LocalisableString Description => "Everything rotates. EVERYTHING.";
+        public override double ScoreMultiplier => 1;
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame) }).ToArray();
+
+        private float theta;
+
+        protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyTransform(hitObject, state);
+
+        protected override void ApplyNormalVisibilityState(DrawableHitObject hitObject, ArmedState state) => applyTransform(hitObject, state);
+
+        private void applyTransform(DrawableHitObject drawable, ArmedState state)
+        {
+            switch (drawable)
+            {
+                case DrawableSliderHead:
+                case DrawableSliderTail:
+                case DrawableSliderTick:
+                case DrawableSliderRepeat:
+                    return;
+
+                default:
+                    var hitObject = (OsuHitObject)drawable.HitObject;
+
+                    float appearDistance = (float)(hitObject.TimePreempt - hitObject.TimeFadeIn) / 2;
+
+                    Vector2 originalPosition = drawable.Position;
+                    Vector2 appearOffset = new Vector2(MathF.Cos(theta), MathF.Sin(theta)) * appearDistance;
+
+                    // the - 1 and + 1 prevents the hit objects to appear in the wrong position.
+                    double appearTime = hitObject.StartTime - hitObject.TimePreempt - 1;
+                    double moveDuration = hitObject.TimePreempt + 1;
+
+                    using (drawable.BeginAbsoluteSequence(appearTime))
+                    {
+                        drawable
+                            .MoveToOffset(appearOffset)
+                            .MoveTo(originalPosition, moveDuration, Easing.InOutSine);
+                    }
+
+                    theta += (float)hitObject.TimeFadeIn / 1000;
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Burn the notes into your memory.";
 
         //Alters the transforms of the approach circles, breaking the effects of these mods.
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModApproachDifferent) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModApproachDifferent), typeof(OsuModTransform) }).ToArray(); 
 
         public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -10,6 +11,9 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osuTK;
+
+
+
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -21,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Everything rotates. EVERYTHING.";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame) }).ToArray();
 
         private float theta;
 


### PR DESCRIPTION
Addressing issue [#25108 ](https://github.com/ppy/osu/issues/25108)

Adding FreezeFrame to the IncompatibleMods of Transform, and vice versa. 


Also noticed that way these mods were added to the IncompatibleMods was different to other mods. It was:
`public override Type[] IncompatibleMods => new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel) };`

Whereas other mods were (taken from OsuModSuddenDeath.cs, but most mods use the same way):
`public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModTargetPractice), }).ToArray();`

So, I changed both FreezeFrame and Transform to be written the same way.