### PR TITLE
Change unstable rate calculation to account for rate-change mods

### DIFF
--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -42,5 +42,37 @@ namespace osu.Game.Tests.NonVisual.Ranking
 
             Assert.AreEqual(0, unstableRate.Value);
         }
+
+        [Test]
+        public void TestStaticRateChange()
+        {
+            var events = new[]
+            {
+                new HitEvent(-150, 1.5, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(-150, 1.5, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(150, 1.5, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(150, 1.5, HitResult.Great, new HitObject(), null, null),
+            };
+
+            var unstableRate = new UnstableRate(events);
+
+            Assert.AreEqual(10 * 100, unstableRate.Value);
+        }
+
+        [Test]
+        public void TestDynamicRateChange()
+        {
+            var events = new[]
+            {
+                new HitEvent(-50, 0.5, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(75, 0.75, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(-100, 1.0, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(125, 1.25, HitResult.Great, new HitObject(), null, null),
+            };
+
+            var unstableRate = new UnstableRate(events);
+
+            Assert.AreEqual(10 * 100, unstableRate.Value);
+        }
     }
 }

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.NonVisual.Ranking
         public void TestDistributedHits()
         {
             var events = Enumerable.Range(-5, 11)
-                                   .Select(t => new HitEvent(t - 5, HitResult.Great, new HitObject(), null, null));
+                                   .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null));
 
             var unstableRate = new UnstableRate(events);
 
@@ -33,9 +33,9 @@ namespace osu.Game.Tests.NonVisual.Ranking
         {
             var events = new[]
             {
-                new HitEvent(-100, HitResult.Miss, new HitObject(), null, null),
-                new HitEvent(0, HitResult.Great, new HitObject(), null, null),
-                new HitEvent(200, HitResult.Meh, new HitObject { HitWindows = HitWindows.Empty }, null, null),
+                new HitEvent(-100, 1.0, HitResult.Miss, new HitObject(), null, null),
+                new HitEvent(0, 1.0, HitResult.Great, new HitObject(), null, null),
+                new HitEvent(200, 1.0, HitResult.Meh, new HitObject { HitWindows = HitWindows.Empty }, null, null),
             };
 
             var unstableRate = new UnstableRate(events);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -79,6 +80,27 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("Create Display", recreateDisplay);
 
             AddUntilStep("UR = 250", () => counter.Current.Value == 250.0);
+        }
+
+        [Test]
+        public void TestStaticRateChange()
+        {
+            AddStep("Create Display", recreateDisplay);
+
+            AddRepeatStep("Set UR to 250 at 1.5x", () => applyJudgement(25, true, 1.5), 4);
+
+            AddUntilStep("UR = 250/1.5", () => counter.Current.Value == Math.Round(250.0 / 1.5));
+        }
+
+        [Test]
+        public void TestDynamicRateChange()
+        {
+            AddStep("Create Display", recreateDisplay);
+
+            AddRepeatStep("Set UR to 100 at 1.0x", () => applyJudgement(10, true, 1.0), 4);
+            AddRepeatStep("Bring UR to 100 at 1.5x", () => applyJudgement(15, true, 1.5), 4);
+
+            AddUntilStep("UR = 100", () => counter.Current.Value == 100.0);
         }
 
         private void recreateDisplay()

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneUnstableRateCounter.cs
@@ -56,6 +56,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                 scoreProcessor.RevertResult(
                     new JudgementResult(new HitCircle { HitWindows = hitWindows }, new Judgement())
                     {
+                        GameplayRate = 1.0,
                         TimeOffset = 25,
                         Type = HitResult.Perfect,
                     });
@@ -92,7 +93,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
-        private void applyJudgement(double offsetMs, bool alt)
+        private void applyJudgement(double offsetMs, bool alt, double gameplayRate = 1.0)
         {
             double placement = offsetMs;
 
@@ -105,6 +106,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             scoreProcessor.ApplyResult(new JudgementResult(new HitCircle { HitWindows = hitWindows }, new Judgement())
             {
                 TimeOffset = placement,
+                GameplayRate = gameplayRate,
                 Type = HitResult.Perfect,
             });
         }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Visual.Ranking
         [Test]
         public void TestAroundCentre()
         {
-            createTest(Enumerable.Range(-150, 300).Select(i => new HitEvent(i / 50f, HitResult.Perfect, placeholder_object, placeholder_object, null)).ToList());
+            createTest(Enumerable.Range(-150, 300).Select(i => new HitEvent(i / 50f, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null)).ToList());
         }
 
         [Test]
@@ -57,12 +57,12 @@ namespace osu.Game.Tests.Visual.Ranking
         {
             createTest(new List<HitEvent>
             {
-                new HitEvent(-7, HitResult.Perfect, placeholder_object, placeholder_object, null),
-                new HitEvent(-6, HitResult.Perfect, placeholder_object, placeholder_object, null),
-                new HitEvent(-5, HitResult.Perfect, placeholder_object, placeholder_object, null),
-                new HitEvent(5, HitResult.Perfect, placeholder_object, placeholder_object, null),
-                new HitEvent(6, HitResult.Perfect, placeholder_object, placeholder_object, null),
-                new HitEvent(7, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(-7, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(-6, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(-5, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(5, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(6, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
+                new HitEvent(7, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null),
             });
         }
 
@@ -78,7 +78,7 @@ namespace osu.Game.Tests.Visual.Ranking
                     : offset > 16 ? HitResult.Good
                     : offset > 8 ? HitResult.Great
                     : HitResult.Perfect;
-                return new HitEvent(h.TimeOffset, result, placeholder_object, placeholder_object, null);
+                return new HitEvent(h.TimeOffset, 1.0, result, placeholder_object, placeholder_object, null);
             }).ToList());
         }
 
@@ -95,7 +95,7 @@ namespace osu.Game.Tests.Visual.Ranking
                     : offset > 8 ? HitResult.Great
                     : HitResult.Perfect;
 
-                return new HitEvent(h.TimeOffset, result, placeholder_object, placeholder_object, null);
+                return new HitEvent(h.TimeOffset, 1.0, result, placeholder_object, placeholder_object, null);
             });
             var narrow = CreateDistributedHitEvents(0, 50).Select(h =>
             {
@@ -106,7 +106,7 @@ namespace osu.Game.Tests.Visual.Ranking
                     : offset > 10 ? HitResult.Good
                     : offset > 5 ? HitResult.Great
                     : HitResult.Perfect;
-                return new HitEvent(h.TimeOffset, result, placeholder_object, placeholder_object, null);
+                return new HitEvent(h.TimeOffset, 1.0, result, placeholder_object, placeholder_object, null);
             });
             createTest(wide.Concat(narrow).ToList());
         }
@@ -114,7 +114,7 @@ namespace osu.Game.Tests.Visual.Ranking
         [Test]
         public void TestZeroTimeOffset()
         {
-            createTest(Enumerable.Range(0, 100).Select(_ => new HitEvent(0, HitResult.Perfect, placeholder_object, placeholder_object, null)).ToList());
+            createTest(Enumerable.Range(0, 100).Select(_ => new HitEvent(0, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null)).ToList());
         }
 
         [Test]
@@ -129,9 +129,9 @@ namespace osu.Game.Tests.Visual.Ranking
             createTest(Enumerable.Range(0, 100).Select(i =>
             {
                 if (i % 2 == 0)
-                    return new HitEvent(0, HitResult.Perfect, placeholder_object, placeholder_object, null);
+                    return new HitEvent(0, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null);
 
-                return new HitEvent(30, HitResult.Miss, placeholder_object, placeholder_object, null);
+                return new HitEvent(30, 1.0, HitResult.Miss, placeholder_object, placeholder_object, null);
             }).ToList());
         }
 
@@ -162,7 +162,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 int count = (int)(Math.Pow(range - Math.Abs(i - range), 2)) / 10;
 
                 for (int j = 0; j < count; j++)
-                    hitEvents.Add(new HitEvent(centre + i - range, HitResult.Perfect, placeholder_object, placeholder_object, null));
+                    hitEvents.Add(new HitEvent(centre + i - range, 1.0, HitResult.Perfect, placeholder_object, placeholder_object, null));
             }
 
             return hitEvents;

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Rulesets.Judgements
         public double TimeAbsolute => RawTime != null ? Math.Min(RawTime.Value, HitObject.GetEndTime() + HitObject.MaximumJudgementOffset) : HitObject.GetEndTime();
 
         /// <summary>
