### PR TITLE
Add ability to toggle labels on argon counter components

### DIFF
--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -12,42 +12,42 @@ namespace osu.Game.Localisation.SkinComponents
         /// <summary>
         /// "Sprite name"
         /// </summary>
-        public static LocalisableString SpriteName => new TranslatableString(getKey(@"sprite_name"), "Sprite name");
+        public static LocalisableString SpriteName => new TranslatableString(getKey(@"sprite_name"), @"Sprite name");
 
         /// <summary>
         /// "The filename of the sprite"
         /// </summary>
-        public static LocalisableString SpriteNameDescription => new TranslatableString(getKey(@"sprite_name_description"), "The filename of the sprite");
+        public static LocalisableString SpriteNameDescription => new TranslatableString(getKey(@"sprite_name_description"), @"The filename of the sprite");
 
         /// <summary>
         /// "Font"
         /// </summary>
-        public static LocalisableString Font => new TranslatableString(getKey(@"font"), "Font");
+        public static LocalisableString Font => new TranslatableString(getKey(@"font"), @"Font");
 
         /// <summary>
         /// "The font to use."
         /// </summary>
-        public static LocalisableString FontDescription => new TranslatableString(getKey(@"font_description"), "The font to use.");
+        public static LocalisableString FontDescription => new TranslatableString(getKey(@"font_description"), @"The font to use.");
 
         /// <summary>
         /// "Text"
         /// </summary>
-        public static LocalisableString TextElementText => new TranslatableString(getKey(@"text_element_text"), "Text");
+        public static LocalisableString TextElementText => new TranslatableString(getKey(@"text_element_text"), @"Text");
 
         /// <summary>
         /// "The text to be displayed."
         /// </summary>
-        public static LocalisableString TextElementTextDescription => new TranslatableString(getKey(@"text_element_text_description"), "The text to be displayed.");
+        public static LocalisableString TextElementTextDescription => new TranslatableString(getKey(@"text_element_text_description"), @"The text to be displayed.");
 
         /// <summary>
         /// "Corner radius"
         /// </summary>
-        public static LocalisableString CornerRadius => new TranslatableString(getKey(@"corner_radius"), "Corner radius");
+        public static LocalisableString CornerRadius => new TranslatableString(getKey(@"corner_radius"), @"Corner radius");
 
         /// <summary>
         /// "How rounded the corners should be."
         /// </summary>
-        public static LocalisableString CornerRadiusDescription => new TranslatableString(getKey(@"corner_radius_description"), "How rounded the corners should be.");
+        public static LocalisableString CornerRadiusDescription => new TranslatableString(getKey(@"corner_radius_description"), @"How rounded the corners should be.");
 
         /// <summary>
         /// "Show label"
@@ -55,10 +55,10 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString ShowLabel => new TranslatableString(getKey(@"show_label"), @"Show label");
 
         /// <summary>
-        /// "Whether the label should be shown."
+        /// "Whether the component&#39;s label should be shown."
         /// </summary>
-        public static LocalisableString ShowLabelDescription => new TranslatableString(getKey(@"show_label_description"), @"Whether the label should be shown.");
+        public static LocalisableString ShowLabelDescription => new TranslatableString(getKey(@"show_label_description"), @"Whether the component's label should be shown.");
 
-        private static string getKey(string key) => $"{prefix}:{key}";
+        private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -49,6 +49,16 @@ namespace osu.Game.Localisation.SkinComponents
         /// </summary>
         public static LocalisableString CornerRadiusDescription => new TranslatableString(getKey(@"corner_radius_description"), "How rounded the corners should be.");
 
