### PR TITLE
Fix some touch device-related issues

### DIFF
--- a/osu.Game/Rulesets/Mods/ModTouchDevice.cs
+++ b/osu.Game/Rulesets/Mods/ModTouchDevice.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Mods
         public sealed override LocalisableString Description => "Automatically applied to plays on devices with a touchscreen.";
         public sealed override double ScoreMultiplier => 1;
         public sealed override ModType Type => ModType.System;
+        public sealed override bool ValidForMultiplayer => false;
+        public sealed override bool ValidForMultiplayerAsFreeMod => false;
         public sealed override bool AlwaysValidForSubmission => true;
         public override Type[] IncompatibleMods => new[] { typeof(ICreateReplayData) };
     }

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Screens.Select
         private void load(OsuColour colours)
         {
             BeatmapOptions.AddButton(ButtonSystemStrings.Edit.ToSentence(), @"beatmap", FontAwesome.Solid.PencilAlt, colours.Yellow, () => Edit());
+
+            AddInternal(new SongSelectTouchInputDetector());
         }
 
         protected void PresentScore(ScoreInfo score) =>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -279,7 +279,6 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.Both,
                 },
-                new SongSelectTouchInputDetector()
             });
 
             if (ShowFooter)


### PR DESCRIPTION
This is supposed to address multiplayer errors as seen on sentry: https://sentry.ppy.sh/organizations/ppy/issues/28940/.

## 69c2c0e4278d4d419b3ee1ea11f4c8e491514247: Fix touch device mod declared valid for multiplayer

Mostly matters for web, so that it doesn't permit creation of playlist items with touch device inside.

## 70d2de56695800a2ca14a027d32cf2c36153e8f5: Move song select touch detector to solo implementation

It should not run in multiplayer. Even if we wanted to allow touch-only playlist items at some point, the current behaviour of multiplayer song selects with respect to touch device mod is currently just broken.