### PR TITLE
Ensure `BarGraph`'s draw quad is thick enough

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
@@ -13,10 +13,10 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public partial class TestSceneGraph : OsuTestScene
     {
-        private readonly BarGraph graph;
-
         public TestSceneGraph()
         {
+            BarGraph graph;
+
             Child = graph = new BarGraph
             {
                 RelativeSizeAxes = Axes.Both,
@@ -34,13 +34,14 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Top to bottom", () => graph.Direction = BarDirection.TopToBottom);
             AddStep("Left to right", () => graph.Direction = BarDirection.LeftToRight);
             AddStep("Right to left", () => graph.Direction = BarDirection.RightToLeft);
-        }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            graph.MoveToY(-10, 1000).Then().MoveToY(10, 1000).Loop();
+            AddToggleStep("Toggle movement", enabled =>
+            {
+                if (enabled)
+                    graph.MoveToY(-10, 1000).Then().MoveToY(10, 1000).Loop();
+                else
+                    graph.ClearTransforms();
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneGraph.cs
@@ -13,22 +13,20 @@ namespace osu.Game.Tests.Visual.Online
     [TestFixture]
     public partial class TestSceneGraph : OsuTestScene
     {
+        private readonly BarGraph graph;
+
         public TestSceneGraph()
         {
-            BarGraph graph;
-
-            Children = new[]
+            Child = graph = new BarGraph
             {
-                graph = new BarGraph
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Size = new Vector2(0.5f),
-                },
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(0.5f),
             };
 
             AddStep("values from 1-10", () => graph.Values = Enumerable.Range(1, 10).Select(i => (float)i));
+            AddStep("small values", () => graph.Values = Enumerable.Range(1, 10).Select(i => i * 0.01f).Concat(new[] { 100f }));
             AddStep("values from 1-100", () => graph.Values = Enumerable.Range(1, 100).Select(i => (float)i));
             AddStep("reversed values from 1-10", () => graph.Values = Enumerable.Range(1, 10).Reverse().Select(i => (float)i));
             AddStep("empty values", () => graph.Values = Array.Empty<float>());
@@ -36,6 +34,13 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Top to bottom", () => graph.Direction = BarDirection.TopToBottom);
             AddStep("Left to right", () => graph.Direction = BarDirection.LeftToRight);
             AddStep("Right to left", () => graph.Direction = BarDirection.RightToLeft);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            graph.MoveToY(-10, 1000).Then().MoveToY(10, 1000).Loop();
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Graphics.UserInterface
                     if (barHeight == 0 || barWidth == 0)
                         continue;
 
-                    // Make sure draw quad is thick enough
+                    // Apply minimum sizing to hide the fact that we don't have fractional anti-aliasing.
                     barHeight = Math.Max(barHeight, 1.5f);
                     barWidth = Math.Max(barWidth, 1.5f);
 

--- a/osu.Game/Graphics/UserInterface/BarGraph.cs
+++ b/osu.Game/Graphics/UserInterface/BarGraph.cs
@@ -145,6 +145,13 @@ namespace osu.Game.Graphics.UserInterface
                     float barHeight = drawSize.Y * ((direction == BarDirection.TopToBottom || direction == BarDirection.BottomToTop) ? lengths[i] : barBreadth);
                     float barWidth = drawSize.X * ((direction == BarDirection.LeftToRight || direction == BarDirection.RightToLeft) ? lengths[i] : barBreadth);
 
+                    if (barHeight == 0 || barWidth == 0)
+                        continue;
+
+                    // Make sure draw quad is thick enough
+                    barHeight = Math.Max(barHeight, 1.5f);
+                    barWidth = Math.Max(barWidth, 1.5f);
+
                     Vector2 topLeft;
 
                     switch (direction)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25324

At first I was going to just add inflation, but that makes flat side of the graph "bumpy" in places where smoothing intersects between bars:
![Снимок экрана (61)](https://github.com/ppy/osu/assets/22874522/7fa65786-6203-4f12-af77-14aadc113666)
![Снимок экрана (60)](https://github.com/ppy/osu/assets/22874522/245265a7-3d8f-4e23-9c66-a959ea91cf2c)

As an alternative I've decided to just ensure that draw quad isn't trying to draw quads smaller than 1.5px (unless it's 0 of course). Not a perfect solution, in some cases flickering is still there, but I'm not sure about alternatives (or the way to remove this "bumpyness").
Test scene has been adjusted to include graph movement in case you want to compare before and after.
![Снимок экрана (62)](https://github.com/ppy/osu/assets/22874522/6504a3bb-b333-44ac-bf7a-8ff8d8958201)