### PR TITLE
Fix gameplay sample trigger source test failure

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -81,7 +81,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 {
                     StartTime = t += spacing,
                 },
-                new TestSlider
+                new Slider
                 {
                     StartTime = t += spacing,
                     Path = new SliderPath(PathType.Linear, new[] { Vector2.Zero, Vector2.UnitY * 200 }),
@@ -222,11 +222,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             }
 
             public new HitObject? GetMostValidObject() => base.GetMostValidObject();
-        }
-
-        private class TestSlider : Slider
-        {
-            protected override HitWindows CreateHitWindows() => new OsuHitWindows();
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -19,7 +19,6 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Scoring;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Storyboards;
 using osuTK;

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplaySampleTriggerSource.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Storyboards;
@@ -63,33 +64,30 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 new HitCircle
                 {
-                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) }
                 },
                 new HitCircle
                 {
-                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_WHISTLE) }
                 },
                 new HitCircle
                 {
-                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT) },
                 },
                 new HitCircle
                 {
-                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                 },
-                new Slider
+                new TestSlider
                 {
-                    HitWindows = new HitWindows(),
                     StartTime = t += spacing,
                     Path = new SliderPath(PathType.Linear, new[] { Vector2.Zero, Vector2.UnitY * 200 }),
                     Samples = new[] { new HitSampleInfo(HitSampleInfo.HIT_WHISTLE, HitSampleInfo.BANK_SOFT) },
+                    // sliders usually don't have a hit window, but add one to test the scenario of playing a nested object's sample first before the main object itself.
+                    HitWindows = new OsuHitWindows(),
                 },
             });
 
@@ -141,7 +139,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             checkValidObjectIndex(0);
 
             // still too far away.
-            seekBeforeIndex(1, 400);
+            seekBeforeIndex(1, OsuHitWindows.MISS_WINDOW * 2 + 50);
             checkValidObjectIndex(0);
 
             // Still object 1 as it's not hit yet.
@@ -158,7 +156,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             waitForAliveObjectIndex(1);
             checkValidObjectIndex(1);
 
-            seekBeforeIndex(1, 400);
+            seekBeforeIndex(1, OsuHitWindows.MISS_WINDOW * 2 + 50);
             checkValidObjectIndex(0);
 
             seekBeforeIndex(3);
@@ -224,6 +222,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             }
 
             public new HitObject? GetMostValidObject() => base.GetMostValidObject();
+        }
+
+        private class TestSlider : Slider
+        {
+            protected override HitWindows CreateHitWindows() => new OsuHitWindows();
         }
     }
 }


### PR DESCRIPTION
Fixes this [test failure](https://github.com/ppy/osu/pull/25269/commits/9ce2c1f49c37e63d3d6c18b8fb854ee3b4766adf#diff-15d15a3de8719c4c4e1d2f6434b9db623050b19ab473c31c5710dd4024adf23b).

`TestSceneGameplaySampleTriggerSource` was relying on a different set of hit windows that contain result types which are not compatible with the osu! ruleset, and will crash when applying them to an object due to not being defined in the [hit results pool dictionary](https://github.com/ppy/osu/blob/768d7b5e1c30329280447dc452fde063b6e440b3/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs#L69-L71).

This PR updates the test scene to work using regular osu! hit windows. 

Alternatively, this could be fixed at `OsuPlayfield` by ignoring any result type that's not valid by `OsuHitWindows`. I could change to that if that's preferred.