### PR TITLE
Implement flow allowing disconnection from online services when another client instance for same user is detected

### DIFF
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Online
         private readonly string endpoint;
         private readonly string versionHash;
         private readonly bool preferMessagePack;
-        private readonly IAPIProvider api;
 
         /// <summary>
         /// The current connection opened by this connector.
@@ -47,7 +46,6 @@ namespace osu.Game.Online
         {
             ClientName = clientName;
             this.endpoint = endpoint;
-            this.api = api;
             this.versionHash = versionHash;
             this.preferMessagePack = preferMessagePack;
 
@@ -70,7 +68,7 @@ namespace osu.Game.Online
                             options.Proxy.Credentials = CredentialCache.DefaultCredentials;
                     }
 
-                    options.Headers.Add("Authorization", $"Bearer {api.AccessToken}");
+                    options.Headers.Add("Authorization", $"Bearer {API.AccessToken}");
                     options.Headers.Add("OsuVersionHash", versionHash);
                 });
 

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -100,7 +100,11 @@ namespace osu.Game.Online
             return Task.FromResult((PersistentEndpointClient)new HubClient(newConnection));
         }
 
-        Task IHubClientConnector.Disconnect() => base.Disconnect();
+        async Task IHubClientConnector.Disconnect()
+        {
+            await Disconnect().ConfigureAwait(false);
+            API.Logout();
+        }
 
         protected override string ClientName { get; }
     }

--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -102,6 +102,8 @@ namespace osu.Game.Online
             return Task.FromResult((PersistentEndpointClient)new HubClient(newConnection));
         }
 
+        Task IHubClientConnector.Disconnect() => base.Disconnect();
+
         protected override string ClientName { get; }
     }
 }

--- a/osu.Game/Online/IHubClientConnector.cs
+++ b/osu.Game/Online/IHubClientConnector.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Online
         public Action<HubConnection>? ConfigureConnection { get; set; }
 
         /// <summary>
+        /// Forcefully disconnects the client from the server.
+        /// </summary>
+        Task Disconnect();
+
+        /// <summary>
         /// Reconnect if already connected.
         /// </summary>
         Task Reconnect();

--- a/osu.Game/Online/IStatefulUserHubClient.cs
+++ b/osu.Game/Online/IStatefulUserHubClient.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+
+namespace osu.Game.Online
+{
+    /// <summary>
+    /// Common interface for clients of "stateful user hubs", i.e. server-side hubs
+    /// that preserve user state.
+    /// In the case of such hubs, concurrency constraints are enforced (only one client
+    /// can be connected at a time).
+    /// </summary>
+    public interface IStatefulUserHubClient
+    {
+        Task DisconnectRequested();
+    }
+}

--- a/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Online.Multiplayer
     /// <summary>
     /// An interface defining a multiplayer client instance.
     /// </summary>
-    public interface IMultiplayerClient
+    public interface IMultiplayerClient : IStatefulUserHubClient
     {
         /// <summary>
         /// Signals that the room has changed state.

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -357,6 +357,8 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task ChangeBeatmapAvailability(BeatmapAvailability newBeatmapAvailability);
 
+        public abstract Task DisconnectInternal();
+
         /// <summary>
         /// Change the local user's mods in the currently joined room.
         /// </summary>
@@ -875,6 +877,12 @@ namespace osu.Game.Online.Multiplayer
             });
 
             return tcs.Task;
+        }
+
+        Task IStatefulUserHubClient.DisconnectRequested()
+        {
+            Schedule(() => DisconnectInternal());
+            return Task.CompletedTask;
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Online.Multiplayer
                     connection.On<MultiplayerPlaylistItem>(nameof(IMultiplayerClient.PlaylistItemAdded), ((IMultiplayerClient)this).PlaylistItemAdded);
                     connection.On<long>(nameof(IMultiplayerClient.PlaylistItemRemoved), ((IMultiplayerClient)this).PlaylistItemRemoved);
                     connection.On<MultiplayerPlaylistItem>(nameof(IMultiplayerClient.PlaylistItemChanged), ((IMultiplayerClient)this).PlaylistItemChanged);
+                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IMultiplayerClient)this).DisconnectRequested);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);
@@ -253,6 +254,14 @@ namespace osu.Game.Online.Multiplayer
             Debug.Assert(connection != null);
 
             return connection.InvokeAsync(nameof(IMultiplayerServer.RemovePlaylistItem), playlistItemId);
