### PR TITLE
Improve free-hand drawing of sliders to the editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -310,7 +310,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
 
             assertPlaced(true);
-            assertLength(760, tolerance: 10);
+            assertLength(808, tolerance: 10);
             assertControlPointCount(5);
             assertControlPointType(0, PathType.BSpline(3));
             assertControlPointType(1, null);
@@ -337,9 +337,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertPlaced(true);
             assertLength(600, tolerance: 10);
             assertControlPointCount(4);
-            assertControlPointType(0, PathType.LINEAR);
-            assertControlPointType(1, null);
-            assertControlPointType(2, null);
+            assertControlPointType(0, PathType.BSpline(3));
+            assertControlPointType(1, PathType.BSpline(3));
+            assertControlPointType(2, PathType.BSpline(3));
             assertControlPointType(3, null);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -312,7 +312,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertPlaced(true);
             assertLength(808, tolerance: 10);
             assertControlPointCount(5);
-            assertControlPointType(0, PathType.BSpline(3));
+            assertControlPointType(0, PathType.BSpline(4));
             assertControlPointType(1, null);
             assertControlPointType(2, null);
             assertControlPointType(3, null);
@@ -337,9 +337,9 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertPlaced(true);
             assertLength(600, tolerance: 10);
             assertControlPointCount(4);
-            assertControlPointType(0, PathType.BSpline(3));
-            assertControlPointType(1, PathType.BSpline(3));
-            assertControlPointType(2, PathType.BSpline(3));
+            assertControlPointType(0, PathType.BSpline(4));
+            assertControlPointType(1, PathType.BSpline(4));
+            assertControlPointType(2, PathType.BSpline(4));
             assertControlPointType(3, null);
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -373,7 +373,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 curveTypeItems.Add(createMenuItemForPathType(PathType.LINEAR));
                 curveTypeItems.Add(createMenuItemForPathType(PathType.PERFECT_CURVE));
                 curveTypeItems.Add(createMenuItemForPathType(PathType.BEZIER));
-                curveTypeItems.Add(createMenuItemForPathType(PathType.BSpline(3)));
+                curveTypeItems.Add(createMenuItemForPathType(PathType.BSpline(4)));
 
                 if (selectedPieces.Any(piece => piece.ControlPoint.Type?.Type == SplineType.Catmull))
                     curveTypeItems.Add(createMenuItemForPathType(PathType.CATMULL));

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -329,7 +329,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     continue;
 
                 // Where possible, we can use the simpler LINEAR path type.
-                PathType? pathType = pointsInSegment == 1 ? PathType.LINEAR : PathType.BSpline(3);
+                PathType? pathType = pointsInSegment == 2 ? PathType.LINEAR : PathType.BSpline(3);
 
                 // Linear segments can be combined, as two adjacent linear sections are computationally the same as one with the points combined.
                 if (lastPathType == pathType && lastPathType == PathType.LINEAR)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -95,6 +95,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     bSplineBuilder.CornerThreshold = e.NewValue;
                     Scheduler.AddOnce(updateSliderPathFromBSplineBuilder);
                 }, true);
+
+                freehandToolboxGroup.CircleThreshold.BindValueChanged(e =>
+                {
+                    Scheduler.AddOnce(updateSliderPathFromBSplineBuilder);
+                }, true);
             }
         }
 
@@ -358,7 +363,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private Vector2[] tryCircleArc(List<Vector2> segment)
         {
-            if (segment.Count < 3) return null;
+            if (segment.Count < 3 || freehandToolboxGroup.CircleThreshold.Value == 0) return null;
 
             // Assume the segment creates a reasonable circular arc and then check if it reasonable
             var points = PathApproximator.BSplineToPiecewiseLinear(segment.ToArray(), bSplineBuilder.Degree);
@@ -412,7 +417,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             loss /= points.Count;
 
-            return loss > 0.002 || totalWinding > MathHelper.TwoPi ? null : circleArcControlPoints;
+            return loss > freehandToolboxGroup.CircleThreshold.Value || totalWinding > MathHelper.TwoPi ? null : circleArcControlPoints;
         }
 
         private enum SliderPlacementState

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -197,7 +197,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             base.OnDragEnd(e);
 
             if (state == SliderPlacementState.Drawing)
+            {
+                bSplineBuilder.Finish();
+                updateSliderPathFromBSplineBuilder();
                 endCurve();
+            }
         }
 
         protected override void OnMouseUp(MouseUpEvent e)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -200,6 +200,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 bSplineBuilder.Finish();
                 updateSliderPathFromBSplineBuilder();
+
+                // Change the state so it will snap the expected distance in endCurve.
+                state = SliderPlacementState.Finishing;
                 endCurve();
             }
         }
