### PR TITLE
Adjust slider follow circle animation to not abruptly scale on early ticks

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonFollowCircle.cs
@@ -88,9 +88,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         protected override void OnSliderTick()
         {
-            this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.08f, 40, Easing.OutQuint)
-                .Then()
-                .ScaleTo(DrawableSliderBall.FOLLOW_AREA, 200f, Easing.OutQuint);
+            if (Scale.X >= DrawableSliderBall.FOLLOW_AREA * 0.98f)
+            {
+                this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.08f, 40, Easing.OutQuint)
+                    .Then()
+                    .ScaleTo(DrawableSliderBall.FOLLOW_AREA, 200f, Easing.OutQuint);
+            }
         }
 
         protected override void OnSliderBreak()

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultFollowCircle.cs
@@ -59,9 +59,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         protected override void OnSliderTick()
         {
-            this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.08f, 40, Easing.OutQuint)
-                .Then()
-                .ScaleTo(DrawableSliderBall.FOLLOW_AREA, 200f, Easing.OutQuint);
+            if (Scale.X >= DrawableSliderBall.FOLLOW_AREA * 0.98f)
+            {
+                this.ScaleTo(DrawableSliderBall.FOLLOW_AREA * 1.08f, 40, Easing.OutQuint)
+                    .Then()
+                    .ScaleTo(DrawableSliderBall.FOLLOW_AREA, 200f, Easing.OutQuint);
+            }
         }
 
         protected override void OnSliderBreak()

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
@@ -44,8 +44,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         protected override void OnSliderTick()
         {
-            this.ScaleTo(2.2f)
-                .ScaleTo(2f, 200);
+            if (Scale.X >= 2f)
+            {
+                this.ScaleTo(2.2f)
+                    .ScaleTo(2f, 200);
+            }
         }
 
         protected override void OnSliderBreak()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25474.

Probably needs adjustments to tests to make this testable. Making `TestSceneSlider` track is a bit of a PITA...