### PR TITLE
Replace obsolete commands in template install README

### DIFF
--- a/Templates/README.md
+++ b/Templates/README.md
@@ -7,7 +7,7 @@ Templates for use when creating osu! dependent projects. Create a fully-testable
 ```bash
 # install (or update) templates package.
 # this only needs to be done once
-dotnet new -i ppy.osu.Game.Templates
+dotnet new install ppy.osu.Game.Templates
 
 # create an empty freeform ruleset
 dotnet new ruleset -n MyCoolRuleset


### PR DESCRIPTION
The commandes `dotnet new --install` and `dotnet new -i` are obsolete, use the new `dotnet new install` instead.