### PR TITLE
Show pp awarded if a play was full combo in performance breakdown

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -395,7 +395,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
         {
-            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap, showFCPerformance : false)
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y

--- a/osu.Game/Graphics/UserInterface/MultiValueBar.cs
+++ b/osu.Game/Graphics/UserInterface/MultiValueBar.cs
@@ -12,25 +12,20 @@ using osu.Framework.Graphics.Shapes;
 namespace osu.Game.Graphics.UserInterface
 {
     // A modified implementation of Bar which supports multiple accent bars
-    public partial class PolyBar : Container
+    public partial class MultiValueBar : Container
     {
-        // Box to represent the background of the bars
         private readonly Box background;
 
-        // Each accent coloured bar within the PolyBar
         private readonly Box[] bars;
 
-        // number of bars, could use bars.Length instead but moved to readonly field for readability
         private readonly int barCount;
 
         private const int resize_duration = 250;
 
         private const Easing easing = Easing.InOutCubic;
 
-        // Each of these maps to a box in bars 1:1, lengths[i] represents the length of bars[i]
         private readonly float[] lengths;
 
-        // getters and setters for the lengths are moved to functions, because C# doesn't support indexed getters
         public void SetLength(int index, float value)
         {
             lengths[index] = Math.Clamp(value, 0, 1);
@@ -39,14 +34,12 @@ namespace osu.Game.Graphics.UserInterface
 
         public float GetLength(int index) => lengths[index];
 
-        // update colour of background through this class
         public Color4 BackgroundColour
         {
             get => background.Colour;
             set => background.Colour = value;
         }
 
-        // getters and setters for colours, maps same as lengths and bars, GetColour(i) returns the colour of bars[i]
         public void SetColour(int index, Color4 value)
         {
             bars[index].Colour = value;
@@ -54,7 +47,6 @@ namespace osu.Game.Graphics.UserInterface
 
         public Color4 GetColour(int index) => bars[index].Colour;
 
-        // Only supports all bars going in the same direction currently
         private BarDirection direction = BarDirection.LeftToRight;
 
         public BarDirection Direction
@@ -67,7 +59,7 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        public PolyBar(int barCount)
+        public MultiValueBar(int barCount)
         {
             lengths = new float[barCount];
             this.barCount = barCount;
@@ -95,7 +87,6 @@ namespace osu.Game.Graphics.UserInterface
             Children = children.ToArray();
         }
 
-        // updates the length of a single bar of the given index, but will update all lengths if an argument of -1 or no argument is given
         private void updateBarLength(int index = -1)
         {
             if (index == -1)
@@ -133,7 +124,6 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        // update the length of every bar
         private void updateBarLengths()
         {
             for (int i = 0; i < barCount; i++)

--- a/osu.Game/Graphics/UserInterface/PolyBar.cs
+++ b/osu.Game/Graphics/UserInterface/PolyBar.cs
@@ -16,35 +16,47 @@ namespace osu.Game.Graphics.UserInterface
     {
         // Box to represent the background of the bars
         private readonly Box background;
+
         // Each accent coloured bar within the PolyBar
         private readonly Box[] bars;
+
         // number of bars, could use bars.Length instead but moved to readonly field for readability
         private readonly int barCount;
+
         private const int resize_duration = 250;
+
         private const Easing easing = Easing.InOutCubic;
+
         // Each of these maps to a box in bars 1:1, lengths[i] represents the length of bars[i]
-        private float[] lengths;
+        private readonly float[] lengths;
+
         // getters and setters for the lengths are moved to functions, because C# doesn't support indexed getters
         public void SetLength(int index, float value)
         {
             lengths[index] = Math.Clamp(value, 0, 1);
             updateBarLength(index);
         }
+
         public float GetLength(int index) => lengths[index];
+
         // update colour of background through this class
         public Color4 BackgroundColour
         {
             get => background.Colour;
             set => background.Colour = value;
         }
+
         // getters and setters for colours, maps same as lengths and bars, GetColour(i) returns the colour of bars[i]
         public void SetColour(int index, Color4 value)
         {
             bars[index].Colour = value;
         }
+
         public Color4 GetColour(int index) => bars[index].Colour;
+
         // Only supports all bars going in the same direction currently
         private BarDirection direction = BarDirection.LeftToRight;
+
         public BarDirection Direction
         {
             get => direction;
@@ -54,10 +66,12 @@ namespace osu.Game.Graphics.UserInterface
                 updateBarLength();
             }
         }
+
         public PolyBar(int barCount)
         {
             lengths = new float[barCount];
             this.barCount = barCount;
+
             List<Drawable> children = new List<Drawable>();
             background = new Box
             {
@@ -65,7 +79,9 @@ namespace osu.Game.Graphics.UserInterface
                 Colour = new Color4(0, 0, 0, 0),
             };
             children.Add(background);
+
             bars = new Box[barCount];
+
             for (int i = 0; i < barCount; i++)
             {
                 bars[i] = new Box
@@ -75,16 +91,19 @@ namespace osu.Game.Graphics.UserInterface
                 };
                 children.Add(bars[i]);
             }
+
             Children = children.ToArray();
         }
+
         // updates the length of a single bar of the given index, but will update all lengths if an argument of -1 or no argument is given
-        private void updateBarLength(int index=-1)
+        private void updateBarLength(int index = -1)
         {
             if (index == -1)
             {
                 updateBarLengths();
                 return;
             }
+
             switch (direction)
             {
                 case BarDirection.LeftToRight:
@@ -112,8 +131,8 @@ namespace osu.Game.Graphics.UserInterface
                     bars[index].Origin = Anchor.BottomRight;
                     break;
             }
-
         }
+
         // update the length of every bar
         private void updateBarLengths()
         {

--- a/osu.Game/Graphics/UserInterface/PolyBar.cs
+++ b/osu.Game/Graphics/UserInterface/PolyBar.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osuTK;
+using osuTK.Graphics;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public partial class PolyBar : Container
+    {
+        private readonly Box background;
+        private readonly Box[] bars;
+        private readonly int barCount;
+        private const int resize_duration = 250;
+        private const Easing easing = Easing.InOutCubic;
+        private float[] lengths;
+        public void SetLength(int index, float value)
+        {
+            lengths[index] = Math.Clamp(value, 0, 1);
+            updateBarLength(index);
+        }
+        public float GetLength(int index) => lengths[index];
+        public Color4 BackgroundColour
+        {
+            get => background.Colour;
+            set => background.Colour = value;
+        }
+        public void SetColour(int index, Color4 value)
+        {
+            bars[index].Colour = value;
+        }
+        public Color4 GetColour(int index) => bars[index].Colour;
+        // This should be modified so bars can go different directions, this is all that's needed for current usecase though
+        private BarDirection direction = BarDirection.LeftToRight;
+        public BarDirection Direction
+        {
+            get => direction;
+            set
+            {
+                direction = value;
+                updateBarLength();
+            }
+        }
+        public PolyBar(int barCount)
+        {
+            lengths = new float[barCount];
+            this.barCount = barCount;
+            List<Drawable> children = new List<Drawable>();
+            background = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = new Color4(0, 0, 0, 0),
+            };
+            children.Add(background);
+            bars = new Box[barCount];
+            for (int i = 0; i < barCount; i++)
+            {
+                bars[i] = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Width = 0,
+                };
+                children.Add(bars[i]);
+            }
+            Children = children.ToArray();
+        }
+        private void updateBarLength(int index=-1)
+        {
+            if (index == -1)
+            {
+                updateBarLengths();
+                return;
+            }
+            switch (direction)
+            {
+                case BarDirection.LeftToRight:
+                case BarDirection.RightToLeft:
+                    bars[index].ResizeTo(new Vector2(lengths[index], 1), resize_duration, easing);
+                    break;
+
+                case BarDirection.TopToBottom:
+                case BarDirection.BottomToTop:
+                    bars[index].ResizeTo(new Vector2(1, lengths[index]), resize_duration, easing);
+                    break;
+            }
+
+            switch (direction)
+            {
+                case BarDirection.LeftToRight:
+                case BarDirection.TopToBottom:
+                    bars[index].Anchor = Anchor.TopLeft;
+                    bars[index].Origin = Anchor.TopLeft;
+                    break;
+
+                case BarDirection.RightToLeft:
+                case BarDirection.BottomToTop:
+                    bars[index].Anchor = Anchor.BottomRight;
+                    bars[index].Origin = Anchor.BottomRight;
+                    break;
+            }
+
+        }
+        private void updateBarLengths()
+        {
+            for (int i = 0; i < barCount; i++)
+                updateBarLength(i);
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/PolyBar.cs
+++ b/osu.Game/Graphics/UserInterface/PolyBar.cs
@@ -11,31 +11,39 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Game.Graphics.UserInterface
 {
+    // A modified implementation of Bar which supports multiple accent bars
     public partial class PolyBar : Container
     {
+        // Box to represent the background of the bars
         private readonly Box background;
+        // Each accent coloured bar within the PolyBar
         private readonly Box[] bars;
+        // number of bars, could use bars.Length instead but moved to readonly field for readability
         private readonly int barCount;
         private const int resize_duration = 250;
         private const Easing easing = Easing.InOutCubic;
+        // Each of these maps to a box in bars 1:1, lengths[i] represents the length of bars[i]
         private float[] lengths;
+        // getters and setters for the lengths are moved to functions, because C# doesn't support indexed getters
         public void SetLength(int index, float value)
         {
             lengths[index] = Math.Clamp(value, 0, 1);
             updateBarLength(index);
         }
         public float GetLength(int index) => lengths[index];
+        // update colour of background through this class
         public Color4 BackgroundColour
         {
             get => background.Colour;
             set => background.Colour = value;
         }
+        // getters and setters for colours, maps same as lengths and bars, GetColour(i) returns the colour of bars[i]
         public void SetColour(int index, Color4 value)
         {
             bars[index].Colour = value;
         }
         public Color4 GetColour(int index) => bars[index].Colour;
-        // This should be modified so bars can go different directions, this is all that's needed for current usecase though
+        // Only supports all bars going in the same direction currently
         private BarDirection direction = BarDirection.LeftToRight;
         public BarDirection Direction
         {
@@ -69,6 +77,7 @@ namespace osu.Game.Graphics.UserInterface
             }
             Children = children.ToArray();
         }
+        // updates the length of a single bar of the given index, but will update all lengths if an argument of -1 or no argument is given
         private void updateBarLength(int index=-1)
         {
             if (index == -1)
@@ -105,6 +114,7 @@ namespace osu.Game.Graphics.UserInterface
             }
 
         }
+        // update the length of every bar
         private void updateBarLengths()
         {
             for (int i = 0; i < barCount; i++)

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -14,9 +14,9 @@ namespace osu.Game.Rulesets.Difficulty
         public PerformanceAttributes Performance { get; set; }
 
         /// <summary>
-        /// Performance if the play was a full combo
+        /// Performance if the play was a perfect full combo (0 miss, max combo)
         /// </summary>
-        public PerformanceAttributes FCPerformance {get; set;}
+        public PerformanceAttributes PFCPerformance {get; set;}
 
         /// <summary>
         /// Performance of a perfect play for comparison.
@@ -27,12 +27,12 @@ namespace osu.Game.Rulesets.Difficulty
         /// Create a new performance breakdown.
         /// </summary>
         /// <param name="performance">Actual gameplay performance.</param>
-        /// <param name="fcPerformance">Performance rewarded if the play was a full combo</param>
+        /// <param name="pfcPerformance">Performance rewarded if the play was a perfect full combo</param>
         /// <param name="perfectPerformance">Performance of a perfect play for comparison.</param>
-        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes fcPerformance, PerformanceAttributes perfectPerformance)
+        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes pfcPerformance, PerformanceAttributes perfectPerformance)
         {
             Performance = performance;
-            FCPerformance = fcPerformance;
+            PFCPerformance = pfcPerformance;
             PerfectPerformance = perfectPerformance;
         }
     }

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Difficulty
         public PerformanceAttributes Performance { get; set; }
 
         /// <summary>
-        /// Performance if the play was a perfect full combo (0 miss, max combo)
+        /// Performance if the play was a full combo
         /// </summary>
         public PerformanceAttributes FCPerformance { get; set; }
 

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Performance if the play was a perfect full combo (0 miss, max combo)
         /// </summary>
-        public PerformanceAttributes PFCPerformance {get; set;}
+        public PerformanceAttributes PfcPerformance { get; set; }
 
         /// <summary>
         /// Performance of a perfect play for comparison.
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Difficulty
         public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes pfcPerformance, PerformanceAttributes perfectPerformance)
         {
             Performance = performance;
-            PFCPerformance = pfcPerformance;
+            PfcPerformance = pfcPerformance;
             PerfectPerformance = perfectPerformance;
         }
     }

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Rulesets.Difficulty
         public PerformanceAttributes Performance { get; set; }
 
         /// <summary>
+        /// Performance if the play was a full combo
+        /// </summary>
+        public PerformanceAttributes FCPerformance {get; set;}
+
+        /// <summary>
         /// Performance of a perfect play for comparison.
         /// </summary>
         public PerformanceAttributes PerfectPerformance { get; set; }
@@ -22,10 +27,12 @@ namespace osu.Game.Rulesets.Difficulty
         /// Create a new performance breakdown.
         /// </summary>
         /// <param name="performance">Actual gameplay performance.</param>
+        /// <param name="fcPerformance">Performance rewarded if the play was a full combo</param>
         /// <param name="perfectPerformance">Performance of a perfect play for comparison.</param>
-        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes perfectPerformance)
+        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes fcPerformance, PerformanceAttributes perfectPerformance)
         {
             Performance = performance;
+            FCPerformance = fcPerformance;
             PerfectPerformance = perfectPerformance;
         }
     }

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdown.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Performance if the play was a perfect full combo (0 miss, max combo)
         /// </summary>
