### PR TITLE
Add `No Stop` Mod

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -120,6 +120,7 @@ namespace osu.Game.Rulesets.Catch
                         new CatchModHidden(),
                         new CatchModFlashlight(),
                         new ModAccuracyChallenge(),
+                        new ModNoStop()
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -250,6 +250,7 @@ namespace osu.Game.Rulesets.Mania
                         new MultiMod(new ManiaModFadeIn(), new ManiaModHidden()),
                         new ManiaModFlashlight(),
                         new ModAccuracyChallenge(),
+                        new ModNoStop(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -170,6 +170,7 @@ namespace osu.Game.Rulesets.Osu
                         new MultiMod(new OsuModFlashlight(), new OsuModBlinds()),
                         new OsuModStrictTracking(),
                         new OsuModAccuracyChallenge(),
+                        new ModNoStop(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -153,6 +153,7 @@ namespace osu.Game.Rulesets.Taiko
                         new TaikoModHidden(),
                         new TaikoModFlashlight(),
                         new ModAccuracyChallenge(),
+                        new ModNoStop(),
                     };
 
                 case ModType.Conversion:

--- a/osu.Game.Tests/Visual/Mods/TestSceneModNoStop.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModNoStop.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Mods
+{
+    public partial class TestSceneModNoStop : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+
+        protected override TestPlayer CreateModPlayer(Ruleset ruleset)
+        {
+            var player = base.CreateModPlayer(ruleset);
+            return player;
+        }
+
+        [Test]
+        public void TestScenePauseToQuit() => CreateModTest(new ModTestData
+        {
+            Mod = new ModNoStop(),
+            Autoplay = false,
+            PassCondition = () =>
+            {
+                InputManager.PressKey(Key.Escape);
+                return Player.GameplayState.HasQuit;
+            }
+        });
+    }
+}

--- a/osu.Game/Rulesets/Mods/IApplicableToPlayerConfiguration.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToPlayerConfiguration.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public interface IApplicableToPlayerConfiguration : IApplicableMod
+    {
+        void ApplyConfiguration(PlayerConfiguration configuration);
+    }
+}

--- a/osu.Game/Rulesets/Mods/IApplicableToPlayerConfiguration.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableToPlayerConfiguration.cs
@@ -5,6 +5,10 @@ using osu.Game.Screens.Play;
 
 namespace osu.Game.Rulesets.Mods
 {
+    /// <summary>
+    /// An interface for a mod which can adjust <see cref="PlayerConfiguration"/> settings.
+    /// <see cref="PlayerConfiguration"/> will adjust before <see cref="Player"/> loaded.
+    /// </summary>
     public interface IApplicableToPlayerConfiguration : IApplicableMod
     {
         void ApplyConfiguration(PlayerConfiguration configuration);

--- a/osu.Game/Rulesets/Mods/ModAutoplay.cs
+++ b/osu.Game/Rulesets/Mods/ModAutoplay.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Mods
         public override bool ValidForMultiplayer => false;
         public override bool ValidForMultiplayerAsFreeMod => false;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ModCinema), typeof(ModRelax), typeof(ModAdaptiveSpeed) };
+        public override Type[] IncompatibleMods => new[] { typeof(ModCinema), typeof(ModRelax), typeof(ModAdaptiveSpeed), typeof(ModNoStop) };
 
         public override bool HasImplementation => GetType().GenericTypeArguments.Length == 0;
 

--- a/osu.Game/Rulesets/Mods/ModNoStop.cs
+++ b/osu.Game/Rulesets/Mods/ModNoStop.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Localisation;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public class ModNoStop : Mod, IApplicableToPlayerConfiguration
+    {
+        public override string Name => "No Stop";
+        public override string Acronym => "NT";
+        public override LocalisableString Description => "Start and no stop";
+        public override double ScoreMultiplier => 1;
+        public override ModType Type => ModType.DifficultyIncrease;
+        public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay) };
+
+        public void ApplyConfiguration(PlayerConfiguration configuration)
+        {
+            configuration.AllowPause = false;
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModNoStop.cs
+++ b/osu.Game/Rulesets/Mods/ModNoStop.cs
@@ -16,6 +16,9 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay) };
 
+        public override bool ValidForMultiplayer => false;
+        public override bool ValidForMultiplayerAsFreeMod => false;
+
         public void ApplyConfiguration(PlayerConfiguration configuration)
         {
             configuration.AllowPause = false;

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -57,7 +57,8 @@ namespace osu.Game.Screens.Play.HUD
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft
                 },
-                button = new HoldButton(player?.Configuration.AllowRestart == false)
+                button = new HoldButton(player?.Configuration.AllowRestart == false
+                                        || player?.Configuration.AllowPause == false)
                 {
                     HoverGained = () => text.FadeIn(500, Easing.OutQuint),
                     HoverLost = () => text.FadeOut(500, Easing.OutQuint),

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -210,6 +210,11 @@ namespace osu.Game.Screens.Play
             if (playableBeatmap == null)
                 return;
 
+            foreach (var mods in Mods.Value.OfType<IApplicableToPlayerConfiguration>())
+            {
+                mods.ApplyConfiguration(Configuration);
+            }
+
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
 
             if (game != null)

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -400,11 +400,6 @@ namespace osu.Game.Screens.Play
             CurrentPlayer.RestartCount = restartCount++;
             CurrentPlayer.RestartRequested = restartRequested;
 
-            foreach (var mods in Mods.Value.OfType<IApplicableToPlayerConfiguration>())
-            {
-                mods.ApplyConfiguration(CurrentPlayer.Configuration);
-            }
-
             LoadTask = LoadComponentAsync(CurrentPlayer, _ =>
             {
                 MetadataInfo.Loading = false;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
@@ -25,7 +24,6 @@ using osu.Game.Input;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Skinning;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
@@ -24,6 +25,7 @@ using osu.Game.Input;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Skinning;
@@ -397,6 +399,11 @@ namespace osu.Game.Screens.Play
             CurrentPlayer.Configuration.AutomaticallySkipIntro |= quickRestart;
             CurrentPlayer.RestartCount = restartCount++;
             CurrentPlayer.RestartRequested = restartRequested;
+
+            foreach (var mods in Mods.Value.OfType<IApplicableToPlayerConfiguration>())
+            {
+                mods.ApplyConfiguration(CurrentPlayer.Configuration);
+            }
 
             LoadTask = LoadComponentAsync(CurrentPlayer, _ =>
             {


### PR DESCRIPTION
- Addressed https://github.com/ppy/osu/discussions/19848

This mod is available in playlist and solo.

When player applied this mod, they will not able to pause. Pause means a quit.

Add a interface named `IApplicableToPlayerConfiguration` and it allow mod to adjust player settings before player loaded.

because Hold for Menu use `PlayerConfiguration` before IApplyToPlayer, and will not able to change its `DangerousAction` status in futher.
https://github.com/ppy/osu/blob/d79ee29f29c64a1922bf32c2f1de34be6b5e8e68/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs#L60