### PR TITLE
Fix incorrect maximum accuracy display with recent slider end changes

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -260,6 +260,30 @@ namespace osu.Game.Tests.Rulesets.Scoring
 #pragma warning restore CS0618
 
         [Test]
+        public void TestMaxAccuracyOnIgnoreMiss()
+        {
+            beatmap = new TestBeatmap(new RulesetInfo())
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new TestHitObject(HitResult.Great),
+                    new TestHitObject(HitResult.LargeTickHit, HitResult.IgnoreMiss),
+                }
+            };
+
+            scoreProcessor = new TestScoreProcessor();
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], beatmap.HitObjects[0].CreateJudgement()) { Type = HitResult.Miss });
+            Assert.That(scoreProcessor.Combo.Value, Is.EqualTo(0));
+            Assert.That(scoreProcessor.Accuracy.Value, Is.EqualTo(0));
+
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], beatmap.HitObjects[1].CreateJudgement()) { Type = HitResult.IgnoreMiss });
+            Assert.That(scoreProcessor.Accuracy.Value, Is.EqualTo(0));
+            Assert.That(scoreProcessor.MaximumAccuracy.Value, Is.EqualTo(0));
+        }
+
+        [Test]
         public void TestComboBreak()
         {
             Assert.That(HitResult.ComboBreak.IncreasesCombo(), Is.False);

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -202,6 +202,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected sealed override void ApplyResultInternal(JudgementResult result)
         {
+            HitResult maxResult = result.Judgement.MaxResult;
+
             result.ComboAtJudgement = Combo.Value;
             result.HighestComboAtJudgement = HighestCombo.Value;
 
@@ -210,29 +212,29 @@ namespace osu.Game.Rulesets.Scoring
 
             scoreResultCounts[result.Type] = scoreResultCounts.GetValueOrDefault(result.Type) + 1;
 
-            if (!result.Type.IsScorable())
-                return;
-
-            if (result.Type.IncreasesCombo())
-                Combo.Value++;
-            else if (result.Type.BreaksCombo())
-                Combo.Value = 0;
-
-            result.ComboAfterJudgement = Combo.Value;
-
-            if (result.Type.AffectsAccuracy())
+            if (maxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore += Judgement.ToNumericResult(result.Judgement.MaxResult);
+                currentMaximumBaseScore += Judgement.ToNumericResult(maxResult);
                 currentBaseScore += Judgement.ToNumericResult(result.Type);
                 currentAccuracyJudgementCount++;
             }
 
-            if (result.Type.IsBonus())
-                currentBonusPortion += GetBonusScoreChange(result);
-            else
-                currentComboPortion += GetComboScoreChange(result);
+            if (!result.Type.IsScorable())
+            {
+                if (result.Type.IncreasesCombo())
+                    Combo.Value++;
+                else if (result.Type.BreaksCombo())
+                    Combo.Value = 0;
 
-            ApplyScoreChange(result);
+                result.ComboAfterJudgement = Combo.Value;
+
+                if (result.Type.IsBonus())
+                    currentBonusPortion += GetBonusScoreChange(result);
+                else
+                    currentComboPortion += GetComboScoreChange(result);
+
+                ApplyScoreChange(result);
+            }
 
             if (!IsSimulating)
             {

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Rulesets.Scoring
                 currentAccuracyJudgementCount++;
             }
 
-            if (!result.Type.IsScorable())
+            if (result.Type.IsScorable())
             {
                 if (result.Type.IncreasesCombo())
                     Combo.Value++;

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -23,11 +23,11 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            AccuracyDisplay.BindValueChanged(mod =>
+            AccuracyDisplay.BindValueChanged(mode =>
             {
                 Current.UnbindBindings();
 
-                switch (mod.NewValue)
+                switch (mode.NewValue)
                 {
                     case AccuracyDisplayMode.Standard:
                         Current.BindTo(scoreProcessor.Accuracy);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25428. Regressed with https://github.com/ppy/osu/pull/25342.

While this does fix the issue, I'm not confident in this one as a forward direction.

- The complexity and ordering of `ScoreProcessor.ApplyResultInternally` annoys me.
- If we're changing the way slider ends behave (ie. modifying judgements to support classic mod / results screen display requirements etc.) then this will likely have to change again, and might be handled in a nicer way.
- In the first place, `IsScoreable` seems like a really weird check. We already have so many other related checks that this one feels like it shouldn't need to exist..