+        }
+
+        public override Task DisconnectInternal()
+        {
+            if (connector == null)
+                return Task.CompletedTask;
+
+            return connector.Disconnect();
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Online/OnlineStatusNotifier.cs
+++ b/osu.Game/Online/OnlineStatusNotifier.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Screens;
+using osu.Game.Online.API;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Spectator;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Screens.OnlinePlay;
+
+namespace osu.Game.Online
+{
+    public partial class OnlineStatusNotifier : Component
+    {
+        private readonly Func<IScreen> getCurrentScreen;
+
+        [Resolved]
+        private MultiplayerClient multiplayerClient { get; set; } = null!;
+
+        [Resolved]
+        private SpectatorClient spectatorClient { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notificationOverlay { get; set; }
+
+        private IBindable<APIState> apiState = null!;
+        private IBindable<bool> multiplayerState = null!;
+        private IBindable<bool> spectatorState = null!;
+        private bool forcedDisconnection;
+
+        public OnlineStatusNotifier(Func<IScreen> getCurrentScreen)
+        {
+            this.getCurrentScreen = getCurrentScreen;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(IAPIProvider api)
+        {
+            apiState = api.State.GetBoundCopy();
+            multiplayerState = multiplayerClient.IsConnected.GetBoundCopy();
+            spectatorState = spectatorClient.IsConnected.GetBoundCopy();
+
+            multiplayerClient.Disconnecting += notifyAboutForcedDisconnection;
+            spectatorClient.Disconnecting += notifyAboutForcedDisconnection;
+        }
+
+        private void notifyAboutForcedDisconnection()
+        {
+            if (forcedDisconnection)
+                return;
+
+            forcedDisconnection = true;
+            notificationOverlay?.Post(new SimpleErrorNotification
+            {
+                Icon = FontAwesome.Solid.ExclamationCircle,
+                Text = "You have been logged out on this device due to a login to your account on another device."
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            apiState.BindValueChanged(_ =>
+            {
+                if (apiState.Value == APIState.Online)
+                    forcedDisconnection = false;
+
+                Scheduler.AddOnce(updateState);
+            });
+            multiplayerState.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+            spectatorState.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+        }
+
+        private void updateState()
+        {
+            if (forcedDisconnection)
+                return;
+
+            if (apiState.Value == APIState.Offline && getCurrentScreen() is OnlinePlayScreen)
+            {
+                notificationOverlay?.Post(new SimpleErrorNotification
+                {
+                    Icon = FontAwesome.Solid.ExclamationCircle,
+                    Text = "API connection was lost. Can't continue with online play."
+                });
+                return;
+            }
+
+            if (!multiplayerClient.IsConnected.Value && multiplayerClient.Room != null)
+            {
+                notificationOverlay?.Post(new SimpleErrorNotification
+                {
+                    Icon = FontAwesome.Solid.ExclamationCircle,
+                    Text = "Connection to the multiplayer server was lost. Exiting multiplayer."
+                });
+            }
+
+            // TODO: handle spectator server failure somehow?
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (spectatorClient.IsNotNull())
+                spectatorClient.Disconnecting -= notifyAboutForcedDisconnection;
+
+            if (multiplayerClient.IsNotNull())
+                multiplayerClient.Disconnecting -= notifyAboutForcedDisconnection;
+        }
+    }
+}

--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -159,6 +159,8 @@ namespace osu.Game.Online
                 await Task.Run(connect, default).ConfigureAwait(false);
         }
 
+        protected Task Disconnect() => disconnect(true);
+
         private async Task disconnect(bool takeLock)
         {
             cancelExistingConnect();

--- a/osu.Game/Online/Spectator/ISpectatorClient.cs
+++ b/osu.Game/Online/Spectator/ISpectatorClient.cs
@@ -8,7 +8,7 @@ namespace osu.Game.Online.Spectator
     /// <summary>
     /// An interface defining a spectator client instance.
     /// </summary>
-    public interface ISpectatorClient
+    public interface ISpectatorClient : IStatefulUserHubClient
     {
         /// <summary>
         /// Signals that a user has begun a new play session.

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -115,12 +115,14 @@ namespace osu.Game.Online.Spectator
             return connection.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
         }
 
-        protected override Task DisconnectInternal()
+        protected override async Task DisconnectInternal()
         {
-            if (connector == null)
-                return Task.CompletedTask;
+            await base.DisconnectInternal().ConfigureAwait(false);
 
-            return connector.Disconnect();
+            if (connector == null)
+                return;
+
+            await connector.Disconnect().ConfigureAwait(false);
         }
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Online.Spectator
                     connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
                     connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
                     connection.On<int, long>(nameof(ISpectatorClient.UserScoreProcessed), ((ISpectatorClient)this).UserScoreProcessed);
+                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IStatefulUserHubClient)this).DisconnectRequested);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);
@@ -112,6 +113,14 @@ namespace osu.Game.Online.Spectator
             Debug.Assert(connection != null);
 
             return connection.InvokeAsync(nameof(ISpectatorServer.EndWatchingUser), userId);
+        }
+
+        protected override Task DisconnectInternal()
+        {
+            if (connector == null)
+                return Task.CompletedTask;
+
+            return connector.Disconnect();
         }
     }
 }

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -174,6 +174,12 @@ namespace osu.Game.Online.Spectator
             return Task.CompletedTask;
         }
 
