### PR TITLE
Rework slider judgements to more closely match stable and be more sane

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneLegacyHitPolicy.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -279,8 +281,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
-            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.LargeTickHit);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Great);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
             addClickActionAssert(0, ClickAction.Hit);
             addClickActionAssert(1, ClickAction.Hit);
@@ -324,8 +326,8 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Ok);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
-            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.LargeTickHit);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
+            addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Great);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
             addClickActionAssert(0, ClickAction.Hit);
             addClickActionAssert(1, ClickAction.Hit);
@@ -407,7 +409,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
             addClickActionAssert(0, ClickAction.Shake);
             addClickActionAssert(1, ClickAction.Hit);
             addClickActionAssert(2, ClickAction.Hit);
@@ -454,8 +456,8 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Time = time_second_slider, Position = positionSecondSlider + new Vector2(0, 10), Actions = { OsuAction.LeftButton } },
             });
 
-            addJudgementAssert(hitObjects[0], HitResult.Ok);
-            addJudgementAssert(hitObjects[1], HitResult.Great);
+            addJudgementAssert(hitObjects[0], HitResult.LegacyOkNoCombo);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
             addClickActionAssert(0, ClickAction.Hit);
             addClickActionAssert(1, ClickAction.Hit);
         }
@@ -546,7 +548,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Time = time_first_slider + 50, Position = midpoint },
             });
 
-            addJudgementAssert(hitObjects[0], HitResult.Ok);
+            addJudgementAssert(hitObjects[0], HitResult.LegacyOkNoCombo);
             addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
             addJudgementAssert(hitObjects[1], HitResult.Miss);
             // the slider head of the first slider prevents the second slider's head from being hit, so the judgement offset should be very late.
@@ -600,9 +602,9 @@ namespace osu.Game.Rulesets.Osu.Tests
                 new OsuReplayFrame { Time = time_second_slider + 75, Position = midpoint },
             });
 
-            addJudgementAssert(hitObjects[0], HitResult.Ok);
+            addJudgementAssert(hitObjects[0], HitResult.LegacyOkNoCombo);
             addJudgementOffsetAssert("first slider head", () => ((Slider)hitObjects[0]).HeadCircle, 0);
-            addJudgementAssert(hitObjects[1], HitResult.Ok);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyOkNoCombo);
             addJudgementOffsetAssert("second slider head", () => ((Slider)hitObjects[1]).HeadCircle, 50);
             addClickActionAssert(0, ClickAction.Hit);
             addClickActionAssert(1, ClickAction.Hit);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
+#pragma warning disable CS0618 // Type or member is obsolete
 
 using System;
 using System.Collections.Generic;
@@ -211,7 +212,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyOkNoCombo);
             addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Miss);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
@@ -254,7 +255,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
             addJudgementAssert("slider head", () => ((Slider)hitObjects[1]).HeadCircle, HitResult.Great);
             addJudgementAssert("slider tick", () => ((Slider)hitObjects[1]).NestedHitObjects[1] as SliderTick, HitResult.LargeTickHit);
         }
@@ -334,7 +335,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             addJudgementAssert(hitObjects[0], HitResult.Great);
-            addJudgementAssert(hitObjects[1], HitResult.IgnoreHit);
+            addJudgementAssert(hitObjects[1], HitResult.LegacyGreatNoCombo);
         }
 
         [Test]
