### PR TITLE
Fix various catch distance snap grid breakage

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
@@ -178,6 +179,34 @@ namespace osu.Game.Rulesets.Catch.Edit
                 default:
                     return null;
             }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            updateDistanceSnapGrid();
+        }
+
+        private void updateDistanceSnapGrid()
+        {
+            if (DistanceSnapProvider.DistanceSnapToggle.Value != TernaryState.True)
+            {
+                distanceSnapGrid.Hide();
+                return;
+            }
+
+            var sourceHitObject = getDistanceSnapGridSourceHitObject();
+
+            if (sourceHitObject == null)
+            {
+                distanceSnapGrid.Hide();
+                return;
+            }
+
+            distanceSnapGrid.Show();
+            distanceSnapGrid.StartTime = sourceHitObject.GetEndTime();
+            distanceSnapGrid.StartX = sourceHitObject.EffectiveX;
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -98,12 +98,6 @@ namespace osu.Game.Rulesets.Edit
                 }
             });
 
-            if (DistanceSpacingMultiplier.Disabled)
-            {
-                distanceSpacingSlider.Hide();
-                return;
-            }
-
             DistanceSpacingMultiplier.Value = editorBeatmap.BeatmapInfo.DistanceSpacing;
             DistanceSpacingMultiplier.BindValueChanged(multiplier =>
             {
@@ -115,6 +109,8 @@ namespace osu.Game.Rulesets.Edit
 
                 editorBeatmap.BeatmapInfo.DistanceSpacing = multiplier.NewValue;
             }, true);
+
+            DistanceSpacingMultiplier.BindDisabledChanged(disabled => distanceSpacingSlider.Alpha = disabled ? 0 : 1, true);
 
             // Manual binding to handle enabling distance spacing when the slider is interacted with.
             distanceSpacingSlider.Current.BindValueChanged(spacing =>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25238.

## 359ae3120494d0b9d3b61599d6f50f5abe0330ba: Fix catch distance snap grid not moving

Regressed in https://github.com/ppy/osu/pull/25154. Specifically, in https://github.com/ppy/osu/commit/013b5fa916d819ec7a8a93b1692d4aa027934a67 and https://github.com/ppy/osu/commit/74b86349d58e5169e52bbdc70cef3dec81579a74.

A simple case of too-much-code-deleted-itis.

## 79910df9593b8478419b4eb2f4be12b0cfd1dbf8: Fix catch distance snap provider not hiding slider properly

Regressed in https://github.com/ppy/osu/pull/25171.

The old code was kinda dependent on correct order of setting `Disabled`. `CatchHitObjectComposer` would disable distance spacing in its BDL, and then via the base `DistancedHitObjectComposer.LoadComplete()`, the slider would be faded out. The switch to composition broke that ordering.

To fix, stop relying on ordering and just respond to changes as they come. That's what bindables are for.

---

I am not adding test coverage for these unless absolutely forced because these are dumb refactor errors and they will 99% not happen again.