### PR TITLE
Add test coverage of accessing skin layout after importing customised default skins

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;

--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -9,10 +9,12 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
+using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Skinning;
+using osu.Game.Tests.Resources;
 using SharpCompress.Archives.Zip;
 
 namespace osu.Game.Tests.Skins.IO
@@ -20,6 +22,25 @@ namespace osu.Game.Tests.Skins.IO
     public class ImportSkinTest : ImportTest
     {
         #region Testing filename metadata inclusion
+
+        [TestCase("Archives/modified-classic-20220723.osk")]
+        [TestCase("Archives/modified-default-20230117.osk")]
+        [TestCase("Archives/modified-argon-20231106.osk")]
+        public Task TestImportModifiedSkinHasResources(string archive) => runSkinTest(async osu =>
+        {
+            using (var stream = TestResources.OpenResource(archive))
+            {
+                var imported = await loadSkinIntoOsu(osu, new ImportTask(stream, "skin.osk"));
+
+                // When the import filename doesn't match, it should be appended (and update the skin.ini).
+
+                var skinManager = osu.Dependencies.Get<SkinManager>();
+
+                skinManager.CurrentSkinInfo.Value = imported;
+
+                Assert.That(skinManager.CurrentSkin.Value.LayoutInfos.Count, Is.EqualTo(2));
+            }
+        });
 
         [Test]
         public Task TestSingleImportDifferentFilename() => runSkinTest(async osu =>

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -15,6 +15,7 @@ using osu.Game.IO.Archives;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
 using osu.Game.Skinning;
+using osu.Game.Skinning.Components;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Skins
@@ -99,6 +100,20 @@ namespace osu.Game.Tests.Skins
 
                 Assert.That(skin.LayoutInfos, Has.Count.EqualTo(2));
                 Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(9));
+            }
+        }
+
+        [Test]
+        public void TestDeserialiseModifiedArgon()
+        {
+            using (var stream = TestResources.OpenResource("Archives/modified-argon-20231106.osk"))
+            using (var storage = new ZipArchiveReader(stream))
+            {
+                var skin = new TestSkin(new SkinInfo(), null, storage);
+
+                Assert.That(skin.LayoutInfos, Has.Count.EqualTo(2));
+                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(10));
+                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(PlayerName)));
             }
         }
 


### PR DESCRIPTION
Can test by reverting 711bf14c069a7a060d48ea08ec5d58397caa17bc.