@@ -385,8 +386,10 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void addJudgementAssert(OsuHitObject hitObject, HitResult result)
         {
-            AddAssert($"({hitObject.GetType().ReadableName()} @ {hitObject.StartTime}) judgement is {result}",
-                () => judgementResults.Single(r => r.HitObject == hitObject).Type == result);
+            AddAssert(
+                $"check ({hitObject.GetType().ReadableName()} judgement @ {hitObject.StartTime})",
+                () => judgementResults.Single(r => r.HitObject == hitObject).Type,
+                () => Is.EqualTo(result));
         }
 
         private void addJudgementAssert(string name, Func<OsuHitObject> hitObject, HitResult result)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -267,37 +267,30 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             SliderBody?.RecyclePath();
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         protected override void CheckForResult(bool userTriggered, double timeOffset)
         {
             if (userTriggered || !TailCircle.Judged || Time.Current < HitObject.EndTime)
                 return;
 
-            if (HitObject.ClassicSliderBehaviour)
+            // Classic behaviour means a slider is judged proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
+            ApplyResult(r =>
             {
-                // Classic behaviour means a slider is judged proportionally to the number of nested hitobjects hit. This is the classic osu!stable scoring.
-                ApplyResult(r =>
-                {
-                    int totalTicks = NestedHitObjects.Count;
-                    int hitTicks = NestedHitObjects.Count(h => h.IsHit);
+                int totalTicks = NestedHitObjects.Count;
+                int hitTicks = NestedHitObjects.Count(h => h.IsHit);
 
-                    if (hitTicks == totalTicks)
-                        r.Type = HitResult.Great;
-                    else if (hitTicks == 0)
-                        r.Type = HitResult.Miss;
-                    else
-                    {
-                        double hitFraction = (double)hitTicks / totalTicks;
-                        r.Type = hitFraction >= 0.5 ? HitResult.Ok : HitResult.Meh;
-                    }
-                });
-            }
-            else
-            {
-                // If only the nested hitobjects are judged, then the slider's own judgement is ignored for scoring purposes.
-                // But the slider needs to still be judged with a reasonable hit/miss result for visual purposes (hit/miss transforms, etc).
-                ApplyResult(r => r.Type = NestedHitObjects.Any(h => h.Result.IsHit) ? r.Judgement.MaxResult : r.Judgement.MinResult);
-            }
+                if (hitTicks == totalTicks)
+                    r.Type = HitResult.LegacyGreatNoCombo;
+                else if (hitTicks == 0)
+                    r.Type = HitResult.Miss;
+                else
+                {
+                    double hitFraction = (double)hitTicks / totalTicks;
+                    r.Type = hitFraction >= 0.5 ? HitResult.LegacyOkNoCombo : HitResult.LegacyMehNoCombo;
+                }
+            });
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         public override void PlaySamples()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -68,10 +68,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (HitObject.ClassicSliderBehaviour)
             {
                 // With classic slider behaviour, heads are considered fully hit if in the largest hit window.
-                // We can't award a full Great because the true Great judgement is awarded on the Slider itself,
-                // reduced based on number of ticks hit,
-                // so we use the most suitable LargeTick judgement here instead.
-                return base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
+                return base.ResultFor(timeOffset).IsHit() ? Result.Judgement.MaxResult : Result.Judgement.MinResult;
             }
 
             return base.ResultFor(timeOffset);

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -135,8 +135,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                 classicSliderBehaviour = value;
                 if (HeadCircle != null)
                     HeadCircle.ClassicSliderBehaviour = value;
-                if (TailCircle != null)
-                    TailCircle.ClassicSliderBehaviour = value;
             }
         }
 
@@ -220,7 +218,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                             StartTime = e.Time,
                             Position = EndPosition,
                             StackHeight = StackHeight,
-                            ClassicSliderBehaviour = ClassicSliderBehaviour,
                         });
                         break;
 
@@ -275,12 +272,15 @@ namespace osu.Game.Rulesets.Osu.Objects
             TailSamples = this.GetNodeSamples(repeatCount + 1);
         }
 
