### PR TITLE
Make FreezeFrame and Transform Incompatible

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFreezeFrame.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => "Burn the notes into your memory.";
 
         //Alters the transforms of the approach circles, breaking the effects of these mods.
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModApproachDifferent) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModApproachDifferent), typeof(OsuModTransform) }).ToArray(); 
 
         public override ModType Type => ModType.Fun;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTransform.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override ModType Type => ModType.Fun;
         public override LocalisableString Description => "Everything rotates. EVERYTHING.";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel) };
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel), typeof(OsuModFreezeFrame) }).ToArray();
 
         private float theta;
 


### PR DESCRIPTION
Fixes #25108.

Makes FreezeFrame and Transform mods incompatible.

While making these changes, I also noticed that these files used a different way of making mods incompatible. The way used was:
`public override Type[] IncompatibleMods => new[] { typeof(OsuModWiggle), typeof(OsuModMagnetised), typeof(OsuModRepel) };`

However, majority of the mods (SuddenDeath used as an exmaple) had it done a different way:
`public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModTargetPractice), }).ToArray();`

So, I also updated these two to what appeared to be the more common method. This can be changed back if you think it should.