### PR TITLE
Add `ManiaHealthProcessor` that uses the legacy drain rate algorithm

### DIFF
--- a/osu.Game.Rulesets.Mania/Scoring/ManiaHealthProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaHealthProcessor.cs
@@ -1,23 +1,61 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Judgements;
+using System.Collections.Generic;
+using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Scoring
 {
-    public partial class ManiaHealthProcessor : DrainingHealthProcessor
+    public partial class ManiaHealthProcessor : LegacyDrainingHealthProcessor
     {
-        /// <inheritdoc/>
         public ManiaHealthProcessor(double drainStartTime)
-            : base(drainStartTime, 1.0)
+            : base(drainStartTime)
         {
         }
 
-        protected override HitResult GetSimulatedHitResult(Judgement judgement)
+        protected override IEnumerable<HitObject> EnumerateTopLevelHitObjects() => Beatmap.HitObjects;
+
+        protected override IEnumerable<HitObject> EnumerateNestedHitObjects(HitObject hitObject) => hitObject.NestedHitObjects;
+
+        protected override double GetHealthIncreaseFor(HitObject hitObject, HitResult result)
         {
-            // Users are not expected to attain perfect judgements for all notes due to the tighter hit window.
-            return judgement.MaxResult == HitResult.Perfect ? HitResult.Great : judgement.MaxResult;
+            double increase = 0;
+
+            switch (result)
+            {
+                case HitResult.Miss:
+                    switch (hitObject)
+                    {
+                        case HeadNote:
+                        case TailNote:
+                            return -(Beatmap.Difficulty.DrainRate + 1) * 0.00375;
+
+                        default:
+                            return -(Beatmap.Difficulty.DrainRate + 1) * 0.0075;
+                    }
+
+                case HitResult.Meh:
+                    return -(Beatmap.Difficulty.DrainRate + 1) * 0.0016;
+
+                case HitResult.Ok:
+                    return 0;
+
+                case HitResult.Good:
+                    increase = 0.004 - Beatmap.Difficulty.DrainRate * 0.0004;
+                    break;
+
+                case HitResult.Great:
+                    increase = 0.005 - Beatmap.Difficulty.DrainRate * 0.0005;
+                    break;
+
+                case HitResult.Perfect:
+                    increase = 0.0055 - Beatmap.Difficulty.DrainRate * 0.0005;
+                    break;
+            }
+
+            return HpMultiplierNormal * increase;
         }
     }
 }


### PR DESCRIPTION
Similar to https://github.com/ppy/osu/pull/25563

Also contains the fix for [the bug with hold notes](https://github.com/ppy/osu-stable-issues/issues/1169) as a result of using the base `LegacyDrainingHealthProcessor` implementation.

Small sampling of comparison against the legacy implementation ([present inside my osu-tools branch](https://github.com/smoogipoo/osu-tools/tree/hp-test)): https://docs.google.com/spreadsheets/d/1FQvCIlhGJqKJ9ssdGFZZOC2cNmq-LGyaVR-smAFRq1k/edit?usp=sharing