### PR TITLE
SFX improvements for `ButtonSystem`/`MainMenu`

### DIFF
--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -267,7 +267,6 @@ namespace osu.Game.Screens.Menu
                     // Samples are explicitly played here in response to user interaction and not when transitioning due to idle.
                     StopSamplePlayback();
                     sampleBackToLogo?.Play();
-                    sampleLogoSwoosh?.Play();
 
                     return true;
 
@@ -362,6 +361,9 @@ namespace osu.Game.Screens.Menu
                         logo?.MoveTo(new Vector2(0.5f), 800, Easing.OutExpo);
                         logo?.ScaleTo(1, 800, Easing.OutExpo);
                     }, buttonArea.Alpha * 150);
+
+                    if (lastState == ButtonSystemState.TopLevel)
+                        sampleLogoSwoosh?.Play();
                     break;
 
                 case ButtonSystemState.TopLevel:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -199,6 +199,7 @@ namespace osu.Game.Screens.Menu
         {
             if (State == ButtonSystemState.Initial)
             {
+                StopSamplePlayback();
                 logo?.TriggerClick();
                 return true;
             }
@@ -264,18 +265,27 @@ namespace osu.Game.Screens.Menu
                     State = ButtonSystemState.Initial;
 
                     // Samples are explicitly played here in response to user interaction and not when transitioning due to idle.
+                    StopSamplePlayback();
                     sampleBackToLogo?.Play();
                     sampleLogoSwoosh?.Play();
 
                     return true;
 
                 case ButtonSystemState.Play:
+                    StopSamplePlayback();
                     backButton.TriggerClick();
                     return true;
 
                 default:
                     return false;
             }
+        }
+
+        public void StopSamplePlayback()
+        {
+            buttonsPlay.ForEach(button => button.StopSamplePlayback());
+            buttonsTopLevel.ForEach(button => button.StopSamplePlayback());
+            logo?.StopSamplePlayback();
         }
 
         private bool onOsuLogo()

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -86,6 +86,7 @@ namespace osu.Game.Screens.Menu
         private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
 
         private Sample sampleBackToLogo;
+        private Sample sampleLogoSwoosh;
 
         private readonly LogoTrackingContainer logoTrackingContainer;
 
@@ -156,6 +157,7 @@ namespace osu.Game.Screens.Menu
             if (idleTracker != null) isIdle.BindTo(idleTracker.IsIdle);
 
             sampleBackToLogo = audio.Samples.Get(@"Menu/back-to-logo");
+            sampleLogoSwoosh = audio.Samples.Get(@"Menu/osu-logo-swoosh");
         }
 
         private void onMultiplayer()
@@ -263,6 +265,8 @@ namespace osu.Game.Screens.Menu
 
                     // Samples are explicitly played here in response to user interaction and not when transitioning due to idle.
                     sampleBackToLogo?.Play();
+                    sampleLogoSwoosh?.Play();
+
                     return true;
 
                 case ButtonSystemState.Play:

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -127,14 +127,14 @@ namespace osu.Game.Screens.Menu
         [BackgroundDependencyLoader(true)]
         private void load(AudioManager audio, IdleTracker idleTracker, GameHost host)
         {
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-solo-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-generic-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M));
-            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-generic-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists, 0, Key.L));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Solo, @"button-default-select", FontAwesome.Solid.User, new Color4(102, 68, 204, 255), () => OnSolo?.Invoke(), WEDGE_WIDTH, Key.P));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Multi, @"button-default-select", FontAwesome.Solid.Users, new Color4(94, 63, 186, 255), onMultiplayer, 0, Key.M));
+            buttonsPlay.Add(new MainMenuButton(ButtonSystemStrings.Playlists, @"button-default-select", OsuIcon.Charts, new Color4(94, 63, 186, 255), onPlaylists, 0, Key.L));
             buttonsPlay.ForEach(b => b.VisibleState = ButtonSystemState.Play);
 
             buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Play, @"button-play-select", OsuIcon.Logo, new Color4(102, 68, 204, 255), () => State = ButtonSystemState.Play, WEDGE_WIDTH, Key.P));
