### PR TITLE
Replace all hexacon lookups with strongly typed properties

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.1121.1" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2023.1124.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayHeader.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOverlayHeader.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.UserInterface
@@ -153,7 +154,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             public TestTitle()
             {
                 Title = "title";
-                IconTexture = "Icons/changelog";
+                Icon = HexaconsIcons.Devtools;
             }
         }
     }

--- a/osu.Game/Graphics/HexaconsIcons.cs
+++ b/osu.Game/Graphics/HexaconsIcons.cs
@@ -16,12 +16,31 @@ namespace osu.Game.Graphics
     {
         public const string FONT_NAME = "Icons/Hexacons";
 
+        public static IconUsage BeatmapPacks => get(HexaconsMapping.beatmap_packs);
+        public static IconUsage Beatmap => get(HexaconsMapping.beatmap);
+        public static IconUsage Calendar => get(HexaconsMapping.calendar);
+        public static IconUsage Chart => get(HexaconsMapping.chart);
+        public static IconUsage Community => get(HexaconsMapping.community);
+        public static IconUsage Contests => get(HexaconsMapping.contests);
+        public static IconUsage Devtools => get(HexaconsMapping.devtools);
+        public static IconUsage Download => get(HexaconsMapping.download);
         public static IconUsage Editor => get(HexaconsMapping.editor);
+        public static IconUsage FeaturedArtist => get(HexaconsMapping.featured_artist);
+        public static IconUsage Home => get(HexaconsMapping.home);
+        public static IconUsage Messaging => get(HexaconsMapping.messaging);
+        public static IconUsage Music => get(HexaconsMapping.music);
+        public static IconUsage News => get(HexaconsMapping.news);
+        public static IconUsage Notification => get(HexaconsMapping.notification);
+        public static IconUsage Profile => get(HexaconsMapping.profile);
+        public static IconUsage Rankings => get(HexaconsMapping.rankings);
+        public static IconUsage Search => get(HexaconsMapping.search);
+        public static IconUsage Settings => get(HexaconsMapping.settings);
+        public static IconUsage Social => get(HexaconsMapping.social);
+        public static IconUsage Store => get(HexaconsMapping.store);
+        public static IconUsage Tournament => get(HexaconsMapping.tournament);
+        public static IconUsage Wiki => get(HexaconsMapping.wiki);
 
-        private static IconUsage get(HexaconsMapping icon)
-        {
-            return new IconUsage((char)icon, FONT_NAME);
-        }
+        private static IconUsage get(HexaconsMapping icon) => new IconUsage((char)icon, FONT_NAME);
 
         // Basically just converting to something we can use in a `char` lookup for FontStore/GlyphStore compatibility.
         // Names should match filenames in resources.

--- a/osu.Game/Graphics/HexaconsIcons.cs
+++ b/osu.Game/Graphics/HexaconsIcons.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Text;
+
+namespace osu.Game.Graphics
+{
+    public static class HexaconsIcons
+    {
+        public const string FONT_NAME = "Icons/Hexacons";
+
+        public static IconUsage Editor => get(HexaconsMapping.editor);
+
+        private static IconUsage get(HexaconsMapping icon)
+        {
+            return new IconUsage((char)icon, FONT_NAME);
+        }
+
+        // Basically just converting to something we can use in a `char` lookup for FontStore/GlyphStore compatibility.
+        // Names should match filenames in resources.
+        private enum HexaconsMapping
+        {
+            beatmap_packs,
+            beatmap,
+            calendar,
+            chart,
+            community,
+            contests,
+            devtools,
+            download,
+            editor,
+            featured_artist,
+            home,
+            messaging,
+            music,
+            news,
+            notification,
+            profile,
+            rankings,
+            search,
+            settings,
+            social,
+            store,
+            tournament,
+            wiki,
+        }
+
+        public class HexaconsStore : ITextureStore, ITexturedGlyphLookupStore
+        {
+            private readonly TextureStore textures;
+
+            public HexaconsStore(TextureStore textures)
+            {
+                this.textures = textures;
+            }
+
+            public void Dispose()
+            {
+                textures.Dispose();
+            }
+
+            public ITexturedCharacterGlyph? Get(string? fontName, char character)
+            {
+                if (fontName == FONT_NAME)
+                    return new Glyph(textures.Get($"{fontName}/{((HexaconsMapping)character).ToString().Replace("_", "-")}"));
+
+                return null;
+            }
+
+            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+
+            public Texture? Get(string name, WrapMode wrapModeS, WrapMode wrapModeT) => null;
+
+            public Texture Get(string name) => throw new NotImplementedException();
+
+            public Task<Texture> GetAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public Stream GetStream(string name) => throw new NotImplementedException();
+
+            public IEnumerable<string> GetAvailableResources() => throw new NotImplementedException();
+
+            public Task<Texture?> GetAsync(string name, WrapMode wrapModeS, WrapMode wrapModeT, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+            public class Glyph : ITexturedCharacterGlyph
+            {
+                public float XOffset => default;
+                public float YOffset => default;
+                public float XAdvance => default;
+                public float Baseline => default;
+                public char Character => default;
+
+                public float GetKerning<T>(T lastGlyph) where T : ICharacterGlyph => throw new NotImplementedException();
+
+                public Texture Texture { get; }
+                public float Width => Texture.Width;
+                public float Height => Texture.Height;
+
+                public Glyph(Texture texture)
+                {
+                    Texture = texture;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -477,6 +477,8 @@ namespace osu.Game
             AddFont(Resources, @"Fonts/Venera/Venera-Light");
             AddFont(Resources, @"Fonts/Venera/Venera-Bold");
             AddFont(Resources, @"Fonts/Venera/Venera-Black");
+
+            Fonts.AddStore(new HexaconsIcons.HexaconsStore(Textures));
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) =>

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingHeader.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using osu.Framework.Graphics;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -23,7 +24,7 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 Title = PageTitleStrings.MainBeatmapsetsControllerIndex;
                 Description = NamedOverlayComponentStrings.BeatmapListingDescription;
-                IconTexture = "Icons/Hexacons/beatmap";
+                Icon = HexaconsIcons.Beatmap;
             }
         }
     }

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeader.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeader.cs
@@ -9,6 +9,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
@@ -59,7 +60,7 @@ namespace osu.Game.Overlays.BeatmapSet
             public BeatmapHeaderTitle()
             {
                 Title = PageTitleStrings.MainBeatmapsetsControllerShow;
-                IconTexture = "Icons/Hexacons/beatmap";
+                Icon = HexaconsIcons.Beatmap;
             }
         }
     }

--- a/osu.Game/Overlays/Changelog/ChangelogHeader.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogHeader.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
@@ -123,7 +124,7 @@ namespace osu.Game.Overlays.Changelog
             {
                 Title = PageTitleStrings.MainChangelogControllerDefault;
                 Description = NamedOverlayComponentStrings.ChangelogDescription;
-                IconTexture = "Icons/Hexacons/devtools";
+                Icon = HexaconsIcons.Devtools;
             }
         }
     }