+        /// <summary>
+        /// "Show label"
+        /// </summary>
+        public static LocalisableString ShowLabel => new TranslatableString(getKey(@"show_label"), @"Show label");
+
+        /// <summary>
+        /// "Whether the label should be shown."
+        /// </summary>
+        public static LocalisableString ShowLabelDescription => new TranslatableString(getKey(@"show_label_description"), @"Whether the label should be shown.");
+
         private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Play.HUD
                         new Container
                         {
                             AutoSizeAxes = Axes.Both,
-                            Child = wholePart = new ArgonCounterTextComponent(Anchor.TopRight, "ACCURACY")
+                            Child = wholePart = new ArgonCounterTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersAccuracy.ToUpper())
                             {
                                 RequiredDisplayDigits = { Value = 3 },
                                 WireframeOpacity = { BindTarget = WireframeOpacity }

--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -2,11 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -25,19 +28,26 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
+
         public bool UsesFixedAnchor { get; set; }
 
         protected override IHasText CreateText() => new ArgonAccuracyTextComponent
         {
             WireframeOpacity = { BindTarget = WireframeOpacity },
+            ShowLabel = { BindTarget = ShowLabel },
         };
 
         private partial class ArgonAccuracyTextComponent : CompositeDrawable, IHasText
         {
             private readonly ArgonCounterTextComponent wholePart;
             private readonly ArgonCounterTextComponent fractionPart;
+            private readonly ArgonCounterTextComponent percentText;
 
             public IBindable<float> WireframeOpacity { get; } = new BindableFloat();
+
+            public Bindable<bool> ShowLabel { get; } = new BindableBool();
 
             public LocalisableString Text
             {
@@ -67,23 +77,33 @@ namespace osu.Game.Screens.Play.HUD
                             Child = wholePart = new ArgonCounterTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersAccuracy.ToUpper())
                             {
                                 RequiredDisplayDigits = { Value = 3 },
-                                WireframeOpacity = { BindTarget = WireframeOpacity }
+                                WireframeOpacity = { BindTarget = WireframeOpacity },
+                                ShowLabel = { BindTarget = ShowLabel },
                             }
                         },
                         fractionPart = new ArgonCounterTextComponent(Anchor.TopLeft)
                         {
-                            Margin = new MarginPadding { Top = 12f * 2f + 4f }, // +4 to account for the extra spaces above the digits.
                             WireframeOpacity = { BindTarget = WireframeOpacity },
                             Scale = new Vector2(0.5f),
                         },
-                        new ArgonCounterTextComponent(Anchor.TopLeft)
+                        percentText = new ArgonCounterTextComponent(Anchor.TopLeft)
                         {
                             Text = @"%",
-                            Margin = new MarginPadding { Top = 12f },
                             WireframeOpacity = { BindTarget = WireframeOpacity }
                         },
                     }
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                ShowLabel.BindValueChanged(s =>
+                {
+                    fractionPart.Margin = new MarginPadding { Top = s.NewValue ? 12f * 2f + 4f : 4f }; // +4 to account for the extra spaces above the digits.
+                    percentText.Margin = new MarginPadding { Top = s.NewValue ? 12f : 0 };
+                }, true);
             }
         }
     }

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -4,10 +4,13 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 using osuTK.Graphics;
@@ -28,6 +31,9 @@ namespace osu.Game.Screens.Play.HUD
             MinValue = 0,
             MaxValue = 1,
         };
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         [BackgroundDependencyLoader]
         private void load(ScoreProcessor scoreProcessor)
@@ -56,6 +62,7 @@ namespace osu.Game.Screens.Play.HUD
         protected override IHasText CreateText() => text = new ArgonCounterTextComponent(Anchor.TopLeft, MatchesStrings.MatchScoreStatsCombo.ToUpper())
         {
             WireframeOpacity = { BindTarget = WireframeOpacity },
+            ShowLabel = { BindTarget = ShowLabel },
         };
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override LocalisableString FormatCount(int count) => $@"{count}x";
 
