### PR TITLE
Create "Key Count" mod to condense One Key, Two Key, etc. mods.

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             int originalColumns = ManiaBeatmapConverter.GetColumnCount(difficulty);
             int actualColumns = originalColumns;
 
-            actualColumns = mods.OfType<ManiaKeyMod>().SingleOrDefault()?.KeyCount ?? actualColumns;
+            actualColumns = mods.OfType<ManiaKeyMod>().SingleOrDefault()?.KeyCount.Value ?? actualColumns;
             if (mods.Any(m => m is ManiaModDualStages))
                 actualColumns *= 2;
 

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -263,18 +263,19 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModInvert(),
                         new ManiaModConstantSpeed(),
                         new ManiaModHoldOff(),
-                        new MultiMod(
-                            new ManiaModKey1(),
-                            new ManiaModKey2(),
-                            new ManiaModKey3(),
-                            new ManiaModKey4(),
-                            new ManiaModKey5(),
-                            new ManiaModKey6(),
-                            new ManiaModKey7(),
-                            new ManiaModKey8(),
-                            new ManiaModKey9(),
-                            new ManiaModKey10()
-                        ),
+                        // new MultiMod(
+                        //     new ManiaModKey1(),
+                        //     new ManiaModKey2(),
+                        //     new ManiaModKey3(),
+                        //     new ManiaModKey4(),
+                        //     new ManiaModKey5(),
+                        //     new ManiaModKey6(),
+                        //     new ManiaModKey7(),
+                        //     new ManiaModKey8(),
+                        //     new ManiaModKey9(),
+                        //     new ManiaModKey10()
+                        // ),
+                        new ManiaModKeyCount()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -32,19 +32,5 @@ namespace osu.Game.Rulesets.Mania.Mods
                 return;
             mbc.TargetColumns = KeyCount.Value;
         }
-
-        // public override Type[] IncompatibleMods => new[]
-        // {
-        //     typeof(ManiaModKey1),
-        //     typeof(ManiaModKey2),
-        //     typeof(ManiaModKey3),
-        //     typeof(ManiaModKey4),
-        //     typeof(ManiaModKey5),
-        //     typeof(ManiaModKey6),
-        //     typeof(ManiaModKey7),
-        //     typeof(ManiaModKey8),
-        //     typeof(ManiaModKey9),
-        //     typeof(ManiaModKey10),
-        // }.Except(new[] { GetType() }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Game.Beatmaps;
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -12,9 +12,16 @@ namespace osu.Game.Rulesets.Mania.Mods
     public abstract class ManiaKeyMod : Mod, IApplicableToBeatmapConverter
     {
         public override string Acronym => Name;
-        public abstract int KeyCount { get; }
+        [SettingSource("Key count", "Number of keys")]
+        public BindableNumber<int> KeyCount { get; } = new BindableInt(4)
+        {
+            MinValue = 1,
+            MaxValue = 10,
+        };
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1; // TODO: Implement the mania key mod score multiplier
+        public override string SettingDescription => $"{KeyCount.Value}";
+        public override string ExtendedIconInformation => SettingDescription;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {
@@ -23,22 +30,21 @@ namespace osu.Game.Rulesets.Mania.Mods
             // Although this can work, for now let's not allow keymods for mania-specific beatmaps
             if (mbc.IsForCurrentRuleset)
                 return;
-
-            mbc.TargetColumns = KeyCount;
+            mbc.TargetColumns = KeyCount.Value;
         }
 
-        public override Type[] IncompatibleMods => new[]
-        {
-            typeof(ManiaModKey1),
-            typeof(ManiaModKey2),
-            typeof(ManiaModKey3),
-            typeof(ManiaModKey4),
-            typeof(ManiaModKey5),
-            typeof(ManiaModKey6),
-            typeof(ManiaModKey7),
-            typeof(ManiaModKey8),
-            typeof(ManiaModKey9),
-            typeof(ManiaModKey10),
-        }.Except(new[] { GetType() }).ToArray();
+        // public override Type[] IncompatibleMods => new[]
+        // {
+        //     typeof(ManiaModKey1),
+        //     typeof(ManiaModKey2),
+        //     typeof(ManiaModKey3),
+        //     typeof(ManiaModKey4),
+        //     typeof(ManiaModKey5),
+        //     typeof(ManiaModKey6),
+        //     typeof(ManiaModKey7),
+        //     typeof(ManiaModKey8),
+        //     typeof(ManiaModKey9),
+        //     typeof(ManiaModKey10),
+        // }.Except(new[] { GetType() }).ToArray();
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey1 : ManiaKeyMod
     {
-        public override int KeyCount => 1;
         public override string Name => "One Key";
         public override string Acronym => "1K";
         public override LocalisableString Description => @"Play with one key.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey10 : ManiaKeyMod
     {
-        public override int KeyCount => 10;
         public override string Name => "Ten Keys";
         public override string Acronym => "10K";
         public override LocalisableString Description => @"Play with ten keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey2 : ManiaKeyMod
     {
-        public override int KeyCount => 2;
         public override string Name => "Two Keys";
         public override string Acronym => "2K";
         public override LocalisableString Description => @"Play with two keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey3 : ManiaKeyMod
     {
-        public override int KeyCount => 3;
         public override string Name => "Three Keys";
         public override string Acronym => "3K";
         public override LocalisableString Description => @"Play with three keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey4.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey4 : ManiaKeyMod
     {
-        public override int KeyCount => 4;
         public override string Name => "Four Keys";
         public override string Acronym => "4K";
         public override LocalisableString Description => @"Play with four keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey5.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey5 : ManiaKeyMod
     {
-        public override int KeyCount => 5;
         public override string Name => "Five Keys";
         public override string Acronym => "5K";
         public override LocalisableString Description => @"Play with five keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey6.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey6 : ManiaKeyMod
     {
-        public override int KeyCount => 6;
         public override string Name => "Six Keys";
         public override string Acronym => "6K";
         public override LocalisableString Description => @"Play with six keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey7.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey7 : ManiaKeyMod
     {
-        public override int KeyCount => 7;
         public override string Name => "Seven Keys";
         public override string Acronym => "7K";
         public override LocalisableString Description => @"Play with seven keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey8.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey8 : ManiaKeyMod
     {
-        public override int KeyCount => 8;
         public override string Name => "Eight Keys";
         public override string Acronym => "8K";
         public override LocalisableString Description => @"Play with eight keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey9.cs
@@ -7,7 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModKey9 : ManiaKeyMod
     {
-        public override int KeyCount => 9;
         public override string Name => "Nine Keys";
         public override string Acronym => "9K";
         public override LocalisableString Description => @"Play with nine keys.";

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKeyCount.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKeyCount.cs
@@ -9,6 +9,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     {
         public override string Name => "Key Count";
         public override string Acronym => "KC";
-        public override LocalisableString Description => @"Change the number of keys";
+        public override LocalisableString Description => @"Change the number of keys.";
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKeyCount.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKeyCount.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModKeyCount : ManiaKeyMod
+    {
+        public override string Name => "Key Count";
+        public override string Acronym => "KC";
+        public override LocalisableString Description => @"Change the number of keys";
+    }
+}


### PR DESCRIPTION
This is a mod that is intended to replace all the Mania Key conversion mods with one "Key Count" mod with a mod setting to change the key count to make the mod select more cleaner (#25252). 

https://github.com/ppy/osu/assets/51544115/dff5a3a5-2150-42f2-a3bf-e7c82cbcab8c

This is my first time contributing anything to a project as large as this, so I apologize if anything is bad or incorrect.

I feel it's also important to note that I kept each key mod as I am not sure how existing plays would be migrated