-        public PerformanceAttributes PfcPerformance { get; set; }
+        public PerformanceAttributes FCPerformance { get; set; }
 
         /// <summary>
         /// Performance of a perfect play for comparison.
@@ -27,12 +27,12 @@ namespace osu.Game.Rulesets.Difficulty
         /// Create a new performance breakdown.
         /// </summary>
         /// <param name="performance">Actual gameplay performance.</param>
-        /// <param name="pfcPerformance">Performance rewarded if the play was a perfect full combo</param>
+        /// <param name="fcPerformance">Performance rewarded if the play was a full combo</param>
         /// <param name="perfectPerformance">Performance of a perfect play for comparison.</param>
-        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes pfcPerformance, PerformanceAttributes perfectPerformance)
+        public PerformanceBreakdown(PerformanceAttributes performance, PerformanceAttributes fcPerformance, PerformanceAttributes perfectPerformance)
         {
             Performance = performance;
-            PfcPerformance = pfcPerformance;
+            FCPerformance = fcPerformance;
             PerfectPerformance = perfectPerformance;
         }
     }

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Difficulty
                 // compute actual performance
                 performanceCache.CalculatePerformanceAsync(score, cancellationToken),
                 // compute performance for a full combo
-                getPFCPerformance(score, cancellationToken),
+                getPfcPerformance(score, cancellationToken),
                 // compute performance for perfect play
                 getPerfectPerformance(score, cancellationToken)
             ).ConfigureAwait(false);