--- a/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
+++ b/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
@@ -45,11 +45,11 @@ namespace osu.Game.Overlays.Chat
                     {
                         new Drawable[]
                         {
-                            new Sprite
+                            new SpriteIcon
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Texture = textures.Get("Icons/Hexacons/messaging"),
+                                Icon = HexaconsIcons.Social,
                                 Size = new Vector2(18),
                             },
                             // Placeholder text

--- a/osu.Game/Overlays/ChatOverlay.cs
+++ b/osu.Game/Overlays/ChatOverlay.cs
@@ -11,11 +11,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
@@ -29,7 +31,7 @@ namespace osu.Game.Overlays
 {
     public partial class ChatOverlay : OsuFocusedOverlayContainer, INamedOverlayComponent, IKeyBindingHandler<PlatformAction>
     {
-        public string IconTexture => "Icons/Hexacons/messaging";
+        public IconUsage Icon => HexaconsIcons.Messaging;
         public LocalisableString Title => ChatStrings.HeaderTitle;
         public LocalisableString Description => ChatStrings.HeaderDescription;
 

--- a/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
+++ b/osu.Game/Overlays/Dashboard/DashboardOverlayHeader.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Dashboard
             {
                 Title = PageTitleStrings.MainHomeControllerIndex;
                 Description = NamedOverlayComponentStrings.DashboardDescription;
-                IconTexture = "Icons/Hexacons/social";
+                Icon = HexaconsIcons.Social;
             }
         }
     }

--- a/osu.Game/Overlays/FullscreenOverlay.cs
+++ b/osu.Game/Overlays/FullscreenOverlay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
@@ -17,7 +18,7 @@ namespace osu.Game.Overlays
     public abstract partial class FullscreenOverlay<T> : WaveOverlayContainer, INamedOverlayComponent
         where T : OverlayHeader
     {
-        public virtual string IconTexture => Header.Title.IconTexture;
+        public virtual IconUsage Icon => Header.Title.Icon;
         public virtual LocalisableString Title => Header.Title.Title;
         public virtual LocalisableString Description => Header.Title.Description;
 

--- a/osu.Game/Overlays/INamedOverlayComponent.cs
+++ b/osu.Game/Overlays/INamedOverlayComponent.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Overlays
 {
     public interface INamedOverlayComponent
     {
-        string IconTexture { get; }
+        IconUsage Icon { get; }
 
         LocalisableString Title { get; }
 

--- a/osu.Game/Overlays/News/NewsHeader.cs
+++ b/osu.Game/Overlays/News/NewsHeader.cs
@@ -7,6 +7,7 @@ using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 
@@ -68,7 +69,7 @@ namespace osu.Game.Overlays.News
             {
                 Title = PageTitleStrings.MainNewsControllerDefault;
                 Description = NamedOverlayComponentStrings.NewsDescription;
-                IconTexture = "Icons/Hexacons/news";
+                Icon = HexaconsIcons.News;
             }
         }
     }

--- a/osu.Game/Overlays/NotificationOverlay.cs
+++ b/osu.Game/Overlays/NotificationOverlay.cs
@@ -13,9 +13,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
@@ -27,7 +29,7 @@ namespace osu.Game.Overlays
 {
     public partial class NotificationOverlay : OsuFocusedOverlayContainer, INamedOverlayComponent, INotificationOverlay
     {
-        public string IconTexture => "Icons/Hexacons/notification";
+        public IconUsage Icon => HexaconsIcons.Notification;
         public LocalisableString Title => NotificationsStrings.HeaderTitle;
         public LocalisableString Description => NotificationsStrings.HeaderDescription;
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays
 {
     public partial class NowPlayingOverlay : OsuFocusedOverlayContainer, INamedOverlayComponent
     {
-        public string IconTexture => "Icons/Hexacons/music";
+        public IconUsage Icon => HexaconsIcons.Music;
         public LocalisableString Title => NowPlayingStrings.HeaderTitle;
         public LocalisableString Description => NowPlayingStrings.HeaderDescription;
 

--- a/osu.Game/Overlays/OverlayTitle.cs
+++ b/osu.Game/Overlays/OverlayTitle.cs
@@ -1,13 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -20,7 +16,7 @@ namespace osu.Game.Overlays
         public const float ICON_SIZE = 30;
 
         private readonly OsuSpriteText titleText;
-        private readonly Container icon;
+        private readonly Container iconContainer;
 
         private LocalisableString title;
 
@@ -32,12 +28,20 @@ namespace osu.Game.Overlays
 
         public LocalisableString Description { get; protected set; }
 
-        private string iconTexture;
+        private IconUsage icon;
 
-        public string IconTexture
+        public IconUsage Icon
         {
-            get => iconTexture;
-            protected set => icon.Child = new OverlayTitleIcon(iconTexture = value);
+            get => icon;
+            protected set => iconContainer.Child = new SpriteIcon
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                FillMode = FillMode.Fit,
+
+                Icon = icon = value,
+            };
         }
 
         protected OverlayTitle()
@@ -51,7 +55,7 @@ namespace osu.Game.Overlays
                 Direction = FillDirection.Horizontal,
                 Children = new Drawable[]
                 {
-                    icon = new Container
+                    iconContainer = new Container
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -67,27 +71,6 @@ namespace osu.Game.Overlays
                     }
                 }
             };
-        }
-
-        private partial class OverlayTitleIcon : Sprite
-        {
-            private readonly string textureName;
-
-            public OverlayTitleIcon(string textureName)
-            {
-                this.textureName = textureName;
-
-                RelativeSizeAxes = Axes.Both;
-                Anchor = Anchor.Centre;
-                Origin = Anchor.Centre;
-                FillMode = FillMode.Fit;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(TextureStore textures)
-            {
-                Texture = textures.Get(textureName);
-            }
         }
     }
 }

--- a/osu.Game/Overlays/Profile/ProfileHeader.cs
+++ b/osu.Game/Overlays/Profile/ProfileHeader.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Overlays.Profile.Header;
 using osu.Game.Overlays.Profile.Header.Components;
 using osu.Game.Resources.Localisation.Web;
@@ -86,7 +87,7 @@ namespace osu.Game.Overlays.Profile
             public ProfileHeaderTitle()
             {
                 Title = PageTitleStrings.MainUsersControllerDefault;
-                IconTexture = "Icons/Hexacons/profile";
+                Icon = HexaconsIcons.Profile;
             }
         }
     }

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 using osu.Framework.Graphics;
+using osu.Game.Graphics;
 using osu.Game.Rulesets;
 using osu.Game.Users;
 
