### PR TITLE
Keep `ArgonKeyCounterDisplay` text upright

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
@@ -31,36 +31,65 @@ namespace osu.Game.Tests.Visual.Gameplay
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
                     Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(72.7f),
-                    Children = new KeyCounterDisplay[]
+                    Spacing = new Vector2(20),
+                    Children = new Drawable[]
                     {
                         new DefaultKeyCounterDisplay
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                         },
-                        new ArgonKeyCounterDisplay
+                        new DefaultKeyCounterDisplay
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
+                            Scale = new Vector2(1, -1)
                         },
                         new ArgonKeyCounterDisplay
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Rotation = -90,
-                        },
-                        new ArgonKeyCounterDisplay
-                        {
-                            Origin = Anchor.Centre,
-                            Anchor = Anchor.Centre,
-                            Rotation = 90,
                         },
                         new ArgonKeyCounterDisplay
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                             Scale = new Vector2(1, -1)
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Spacing = new Vector2(20),
+                            Children = new Drawable[]
+                            {
+                                new DefaultKeyCounterDisplay
+                                {
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre,
+                                    Rotation = -90,
+                                },
+                                new DefaultKeyCounterDisplay
+                                {
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre,
+                                    Rotation = 90,
+                                },
+                                new ArgonKeyCounterDisplay
+                                {
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre,
+                                    Rotation = -90,
+                                },
+                                new ArgonKeyCounterDisplay
+                                {
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre,
+                                    Rotation = 90,
+                                },
+                            }
                         },
                     }
                 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
@@ -124,8 +124,15 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("Disable counting", () => controller.IsCounting.Value = false);
             addPressKeyStep();
             AddAssert($"Check {testKey} count has not changed", () => testTrigger.ActivationCount.Value == 2);
+            AddStep("Enable counting", () => controller.IsCounting.Value = true);
+            addPressKeyStep(100);
+            addPressKeyStep(1000);
 
-            void addPressKeyStep() => AddStep($"Press {testKey} key", () => InputManager.Key(testKey));
+            void addPressKeyStep(int repeat = 1) => AddStep($"Press {testKey} key {repeat} times", () =>
+            {
+                for (int i = 0; i < repeat; i++)
+                    InputManager.Key(testKey);
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneKeyCounter.cs
@@ -43,7 +43,25 @@ namespace osu.Game.Tests.Visual.Gameplay
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                        }
+                        },
+                        new ArgonKeyCounterDisplay
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Rotation = -90,
+                        },
+                        new ArgonKeyCounterDisplay
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Rotation = 90,
+                        },
+                        new ArgonKeyCounterDisplay
+                        {
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Scale = new Vector2(1, -1)
+                        },
                     }
                 }
             };

--- a/osu.Game/Screens/Play/ArgonKeyCounter.cs
+++ b/osu.Game/Screens/Play/ArgonKeyCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -17,6 +18,8 @@ namespace osu.Game.Screens.Play
         private Circle inputIndicator = null!;
         private OsuSpriteText keyNameText = null!;
         private OsuSpriteText countText = null!;
+
+        private UprightAspectMaintainingContainer uprightContainer = null!;
 
         // These values were taken from Figma
         private const float line_height = 3;
