### PR TITLE
Fix spectator mode not showing when a spectated user quits correctly

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -100,19 +100,18 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             start();
 
-            AddUntilStep("wait for player loader", () => (Stack.CurrentScreen as PlayerLoader)?.IsLoaded == true);
+            AddUntilStep("wait for player loader", () => this.ChildrenOfType<PlayerLoader>().SingleOrDefault()?.IsLoaded == true);
 
             AddUntilStep("queue send frames on player load", () =>
             {
-                var loadingPlayer = (Stack.CurrentScreen as PlayerLoader)?.CurrentPlayer;
+                var loadingPlayer = this.ChildrenOfType<PlayerLoader>().SingleOrDefault()?.CurrentPlayer;
 
                 if (loadingPlayer == null)
                     return false;
 
                 loadingPlayer.OnLoadComplete += _ =>
-                {
                     spectatorClient.SendFramesFromUser(streamingUser.Id, 10, gameplay_start);
-                };
+
                 return true;
             });
 
@@ -360,12 +359,12 @@ namespace osu.Game.Tests.Visual.Gameplay
         private OsuFramedReplayInputHandler replayHandler =>
             (OsuFramedReplayInputHandler)Stack.ChildrenOfType<OsuInputManager>().First().ReplayInputHandler;
 
-        private Player player => Stack.CurrentScreen as Player;
+        private Player player => this.ChildrenOfType<Player>().Single();
 
         private double currentFrameStableTime
             => player.ChildrenOfType<FrameStabilityContainer>().First().CurrentTime;
 
-        private void waitForPlayer() => AddUntilStep("wait for player", () => (Stack.CurrentScreen as Player)?.IsLoaded == true);
+        private void waitForPlayer() => AddUntilStep("wait for player", () => this.ChildrenOfType<Player>().SingleOrDefault()?.IsLoaded == true);
 
         private void start(int? beatmapId = null) => AddStep("start play", () => spectatorClient.SendStartPlay(streamingUser.Id, beatmapId ?? importedBeatmapId));
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -332,6 +332,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("send quit", () => spectatorClient.SendEndPlay(streamingUser.Id));
             AddUntilStep("state is quit", () => spectatorClient.WatchedUserStates[streamingUser.Id].State == SpectatedUserState.Quit);
 
+            AddUntilStep("wait for player exit", () => !this.ChildrenOfType<Player>().Any());
+
             start();
             sendFrames();
             waitForPlayer();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private TestSpectatorClient spectatorClient => dependenciesScreen.SpectatorClient;
         private DependenciesScreen dependenciesScreen;
-        private SoloSpectator spectatorScreen;
+        private SoloSpectatorScreen spectatorScreen;
 
         private BeatmapSetInfo importedBeatmap;
         private int importedBeatmapId;
@@ -127,7 +127,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             loadSpectatingScreen();
 
-            AddAssert("screen hasn't changed", () => Stack.CurrentScreen is SoloSpectator);
+            AddAssert("screen hasn't changed", () => Stack.CurrentScreen is SoloSpectatorScreen);
 
             start();
             waitForPlayer();
@@ -255,7 +255,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             start(-1234);
             sendFrames();
 
-            AddAssert("screen didn't change", () => Stack.CurrentScreen is SoloSpectator);
+            AddAssert("screen didn't change", () => Stack.CurrentScreen is SoloSpectatorScreen);
         }
 
         [Test]
@@ -381,7 +381,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private void loadSpectatingScreen()
         {
-            AddStep("load spectator", () => LoadScreen(spectatorScreen = new SoloSpectator(streamingUser)));
+            AddStep("load spectator", () => LoadScreen(spectatorScreen = new SoloSpectatorScreen(streamingUser)));
             AddUntilStep("wait for screen load", () => spectatorScreen.LoadState == LoadState.Loaded);
         }
 

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Online.Spectator
 
         private IHubClientConnector? connector;
 