@@ -46,17 +46,17 @@ namespace osu.Game.Rulesets.Difficulty
         }
 
         [ItemCanBeNull]
-        private Task<PerformanceAttributes> getPFCPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
+        private Task<PerformanceAttributes> getPfcPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
         {
             return Task.Run(async () =>
             {
                 Ruleset rulest = score.Ruleset.CreateInstance();
-                ScoreInfo PFCPlay = score.DeepClone();
-                PFCPlay.Passed = true;
+                ScoreInfo pfcPlay = score.DeepClone();
+                pfcPlay.Passed = true;
 
                 // Update the play to be a pfc
-                PFCPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
-                PFCPlay.Statistics[HitResult.Miss] = 0;
+                pfcPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
+                pfcPlay.Statistics[HitResult.Miss] = 0;
 
                 var difficulty = await difficultyCache.GetDifficultyAsync(
                     playableBeatmap.BeatmapInfo,
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Difficulty
                     cancellationToken
                 ).ConfigureAwait(false);
 
-                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(PFCPlay, difficulty.Value.Attributes.AsNonNull());
+                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(pfcPlay, difficulty.Value.Attributes.AsNonNull());
             }, cancellationToken);
         }
 

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Difficulty
                 // compute actual performance
                 performanceCache.CalculatePerformanceAsync(score, cancellationToken),
                 // compute performance for a full combo
-                getPfcPerformance(score, cancellationToken),
+                getFCPerformance(score, cancellationToken),
                 // compute performance for perfect play
                 getPerfectPerformance(score, cancellationToken)
             ).ConfigureAwait(false);
@@ -46,17 +46,17 @@ namespace osu.Game.Rulesets.Difficulty
         }
 
         [ItemCanBeNull]