+        /// The gameplay rate at the time this <see cref="JudgementResult"/> occurred.
+        /// </summary>
+        public double GameplayRate { get; internal set; }
+
+        /// <summary>
         /// The combo prior to this <see cref="JudgementResult"/> occurring.
         /// </summary>
         public int ComboAtJudgement { get; internal set; }

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Judgements
         /// <summary>
         /// The gameplay rate at the time this <see cref="JudgementResult"/> occurred.
         /// </summary>
-        public double GameplayRate { get; internal set; }
+        public double? GameplayRate { get; internal set; }
 
         /// <summary>
         /// The combo prior to this <see cref="JudgementResult"/> occurring.

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -154,9 +154,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         [Resolved(CanBeNull = true)]
         private IPooledHitObjectProvider pooledObjectProvider { get; set; }
 
-        [Resolved(CanBeNull = true)]
-        private IGameplayClock gameplayClock { get; set; }
-
         /// <summary>
         /// Whether the initialization logic in <see cref="Playfield" /> has applied.
         /// </summary>
@@ -707,7 +704,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = gameplayClock?.GetTrueGameplayRate() ?? 1.0;
+            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? 1.0;
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -704,6 +704,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
+            Result.GameplayRate = Clock.Rate;
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -704,7 +704,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? 1.0;
+            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? Clock.Rate;
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -704,7 +704,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate();
+            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? 1.0;
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -154,6 +154,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
         [Resolved(CanBeNull = true)]
         private IPooledHitObjectProvider pooledObjectProvider { get; set; }
 