-        public override IBindable<bool> IsConnected { get; } = new BindableBool();
+        protected override IBindable<bool> IsConnected { get; } = new BindableBool();
 
         private HubConnection? connection => connector?.CurrentConnection;
 

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -33,12 +33,12 @@ namespace osu.Game.Online.Spectator
         /// Whether the <see cref="SpectatorClient"/> is currently connected.
         /// This is NOT thread safe and usage should be scheduled.
         /// </summary>
-        public abstract IBindable<bool> IsConnected { get; }
+        protected abstract IBindable<bool> IsConnected { get; }
 
         /// <summary>
         /// The states of all users currently being watched.
         /// </summary>
-        public virtual IBindableDictionary<int, SpectatorState> WatchedUserStates => watchedUserStates;
+        public IBindableDictionary<int, SpectatorState> WatchedUserStates => watchedUserStates;
 
         /// <summary>
         /// A global list of all players currently playing.
@@ -46,29 +46,29 @@ namespace osu.Game.Online.Spectator
         public IBindableList<int> PlayingUsers => playingUsers;
 
         /// <summary>
-        /// Whether the local user is playing.
+        /// Whether the spectated user is playing.
         /// </summary>
-        protected internal bool IsPlaying { get; private set; }
+        private bool isPlaying { get; set; }
 
         /// <summary>
         /// Called whenever new frames arrive from the server.
         /// </summary>
-        public virtual event Action<int, FrameDataBundle>? OnNewFrames;
+        public event Action<int, FrameDataBundle>? OnNewFrames;
 
         /// <summary>
         /// Called whenever a user starts a play session, or immediately if the user is being watched and currently in a play session.
         /// </summary>
-        public virtual event Action<int, SpectatorState>? OnUserBeganPlaying;
+        public event Action<int, SpectatorState>? OnUserBeganPlaying;
 
         /// <summary>
         /// Called whenever a user finishes a play session.
         /// </summary>
-        public virtual event Action<int, SpectatorState>? OnUserFinishedPlaying;
+        public event Action<int, SpectatorState>? OnUserFinishedPlaying;
 
         /// <summary>
         /// Called whenever a user-submitted score has been fully processed.
         /// </summary>
-        public virtual event Action<int, long>? OnUserScoreProcessed;
+        public event Action<int, long>? OnUserScoreProcessed;
 
         /// <summary>
         /// A dictionary containing all users currently being watched, with the number of watching components for each user.
@@ -114,7 +114,7 @@ namespace osu.Game.Online.Spectator
                     }
 
                     // re-send state in case it wasn't received
-                    if (IsPlaying)
+                    if (isPlaying)
                         // TODO: this is likely sent out of order after a reconnect scenario. needs further consideration.
                         BeginPlayingInternal(currentScoreToken, currentState);
                 }
