### PR TITLE
Fix quick retry immediately after completion marking score as failed

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -247,6 +247,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("end spectator before retry", () => Game.SpectatorClient.EndPlaying(player.GameplayState));
 
             AddStep("attempt to retry", () => player.ChildrenOfType<HotkeyRetryOverlay>().First().Action());
+            AddAssert("old player score marked failed", () => player.Score.ScoreInfo.Rank, () => Is.EqualTo(ScoreRank.F));
             AddUntilStep("wait for old player gone", () => Game.ScreenStack.CurrentScreen != player);
 
             AddUntilStep("get new player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -259,6 +259,7 @@ namespace osu.Game.Tests.Visual.Navigation
             var getOriginalPlayer = playToCompletion();
 
             AddStep("attempt to retry", () => getOriginalPlayer().ChildrenOfType<HotkeyRetryOverlay>().First().Action());
+            AddAssert("original play isn't failed", () => getOriginalPlayer().Score.ScoreInfo.Rank, () => Is.Not.EqualTo(ScoreRank.F));
             AddUntilStep("wait for player", () => Game.ScreenStack.CurrentScreen != getOriginalPlayer() && Game.ScreenStack.CurrentScreen is Player);
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1112,6 +1112,8 @@ namespace osu.Game.Screens.Play
 
             if (LoadedBeatmapSuccessfully && !GameplayState.HasPassed)
             {
+                Debug.Assert(resultsDisplayDelegate == null && prepareScoreForDisplayTask == null);
+
                 if (!GameplayState.HasFailed)
                     GameplayState.HasQuit = true;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1115,8 +1115,7 @@ namespace osu.Game.Screens.Play
                 if (!GameplayState.HasPassed && !GameplayState.HasFailed)
                     GameplayState.HasQuit = true;
 
-                // if arriving here and the results screen preparation task hasn't run, it's safe to say the user has not completed the beatmap.
-                if (prepareScoreForDisplayTask == null && DrawableRuleset.ReplayScore == null)
+                if (!GameplayState.HasPassed && DrawableRuleset.ReplayScore == null)
                     ScoreProcessor.FailScore(Score.ScoreInfo);
             }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1110,12 +1110,12 @@ namespace osu.Game.Screens.Play
             failAnimationContainer?.Stop();
             PauseOverlay?.StopAllSamples();
 
-            if (LoadedBeatmapSuccessfully)
+            if (LoadedBeatmapSuccessfully && !GameplayState.HasPassed)
             {
-                if (!GameplayState.HasPassed && !GameplayState.HasFailed)
+                if (!GameplayState.HasFailed)
                     GameplayState.HasQuit = true;
 
-                if (!GameplayState.HasPassed && DrawableRuleset.ReplayScore == null)
+                if (DrawableRuleset.ReplayScore == null)
                     ScoreProcessor.FailScore(Score.ScoreInfo);
             }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1112,7 +1112,7 @@ namespace osu.Game.Screens.Play
 
             if (LoadedBeatmapSuccessfully && !GameplayState.HasPassed)
             {
-                Debug.Assert(resultsDisplayDelegate == null && prepareScoreForDisplayTask == null);
+                Debug.Assert(resultsDisplayDelegate == null);
 
                 if (!GameplayState.HasFailed)
                     GameplayState.HasQuit = true;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25247.

Likely broke with https://github.com/ppy/osu/pull/25097 (although I haven't really bothered to 100% confirm this).

The scenario involved here is as follows:

1. User completes beatmap by hitting all notes.
2. `checkScoreCompleted()` determines completion, and calls `progressToResults(withDelay: true)`.
3. `progressToResults()` schedules `resultsDisplayDelegate`, which includes a call to `prepareAndImportScoreAsync()`, a second in the future.
4. User presses quick retry hotkey. This calls `Player.Restart(quickRestart: true)`, which invokes `Player.RestartRequested`, which in turn calls `PlayerLoader.restartRequested(true)`, which in turn causes `PlayerLoader` to make itself current, which means that `Player.OnExiting()` will get called.
5. `Player.OnExiting()` sees that `prepareScoreForDisplayTask` is null (because `prepareAndImportScoreAsync()` - which sets it - is scheduled to happen in the future), and as such assumes that the score did not complete. Thus, it marks the score as failed.
6. `Player.Restart()` after invoking `RestartRequested` calls `PerformExit(false)`, which then will unconditionally call `prepareAndImportScoreAsync()`. But the score has already been marked as failed.

The flow above can be described as "convoluted", but I'm not sure I have it in me right now to try and refactor it again. Therefore, to fix, switch the `prepareScoreForDisplayTask` null check in `Player.OnExiting()` to check `GameplayState.HasPassed` instead, as it is not susceptible to the same out-of-order read issue.