-        private Task<PerformanceAttributes> getPfcPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
+        private Task<PerformanceAttributes> getFCPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
         {
             return Task.Run(async () =>
             {
                 Ruleset rulest = score.Ruleset.CreateInstance();
-                ScoreInfo pfcPlay = score.DeepClone();
-                pfcPlay.Passed = true;
+                ScoreInfo fcPlay = score.DeepClone();
+                fcPlay.Passed = true;
 
-                // Update the play to be a pfc
-                pfcPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
-                pfcPlay.Statistics[HitResult.Miss] = 0;
+                // Update the play to be a full combo
+                fcPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
+                fcPlay.Statistics[HitResult.Miss] = 0;
 
                 var difficulty = await difficultyCache.GetDifficultyAsync(
                     playableBeatmap.BeatmapInfo,
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Difficulty
                     cancellationToken
                 ).ConfigureAwait(false);
 
-                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(pfcPlay, difficulty.Value.Attributes.AsNonNull());
+                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(fcPlay, difficulty.Value.Attributes.AsNonNull());
             }, cancellationToken);
         }
 

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -56,7 +56,10 @@ namespace osu.Game.Rulesets.Difficulty
 
                 // Update the play to be a full combo
                 fcPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
+                fcPlay.Statistics[HitResult.Great] += fcPlay.Statistics[HitResult.Miss];
                 fcPlay.Statistics[HitResult.Miss] = 0;
+                // Recalculate Accuracy with misses converted to 300s
+                fcPlay.CalculateAccuracy();
 
                 var difficulty = await difficultyCache.GetDifficultyAsync(
                     playableBeatmap.BeatmapInfo,

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Difficulty
                 // compute actual performance
                 performanceCache.CalculatePerformanceAsync(score, cancellationToken),
                 // compute performance for a full combo
-                getFCPerformance(score, cancellationToken),
+                getPFCPerformance(score, cancellationToken),
                 // compute performance for perfect play
                 getPerfectPerformance(score, cancellationToken)
             ).ConfigureAwait(false);
@@ -46,16 +46,17 @@ namespace osu.Game.Rulesets.Difficulty
         }
 
         [ItemCanBeNull]
-        private Task<PerformanceAttributes> getFCPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
+        private Task<PerformanceAttributes> getPFCPerformance(ScoreInfo score, CancellationToken cancellationToken = default)
         {
             return Task.Run(async () =>
             {
                 Ruleset rulest = score.Ruleset.CreateInstance();
-                ScoreInfo FCPlay = score.DeepClone();
-                FCPlay.Passed = true;
+                ScoreInfo PFCPlay = score.DeepClone();
+                PFCPlay.Passed = true;
 
-                FCPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
-                FCPlay.Statistics[HitResult.Miss] = 0;
+                // Update the play to be a pfc
+                PFCPlay.MaxCombo = calculateMaxCombo(playableBeatmap);
+                PFCPlay.Statistics[HitResult.Miss] = 0;
 
                 var difficulty = await difficultyCache.GetDifficultyAsync(
                     playableBeatmap.BeatmapInfo,
@@ -64,7 +65,7 @@ namespace osu.Game.Rulesets.Difficulty
                     cancellationToken
                 ).ConfigureAwait(false);
 
-                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(FCPlay, difficulty.Value.Attributes.AsNonNull());
+                return difficulty == null ? null : rulest.CreatePerformanceCalculator()?.Calculate(PFCPlay, difficulty.Value.Attributes.AsNonNull());
             }, cancellationToken);
         }
 

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -65,10 +65,8 @@ namespace osu.Game.Rulesets.Difficulty
                     int count300 = fcPlay.Statistics.Where(x => Judgement.ToNumericResult(x.Key) >= 300).Sum(x => x.Value);
                     // The ratio of 300s to other values not including misses
                     double ratio300 = (double)count300 / (fcPlay.Statistics.Sum(x => x.Value) - fcPlay.Statistics[HitResult.Miss]);
-                    Console.WriteLine($"{ratio300}");
                     // The number of extra greats to add
                     int newGreat = (int)Math.Round(fcPlay.Statistics[HitResult.Miss] * ratio300);
-                    Console.WriteLine($"{newGreat}");
                     // The number of extra oks to add
                     int newOk = fcPlay.Statistics[HitResult.Miss] - newGreat;
                     fcPlay.Statistics[HitResult.Great] += newGreat;

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -14,7 +13,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Scoring;
 
 namespace osu.Game.Rulesets.Difficulty
@@ -61,18 +59,12 @@ namespace osu.Game.Rulesets.Difficulty
                 // Only recalculate accuracy if it's different
                 if (fcPlay.Statistics[HitResult.Miss] > 0)
                 {
-                    // number of hits which are worth 300 or more score (greats and perfects)
-                    int count300 = fcPlay.Statistics.Where(x => Judgement.ToNumericResult(x.Key) >= 300).Sum(x => x.Value);
-                    // The ratio of 300s to other values not including misses
-                    double ratio300 = (double)count300 / (fcPlay.Statistics.Sum(x => x.Value) - fcPlay.Statistics[HitResult.Miss]);
-                    // The number of extra greats to add
-                    int newGreat = (int)Math.Round(fcPlay.Statistics[HitResult.Miss] * ratio300);
-                    // The number of extra oks to add
-                    int newOk = fcPlay.Statistics[HitResult.Miss] - newGreat;
-                    fcPlay.Statistics[HitResult.Great] += newGreat;
-                    fcPlay.Statistics[HitResult.Ok] += newOk;
+                    if (fcPlay.Statistics.ContainsKey(HitResult.Perfect))
+                        fcPlay.Statistics[HitResult.Perfect] += fcPlay.Statistics[HitResult.Miss];
+                    else
+                        fcPlay.Statistics[HitResult.Great] += fcPlay.Statistics[HitResult.Miss];
                     fcPlay.Statistics[HitResult.Miss] = 0;
-                    // Recalculate Accuracy with misses converted to 300s
+                    // Recalculate Accuracy with converted misses
                     fcPlay.CalculateAccuracy();
                 }
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -15,6 +15,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Users;
 using osu.Game.Utils;
