### PR TITLE
Add ban count option to round editor

### DIFF
--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -10,6 +10,7 @@ using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.MapPool;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
@@ -318,7 +319,7 @@ namespace osu.Game.Tournament.Tests.Screens
         private void clickBeatmapPanel(int index)
         {
             InputManager.MoveMouseTo(screen.ChildrenOfType<TournamentBeatmapPanel>().ElementAt(index));
-            InputManager.Click(osuTK.Input.MouseButton.Left);
+            InputManager.Click(MouseButton.Left);
         }
 
         private partial class TestMapPoolScreen : MapPoolScreen

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -169,44 +169,26 @@ namespace osu.Game.Tournament.Tests.Screens
             AddStep("update displayed maps", () => Ladder.SplitMapPoolByMods.Value = false);
 
             AddStep("start bans from blue team", () => screen.ChildrenOfType<TourneyButton>().First(btn => btn.Text == "Blue Ban").TriggerClick());
+
             AddStep("ban map", () => clickBeatmapPanel(0));
-            AddAssert("one ban registered", () => Ladder.CurrentMatch.Value!.PicksBans, () => Has.Count.EqualTo(1));
-            AddAssert("ban was blue's",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Ban && pb.Team == TeamColour.Blue),
-                () => Is.EqualTo(1));
+            checkTotalPickBans(1);
+            checkLastPick(ChoiceType.Ban, TeamColour.Blue);
 
             AddStep("ban map", () => clickBeatmapPanel(1));
-            AddAssert("two bans registered", () => Ladder.CurrentMatch.Value!.PicksBans, () => Has.Count.EqualTo(2));
-            AddAssert("one ban for red team",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Ban && pb.Team == TeamColour.Red),
-                () => Is.EqualTo(1));
-            AddAssert("one ban for blue team",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Ban && pb.Team == TeamColour.Blue),
-                () => Is.EqualTo(1));
+            checkTotalPickBans(2);
+            checkLastPick(ChoiceType.Ban, TeamColour.Red);
 
             AddStep("pick map", () => clickBeatmapPanel(2));
-            AddAssert("one pick registered",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Pick),
-                () => Is.EqualTo(1));
-            AddAssert("pick was red's",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Last().Team,
-                () => Is.EqualTo(TeamColour.Red));
+            checkTotalPickBans(3);
+            checkLastPick(ChoiceType.Pick, TeamColour.Red);
 
             AddStep("pick map", () => clickBeatmapPanel(3));
-            AddAssert("two picks registered",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Pick),
-                () => Is.EqualTo(2));
-            AddAssert("pick was blue's",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Last().Team,
-                () => Is.EqualTo(TeamColour.Blue));
+            checkTotalPickBans(4);
+            checkLastPick(ChoiceType.Pick, TeamColour.Blue);
 
             AddStep("pick map", () => clickBeatmapPanel(4));
-            AddAssert("three picks registered",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Count(pb => pb.Type == ChoiceType.Pick),
-                () => Is.EqualTo(3));
-            AddAssert("pick was red's",
-                () => Ladder.CurrentMatch.Value!.PicksBans.Last().Team,
-                () => Is.EqualTo(TeamColour.Red));
+            checkTotalPickBans(5);
+            checkLastPick(ChoiceType.Pick, TeamColour.Red);
 
             AddStep("reset match", () =>
             {
@@ -214,6 +196,13 @@ namespace osu.Game.Tournament.Tests.Screens
                 Ladder.CurrentMatch.Value = Ladder.Matches.First();
                 Ladder.CurrentMatch.Value.PicksBans.Clear();
             });
+
+            void checkTotalPickBans(int expected) => AddAssert($"total pickbans is {expected}", () => Ladder.CurrentMatch.Value!.PicksBans, () => Has.Count.EqualTo(expected));
+
+            void checkLastPick(ChoiceType expectedChoice, TeamColour expectedColour) =>
+                AddAssert($"last choice was {expectedChoice} by {expectedColour}",
+                    () => Ladder.CurrentMatch.Value!.PicksBans.Select(pb => (pb.Type, pb.Team)).Last(),
+                    () => Is.EqualTo((expectedChoice, expectedColour)));
         }
 
         [Test]

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Tournament.Tests.Screens
         }
 
         [Test]
