### PR TITLE
Fix resume cursor following gameplay cursor scale setting

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneGameplayCursor.cs
@@ -94,16 +94,16 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddStep("load content", loadContent);
 
-            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize) * userScale);
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.CursorScale.Value == OsuCursor.GetScaleForCircleSize(circleSize) * userScale);
 
             AddStep("set user scale to 1", () => config.SetValue(OsuSetting.GameplayCursorSize, 1f));
-            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == OsuCursorContainer.GetScaleForCircleSize(circleSize));
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.CursorScale.Value == OsuCursor.GetScaleForCircleSize(circleSize));
 
             AddStep("turn off autosizing", () => config.SetValue(OsuSetting.AutoCursorSize, false));
-            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == 1);
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.CursorScale.Value == 1);
 
             AddStep($"set user scale to {userScale}", () => config.SetValue(OsuSetting.GameplayCursorSize, userScale));
-            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.Scale.X == userScale);
+            AddUntilStep("cursor size correct", () => lastContainer.ActiveCursor.CursorScale.Value == userScale);
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
@@ -1,16 +1,20 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Testing;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Visual;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests
 {
@@ -54,9 +58,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         [SetUp]
         public void SetUp() => Schedule(loadContent);
 
-        [Test]
-        public void TestResume()
+        [TestCase(1)]
+        [TestCase(0.5f)]
+        [TestCase(2)]
+        public void TestResume(float cursorSize)
         {
+            AddStep($"set cursor size to {cursorSize}", () => localConfig.SetValue(OsuSetting.GameplayCursorSize, cursorSize));
+
             AddStep("move mouse to center", () => InputManager.MoveMouseTo(ScreenSpaceDrawQuad.Centre));
             AddStep("show", () => resume.Show());
 
@@ -64,7 +72,27 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("click", () => osuInputManager.GameClick());
             AddAssert("not dismissed", () => !resumeFired && resume.State.Value == Visibility.Visible);
 
-            AddStep("move mouse back", () => InputManager.MoveMouseTo(ScreenSpaceDrawQuad.Centre));
+            AddStep("move mouse just out of range", () =>
+            {
+                var resumeOverlay = this.ChildrenOfType<OsuResumeOverlay>().Single();
+                var resumeOverlayCursor = resumeOverlay.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single();
+
+                Vector2 offset = resumeOverlay.ToScreenSpace(new Vector2(OsuCursor.SIZE / 2)) - resumeOverlay.ToScreenSpace(Vector2.Zero);
+                InputManager.MoveMouseTo(resumeOverlayCursor.ScreenSpaceDrawQuad.Centre - offset - new Vector2(1));
+            });
+
+            AddStep("click", () => osuInputManager.GameClick());
+            AddAssert("not dismissed", () => !resumeFired && resume.State.Value == Visibility.Visible);
+
+            AddStep("move mouse just within range", () =>
+            {
+                var resumeOverlay = this.ChildrenOfType<OsuResumeOverlay>().Single();
+                var resumeOverlayCursor = resumeOverlay.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single();
+
+                Vector2 offset = resumeOverlay.ToScreenSpace(new Vector2(OsuCursor.SIZE / 2)) - resumeOverlay.ToScreenSpace(Vector2.Zero);
+                InputManager.MoveMouseTo(resumeOverlayCursor.ScreenSpaceDrawQuad.Centre - offset + new Vector2(1));
+            });
+
             AddStep("click", () => osuInputManager.GameClick());
             AddAssert("dismissed", () => resumeFired && resume.State.Value == Visibility.Hidden);
         }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -12,14 +13,15 @@ namespace osu.Game.Rulesets.Osu.Tests
 {
     public partial class TestSceneResumeOverlay : OsuManualInputManagerTestScene
     {
-        public TestSceneResumeOverlay()
+        private ManualOsuInputManager osuInputManager = null!;
+        private CursorContainer cursor = null!;
+        private ResumeOverlay resume = null!;
+
+        private bool resumeFired;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
-            ManualOsuInputManager osuInputManager;
-            CursorContainer cursor;
-            ResumeOverlay resume;
-
-            bool resumeFired = false;
-
             Child = osuInputManager = new ManualOsuInputManager(new OsuRuleset().RulesetInfo)
             {
                 Children = new Drawable[]
@@ -32,8 +34,13 @@ namespace osu.Game.Rulesets.Osu.Tests
                 }
             };
 
+            resumeFired = false;
             resume.ResumeAction = () => resumeFired = true;
+        });
 
