### PR TITLE
Fix default argon health bar width being zero

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -94,6 +94,13 @@ namespace osu.Game.Screens.Play.HUD
         public ArgonHealthDisplay()
         {
             AddLayout(drawSizeLayout);
+
+            // sane default width specification.
+            // this only matters if the health display isn't part of the default skin
+            // (in which case width will be set to 300 via `ArgonSkin.GetDrawableComponent()`),
+            // and if the user hasn't applied their own modifications
+            // (which are applied via `SerialisedDrawableInfo.ApplySerialisedInfo()`).
+            Width = 0.98f;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Closes #25460.

Regressed with the removal of the width setting in 374e13b496dc3780e03f2c9f76a850ab0a8050e5.

Will fix:
- appearance of the health bar in toolbox
- size of the health bar when added from toolbox
- skins which had the default value of the width setting set

Will not fix skins that have been modified after this bug's presentation in latest release.

The management of this width spec is getting a little annoying now, but it's probably fine...?