### PR TITLE
Fix all spinner ticks being alive and causing performance degradation

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -277,17 +277,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 spinningSample.Frequency.Value = spinning_sample_modulated_base_frequency + Progress;
 
             // Ticks can theoretically be judged at any point in the spinner's duration.
-            // For performance reasons, we only want to keep the next tick alive.
+            // A tick must be alive to correctly play back samples,
+            // but for performance reasons, we only want to keep the next tick alive.
             var next = NestedHitObjects.FirstOrDefault(h => !h.Judged);
 
             // See default `LifetimeStart` as set in `DrawableSpinnerTick`.
             if (next?.LifetimeStart == double.MaxValue)
-            {
-                // the tick can be theoretically judged at any point in the spinner's duration,
-                // so it must be alive throughout the spinner's entire lifetime.
-                // this mostly matters for correct sample playback.
                 next.LifetimeStart = HitObject.StartTime;
-            }
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -275,6 +275,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (spinningSample != null && spinnerFrequencyModulate)
                 spinningSample.Frequency.Value = spinning_sample_modulated_base_frequency + Progress;
+
+            // Ticks can theoretically be judged at any point in the spinner's duration.
+            // For performance reasons, we only want to keep the next tick alive.
+            var next = NestedHitObjects.FirstOrDefault(h => !h.Judged);
+
+            // See default `LifetimeStart` as set in `DrawableSpinnerTick`.
+            if (next?.LifetimeStart == double.MaxValue)
+            {
+                // the tick can be theoretically judged at any point in the spinner's duration,
+                // so it must be alive throughout the spinner's entire lifetime.
+                // this mostly matters for correct sample playback.
+                next.LifetimeStart = HitObject.StartTime;
+            }
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerTick.cs
@@ -11,8 +11,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         public override bool DisplayResult => false;
 
-        protected DrawableSpinner DrawableSpinner => (DrawableSpinner)ParentHitObject;
-
         public DrawableSpinnerTick()
             : this(null)
         {
@@ -29,10 +27,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.OnApply();
 
-            // the tick can be theoretically judged at any point in the spinner's duration,
-            // so it must be alive throughout the spinner's entire lifetime.
-            // this mostly matters for correct sample playback.
-            LifetimeStart = DrawableSpinner.HitObject.StartTime;
+            // Lifetime will be managed by `DrawableSpinner`.
+            LifetimeStart = double.MaxValue;
         }
 
         /// <summary>


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/25216.

The new logic will ensure at least one tick is ready for judgement. There shouldn't be a case where more than one is needed in a single frame.

I also noticed there is a stutter when a *very* long spinner (minutes long, for testing) first comes into view. This looks to be related to the fact that every nested object fetches from the pool at once, causing a huge overhead:

![CleanShot 2023-11-01 at 09 50 49](https://github.com/ppy/osu/assets/191335/24a617a1-7217-451d-bf95-9c732f7e92b8)

I don't believe that is going to be easy to fix, but will be writing it up as an issue, because it definitely feels like something we'll want to consider in the future if we are going to continue to have hundreds of nested objects for things like spinners.