@@ -35,7 +36,7 @@ namespace osu.Game.Overlays.Rankings
             {
                 Title = PageTitleStrings.MainRankingControllerDefault;
                 Description = NamedOverlayComponentStrings.RankingsDescription;
-                IconTexture = "Icons/Hexacons/rankings";
+                Icon = HexaconsIcons.Rankings;
             }
         }
     }

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -12,14 +12,16 @@ using osu.Game.Overlays.Settings.Sections.Input;
 using osuTK.Graphics;
 using System.Collections.Generic;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 
 namespace osu.Game.Overlays
 {
     public partial class SettingsOverlay : SettingsPanel, INamedOverlayComponent
     {
-        public string IconTexture => "Icons/Hexacons/settings";
+        public IconUsage Icon => HexaconsIcons.Settings;
         public LocalisableString Title => SettingsStrings.HeaderTitle;
         public LocalisableString Description => SettingsStrings.HeaderDescription;
 

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -10,12 +10,11 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Game.Database;
 using osu.Framework.Localisation;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
@@ -37,15 +36,12 @@ namespace osu.Game.Overlays.Toolbar
         }
 
         [Resolved]
-        private TextureStore textures { get; set; } = null!;
-
-        [Resolved]
         private ReadableKeyCombinationProvider keyCombinationProvider { get; set; } = null!;
 
-        public void SetIcon(string texture) =>
-            SetIcon(new Sprite
+        public void SetIcon(IconUsage icon) =>
+            SetIcon(new SpriteIcon
             {
-                Texture = textures.Get(texture),
+                Icon = icon,
             });
 
         public LocalisableString Text

--- a/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Game.Graphics;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 
@@ -20,7 +21,7 @@ namespace osu.Game.Overlays.Toolbar
         {
             TooltipMain = ToolbarStrings.HomeHeaderTitle;
             TooltipSub = ToolbarStrings.HomeHeaderDescription;
-            SetIcon("Icons/Hexacons/home");
+            SetIcon(HexaconsIcons.Home);
         }
     }
 }

