### PR TITLE
Attempt to fix diffcalc script comment-based variable extraction once again

### DIFF
--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -189,8 +189,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           # Add comment environment
-          echo $COMMENT_BODY | sed -r 's/\r$//' | grep -E '^\w+=' | while read -r line; do
-              opt=$(echo ${line} | cut -d '=' -f1)
+          echo "$COMMENT_BODY" | sed -r 's/\r$//' | grep -E '^\w+=' | while read -r line; do
+              opt=$(echo "${line}" | cut -d '=' -f1)
               sed -i "s;^${opt}=.*$;${line};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
           done
 


### PR DESCRIPTION
With @nanaya 's help, this may just work as-is... This was previously a github expansion (`'${{ github.... }}'`), whereas as a bash expansion it may just work?