### PR TITLE
Fix cut and copy not working in song select search filter textbox

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -13,6 +13,7 @@ using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
@@ -1109,6 +1110,23 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddUntilStep("delete dialog shown", () => DialogOverlay.CurrentDialog, Is.InstanceOf<BeatmapDeleteDialog>);
             AddStep("confirm deletion", () => DialogOverlay.CurrentDialog!.PerformAction<PopupDialogDangerousButton>());
             AddAssert("0 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "0 matches");
+        }
+
+        [Test]
+        public void TestCutInFilterTextBox()
+        {
+            createSongSelect();
+
+            AddStep("set filter text", () => songSelect!.FilterControl.ChildrenOfType<SearchTextBox>().First().Text = "nonono");
+            AddStep("select all", () => InputManager.Keys(PlatformAction.SelectAll));
+            AddStep("press ctrl-x", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.X);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddAssert("filter text cleared", () => songSelect!.FilterControl.ChildrenOfType<SearchTextBox>().First().Text, () => Is.Empty);
         }
 
         private void waitForInitialSelection()

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Collections;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Select
 {
@@ -254,9 +256,6 @@ namespace osu.Game.Screens.Select
 
             public OsuSpriteText FilterText { get; private set; }
 
-            // clipboard is disabled because one of the "cut" platform key bindings (shift-delete) conflicts with the beatmap deletion action.
-            protected override bool AllowClipboardExport => false;
-
             public FilterControlTextBox()
             {
                 Height += filter_text_size;
@@ -276,6 +275,15 @@ namespace osu.Game.Screens.Select
                     Margin = new MarginPadding { Top = 2, Left = 2 },
                     Colour = colours.Yellow
                 });
+            }
+
+            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+            {
+                // the "cut" platform key binding (shift-delete) conflicts with the beatmap deletion action.
+                if (e.Action == PlatformAction.Cut && e.ShiftPressed && e.CurrentState.Keyboard.Keys.IsPressed(Key.Delete))
+                    return false;
+
+                return base.OnPressed(e);
             }
         }
     }


### PR DESCRIPTION
- Regressed with / intentionally disabled by https://github.com/ppy/osu/pull/24878

Usually, the Shift-Delete cut text framework action [has priority](https://github.com/ppy/osu-framework/blob/75ed421f60228920abd819cebc5982cb7799bbbb/osu.Framework/Input/FrameworkActionContainer.cs#L30) over the regular [delete beatmap action](https://github.com/ppy/osu/blob/2fa221738184c9ded7f091cea16bf40f4e02765d/osu.Game/Screens/Select/SongSelect.cs#L982-L988). This is normal and expected behaviour, framework (and global osu!) actions should have priority.
But in song select, shift-delete is an exception. So treat it as one and implement the minimum viable / least invasive workaround.


Discord message about this from @frenzibyte https://discord.com/channels/188630481301012481/188630652340404224/1167620747838111824:
> it's been about a month since clipboard export was disabled in song select search box, and now as I was navigating around with song select, I thought it's a bug. especially since you can paste but you can't copy

I also think the current solution is really strange, it breaks my muscle memory for deleting all text in the search box: I'd press Ctrl-A and then Ctrl-X to delete.