@@ -179,10 +179,10 @@ namespace osu.Game.Online.Spectator
             // This schedule is only here to match the one below in `EndPlaying`.
             Schedule(() =>
             {
-                if (IsPlaying)
+                if (isPlaying)
                     throw new InvalidOperationException($"Cannot invoke {nameof(BeginPlaying)} when already playing");
 
-                IsPlaying = true;
+                isPlaying = true;
 
                 // transfer state at point of beginning play
                 currentState.BeatmapID = score.ScoreInfo.BeatmapInfo!.OnlineID;
@@ -202,7 +202,7 @@ namespace osu.Game.Online.Spectator
 
         public void HandleFrame(ReplayFrame frame) => Schedule(() =>
         {
-            if (!IsPlaying)
+            if (!isPlaying)
             {
                 Logger.Log($"Frames arrived at {nameof(SpectatorClient)} outside of gameplay scope and will be ignored.");
                 return;
@@ -224,7 +224,7 @@ namespace osu.Game.Online.Spectator
             // We probably need to find a better way to handle this...
             Schedule(() =>
             {
-                if (!IsPlaying)
+                if (!isPlaying)
                     return;
 
                 // Disposal can take some time, leading to EndPlaying potentially being called after a future play session.
@@ -235,7 +235,7 @@ namespace osu.Game.Online.Spectator
                 if (pendingFrames.Count > 0)
                     purgePendingFrames();
 
-                IsPlaying = false;
+                isPlaying = false;
                 currentBeatmap = null;
 
                 if (state.HasPassed)
@@ -249,7 +249,7 @@ namespace osu.Game.Online.Spectator
             });
         }
 
-        public virtual void WatchUser(int userId)
+        public void WatchUser(int userId)
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Online.Spectator
         /// <summary>
         /// The states of all users currently being watched.
         /// </summary>
-        public IBindableDictionary<int, SpectatorState> WatchedUserStates => watchedUserStates;
+        public virtual IBindableDictionary<int, SpectatorState> WatchedUserStates => watchedUserStates;
 
         /// <summary>
         /// A global list of all players currently playing.
@@ -53,7 +53,7 @@ namespace osu.Game.Online.Spectator
         /// <summary>
         /// Called whenever new frames arrive from the server.
         /// </summary>
-        public event Action<int, FrameDataBundle>? OnNewFrames;
+        public virtual event Action<int, FrameDataBundle>? OnNewFrames;
 
         /// <summary>
         /// Called whenever a user starts a play session, or immediately if the user is being watched and currently in a play session.
@@ -249,7 +249,7 @@ namespace osu.Game.Online.Spectator
             });
         }
 
-        public void WatchUser(int userId)
+        public virtual void WatchUser(int userId)
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 

--- a/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/CurrentlyPlayingDisplay.cs
@@ -212,7 +212,7 @@ namespace osu.Game.Overlays.Dashboard
                                 Text = "Spectate",
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
-                                Action = () => performer?.PerformFromScreen(s => s.Push(new SoloSpectator(User))),
+                                Action = () => performer?.PerformFromScreen(s => s.Push(new SoloSpectatorScreen(User))),
                                 Enabled = { Value = User.Id != api.LocalUser.Value.Id }
                             }
                         }

--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -33,7 +33,7 @@ using osuTK;
 namespace osu.Game.Screens.Play
 {
     [Cached(typeof(IPreviewTrackOwner))]
-    public partial class SoloSpectator : SpectatorScreen, IPreviewTrackOwner
+    public partial class SoloSpectatorScreen : SpectatorScreen, IPreviewTrackOwner
     {
         [NotNull]
         private readonly APIUser targetUser;
@@ -67,7 +67,7 @@ namespace osu.Game.Screens.Play
 
         private APIBeatmapSet beatmapSet;
 
-        public SoloSpectator([NotNull] APIUser targetUser)
+        public SoloSpectatorScreen([NotNull] APIUser targetUser)
             : base(targetUser.Id)
         {
             this.targetUser = targetUser;

--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -63,6 +63,12 @@ namespace osu.Game.Screens.Play
 
         private APIBeatmapSet? beatmapSet;
 
+        private OsuScreenStack playerScreenStack = null!;
+
+        private Container screenStackContainer = null!;
+
+        public override bool DisallowExternalBeatmapRulesetChanges => true;
+
         public SoloSpectatorScreen(APIUser targetUser)
             : base(targetUser.Id)
         {
@@ -156,6 +162,20 @@ namespace osu.Game.Screens.Play
                     }
                 }
             };
+
+            AddInternal(screenStackContainer = new Container
+            {
+                CornerRadius = 10,
+                Masking = true,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                Scale = new Vector2(0.95f),
+                Children = new Drawable[]
+                {
+                    playerScreenStack = new OsuScreenStack()
+                }
+            });
         }
 
         protected override void LoadComplete()
@@ -185,6 +205,8 @@ namespace osu.Game.Screens.Play
             watchButton.Enabled.Value = false;
 
             clearDisplay();
+
+            playerScreenStack.CurrentScreen?.Exit();
         }
 
         private void clearDisplay()
@@ -216,7 +238,21 @@ namespace osu.Game.Screens.Play
                 Beatmap.Value = spectatorGameplayState.Beatmap;
                 Ruleset.Value = spectatorGameplayState.Ruleset.RulesetInfo;
 
