### PR TITLE
Fix chat overlay top bar icon being incorrect

### DIFF
--- a/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
+++ b/osu.Game/Overlays/Chat/ChatOverlayTopBar.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays.Chat
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                                Icon = HexaconsIcons.Social,
+                                Icon = HexaconsIcons.Messaging,
                                 Size = new Vector2(24),
                             },
                             // Placeholder text


### PR DESCRIPTION
- Noticed in https://discord.com/channels/188630481301012481/1097318920991559880/1179824493691150346.
- Regressed in https://github.com/ppy/osu/pull/25560/files#diff-96884bc35666b36fc2dc5f54a3c32c0cb1a9fb401a3592236743c1bd404711ad