### PR TITLE
Uncomment net6.0 code and remove old code in `BeatmapListingOverlay`

### DIFF
--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -183,9 +183,7 @@ namespace osu.Game.Overlays
                 // new results may contain beatmaps from a previous page,
                 // this is dodgy but matches web behaviour for now.
                 // see: https://github.com/ppy/osu-web/issues/9270
-                // todo: replace custom equality compraer with ExceptBy in net6.0
-                // newCards = newCards.ExceptBy(foundContent.Select(c => c.BeatmapSet.OnlineID), c => c.BeatmapSet.OnlineID);
-                newCards = newCards.Except(foundContent, BeatmapCardEqualityComparer.Default);
+                newCards = newCards.ExceptBy(foundContent.Select(c => c.BeatmapSet.OnlineID), c => c.BeatmapSet.OnlineID);
 
                 panelLoadTask = LoadComponentsAsync(newCards, loaded =>
                 {
@@ -377,22 +375,6 @@ namespace osu.Game.Overlays
 
             if (shouldShowMore)
                 filterControl.FetchNextPage();
-        }
-
-        private class BeatmapCardEqualityComparer : IEqualityComparer<BeatmapCard>
-        {
-            public static BeatmapCardEqualityComparer Default { get; } = new BeatmapCardEqualityComparer();
-
-            public bool Equals(BeatmapCard x, BeatmapCard y)
-            {
-                if (ReferenceEquals(x, y)) return true;
-                if (ReferenceEquals(x, null)) return false;
-                if (ReferenceEquals(y, null)) return false;
-
-                return x.BeatmapSet.Equals(y.BeatmapSet);
-            }
-
-            public int GetHashCode(BeatmapCard obj) => obj.BeatmapSet.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
I was looking for TODOs relevant for something and noticed this in passing.