### PR TITLE
Fix skin editor freezing game if opened during active gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Tests.Visual.Navigation
         private SkinEditor skinEditor => Game.ChildrenOfType<SkinEditor>().FirstOrDefault();
 
         [Test]
-        public void TestEditComponentDuringGameplay()
+        public void TestEditComponentFromGameplayScene()
         {
             advanceToSongSelect();
             openSkinEditor();

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -18,6 +19,7 @@ using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
+using osu.Game.Skinning;
 using osu.Game.Tests.Beatmaps.IO;
 using osuTK;
 using osuTK.Input;
@@ -67,6 +69,28 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("adjust slider via keyboard", () => InputManager.Key(Key.Left));
 
             AddAssert("value is less than default", () => hitErrorMeter.JudgementLineThickness.Value < hitErrorMeter.JudgementLineThickness.Default);
+        }
+
+        [Test]
+        public void TestMutateProtectedSkinDuringGameplay()
+        {
+            advanceToSongSelect();
+            AddStep("set default skin", () => Game.Dependencies.Get<SkinManager>().CurrentSkinInfo.SetDefault());
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("enable NF", () => Game.SelectedMods.Value = new[] { new OsuModNoFail() });
+            AddStep("enter gameplay", () => InputManager.Key(Key.Enter));
+
+            AddUntilStep("wait for player", () =>
+            {
+                DismissAnyNotifications();
+                return Game.ScreenStack.CurrentScreen is Player;
+            });
+
+            openSkinEditor();
+            AddUntilStep("current skin is mutable", () => !Game.Dependencies.Get<SkinManager>().CurrentSkin.Value.SkinInfo.Value.Protected);
         }
 
         [Test]

--- a/osu.Game/Database/ImportParameters.cs
+++ b/osu.Game/Database/ImportParameters.cs
@@ -21,5 +21,11 @@ namespace osu.Game.Database
         /// Whether this import should use hard links rather than file copy operations if available.
         /// </summary>
         public bool PreferHardLinks { get; set; }
+
+        /// <summary>
+        /// If set to <see langword="true"/>, this import will not respect <see cref="RealmArchiveModelImporter{TModel}.PauseImports"/>.
+        /// This is useful for cases where an import <em>must</em> complete even if gameplay is in progress.
+        /// </summary>
+        public bool ImportImmediately { get; set; }
     }
 }

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -261,7 +261,7 @@ namespace osu.Game.Database
         /// <param name="cancellationToken">An optional cancellation token.</param>
         public virtual Live<TModel>? ImportModel(TModel item, ArchiveReader? archive = null, ImportParameters parameters = default, CancellationToken cancellationToken = default) => Realm.Run(realm =>
         {
-            pauseIfNecessary(cancellationToken);
+            pauseIfNecessary(parameters, cancellationToken);
 
             TModel? existing;
 
@@ -560,9 +560,9 @@ namespace osu.Game.Database
         /// <returns>Whether to perform deletion.</returns>
         protected virtual bool ShouldDeleteArchive(string path) => false;
 
-        private void pauseIfNecessary(CancellationToken cancellationToken)
+        private void pauseIfNecessary(ImportParameters importParameters, CancellationToken cancellationToken)
         {
-            if (!PauseImports)
+            if (!PauseImports || importParameters.ImportImmediately)
                 return;
 
             Logger.Log($@"{GetType().Name} is being paused.");

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -182,7 +182,10 @@ namespace osu.Game.Skinning
                     Name = NamingUtils.GetNextBestName(existingSkinNames, $@"{s.Name} (modified)")
                 };
 
-                var result = skinImporter.ImportModel(skinInfo);
+                var result = skinImporter.ImportModel(skinInfo, parameters: new ImportParameters
+                {
+                    ImportImmediately = true // to avoid possible deadlocks when editing skin during gameplay.
+                });
 
                 if (result != null)
                 {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/22486.

I also considered something along the lines of

```diff
diff --git a/osu.Game/Skinning/SkinManager.cs b/osu.Game/Skinning/SkinManager.cs
index ca46d3af0c..4393801dfe 100644
--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -182,7 +182,11 @@ public bool EnsureMutableSkin()
                     Name = NamingUtils.GetNextBestName(existingSkinNames, $@"{s.Name} (modified)")
                 };
 
+                bool importsWerePaused = PauseImports;
+
+                PauseImports = false;
                 var result = skinImporter.ImportModel(skinInfo);
+                PauseImports = importsWerePaused;
 
                 if (result != null)
                 {

```

but I was somewhat worried of the data race potential there as `PauseImports` is externally managed by `OsuGame`, so this feels like the safer way out.