### PR TITLE
Dispose PreviewTrack once it's done playing in PlayButton

### DIFF
--- a/osu.Game/Audio/PreviewTrack.cs
+++ b/osu.Game/Audio/PreviewTrack.cs
@@ -115,6 +115,8 @@ namespace osu.Game.Audio
 
             Stop();
             Track?.Dispose();
+
+            Track = null;
         }
     }
 }

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -109,7 +109,13 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         {
             toggleLoading(false);
             Playing.Value = false;
-            previewTrack?.Stop();
+
+            if (previewTrack != null)
+            {
+                previewTrack.Stop();
+                RemoveInternal(previewTrack, true);
+                previewTrack = null;
+            }
         }
 
         private void onPreviewLoaded(PreviewTrack loadedPreview)


### PR DESCRIPTION
PreviewTrack in PlayButtons doesn't get disposed until I perform search again (they remain even if I close the beatmap listing).

![tracksnum](https://github.com/ppy/osu/assets/9151706/708403a8-4107-4fca-80ce-7854d972dddc)

This PR fixes it by disposing the track once it's done playing, effectively making it work like a sample. Not so sure if it's in the right direction, though...

I did consider using samples for a second, but it would require some changes in framework since samples don't report channel position (don't think BASS even supports it), so I tried fixing what we have for now.