-            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-edit-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
-            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-direct-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(), 0, Key.B, Key.D));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Edit, @"button-default-select", OsuIcon.EditCircle, new Color4(238, 170, 0, 255), () => OnEdit?.Invoke(), 0, Key.E));
+            buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Browse, @"button-default-select", OsuIcon.ChevronDownCircle, new Color4(165, 204, 0, 255), () => OnBeatmapListing?.Invoke(), 0, Key.B, Key.D));
 
             if (host.CanExit)
                 buttonsTopLevel.Add(new MainMenuButton(ButtonSystemStrings.Exit, string.Empty, OsuIcon.CrossCircle, new Color4(238, 51, 153, 255), () => OnExit?.Invoke(), 0, Key.Q));

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Menu
         private readonly List<MainMenuButton> buttonsTopLevel = new List<MainMenuButton>();
         private readonly List<MainMenuButton> buttonsPlay = new List<MainMenuButton>();
 
-        private Sample sampleBack;
+        private Sample sampleBackToLogo;
 
         private readonly LogoTrackingContainer logoTrackingContainer;
 
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Menu
             buttonArea.AddRange(new Drawable[]
             {
                 new MainMenuButton(ButtonSystemStrings.Settings, string.Empty, FontAwesome.Solid.Cog, new Color4(85, 85, 85, 255), () => OnSettings?.Invoke(), -WEDGE_WIDTH, Key.O),
-                backButton = new MainMenuButton(ButtonSystemStrings.Back, @"button-back-select", OsuIcon.LeftCircle, new Color4(51, 58, 94, 255), () => State = ButtonSystemState.TopLevel,
+                backButton = new MainMenuButton(ButtonSystemStrings.Back, @"back-to-top", OsuIcon.LeftCircle, new Color4(51, 58, 94, 255), () => State = ButtonSystemState.TopLevel,
                     -WEDGE_WIDTH)
                 {
                     VisibleState = ButtonSystemState.Play,
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Menu
 
             if (idleTracker != null) isIdle.BindTo(idleTracker.IsIdle);
 
-            sampleBack = audio.Samples.Get(@"Menu/button-back-select");
+            sampleBackToLogo = audio.Samples.Get(@"Menu/back-to-logo");
         }
 
         private void onMultiplayer()
@@ -260,7 +260,9 @@ namespace osu.Game.Screens.Menu
             {
                 case ButtonSystemState.TopLevel:
                     State = ButtonSystemState.Initial;
-                    sampleBack?.Play();
+
+                    // Samples are explicitly played here in response to user interaction and not when transitioning due to idle.
+                    sampleBackToLogo?.Play();
                     return true;
 
                 case ButtonSystemState.Play:

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -297,6 +297,8 @@ namespace osu.Game.Screens.Menu
         {
             base.OnResuming(e);
 
+            // Ensures any playing `ButtonSystem` samples are stopped when returning to MainMenu (as to not overlap with the 'back' sample)
+            Buttons.StopSamplePlayback();
             reappearSampleSwoosh?.Play();
 
             ApplyToBackground(b => (b as BackgroundScreenDefault)?.Next());

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -7,6 +7,8 @@ using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -89,8 +91,10 @@ namespace osu.Game.Screens.Menu
         private SongTicker songTicker;
         private Container logoTarget;
 
+        private Sample reappearSampleSwoosh;
+
         [BackgroundDependencyLoader(true)]
-        private void load(BeatmapListingOverlay beatmapListing, SettingsOverlay settings, OsuConfigManager config, SessionStatics statics)
+        private void load(BeatmapListingOverlay beatmapListing, SettingsOverlay settings, OsuConfigManager config, SessionStatics statics, AudioManager audio)
         {
             holdDelay = config.GetBindable<double>(OsuSetting.UIHoldActivationDelay);
             loginDisplayed = statics.GetBindable<bool>(Static.LoginOverlayDisplayed);
@@ -161,6 +165,8 @@ namespace osu.Game.Screens.Menu
 
             Buttons.OnSettings = () => settings?.ToggleVisibility();
             Buttons.OnBeatmapListing = () => beatmapListing?.ToggleVisibility();
+
+            reappearSampleSwoosh = audio.Samples.Get(@"Menu/reappear-swoosh");
 
             preloadSongSelect();
         }
@@ -290,6 +296,8 @@ namespace osu.Game.Screens.Menu
         public override void OnResuming(ScreenTransitionEvent e)
         {
             base.OnResuming(e);
+
+            reappearSampleSwoosh?.Play();
 
             ApplyToBackground(b => (b as BackgroundScreenDefault)?.Next());
 

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -51,6 +51,7 @@ namespace osu.Game.Screens.Menu
         private readonly Action clickAction;
         private Sample sampleClick;
         private Sample sampleHover;
+        private SampleChannel sampleChannel;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => box.ReceivePositionalInputAt(screenSpacePos);
 
@@ -225,7 +226,8 @@ namespace osu.Game.Screens.Menu
 
         private void trigger()
         {
-            sampleClick?.Play();
+            sampleChannel = sampleClick?.GetChannel();
+            sampleChannel?.Play();
 
             clickAction?.Invoke();
 
@@ -236,6 +238,8 @@ namespace osu.Game.Screens.Menu
 
         public override bool HandleNonPositionalInput => state == ButtonState.Expanded;
         public override bool HandlePositionalInput => state != ButtonState.Exploded && box.Scale.X >= 0.8f;
+
+        public void StopSamplePlayback() => sampleChannel?.Stop();
 
         protected override void Update()
         {

--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -52,6 +52,8 @@ namespace osu.Game.Screens.Menu
         private readonly IntroSequence intro;
 
         private Sample sampleClick;
+        private SampleChannel sampleClickChannel;
+
         private Sample sampleBeat;
         private Sample sampleDownbeat;
 
@@ -391,7 +393,11 @@ namespace osu.Game.Screens.Menu
             flashLayer.FadeOut(1500, Easing.OutExpo);
 
             if (Action?.Invoke() == true)
-                sampleClick.Play();
+            {
+                StopSamplePlayback();
+                sampleClickChannel = sampleClick.GetChannel();
+                sampleClickChannel.Play();
+            }
 
             return true;
         }
@@ -439,6 +445,8 @@ namespace osu.Game.Screens.Menu
         private Container defaultProxyTarget;
         private Container currentProxyTarget;
         private Drawable proxy;
+
+        public void StopSamplePlayback() => sampleClickChannel?.Stop();
 
         public Drawable ProxyToContainer(Container c)
         {

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.1030.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1023.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1109.0" />
     <PackageReference Include="Sentry" Version="3.40.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.33.0" />


### PR DESCRIPTION
- Updates references to renamed/replaced samples in `ButtonSystem` (`Menu/button-default-select` replacing `Menu/button-{solo,generic,edit,direct}-select`, which used to be duplicates)
- Adds tiered 'back' samples (i.e. play different 'back' samples depending on what level of menu the player is returning from)
- Adds swooshes to match `MainMenu` animations (when reappearing, going back to logo)
- Implements sample 'choking' or 'muting' for `ButtonSystem` sample playback (to allow for using select longer samples without having them overlap with each other)

Makes the main menu feel a bit more polished IMO while also reducing the ability to spike playback volume by spamming stuff.


https://github.com/ppy/osu/assets/272140/2b63db56-0e50-4498-9d41-5c640ec0f8a3



- [x] Depends on ppy/osu-resources#290