### PR TITLE
Add support for adjusting size of skin elements

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             SelectionBox.CanFlipX = SelectionBox.CanScaleX = quad.Width > 0;
             SelectionBox.CanFlipY = SelectionBox.CanScaleY = quad.Height > 0;
+            SelectionBox.CanScaleProportionally = SelectionBox.CanScaleX && SelectionBox.CanScaleY;
             SelectionBox.CanReverse = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             SelectionBox.CanFlipX = SelectionBox.CanScaleX = quad.Width > 0;
             SelectionBox.CanFlipY = SelectionBox.CanScaleY = quad.Height > 0;
-            SelectionBox.CanScaleProportionally = SelectionBox.CanScaleX && SelectionBox.CanScaleY;
+            SelectionBox.CanScaleDiagonally = SelectionBox.CanScaleX && SelectionBox.CanScaleY;
             SelectionBox.CanReverse = EditorBeatmap.SelectedHitObjects.Count > 1 || EditorBeatmap.SelectedHitObjects.Any(s => s is Slider);
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -47,6 +47,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                         CanScaleX = true,
                         CanScaleY = true,
+                        CanScaleProportionally = true,
                         CanFlipX = true,
                         CanFlipY = true,
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Tests.Visual.Editing
 
                         CanScaleX = true,
                         CanScaleY = true,
-                        CanScaleProportionally = true,
+                        CanScaleDiagonally = true,
                         CanFlipX = true,
                         CanFlipY = true,
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -47,12 +47,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                 };
             });
 