@@ -304,7 +307,10 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSlider()
         {
-            HitObject.Path.ExpectedDistance.Value = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)HitObject.Path.CalculatedDistance) ?? (float)HitObject.Path.CalculatedDistance;
+            if (state == SliderPlacementState.Drawing)
+                HitObject.Path.ExpectedDistance.Value = (float)HitObject.Path.CalculatedDistance;
+            else
+                HitObject.Path.ExpectedDistance.Value = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)HitObject.Path.CalculatedDistance) ?? (float)HitObject.Path.CalculatedDistance;
 
             bodyPiece.UpdateFrom(HitObject);
             headCirclePiece.UpdateFrom(HitObject.HeadCircle);
@@ -343,7 +349,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             Initial,
             ControlPoints,
-            Drawing
+            Drawing,
+            Finishing
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -318,8 +318,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
             HitObject.Path.ControlPoints.Clear();
 
-            // Iterate through generated points, finding each segment and adding non-inheriting path types where appropriate.
-            // Importantly, the B-Spline builder returns three Vector2s at the same location when a new segment is to be started.
+            // Iterate through generated segments and adding non-inheriting path types where appropriate.
             for (int i = 0; i < builderPoints.Count; i++)
             {
                 bool isLastSegment = i == builderPoints.Count - 1;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [Resolved(CanBeNull = true)]
         private FreehandSliderToolboxGroup freehandToolboxGroup { get; set; }
 
-        private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder();
+        private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder { Degree = 4 };
 
         protected override bool IsValidForPlacement => HitObject.Path.HasValidLength;
 
@@ -239,7 +239,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             if (state == SliderPlacementState.Drawing)
             {
-                segmentStart.Type = PathType.BSpline(3);
+                segmentStart.Type = PathType.BSpline(4);
                 return;
             }
 
@@ -335,7 +335,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 if (segment.Count == 0)
                     continue;
 
-                HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], PathType.BSpline(3)));
+                HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], PathType.BSpline(4)));
                 for (int j = 1; j < segment.Count - 1; j++)
                     HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[j]));
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -331,17 +331,16 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 bool isLastSegment = i == builderPoints.Count - 1;
                 var segment = builderPoints[i];
-                int pointsInSegment = segment.Count;
 
                 if (segment.Count == 0)
                     continue;
 
                 HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], PathType.BSpline(3)));
-                for (int j = 1; j < pointsInSegment - 1; j++)
+                for (int j = 1; j < segment.Count - 1; j++)
                     HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[j]));
 
                 if (isLastSegment)
-                    HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[pointsInSegment - 1]));
+                    HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[^1]));
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -311,7 +311,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         {
             IReadOnlyList<List<Vector2>> builderPoints = bSplineBuilder.ControlPoints;
 
-            if (builderPoints.Count == 0)
+            if (builderPoints.Count == 0 || builderPoints[0].Count == 0)
                 return;
 
             PathType? lastPathType = null;
@@ -325,6 +325,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 bool isLastSegment = i == builderPoints.Count - 1;
                 var segment = builderPoints[i];
                 int pointsInSegment = segment.Count;
+
+                if (segment.Count == 0)
+                    continue;
 
                 // Where possible, we can use the simpler LINEAR path type.
                 PathType? pathType = pointsInSegment == 1 ? PathType.LINEAR : PathType.BSpline(3);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -314,8 +314,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (builderPoints.Count == 0 || builderPoints[0].Count == 0)
                 return;
 
-            PathType? lastPathType = null;
-
             HitObject.Path.ControlPoints.Clear();
 
             // Iterate through generated segments and adding non-inheriting path types where appropriate.
@@ -328,21 +326,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                 if (segment.Count == 0)
                     continue;
 
-                // Where possible, we can use the simpler LINEAR path type.
-                PathType? pathType = pointsInSegment == 2 ? PathType.LINEAR : PathType.BSpline(3);
-
-                // Linear segments can be combined, as two adjacent linear sections are computationally the same as one with the points combined.
-                if (lastPathType == pathType && lastPathType == PathType.LINEAR)
-                    pathType = null;
-
-                HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], pathType));
+                HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], PathType.BSpline(3)));
                 for (int j = 1; j < pointsInSegment - 1; j++)
                     HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[j]));
 
                 if (isLastSegment)
                     HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[pointsInSegment - 1]));
