### PR TITLE
Use better colours for system mods

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Graphics
                     return Pink1;
 
                 case ModType.System:
-                    return Gray5;
+                    return Yellow;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(modType), modType, "Unknown mod type");

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Graphics
                     return Pink1;
 
                 case ModType.System:
-                    return Gray7;
+                    return Gray5;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(modType), modType, "Unknown mod type");

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -204,9 +204,7 @@ namespace osu.Game.Rulesets.UI
 
         private void updateColour()
         {
-            modAcronym.Colour = modIcon.Colour = mod.Type != ModType.System
-                ? OsuColour.Gray(84)
-                : colours.Yellow;
+            modAcronym.Colour = modIcon.Colour = OsuColour.Gray(84);
 
             extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
             extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -138,7 +138,6 @@ namespace osu.Game.Rulesets.UI
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Colour = OsuColour.Gray(84),
                             Alpha = 0,
                             Font = OsuFont.Numeric.With(null, 22f),
                             UseFullGlyphHeight = false,
@@ -148,7 +147,6 @@ namespace osu.Game.Rulesets.UI
                         {
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
-                            Colour = OsuColour.Gray(84),
                             Size = new Vector2(45),
                             Icon = FontAwesome.Solid.Question
                         },
@@ -206,6 +204,10 @@ namespace osu.Game.Rulesets.UI
 
         private void updateColour()
         {
+            modAcronym.Colour = modIcon.Colour = mod.Type != ModType.System
+                ? OsuColour.Gray(84)
+                : colours.Yellow;
+
             extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
             extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);
         }

--- a/osu.Game/Rulesets/UI/ModSwitchSmall.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchSmall.cs
@@ -88,12 +88,10 @@ namespace osu.Game.Rulesets.UI
             var modTypeColour = colours.ForModType(mod.Type);
 
             inactiveForegroundColour = colourProvider?.Background5 ?? colours.Gray3;
-            activeForegroundColour = mod.Type != ModType.System ? modTypeColour : colours.Yellow;
+            activeForegroundColour = modTypeColour;
 
             inactiveBackgroundColour = colourProvider?.Background2 ?? colours.Gray5;
-            activeBackgroundColour = mod.Type != ModType.System
-                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1)
-                : modTypeColour;
+            activeBackgroundColour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Rulesets/UI/ModSwitchSmall.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchSmall.cs
@@ -85,11 +85,15 @@ namespace osu.Game.Rulesets.UI
                 tinySwitch.Scale = new Vector2(0.3f);
             }
 
+            var modTypeColour = colours.ForModType(mod.Type);
+
             inactiveForegroundColour = colourProvider?.Background5 ?? colours.Gray3;
-            activeForegroundColour = colours.ForModType(mod.Type);
+            activeForegroundColour = mod.Type != ModType.System ? modTypeColour : colours.Yellow;
 
             inactiveBackgroundColour = colourProvider?.Background2 ?? colours.Gray5;
-            activeBackgroundColour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, activeForegroundColour, 0, 1);
+            activeBackgroundColour = mod.Type != ModType.System
+                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1)
+                : modTypeColour;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Rulesets/UI/ModSwitchTiny.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchTiny.cs
@@ -106,11 +106,15 @@ namespace osu.Game.Rulesets.UI
         [BackgroundDependencyLoader(true)]
         private void load(OsuColour colours, OverlayColourProvider? colourProvider)
         {
+            var modTypeColour = colours.ForModType(Mod.Type);
+
             inactiveBackgroundColour = colourProvider?.Background5 ?? colours.Gray3;
             activeBackgroundColour = colours.ForModType(Mod.Type);
 
             inactiveForegroundColour = colourProvider?.Background2 ?? colours.Gray5;
-            activeForegroundColour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, activeForegroundColour, 0, 1);
+            activeForegroundColour = Mod.Type != ModType.System
+                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, activeForegroundColour, 0, 1)
+                : colours.Yellow;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Rulesets/UI/ModSwitchTiny.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchTiny.cs
@@ -109,11 +109,11 @@ namespace osu.Game.Rulesets.UI
             var modTypeColour = colours.ForModType(Mod.Type);
 
             inactiveBackgroundColour = colourProvider?.Background5 ?? colours.Gray3;
-            activeBackgroundColour = colours.ForModType(Mod.Type);
+            activeBackgroundColour = modTypeColour;
 
             inactiveForegroundColour = colourProvider?.Background2 ?? colours.Gray5;
             activeForegroundColour = Mod.Type != ModType.System
-                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, activeForegroundColour, 0, 1)
+                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1)
                 : colours.Yellow;
         }
 

--- a/osu.Game/Rulesets/UI/ModSwitchTiny.cs
+++ b/osu.Game/Rulesets/UI/ModSwitchTiny.cs
@@ -112,9 +112,7 @@ namespace osu.Game.Rulesets.UI
             activeBackgroundColour = modTypeColour;
 
             inactiveForegroundColour = colourProvider?.Background2 ?? colours.Gray5;
-            activeForegroundColour = Mod.Type != ModType.System
-                ? Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1)
-                : colours.Yellow;
+            activeForegroundColour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, modTypeColour, 0, 1);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Reasoning: https://github.com/ppy/osu/pull/25348#discussion_r1382988284

| | master | this PR |
| :- | :-: | :-: |
| `ModIcon` | ![1699266949](https://github.com/ppy/osu/assets/20418176/aa7ff913-c50b-40d2-8ac9-3133df942022) | ![1699267352](https://github.com/ppy/osu/assets/20418176/3802f6d2-d8c6-4cbc-acda-d28b3296c032) |
| `ModSwitchSmall` (inactive) | ![1699266960](https://github.com/ppy/osu/assets/20418176/9390df70-47bc-4c44-9eb8-35db61c375b3) | ![1699267359](https://github.com/ppy/osu/assets/20418176/29f2ea04-cf6f-4dbe-8857-5fcb0bae817b) |
| `ModSwitchSmall` (active) | ![1699266964](https://github.com/ppy/osu/assets/20418176/e5461a4a-62e5-41b8-a897-92bba0e675b9) | ![1699267362](https://github.com/ppy/osu/assets/20418176/4a9ea869-bca9-4534-97a2-5438c8c009fc) |
| `ModSwitchTiny` (inactive) | ![1699266971](https://github.com/ppy/osu/assets/20418176/f84a5a8a-082c-42a2-9ede-bcf698dc0181) | ![1699267370](https://github.com/ppy/osu/assets/20418176/c638e6e8-768f-4725-b445-bf384bb2f5d0) |
| `ModSwitchTiny` (active) | ![1699266974](https://github.com/ppy/osu/assets/20418176/3a1dae42-1143-4e9a-8314-cdd348167596) | ![1699267373](https://github.com/ppy/osu/assets/20418176/776299ef-1fec-4e7b-b965-f90b9612dfea) |