### PR TITLE
Fix freehand-drawn sliders with distance snap

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (controlPointCount > 2 || (controlPointCount == 2 && HitObject.Path.ControlPoints.Last() != cursor))
                 return base.OnDragStart(e);
 
-            HitObject.Position = ToLocalSpace(e.ScreenSpaceMouseDownPosition);
+            bSplineBuilder.AddLinearPoint(Vector2.Zero);
             bSplineBuilder.AddLinearPoint(ToLocalSpace(e.ScreenSpaceMouseDownPosition) - HitObject.Position);
             state = SliderPlacementState.Drawing;
             return true;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -175,6 +175,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (controlPointCount > 2 || (controlPointCount == 2 && HitObject.Path.ControlPoints.Last() != cursor))
                 return base.OnDragStart(e);
 
+            HitObject.Position = ToLocalSpace(e.ScreenSpaceMouseDownPosition);
             bSplineBuilder.AddLinearPoint(ToLocalSpace(e.ScreenSpaceMouseDownPosition) - HitObject.Position);
             state = SliderPlacementState.Drawing;
             return true;


### PR DESCRIPTION
Trying to freehand draw a slider when distance snap is active causes the control points to be offset from the slider curve.

The following video demonstrates the current behaviour on master:

https://github.com/ppy/osu/assets/4215321/0c4f71d8-bbae-411e-930d-730bf2e93762


There are two possible ways to fix it:
* We can insert the linear point (0, 0) into the bspline builder to trace a path from the hitobjects snapped position to the current cursor position, resulting in this behaviour:

https://github.com/ppy/osu/assets/4215321/5bb33196-dd9b-4647-a5e4-afa150c30a0b

* Or we can reposition the hit object so it ignores distance snap and instead starts at the current cursors location


https://github.com/ppy/osu/assets/4215321/6c4b2660-cf54-4b2c-9ebe-723bcbbe3e18


Given that freehand drawing in combination with snap feels strange, another option would be to simply disable the option to freehand draw (ie returning false from OnDragStart) if the hitobjects position is sufficiently far away from the cursor position, however, I fear this might be unintuitive to users.

This PR implements repositioning of the slider to the cursors current location when freehand drawing starts, because to me this seems like the most intuitive approach.