-            AddSliderStep("Width", 0, 1f, 1f, val =>
-            {
-                if (healthDisplay.IsNotNull())
-                    healthDisplay.BarLength.Value = val;
-            });
-
             AddSliderStep("Height", 0, 64, 0, val =>
             {
                 if (healthDisplay.IsNotNull())

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -4,6 +4,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Unicode;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -214,7 +217,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("Press undo", () => InputManager.Keys(PlatformAction.Undo));
-            AddAssert("Nothing changed", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
+
+            AddAssert("Nothing changed",
+                () => JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(defaultState)),
+                () => Is.EqualTo(JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(changeHandler.GetCurrentState())))
+            );
 
             AddStep("Add components", () =>
             {
@@ -243,7 +250,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             void revertAndCheckUnchanged()
             {
                 AddStep("Revert changes", () => changeHandler.RestoreState(int.MinValue));
-                AddAssert("Current state is same as default", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
+
+                AddAssert("Current state is same as default",
+                    () => JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(defaultState)),
+                    () => Is.EqualTo(JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(changeHandler.GetCurrentState())))
+                );
             }
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -243,7 +244,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             void revertAndCheckUnchanged()
             {
                 AddStep("Revert changes", () => changeHandler.RestoreState(int.MinValue));
-                AddAssert("Current state is same as default", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
+                AddAssert("Current state is same as default",
+                    () => Encoding.UTF8.GetString(defaultState),
+                    () => Is.EqualTo(Encoding.UTF8.GetString(changeHandler.GetCurrentState())));
             }
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -216,11 +214,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddStep("Press undo", () => InputManager.Keys(PlatformAction.Undo));
-
-            AddAssert("Nothing changed",
-                () => JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(defaultState)),
-                () => Is.EqualTo(JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(changeHandler.GetCurrentState())))
-            );
+            AddAssert("Nothing changed", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
 
             AddStep("Add components", () =>
             {
@@ -249,11 +243,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             void revertAndCheckUnchanged()
             {
                 AddStep("Revert changes", () => changeHandler.RestoreState(int.MinValue));
-
-                AddAssert("Current state is same as default",
-                    () => JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(defaultState)),
-                    () => Is.EqualTo(JsonConvert.DeserializeObject<IEnumerable<SerialisedDrawableInfo>>(Encoding.UTF8.GetString(changeHandler.GetCurrentState())))
-                );
+                AddAssert("Current state is same as default", () => defaultState.SequenceEqual(changeHandler.GetCurrentState()));
             }
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.Unicode;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -252,8 +252,11 @@ namespace osu.Game.Overlays.SkinEditor
                 {
                     var blueprintItem = ((Drawable)blueprint.Item);
                     blueprintItem.Scale = Vector2.One;
-                    if (RelativeSizeAxes == Axes.Both)
-                        blueprintItem.Size = Vector2.One;
+
+                    if (blueprintItem.RelativeSizeAxes.HasFlagFast(Axes.X))
+                        blueprintItem.Width = 1;
+                    if (blueprintItem.RelativeSizeAxes.HasFlagFast(Axes.Y))
+                        blueprintItem.Height = 1;
                 }
             });
 

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -221,7 +221,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             SelectionBox.CanScaleX = allSelectedSupportManualSizing(Axes.X);
             SelectionBox.CanScaleY = allSelectedSupportManualSizing(Axes.Y);
-            SelectionBox.CanScaleProportionally = true;
+            SelectionBox.CanScaleDiagonally = true;
             SelectionBox.CanFlipX = true;
             SelectionBox.CanFlipY = true;
             SelectionBox.CanReverse = false;

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -249,7 +249,12 @@ namespace osu.Game.Overlays.SkinEditor
             yield return new OsuMenuItem("Reset scale", MenuItemType.Standard, () =>
             {
                 foreach (var blueprint in SelectedBlueprints)
-                    ((Drawable)blueprint.Item).Scale = Vector2.One;
+                {
+                    var blueprintItem = ((Drawable)blueprint.Item);
+                    blueprintItem.Scale = Vector2.One;
+                    if (RelativeSizeAxes == Axes.Both)
+                        blueprintItem.Size = Vector2.One;
+                }
             });
 
             yield return new EditorMenuItemSpacer();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -91,6 +91,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
+        private bool canScaleProportionally;
+
+        /// <summary>
+        /// Whether vertical scaling support should be enabled.
+        /// </summary>
+        public bool CanScaleProportionally
+        {
+            get => canScaleProportionally;
+            set
+            {
+                if (canScaleProportionally == value) return;
+
+                canScaleProportionally = value;
+                recreate();
+            }
+        }
+
         private bool canFlipX;
 
         /// <summary>
@@ -245,7 +262,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
 
             if (CanScaleX) addXScaleComponents();
-            if (CanScaleX && CanScaleY) addFullScaleComponents();
+            if (CanScaleProportionally) addFullScaleComponents();
             if (CanScaleY) addYScaleComponents();
             if (CanFlipX) addXFlipComponents();
             if (CanFlipY) addYFlipComponents();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool canScaleX;
 
         /// <summary>
-        /// Whether horizontal scaling support should be enabled.
+        /// Whether horizontal scaling (from the left or right edge) support should be enabled.
         /// </summary>
         public bool CanScaleX
         {
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         private bool canScaleY;
 
         /// <summary>
-        /// Whether vertical scaling support should be enabled.
+        /// Whether vertical scaling (from the top or bottom edge) support should be enabled.
         /// </summary>
         public bool CanScaleY
         {
@@ -91,19 +91,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
             }
         }
 
-        private bool canScaleProportionally;
+        private bool canScaleDiagonally;
 
         /// <summary>
-        /// Whether vertical scaling support should be enabled.
+        /// Whether diagonal scaling (from a corner) support should be enabled.
         /// </summary>
-        public bool CanScaleProportionally
+        /// <remarks>
+        /// There are some cases where we only want to allow proportional resizing, and not allow
+        /// one or both explicit directions of scale.
+        /// </remarks>
+        public bool CanScaleDiagonally
         {
-            get => canScaleProportionally;
+            get => canScaleDiagonally;
             set
             {
-                if (canScaleProportionally == value) return;
+                if (canScaleDiagonally == value) return;
 
-                canScaleProportionally = value;
+                canScaleDiagonally = value;
                 recreate();
             }
         }
@@ -262,7 +266,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
 
             if (CanScaleX) addXScaleComponents();
-            if (CanScaleProportionally) addFullScaleComponents();
+            if (CanScaleDiagonally) addFullScaleComponents();
             if (CanScaleY) addYScaleComponents();
             if (CanFlipX) addXFlipComponents();
             if (CanFlipY) addYFlipComponents();

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -35,14 +35,6 @@ namespace osu.Game.Screens.Play.HUD
             Precision = 1
         };
 
