### PR TITLE
Fix `CommentMarkdownTextFlowContainer` not inheriting osu! class

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableComment.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Tests.Visual.Online
             new[] { "Plain", "This is plain comment" },
             new[] { "Pinned", "This is pinned comment" },
             new[] { "Link", "Please visit https://osu.ppy.sh" },
-            new[] { "Big Image", "![](Backgrounds/bg1)" },
+            new[] { "Big Image", "![](Backgrounds/bg1 \"Big Image\")" },
             new[] { "Small Image", "![](Cursor/cursortrail)" },
             new[]
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMarkdownContainer.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
@@ -298,7 +297,7 @@ This is a line after the fenced code block!
         {
             public LinkInline Link;
 
-            public override MarkdownTextFlowContainer CreateTextFlow() => new TestMarkdownTextFlowContainer
+            public override OsuMarkdownTextFlowContainer CreateTextFlow() => new TestMarkdownTextFlowContainer
             {
                 UrlAdded = link => Link = link,
             };

--- a/osu.Game/Graphics/Containers/Markdown/Footnotes/OsuMarkdownFootnoteTooltip.cs
+++ b/osu.Game/Graphics/Containers/Markdown/Footnotes/OsuMarkdownFootnoteTooltip.cs
@@ -5,7 +5,6 @@ using Markdig.Extensions.Footnotes;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Overlays;
@@ -62,7 +61,7 @@ namespace osu.Game.Graphics.Containers.Markdown.Footnotes
                 lastFootnote = Text = footnote;
             }
 
-            public override MarkdownTextFlowContainer CreateTextFlow() => new FootnoteMarkdownTextFlowContainer();
+            public override OsuMarkdownTextFlowContainer CreateTextFlow() => new FootnoteMarkdownTextFlowContainer();
         }
 
         private partial class FootnoteMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer

--- a/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
+++ b/osu.Game/Graphics/Containers/Markdown/OsuMarkdownContainer.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Graphics.Containers.Markdown
             Font = OsuFont.GetFont(Typeface.Inter, size: 14, weight: FontWeight.Regular),
         };
 
-        public override MarkdownTextFlowContainer CreateTextFlow() => new OsuMarkdownTextFlowContainer();
+        public override OsuMarkdownTextFlowContainer CreateTextFlow() => new OsuMarkdownTextFlowContainer();
 
         protected override MarkdownHeading CreateHeading(HeadingBlock headingBlock) => new OsuMarkdownHeading(headingBlock);
 

--- a/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
@@ -51,12 +51,12 @@ namespace osu.Game.Overlays.Comments
 
         private partial class CommentMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
         {
-            protected override void AddImage(LinkInline linkInline) => AddDrawable(new CommentMarkdownImage(linkInline.Url));
+            protected override void AddImage(LinkInline linkInline) => AddDrawable(new CommentMarkdownImage(linkInline));
 
-            private partial class CommentMarkdownImage : MarkdownImage
+            private partial class CommentMarkdownImage : OsuMarkdownImage
             {
-                public CommentMarkdownImage(string url)
-                    : base(url)
+                public CommentMarkdownImage(LinkInline linkInline)
+                    : base(linkInline)
                 {
                 }
 

--- a/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
+++ b/osu.Game/Overlays/Comments/CommentMarkdownContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Overlays.Comments
 
         protected override MarkdownHeading CreateHeading(HeadingBlock headingBlock) => new CommentMarkdownHeading(headingBlock);
 
-        public override MarkdownTextFlowContainer CreateTextFlow() => new CommentMarkdownTextFlowContainer();
+        public override OsuMarkdownTextFlowContainer CreateTextFlow() => new CommentMarkdownTextFlowContainer();
 
         private partial class CommentMarkdownHeading : OsuMarkdownHeading
         {
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.Comments
             }
         }
 
-        private partial class CommentMarkdownTextFlowContainer : MarkdownTextFlowContainer
+        private partial class CommentMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
         {
             protected override void AddImage(LinkInline linkInline) => AddDrawable(new CommentMarkdownImage(linkInline.Url));
 

--- a/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownContainer.cs
+++ b/osu.Game/Overlays/Wiki/Markdown/WikiMarkdownContainer.cs
@@ -7,7 +7,6 @@ using Markdig.Extensions.Yaml;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Containers.Markdown;
 using osu.Game.Graphics.Containers.Markdown;
 
 namespace osu.Game.Overlays.Wiki.Markdown
@@ -53,7 +52,7 @@ namespace osu.Game.Overlays.Wiki.Markdown
             base.AddMarkdownComponent(markdownObject, container, level);
         }
 
-        public override MarkdownTextFlowContainer CreateTextFlow() => new WikiMarkdownTextFlowContainer();
+        public override OsuMarkdownTextFlowContainer CreateTextFlow() => new WikiMarkdownTextFlowContainer();
 
         private partial class WikiMarkdownTextFlowContainer : OsuMarkdownTextFlowContainer
         {

--- a/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
+++ b/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Overlays.Wiki
 
             public override SpriteText CreateSpriteText() => base.CreateSpriteText().With(t => t.Font = t.Font.With(Typeface.Torus, weight: FontWeight.Bold));
 
-            public override MarkdownTextFlowContainer CreateTextFlow() => base.CreateTextFlow().With(f => f.TextAnchor = Anchor.TopCentre);
+            public override OsuMarkdownTextFlowContainer CreateTextFlow() => base.CreateTextFlow().With(f => f.TextAnchor = Anchor.TopCentre);
 
             protected override MarkdownParagraph CreateParagraph(ParagraphBlock paragraphBlock, int level)
                 => base.CreateParagraph(paragraphBlock, level).With(p => p.Margin = new MarginPadding { Bottom = 10 });


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu/pull/25202

| Before | After |
| --- | --- |
| <img width="317" alt="Screenshot 2023-11-15 at 11 02 41 PM" src="https://github.com/ppy/osu/assets/35318437/391fb9eb-d326-4f71-a4ed-8449b78f1227"> | <img width="311" alt="Screenshot 2023-11-15 at 10 59 33 PM" src="https://github.com/ppy/osu/assets/35318437/0aa792bb-0017-43d0-b533-8ace343cca9d"> |

Uses covariant return types on `override` to enforce using osu! classes (`OsuMarkdownTextFlowContainer` for now).

Can't enforce the image one because `OsuMarkdownTextFlowContainer` uses `void` overrides. Not sure why its overrides are:
```c#
protected override void AddImage(LinkInline linkInline) => AddDrawable(new CommentMarkdownImage(linkInline));

// usage
AddImage(linkInline);
```
and not written like `OsuMarkdownContainer`'s:
```c#
protected override CommentMarkdownImage CreateImage(LinkInline linkInline) => new CommentMarkdownImage(linkInline);

// usage
AddDrawable(CreateImage(linkInline));
```