### PR TITLE
Change `ResourceStore` provided to `Skin` to be a fallback, not replacement

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchSkinColourDecodingTest.cs
@@ -28,9 +28,9 @@ namespace osu.Game.Rulesets.Catch.Tests
 
         private class TestLegacySkin : LegacySkin
         {
-            public TestLegacySkin(SkinInfo skin, IResourceStore<byte[]> storage)
+            public TestLegacySkin(SkinInfo skin, IResourceStore<byte[]> fallbackStore)
                 // Bypass LegacySkinResourceStore to avoid returning null for retrieving files due to bad skin info (SkinInfo.Files = null).
-                : base(skin, null, storage)
+                : base(skin, null, fallbackStore)
             {
             }
         }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -174,8 +174,8 @@ namespace osu.Game.Tests.Beatmaps.Formats
 
         private class TestLegacySkin : LegacySkin
         {
-            public TestLegacySkin(IResourceStore<byte[]> storage, string fileName)
-                : base(new SkinInfo { Name = "Test Skin", Creator = "Craftplacer" }, null, storage, fileName)
+            public TestLegacySkin(IResourceStore<byte[]> fallbackStore, string fileName)
+                : base(new SkinInfo { Name = "Test Skin", Creator = "Craftplacer" }, null, fallbackStore, fileName)
             {
             }
         }

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -149,8 +149,8 @@ namespace osu.Game.Tests.Skins
 
         private class TestSkin : Skin
         {
-            public TestSkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage = null, string configurationFilename = "skin.ini")
-                : base(skin, resources, storage, configurationFilename)
+            public TestSkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? fallbackStore = null, string configurationFilename = "skin.ini")
+                : base(skin, resources, fallbackStore, configurationFilename)
             {
             }
 

--- a/osu.Game.Tests/Skins/TestSceneSkinResources.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinResources.cs
@@ -95,8 +95,8 @@ namespace osu.Game.Tests.Skins
         {
             public const string SAMPLE_NAME = "test-sample";
 
-            public TestSkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage = null, string configurationFilename = "skin.ini")
-                : base(skin, resources, storage, configurationFilename)
+            public TestSkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? fallbackStore = null, string configurationFilename = "skin.ini")
+                : base(skin, resources, fallbackStore, configurationFilename)
             {
             }
 

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -31,8 +31,7 @@ namespace osu.Game.Skinning
             : base(
                 skin,
                 resources,
-                // In the case of the actual default legacy skin (ie. the fallback one, which a user hasn't applied any modifications to) we want to use the game provided resources.
-                skin.Protected ? new NamespacedResourceStore<byte[]>(resources.Resources, "Skins/Legacy") : null
+                new NamespacedResourceStore<byte[]>(resources.Resources, "Skins/Legacy")
             )
         {
             Configuration.CustomColours["SliderBall"] = new Color4(2, 170, 255, 255);

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Skinning
                     // needs to be removed else it will cause incorrect skin behaviours. This is due to the config lookup having no context of which skin
                     // it should be returning the version for.
 
-                    Skin.LogLookupDebug(this, lookup, Skin.LookupDebugType.Miss);
+                    LogLookupDebug(this, lookup, LookupDebugType.Miss);
                     return null;
             }
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -16,7 +16,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Game.Audio;
 using osu.Game.Beatmaps.Formats;
-using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.IO;
 using osu.Game.Rulesets.Objects.Types;
@@ -51,10 +50,10 @@ namespace osu.Game.Skinning
         /// </summary>
         /// <param name="skin">The model for this skin.</param>
         /// <param name="resources">Access to raw game resources.</param>
-        /// <param name="storage">An optional store which will be used for looking up skin resources. If null, one will be created from realm <see cref="IHasRealmFiles"/> pattern.</param>
+        /// <param name="fallbackStore">An optional fallback store which will be used for file lookups that are not serviced by realm user storage.</param>
         /// <param name="configurationFilename">The user-facing filename of the configuration file to be parsed. Can accept an .osu or skin.ini file.</param>