@@ -383,5 +384,13 @@ namespace osu.Game.Scoring
         public bool Equals(ScoreInfo? other) => other?.ID == ID;
 
         public override string ToString() => this.GetDisplayTitle();
+        
+        // Recalculate accuracy based off of the current state of Statistics
+        public void CalculateAccuracy()
+        {
+            // This iterates through statistics 3 times, which is probably not major for performance but is certainly not ideal
+            double scoreSum = Statistics.Sum(x => Judgement.ToNumericResult(x.Key) * x.Value);
+            Accuracy = scoreSum / (MaximumStatistics.Sum(x => Judgement.ToNumericResult(x.Key) * x.Value));
+        }
     }
 }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -384,7 +384,7 @@ namespace osu.Game.Scoring
         public bool Equals(ScoreInfo? other) => other?.ID == ID;
 
         public override string ToString() => this.GetDisplayTitle();
-        
+
         // Recalculate accuracy based off of the current state of Statistics
         public void CalculateAccuracy()
         {

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -388,9 +388,8 @@ namespace osu.Game.Scoring
         // Recalculate accuracy based off of the current state of Statistics
         public void CalculateAccuracy()
         {
-            // This iterates through statistics 3 times, which is probably not major for performance but is certainly not ideal
-            double scoreSum = Statistics.Sum(x => Judgement.ToNumericResult(x.Key) * x.Value);
-            Accuracy = scoreSum / (MaximumStatistics.Sum(x => Judgement.ToNumericResult(x.Key) * x.Value));
+            double scoreSum = Statistics.Where(x => x.Key.AffectsAccuracy()).Sum(x => Judgement.ToNumericResult(x.Key) * x.Value);
+            Accuracy = scoreSum / (MaximumStatistics.Where(x => x.Key.AffectsAccuracy()).Sum(x => Judgement.ToNumericResult(x.Key) * x.Value));
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -37,9 +37,11 @@ namespace osu.Game.Screens.Ranking.Statistics
         private OsuSpriteText achievedPerformance;
         private OsuSpriteText pfcPerformance;
         private OsuSpriteText maximumPerformance;
+
         // Colours of the achieved and pfc text and bars
-        private Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
-        private Color4 pfcColor = Color4Extensions.FromHex("#609882");
+        private readonly Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
+
+        private readonly Color4 pfcColor = Color4Extensions.FromHex("#609882");
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
@@ -182,7 +184,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             content.FadeIn(200);
 
             var displayAttributes = breakdown.Performance.GetAttributesForDisplay();
-            var pfcAttribute = breakdown.PFCPerformance.GetAttributesForDisplay();
+            var pfcAttribute = breakdown.PfcPerformance.GetAttributesForDisplay();
             var perfectDisplayAttributes = breakdown.PerfectPerformance.GetAttributesForDisplay();
 
             setTotalValues(

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             {
                 if (attr.PropertyName == nameof(PerformanceAttributes.Total)) continue;
 
-                var row = createAttributeRow(attr, perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
+                var row = createAttributeRow(attr, fcAttribute.First(a => a.PropertyName == attr.PropertyName), perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
 
                 if (row != null)
                 {
@@ -216,7 +216,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         }
 
         [CanBeNull]
-        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute perfectAttribute)
+        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             // Don't display the attribute if its maximum is 0
             // For example, flashlight bonus would be zero if flashlight mod isn't on
@@ -224,6 +224,22 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return null;
 
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
+            float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
+
+            PolyBar bar = new PolyBar(2)
+            {
+                RelativeSizeAxes = Axes.X,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                CornerRadius = 2.5f,
+                Masking = true,
+                Height = 5,
+                BackgroundColour = Color4.White.Opacity(0.5f),
+            };
+            bar.SetColour(1, Color4Extensions.FromHex("#66FFCC"));
+            bar.SetColour(0, Color4Extensions.FromHex("#FF6699"));
+            bar.SetLength(1, percentage);
+            bar.SetLength(0, fcPercentage);
 
             return new Drawable[]
             {
@@ -239,18 +255,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Left = 10, Right = 10 },
-                    Child = new Bar
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        Origin = Anchor.Centre,
-                        Anchor = Anchor.Centre,
-                        CornerRadius = 2.5f,
-                        Masking = true,
-                        Height = 5,
-                        BackgroundColour = Color4.White.Opacity(0.5f),
-                        AccentColour = Color4Extensions.FromHex("#66FFCC"),
-                        Length = percentage
-                    }
+                    Child = bar
                 },
                 new OsuSpriteText
                 {

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -38,9 +38,9 @@ namespace osu.Game.Screens.Ranking.Statistics
         private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
 
-        private readonly Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
+        private readonly Color4 achieveColour = Color4Extensions.FromHex("#66FFCC");
 
-        private readonly Color4 fcColor = Color4Extensions.FromHex("#609882");
+        private readonly Color4 fcColour = Color4Extensions.FromHex("#609882");
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
@@ -105,14 +105,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "Achieved PP",
-                                        Colour = achieveColor
+                                        Colour = achieveColour
                                     },
                                     achievedPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = achieveColor
+                                        Colour = achieveColour
                                     }
                                 },
                                 new Drawable[]
@@ -123,14 +123,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "PP for Full Combo",
-                                        Colour = fcColor
+                                        Colour = fcColour
                                     },
                                     fcPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = fcColor
+                                        Colour = fcColour
                                     }
                                 },
                                 new Drawable[]
@@ -230,7 +230,10 @@ namespace osu.Game.Screens.Ranking.Statistics
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
             float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
 
