### PR TITLE
Fix several edge cases in skin editor gameplay scene opening flow

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -12,9 +12,11 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
+using osu.Game.Online.API;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Play;
@@ -257,6 +259,19 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("blueprint container present", () => skinEditor.ChildrenOfType<SkinBlueprintContainer>().Count(), () => Is.EqualTo(1));
             AddAssert("placeholder not present", () => skinEditor.ChildrenOfType<NonSkinnableScreenPlaceholder>().Count(), () => Is.Zero);
             AddAssert("editor sidebars not empty", () => skinEditor.ChildrenOfType<EditorSidebar>().SelectMany(sidebar => sidebar.Children).Count(), () => Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestOpenSkinEditorGameplaySceneOnBeatmapWithNoObjects()
+        {
+            AddStep("set dummy beatmap", () => Game.Beatmap.SetDefault());
+            advanceToSongSelect();
+
+            AddStep("create empty beatmap", () => Game.BeatmapManager.CreateNew(new OsuRuleset().RulesetInfo, new GuestUser()));
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            openSkinEditor();
+            switchToGameplayScene();
         }
 
         private void advanceToSongSelect()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Tests.Visual.Navigation
             advanceToSongSelect();
             openSkinEditor();
 
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
             switchToGameplayScene();
 
             BarHitErrorMeter hitErrorMeter = null;
@@ -98,6 +101,10 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             advanceToSongSelect();
             openSkinEditor();
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
             switchToGameplayScene();
 
             AddUntilStep("wait for components", () => skinEditor.ChildrenOfType<SkinBlueprint>().Any());
@@ -162,6 +169,9 @@ namespace osu.Game.Tests.Visual.Navigation
             openSkinEditor();
             AddStep("select DT", () => Game.SelectedMods.Value = new Mod[] { new OsuModDoubleTime() });
 
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
             switchToGameplayScene();
 
             AddAssert("DT still selected", () => ((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Single() is OsuModDoubleTime);
@@ -173,6 +183,9 @@ namespace osu.Game.Tests.Visual.Navigation
             advanceToSongSelect();
             openSkinEditor();
             AddStep("select relax and spun out", () => Game.SelectedMods.Value = new Mod[] { new OsuModRelax(), new OsuModSpunOut() });
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
 
             switchToGameplayScene();
 
@@ -186,6 +199,9 @@ namespace osu.Game.Tests.Visual.Navigation
             openSkinEditor();
             AddStep("select autoplay", () => Game.SelectedMods.Value = new Mod[] { new OsuModAutoplay() });
 
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
             switchToGameplayScene();
 
             AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
@@ -197,6 +213,9 @@ namespace osu.Game.Tests.Visual.Navigation
             advanceToSongSelect();
             openSkinEditor();
             AddStep("select cinema", () => Game.SelectedMods.Value = new Mod[] { new OsuModCinema() });
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
 
             switchToGameplayScene();
 
@@ -266,9 +285,6 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private void switchToGameplayScene()
         {
-            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
-            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
-
             AddStep("Click gameplay scene button", () =>
             {
                 InputManager.MoveMouseTo(skinEditor.ChildrenOfType<SkinEditorSceneLibrary.SceneButton>().First(b => b.Text.ToString() == "Gameplay"));

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -274,6 +274,15 @@ namespace osu.Game.Tests.Visual.Navigation
             switchToGameplayScene();
         }
 
+        [Test]
+        public void TestOpenSkinEditorGameplaySceneWhenDummyBeatmapActive()
+        {
+            AddStep("set dummy beatmap", () => Game.Beatmap.SetDefault());
+
+            openSkinEditor();
+            switchToGameplayScene();
+        }
+
         private void advanceToSongSelect()
         {
             PushAndConfirm(() => songSelect = new TestPlaySongSelect());

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -13,6 +13,7 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Game.Online.API;
+using osu.Game.Beatmaps;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets.Mods;
@@ -278,6 +279,22 @@ namespace osu.Game.Tests.Visual.Navigation
         public void TestOpenSkinEditorGameplaySceneWhenDummyBeatmapActive()
         {
             AddStep("set dummy beatmap", () => Game.Beatmap.SetDefault());
+
+            openSkinEditor();
+            switchToGameplayScene();
+        }
+
+        [Test]
+        public void TestOpenSkinEditorGameplaySceneWhenDifferentRulesetActive()
+        {
+            BeatmapSetInfo beatmapSet = null!;
+
+            AddStep("import beatmap", () => beatmapSet = BeatmapImportHelper.LoadQuickOszIntoOsu(Game).GetResultSafely());
+            AddStep("select mania difficulty", () =>
+            {
+                var beatmap = beatmapSet.Beatmaps.First(b => b.Ruleset.OnlineID == 3);
+                Game.Beatmap.Value = Game.BeatmapManager.GetWorkingBeatmap(beatmap);
+            });
 
             openSkinEditor();
             switchToGameplayScene();

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -281,7 +281,6 @@ namespace osu.Game.Tests.Visual.Navigation
             AddStep("set dummy beatmap", () => Game.Beatmap.SetDefault());
 
             openSkinEditor();
-            switchToGameplayScene();
         }
 
         [Test]

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Overlays.SkinEditor
                 if (screen is Player)
                     return;
 
-                var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
+                var replayGeneratingMod = beatmap.Value.BeatmapInfo.Ruleset.CreateInstance().GetAutoplayMod();
 
                 IReadOnlyList<Mod> usableMods = mods.Value;
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -26,6 +26,7 @@ using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Select;
+using osu.Game.Users;
 using osu.Game.Utils;
 using osuTK;
 
@@ -285,6 +286,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         private partial class EndlessPlayer : ReplayPlayer
         {
+            protected override UserActivity? InitialActivity => null;
+
             public EndlessPlayer(Func<IBeatmap, IReadOnlyList<Mod>, Score> createScore)
                 : base(createScore, new PlayerConfiguration
                 {

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -17,7 +17,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
-using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens;

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -140,6 +140,12 @@ namespace osu.Game.Overlays.SkinEditor
         {
             performer?.PerformFromScreen(screen =>
             {
+                if (beatmap.Value is DummyWorkingBeatmap)
+                {
+                    // presume we don't have anything good to play and just bail.
+                    return;
+                }
+
                 // If we're playing the intro, switch away to another beatmap.
                 if (beatmap.Value.BeatmapSetInfo.Protected)
                 {

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -57,9 +57,6 @@ namespace osu.Game.Overlays.SkinEditor
         private MusicController music { get; set; } = null!;
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
-
-        [Resolved]
         private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         [Resolved]

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -297,9 +297,20 @@ namespace osu.Game.Overlays.SkinEditor
             {
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                if (!LoadedBeatmapSuccessfully)
+                    Scheduler.AddDelayed(this.Exit, 3000);
+            }
+
             protected override void Update()
             {
                 base.Update();
+
+                if (!LoadedBeatmapSuccessfully)
+                    return;
 
                 if (GameplayState.HasPassed)
                     GameplayClockContainer.Seek(0);


### PR DESCRIPTION
I'm bundling all three fixes together because they're in the same place and small.

- Closes https://github.com/ppy/osu/issues/25634
  - When the skin editor is opened with a no-object beatmap globally selected, the "Beatmap has no hitobjects!" notification will display, the player screen will hang around for 3 seconds, and then it will exit itself. See https://github.com/ppy/osu/commit/9d39b70e38d6beef46e0ad3a7fad03acf0673dc5.
- Closes https://github.com/ppy/osu/issues/25664
  - This presents when opening the gameplay scene when the dummy beatmap is active. The fix above partially addresses this; the other things that address this are https://github.com/ppy/osu/commit/055fb5bd8f482d4fc23658f259a9f9108cf4bc29 (it seems generally wrong to be changing the player's activity to "watching replay" in a skin editor flow of all places), and https://github.com/ppy/osu/commit/063694f5444a3d2b22409e45c121a67470800446 (if the dummy beatmap is active, do not attempt to progress to gameplay at all. Cheap cop-out, you could *probably* try harder to find *something* to play, but honestly I'd rather not.)
- Closes https://github.com/ppy/osu/issues/25663
  - Presents when going to gameplay from main menu, when ambient game ruleset is different from the ruleset of the current ambient game beatmap. Fixed by https://github.com/ppy/osu/commit/8754fa40f4251bd5c94752eb3fadccaf2e95a490.

All scenarios covered by unit tests. Decisions on what to do in each situations were ad hoc and are generally disputable, I ended up going the easiest route in all cases basically.

An alternative to this that would fix the first two issues *could* be to revert https://github.com/ppy/osu/pull/25568, if one was to go this way I suppose. The third was present even before that PR.