### PR TITLE
Refactor `KeyCounterDisplay` to use autosize

### DIFF
--- a/osu.Game/Screens/Play/ArgonKeyCounterDisplay.cs
+++ b/osu.Game/Screens/Play/ArgonKeyCounterDisplay.cs
@@ -10,8 +10,6 @@ namespace osu.Game.Screens.Play
 {
     public partial class ArgonKeyCounterDisplay : KeyCounterDisplay
     {
-        private const int duration = 100;
-
         protected override FillFlowContainer<KeyCounter> KeyFlow { get; }
 
         public ArgonKeyCounterDisplay()
@@ -25,16 +23,6 @@ namespace osu.Game.Screens.Play
             };
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            Size = KeyFlow.Size;
-        }
-
         protected override KeyCounter CreateCounter(InputTrigger trigger) => new ArgonKeyCounter(trigger);
-
-        protected override void UpdateVisibility()
-            => KeyFlow.FadeTo(AlwaysVisible.Value || ConfigVisibility.Value ? 1 : 0, duration);
     }
 }

--- a/osu.Game/Screens/Play/HUD/DefaultKeyCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultKeyCounterDisplay.cs
@@ -10,7 +10,6 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class DefaultKeyCounterDisplay : KeyCounterDisplay
     {
-        private const int duration = 100;
         private const double key_fade_time = 80;
 
         protected override FillFlowContainer<KeyCounter> KeyFlow { get; }
@@ -25,25 +24,12 @@ namespace osu.Game.Screens.Play.HUD
             };
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            // Don't use autosize as it will shrink to zero when KeyFlow is hidden.
-            // In turn this can cause the display to be masked off screen and never become visible again.
-            Size = KeyFlow.Size;
-        }
-
         protected override KeyCounter CreateCounter(InputTrigger trigger) => new DefaultKeyCounter(trigger)
         {
             FadeTime = key_fade_time,
             KeyDownTextColor = KeyDownTextColor,
             KeyUpTextColor = KeyUpTextColor,
         };
-
-        protected override void UpdateVisibility() =>
-            // Isolate changing visibility of the key counters from fading this component.
-            KeyFlow.FadeTo(AlwaysVisible.Value || ConfigVisibility.Value ? 1 : 0, duration);
 
         private Color4 keyDownTextColor = Color4.DarkGray;
 

--- a/osu.Game/Screens/Play/HUD/KeyCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/KeyCounterDisplay.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.UI;
@@ -31,13 +32,27 @@ namespace osu.Game.Screens.Play.HUD
         [Resolved]
         private InputCountController controller { get; set; } = null!;
 
-        protected abstract void UpdateVisibility();
+        private const int duration = 100;
+
+        protected void UpdateVisibility()
+        {
+            bool visible = AlwaysVisible.Value || ConfigVisibility.Value;
+
+            // Isolate changing visibility of the key counters from fading this component.
+            KeyFlow.FadeTo(visible ? 1 : 0, duration);
+
+            // Ensure a valid size is immediately obtained even if partially off-screen
+            // See https://github.com/ppy/osu/issues/14793.
+            KeyFlow.AlwaysPresent = visible;
+        }
 
         protected abstract KeyCounter CreateCounter(InputTrigger trigger);
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, DrawableRuleset? drawableRuleset)
         {
+            AutoSizeAxes = Axes.Both;
+
             config.BindWith(OsuSetting.KeyOverlay, ConfigVisibility);
 
             if (drawableRuleset != null)


### PR DESCRIPTION
A previous attempt at this was unsuccessful due to a partially off-screen elements not getting the correct size early enough (see https://github.com/ppy/osu/issues/14793). This can be accounted for by setting `AlwaysPresent` when visibility is expected.

This fixes [test failures](https://github.com/ppy/osu/actions/runs/6838444698/job/18595535795) due to the newly added `Width` / `Height` being persisted with floating-point errors (by not persisting the values in the first place, via `AutoSize.Both`).