-        [SettingSource("Bar length")]
-        public BindableFloat BarLength { get; } = new BindableFloat(0.98f)
-        {
-            MinValue = 0.2f,
-            MaxValue = 1,
-            Precision = 0.01f,
-        };
-
         private BarPath mainBar = null!;
 
         /// <summary>
@@ -140,7 +132,6 @@ namespace osu.Game.Screens.Play.HUD
 
             Current.BindValueChanged(_ => Scheduler.AddOnce(updateCurrent), true);
 
-            BarLength.BindValueChanged(l => Width = l.NewValue, true);
             BarHeight.BindValueChanged(_ => updatePath());
             updatePath();
         }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Screens.Play.HUD
         private readonly ArgonSongProgressGraph graph;
         private readonly ArgonSongProgressBar bar;
         private readonly Container graphContainer;
+        private readonly Container content;
 
         private const float bar_height = 10;
 
@@ -30,43 +31,50 @@ namespace osu.Game.Screens.Play.HUD
 
         public ArgonSongProgress()
         {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
             Anchor = Anchor.BottomCentre;
             Origin = Anchor.BottomCentre;
             Masking = true;
             CornerRadius = 5;
-            Children = new Drawable[]
+
+            Child = content = new Container
             {
-                info = new SongProgressInfo
+                RelativeSizeAxes = Axes.X,
+                Children = new Drawable[]
                 {
-                    Origin = Anchor.TopLeft,
-                    Name = "Info",
-                    Anchor = Anchor.TopLeft,
-                    RelativeSizeAxes = Axes.X,
-                    ShowProgress = false
-                },
-                bar = new ArgonSongProgressBar(bar_height)
-                {
-                    Name = "Seek bar",
-                    Origin = Anchor.BottomLeft,
-                    Anchor = Anchor.BottomLeft,
-                    OnSeek = time => player?.Seek(time),
-                },
-                graphContainer = new Container
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    Masking = true,
-                    CornerRadius = 5,
-                    Child = graph = new ArgonSongProgressGraph
+                    info = new SongProgressInfo
                     {
-                        Name = "Difficulty graph",
-                        RelativeSizeAxes = Axes.Both,
-                        Blending = BlendingParameters.Additive
+                        Origin = Anchor.TopLeft,
+                        Name = "Info",
+                        Anchor = Anchor.TopLeft,
+                        RelativeSizeAxes = Axes.X,
+                        ShowProgress = false
                     },
-                    RelativeSizeAxes = Axes.X,
-                },
+                    bar = new ArgonSongProgressBar(bar_height)
+                    {
+                        Name = "Seek bar",
+                        Origin = Anchor.BottomLeft,
+                        Anchor = Anchor.BottomLeft,
+                        OnSeek = time => player?.Seek(time),
+                    },
+                    graphContainer = new Container
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Masking = true,
+                        CornerRadius = 5,
+                        Child = graph = new ArgonSongProgressGraph
+                        {
+                            Name = "Difficulty graph",
+                            RelativeSizeAxes = Axes.Both,
+                            Blending = BlendingParameters.Additive
+                        },
+                        RelativeSizeAxes = Axes.X,
+                    },
+                }
             };
-            RelativeSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader]
@@ -100,7 +108,7 @@ namespace osu.Game.Screens.Play.HUD
         protected override void Update()
         {
             base.Update();
-            Height = bar.Height + bar_height + info.Height;
+            content.Height = bar.Height + bar_height + info.Height;
             graphContainer.Height = bar.Height;
         }
 

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -27,6 +28,7 @@ namespace osu.Game.Screens.Play.HUD
         private readonly DefaultSongProgressBar bar;
         private readonly DefaultSongProgressGraph graph;
         private readonly SongProgressInfo info;
+        private readonly Container content;
 
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowGraph), nameof(SongProgressStrings.ShowGraphDescription))]
         public Bindable<bool> ShowGraph { get; } = new BindableBool(true);