-        public void TestSingleTeamBan()
+        public void TestPickBanOrder()
         {
             AddStep("set ban count", () => Ladder.CurrentMatch.Value!.Round.Value!.BanCount.Value = 1);
 

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Testing;
 using osu.Game.Tournament.Components;
 using osu.Game.Tournament.Models;
 using osu.Game.Tournament.Screens.MapPool;
+using osuTK;
 
 namespace osu.Game.Tournament.Tests.Screens
 {
@@ -19,7 +20,7 @@ namespace osu.Game.Tournament.Tests.Screens
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(screen = new MapPoolScreen { Width = 0.7f });
+            Add(screen = new TestMapPoolScreen { Width = 0.7f });
         }
 
         [SetUp]
@@ -208,7 +209,6 @@ namespace osu.Game.Tournament.Tests.Screens
 
             AddStep("reset match", () =>
             {
-                InputManager.UseParentInput = true;
                 Ladder.CurrentMatch.Value = new TournamentMatch();
                 Ladder.CurrentMatch.Value = Ladder.Matches.First();
                 Ladder.CurrentMatch.Value.PicksBans.Clear();
@@ -300,7 +300,6 @@ namespace osu.Game.Tournament.Tests.Screens
 
             AddStep("reset match", () =>
             {
-                InputManager.UseParentInput = true;
                 Ladder.CurrentMatch.Value = new TournamentMatch();
                 Ladder.CurrentMatch.Value = Ladder.Matches.First();
                 Ladder.CurrentMatch.Value.PicksBans.Clear();
@@ -320,6 +319,17 @@ namespace osu.Game.Tournament.Tests.Screens
         {
             InputManager.MoveMouseTo(screen.ChildrenOfType<TournamentBeatmapPanel>().ElementAt(index));
             InputManager.Click(osuTK.Input.MouseButton.Left);
+        }
+
+        private partial class TestMapPoolScreen : MapPoolScreen
+        {
+            // this is a bit of a test-specific workaround.
+            // the way pick/ban is implemented is a bit funky; the screen itself is what handles the mouse there,
+            // rather than the beatmap panels themselves.
+            // in some extreme situations headless it may turn out that the panels overflow the screen,
+            // and as such picking stops working anymore outside of the bounds of the screen drawable.
+            // this override makes it so the screen sees all of the input at all times, making that impossible to happen.
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
         }
     }
 }

--- a/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
+++ b/osu.Game.Tournament.Tests/Screens/TestSceneMapPoolScreen.cs
@@ -24,14 +24,24 @@ namespace osu.Game.Tournament.Tests.Screens
             Add(screen = new TestMapPoolScreen { Width = 0.7f });
         }
 
-        [SetUp]
-        public void SetUp() => Schedule(() =>
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            AddStep("reset state", resetState);
+        }
+
+        private void resetState()
         {
             Ladder.SplitMapPoolByMods.Value = true;
 
             Ladder.CurrentMatch.Value = new TournamentMatch();
             Ladder.CurrentMatch.Value = Ladder.Matches.First();
             Ladder.CurrentMatch.Value.PicksBans.Clear();
+        }
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
         });
 
         [Test]
@@ -48,7 +58,6 @@ namespace osu.Game.Tournament.Tests.Screens
             AddStep("reset match", () =>
             {
                 Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
             });
 
             assertTwoWide();
@@ -65,11 +74,7 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap();
             });
 
-            AddStep("reset match", () =>
-            {
-                Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
-            });
+            AddStep("reset state", resetState);
 
             assertTwoWide();
         }
@@ -85,11 +90,7 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap();
             });
 
-            AddStep("reset match", () =>
-            {
-                Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
-            });
+            AddStep("reset state", resetState);
 
             assertThreeWide();
         }
@@ -105,11 +106,7 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
             });
 
-            AddStep("reset match", () =>
-            {
-                Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
-            });
+            AddStep("reset state", resetState);
 
             assertTwoWide();
         }
@@ -131,11 +128,7 @@ namespace osu.Game.Tournament.Tests.Screens
                     addBeatmap(i > 4 ? Ruleset.Value.CreateInstance().AllMods.ElementAt(i).Acronym : "NM");
             });
 
-            AddStep("reset match", () =>
-            {
-                Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
-            });
+            AddStep("reset state", resetState);
 
             assertThreeWide();
         }
@@ -153,11 +146,7 @@ namespace osu.Game.Tournament.Tests.Screens
 
             AddStep("disable splitting map pool by mods", () => Ladder.SplitMapPoolByMods.Value = false);
 
-            AddStep("reset match", () =>
-            {
-                Ladder.CurrentMatch.Value = new TournamentMatch();
-                Ladder.CurrentMatch.Value = Ladder.Matches.First();
-            });
+            AddStep("reset state", resetState);
         }
 
         [Test]