--- a/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarOverlayToggleButton.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Toolbar
                 {
                     TooltipMain = named.Title;
                     TooltipSub = named.Description;
-                    SetIcon(named.IconTexture);
+                    SetIcon(named.Icon);
                 }
             }
         }

--- a/osu.Game/Overlays/Wiki/WikiHeader.cs
+++ b/osu.Game/Overlays/Wiki/WikiHeader.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
@@ -81,7 +82,7 @@ namespace osu.Game.Overlays.Wiki
             {
                 Title = PageTitleStrings.MainWikiControllerDefault;
                 Description = NamedOverlayComponentStrings.WikiDescription;
-                IconTexture = "Icons/Hexacons/wiki";
+                Icon = HexaconsIcons.Wiki;
             }
         }
     }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -46,12 +46,12 @@ namespace osu.Game.Screens.Edit.Components.Menus
                     Padding = new MarginPadding(8),
                     Children = new Drawable[]
                     {
-                        new Sprite
+                        new SpriteIcon
                         {
                             Size = new Vector2(26),
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            Texture = textures.Get("Icons/Hexacons/editor"),
+                            Icon = HexaconsIcons.Editor,
                         },
                         text = new TextFlowContainer
                         {

--- a/osu.Game/Screens/Edit/Setup/SetupScreenHeader.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreenHeader.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osuTK.Graphics;
@@ -79,7 +80,7 @@ namespace osu.Game.Screens.Edit.Setup
             {
                 Title = EditorSetupStrings.BeatmapSetup.ToLower();
                 Description = EditorSetupStrings.BeatmapSetupDescription;
-                IconTexture = "Icons/Hexacons/social";
+                Icon = HexaconsIcons.Social;
             }
         }
 

--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Play.HUD
                     this.getLookup = getLookup;
                 }
 
-                public ITexturedCharacterGlyph? Get(string fontName, char character)
+                public ITexturedCharacterGlyph? Get(string? fontName, char character)
                 {
                     string lookup = getLookup(character);
                     var texture = textures.Get($"Gameplay/Fonts/{fontName}-{lookup}");

--- a/osu.Game/Skinning/LegacySpriteText.cs
+++ b/osu.Game/Skinning/LegacySpriteText.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Skinning
                 this.maxSize = maxSize;
             }
 
-            public ITexturedCharacterGlyph? Get(string fontName, char character)
+            public ITexturedCharacterGlyph? Get(string? fontName, char character)
             {
                 string lookup = getLookupName(character);
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2023.1121.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2023.1124.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1114.0" />
     <PackageReference Include="Sentry" Version="3.40.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -23,6 +23,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.1121.1" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2023.1124.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6059

Rabbit hole which will allow me to easily use newer icons on the main menu, and probably elsewhere (ie. conform to `SpriteIcon` / `IconUsage` requirements).