### PR TITLE
Clean up mod usability flags

### DIFF
--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -107,12 +107,52 @@ namespace osu.Game.Rulesets.Mods
         [JsonIgnore]
         public virtual bool HasImplementation => this is IApplicableMod;
 
+        /// <summary>
+        /// Whether this mod can be played by a real human user.
+        /// Non-user-playable mods are not viable for single-player score submission.
+        /// </summary>
+        /// <example>
+        /// <list type="bullet">
+        /// <item><see cref="ModDoubleTime"/> is user-playable.</item>
+        /// <item><see cref="ModAutoplay"/> is not user-playable.</item>
+        /// </list>
+        /// </example>
         [JsonIgnore]
         public virtual bool UserPlayable => true;
 
+        /// <summary>
+        /// Whether this mod can be specified as a "required" mod in a multiplayer context.
+        /// </summary>
+        /// <example>
+        /// <list type="bullet">
+        /// <item><see cref="ModHardRock"/> is valid for multiplayer.</item>
+        /// <item>
+        /// <see cref="ModDoubleTime"/> is valid for multiplayer as long as it is a <b>required</b> mod,
+        /// as that ensures the same duration of gameplay for all users in the room.
+        /// </item>
+        /// <item>
+        /// <see cref="ModAdaptiveSpeed"/> is not valid for multiplayer, as it leads to varying
+        /// gameplay duration depending on how the users in the room play.
+        /// </item>
+        /// <item><see cref="ModAutoplay"/> is not valid for multiplayer.</item>
+        /// </list>
+        /// </example>
         [JsonIgnore]
         public virtual bool ValidForMultiplayer => true;
 
+        /// <summary>
+        /// Whether this mod can be specified as a "free" or "allowed" mod in a multiplayer context.
+        /// </summary>
+        /// <example>
+        /// <list type="bullet">
+        /// <item><see cref="ModHardRock"/> is valid for multiplayer as a free mod.</item>
+        /// <item>
+        /// <see cref="ModDoubleTime"/> is <b>not</b> valid for multiplayer as a free mod,
+        /// as it could to varying gameplay duration between users in the room depending on whether they picked it.
+        /// </item>
+        /// <item><see cref="ModAutoplay"/> is not valid for multiplayer as a free mod.</item>
+        /// </list>
+        /// </example>
         [JsonIgnore]
         public virtual bool ValidForMultiplayerAsFreeMod => true;
 

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Rulesets.Mods
 
         public override double ScoreMultiplier => 0.5;
 
-        public override bool ValidForMultiplayer => false;
-        public override bool ValidForMultiplayerAsFreeMod => false;
+        public sealed override bool ValidForMultiplayer => false;
+        public sealed override bool ValidForMultiplayerAsFreeMod => false;
 
         public override Type[] IncompatibleMods => new[] { typeof(ModRateAdjust), typeof(ModTimeRamp), typeof(ModAutoplay) };
 

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -20,9 +20,9 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Watch a perfect automated play through the song.";
         public override double ScoreMultiplier => 1;
 
-        public override bool UserPlayable => false;
-        public override bool ValidForMultiplayer => false;
-        public override bool ValidForMultiplayerAsFreeMod => false;
+        public sealed override bool UserPlayable => false;
+        public sealed override bool ValidForMultiplayer => false;
+        public sealed override bool ValidForMultiplayerAsFreeMod => false;
 
         public override Type[] IncompatibleMods => new[] { typeof(ModCinema), typeof(ModRelax), typeof(ModAdaptiveSpeed) };
 

--- a/osu.Game/Rulesets/Mods/ModRateAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModRateAdjust.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Mods
 {
     public abstract class ModRateAdjust : Mod, IApplicableToRate
     {
-        public override bool ValidForMultiplayerAsFreeMod => false;
+        public sealed override bool ValidForMultiplayerAsFreeMod => false;
 
         public abstract BindableNumber<double> SpeedChange { get; }
 

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -9,7 +9,7 @@ namespace osu.Game.Rulesets.Mods
     /// This mod is used strictly to mark osu!stable scores set with the "Score V2" mod active.
     /// It should not be used in any real capacity going forward.
     /// </remarks>
-    public class ModScoreV2 : Mod
+    public sealed class ModScoreV2 : Mod
     {
         public override string Name => "Score V2";
         public override string Acronym => @"SV2";

--- a/osu.Game/Rulesets/Mods/ModScoreV2.cs
+++ b/osu.Game/Rulesets/Mods/ModScoreV2.cs
@@ -17,5 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Score set on earlier osu! versions with the V2 scoring algorithm active.";
         public override double ScoreMultiplier => 1;
         public override bool UserPlayable => false;
+        public override bool ValidForMultiplayer => false;
+        public override bool ValidForMultiplayerAsFreeMod => false;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModTimeRamp.cs
+++ b/osu.Game/Rulesets/Mods/ModTimeRamp.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mods
         [SettingSource("Adjust pitch", "Should pitch be adjusted with speed")]
         public abstract BindableBool AdjustPitch { get; }
 
-        public override bool ValidForMultiplayerAsFreeMod => false;
+        public sealed override bool ValidForMultiplayerAsFreeMod => false;
 
         public override Type[] IncompatibleMods => new[] { typeof(ModRateAdjust), typeof(ModAdaptiveSpeed) };
 

--- a/osu.Game/Rulesets/Mods/UnknownMod.cs
+++ b/osu.Game/Rulesets/Mods/UnknownMod.cs
@@ -5,7 +5,7 @@ using osu.Framework.Localisation;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public class UnknownMod : Mod
+    public sealed class UnknownMod : Mod
     {
         /// <summary>
         /// The acronym of the mod which could not be resolved.


### PR DESCRIPTION
This is a grab-bag of various changes that i figured would be nice-to-have while I was figuring out how to make https://github.com/ppy/osu/issues/5378 work on the web/validation side of things. There's nothing particularly groundbreaking here (or even really related to touch device handling), just various cleanups.

Of note:

- 7ea298a1b6a4f17a8ae3b505c599f04ac498e4ce adds some xmldocs to the aforementioned mod usability flags
- 3a2645efb17dbe9bee7251b4a8ecc0868cf8799d seals those flags for autoplay (and derived, i.e. cinema) mods so that no ruleset can change them around
- a644c75957247c8f16674ea47e1eec4a239f1159 marks `ModScoreV2` as invalid for multiplayer which doesn't really matter for client but will for web, since without those flags web would just accept SV2 as a valid mod when creating multiplayer / playlist rooms.

There's some more other less remarkable sealing around. Recommend reading commit by commit.