### PR TITLE
Rename and invert flags for slider classic behaviours

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -41,10 +41,10 @@ namespace osu.Game.Rulesets.Osu.Mods
             switch (hitObject)
             {
                 case Slider slider:
-                    slider.OnlyJudgeNestedObjects = !NoSliderHeadAccuracy.Value;
+                    slider.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
 
                     foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
-                        head.JudgeAsNormalHitCircle = !NoSliderHeadAccuracy.Value;
+                        head.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
 
                     break;
             }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -42,10 +42,6 @@ namespace osu.Game.Rulesets.Osu.Mods
             {
                 case Slider slider:
                     slider.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
-
-                    foreach (var head in slider.NestedHitObjects.OfType<SliderHeadCircle>())
-                        head.ClassicSliderBehaviour = NoSliderHeadAccuracy.Value;
-
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -69,8 +69,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 // With classic slider behaviour, heads are considered fully hit if in the largest hit window.
                 // We can't award a full Great because the true Great judgement is awarded on the Slider itself,
-                // reduced based on number of ticks hit.
-                //
+                // reduced based on number of ticks hit,
                 // so we use the most suitable LargeTick judgement here instead.
                 return base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -16,7 +16,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
-        public override bool DisplayResult => HitObject?.JudgeAsNormalHitCircle ?? base.DisplayResult;
+        public override bool DisplayResult
+        {
+            get
+            {
+                if (HitObject?.ClassicSliderBehaviour == true)
+                    return false;
+
+                return base.DisplayResult;
+            }
+        }
 
         private readonly IBindable<int> pathVersion = new Bindable<int>();
 
@@ -56,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             Debug.Assert(HitObject != null);
 
-            if (HitObject.JudgeAsNormalHitCircle)
+            if (!HitObject.ClassicSliderBehaviour)
                 return base.ResultFor(timeOffset);
 
             // If not judged as a normal hitcircle, judge as a slider tick instead. This is the classic osu!stable scoring.

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -65,14 +65,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             Debug.Assert(HitObject != null);
 
-            return HitObject.ClassicSliderBehaviour
-                // In classic slider behaviour, heads are considered fully hit if in the largest hit window.
+            if (HitObject.ClassicSliderBehaviour)
+            {
+                // With classic slider behaviour, heads are considered fully hit if in the largest hit window.
                 // We can't award a full Great because the true Great judgement is awarded on the Slider itself,
                 // reduced based on number of ticks hit.
                 //
                 // so we use the most suitable LargeTick judgement here instead.
-                ? base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss
-                : base.ResultFor(timeOffset);
+                return base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
+            }
+
+            return base.ResultFor(timeOffset);
         }
 
         public override void Shake()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -65,12 +65,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             Debug.Assert(HitObject != null);
 
-            if (!HitObject.ClassicSliderBehaviour)
-                return base.ResultFor(timeOffset);
-
-            // If not judged as a normal hitcircle, judge as a slider tick instead. This is the classic osu!stable scoring.
-            var result = base.ResultFor(timeOffset);
-            return result.IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
+            return HitObject.ClassicSliderBehaviour
+                // In classic slider behaviour, heads are considered fully hit if in the largest hit window.
+                // We can't award a full Great because the true Great judgement is awarded on the Slider itself,
+                // reduced based on number of ticks hit.
+                //
+                // so we use the most suitable LargeTick judgement here instead.
+                ? base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss
+                : base.ResultFor(timeOffset);
         }
 
         public override void Shake()

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -124,8 +124,8 @@ namespace osu.Game.Rulesets.Osu.Objects
         public double TickDistanceMultiplier = 1;
 
         /// <summary>