+        [Resolved]
+        private IGameplayClock gameplayClock { get; set; } = null!;
+
         /// <summary>
         /// Whether the initialization logic in <see cref="Playfield" /> has applied.
         /// </summary>
@@ -704,7 +707,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = Clock.Rate;
+            Result.GameplayRate = gameplayClock.GetTrueGameplayRate();
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -704,7 +704,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate() ?? 1.0;
+            Result.GameplayRate = (Clock as IGameplayClock)?.GetTrueGameplayRate();
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -154,8 +154,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         [Resolved(CanBeNull = true)]
         private IPooledHitObjectProvider pooledObjectProvider { get; set; }
 
-        [Resolved]
-        private IGameplayClock gameplayClock { get; set; } = null!;
+        [Resolved(CanBeNull = true)]
+        private IGameplayClock gameplayClock { get; set; }
 
         /// <summary>
         /// Whether the initialization logic in <see cref="Playfield" /> has applied.
@@ -707,7 +707,7 @@ namespace osu.Game.Rulesets.Objects.Drawables
             }
 
             Result.RawTime = Time.Current;
-            Result.GameplayRate = gameplayClock.GetTrueGameplayRate();
+            Result.GameplayRate = gameplayClock?.GetTrueGameplayRate() ?? 1.0;
 
             if (Result.HasResult)
                 updateState(Result.IsHit ? ArmedState.Hit : ArmedState.Miss);

--- a/osu.Game/Rulesets/Scoring/HitEvent.cs
+++ b/osu.Game/Rulesets/Scoring/HitEvent.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <summary>
         /// The true gameplay rate at the time of the event.
         /// </summary>