-        protected override IHasText CreateText() => text = new ArgonCounterTextComponent(Anchor.TopLeft, "COMBO")
+        protected override IHasText CreateText() => text = new ArgonCounterTextComponent(Anchor.TopLeft, MatchesStrings.MatchScoreStatsCombo.ToUpper())
         {
             WireframeOpacity = { BindTarget = WireframeOpacity },
         };

--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Screens.Play.HUD
 
         public IBindable<float> WireframeOpacity { get; } = new BindableFloat();
         public Bindable<int> RequiredDisplayDigits { get; } = new BindableInt();
+        public Bindable<bool> ShowLabel { get; } = new BindableBool();
 
         public Container NumberContainer { get; private set; }
 
@@ -56,7 +57,7 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     labelText = new OsuSpriteText
                     {
-                        Alpha = label != null ? 1 : 0,
+                        Alpha = 0,
                         Text = label.GetValueOrDefault(),
                         Font = OsuFont.Torus.With(size: 12, weight: FontWeight.Bold),
                         Margin = new MarginPadding { Left = 2.5f },
@@ -114,6 +115,7 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
             WireframeOpacity.BindValueChanged(v => wireframesPart.Alpha = v.NewValue, true);
+            ShowLabel.BindValueChanged(s => labelText.Alpha = s.NewValue ? 1 : 0, true);
         }
 
         private partial class ArgonCounterSpriteText : OsuSpriteText

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Play.HUD
         };
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
-        public Bindable<bool> ShowLabel { get; } = new BindableBool();
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -7,6 +7,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Localisation.SkinComponents;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Play.HUD
@@ -24,14 +26,18 @@ namespace osu.Game.Screens.Play.HUD
             MaxValue = 1,
         };
 
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool();
+
         public bool UsesFixedAnchor { get; set; }
 
         protected override LocalisableString FormatCount(long count) => count.ToLocalisableString();
 
-        protected override IHasText CreateText() => new ArgonScoreTextComponent(Anchor.TopRight)
+        protected override IHasText CreateText() => new ArgonScoreTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersScore.ToUpper())
         {
             RequiredDisplayDigits = { BindTarget = RequiredDisplayDigits },
             WireframeOpacity = { BindTarget = WireframeOpacity },
+            ShowLabel = { BindTarget = ShowLabel },
         };
 
         private partial class ArgonScoreTextComponent : ArgonCounterTextComponent

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -214,7 +214,10 @@ namespace osu.Game.Skinning
                                         Size = new Vector2(380, 72),
                                         Position = new Vector2(4, 5)
                                     },
-                                    new ArgonScoreCounter(),
+                                    new ArgonScoreCounter
+                                    {
+                                        ShowLabel = { Value = false },
+                                    },
                                     new ArgonHealthDisplay(),
                                     new BoxElement
                                     {


### PR DESCRIPTION
- Discussed in https://github.com/ppy/osu/discussions/25457

![Kapture 2023-11-14 at 20 52 13](https://github.com/ppy/osu/assets/35318437/919cf075-c992-4c8f-8d67-ae0451d2c07e)

Localisation done manually pending analyzer `SettingSourceAttribute` support: https://github.com/ppy/osu-localisation-analyser/issues/59

Not sure if the defaults should be based on argon or have the same default (`ArgonScoreCounter` has the label hidden component-level right now).

The usage of `MatchesStrings.MatchScoreStatsCombo` fits here (during in-game), but the usage in web (match pages) should've been `Max Combo` (web equivalent of`BeatmapsetsStrings.ShowScoreboardHeadersCombo`), so the string is temporary and may change.

---

Thinking about this again before pressing the create button, but the label and counter can be separate components. I mean we have this already:
<img width="398" alt="Screenshot 2023-11-14 at 9 13 49 PM" src="https://github.com/ppy/osu/assets/35318437/38d470c0-e1d9-4e49-8142-f15e6dc10013">

Just something to think of. I'm kind of leaning toward separating them by a small margin (that will make the combo label not move with the counter though), but just did the easier route of adding a toggle.