-        /// Whether this <see cref="Slider"/>'s judgement is fully handled by its nested <see cref="HitObject"/>s.
-        /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of nested <see cref="HitObject"/>s hit.
+        /// If <see langword="false"/>, <see cref="Slider"/>'s judgement is fully handled by its nested <see cref="HitObject"/>s.
+        /// If <see langword="true"/>, this <see cref="Slider"/> will be judged proportionally to the number of nested <see cref="HitObject"/>s hit.
         /// </summary>
         public bool ClassicSliderBehaviour
         {

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// Whether this <see cref="Slider"/>'s judgement is fully handled by its nested <see cref="HitObject"/>s.
         /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of nested <see cref="HitObject"/>s hit.
         /// </summary>
-        public bool OnlyJudgeNestedObjects = true;
+        public bool ClassicSliderBehaviour = false;
 
         public BindableNumber<double> SliderVelocityMultiplierBindable { get; } = new BindableDouble(1)
         {
@@ -262,7 +262,11 @@ namespace osu.Game.Rulesets.Osu.Objects
             TailSamples = this.GetNodeSamples(repeatCount + 1);
         }
 
-        public override Judgement CreateJudgement() => OnlyJudgeNestedObjects ? new OsuIgnoreJudgement() : new OsuJudgement();
+        public override Judgement CreateJudgement() => ClassicSliderBehaviour
+            // See logic in `DrawableSlider.CheckForResult()`
+            ? new OsuJudgement()
+            // Of note, this creates a combo discrepancy for non-classic-mod sliders (there is no combo increase for tail or slider judgement).
+            : new OsuIgnoreJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
     }

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -127,7 +127,18 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// Whether this <see cref="Slider"/>'s judgement is fully handled by its nested <see cref="HitObject"/>s.
         /// If <c>false</c>, this <see cref="Slider"/> will be judged proportionally to the number of nested <see cref="HitObject"/>s hit.
         /// </summary>
-        public bool ClassicSliderBehaviour = false;
+        public bool ClassicSliderBehaviour
+        {
+            get => classicSliderBehaviour;
+            set
+            {
+                classicSliderBehaviour = value;
+                if (HeadCircle != null)
+                    HeadCircle.ClassicSliderBehaviour = value;
+            }
+        }
+
+        private bool classicSliderBehaviour;
 
         public BindableNumber<double> SliderVelocityMultiplierBindable { get; } = new BindableDouble(1)
         {
@@ -196,6 +207,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                             StartTime = e.Time,
                             Position = Position,
                             StackHeight = StackHeight,
+                            ClassicSliderBehaviour = ClassicSliderBehaviour,
                         });
                         break;
 

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -187,7 +187,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                             StartTime = e.Time,
                             Position = Position + Path.PositionAt(e.PathProgress),
                             StackHeight = StackHeight,
-                            Scale = Scale,
                         });
                         break;
 
@@ -206,7 +205,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                             RepeatIndex = e.SpanIndex,
                             StartTime = e.Time,
                             Position = EndPosition,
-                            StackHeight = StackHeight
+                            StackHeight = StackHeight,
                         });
                         break;
 
@@ -217,7 +216,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                             StartTime = StartTime + (e.SpanIndex + 1) * SpanDuration,
                             Position = Position + Path.PositionAt(e.PathProgress),
                             StackHeight = StackHeight,
-                            Scale = Scale,
                         });
                         break;
                 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -9,8 +9,8 @@ namespace osu.Game.Rulesets.Osu.Objects
     public class SliderHeadCircle : HitCircle
     {
         /// <summary>
-        /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
-        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
+        /// If <see langword="false"/>, treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
+        /// If <see langword="true"/>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
         /// </summary>
         public bool ClassicSliderBehaviour;
 

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
         /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
         /// </summary>
-        public bool JudgeAsNormalHitCircle = true;
+        public bool ClassicSliderBehaviour;
 
-        public override Judgement CreateJudgement() => JudgeAsNormalHitCircle ? base.CreateJudgement() : new SliderTickJudgement();
+        public override Judgement CreateJudgement() => ClassicSliderBehaviour ? new SliderTickJudgement() : base.CreateJudgement();
     }
 }


### PR DESCRIPTION
They were really confusing, so I've inverted them, and also added some more comments.

bf9f20705f06e3094ae7e772f4ac59fa45472856 is optional – i was hoping to reduce to one `bool` in `Slider`, but I'm not confident in giving `SliderHead` a reference to `Slider` (doesn't seem like something we do with non-drawable `HitObjects`).