### PR TITLE
Fix incorrect assertion placement in spinner rotation tracker

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
@@ -130,7 +130,6 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("set DT", () => SelectedMods.Value = new[] { new OsuModDoubleTime { SpeedChange = { Value = rate } } });
             performTest(frames);
 
-            assertTicksHit(0);
             assertSpinnerHit(false);
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/SpinnerRotationTracker.cs
@@ -101,10 +101,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 rotationTransferred = true;
             }
 
+            Debug.Assert(Math.Abs(delta) <= 180);
+
             double rate = gameplayClock?.GetTrueGameplayRate() ?? Clock.Rate;
             delta = (float)(delta * Math.Abs(rate));
-
-            Debug.Assert(Math.Abs(delta) <= 180);
 
             currentRotation += delta;
             drawableSpinner.Result.History.ReportDelta(Time.Current, delta);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25309

Checking the delta after the application of rate is not correct. The delta is in screen-space *before* the rate from rate-changing mods is applied; the point of the application of the rate is to compensate for the fact that the spinner is still judged in "track time" - but the goal is to keep the spinner's difficulty *independent* of rate, which means that with DT active the user's spin is "twice as effective" to compensate for the fact that the spinner is twice as short in real time.

In another formulation, with DT active, the user gets to record replay frames "half as often" as in normal gameplay.