### PR TITLE
Fix `StopUsingBeatmapClock()` applying adjustments to track it was supposed to stop using

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneMasterGameplayClockContainer.cs
@@ -108,6 +108,28 @@ namespace osu.Game.Tests.Gameplay
             AddAssert("gameplay clock time = 10000", () => gameplayClockContainer.CurrentTime, () => Is.EqualTo(10000).Within(10f));
         }
 
+        [Test]
+        public void TestStopUsingBeatmapClock()
+        {
+            ClockBackedTestWorkingBeatmap working = null;
+            MasterGameplayClockContainer gameplayClockContainer = null;
+            BindableDouble frequencyAdjustment = new BindableDouble(2);
+
+            AddStep("create container", () =>
+            {
+                working = new ClockBackedTestWorkingBeatmap(new OsuRuleset().RulesetInfo, new FramedClock(new ManualClock()), Audio);
+                Child = gameplayClockContainer = new MasterGameplayClockContainer(working, 0);
+
+                gameplayClockContainer.Reset(startClock: true);
+            });
+
+            AddStep("apply frequency adjustment", () => gameplayClockContainer.AdjustmentsFromMods.AddAdjustment(AdjustableProperty.Frequency, frequencyAdjustment));
+            AddAssert("track frequency changed", () => working.Track.AggregateFrequency.Value, () => Is.EqualTo(2));
+
+            AddStep("stop using beatmap clock", () => gameplayClockContainer.StopUsingBeatmapClock());
+            AddAssert("frequency adjustment unapplied", () => working.Track.AggregateFrequency.Value, () => Is.EqualTo(1));
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             localConfig?.Dispose();

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Screens.Play
 
         protected override void StartGameplayClock()
         {
-            addSourceClockAdjustments();
+            addAdjustmentsToTrack();
 
             base.StartGameplayClock();
 
@@ -186,7 +186,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public void StopUsingBeatmapClock()
         {
-            removeSourceClockAdjustments();
+            removeAdjustmentsFromTrack();
 
             track = new TrackVirtual(beatmap.Track.Length);
             track.Seek(CurrentTime);
@@ -194,12 +194,12 @@ namespace osu.Game.Screens.Play
                 track.Start();
             ChangeSource(track);
 
-            addSourceClockAdjustments();
+            addAdjustmentsToTrack();
         }
 
         private bool speedAdjustmentsApplied;
 
-        private void addSourceClockAdjustments()
+        private void addAdjustmentsToTrack()
         {
             if (speedAdjustmentsApplied)
                 return;
@@ -213,7 +213,7 @@ namespace osu.Game.Screens.Play
             speedAdjustmentsApplied = true;
         }
 
-        private void removeSourceClockAdjustments()
+        private void removeAdjustmentsFromTrack()
         {
             if (!speedAdjustmentsApplied)
                 return;
@@ -228,7 +228,7 @@ namespace osu.Game.Screens.Play
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            removeSourceClockAdjustments();
+            removeAdjustmentsFromTrack();
         }
 
         ControlPointInfo IBeatSyncProvider.ControlPoints => beatmap.Beatmap.ControlPointInfo;

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play
 
         private readonly WorkingBeatmap beatmap;
 
-        private readonly Track track;
+        private Track track;
 
         private readonly double skipTargetTime;
 
@@ -188,11 +188,11 @@ namespace osu.Game.Screens.Play
         {
             removeSourceClockAdjustments();
 
-            var virtualTrack = new TrackVirtual(beatmap.Track.Length);
-            virtualTrack.Seek(CurrentTime);
+            track = new TrackVirtual(beatmap.Track.Length);
+            track.Seek(CurrentTime);
             if (IsRunning)
-                virtualTrack.Start();
-            ChangeSource(virtualTrack);
+                track.Start();
+            ChangeSource(track);
 
             addSourceClockAdjustments();
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25248
- Possibly also closes https://github.com/ppy/osu/issues/20475

Regressed in https://github.com/ppy/osu/commit/e33486a766044c17c2f254f5e8df6d72b29c341e.

`StopUsingBeatmapClock()` intends to, as the name says, stop operating on the working beatmap clock to yield its usage to other components on exit. As part of that it tries to unapply audio adjustments so that other screens can apply theirs freely instead.

However, the aforementioned commit introduced a bug in this. Previously to it, `track` was an alias for the `SourceClock`, which could be mutated in an indirect way via `ChangeSource()` calls. The aforementioned commit made `track` a `readonly` field, initialised in constructor, which would _never_ change value. In particular, it would
_always_ be the beatmap track, which meant that `StopUsingBeatmapClock()` would remove the adjustments from the beatmap track, but then at the end of the method, _apply them onto that same track again_.

This was only saved by the fact that clock adjustments are removed again on disposal of the `MasterGameplayClockContainer`. This - due to async disposal pressure - could explain infrequently reported cases wherein the track would just continue to speed up ad infinitum.

To fix, fully substitute the beatmap track for a virtual track at the point of calling `StopUsingBeatmapClock()`.