### PR TITLE
Use existing localisation for corner radius in `BoxElement`

### DIFF
--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -216,7 +216,10 @@ namespace osu.Game.Skinning
                                     },
                                     new ArgonScoreCounter(),
                                     new ArgonHealthDisplay(),
-                                    new BoxElement(),
+                                    new BoxElement
+                                    {
+                                        CornerRadius = { Value = 0.5f }
+                                    },
                                     new ArgonAccuracyCounter(),
                                     new ArgonComboCounter
                                     {

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Skinning.Components
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.CornerRadius), nameof(SkinnableComponentStrings.CornerRadiusDescription),
             SettingControlType = typeof(SettingsPercentageSlider<float>))]
-        public BindableFloat CornerRounding { get; } = new BindableFloat(1)
+        public new BindableFloat CornerRadius { get; } = new BindableFloat(1)
         {
             Precision = 0.01f,
             MinValue = 0,
@@ -47,7 +47,7 @@ namespace osu.Game.Skinning.Components
         {
             base.Update();
 
-            CornerRadius = CornerRounding.Value * Math.Min(DrawWidth, DrawHeight) * 0.5f;
+            base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight) * 0.5f;
         }
     }
 }

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -20,11 +20,11 @@ namespace osu.Game.Skinning.Components
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.CornerRadius), nameof(SkinnableComponentStrings.CornerRadiusDescription),
             SettingControlType = typeof(SettingsPercentageSlider<float>))]
-        public new BindableFloat CornerRadius { get; } = new BindableFloat(1)
+        public new BindableFloat CornerRadius { get; } = new BindableFloat(0.25f)
         {
-            Precision = 0.01f,
             MinValue = 0,
-            MaxValue = 1,
+            MaxValue = 0.5f,
+            Precision = 0.01f
         };
 
         public BoxElement()
@@ -47,7 +47,7 @@ namespace osu.Game.Skinning.Components
         {
             base.Update();
 
-            base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight) * 0.5f;
+            base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight);
         }
     }
 }

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -7,6 +7,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Overlays.Settings;
 using osuTK;
 using osuTK.Graphics;
 
@@ -16,7 +18,8 @@ namespace osu.Game.Skinning.Components
     {
         public bool UsesFixedAnchor { get; set; }
 
-        [SettingSource("Corner rounding", "How round the corners of the box should be.")]
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.CornerRadius), nameof(SkinnableComponentStrings.CornerRadiusDescription),
+            SettingControlType = typeof(SettingsPercentageSlider<float>))]
         public BindableFloat CornerRounding { get; } = new BindableFloat(1)
         {
             Precision = 0.01f,


### PR DESCRIPTION
Copied from `PlayerAvatar`. The breaking serialisation differences from `PlayerAvatar` are:
- property name (`BoxElement` is `CornerRounding`, `PlayerAvatar` is `CornerRadius`)
- max value (`BoxElement` is 1, `PlayerAvatar` is 0.5)

Not sure what the right ones are and if we should change for consistency and break early (if we don't want having migration).