-
-                if (pathType != null) lastPathType = pathType;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -309,12 +309,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSliderPathFromBSplineBuilder()
         {
-            IReadOnlyList<Vector2> builderPoints = bSplineBuilder.ControlPoints;
+            IReadOnlyList<List<Vector2>> builderPoints = bSplineBuilder.ControlPoints;
 
             if (builderPoints.Count == 0)
                 return;
 
-            int lastSegmentStart = 0;
             PathType? lastPathType = null;
 
             HitObject.Path.ControlPoints.Clear();
@@ -323,31 +322,25 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             // Importantly, the B-Spline builder returns three Vector2s at the same location when a new segment is to be started.
             for (int i = 0; i < builderPoints.Count; i++)
             {
-                bool isLastPoint = i == builderPoints.Count - 1;
-                bool isNewSegment = i < builderPoints.Count - 2 && builderPoints[i] == builderPoints[i + 1] && builderPoints[i] == builderPoints[i + 2];
+                bool isLastSegment = i == builderPoints.Count - 1;
+                var segment = builderPoints[i];
+                int pointsInSegment = segment.Count;
 
-                if (isNewSegment || isLastPoint)
-                {
-                    int pointsInSegment = i - lastSegmentStart;
+                // Where possible, we can use the simpler LINEAR path type.
+                PathType? pathType = pointsInSegment == 1 ? PathType.LINEAR : PathType.BSpline(3);
 
-                    // Where possible, we can use the simpler LINEAR path type.
-                    PathType? pathType = pointsInSegment == 1 ? PathType.LINEAR : PathType.BSpline(3);
+                // Linear segments can be combined, as two adjacent linear sections are computationally the same as one with the points combined.
+                if (lastPathType == pathType && lastPathType == PathType.LINEAR)
+                    pathType = null;
 
-                    // Linear segments can be combined, as two adjacent linear sections are computationally the same as one with the points combined.
-                    if (lastPathType == pathType && lastPathType == PathType.LINEAR)
-                        pathType = null;
+                HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[0], pathType));
+                for (int j = 1; j < pointsInSegment - 1; j++)
+                    HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[j]));
 
-                    HitObject.Path.ControlPoints.Add(new PathControlPoint(builderPoints[lastSegmentStart], pathType));
-                    for (int j = lastSegmentStart + 1; j < i; j++)
-                        HitObject.Path.ControlPoints.Add(new PathControlPoint(builderPoints[j]));
+                if (isLastSegment)
+                    HitObject.Path.ControlPoints.Add(new PathControlPoint(segment[pointsInSegment - 1]));
 
-                    if (isLastPoint)
-                        HitObject.Path.ControlPoints.Add(new PathControlPoint(builderPoints[i]));
-
-                    // Skip the redundant duplicated points (see isNewSegment above) which have been coalesced into a path type.
-                    lastSegmentStart = (i += 2);
-                    if (pathType != null) lastPathType = pathType;
-                }
+                if (pathType != null) lastPathType = pathType;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        public BindableFloat Tolerance { get; } = new BindableFloat(1.5f)
+        public BindableFloat Tolerance { get; } = new BindableFloat(2f)
         {
             MinValue = 0.05f,
             MaxValue = 3f,
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         };
 
         // We map internal ranges to a more standard range of values for display to the user.
-        private readonly BindableInt displayTolerance = new BindableInt(40)
+        private readonly BindableInt displayTolerance = new BindableInt(66)
         {
             MinValue = 5,
             MaxValue = 100

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         public BindableFloat Tolerance { get; } = new BindableFloat(2f)
         {
             MinValue = 0.05f,
-            MaxValue = 3f,
+            MaxValue = 2.0f,
             Precision = 0.01f
         };
 
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         };
 
         // We map internal ranges to a more standard range of values for display to the user.
-        private readonly BindableInt displayTolerance = new BindableInt(66)
+        private readonly BindableInt displayTolerance = new BindableInt(100)
         {
             MinValue = 5,
             MaxValue = 100
@@ -90,8 +90,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                 displayCornerThreshold.Value = internalToDisplayCornerThreshold(threshold.NewValue)
             );
 
-            float displayToInternalTolerance(float v) => v / 33f;
-            int internalToDisplayTolerance(float v) => (int)Math.Round(v * 33f);
+            float displayToInternalTolerance(float v) => v / 50f;
+            int internalToDisplayTolerance(float v) => (int)Math.Round(v * 50f);
 
             float displayToInternalCornerThreshold(float v) => v / 100f;
             int internalToDisplayCornerThreshold(float v) => (int)Math.Round(v * 100f);

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
-        public BindableFloat Tolerance { get; } = new BindableFloat(2f)
+        public BindableFloat Tolerance { get; } = new BindableFloat(1.8f)
         {
             MinValue = 0.05f,
             MaxValue = 2.0f,
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             Precision = 0.01f
         };
 
-        public BindableFloat CircleThreshold { get; } = new BindableFloat(0.002f)
+        public BindableFloat CircleThreshold { get; } = new BindableFloat(0.0015f)
         {
             MinValue = 0f,
             MaxValue = 0.005f,
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         };
 
         // We map internal ranges to a more standard range of values for display to the user.
