### PR TITLE
Add support for "argon" default skin to expand columns when on mobile devices

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -99,9 +100,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                         return SkinUtils.As<TValue>(new Bindable<float>(30));
 
                     case LegacyManiaSkinConfigurationLookups.ColumnWidth:
-                        return SkinUtils.As<TValue>(new Bindable<float>(
-                            stage.IsSpecialColumn(columnIndex) ? 120 : 60
-                        ));
+
+                        float width = 60;
+
+                        // Best effort until we have better mobile support.
+                        if (RuntimeInfo.IsMobile)
+                            width = 180 * Math.Min(1, 7f / beatmap.TotalColumns);
+
+                        return SkinUtils.As<TValue>(new Bindable<float>(stage.IsSpecialColumn(columnIndex) ? width * 2 : width));
 
                     case LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour:
 

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -101,13 +101,17 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
 
                     case LegacyManiaSkinConfigurationLookups.ColumnWidth:
 
-                        float width = 60;
+                        float width;
+
+                        bool isSpecialColumn = stage.IsSpecialColumn(columnIndex);
 
                         // Best effort until we have better mobile support.
                         if (RuntimeInfo.IsMobile)
-                            width = 180 * Math.Min(1, 7f / beatmap.TotalColumns);
+                            width = 170 * Math.Min(1, 7f / beatmap.TotalColumns) * (isSpecialColumn ? 1.8f : 1);
+                        else
+                            width = 60 * (isSpecialColumn ? 2 : 1);
 
-                        return SkinUtils.As<TValue>(new Bindable<float>(stage.IsSpecialColumn(columnIndex) ? width * 2 : width));
+                        return SkinUtils.As<TValue>(new Bindable<float>(width));
 
                     case LegacyManiaSkinConfigurationLookups.ColumnBackgroundColour:
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23377.

Note that screenshots are taken at a less-wide-than-most-phones-these-days aspect ratio, so if anything, on a device there will be more padding on the sides. Also note that I set an upper limit to the width at lower key counts. We could adjust this based on feedback, but it's basically in place to stop the game from looking silly.

---

Should ease those looking to play the game on mobile until we (potentially) have a better solution in the future.

If this works out well, we can consider rolling it out to other skins.

| Keys |  |
|--------|--------|
| 4 | ![CleanShot 2023-11-02 at 06 17 51](https://github.com/ppy/osu/assets/191335/0689b524-72d5-4d57-9031-10b0f92ff0a5) |
| 5 | ![CleanShot 2023-11-02 at 06 18 17](https://github.com/ppy/osu/assets/191335/5cd59d57-be5b-4641-90ef-2c06d21c59f6)|
| 7 | ![CleanShot 2023-11-02 at 06 12 42](https://github.com/ppy/osu/assets/191335/e047bc49-db30-4590-b339-1c50d6afb87b) |
| 20 | ![CleanShot 2023-11-02 at 06 18 57](https://github.com/ppy/osu/assets/191335/d24fbc3b-739a-4e94-beb6-b25bcb7eeb23)| 