### PR TITLE
Fix `TestScenePlayerMaxDimensions` texture loading process bottlenecking CI

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
@@ -3,20 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Game.IO;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
@@ -3,14 +3,21 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Game.IO;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {
@@ -21,6 +28,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     /// <remarks>
     /// The HUD is hidden as it does't really affect game balance if HUD elements are larger than they should be.
     /// </remarks>
+    [Ignore("This test is for visual testing, and has no value in being run in standard CI runs.")]
     public partial class TestScenePlayerMaxDimensions : TestSceneAllRulesetPlayers
     {
         // scale textures to 4 times their size.
@@ -66,18 +74,66 @@ namespace osu.Game.Tests.Visual.Gameplay
                 remove { }
             }
 
-            public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
-            {
-                var texture = base.GetTexture(componentName, wrapModeS, wrapModeT);
-
-                if (texture != null)
-                    texture.ScaleAdjust /= scale_factor;
-
-                return texture;
-            }
-
             public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => this;
             public IEnumerable<ISkin> AllSources => new[] { this };
+
+            protected override IResourceStore<TextureUpload> CreateTextureLoaderStore(IStorageResourceProvider resources, IResourceStore<byte[]> storage)
+                => new UpscaledTextureLoaderStore(base.CreateTextureLoaderStore(resources, storage));
+
+            private class UpscaledTextureLoaderStore : IResourceStore<TextureUpload>
+            {
+                private readonly IResourceStore<TextureUpload>? textureStore;
+
+                public UpscaledTextureLoaderStore(IResourceStore<TextureUpload>? textureStore)
+                {
+                    this.textureStore = textureStore;
+                }
+
+                public void Dispose()
+                {
+                    textureStore?.Dispose();
+                }
+
+                public TextureUpload Get(string name)
+                {
+                    var textureUpload = textureStore?.Get(name);
+
+                    // NRT not enabled on framework side classes (IResourceStore / TextureLoaderStore), welp.
+                    if (textureUpload == null)
+                        return null!;
+
+                    return upscale(textureUpload);
+                }
+
+                public async Task<TextureUpload> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken())
+                {
+                    // NRT not enabled on framework side classes (IResourceStore / TextureLoaderStore), welp.
+                    if (textureStore == null)
+                        return null!;
+
+                    var textureUpload = await textureStore.GetAsync(name, cancellationToken).ConfigureAwait(false);
+
+                    if (textureUpload == null)
+                        return null!;
+
+                    return await Task.Run(() => upscale(textureUpload), cancellationToken).ConfigureAwait(false);
+                }
+
+                private TextureUpload upscale(TextureUpload textureUpload)
+                {
+                    var image = Image.LoadPixelData(textureUpload.Data.ToArray(), textureUpload.Width, textureUpload.Height);
+
+                    // The original texture upload will no longer be returned or used.
+                    textureUpload.Dispose();
+
+                    image.Mutate(i => i.Resize(new Size(textureUpload.Width, textureUpload.Height) * scale_factor));
+                    return new TextureUpload(image);
+                }
+
+                public Stream? GetStream(string name) => textureStore?.GetStream(name);
+
+                public IEnumerable<string> GetAvailableResources() => textureStore?.GetAvailableResources() ?? Array.Empty<string>();
+            }
         }
     }
 }


### PR DESCRIPTION
Likely resolves the following test failure:
![CleanShot 2023-10-28 at 06 11 53](https://github.com/ppy/osu/assets/22781491/56f2a57a-f1a7-4b9a-8710-1d826ba61824)
([run](https://github.com/bdach/osu/actions/runs/6673621737/job/18139454804))

The test was loading up the image of each texture, scaling them up by a factor of 4, then loading a texture for each one of them. This looks to have had a huge impact on the CI due to the resultant sizes of each sprite as shown in the logs:
```
 [runtime] 2023-10-28 00:57:36 [verbose]: 💨 Class: TestScenePlayerMaxDimensions
 [runtime] 2023-10-28 00:57:36 [verbose]: 🔶 Test:  TestOsu
 [runtime] 2023-10-28 00:57:36 [verbose]: 🔸 Step #1 exit all screens
 [runtime] 2023-10-28 00:57:36 [verbose]: 🔸 Step #2 load osu! player
 [runtime] 2023-10-28 00:57:36 [verbose]: Game-wide working beatmap updated to Kuba Oms - My Love (W h i t e) [Hard]
 [runtime] 2023-10-28 00:57:36 [verbose]: ScreenTestScene screen changed → TestPlayer
 [runtime] 2023-10-28 00:57:36 [verbose]: 📺 ScreenTestScene(OsuScreenStack)#946(depth:1) loading TestPlayer#380
 [runtime] 2023-10-28 00:57:36 [verbose]: 🔸 Step #3 player loaded
 [performance] 2023-10-28 00:57:36 [verbose]: TextureAtlas size exceeded 4 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:36 [verbose]: Texture requested (1472x1472) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:36 [verbose]: TextureAtlas size exceeded 5 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 6 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 7 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: Texture requested (1024x1024) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:37 [verbose]: Texture requested (1024x1024) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:37 [verbose]: Texture requested (1008x1024) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:37 [verbose]: Texture requested (2072x2072) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 8 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 9 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 10 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 11 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 12 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 13 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 14 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 15 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 16 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 17 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 18 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 19 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:37 [verbose]: TextureAtlas size exceeded 20 time(s); generating new texture (1024x1024)
 [performance] 2023-10-28 00:57:38 [verbose]: Texture requested (5336x5336) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:38 [verbose]: Texture requested (2744x952) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:39 [verbose]: Texture requested (2552x976) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:39 [verbose]: Texture requested (2240x448) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:41 [verbose]: Texture requested (6816x6816) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [performance] 2023-10-28 00:57:45 [verbose]: Texture requested (5336x5336) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
 [runtime] 2023-10-28 00:57:46 [verbose]: 💥 Failed (on attempt 8,501)
```

Rather than shocking the CI with gigantic texture images, this PR overrides `GetTexture` and uses `ScaleAdjust` to visualise the textures at such scale without the underlying images being so.

Have made sure this isn't changing the original behaviour of the test:
| master | this PR |
|--------|---------|
| ![CleanShot 2023-10-28 at 06 04 51](https://github.com/ppy/osu/assets/22781491/bcea6765-1fe7-442f-b0fb-90fd2b446492) | ![CleanShot 2023-10-28 at 06 05 20](https://github.com/ppy/osu/assets/22781491/25683e53-9106-4dc1-818a-2fbee88e4f5e) |