-        public override Judgement CreateJudgement() => ClassicSliderBehaviour
-            // Final combo is provided by the slider itself - see logic in `DrawableSlider.CheckForResult()`
-            ? new OsuJudgement()
-            // Final combo is provided by the tail circle - see `SliderTailCircle`
-            : new OsuIgnoreJudgement();
+        public override Judgement CreateJudgement() => new SliderJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+
+        private class SliderJudgement : OsuJudgement
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            public override HitResult MaxResult => HitResult.LegacyGreatNoCombo;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderEndCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderEndCircle.cs
@@ -3,8 +3,6 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects
@@ -45,12 +43,5 @@ namespace osu.Game.Rulesets.Osu.Objects
         }
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
-
-        public override Judgement CreateJudgement() => new SliderEndJudgement();
-
-        public class SliderEndJudgement : OsuJudgement
-        {
-            public override HitResult MaxResult => HitResult.LargeTickHit;
-        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderHeadCircle.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Osu.Judgements;
-
 namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderHeadCircle : HitCircle
     {
         /// <summary>
         /// If <see langword="false"/>, treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
-        /// If <see langword="true"/>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
+        /// If <see langword="true"/>, this <see cref="SliderHeadCircle"/> will be judged as the maximum result at all times within the judgement window.
         /// </summary>
         public bool ClassicSliderBehaviour;
-
-        public override Judgement CreateJudgement() => ClassicSliderBehaviour ? new SliderTickJudgement() : base.CreateJudgement();
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderRepeat.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Scoring;
+
 namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderRepeat : SliderEndCircle
@@ -8,6 +12,13 @@ namespace osu.Game.Rulesets.Osu.Objects
         public SliderRepeat(Slider slider)
             : base(slider)
         {
+        }
+
+        public override Judgement CreateJudgement() => new SliderRepeatJudgement();
+
+        private class SliderRepeatJudgement : OsuJudgement
+        {
+            public override HitResult MaxResult => HitResult.LargeTickHit;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -9,25 +9,14 @@ namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderTailCircle : SliderEndCircle
     {
-        /// <summary>
-        /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
-        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
-        /// </summary>
-        public bool ClassicSliderBehaviour;
-
         public SliderTailCircle(Slider slider)
             : base(slider)
         {
         }
 
-        public override Judgement CreateJudgement() => ClassicSliderBehaviour ? new LegacyTailJudgement() : new TailJudgement();
+        public override Judgement CreateJudgement() => new TailJudgement();
 
-        public class LegacyTailJudgement : OsuJudgement
-        {
-            public override HitResult MaxResult => HitResult.SmallTickHit;
-        }
-
-        public class TailJudgement : SliderEndJudgement
+        private class TailJudgement : OsuJudgement
         {
             public override HitResult MaxResult => HitResult.LargeTickHit;
             public override HitResult MinResult => HitResult.IgnoreMiss;

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -62,14 +64,17 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     increase = hitObject is SliderTick ? 0.015 : 0.02;
                     break;
 
+                case HitResult.LegacyMehNoCombo:
                 case HitResult.Meh:
                     increase = 0.002;
                     break;
 
+                case HitResult.LegacyOkNoCombo:
                 case HitResult.Ok:
                     increase = 0.011;
                     break;
 
+                case HitResult.LegacyGreatNoCombo:
                 case HitResult.Great:
                     increase = 0.03;
                     break;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
+#pragma warning disable CS0618 // Type or member is obsolete
 
 using System;
 using System.Collections.Generic;
@@ -69,6 +70,9 @@ namespace osu.Game.Rulesets.Osu.UI
             var hitWindows = new OsuHitWindows();
             foreach (var result in Enum.GetValues<HitResult>().Where(r => r > HitResult.None && hitWindows.IsHitResultAllowed(r)))
                 poolDictionary.Add(result, new DrawableJudgementPool(result, onJudgementLoaded));
+            poolDictionary.Add(HitResult.LegacyGreatNoCombo, new DrawableJudgementPool(HitResult.LegacyGreatNoCombo, onJudgementLoaded));
+            poolDictionary.Add(HitResult.LegacyOkNoCombo, new DrawableJudgementPool(HitResult.LegacyOkNoCombo, onJudgementLoaded));
+            poolDictionary.Add(HitResult.LegacyMehNoCombo, new DrawableJudgementPool(HitResult.LegacyMehNoCombo, onJudgementLoaded));
 
             AddRangeInternal(poolDictionary.Values);
 

--- a/osu.Game.Tests/Rulesets/Scoring/HitResultTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/HitResultTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -16,6 +18,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(new[] { HitResult.SmallTickHit }, new[] { HitResult.SmallTickMiss, HitResult.IgnoreMiss })]
         [TestCase(new[] { HitResult.LargeBonus, HitResult.SmallBonus }, new[] { HitResult.IgnoreMiss })]
         [TestCase(new[] { HitResult.IgnoreHit }, new[] { HitResult.IgnoreMiss, HitResult.ComboBreak })]
+        [TestCase(new[] { HitResult.LegacyGreatNoCombo, HitResult.LegacyOkNoCombo, HitResult.LegacyMehNoCombo }, new[] { HitResult.Miss, HitResult.IgnoreMiss })]
         public void TestValidResultPairs(HitResult[] maxResults, HitResult[] minResults)
         {
             HitResult[] unsupportedResults = HitResultExtensions.ALL_TYPES.Where(t => !minResults.Contains(t)).ToArray();

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable CS0618
+
 #nullable disable
 
 using System;
@@ -169,6 +171,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, HitResult.LargeTickMiss)]
         [TestCase(HitResult.SmallBonus, HitResult.IgnoreMiss)]
         [TestCase(HitResult.LargeBonus, HitResult.IgnoreMiss)]
+        [TestCase(HitResult.LegacyMehNoCombo, HitResult.Miss)]
+        [TestCase(HitResult.LegacyOkNoCombo, HitResult.Miss)]
+        [TestCase(HitResult.LegacyGreatNoCombo, HitResult.Miss)]
         public void TestMinResults(HitResult hitResult, HitResult expectedMinResult)
         {
             Assert.AreEqual(expectedMinResult, new TestJudgement(hitResult).MinResult);
@@ -189,6 +194,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
+        [TestCase(HitResult.LegacyMehNoCombo, false)]
+        [TestCase(HitResult.LegacyOkNoCombo, false)]
+        [TestCase(HitResult.LegacyGreatNoCombo, false)]
         public void TestAffectsCombo(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.AffectsCombo());
@@ -209,6 +217,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
+        [TestCase(HitResult.LegacyMehNoCombo, true)]
+        [TestCase(HitResult.LegacyOkNoCombo, true)]
+        [TestCase(HitResult.LegacyGreatNoCombo, true)]
         public void TestAffectsAccuracy(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.AffectsAccuracy());
@@ -229,6 +240,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, false)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.LegacyMehNoCombo, false)]
+        [TestCase(HitResult.LegacyOkNoCombo, false)]
+        [TestCase(HitResult.LegacyGreatNoCombo, false)]
         public void TestIsBonus(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsBonus());
@@ -249,6 +263,9 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.LegacyMehNoCombo, true)]
+        [TestCase(HitResult.LegacyOkNoCombo, true)]
+        [TestCase(HitResult.LegacyGreatNoCombo, true)]
         public void TestIsHit(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsHit());