+        Task IStatefulUserHubClient.DisconnectRequested()
+        {
+            Schedule(() => DisconnectInternal());
+            return Task.CompletedTask;
+        }
+
         public void BeginPlaying(long? scoreToken, GameplayState state, Score score)
         {
             // This schedule is only here to match the one below in `EndPlaying`.
@@ -290,6 +296,8 @@ namespace osu.Game.Online.Spectator
         protected abstract Task WatchUserInternal(int userId);
 
         protected abstract Task StopWatchingUserInternal(int userId);
+
+        protected abstract Task DisconnectInternal();
 
         protected override void Update()
         {

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -71,6 +71,11 @@ namespace osu.Game.Online.Spectator
         public virtual event Action<int, long>? OnUserScoreProcessed;
 
         /// <summary>
+        /// Invoked just prior to disconnection requested by the server via <see cref="IStatefulUserHubClient.DisconnectRequested"/>.
+        /// </summary>
+        public event Action? Disconnecting;
+
+        /// <summary>
         /// A dictionary containing all users currently being watched, with the number of watching components for each user.
         /// </summary>
         private readonly Dictionary<int, int> watchedUsersRefCounts = new Dictionary<int, int>();
@@ -297,7 +302,11 @@ namespace osu.Game.Online.Spectator
 
         protected abstract Task StopWatchingUserInternal(int userId);
 
-        protected abstract Task DisconnectInternal();
+        protected virtual Task DisconnectInternal()
+        {
+            Disconnecting?.Invoke();
+            return Task.CompletedTask;
+        }
 
         protected override void Update()
         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1054,6 +1054,7 @@ namespace osu.Game
             Add(difficultyRecommender);
             Add(externalLinkOpener = new ExternalLinkOpener());
             Add(new MusicKeyBindingHandler());
+            Add(new OnlineStatusNotifier(() => ScreenStack.CurrentScreen));
 
             // side overlays which cancel each other.
             var singleDisplaySideOverlays = new OverlayContainer[] { Settings, Notifications, FirstRunOverlay };

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -98,7 +98,9 @@ namespace osu.Game.Screens.OnlinePlay.Components
             if (JoinedRoom.Value == null)
                 return;
 
-            api.Queue(new PartRoomRequest(joinedRoom.Value));
+            if (api.State.Value == APIState.Online)
+                api.Queue(new PartRoomRequest(joinedRoom.Value));
+
             joinedRoom.Value = null;
         }
 

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.OnlinePlay
                     screenStack = new OnlinePlaySubScreenStack { RelativeSizeAxes = Axes.Both },
                     new Header(ScreenTitle, screenStack),
                     RoomManager,
-                    ongoingOperationTracker
+                    ongoingOperationTracker,
                 }
             };
         }
@@ -79,10 +79,7 @@ namespace osu.Game.Screens.OnlinePlay
         private void onlineStateChanged(ValueChangedEvent<APIState> state) => Schedule(() =>
         {
             if (state.NewValue != APIState.Online)
-            {
-                Logger.Log("API connection was lost, can't continue with online play", LoggingTarget.Network, LogLevel.Important);
                 Schedule(forcefullyExit);
-            }
         });
 
         protected override void LoadComplete()

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -658,5 +658,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
             PlayedAt = item.PlayedAt,
             StarRating = item.Beatmap.StarRating,
         };
+
+        public override Task DisconnectInternal()
+        {
+            isConnected.Value = false;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -33,7 +33,8 @@ namespace osu.Game.Tests.Visual.Spectator
 
         public int FrameSendAttempts { get; private set; }
 
-        public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
+        public override IBindable<bool> IsConnected => isConnected;
+        private readonly BindableBool isConnected = new BindableBool(true);
 
         public IReadOnlyDictionary<int, ReplayFrame> LastReceivedUserFrames => lastReceivedUserFrames;
 
@@ -178,6 +179,12 @@ namespace osu.Game.Tests.Visual.Spectator
                 Mods = userModsDictionary[userId],
                 State = SpectatedUserState.Playing
             });
+        }
+
+        protected override Task DisconnectInternal()
+        {
+            isConnected.Value = false;
+            return Task.CompletedTask;
         }
     }
 }

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -181,10 +181,10 @@ namespace osu.Game.Tests.Visual.Spectator
             });
         }
 
-        protected override Task DisconnectInternal()
+        protected override async Task DisconnectInternal()
         {
+            await base.DisconnectInternal().ConfigureAwait(false);
             isConnected.Value = false;
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Prerequisite for https://github.com/ppy/osu-server-spectator/issues/80.

In action:

https://github.com/ppy/osu/assets/20418176/6ea21370-cae1-4cdc-b845-c4fc60cdb306

In short, when a user logs in on one client instance, and then on another, the previous instance is forcibly logged out. It can be restored to full online operation by logging in again, at which point any _other_ online instance will be forcibly logged out. So the goal here is to keep concurrency to 1.

The reason that this does a full logout rather than something more limited is (a) that it's easy to integrate with existing systems, and also (b) avoids weirdness. For instance, we _could_ theoretically allow the user to solo even with concurrent client instances, _were it not_ for the fact that `osu-server-spectator` - namely `SpectatorHub` - participates in the replay recording part of score submission, and cannot handle concurrency.

This currently has no testing other than manual, but I'm not sure anything more is feasible anyway. I'm also not sure of the general shape of this, which is why I'm opening as draft and refraining from adding tests until requested _and_ I am sure that there's at least an agreement that this looks how everyone would want it to look.