@@ -53,7 +56,7 @@ namespace osu.Game.Screens.Play
                     Padding = new MarginPadding { Top = line_height * scale_factor + indicator_press_offset },
                     Children = new Drawable[]
                     {
-                        new UprightAspectMaintainingContainer
+                        uprightContainer = new UprightAspectMaintainingContainer
                         {
                             RelativeSizeAxes = Axes.Both,
                             Anchor = Anchor.Centre,
@@ -62,16 +65,16 @@ namespace osu.Game.Screens.Play
                             {
                                 keyNameText = new OsuSpriteText
                                 {
-                                    Anchor = Anchor.TopCentre,
-                                    Origin = Anchor.TopCentre,
+                                    Anchor = Anchor.TopLeft,
+                                    Origin = Anchor.TopLeft,
                                     Font = OsuFont.Torus.With(size: name_font_size * scale_factor, weight: FontWeight.Bold),
                                     Colour = colours.Blue0,
                                     Text = Trigger.Name
                                 },
                                 countText = new OsuSpriteText
                                 {
-                                    Anchor = Anchor.BottomCentre,
-                                    Origin = Anchor.BottomCentre,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
                                     Font = OsuFont.Torus.With(size: count_font_size * scale_factor, weight: FontWeight.Bold),
                                 },
                             }
@@ -91,6 +94,21 @@ namespace osu.Game.Screens.Play
             base.LoadComplete();
 
             CountPresses.BindValueChanged(e => countText.Text = e.NewValue.ToString(@"#,0"), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            const float allowance = 6;
+            float absRotation = Math.Abs(uprightContainer.Rotation) % 180;
+            bool isRotated = absRotation > allowance && absRotation < (180 - allowance);
+
+            keyNameText.Anchor =
+                keyNameText.Origin = isRotated ? Anchor.TopCentre : Anchor.TopLeft;
+
+            countText.Anchor =
+                countText.Origin = isRotated ? Anchor.BottomCentre : Anchor.BottomLeft;
         }
 
         protected override void Activate(bool forwardPlayback = true)

--- a/osu.Game/Screens/Play/ArgonKeyCounter.cs
+++ b/osu.Game/Screens/Play/ArgonKeyCounter.cs
@@ -9,7 +9,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play.HUD;
-using osuTK;
 
 namespace osu.Game.Screens.Play
 {
@@ -26,6 +25,8 @@ namespace osu.Game.Screens.Play
 
         // Make things look bigger without using Scale
         private const float scale_factor = 1.5f;
+
+        private const float indicator_press_offset = 4;
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -48,8 +49,8 @@ namespace osu.Game.Screens.Play
                 },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.X,
-                    Height = 40,
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = line_height * scale_factor + indicator_press_offset },
                     Children = new Drawable[]
                     {
                         new UprightAspectMaintainingContainer
@@ -69,9 +70,8 @@ namespace osu.Game.Screens.Play
                                 },
                                 countText = new OsuSpriteText
                                 {
-                                    Anchor = Anchor.TopCentre,
-                                    Origin = Anchor.TopCentre,
-                                    Position = new Vector2(0, 13) * scale_factor,
+                                    Anchor = Anchor.BottomCentre,
+                                    Origin = Anchor.BottomCentre,
                                     Font = OsuFont.Torus.With(size: count_font_size * scale_factor, weight: FontWeight.Bold),
                                 },
                             }
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Play
                 .FadeIn(10, Easing.OutQuint)
                 .MoveToY(0)
                 .Then()
-                .MoveToY(4, 60, Easing.OutQuint);
+                .MoveToY(indicator_press_offset, 60, Easing.OutQuint);
         }
 
         protected override void Deactivate(bool forwardPlayback = true)

--- a/osu.Game/Screens/Play/ArgonKeyCounter.cs
+++ b/osu.Game/Screens/Play/ArgonKeyCounter.cs
@@ -3,8 +3,10 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Screens.Play.HUD;
 using osuTK;
