### PR TITLE
Load gameplay immediately on entering the skin editor while at the main menu

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -53,10 +53,16 @@ namespace osu.Game.Overlays.SkinEditor
         private OsuGame game { get; set; } = null!;
 
         [Resolved]
+        private MusicController music { get; set; } = null!;
+
+        [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
 
         private OsuScreen? lastTargetScreen;
 
@@ -133,6 +139,14 @@ namespace osu.Game.Overlays.SkinEditor
         {
             performer?.PerformFromScreen(screen =>
             {
+                // If we're playing the intro, switch away to another beatmap.
+                if (beatmap.Value.BeatmapSetInfo.Protected)
+                {
+                    music.NextTrack();
+                    Schedule(PresentGameplay);
+                    return;
+                }
+
                 if (screen is Player)
                     return;
 
@@ -275,6 +289,7 @@ namespace osu.Game.Overlays.SkinEditor
                 : base(createScore, new PlayerConfiguration
                 {
                     ShowResults = false,
+                    AutomaticallySkipIntro = true,
                 })
             {
             }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -14,12 +11,8 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Screens;
-using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
-using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Overlays.SkinEditor
@@ -36,10 +29,7 @@ namespace osu.Game.Overlays.SkinEditor
         private IPerformFromScreenRunner? performer { get; set; }
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
-
-        [Resolved]
-        private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
+        private SkinEditorOverlay skinEditorOverlay { get; set; } = null!;
 
         public SkinEditorSceneLibrary()
         {
@@ -96,24 +86,7 @@ namespace osu.Game.Overlays.SkinEditor
                                     Text = SkinEditorStrings.Gameplay,
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Action = () => performer?.PerformFromScreen(screen =>
-                                    {
-                                        if (screen is Player)
-                                            return;
-
-                                        var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
-
-                                        IReadOnlyList<Mod> usableMods = mods.Value;
-
-                                        if (replayGeneratingMod != null)
-                                            usableMods = usableMods.Append(replayGeneratingMod).ToArray();
-
-                                        if (!ModUtils.CheckCompatibleSet(usableMods, out var invalid))
-                                            mods.Value = mods.Value.Except(invalid).ToArray();
-
-                                        if (replayGeneratingMod != null)
-                                            screen.Push(new PlayerLoader(() => new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))));
-                                    }, new[] { typeof(Player), typeof(PlaySongSelect) })
+                                    Action = () => skinEditorOverlay.PresentGameplay(),
                                 },
                             }
                         },
@@ -137,5 +110,6 @@ namespace osu.Game.Overlays.SkinEditor
                 Content.CornerRadius = 5;
             }
         }
+
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
@@ -110,6 +110,5 @@ namespace osu.Game.Overlays.SkinEditor
                 Content.CornerRadius = 5;
             }
         }
-
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorSceneLibrary.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Overlays.SkinEditor
         private IPerformFromScreenRunner? performer { get; set; }
 
         [Resolved]
-        private SkinEditorOverlay skinEditorOverlay { get; set; } = null!;
+        private SkinEditorOverlay? skinEditorOverlay { get; set; }
 
         public SkinEditorSceneLibrary()
         {
@@ -86,7 +86,7 @@ namespace osu.Game.Overlays.SkinEditor
                                     Text = SkinEditorStrings.Gameplay,
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
-                                    Action = () => skinEditorOverlay.PresentGameplay(),
+                                    Action = () => skinEditorOverlay?.PresentGameplay(),
                                 },
                             }
                         },


### PR DESCRIPTION
This will also loop gameplay so it doesn't rudely exit to the results screen while you are editing a skin.

https://github.com/ppy/osu/assets/191335/784f362a-002b-4fd8-b648-b0fb49d573a6