@@ -269,12 +286,14 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.LargeTickHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.LegacyMehNoCombo, true)]
+        [TestCase(HitResult.LegacyOkNoCombo, true)]
+        [TestCase(HitResult.LegacyGreatNoCombo, true)]
         public void TestIsScorable(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsScorable());
         }
 
-#pragma warning disable CS0618
         [Test]
         public void TestLegacyComboIncrease()
         {
@@ -289,7 +308,6 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(HitResult.LegacyComboIncrease.IsScorable(), Is.True);
             Assert.That(HitResultExtensions.ALL_TYPES, Does.Not.Contain(HitResult.LegacyComboIncrease));
         }
-#pragma warning restore CS0618
 
         [Test]
         public void TestComboBreak()

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -47,17 +47,26 @@ namespace osu.Game.Tests.Rulesets.Scoring
             };
         }
 
-        [TestCase(ScoringMode.Standardised, HitResult.Meh, 116_667)]
-        [TestCase(ScoringMode.Standardised, HitResult.Ok, 233_338)]
-        [TestCase(ScoringMode.Standardised, HitResult.Great, 1_000_000)]
-        [TestCase(ScoringMode.Classic, HitResult.Meh, 11_670)]
-        [TestCase(ScoringMode.Classic, HitResult.Ok, 23_341)]
-        [TestCase(ScoringMode.Classic, HitResult.Great, 100_033)]
-        public void TestSingleOsuHit(ScoringMode scoringMode, HitResult hitResult, int expectedScore)
+        [TestCase(ScoringMode.Standardised, HitResult.Meh, 116_667, false)]
+        [TestCase(ScoringMode.Standardised, HitResult.Ok, 233_338, false)]
+        [TestCase(ScoringMode.Standardised, HitResult.Great, 1_000_000, false)]
+        [TestCase(ScoringMode.Classic, HitResult.Meh, 11_670, false)]
+        [TestCase(ScoringMode.Classic, HitResult.Ok, 23_341, false)]
+        [TestCase(ScoringMode.Classic, HitResult.Great, 100_033, false)]
+        [TestCase(ScoringMode.Standardised, HitResult.LegacyMehNoCombo, 116_667, true)]
+        [TestCase(ScoringMode.Standardised, HitResult.LegacyOkNoCombo, 233_338, true)]
+        [TestCase(ScoringMode.Standardised, HitResult.LegacyGreatNoCombo, 1_000_000, true)]
+        public void TestSingleOsuHit(ScoringMode scoringMode, HitResult hitResult, int expectedScore, bool isSlider)
         {
-            scoreProcessor.ApplyBeatmap(beatmap);
+            scoreProcessor.ApplyBeatmap(new TestBeatmap(new RulesetInfo())
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new TestHitObject(isSlider ? new Slider().CreateJudgement().MaxResult : new HitCircle().CreateJudgement().MaxResult)
+                }
+            });
 
-            var judgementResult = new JudgementResult(beatmap.HitObjects.Single(), new OsuJudgement())
+            var judgementResult = new JudgementResult(beatmap.HitObjects.Single(), isSlider ? new Slider().CreateJudgement() : new HitCircle().CreateJudgement())
             {
                 Type = hitResult
             };

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 
@@ -135,15 +137,18 @@ namespace osu.Game.Rulesets.Judgements
                 case HitResult.Miss:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 2;
 
