### PR TITLE
Refactor `OsuAutoGenerator` to allow custom SPM specifications

### DIFF
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -340,7 +340,7 @@ namespace osu.Game.Rulesets.Osu.Replays
             AddFrameToReplay(startFrame);
 
             // ~477 as per stable.
-            const float spin_rpm = 60000f / 20 * (180 / MathF.PI) / 360;
+            const float spin_rpm = 0.05f / (2 * MathF.PI) * 60000;
             float radsPerMillisecond = MathUtils.DegreesToRadians(spin_rpm * 360) / 60000;
 
             switch (h)

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -339,6 +339,10 @@ namespace osu.Game.Rulesets.Osu.Replays
 
             AddFrameToReplay(startFrame);
 
+            // ~477 as per stable.
+            const float spin_rpm = 60000f / 20 * (180 / MathF.PI) / 360;
+            float radsPerMillisecond = MathUtils.DegreesToRadians(spin_rpm * 360) / 60000;
+
             switch (h)
             {
                 // We add intermediate frames for spinning / following a slider here.
@@ -354,7 +358,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                     for (double nextFrame = h.StartTime + GetFrameDelay(h.StartTime); nextFrame < spinner.EndTime; nextFrame += GetFrameDelay(nextFrame))
                     {
                         t = ApplyModsToTimeDelta(previousFrame, nextFrame) * spinnerDirection;
-                        angle += (float)t / 20;
+                        angle += (float)t * radsPerMillisecond;
 
                         Vector2 pos = SPINNER_CENTRE + CirclePosition(angle, SPIN_RADIUS);
                         AddFrameToReplay(new OsuReplayFrame((int)nextFrame, new Vector2(pos.X, pos.Y), action));
@@ -363,7 +367,7 @@ namespace osu.Game.Rulesets.Osu.Replays
                     }
 
                     t = ApplyModsToTimeDelta(previousFrame, spinner.EndTime) * spinnerDirection;
-                    angle += (float)t / 20;
+                    angle += (float)t * radsPerMillisecond;
 
                     Vector2 endPosition = SPINNER_CENTRE + CirclePosition(angle, SPIN_RADIUS);
 

--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -339,7 +339,8 @@ namespace osu.Game.Rulesets.Osu.Replays
 
             AddFrameToReplay(startFrame);
 
-            // ~477 as per stable.
+            // 0.05 rad/ms, or ~477 RPM, as per stable.
+            // the redundant conversion from RPM to rad/ms is here for ease of testing custom SPM specs.
             const float spin_rpm = 0.05f / (2 * MathF.PI) * 60000;
             float radsPerMillisecond = MathUtils.DegreesToRadians(spin_rpm * 360) / 60000;
 


### PR DESCRIPTION
For testing purposes I would like to be able to easily set autoplay to spin at a certain SPM. This was pretty hard previously due to the "477" coming from a very abstract number.

I've adding a constant so it can be easily updated to a custom number as such:

```diff
diff --git a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
index acce8c03e8..66737223ca 100644
--- a/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
+++ b/osu.Game.Rulesets.Osu/Replays/OsuAutoGenerator.cs
@@ -340,7 +340,7 @@ private void addHitObjectClickFrames(OsuHitObject h, Vector2 startPosition, floa
             AddFrameToReplay(startFrame);
 
             // ~477 as per stable.
-            const float spin_rpm = 60000f / 20 * (180 / MathF.PI) / 360;
+            const float spin_rpm = 400;
             float radsPerMillisecond = MathUtils.DegreesToRadians(spin_rpm * 360) / 60000;
 
             switch (h)

```