-                this.Push(new SpectatorPlayerLoader(spectatorGameplayState.Score, () => new SoloSpectatorPlayer(spectatorGameplayState.Score)));
+                screenStackContainer.FadeInFromZero(500);
+                screenStackContainer
+                    .ScaleTo(0.9f)
+                    .ScaleTo(0.95f, 500, Easing.OutQuint);
+                playerScreenStack.Push(new SpectatorPlayerLoader(spectatorGameplayState.Score, () => new SoloSpectatorPlayer(spectatorGameplayState.Score)));
+
+                // LoadComponentAsync(new SpectatorPlayerLoader(spectatorGameplayState.Score, () => new SoloSpectatorPlayer(spectatorGameplayState.Score)), loader =>
+                // {
+                //     playerScreenStack.FadeInFromZero(500);
+                //     playerScreenStack
+                //         .ScaleTo(0.9f)
+                //         .ScaleTo(0.95f, 500, Easing.OutQuint);
+                //
+                //     playerScreenStack.PushSynchronously(loader);
+                // });
             }
         }
 

--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -35,39 +32,38 @@ namespace osu.Game.Screens.Play
     [Cached(typeof(IPreviewTrackOwner))]
     public partial class SoloSpectatorScreen : SpectatorScreen, IPreviewTrackOwner
     {
-        [NotNull]
-        private readonly APIUser targetUser;
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private PreviewTrackManager previewTrackManager { get; set; } = null!;
 
         [Resolved]
-        private PreviewTrackManager previewTrackManager { get; set; }
+        private BeatmapManager beatmaps { get; set; } = null!;
 
         [Resolved]
-        private BeatmapManager beatmaps { get; set; }
-
-        [Resolved]
-        private BeatmapModelDownloader beatmapDownloader { get; set; }
+        private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
 
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
-        private Container beatmapPanelContainer;
-        private RoundedButton watchButton;
-        private SettingsCheckbox automaticDownload;
+        private Container beatmapPanelContainer = null!;
+        private RoundedButton watchButton = null!;
+        private SettingsCheckbox automaticDownload = null!;
+
+        private readonly APIUser targetUser;
 
         /// <summary>
         /// The player's immediate online gameplay state.
         /// This doesn't always reflect the gameplay state being watched.
         /// </summary>
-        private SpectatorGameplayState immediateSpectatorGameplayState;
+        private SpectatorGameplayState? immediateSpectatorGameplayState;
 
-        private GetBeatmapSetRequest onlineBeatmapRequest;
+        private GetBeatmapSetRequest? onlineBeatmapRequest;
 
-        private APIBeatmapSet beatmapSet;
+        private APIBeatmapSet? beatmapSet;
 
-        public SoloSpectatorScreen([NotNull] APIUser targetUser)
+        public SoloSpectatorScreen(APIUser targetUser)
             : base(targetUser.Id)
         {
             this.targetUser = targetUser;
@@ -199,10 +195,12 @@ namespace osu.Game.Screens.Play
             previewTrackManager.StopAnyPlaying(this);
         }
 
-        private ScheduledDelegate scheduledStart;
+        private ScheduledDelegate? scheduledStart;
 
-        private void scheduleStart(SpectatorGameplayState spectatorGameplayState)
+        private void scheduleStart(SpectatorGameplayState? spectatorGameplayState)
         {
+            Debug.Assert(spectatorGameplayState != null);
+
             // This function may be called multiple times in quick succession once the screen becomes current again.
             scheduledStart?.Cancel();
             scheduledStart = Schedule(() =>

--- a/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayerLoader.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Scoring;
+using osu.Game.Screens.Menu;
 
 namespace osu.Game.Screens.Play
 {
@@ -27,6 +29,15 @@ namespace osu.Game.Screens.Play
             Ruleset.Value = Score.Ruleset;
 
             base.OnEntering(e);
+        }
+
+        protected override void LogoExiting(OsuLogo logo)
+        {
+            const double logo_transition = 250;
+
+            base.LogoExiting(logo);
+            logo.ScaleTo(0.2f, logo_transition / 2, Easing.Out);
+            logo.FadeOut(logo_transition / 2, Easing.Out);
         }
     }
 }

--- a/osu.Game/Screens/Spectate/SpectatorScreen.cs
+++ b/osu.Game/Screens/Spectate/SpectatorScreen.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -33,21 +30,26 @@ namespace osu.Game.Screens.Spectate
         private readonly List<int> users = new List<int>();
 
         [Resolved]
-        private BeatmapManager beatmaps { get; set; }
+        private BeatmapManager beatmaps { get; set; } = null!;
 
         [Resolved]
-        private RulesetStore rulesets { get; set; }
+        private RulesetStore rulesets { get; set; } = null!;
 
         [Resolved]
-        private SpectatorClient spectatorClient { get; set; }
+        private SpectatorClient spectatorClient { get; set; } = null!;
 
         [Resolved]
-        private UserLookupCache userLookupCache { get; set; }
+        private UserLookupCache userLookupCache { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
 
         private readonly IBindableDictionary<int, SpectatorState> userStates = new BindableDictionary<int, SpectatorState>();
 
         private readonly Dictionary<int, APIUser> userMap = new Dictionary<int, APIUser>();
         private readonly Dictionary<int, SpectatorGameplayState> gameplayStates = new Dictionary<int, SpectatorGameplayState>();
+
+        private IDisposable? realmSubscription;
 
         /// <summary>
         /// Creates a new <see cref="SpectatorScreen"/>.
@@ -57,11 +59,6 @@ namespace osu.Game.Screens.Spectate
         {
             this.users.AddRange(users);
         }
-
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
-        private IDisposable realmSubscription;
 
         protected override void LoadComplete()
         {
@@ -90,7 +87,7 @@ namespace osu.Game.Screens.Spectate
             }));
         }
 
