### PR TITLE
Fix key binding row fire-and-forgetting writes

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -498,7 +498,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             if (existingBinding == null)
             {
-                realm.WriteAsync(r => r.Find<RealmKeyBinding>(keyBinding.ID)!.KeyCombinationString = keyBinding.KeyCombination.ToString());
+                realm.Write(r => r.Find<RealmKeyBinding>(keyBinding.ID)!.KeyCombinationString = keyBinding.KeyCombination.ToString());
                 BindingUpdated?.Invoke(this, new KeyBindingUpdatedEventArgs(bindingConflictResolved: false, advanceToNextBinding));
                 return;
             }


### PR DESCRIPTION
Intends to fix test failures as seen in https://github.com/ppy/osu/actions/runs/6692350567/job/18181352642#step:5:129

This is what happens if you carelessly fire and forget.

The working theory (that I'm not sure I have the tools to conclusively confirm) is that the async write from the key binding changing could fire _after_ the section is reset.

I briefly considered having the test wait for the change, but given that the entirety of the surrounding flow is using sync operations, this just looks like a bug to me. And there's no real sane way to inject async into that flow due to dependence on `OsuButton.Action`.