### PR TITLE
Fix `ArgonHealthDisplay` sometimes behaving weirdly on miss judgements (alternative)

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -87,14 +87,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             }, 3);
         }
 
-        private void applyPerfectHit()
-        {
-            healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
-            {
-                Type = HitResult.Perfect
-            });
-        }
-
         [Test]
         public void TestLateMissAfterConsequentMisses()
         {
@@ -158,6 +150,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void applyMiss()
         {
             healthProcessor.ApplyResult(new JudgementResult(new HitObject(), new Judgement()) { Type = HitResult.Miss });
+        }
+
+        private void applyPerfectHit()
+        {
+            healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
+            {
+                Type = HitResult.Perfect
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -83,11 +83,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddRepeatStep(@"increase hp with flash", delegate
             {
                 healthProcessor.Health.Value += 0.1f;
-                healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
-                {
-                    Type = HitResult.Perfect
-                });
+                applyPerfectHit();
             }, 3);
+        }
+
+        private void applyPerfectHit()
+        {
+            healthProcessor.ApplyResult(new JudgementResult(new HitCircle(), new OsuJudgement())
+            {
+                Type = HitResult.Perfect
+            });
         }
 
         [Test]
@@ -121,6 +126,29 @@ namespace osu.Game.Tests.Visual.Gameplay
                         Scheduler.AddDelayed(applyMiss, i * interval);
                     }
                 }
+            });
+        }
+
+        [Test]
+        public void TestMissThenHitAtSameUpdateFrame()
+        {
+            AddUntilStep("wait for health", () => healthDisplay.Current.Value == 1);
+            AddStep("set half health", () => healthProcessor.Health.Value = 0.5f);
+            AddStep("apply miss and hit", () =>
+            {
+                applyMiss();
+                applyMiss();
+                applyPerfectHit();
+                applyPerfectHit();
+            });
+            AddWaitStep("wait", 3);
+            AddStep("apply miss and cancel with hit", () =>
+            {
+                applyMiss();
+                applyPerfectHit();
+                applyPerfectHit();
+                applyPerfectHit();
+                applyPerfectHit();
             });
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             AddUntilStep("wait for health", () => healthDisplay.Current.Value == 1);
             AddStep("set half health", () => healthProcessor.Health.Value = 0.5f);
+
             AddStep("apply miss and hit", () =>
             {
                 applyMiss();
@@ -141,7 +142,9 @@ namespace osu.Game.Tests.Visual.Gameplay
                 applyPerfectHit();
                 applyPerfectHit();
             });
+
             AddWaitStep("wait", 3);
+
             AddStep("apply miss and cancel with hit", () =>
             {
                 applyMiss();

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplay.cs
@@ -174,6 +174,7 @@ namespace osu.Game.Screens.Play.HUD
         private void onNewJudgement(JudgementResult result) => pendingJudgementResult = result;
 
         private void onCurrentChanged(ValueChangedEvent<double> valueChangedEvent)
+            // schedule display updates one frame later to ensure we know the judgement result causing this change (if there is one).
             => Scheduler.AddOnce(updateDisplay);
 
         private void updateDisplay()

--- a/osu.Game/Screens/Play/HUD/HealthDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HealthDisplay.cs
@@ -45,14 +45,6 @@ namespace osu.Game.Screens.Play.HUD
         {
         }
 
-        /// <summary>
-        /// Triggered when a <see cref="Judgement"/> resulted in the player losing health.
-        /// Calls to this method are debounced.
-        /// </summary>
-        protected virtual void Miss()
-        {
-        }
-
         [Resolved]
         private HUDOverlay? hudOverlay { get; set; }
 
@@ -122,8 +114,6 @@ namespace osu.Game.Screens.Play.HUD
         {
             if (judgement.IsHit && judgement.Type != HitResult.IgnoreHit)
                 Scheduler.AddOnce(Flash);
-            else if (judgement.Judgement.HealthIncreaseFor(judgement) < 0)
-                Scheduler.AddOnce(Miss);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
- Supersedes and closes #25592 
- Addresses https://github.com/ppy/osu/discussions/25351

Took a completely different approach using schedules, works pretty well and 10x simpler than #25592.

Before:

https://github.com/ppy/osu/assets/22781491/187229e8-bc63-4595-94cc-9b4942919440

After:

https://github.com/ppy/osu/assets/22781491/b2c7632c-44c8-4826-b680-64b46ddbe80a