@@ -40,26 +42,39 @@ namespace osu.Game.Screens.Play
             {
                 inputIndicator = new Circle
                 {
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.X,
                     Height = line_height * scale_factor,
                     Alpha = 0.5f
                 },
-                keyNameText = new OsuSpriteText
+                new Container
                 {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Position = new Vector2(0, -13) * scale_factor,
-                    Font = OsuFont.Torus.With(size: name_font_size * scale_factor, weight: FontWeight.Bold),
-                    Colour = colours.Blue0,
-                    Text = Trigger.Name
-                },
-                countText = new OsuSpriteText
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Font = OsuFont.Torus.With(size: count_font_size * scale_factor, weight: FontWeight.Bold),
+                    RelativeSizeAxes = Axes.X,
+                    Height = 40,
+                    Children = new Drawable[]
+                    {
+                        new UprightAspectMaintainingContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                keyNameText = new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Font = OsuFont.Torus.With(size: name_font_size * scale_factor, weight: FontWeight.Bold),
+                                    Colour = colours.Blue0,
+                                    Text = Trigger.Name
+                                },
+                                countText = new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopCentre,
+                                    Origin = Anchor.TopCentre,
+                                    Position = new Vector2(0, 13) * scale_factor,
+                                    Font = OsuFont.Torus.With(size: count_font_size * scale_factor, weight: FontWeight.Bold),
+                                },
+                            }
+                        }
+                    }
                 },
             };
 

--- a/osu.Game/Screens/Play/ArgonKeyCounter.cs
+++ b/osu.Game/Screens/Play/ArgonKeyCounter.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Screens.Play
                         new UprightAspectMaintainingContainer
                         {
                             RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
                             Children = new Drawable[]
                             {
                                 keyNameText = new OsuSpriteText


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/25290

Didn't do triangles as the key and counter will overlap (see X and 1000, there's no spacing but if it's M1 it'll overlap).

A design change is that the text is now centred (kept it as it was attempted like that).

| Before (just test changes for visualisation) | After | After (with default (triangles) key counter change) |
| --- | --- | --- |
| ![E2DTb5THNu](https://github.com/ppy/osu/assets/35318437/b15779c3-43ed-4808-b331-1a1d7bcc1bd5) | ![bLF3vRs7rq](https://github.com/ppy/osu/assets/35318437/6092de7e-d961-4427-bad6-1ff8a240a335) | ![qS8OvouaGT](https://github.com/ppy/osu/assets/35318437/a3e127c0-d2bb-48d8-aa7c-f77c7751dd04) |

Here's the triangles change if we want to / can improve it:
```diff
diff --git a/osu.Game/Screens/Play/HUD/DefaultKeyCounter.cs b/osu.Game/Screens/Play/HUD/DefaultKeyCounter.cs
index f7ac72035f..632d27d72a 100644
--- a/osu.Game/Screens/Play/HUD/DefaultKeyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultKeyCounter.cs
@@ -7,8 +7,8 @@
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD
@@ -53,26 +53,45 @@ private void load(TextureStore textures)
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Vertical = 10 },
                     Children = new Drawable[]
                     {
-                        new OsuSpriteText
+                        new Container
                         {
-                            Text = Trigger.Name,
-                            Font = OsuFont.Numeric.With(size: 12),
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            RelativePositionAxes = Axes.Both,
-                            Position = new Vector2(0, -0.25f),
-                            Colour = KeyUpTextColor
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            AutoSizeAxes = Axes.Both,
+                            Child = new UprightAspectMaintainingContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                AutoSizeAxes = Axes.Both,
+                                Child = new OsuSpriteText
+                                {
+                                    Text = Trigger.Name,
+                                    Font = OsuFont.Numeric.With(size: 12),
+                                    Colour = KeyUpTextColor,
+                                    UseFullGlyphHeight = false,
+                                },
+                            },
                         },
-                        countSpriteText = new OsuSpriteText
+                        new Container
                         {
-                            Text = CountPresses.Value.ToString(@"#,0"),
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            RelativePositionAxes = Axes.Both,
-                            Position = new Vector2(0, 0.25f),
-                            Colour = KeyUpTextColor
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            AutoSizeAxes = Axes.Both,
+                            Child = new UprightAspectMaintainingContainer
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                AutoSizeAxes = Axes.Both,
+                                Child = countSpriteText = new OsuSpriteText
+                                {
+                                    Text = CountPresses.Value.ToString(@"#,0"),
+                                    Colour = KeyUpTextColor,
+                                    UseFullGlyphHeight = false,
+                                }
+                            }
                         }
                     }
                 }

```