-        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> items, ChangeSet changes)
+        private void beatmapsChanged(IRealmCollection<BeatmapSetInfo> items, ChangeSet? changes)
         {
             if (changes?.InsertedIndices == null) return;
 
@@ -109,7 +106,7 @@ namespace osu.Game.Screens.Spectate
             }
         }
 
-        private void onUserStatesChanged(object sender, NotifyDictionaryChangedEventArgs<int, SpectatorState> e)
+        private void onUserStatesChanged(object? sender, NotifyDictionaryChangedEventArgs<int, SpectatorState> e)
         {
             switch (e.Action)
             {
@@ -207,14 +204,14 @@ namespace osu.Game.Screens.Spectate
         /// </summary>
         /// <param name="userId">The user whose state has changed.</param>
         /// <param name="spectatorState">The new state.</param>
-        protected abstract void OnNewPlayingUserState(int userId, [NotNull] SpectatorState spectatorState);
+        protected abstract void OnNewPlayingUserState(int userId, SpectatorState spectatorState);
 
         /// <summary>
         /// Starts gameplay for a user.
         /// </summary>
         /// <param name="userId">The user to start gameplay for.</param>
         /// <param name="spectatorGameplayState">The gameplay state.</param>
-        protected abstract void StartGameplay(int userId, [NotNull] SpectatorGameplayState spectatorGameplayState);
+        protected abstract void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState);
 
         /// <summary>
         /// Quits gameplay for a user.
@@ -243,7 +240,7 @@ namespace osu.Game.Screens.Spectate
         {
             base.Dispose(isDisposing);
 
-            if (spectatorClient != null)
+            if (spectatorClient.IsNotNull())
             {
                 foreach ((int userId, var _) in userMap)
                     spectatorClient.StopWatchingUser(userId);

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Tests.Visual.Spectator
 
         public int FrameSendAttempts { get; private set; }
 
-        public override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
+        protected override IBindable<bool> IsConnected { get; } = new Bindable<bool>(true);
 
         public IReadOnlyDictionary<int, ReplayFrame> LastReceivedUserFrames => lastReceivedUserFrames;
 


### PR DESCRIPTION
This PR switches `SoloSpectatorScreen` to use a nested screen for gameplay.

Spectator relies on the `SpectatorScreen` (which importantly, is not the `SpectatorPlayer` but a separate screen) to be alive and present in order to function correctly, due to `Schedule`d operations).

This was already true for multiplayer but not for solo play, so it seems logical to standardise things here.

Closes https://github.com/ppy/osu/issues/25535.

---


https://github.com/ppy/osu/assets/191335/f6ecdc22-7c48-454b-9d63-145f1b37b546