-        public readonly double GameplayRate;
+        public readonly double? GameplayRate;
 
         /// <summary>
         /// The hit result.
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="hitObject">The <see cref="HitObject"/> that triggered the event.</param>
         /// <param name="lastHitObject">The previous <see cref="HitObject"/>.</param>
         /// <param name="position">A position corresponding to the event.</param>
-        public HitEvent(double timeOffset, double gameplayRate, HitResult result, HitObject hitObject, [CanBeNull] HitObject lastHitObject, [CanBeNull] Vector2? position)
+        public HitEvent(double timeOffset, double? gameplayRate, HitResult result, HitObject hitObject, [CanBeNull] HitObject lastHitObject, [CanBeNull] Vector2? position)
         {
             TimeOffset = timeOffset;
             GameplayRate = gameplayRate;

--- a/osu.Game/Rulesets/Scoring/HitEvent.cs
+++ b/osu.Game/Rulesets/Scoring/HitEvent.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Rulesets.Scoring
         public readonly double TimeOffset;
 
         /// <summary>
+        /// The true gameplay rate at the time of the event.
+        /// </summary>
+        public readonly double GameplayRate;
+
+        /// <summary>
         /// The hit result.
         /// </summary>
         public readonly HitResult Result;
@@ -46,12 +51,14 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         /// <param name="timeOffset">The time offset from the end of <paramref name="hitObject"/> at which the event occurs.</param>
         /// <param name="result">The <see cref="HitResult"/>.</param>
+        /// <param name="gameplayRate">The true gameplay rate at the time of the event.</param>
         /// <param name="hitObject">The <see cref="HitObject"/> that triggered the event.</param>
         /// <param name="lastHitObject">The previous <see cref="HitObject"/>.</param>
         /// <param name="position">A position corresponding to the event.</param>
-        public HitEvent(double timeOffset, HitResult result, HitObject hitObject, [CanBeNull] HitObject lastHitObject, [CanBeNull] Vector2? position)
+        public HitEvent(double timeOffset, double gameplayRate, HitResult result, HitObject hitObject, [CanBeNull] HitObject lastHitObject, [CanBeNull] Vector2? position)
         {
             TimeOffset = timeOffset;
+            GameplayRate = gameplayRate;
             Result = result;
             HitObject = hitObject;
             LastHitObject = lastHitObject;
@@ -63,6 +70,6 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         /// <param name="positionOffset">The positional offset.</param>
         /// <returns>The new <see cref="HitEvent"/>.</returns>
-        public HitEvent With(Vector2? positionOffset) => new HitEvent(TimeOffset, Result, HitObject, LastHitObject, positionOffset);
+        public HitEvent With(Vector2? positionOffset) => new HitEvent(TimeOffset, GameplayRate, Result, HitObject, LastHitObject, positionOffset);
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace osu.Game.Rulesets.Scoring
@@ -18,8 +19,10 @@ namespace osu.Game.Rulesets.Scoring
         /// </returns>
         public static double? CalculateUnstableRate(this IEnumerable<HitEvent> hitEvents)
         {
+            Debug.Assert(!hitEvents.Any(ev => ev.GameplayRate == null));
+
             // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
-            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset / ev.GameplayRate).ToArray();
+            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset / ev.GameplayRate!.Value).ToArray();
             return 10 * standardDeviation(timeOffsets);
         }
 

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -18,7 +18,8 @@ namespace osu.Game.Rulesets.Scoring
         /// </returns>
         public static double? CalculateUnstableRate(this IEnumerable<HitEvent> hitEvents)
         {
-            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset).ToArray();
+            // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
+            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset / ev.GameplayRate).ToArray();
             return 10 * standardDeviation(timeOffsets);
         }
 

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </returns>
         public static double? CalculateUnstableRate(this IEnumerable<HitEvent> hitEvents)
         {
-            Debug.Assert(!hitEvents.Any(ev => ev.GameplayRate == null));
+            Debug.Assert(hitEvents.All(ev => ev.GameplayRate != null));
 
             // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
             double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset / ev.GameplayRate!.Value).ToArray();

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Rulesets.Scoring
         /// <param name="result">The <see cref="JudgementResult"/> to describe.</param>
         /// <returns>The <see cref="HitEvent"/>.</returns>
         protected virtual HitEvent CreateHitEvent(JudgementResult result)