-        private readonly BindableInt displayTolerance = new BindableInt(100)
+        private readonly BindableInt displayTolerance = new BindableInt(90)
         {
             MinValue = 5,
             MaxValue = 100
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             MaxValue = 100
         };
 
-        private readonly BindableInt displayCircleThreshold = new BindableInt(40)
+        private readonly BindableInt displayCircleThreshold = new BindableInt(30)
         {
             MinValue = 0,
             MaxValue = 100

--- a/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/FreehandSliderToolboxGroup.cs
@@ -31,6 +31,13 @@ namespace osu.Game.Rulesets.Osu.Edit
             Precision = 0.01f
         };
 
+        public BindableFloat CircleThreshold { get; } = new BindableFloat(0.002f)
+        {
+            MinValue = 0f,
+            MaxValue = 0.005f,
+            Precision = 0.0001f
+        };
+
         // We map internal ranges to a more standard range of values for display to the user.
         private readonly BindableInt displayTolerance = new BindableInt(100)
         {
@@ -44,8 +51,15 @@ namespace osu.Game.Rulesets.Osu.Edit
             MaxValue = 100
         };
 
+        private readonly BindableInt displayCircleThreshold = new BindableInt(40)
+        {
+            MinValue = 0,
+            MaxValue = 100
+        };
+
         private ExpandableSlider<int> toleranceSlider = null!;
         private ExpandableSlider<int> cornerThresholdSlider = null!;
+        private ExpandableSlider<int> circleThresholdSlider = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -59,6 +73,10 @@ namespace osu.Game.Rulesets.Osu.Edit
                 cornerThresholdSlider = new ExpandableSlider<int>
                 {
                     Current = displayCornerThreshold
+                },
+                circleThresholdSlider = new ExpandableSlider<int>
+                {
+                    Current = displayCircleThreshold
                 }
             };
         }
@@ -83,11 +101,22 @@ namespace osu.Game.Rulesets.Osu.Edit
                 CornerThreshold.Value = displayToInternalCornerThreshold(threshold.NewValue);
             }, true);
 
+            displayCircleThreshold.BindValueChanged(threshold =>
+            {
+                circleThresholdSlider.ContractedLabelText = $"P. C. T.: {threshold.NewValue:N0}";
+                circleThresholdSlider.ExpandedLabelText = $"Perfect Curve Threshold: {threshold.NewValue:N0}";
+
+                CircleThreshold.Value = displayToInternalCircleThreshold(threshold.NewValue);
+            }, true);
+
             Tolerance.BindValueChanged(tolerance =>
                 displayTolerance.Value = internalToDisplayTolerance(tolerance.NewValue)
             );
             CornerThreshold.BindValueChanged(threshold =>
                 displayCornerThreshold.Value = internalToDisplayCornerThreshold(threshold.NewValue)
+            );
+            CircleThreshold.BindValueChanged(threshold =>
+                displayCircleThreshold.Value = internalToDisplayCircleThreshold(threshold.NewValue)
             );
 
             float displayToInternalTolerance(float v) => v / 50f;
@@ -95,6 +124,9 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             float displayToInternalCornerThreshold(float v) => v / 100f;
             int internalToDisplayCornerThreshold(float v) => (int)Math.Round(v * 100f);
+
+            float displayToInternalCircleThreshold(float v) => v / 20000f;
+            int internalToDisplayCircleThreshold(float v) => (int)Math.Round(v * 20000f);
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6056
- [x] Depends on https://github.com/ppy/osu-framework/pull/6066

This PR implements the improvements made to `IncrementalBSplineBuilder` and changes some behaviour of the slider drawing to be better in my opinion.

- Change how segments are created from the output of `IncrementalBSplineBuilder`. Because it gives the segments explicitly, the logic becomes a lot simpler.
- Increase the default tolerance value for slider drawing. The improved builder algorithm needs fewer control points to match the input path so a higher tolerance is preferred.
- Remove the behaviour of 'simplifying' linear segments to a merged linear type segment. This seems to be something that peppy added in as an afterthought, but I found that in most cases this makes editing the slider afterwards a lot more painful. In most cases you draw a slider, you have some segments that are either linear when you want them to be curved or curved when you want them to be linear. In those cases its easier if you can just add or remove a control point, but if linear type control points are mixed-in, then you have to do a lot of changing control point path types, which is a pain.
- Prevent snapping slider expected distance while drawing the slider. This makes the drawing a lot smoother and a joy to use.
- Changed default B-Spline order to 4.
- Added Perfect Curve type segments and a threshold parameter.


https://github.com/ppy/osu/assets/17460441/6e8c4187-f745-44b7-9cb6-58d31833c930

https://github.com/ppy/osu/assets/17460441/74380e9d-05f9-4612-abe6-7dfa7e8adfbb