+                case HitResult.LegacyMehNoCombo:
                 case HitResult.Meh:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.05;
 
+                case HitResult.LegacyOkNoCombo:
                 case HitResult.Ok:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
                 case HitResult.Good:
                     return DEFAULT_MAX_HEALTH_INCREASE * 0.75;
 
+                case HitResult.LegacyGreatNoCombo:
                 case HitResult.Great:
                     return DEFAULT_MAX_HEALTH_INCREASE;
 
@@ -180,15 +185,18 @@ namespace osu.Game.Rulesets.Judgements
                 case HitResult.LargeTickHit:
                     return 30;
 
+                case HitResult.LegacyMehNoCombo:
                 case HitResult.Meh:
                     return 50;
 
+                case HitResult.LegacyOkNoCombo:
                 case HitResult.Ok:
                     return 100;
 
                 case HitResult.Good:
                     return 200;
 
+                case HitResult.LegacyGreatNoCombo:
                 case HitResult.Great:
                 // Perfect doesn't actually give more score / accuracy directly.
                 case HitResult.Perfect:

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -146,7 +146,31 @@ namespace osu.Game.Rulesets.Scoring
         [EnumMember(Value = "legacy_combo_increase")]
         [Order(99)]
         [Obsolete("Do not use.")]
-        LegacyComboIncrease = 99
+        LegacyComboIncrease = 99,
+
+        /// <summary>
+        /// Special result for legacy rulesets that provide a <see cref="Meh"/> judgement that does not increase combo.
+        /// </summary>
+        [EnumMember(Value = "legacy_meh_no_combo")]
+        [Order(100)]
+        [Obsolete("Do not use.")]
+        LegacyMehNoCombo = 100,
+
+        /// <summary>
+        /// Special result for legacy rulesets that provide an <see cref="Ok"/> judgement that does not increase combo.
+        /// </summary>
+        [EnumMember(Value = "legacy_ok_no_combo")]
+        [Order(100)]
+        [Obsolete("Do not use.")]
+        LegacyOkNoCombo = 101,
+
+        /// <summary>
+        /// Special result for legacy rulesets that provide a <see cref="Great"/> judgement that does not increase combo.
+        /// </summary>
+        [EnumMember(Value = "legacy_great_no_combo")]
+        [Order(100)]
+        [Obsolete("Do not use.")]
+        LegacyGreatNoCombo = 102
     }
 
 #pragma warning disable CS0618
@@ -297,6 +321,12 @@ namespace osu.Game.Rulesets.Scoring
 
                 // ComboBreak is its own type that affects score via combo.
                 case HitResult.ComboBreak:
+                    return true;
+
+                // Special single-use legacy types that fall outside the standard valid range.
+                case HitResult.LegacyMehNoCombo:
+                case HitResult.LegacyOkNoCombo:
+                case HitResult.LegacyGreatNoCombo:
                     return true;
 
                 default:


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/11769

Slider mechanics:
- Slider head accuracy is maintained (`Great / Ok / Meh / Miss`).
    - With classic mod, slider heads are limited to `Great / Miss`, as compared to osu-stable's `30 / Miss`, so the raw accuracy value differs.
- Slider ticks are judged as `LargeTickHit / LargeTickMiss`.
- Slider repeats are judged as `LargeTickHit / LargeTickMiss`.
- Slider tail (the final tick of the slider) is judged as `LargeTickHit / IgnoreMiss` (no combo break on miss).
- The slider itself is judged proportionally to the number of ticks hit, similar to ScoreV1/ScoreV2 in osu!stable.
- The slider itself is judged with `LegacyGreatNoCombo / LegacyOkNoCombo / LegacyMehNoCombo` (non-combo-increasing variants of `Great / Ok / Meh`).

Differences between this implementation and the legacy scorev1/scorev2 implementation:
- In ScoreV1/ScoreV2, slider heads are worth a maximum of 30 score.
    - In this implementation, it's worth a maximum of 300 score.
- In ScoreV2, sliders are capped by the judgement of the head. For example, hitting the head in the 50 timing window will award the maximum score for the head (30), but cap the slider's judgement at 50 regardless of how many ticks were hit.
    - In this implementation, only the head's judgement is affected. In the same scenario as above, you'll receive 50 score for the head but 300 score for the slider (assuming you hit all other ticks perfectly).
- In ScoreV2, missing the head will cap the slider's judgement to 50 and not award any score for the head.
    - In this implementation, you'll miss the head and be capped at 100 score for the slider (the head is itself counted as a tick for the slider's judgement).

Although all the tests pass, this still needs some rigorous manual testing before merge.