### PR TITLE
Fix implicitly used method being named incorrectly

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             yield return (ATTRIB_ID_APPROACH_RATE, ApproachRate);
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
 
-            if (ShouldSerializeFlashlightRating())
+            if (ShouldSerializeFlashlightDifficulty())
                 yield return (ATTRIB_ID_FLASHLIGHT, FlashlightDifficulty);
 
             yield return (ATTRIB_ID_SLIDER_FACTOR, SliderFactor);
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         // unless the fields are also renamed.
 
         [UsedImplicitly]
-        public bool ShouldSerializeFlashlightRating() => Mods.Any(m => m is ModFlashlight);
+        public bool ShouldSerializeFlashlightDifficulty() => Mods.Any(m => m is ModFlashlight);
 
         #endregion
     }


### PR DESCRIPTION
Was just reading up on the changes over the years and noticed this.
Probably not very consequential, given it's been broken for nearly 2 years at this point (https://github.com/ppy/osu/pull/16135), but probably worth fixing nevertheless!