-        protected LegacySkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage, string configurationFilename = @"skin.ini")
-            : base(skin, resources, storage, configurationFilename)
+        protected LegacySkin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? fallbackStore, string configurationFilename = @"skin.ini")
+            : base(skin, resources, fallbackStore, configurationFilename)
         {
         }
 

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Skinning
             where TLookup : notnull
             where TValue : notnull;
 
-        private readonly RealmBackedResourceStore<SkinInfo>? realmBackedStorage;
+        private readonly ResourceStore<byte[]> store = new ResourceStore<byte[]>();
 
         public string Name { get; }
 
@@ -64,9 +64,9 @@ namespace osu.Game.Skinning
         /// </summary>
         /// <param name="skin">The skin's metadata. Usually a live realm object.</param>
         /// <param name="resources">Access to game-wide resources.</param>
-        /// <param name="storage">An optional store which will *replace* all file lookups that are usually sourced from <paramref name="skin"/>.</param>
+        /// <param name="fallbackStore">An optional fallback store which will be used for file lookups that are not serviced by realm user storage.</param>
         /// <param name="configurationFilename">An optional filename to read the skin configuration from. If not provided, the configuration will be retrieved from the storage using "skin.ini".</param>
-        protected Skin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? storage = null, string configurationFilename = @"skin.ini")
+        protected Skin(SkinInfo skin, IStorageResourceProvider? resources, IResourceStore<byte[]>? fallbackStore = null, string configurationFilename = @"skin.ini")
         {
             Name = skin.Name;
 
@@ -74,9 +74,9 @@ namespace osu.Game.Skinning
             {
                 SkinInfo = skin.ToLive(resources.RealmAccess);
 
-                storage ??= realmBackedStorage = new RealmBackedResourceStore<SkinInfo>(SkinInfo, resources.Files, resources.RealmAccess);
+                store.AddStore(new RealmBackedResourceStore<SkinInfo>(SkinInfo, resources.Files, resources.RealmAccess));
 
-                var samples = resources.AudioManager?.GetSampleStore(storage);
+                var samples = resources.AudioManager?.GetSampleStore(store);
 
                 if (samples != null)
                 {
@@ -88,7 +88,7 @@ namespace osu.Game.Skinning
                 }
 
                 Samples = samples;
-                Textures = new TextureStore(resources.Renderer, CreateTextureLoaderStore(resources, storage));
+                Textures = new TextureStore(resources.Renderer, CreateTextureLoaderStore(resources, store));
             }
             else
             {
@@ -96,7 +96,10 @@ namespace osu.Game.Skinning
                 SkinInfo = skin.ToLiveUnmanaged();
             }
 
-            var configurationStream = storage?.GetStream(configurationFilename);
+            if (fallbackStore != null)
+                store.AddStore(fallbackStore);
+
+            var configurationStream = store.GetStream(configurationFilename);
 
             if (configurationStream != null)
             {
@@ -119,7 +122,7 @@ namespace osu.Game.Skinning
             {
                 string filename = $"{skinnableTarget}.json";
 
-                byte[]? bytes = storage?.Get(filename);
+                byte[]? bytes = store?.Get(filename);
 
                 if (bytes == null)
                     continue;
@@ -252,7 +255,7 @@ namespace osu.Game.Skinning
             Textures?.Dispose();
             Samples?.Dispose();
 
-            realmBackedStorage?.Dispose();
+            store.Dispose();
         }
 
         #endregion

--- a/osu.Game/Tests/Visual/SkinnableTestScene.cs
+++ b/osu.Game/Tests/Visual/SkinnableTestScene.cs
@@ -201,8 +201,8 @@ namespace osu.Game.Tests.Visual
         {
             private readonly bool extrapolateAnimations;
 
-            public TestLegacySkin(SkinInfo skin, IResourceStore<byte[]> storage, IStorageResourceProvider resources, bool extrapolateAnimations)
-                : base(skin, resources, storage)
+            public TestLegacySkin(SkinInfo skin, IResourceStore<byte[]> fallbackStore, IStorageResourceProvider resources, bool extrapolateAnimations)
+                : base(skin, resources, fallbackStore)
             {
                 this.extrapolateAnimations = extrapolateAnimations;
             }


### PR DESCRIPTION
This seems like the safest direction for now. With this change, a modification like what happened in https://github.com/ppy/osu/pull/25443 will not break lookups anymore.