+        [Test]
+        public void TestResume()
+        {
             AddStep("move mouse to center", () => InputManager.MoveMouseTo(ScreenSpaceDrawQuad.Centre));
             AddStep("show", () => resume.Show());
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneResumeOverlay.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Play;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Osu.Tests
@@ -19,24 +22,37 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private bool resumeFired;
 
-        [SetUp]
-        public void SetUp() => Schedule(() =>
-        {
-            Child = osuInputManager = new ManualOsuInputManager(new OsuRuleset().RulesetInfo)
-            {
-                Children = new Drawable[]
-                {
-                    cursor = new CursorContainer(),
-                    resume = new OsuResumeOverlay
-                    {
-                        GameplayCursor = cursor
-                    },
-                }
-            };
+        private OsuConfigManager localConfig = null!;
 
-            resumeFired = false;
-            resume.ResumeAction = () => resumeFired = true;
-        });
+        [Cached]
+        private GameplayState gameplayState;
+
+        public TestSceneResumeOverlay()
+        {
+            gameplayState = TestGameplayState.Create(new OsuRuleset());
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Dependencies.Cache(localConfig = new OsuConfigManager(LocalStorage));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            AddSliderStep("cursor size", 0.1f, 2f, 1f, v => localConfig.SetValue(OsuSetting.GameplayCursorSize, v));
+            AddSliderStep("circle size", 0f, 10f, 0f, val =>
+            {
+                gameplayState.Beatmap.Difficulty.CircleSize = val;
+                SetUp();
+            });
+
+            AddToggleStep("auto size", v => localConfig.SetValue(OsuSetting.AutoCursorSize, v));
+        }
+
+        [SetUp]
+        public void SetUp() => Schedule(loadContent);
 
         [Test]
         public void TestResume()
@@ -51,6 +67,14 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddStep("move mouse back", () => InputManager.MoveMouseTo(ScreenSpaceDrawQuad.Centre));
             AddStep("click", () => osuInputManager.GameClick());
             AddAssert("dismissed", () => resumeFired && resume.State.Value == Visibility.Hidden);
+        }
+
+        private void loadContent()
+        {
+            Child = osuInputManager = new ManualOsuInputManager(new OsuRuleset().RulesetInfo) { Children = new Drawable[] { cursor = new CursorContainer(), resume = new OsuResumeOverlay { GameplayCursor = cursor }, } };
+
+            resumeFired = false;
+            resume.ResumeAction = () => resumeFired = true;
         }
 
         private partial class ManualOsuInputManager : OsuInputManager

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 {
     public partial class OsuCursor : SkinReloadableDrawable
     {
-        private const float size = 28;
+        public const float SIZE = 28;
 
         private const float pressed_scale = 1.2f;
         private const float released_scale = 1f;
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             Origin = Anchor.Centre;
 
-            Size = new Vector2(size);
+            Size = new Vector2(SIZE);
         }
 
         [BackgroundDependencyLoader]
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                         Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
                         Masking = true,
-                        BorderThickness = size / 6,
+                        BorderThickness = SIZE / 6,
                         BorderColour = Color4.White,
                         EdgeEffect = new EdgeEffectParameters
                         {
@@ -156,7 +156,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                                 Anchor = Anchor.Centre,
                                 RelativeSizeAxes = Axes.Both,
                                 Masking = true,
-                                BorderThickness = size / 3,
+                                BorderThickness = SIZE / 3,
                                 BorderColour = Color4.White.Opacity(0.5f),
                                 Children = new Drawable[]
                                 {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -84,12 +84,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             calculateCursorScale();
         }
 
-        /// <summary>
-        /// Get the scale applicable to the ActiveCursor based on a beatmap's circle size.
-        /// </summary>
-        public static float GetScaleForCircleSize(float circleSize) =>
-            1f - 0.7f * (1f + circleSize - BeatmapDifficulty.DEFAULT_DIFFICULTY) / BeatmapDifficulty.DEFAULT_DIFFICULTY;
-
         private void calculateCursorScale()
         {
             float scale = userCursorScale.Value;
@@ -116,6 +110,12 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         }
 
         public void Contract() => expandTarget.ScaleTo(released_scale, 400, Easing.OutQuad);
+
+        /// <summary>
+        /// Get the scale applicable to the ActiveCursor based on a beatmap's circle size.
+        /// </summary>
+        public static float GetScaleForCircleSize(float circleSize) =>
+            1f - 0.7f * (1f + circleSize - BeatmapDifficulty.DEFAULT_DIFFICULTY) / BeatmapDifficulty.DEFAULT_DIFFICULTY;
 
         private partial class DefaultCursor : OsuCursorSprite
         {

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -11,11 +11,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Beatmaps;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -23,6 +20,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 {
     public partial class OsuCursorContainer : GameplayCursorContainer, IKeyBindingHandler<OsuAction>
     {
+        public new OsuCursor ActiveCursor => (OsuCursor)base.ActiveCursor;
+
         protected override Drawable CreateCursor() => new OsuCursor();
 
         protected override Container<Drawable> Content => fadeContainer;
@@ -32,13 +31,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private readonly Bindable<bool> showTrail = new Bindable<bool>(true);
 
         private readonly Drawable cursorTrail;
-
-        public IBindable<float> CursorScale => cursorScale;
-
-        private readonly Bindable<float> cursorScale = new BindableFloat(1);
-
-        private Bindable<float> userCursorScale;
-        private Bindable<bool> autoCursorScale;
 
         private readonly CursorRippleVisualiser rippleVisualiser;
 
@@ -56,12 +48,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             };
         }
 
-        [Resolved(canBeNull: true)]
-        private GameplayState state { get; set; }
-
-        [Resolved]
-        private OsuConfigManager config { get; set; }
-
         [BackgroundDependencyLoader(true)]
         private void load(OsuRulesetConfigManager rulesetConfig)
         {
@@ -74,46 +60,13 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
             showTrail.BindValueChanged(v => cursorTrail.FadeTo(v.NewValue ? 1 : 0, 200), true);
 
-            userCursorScale = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
-            userCursorScale.ValueChanged += _ => calculateScale();
-
-            autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
-            autoCursorScale.ValueChanged += _ => calculateScale();
-
-            CursorScale.BindValueChanged(e =>
+            ActiveCursor.CursorScale.BindValueChanged(e =>
             {
                 var newScale = new Vector2(e.NewValue);
 
-                ActiveCursor.Scale = newScale;
                 rippleVisualiser.CursorScale = newScale;
                 cursorTrail.Scale = newScale;
             }, true);
-
-            calculateScale();
-        }
-
-        /// <summary>
-        /// Get the scale applicable to the ActiveCursor based on a beatmap's circle size.
-        /// </summary>
-        public static float GetScaleForCircleSize(float circleSize) =>
-            1f - 0.7f * (1f + circleSize - BeatmapDifficulty.DEFAULT_DIFFICULTY) / BeatmapDifficulty.DEFAULT_DIFFICULTY;
-
-        private void calculateScale()
-        {
-            float scale = userCursorScale.Value;
-
-            if (autoCursorScale.Value && state != null)
-            {
-                // if we have a beatmap available, let's get its circle size to figure out an automatic cursor scale modifier.
-                scale *= GetScaleForCircleSize(state.Beatmap.Difficulty.CircleSize);
-            }
-
-            cursorScale.Value = scale;
-
-            var newScale = new Vector2(scale);
-
-            ActiveCursor.ScaleTo(newScale, 400, Easing.OutQuint);
-            cursorTrail.Scale = newScale;
         }
 
         private int downCount;
@@ -121,9 +74,9 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private void updateExpandedState()
         {
             if (downCount > 0)
-                (ActiveCursor as OsuCursor)?.Expand();
+                ActiveCursor.Expand();
             else
-                (ActiveCursor as OsuCursor)?.Contract();
+                ActiveCursor.Contract();
         }
 
         public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
@@ -160,13 +113,13 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         protected override void PopIn()
         {
             fadeContainer.FadeTo(1, 300, Easing.OutQuint);
-            ActiveCursor.ScaleTo(CursorScale.Value, 400, Easing.OutQuint);
+            ActiveCursor.ScaleTo(1f, 400, Easing.OutQuint);
         }
 
         protected override void PopOut()
         {
             fadeContainer.FadeTo(0.05f, 450, Easing.OutQuint);
-            ActiveCursor.ScaleTo(CursorScale.Value * 0.8f, 450, Easing.OutQuint);
+            ActiveCursor.ScaleTo(0.8f, 450, Easing.OutQuint);
         }
 
         private partial class DefaultCursorTrail : CursorTrail

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -5,7 +5,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -14,7 +13,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.UI
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.UI
         private OsuClickToResumeCursor clickToResumeCursor;
 
         private OsuCursorContainer localCursorContainer;
-        private IBindable<float> localCursorScale;
 
         public override CursorContainer LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
 
@@ -49,13 +46,7 @@ namespace osu.Game.Rulesets.Osu.UI
             clickToResumeCursor.Appear();
 
             if (localCursorContainer == null)
-            {
                 Add(localCursorContainer = new OsuCursorContainer());
-
-                localCursorScale = new BindableFloat();
-                localCursorScale.BindTo(localCursorContainer.CursorScale);
-                localCursorScale.BindValueChanged(scale => cursorScaleContainer.Scale = new Vector2(scale.NewValue), true);
-            }
         }
 
         protected override void PopOut()
@@ -98,7 +89,8 @@ namespace osu.Game.Rulesets.Osu.UI
                 {
                     case OsuAction.LeftButton:
                     case OsuAction.RightButton:
-                        if (!IsHovered) return false;
+                        if (!IsHovered)
+                            return false;
 
                         this.ScaleTo(2, TRANSITION_TIME, Easing.OutQuint);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.UI
 {
     public partial class OsuResumeOverlay : ResumeOverlay
     {
-        private Container cursorScaleContainer;
+        private Container resumeCursorContainer;
         private OsuClickToResumeCursor clickToResumeCursor;
 
         private OsuCursorContainer localCursorContainer;
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(cursorScaleContainer = new Container
+            Add(resumeCursorContainer = new Container
             {
                 Child = clickToResumeCursor = new OsuClickToResumeCursor { ResumeRequested = Resume }
             });
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.UI
             base.PopIn();
 
             GameplayCursor.ActiveCursor.Hide();
-            cursorScaleContainer.Position = ToLocalSpace(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre);
+            resumeCursorContainer.Position = ToLocalSpace(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre);
             clickToResumeCursor.Appear();
 
             if (localCursorContainer == null)

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -5,7 +5,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -14,7 +13,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.UI
@@ -25,7 +23,6 @@ namespace osu.Game.Rulesets.Osu.UI
         private OsuClickToResumeCursor clickToResumeCursor;
 
         private OsuCursorContainer localCursorContainer;
-        private IBindable<float> localCursorScale;
 
         public override CursorContainer LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
 
@@ -49,13 +46,7 @@ namespace osu.Game.Rulesets.Osu.UI
             clickToResumeCursor.Appear();
 
             if (localCursorContainer == null)
-            {
                 Add(localCursorContainer = new OsuCursorContainer());
-
-                localCursorScale = new BindableFloat();
-                localCursorScale.BindTo(localCursorContainer.CursorScale);
-                localCursorScale.BindValueChanged(scale => cursorScaleContainer.Scale = new Vector2(scale.NewValue), true);
-            }
         }
 
         protected override void PopOut()

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -13,16 +14,18 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Screens.Play;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
     public partial class OsuResumeOverlay : ResumeOverlay
     {
-        private Container resumeCursorContainer;
+        private Container cursorScaleContainer;
         private OsuClickToResumeCursor clickToResumeCursor;
 
         private OsuCursorContainer localCursorContainer;
+        private IBindable<float> localCursorScale;
 
         public override CursorContainer LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
 
@@ -31,7 +34,7 @@ namespace osu.Game.Rulesets.Osu.UI
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(resumeCursorContainer = new Container
+            Add(cursorScaleContainer = new Container
             {
                 Child = clickToResumeCursor = new OsuClickToResumeCursor { ResumeRequested = Resume }
             });
@@ -42,11 +45,17 @@ namespace osu.Game.Rulesets.Osu.UI
             base.PopIn();
 
             GameplayCursor.ActiveCursor.Hide();
-            resumeCursorContainer.Position = ToLocalSpace(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre);
+            cursorScaleContainer.Position = ToLocalSpace(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre);
             clickToResumeCursor.Appear();
 
             if (localCursorContainer == null)
+            {
                 Add(localCursorContainer = new OsuCursorContainer());
+
+                localCursorScale = new BindableFloat();
+                localCursorScale.BindTo(localCursorContainer.CursorScale);
+                localCursorScale.BindValueChanged(scale => cursorScaleContainer.Scale = new Vector2(scale.NewValue), true);
+            }
         }
 
         protected override void PopOut()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25331

I was going to write a test case for this but I've had spent too much time trying to figure out how to logically get the size of a drawable at 1x scale without getting into technical details (like fetching the container that's actually being scaled), so I gave up on it.