-            => new HitEvent(result.TimeOffset, result.Type, result.HitObject, lastHitObject, null);
+            => new HitEvent(result.TimeOffset, result.GameplayRate, result.Type, result.HitObject, lastHitObject, null);
 
         protected sealed override void RevertResultInternal(JudgementResult result)
         {

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -473,7 +473,7 @@ namespace osu.Game.Rulesets.UI
 
         private void onNewResult(DrawableHitObject drawable, JudgementResult result)
         {
-            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null && result.GameplayRate != null);
+            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null);
             judgedEntries.Push(drawable.Entry.AsNonNull());
 
             NewResult?.Invoke(drawable, result);

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -473,7 +473,7 @@ namespace osu.Game.Rulesets.UI
 
         private void onNewResult(DrawableHitObject drawable, JudgementResult result)
         {
-            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null && result.GameplayRate != 0.0);
+            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null && result.GameplayRate != null);
             judgedEntries.Push(drawable.Entry.AsNonNull());
 
             NewResult?.Invoke(drawable, result);

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -473,7 +473,7 @@ namespace osu.Game.Rulesets.UI
 
         private void onNewResult(DrawableHitObject drawable, JudgementResult result)
         {
-            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null);
+            Debug.Assert(result != null && drawable.Entry?.Result == result && result.RawTime != null && result.GameplayRate != 0.0);
             judgedEntries.Push(drawable.Entry.AsNonNull());
 
             NewResult?.Invoke(drawable, result);

--- a/osu.Game/Screens/Utility/CircleGameplay.cs
+++ b/osu.Game/Screens/Utility/CircleGameplay.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Screens.Utility
                     .FadeOut(duration)
                     .ScaleTo(1.5f, duration);
 
-                HitEvent = new HitEvent(Clock.CurrentTime - HitTime, HitResult.Good, new HitObject
+                HitEvent = new HitEvent(Clock.CurrentTime - HitTime, 1.0, HitResult.Good, new HitObject
                 {
                     HitWindows = new HitWindows(),
                 }, null, null);

--- a/osu.Game/Screens/Utility/ScrollingGameplay.cs
+++ b/osu.Game/Screens/Utility/ScrollingGameplay.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Screens.Utility
                     .FadeOut(duration / 2)
                     .ScaleTo(1.5f, duration / 2);
 
-                HitEvent = new HitEvent(Clock.CurrentTime - HitTime, HitResult.Good, new HitObject
+                HitEvent = new HitEvent(Clock.CurrentTime - HitTime, 1.0, HitResult.Good, new HitObject
                 {
                     HitWindows = new HitWindows(),
                 }, null, null);


### PR DESCRIPTION
In community parlance, cv. UR (converted unstable rate) is unstable rate divided by the rate-change of the mods used. This accounts for UR not scaling against rate-change, making it possible to compare UR on scores with or without rate-change mods.  PR #24812 proposed adding a toggle to the unstable rate HUD counter which would display cv. UR, but it was ultimately decided in discussion that cv. UR shouldn't need to exist and that UR should always correspond to milliseconds no matter the rate change.

This PR does just that by storing the local gameplay rate in `HitEvent` and `JudgementResult` and accounting for it when calculating UR. This approach has the benefit of working with any type of rate change, including static (e.g. Double Time), linear (e.g. Wind Up), and dynamic (e.g. Adaptive Speed).