-            MultiValueBar bar = new MultiValueBar(2)
+            float[] lengths = { fcPercentage, percentage };
+            Color4[] colours = { fcColour, achieveColour };
+
+            MultiValueBar bar = new MultiValueBar(2, lengths, colours)
             {
                 RelativeSizeAxes = Axes.X,
                 Origin = Anchor.Centre,
@@ -240,10 +243,6 @@ namespace osu.Game.Screens.Ranking.Statistics
                 Height = 5,
                 BackgroundColour = Color4.White.Opacity(0.5f),
             };
-            bar.SetColour(1, achieveColor);
-            bar.SetColour(0, fcColor);
-            bar.SetLength(1, percentage);
-            bar.SetLength(0, fcPercentage);
 
             return new Drawable[]
             {

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -50,15 +50,82 @@ namespace osu.Game.Screens.Ranking.Statistics
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; }
 
-        public PerformanceBreakdownChart(ScoreInfo score, IBeatmap playableBeatmap)
+        private readonly bool showFCPerformance;
+
+        public PerformanceBreakdownChart(ScoreInfo score, IBeatmap playableBeatmap, bool showFCPerformance = true)
         {
             this.score = score;
             this.playableBeatmap = playableBeatmap;
+            this.showFCPerformance = showFCPerformance;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            var texts = new List<Drawable[]>
+            {
+                new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Origin = Anchor.CentreLeft,
+                        Anchor = Anchor.CentreLeft,
+                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
+                        Text = "Achieved",
+                        Colour = achieveColour
+                    },
+                    achievedPerformance = new OsuSpriteText
+                    {
+                        Origin = Anchor.CentreRight,
+                        Anchor = Anchor.CentreRight,
+                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
+                        Colour = achieveColour
+                    }
+                },
+            };
+
+            if (showFCPerformance)
+            {
+                texts.Add(
+                    new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Origin = Anchor.CentreLeft,
+                            Anchor = Anchor.CentreLeft,
+                            Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
+                            Text = "On Full Combo",
+                            Colour = fcColour
+                        },
+                        fcPerformance = new OsuSpriteText
+                        {
+                            Origin = Anchor.CentreRight,
+                            Anchor = Anchor.CentreRight,
+                            Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
+                            Colour = fcColour
+                        }
+                    });
+            }
+
+            texts.Add(
+                new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Origin = Anchor.CentreLeft,
+                        Anchor = Anchor.CentreLeft,
+                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
+                        Text = "Maximum",
+                        Colour = OsuColour.Gray(0.7f)
+                    },
+                    maximumPerformance = new OsuSpriteText
+                    {
+                        Origin = Anchor.CentreLeft,
+                        Anchor = Anchor.CentreLeft,
+                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
+                        Colour = OsuColour.Gray(0.7f)
+                    }
+                });
             Children = new[]
             {
                 spinner = new LoadingSpinner(true)
@@ -95,63 +162,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                 new Dimension(GridSizeMode.AutoSize),
                                 new Dimension(GridSizeMode.AutoSize)
                             },
-                            Content = new[]
-                            {
-                                new Drawable[]
-                                {
-                                    new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreLeft,
-                                        Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "Achieved",
-                                        Colour = achieveColour
-                                    },
-                                    achievedPerformance = new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreRight,
-                                        Anchor = Anchor.CentreRight,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = achieveColour
-                                    }
-                                },
-                                new Drawable[]
-                                {
-                                    new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreLeft,
-                                        Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "On Full Combo",
-                                        Colour = fcColour
-                                    },
-                                    fcPerformance = new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreRight,
-                                        Anchor = Anchor.CentreRight,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = fcColour
-                                    }
-                                },
-                                new Drawable[]
-                                {
-                                    new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreLeft,
-                                        Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "Maximum",
-                                        Colour = OsuColour.Gray(0.7f)
-                                    },
-                                    maximumPerformance = new OsuSpriteText
-                                    {
-                                        Origin = Anchor.CentreLeft,
-                                        Anchor = Anchor.CentreLeft,
-                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Colour = OsuColour.Gray(0.7f)
-                                    }
-                                }
-                            }
+                            Content = texts.ToArray(),
                         },
                         chart = new GridContainer
                         {
@@ -215,7 +226,8 @@ namespace osu.Game.Screens.Ranking.Statistics
         private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             achievedPerformance.Text = Math.Round(attribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
-            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
+            if (showFCPerformance)
+                fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 
@@ -228,7 +240,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return null;
 
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
-            float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
+            float fcPercentage = showFCPerformance ? (float)(fcAttribute.Value / perfectAttribute.Value) : 0;
 
             float[] lengths = { fcPercentage, percentage };
             Color4[] colours = { fcColour, achieveColour };

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "PP for FC",
+                                        Text = "PP for Perfect Combo",
                                         Colour = Color4Extensions.FromHex("#FF6699")
                                     },
                                     fcPerformance = new OsuSpriteText

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "Achieved PP",
+                                        Text = "Achieved",
                                         Colour = achieveColour
                                     },
                                     achievedPerformance = new OsuSpriteText
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "PP for Full Combo",
+                                        Text = "On Full Combo",
                                         Colour = fcColour
                                     },
                                     fcPerformance = new OsuSpriteText

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
         private Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
-        private Color4 pfcColor = Color4Extensions.FromHex("#FF66E5");
+        private Color4 pfcColor = Color4Extensions.FromHex("#609882");
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         private Drawable content;
         private GridContainer chart;
         private OsuSpriteText achievedPerformance;
+        private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -116,6 +117,24 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
+                                        Text = "PP for FC",
+                                        Colour = OsuColour.Gray(1.0f)
+                                    },
+                                    fcPerformance = new OsuSpriteText
+                                    {
+                                        Origin = Anchor.CentreRight,
+                                        Anchor = Anchor.CentreRight,
+                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, sizeof: StatisticItem.FONT_SIZE),
+                                        Colour = OsuColour.Gray(1.0f)
+                                    }
+                                }
+                                new Drawable[]
+                                {
+                                    new OsuSpriteText
+                                    {
+                                        Origin = Anchor.CentreLeft,
+                                        Anchor = Anchor.CentreLeft,
+                                        Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "Maximum",
                                         Colour = OsuColour.Gray(0.7f)
                                     },
@@ -186,9 +205,10 @@ namespace osu.Game.Screens.Ranking.Statistics
             chart.Content = rows.ToArray();
         }
 
