### PR TITLE
Continue to play spinner bonus sounds when MAX display occurs

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -153,7 +154,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 base.Update();
                 if (auto)
-                    RotationTracker.AddRotation((float)(Clock.ElapsedFrameTime * spinRate.Value));
+                    RotationTracker.AddRotation((float)Math.Min(180, Clock.ElapsedFrameTime * spinRate.Value));
             }
         }
     }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinner.cs
@@ -37,6 +37,12 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddSliderStep("Spin rate", 0.5, 5, 1, val => spinRate.Value = val);
         }
 
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Reset rate", () => spinRate.Value = 1);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void TestVariousSpinners(bool autoplay)
@@ -45,6 +51,36 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep($"{term} Big", () => SetContents(_ => testSingle(2, autoplay)));
             AddStep($"{term} Medium", () => SetContents(_ => testSingle(5, autoplay)));
             AddStep($"{term} Small", () => SetContents(_ => testSingle(7, autoplay)));
+        }
+
+        [Test]
+        public void TestSpinnerNoBonus()
+        {
+            AddStep("Set high spin rate", () => spinRate.Value = 5);
+
+            Spinner spinner;
+
+            AddStep("add spinner", () => SetContents(_ =>
+            {
+                spinner = new Spinner
+                {
+                    StartTime = Time.Current,
+                    EndTime = Time.Current + 750,
+                    Samples = new List<HitSampleInfo>
+                    {
+                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
+                    }
+                };
+
+                spinner.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty { OverallDifficulty = 0 });
+
+                return drawableSpinner = new TestDrawableSpinner(spinner, true, spinRate)
+                {
+                    Anchor = Anchor.Centre,
+                    Depth = depthIndex++,
+                    Scale = new Vector2(0.75f)
+                };
+            }));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -144,7 +145,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             spinningSample.Samples = HitObject.CreateSpinningSamples().Cast<ISampleInfo>().ToArray();
             spinningSample.Frequency.Value = spinning_sample_initial_frequency;
 
-            maxBonusSample.Samples = new ISampleInfo[] { HitObject.CreateHitSampleInfo("spinnerbonus") };
+            maxBonusSample.Samples = new ISampleInfo[] { new SpinnerBonusMaxSampleInfo(HitObject.CreateHitSampleInfo()) };
         }
 
         private void updateSpinningSample(ValueChangedEvent<bool> tracking)
@@ -342,6 +343,27 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     tick.TriggerResult(true);
 
                 completedFullSpins.Value++;
+            }
+        }
+
+        public class SpinnerBonusMaxSampleInfo : HitSampleInfo
+        {
+            public override IEnumerable<string> LookupNames
+            {
+                get
+                {
+                    foreach (string name in base.LookupNames)
+                        yield return name;
+
+                    foreach (string name in base.LookupNames)
+                        yield return name.Replace("-max", string.Empty);
+                }
+            }
+
+            public SpinnerBonusMaxSampleInfo(HitSampleInfo sampleInfo)
+                : base("spinnerbonus-max", sampleInfo.Bank, sampleInfo.Suffix, sampleInfo.Volume)
+
+            {
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -303,6 +303,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private static readonly int score_per_tick = new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxNumericResult;
 
+        private int lastMaxSamplePlayback;
+
         private void updateBonusScore()
         {
             if (ticks.Count == 0)
@@ -322,7 +324,15 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
 
                 // tick may be null if we've hit the spin limit.
-                tick?.TriggerResult(true);
+                if (tick == null)
+                {
+                    // we still want to play a sound. this will probably be a new sound in the future, but for now let's continue playing the bonus sound.
+                    // round robin to avoid hitting playback concurrency.
+                    tick = ticks.OfType<DrawableSpinnerBonusTick>().Skip(lastMaxSamplePlayback++ % HitObject.MaximumBonusSpins).First();
+                    tick.PlaySamples();
+                }
+                else
+                    tick.TriggerResult(true);
 
                 completedFullSpins.Value++;
             }


### PR DESCRIPTION
I implemented the MAX display with sound muted, so didn't realise how bad it felt without some kind of sound accompanying it. This resolves that issue.

Don't mind the implementation. It will likely change in the near future as @nekodex may be working on a proper sample for this.