### PR TITLE
Fix potential texture corruption when cropping gameplay textures of weird aspect ratios

### DIFF
--- a/osu.Game/Skinning/LegacySkinExtensions.cs
+++ b/osu.Game/Skinning/LegacySkinExtensions.cs
@@ -115,7 +115,18 @@ namespace osu.Game.Skinning
 
             maxSize *= texture.ScaleAdjust;
 
-            var croppedTexture = texture.Crop(new RectangleF(texture.Width / 2f - maxSize.X / 2f, texture.Height / 2f - maxSize.Y / 2f, maxSize.X, maxSize.Y));
+            // Importantly, check per-axis for the minimum dimension to avoid accidentally inflating
+            // textures with weird aspect ratios.
+            float newWidth = Math.Min(texture.Width, maxSize.X);
+            float newHeight = Math.Min(texture.Height, maxSize.Y);
+
+            var croppedTexture = texture.Crop(new RectangleF(
+                texture.Width / 2f - newWidth / 2f,
+                texture.Height / 2f - newHeight / 2f,
+                newWidth,
+                newHeight
+            ));
+
             croppedTexture.ScaleAdjust = texture.ScaleAdjust;
             return croppedTexture;
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25273.

Can attempt to repro using this skin, although YMMV as it depends if bad stuff appears next to the sprite in the atlas. I might have removed too much of the skin for it to look wrong.

[test-skin.osk.zip](https://github.com/ppy/osu/files/13214027/test-skin.osk.zip)

The code / fail case should be self explanatory though.