-        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute perfectAttribute)
+        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             achievedPerformance.Text = Math.Round(attribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
+            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRound.AwayFromZero).ToLocalisableString();
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -35,8 +35,9 @@ namespace osu.Game.Screens.Ranking.Statistics
         private Drawable content;
         private GridContainer chart;
         private OsuSpriteText achievedPerformance;
-        private OsuSpriteText fcPerformance;
+        private OsuSpriteText pfcPerformance;
         private OsuSpriteText maximumPerformance;
+        // Colours of the achieved and pfc text and bars
         private Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
         private Color4 pfcColor = Color4Extensions.FromHex("#609882");
 
@@ -123,7 +124,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Text = "PP for Perfect Combo",
                                         Colour = pfcColor
                                     },
-                                    fcPerformance = new OsuSpriteText
+                                    pfcPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
@@ -181,12 +182,12 @@ namespace osu.Game.Screens.Ranking.Statistics
             content.FadeIn(200);
 
             var displayAttributes = breakdown.Performance.GetAttributesForDisplay();
-            var fcAttribute = breakdown.FCPerformance.GetAttributesForDisplay();
+            var pfcAttribute = breakdown.PFCPerformance.GetAttributesForDisplay();
             var perfectDisplayAttributes = breakdown.PerfectPerformance.GetAttributesForDisplay();
 
             setTotalValues(
                 displayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
-                fcAttribute.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
+                pfcAttribute.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
                 perfectDisplayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total))
             );
 
@@ -197,7 +198,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             {
                 if (attr.PropertyName == nameof(PerformanceAttributes.Total)) continue;
 
-                var row = createAttributeRow(attr, fcAttribute.First(a => a.PropertyName == attr.PropertyName), perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
+                var row = createAttributeRow(attr, pfcAttribute.First(a => a.PropertyName == attr.PropertyName), perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
 
                 if (row != null)
                 {
@@ -210,15 +211,15 @@ namespace osu.Game.Screens.Ranking.Statistics
             chart.Content = rows.ToArray();
         }
 
-        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
+        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute pfcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             achievedPerformance.Text = Math.Round(attribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
-            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
+            pfcPerformance.Text = Math.Round(pfcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 
         [CanBeNull]
-        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
+        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute pfcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             // Don't display the attribute if its maximum is 0
             // For example, flashlight bonus would be zero if flashlight mod isn't on
@@ -226,7 +227,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return null;
 
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
-            float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
+            float fcPercentage = (float)(pfcAttribute.Value / perfectAttribute.Value);
 
             PolyBar bar = new PolyBar(2)
             {

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Screens.Ranking.Statistics
         private OsuSpriteText achievedPerformance;
         private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
+        private Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
+        private Color4 pfcColor = Color4Extensions.FromHex("#FF66E5");
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
@@ -101,14 +103,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "Achieved PP",
-                                        Colour = Color4Extensions.FromHex("#66FFCC")
+                                        Colour = achieveColor
                                     },
                                     achievedPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = Color4Extensions.FromHex("#66FFCC")
+                                        Colour = achieveColor
                                     }
                                 },
                                 new Drawable[]
@@ -119,14 +121,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "PP for Perfect Combo",
-                                        Colour = Color4Extensions.FromHex("#FF6699")
+                                        Colour = pfcColor
                                     },
                                     fcPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = Color4Extensions.FromHex("#FF6699")
+                                        Colour = pfcColor
                                     }
                                 },
                                 new Drawable[]
@@ -236,8 +238,8 @@ namespace osu.Game.Screens.Ranking.Statistics
                 Height = 5,
                 BackgroundColour = Color4.White.Opacity(0.5f),
             };
-            bar.SetColour(1, Color4Extensions.FromHex("#66FFCC"));
-            bar.SetColour(0, Color4Extensions.FromHex("#FF6699"));
+            bar.SetColour(1, achieveColor);
+            bar.SetColour(0, pfcColor);
             bar.SetLength(1, percentage);
             bar.SetLength(0, fcPercentage);
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -124,10 +124,10 @@ namespace osu.Game.Screens.Ranking.Statistics
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
-                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, sizeof: StatisticItem.FONT_SIZE),
+                                        Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
                                         Colour = OsuColour.Gray(1.0f)
                                     }
-                                }
+                                },
                                 new Drawable[]
                                 {
                                     new OsuSpriteText
@@ -178,10 +178,12 @@ namespace osu.Game.Screens.Ranking.Statistics
             content.FadeIn(200);
 
             var displayAttributes = breakdown.Performance.GetAttributesForDisplay();
+            var fcAttribute = breakdown.FCPerformance.GetAttributesForDisplay();
             var perfectDisplayAttributes = breakdown.PerfectPerformance.GetAttributesForDisplay();
 
             setTotalValues(
                 displayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
+                fcAttribute.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
                 perfectDisplayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total))
             );
 
@@ -208,7 +210,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             achievedPerformance.Text = Math.Round(attribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
-            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRound.AwayFromZero).ToLocalisableString();
+            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -88,6 +88,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             RowDimensions = new[]
                             {
                                 new Dimension(GridSizeMode.AutoSize),
+                                new Dimension(GridSizeMode.AutoSize),
                                 new Dimension(GridSizeMode.AutoSize)
                             },
                             Content = new[]
@@ -118,14 +119,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
                                         Text = "PP for FC",
