### PR TITLE
Fix iOS AOT compilation failure due to SharpCompress library upgrade

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -39,7 +39,8 @@
     <PackageReference Include="ppy.osu.Framework" Version="2023.1012.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1023.0" />
     <PackageReference Include="Sentry" Version="3.40.0" />
-    <PackageReference Include="SharpCompress" Version="0.34.1" />
+    <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
+    <PackageReference Include="SharpCompress" Version="0.33.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />


### PR DESCRIPTION
Deployed and confirmed working
