### PR TITLE
Fix skin editor not clearing undo history on skin change

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -406,7 +406,14 @@ namespace osu.Game.Overlays.SkinEditor
                 cp.Colour = colours.Yellow;
             });
 
+            changeHandler?.Dispose();
+
             skins.EnsureMutableSkin();
+
+            var targetContainer = getTarget(selectedTarget.Value);
+
+            if (targetContainer != null)
+                changeHandler = new SkinEditorChangeHandler(targetContainer);
             hasBegunMutating = true;
         }
 


### PR DESCRIPTION
As discovered when attempting to fix https://github.com/ppy/osu/pull/25402.

Reproduction scenario:

1. Change skin to a protected one (i.e. argon)
2. Open skin editor during gameplay, which makes the skin mutable
3. Undo will be available; if you undo, all elements are deleted

https://github.com/ppy/osu/assets/20418176/da01ea1d-1085-4819-afc5-a3829876411f

With this PR:

https://github.com/ppy/osu/assets/20418176/e9f64db7-0bd7-4089-9412-f5a371afddd5

When ran on its own, `TestSceneSkinEditor.TestUndoEditHistory()` will also exhibit this behaviour, but _only_ when ran on its own. If it is preceded by any other test, the skin will be made mutable by the preceding test(s), and the behaviour will not exhibit. I am not fixing this, because trying to fix it causes more tests in the class to fail, and I really just want to ship https://github.com/ppy/osu/pull/25402 and then https://github.com/ppy/osu/pull/25226. Whoever can be bothered to fiddle with the test can fix it if so inclined.