-                                        Colour = OsuColour.Gray(1.0f)
+                                        Colour = Color4Extensions.FromHex("#FF6699")
                                     },
                                     fcPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = OsuColour.Gray(1.0f)
+                                        Colour = Color4Extensions.FromHex("#FF6699")
                                     }
                                 },
                                 new Drawable[]

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -35,13 +35,13 @@ namespace osu.Game.Screens.Ranking.Statistics
         private Drawable content;
         private GridContainer chart;
         private OsuSpriteText achievedPerformance;
-        private OsuSpriteText pfcPerformance;
+        private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
 
         // Colours of the achieved and pfc text and bars
         private readonly Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
 
-        private readonly Color4 pfcColor = Color4Extensions.FromHex("#609882");
+        private readonly Color4 fcColor = Color4Extensions.FromHex("#609882");
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
@@ -123,15 +123,15 @@ namespace osu.Game.Screens.Ranking.Statistics
                                         Origin = Anchor.CentreLeft,
                                         Anchor = Anchor.CentreLeft,
                                         Font = OsuFont.GetFont(weight: FontWeight.Regular, size: StatisticItem.FONT_SIZE),
-                                        Text = "PP for Perfect Combo",
-                                        Colour = pfcColor
+                                        Text = "PP for Full Combo",
+                                        Colour = fcColor
                                     },
-                                    pfcPerformance = new OsuSpriteText
+                                    fcPerformance = new OsuSpriteText
                                     {
                                         Origin = Anchor.CentreRight,
                                         Anchor = Anchor.CentreRight,
                                         Font = OsuFont.GetFont(weight: FontWeight.SemiBold, size: StatisticItem.FONT_SIZE),
-                                        Colour = pfcColor
+                                        Colour = fcColor
                                     }
                                 },
                                 new Drawable[]
@@ -184,12 +184,12 @@ namespace osu.Game.Screens.Ranking.Statistics
             content.FadeIn(200);
 
             var displayAttributes = breakdown.Performance.GetAttributesForDisplay();
-            var pfcAttribute = breakdown.PfcPerformance.GetAttributesForDisplay();
+            var fcAttribute = breakdown.FCPerformance.GetAttributesForDisplay();
             var perfectDisplayAttributes = breakdown.PerfectPerformance.GetAttributesForDisplay();
 
             setTotalValues(
                 displayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
-                pfcAttribute.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
+                fcAttribute.First(a => a.PropertyName == nameof(PerformanceAttributes.Total)),
                 perfectDisplayAttributes.First(a => a.PropertyName == nameof(PerformanceAttributes.Total))
             );
 
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             {
                 if (attr.PropertyName == nameof(PerformanceAttributes.Total)) continue;
 
-                var row = createAttributeRow(attr, pfcAttribute.First(a => a.PropertyName == attr.PropertyName), perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
+                var row = createAttributeRow(attr, fcAttribute.First(a => a.PropertyName == attr.PropertyName), perfectDisplayAttributes.First(a => a.PropertyName == attr.PropertyName));
 
                 if (row != null)
                 {
@@ -213,15 +213,15 @@ namespace osu.Game.Screens.Ranking.Statistics
             chart.Content = rows.ToArray();
         }
 
-        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute pfcAttribute, PerformanceDisplayAttribute perfectAttribute)
+        private void setTotalValues(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             achievedPerformance.Text = Math.Round(attribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
-            pfcPerformance.Text = Math.Round(pfcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
+            fcPerformance.Text = Math.Round(fcAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 
         [CanBeNull]
-        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute pfcAttribute, PerformanceDisplayAttribute perfectAttribute)
+        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute fcAttribute, PerformanceDisplayAttribute perfectAttribute)
         {
             // Don't display the attribute if its maximum is 0
             // For example, flashlight bonus would be zero if flashlight mod isn't on
@@ -229,7 +229,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 return null;
 
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
-            float fcPercentage = (float)(pfcAttribute.Value / perfectAttribute.Value);
+            float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
 
             PolyBar bar = new PolyBar(2)
             {
@@ -242,7 +242,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 BackgroundColour = Color4.White.Opacity(0.5f),
             };
             bar.SetColour(1, achieveColor);
-            bar.SetColour(0, pfcColor);
+            bar.SetColour(0, fcColor);
             bar.SetLength(1, percentage);
             bar.SetLength(0, fcPercentage);
 

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -38,7 +38,6 @@ namespace osu.Game.Screens.Ranking.Statistics
         private OsuSpriteText fcPerformance;
         private OsuSpriteText maximumPerformance;
 
-        // Colours of the achieved and pfc text and bars
         private readonly Color4 achieveColor = Color4Extensions.FromHex("#66FFCC");
 
         private readonly Color4 fcColor = Color4Extensions.FromHex("#609882");
@@ -231,7 +230,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             float percentage = (float)(attribute.Value / perfectAttribute.Value);
             float fcPercentage = (float)(fcAttribute.Value / perfectAttribute.Value);
 
-            PolyBar bar = new PolyBar(2)
+            MultiValueBar bar = new MultiValueBar(2)
             {
                 RelativeSizeAxes = Axes.X,
                 Origin = Anchor.Centre,


### PR DESCRIPTION
As title, adds a third value shown in performance breakdown chart that is the pp value for a play with 0 misses and max combo with the same accuracy.

STD Appearance
![image](https://github.com/ppy/osu/assets/50683296/43a89638-c198-42d1-9639-5671c11fe271)
![image](https://github.com/ppy/osu/assets/50683296/0ada6044-58d1-4b3e-9705-1fd40b6a7c3f)

Taiko Appearance
![image](https://github.com/ppy/osu/assets/50683296/771d04b5-0a01-4a0a-8354-d53af0b2bcab)

CTB Appearance
![image](https://github.com/ppy/osu/assets/50683296/6fef90cf-4e66-46d3-b91a-ae19278f481d)