--- a/osu.Game.Tournament/Models/TournamentRound.cs
+++ b/osu.Game.Tournament/Models/TournamentRound.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Tournament.Models
         public readonly Bindable<string> Description = new Bindable<string>(string.Empty);
 
         public readonly BindableInt BestOf = new BindableInt(9) { Default = 9, MinValue = 3, MaxValue = 23 };
+        public readonly BindableInt BanCount = new BindableInt(1) { Default = 1, MinValue = 0, MaxValue = 5 };
 
         [JsonProperty]
         public readonly BindableList<RoundBeatmap> Beatmaps = new BindableList<RoundBeatmap>();

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -83,6 +83,12 @@ namespace osu.Game.Tournament.Screens.Editors
                             },
                             new SettingsSlider<int>
                             {
+                                LabelText = "# of Bans",
+                                Width = 0.33f,
+                                Current = Model.BanCount
+                            },
+                            new SettingsSlider<int>
+                            {
                                 LabelText = "Best of",
                                 Width = 0.33f,
                                 Current = Model.BestOf

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             if (!hasAllBans)
                 // If it's the third ban or later, we need to check if it's the team's first or second ban in a row
-                nextColour = (CurrentMatch.Value.PicksBans.Count() >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
+                nextColour = (CurrentMatch.Value.PicksBans.Count >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
             if (hasAllBans && pickType == ChoiceType.Ban)
             {

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -151,9 +151,7 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             int totalBansRequired = CurrentMatch.Value.Round.Value.BanCount.Value * 2;
 
-            const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
-
-            var previousColour = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner;
+            TeamColour lastPickColour = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? TeamColour.Red;
 
             TeamColour nextColour;
 
@@ -161,22 +159,17 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             if (!hasAllBans)
             {
-                // Ban phase.
-                // Switch teams every second ban.
+                // Ban phase: switch teams every second ban.
                 nextColour = CurrentMatch.Value.PicksBans.Count % 2 == 1
-                    ? getOppositeTeamColour(previousColour)
-                    : previousColour;
-            }
-            else if (pickType == ChoiceType.Ban)
-            {
-                // Switching from bans to picks - stay with the last team that was banning.
-                nextColour = pickColour;
+                    ? getOppositeTeamColour(lastPickColour)
+                    : lastPickColour;
             }
             else
             {
-                // Pick phase.
-                // Switch teams every pick.
-                nextColour = getOppositeTeamColour(previousColour);
+                // Pick phase : switch teams every pick, except for the first pick which generally goes to the team that placed the last ban.
+                nextColour = pickType == ChoiceType.Pick
+                    ? getOppositeTeamColour(lastPickColour)
+                    : lastPickColour;
             }
 
             setMode(nextColour, hasAllBans ? ChoiceType.Pick : ChoiceType.Ban);

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -155,9 +155,13 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             var previousBan = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner;
 
-            var nextColour = (CurrentMatch.Value.PicksBans.Count() >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
+            var nextColour = previousBan == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
             bool hasAllBans = CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= totalBansRequired;
+
+            if (!hasAllBans)
+                // If it's the third ban or later, we need to check if it's the team's first or second ban in a row
+                nextColour = (CurrentMatch.Value.PicksBans.Count() >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
             if (hasAllBans && pickType == ChoiceType.Ban)
             {

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -153,7 +153,9 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
 
-            var nextColour = (CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
+            var previousBan = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner;
+
+            var nextColour = (CurrentMatch.Value.PicksBans.Count() >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
             bool hasAllBans = CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= totalBansRequired;
 

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -146,17 +146,24 @@ namespace osu.Game.Tournament.Screens.MapPool
 
         private void setNextMode()
         {
+            int banCount = 2;
+
             if (CurrentMatch.Value == null)
                 return;
+
+            if (CurrentMatch.Value.Round.Value != null)
+            {
+                banCount = CurrentMatch.Value.Round.Value.BanCount.Value * 2;
+            }
 
             const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
 
             var nextColour = (CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
-            if (pickType == ChoiceType.Ban && CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= 2)
+            if (pickType == ChoiceType.Ban && CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= banCount)
                 setMode(pickColour, ChoiceType.Pick);
             else
-                setMode(nextColour, CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= 2 ? ChoiceType.Pick : ChoiceType.Ban);
+                setMode(nextColour, CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= banCount ? ChoiceType.Pick : ChoiceType.Ban);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -153,23 +153,35 @@ namespace osu.Game.Tournament.Screens.MapPool
 
             const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
 
-            var previousBan = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner;
+            var previousColour = CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner;
 
-            var nextColour = previousBan == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
+            TeamColour nextColour;
 
             bool hasAllBans = CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= totalBansRequired;
 
             if (!hasAllBans)
-                // If it's the third ban or later, we need to check if it's the team's first or second ban in a row
-                nextColour = (CurrentMatch.Value.PicksBans.Count >= 2 ? CurrentMatch.Value.PicksBans[^2]?.Team : previousBan) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
-
-            if (hasAllBans && pickType == ChoiceType.Ban)
             {
-                // When switching from bans to picks, we don't rotate the team colour.
+                // Ban phase.
+                // Switch teams every second ban.
+                nextColour = CurrentMatch.Value.PicksBans.Count % 2 == 1
+                    ? getOppositeTeamColour(previousColour)
+                    : previousColour;
+            }
+            else if (pickType == ChoiceType.Ban)
+            {
+                // Switching from bans to picks - stay with the last team that was banning.
                 nextColour = pickColour;
+            }
+            else
+            {
+                // Pick phase.
+                // Switch teams every pick.
+                nextColour = getOppositeTeamColour(previousColour);
             }
 
             setMode(nextColour, hasAllBans ? ChoiceType.Pick : ChoiceType.Ban);
+
+            TeamColour getOppositeTeamColour(TeamColour colour) => colour == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
+++ b/osu.Game.Tournament/Screens/MapPool/MapPoolScreen.cs
@@ -136,34 +136,34 @@ namespace osu.Game.Tournament.Screens.MapPool
             pickColour = colour;
             pickType = choiceType;
 
-            static Color4 setColour(bool active) => active ? Color4.White : Color4.Gray;
-
             buttonRedBan.Colour = setColour(pickColour == TeamColour.Red && pickType == ChoiceType.Ban);
             buttonBlueBan.Colour = setColour(pickColour == TeamColour.Blue && pickType == ChoiceType.Ban);
             buttonRedPick.Colour = setColour(pickColour == TeamColour.Red && pickType == ChoiceType.Pick);
             buttonBluePick.Colour = setColour(pickColour == TeamColour.Blue && pickType == ChoiceType.Pick);
+
+            static Color4 setColour(bool active) => active ? Color4.White : Color4.Gray;
         }
 
         private void setNextMode()
         {
-            int banCount = 2;
-
-            if (CurrentMatch.Value == null)
+            if (CurrentMatch.Value?.Round.Value == null)
                 return;
 
-            if (CurrentMatch.Value.Round.Value != null)
-            {
-                banCount = CurrentMatch.Value.Round.Value.BanCount.Value * 2;
-            }
+            int totalBansRequired = CurrentMatch.Value.Round.Value.BanCount.Value * 2;
 
             const TeamColour roll_winner = TeamColour.Red; //todo: draw from match
 
             var nextColour = (CurrentMatch.Value.PicksBans.LastOrDefault()?.Team ?? roll_winner) == TeamColour.Red ? TeamColour.Blue : TeamColour.Red;
 
-            if (pickType == ChoiceType.Ban && CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= banCount)
-                setMode(pickColour, ChoiceType.Pick);
-            else
-                setMode(nextColour, CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= banCount ? ChoiceType.Pick : ChoiceType.Ban);
+            bool hasAllBans = CurrentMatch.Value.PicksBans.Count(p => p.Type == ChoiceType.Ban) >= totalBansRequired;
+
+            if (hasAllBans && pickType == ChoiceType.Ban)
+            {
+                // When switching from bans to picks, we don't rotate the team colour.
+                nextColour = pickColour;
+            }
+
+            setMode(nextColour, hasAllBans ? ChoiceType.Pick : ChoiceType.Ban);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e)


### PR DESCRIPTION
# osu.Game.Tournament.Models
+ Add: New property BanCount in TournamentRound to save the number of bans

# osu.Game.Tournament/Screens
+ Add: New slider setting in RoundEditorScreen to select the number of bans per round
* Change: Modified setNextMode behavior to get the round ban count, and select bans accordingly

~ This idea came from this [comment](https://github.com/ppy/osu/issues/24857#issuecomment-1725083733), which remembered me that indeed it's always assumed it's a single ban, even tho (even in OWC) having 2 bans per team further in the bracket is the norm. This development does just that, allowing for the number of bans to be specified per round. I decided in a 0-5 ban count to be on the safe side.