### PR TITLE
Fix `ArgonHealthDisplay` sometimes behaving weirdly on miss judgements

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModPerfect.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModPerfect.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                 {
                     base.Reset(storeResults);
 
-                    Health.Value = 1; // Don't care about the health condition (only the mod condition)
+                    SetHealth(1); // Don't care about the health condition (only the mod condition)
                 }
             }
         }

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -341,7 +341,7 @@ namespace osu.Game.Tests.Gameplay
 
         private void setTime(double time) => AddStep($"set time = {time}", () => clock.CurrentTime = time);
 
-        private void setHealth(double health) => AddStep($"set health = {health}", () => processor.Health.Value = health);
+        private void setHealth(double health) => AddStep($"set health = {health}", () => processor.SetHealth(health));
 
         private void assertHealthEqualTo(double value)
             => AddAssert($"health = {value}", () => Precision.AlmostEquals(value, processor.Health.Value, 0.0001f));

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep(@"Reset all", delegate
             {
-                healthProcessor.Health.Value = 1;
+                healthProcessor.SetHealth(1);
                 healthProcessor.Failed += () => false; // health won't be updated if the processor gets into a "fail" state.
 
                 Children = new Drawable[]
@@ -72,17 +72,17 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddRepeatStep(@"decrease hp slightly", delegate
             {
-                healthProcessor.Health.Value -= 0.01f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value - 0.01f);
             }, 10);
 
             AddRepeatStep(@"increase hp without flash", delegate
             {
-                healthProcessor.Health.Value += 0.1f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value + 0.1f);
             }, 3);
 
             AddRepeatStep(@"increase hp with flash", delegate
             {
-                healthProcessor.Health.Value += 0.1f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value + 0.1f);
                 healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
                 {
                     Type = HitResult.Perfect

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHealthDisplay.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddStep(@"Reset all", delegate
             {
-                healthProcessor.Health.Value = 1;
+                healthProcessor.SetHealth(1);
                 healthProcessor.Failed += () => false; // health won't be updated if the processor gets into a "fail" state.
             });
         }
@@ -45,17 +45,17 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddRepeatStep(@"decrease hp slightly", delegate
             {
-                healthProcessor.Health.Value -= 0.01f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value - 0.01f);
             }, 10);
 
             AddRepeatStep(@"increase hp without flash", delegate
             {
-                healthProcessor.Health.Value += 0.1f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value + 0.1f);
             }, 3);
 
             AddRepeatStep(@"increase hp with flash", delegate
             {
-                healthProcessor.Health.Value += 0.1f;
+                healthProcessor.SetHealth(healthProcessor.Health.Value + 0.1f);
                 healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
                 {
                     Type = HitResult.Perfect

--- a/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
+++ b/osu.Game/Rulesets/Mods/ModEasyWithExtraLives.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
 
         private int retries;
 
-        private readonly BindableNumber<double> health = new BindableDouble();
+        private Action? resetHealthToMaxValue;
 
         public override void ApplyToDifficulty(BeatmapDifficulty difficulty)
         {
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Mods
         {
             if (retries == 0) return true;
 
-            health.Value = health.MaxValue;
+            resetHealthToMaxValue?.Invoke();
             retries--;
 
             return false;
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Mods
 
         public void ApplyToHealthProcessor(HealthProcessor healthProcessor)
         {
-            health.BindTo(healthProcessor.Health);
+            resetHealthToMaxValue = () => healthProcessor.SetHealth(healthProcessor.Health.MaxValue);
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/AccumulatingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/AccumulatingHealthProcessor.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.Reset(storeResults);
 
-            Health.Value = 0;
+            SetHealth(0);
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Scoring
             double currentGameplayTime = Math.Clamp(Time.Current, DrainStartTime, gameplayEndTime);
 
             if (DrainLenience < 1)
-                Health.Value -= DrainRate * (currentGameplayTime - lastGameplayTime);
+                SetHealth(Health.Value - DrainRate * (currentGameplayTime - lastGameplayTime));
         }
 
         public override void ApplyBeatmap(IBeatmap beatmap)

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private ScheduledDelegate? finishMissDisplayDelegate;
 
-        private bool duringMissTransition => finishMissDisplayDelegate != null;
+        private bool displayingMiss => finishMissDisplayDelegate != null;
 
         private readonly List<Vector2> missBarVertices = new List<Vector2>();
         private readonly List<Vector2> healthBarVertices = new List<Vector2>();
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.Play.HUD
 
             if (result != null && result.Judgement.HealthIncreaseFor(result) < 0)
                 Scheduler.AddOnce(displayMiss);
-            else if (!duringMissTransition)
+            else if (!displayingMiss)
                 this.TransformTo(nameof(GlowBarValue), newValue, time, Easing.OutQuint);
         }
 
@@ -202,7 +202,7 @@ namespace osu.Game.Screens.Play.HUD
             mainBar.TransformTo(nameof(BarPath.GlowColour), main_bar_glow_colour.Opacity(0.8f))
                    .TransformTo(nameof(BarPath.GlowColour), main_bar_glow_colour, 300, Easing.OutQuint);
 
-            if (!duringMissTransition)
+            if (!displayingMiss)
             {
                 glowBar.TransformTo(nameof(BarPath.BarColour), Colour4.White, 30, Easing.OutQuint)
                        .Then()
@@ -237,7 +237,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private void finishMissDisplay()
         {
-            if (finishMissDisplayDelegate == null)
+            if (!displayingMiss)
                 return;
 
             if (Current.Value > 0)


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/25351

The issue mainly resided in the fact that `ArgonHealthDisplay` does not know whether a health change came specifically from a miss judgement. On master, when a miss judgement occurs, the component would update the length of the "glow" bar alongside the main bar, then `Miss` would be called and it would overwrite any transforms applied to the "glow" bar, by setting it to match `HealthBarValue`.

One solution I thought of was to just clear any existing transforms to `GlowBarValue`, rather than explicitly setting it to `HealthBarValue`. But that resulted in an [ugly animation](https://discord.com/channels/188630481301012481/188630652340404224/1178823623843262475) where the glow/miss bar would freeze at its current state once the miss judgement occurs, rather than continuing to decrease until the point of the health after last miss judgement (see video attached below "After").

To achieve that behaviour, `ArgonHealthDisplay` has to be aware of the source of the health change, so that it doesn't apply a transform to `GlowBarValue` when the change came from a miss judgement, and the miss animation would no longer have to overwrite/clear the state of `GlowBarValue`.

The approach I've taken to achieve that behaviour may have been a bit too extreme, but it's hard to decide by myself. Need feedback.

Before:

https://github.com/ppy/osu/assets/22781491/6613506a-163c-4fb8-9a3d-d9c3bfa7c679

After:

https://github.com/ppy/osu/assets/22781491/c32f1977-72ce-453a-b89b-2b7a6b1b8f7a

