### PR TITLE
Exclude video events from being accounted for when calculating storyboard time bounds

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -287,5 +287,26 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(manyTimes.EndTime, Is.EqualTo(9000 + loop_duration));
             }
         }
+
+        [Test]
+        public void TestVideoAndBackgroundEventsDoNotAffectStoryboardBounds()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using var resStream = TestResources.OpenResource("video-background-events-ignored.osb");
+            using var stream = new LineBufferedReader(resStream);
+
+            var storyboard = decoder.Decode(stream);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(storyboard.GetLayer(@"Video").Elements, Has.Count.EqualTo(1));
+                Assert.That(storyboard.GetLayer(@"Video").Elements.Single(), Is.InstanceOf<StoryboardVideo>());
+                Assert.That(storyboard.GetLayer(@"Video").Elements.Single().StartTime, Is.EqualTo(-5678));
+
+                Assert.That(storyboard.EarliestEventTime, Is.Null);
+                Assert.That(storyboard.LatestEventTime, Is.Null);
+            });
+        }
     }
 }

--- a/osu.Game.Tests/Resources/video-background-events-ignored.osb
+++ b/osu.Game.Tests/Resources/video-background-events-ignored.osb
@@ -1,0 +1,5 @@
+osu file format v14
+
+[Events]
+0,-1234,"BG.jpg",0,0
+Video,-5678,"Video.avi",0,0

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -30,8 +30,11 @@ namespace osu.Game.Storyboards
         /// </summary>
         /// <remarks>
         /// This iterates all elements and as such should be used sparingly or stored locally.
+        /// Video and background events are not included to match stable.
         /// </remarks>
-        public double? EarliestEventTime => Layers.SelectMany(l => l.Elements).MinBy(e => e.StartTime)?.StartTime;
+        public double? EarliestEventTime => Layers.SelectMany(l => l.Elements)
+                                                  .Where(e => e is not StoryboardVideo)
+                                                  .MinBy(e => e.StartTime)?.StartTime;
 
         /// <summary>
         /// Across all layers, find the latest point in time that a storyboard element ends at.
@@ -39,9 +42,12 @@ namespace osu.Game.Storyboards
         /// </summary>
         /// <remarks>
         /// This iterates all elements and as such should be used sparingly or stored locally.
-        /// Videos and samples return StartTime as their EndTIme.
+        /// Samples return StartTime as their EndTIme.
+        /// Video and background events are not included to match stable.
         /// </remarks>
-        public double? LatestEventTime => Layers.SelectMany(l => l.Elements).MaxBy(e => e.GetEndTime())?.GetEndTime();
+        public double? LatestEventTime => Layers.SelectMany(l => l.Elements)
+                                                .Where(e => e is not StoryboardVideo)
+                                                .MaxBy(e => e.GetEndTime())?.GetEndTime();
 
         /// <summary>
         /// Depth of the currently front-most storyboard layer, excluding the overlay layer.

--- a/osu.Game/Storyboards/Storyboard.cs
+++ b/osu.Game/Storyboards/Storyboard.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Storyboards
         /// </summary>
         /// <remarks>
         /// This iterates all elements and as such should be used sparingly or stored locally.
+        /// Sample events use their start time as "end time" during this calculation.
         /// Video and background events are not included to match stable.
         /// </remarks>
         public double? EarliestEventTime => Layers.SelectMany(l => l.Elements)
@@ -42,7 +43,7 @@ namespace osu.Game.Storyboards
         /// </summary>
         /// <remarks>
         /// This iterates all elements and as such should be used sparingly or stored locally.
-        /// Samples return StartTime as their EndTIme.
+        /// Sample events use their start time as "end time" during this calculation.
         /// Video and background events are not included to match stable.
         /// </remarks>
         public double? LatestEventTime => Layers.SelectMany(l => l.Elements)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25263.

stable:

https://github.com/ppy/osu/assets/20418176/0783590d-427d-41b3-8a5b-13a23f7c1029

master:

https://github.com/ppy/osu/assets/20418176/bfcbedc7-18e3-414d-a3f4-72cab060eb98

this PR:

https://github.com/ppy/osu/assets/20418176/b4e30708-c12a-4a86-a8c0-392d1ce9a69e

---

In some circumstances, [stable allows skipping twice if a particularly long storyboarded intro is being displayed](https://github.com/peppy/osu-stable-reference/blob/master/osu!/GameModes/Play/Player.cs#L1728-L1736). `AllowDoubleSkip` is calculated [thus](https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameModes/Play/Player.cs#L1761-L1770) and `leadInTime` is calculated [thus](https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameModes/Play/Player.cs#L1342-L1351).

The key to watch out for here is `{first,last}EventTime`. `EventManager` [will calculate it on-the-fly as it adds storyboard elements](https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/GameplayElements/Events/EventManager.cs#L253-L256). However, that pathway is only used for sprite, animation, sample, and break events. Video and background events [use the following pathway](https://github.com/peppy/osu-stable-reference/blob/master/osu!/GameplayElements/Events/EventManager.cs#L368).

Note that this particular overload does not mutate either bound. Which means that for the purposes of determining where a storyboard starts and ends temporally, a video event's start time is essentially ignored.

To reflect that, add a clause that excludes video events from calculations of `{Earliest,Latest}EventTime`.