@@ -37,31 +39,36 @@ namespace osu.Game.Screens.Play.HUD
         public DefaultSongProgress()
         {
             RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
             Anchor = Anchor.BottomRight;
             Origin = Anchor.BottomRight;
 
-            Children = new Drawable[]
+            Child = content = new Container
             {
-                info = new SongProgressInfo
+                RelativeSizeAxes = Axes.X,
+                Children = new Drawable[]
                 {
-                    Origin = Anchor.BottomLeft,
-                    Anchor = Anchor.BottomLeft,
-                    RelativeSizeAxes = Axes.X,
-                },
-                graph = new DefaultSongProgressGraph
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Origin = Anchor.BottomLeft,
-                    Anchor = Anchor.BottomLeft,
-                    Height = graph_height,
-                    Margin = new MarginPadding { Bottom = bottom_bar_height },
-                },
-                bar = new DefaultSongProgressBar(bottom_bar_height, graph_height, handle_size)
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    OnSeek = time => player?.Seek(time),
-                },
+                    info = new SongProgressInfo
+                    {
+                        Origin = Anchor.BottomLeft,
+                        Anchor = Anchor.BottomLeft,
+                        RelativeSizeAxes = Axes.X,
+                    },
+                    graph = new DefaultSongProgressGraph
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Origin = Anchor.BottomLeft,
+                        Anchor = Anchor.BottomLeft,
+                        Height = graph_height,
+                        Margin = new MarginPadding { Bottom = bottom_bar_height },
+                    },
+                    bar = new DefaultSongProgressBar(bottom_bar_height, graph_height, handle_size)
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        OnSeek = time => player?.Seek(time),
+                    },
+                }
             };
         }
 
@@ -107,7 +114,7 @@ namespace osu.Game.Screens.Play.HUD
             float newHeight = bottom_bar_height + graph_height + handle_size.Y + info.Height - graph.Y;
 
             if (!Precision.AlmostEquals(Height, newHeight, 5f))
-                Height = newHeight;
+                content.Height = newHeight;
         }
 
         private void updateBarVisibility()

--- a/osu.Game/Skinning/LegacySongProgress.cs
+++ b/osu.Game/Skinning/LegacySongProgress.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Skinning
         public LegacySongProgress()
         {
             // User shouldn't be able to adjust width/height of this as `CircularProgress` doesn't
-            // handle stretched cases ell.
+            // handle stretched cases well.
             AutoSizeAxes = Axes.Both;
         }
 

--- a/osu.Game/Skinning/LegacySongProgress.cs
+++ b/osu.Game/Skinning/LegacySongProgress.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Skinning
 
         public LegacySongProgress()
         {
+            // User shouldn't be able to adjust width/height of this as `CircularProgress` doesn't
+            // handle stretched cases ell.
             AutoSizeAxes = Axes.Both;
         }
 

--- a/osu.Game/Skinning/LegacySongProgress.cs
+++ b/osu.Game/Skinning/LegacySongProgress.cs
@@ -19,11 +19,14 @@ namespace osu.Game.Skinning
         public override bool HandleNonPositionalInput => false;
         public override bool HandlePositionalInput => false;
 
+        public LegacySongProgress()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
-            Size = new Vector2(33);
-
             InternalChildren = new Drawable[]
             {
                 new Container
@@ -39,7 +42,7 @@ namespace osu.Game.Skinning
                 },
                 new CircularContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(33),
                     Masking = true,
                     BorderColour = Colour4.White,
                     BorderThickness = 2,

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
@@ -19,8 +20,10 @@ namespace osu.Game.Skinning
             // todo: can probably make this better via deserialisation directly using a common interface.
             component.Position = drawableInfo.Position;
             component.Rotation = drawableInfo.Rotation;
-            if (drawableInfo.Size != Vector2.Zero && (component as CompositeDrawable)?.AutoSizeAxes == Axes.None)
-                component.Size = drawableInfo.Size;
+            if (drawableInfo.Width is float width && width != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.X) == false)
+                component.Width = width;
+            if (drawableInfo.Height is float height && height != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.Y) == false)
+                component.Height = height;
             component.Scale = drawableInfo.Scale;
             component.Anchor = drawableInfo.Anchor;
             component.Origin = drawableInfo.Origin;

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
+using osuTK;
 
 namespace osu.Game.Skinning
 {
@@ -18,6 +19,8 @@ namespace osu.Game.Skinning
             // todo: can probably make this better via deserialisation directly using a common interface.
             component.Position = drawableInfo.Position;
             component.Rotation = drawableInfo.Rotation;
+            if (drawableInfo.Size != Vector2.Zero && (component as CompositeDrawable)?.AutoSizeAxes == Axes.None)
+                component.Size = drawableInfo.Size;
             component.Scale = drawableInfo.Scale;
             component.Anchor = drawableInfo.Anchor;
             component.Origin = drawableInfo.Origin;

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -19,9 +19,9 @@ namespace osu.Game.Skinning
             // todo: can probably make this better via deserialisation directly using a common interface.
             component.Position = drawableInfo.Position;
             component.Rotation = drawableInfo.Rotation;
-            if (drawableInfo.Width is float width && width != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.X) == false)
+            if (drawableInfo.Width is float width && width != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.X) != true)
                 component.Width = width;
-            if (drawableInfo.Height is float height && height != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.Y) == false)
+            if (drawableInfo.Height is float height && height != 0 && (component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.Y) != true)
                 component.Height = height;
             component.Scale = drawableInfo.Scale;
             component.Anchor = drawableInfo.Anchor;

--- a/osu.Game/Skinning/SerialisableDrawableExtensions.cs
+++ b/osu.Game/Skinning/SerialisableDrawableExtensions.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
-using osuTK;
 
 namespace osu.Game.Skinning
 {

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -35,7 +35,9 @@ namespace osu.Game.Skinning
 
         public Vector2 Scale { get; set; }
 
-        public Vector2 Size { get; set; }
+        public float? Width { get; set; }
+
+        public float? Height { get; set; }
 
         public Anchor Anchor { get; set; }
 
@@ -64,7 +66,8 @@ namespace osu.Game.Skinning
             Position = component.Position;
             Rotation = component.Rotation;
             Scale = component.Scale;
-            Size = component.Size;
+            Height = component.Height;
+            Width = component.Width;
             Anchor = component.Anchor;
             Origin = component.Origin;
 

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -35,6 +35,8 @@ namespace osu.Game.Skinning
 
         public Vector2 Scale { get; set; }
 
+        public Vector2 Size { get; set; }
+
         public Anchor Anchor { get; set; }
 
         public Anchor Origin { get; set; }
@@ -62,6 +64,7 @@ namespace osu.Game.Skinning
             Position = component.Position;
             Rotation = component.Rotation;
             Scale = component.Scale;
+            Size = component.Size;
             Anchor = component.Anchor;
             Origin = component.Origin;
 

--- a/osu.Game/Skinning/SerialisedDrawableInfo.cs
+++ b/osu.Game/Skinning/SerialisedDrawableInfo.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -66,8 +67,13 @@ namespace osu.Game.Skinning
             Position = component.Position;
             Rotation = component.Rotation;
             Scale = component.Scale;
-            Height = component.Height;
-            Width = component.Width;
+
+            if ((component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.X) != true)
+                Width = component.Width;
+
+            if ((component as CompositeDrawable)?.AutoSizeAxes.HasFlagFast(Axes.Y) != true)
+                Height = component.Height;
+
             Anchor = component.Anchor;
             Origin = component.Origin;
 

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -823,6 +823,7 @@ See the LICENCE file in the repository root for full licence text.&#xD;
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ENumerics_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ESecurity_002ECryptography_002ERSA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=TagLib_002EMpeg4_002EBox/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Of note, a few components will still show the drag handles even though adjustments won't work. This is because there's some weird cases like `Update() { Size = ... }`. I don't see this as a deal-breaker or something we need to address immediately.

---

Dragging a skin elements from an edge will now adjust size, not scale. This allows resizing elements which support it without stretching them (which looked really bad).

Support is limited for now, but we can easily roll this out to more components in the future.

| Before | After |
| :---: | :---: |
| ![CleanShot 2023-11-10 at 05 37 19](https://github.com/ppy/osu/assets/191335/fbebe760-e2de-40ae-9cc1-8d1102bfbec2) | ![CleanShot 2023-11-10 at 05 39 58](https://github.com/ppy/osu/assets/191335/67f1d580-53b5-4e80-b38b-e133412b53c8) |

https://github.com/ppy/osu/assets/191335/a15d7697-3b74-4266-a209-c0b95d90f11d

