### PR TITLE
Changed the LabelledFileChooser in the setup to show the file name of the file that is was selected

### DIFF
--- a/osu.Game/Localisation/EditorSetupStrings.cs
+++ b/osu.Game/Localisation/EditorSetupStrings.cs
@@ -180,19 +180,9 @@ namespace osu.Game.Localisation
         public static LocalisableString ClickToSelectTrack => new TranslatableString(getKey(@"click_to_select_track"), @"Click to select a track");
 
         /// <summary>
-        /// "Click to replace the track"
-        /// </summary>
-        public static LocalisableString ClickToReplaceTrack => new TranslatableString(getKey(@"click_to_replace_track"), @"Click to replace the track");
-
-        /// <summary>
         /// "Click to select a background image"
         /// </summary>
         public static LocalisableString ClickToSelectBackground => new TranslatableString(getKey(@"click_to_select_background"), @"Click to select a background image");
-
-        /// <summary>
-        /// "Click to replace the background image"
-        /// </summary>
-        public static LocalisableString ClickToReplaceBackground => new TranslatableString(getKey(@"click_to_replace_background"), @"Click to replace the background image");
 
         /// <summary>
         /// "Ruleset ({0})"

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -146,13 +146,8 @@ namespace osu.Game.Screens.Edit.Setup
 
         private void updatePlaceholderText()
         {
-            audioTrackChooser.Text = audioTrackChooser.Current.Value == null
-                ? EditorSetupStrings.ClickToSelectTrack
-                : EditorSetupStrings.ClickToReplaceTrack;
-
-            backgroundChooser.Text = backgroundChooser.Current.Value == null
-                ? EditorSetupStrings.ClickToSelectBackground
-                : EditorSetupStrings.ClickToReplaceBackground;
+            audioTrackChooser.Text = audioTrackChooser.Current.Value?.Name ?? EditorSetupStrings.ClickToSelectTrack;
+            backgroundChooser.Text = backgroundChooser.Current.Value?.Name ?? EditorSetupStrings.ClickToSelectBackground;
         }
     }
 }


### PR DESCRIPTION
part of #24545 (although this applies to all gamemodes)

Changed the LabelledFileChooser in the setup to show the file name of the file that is was selected. I chose to completely remove the text "Click to replace the track" as I didn't think it was needed and this is also how most other file selectors work.

before
![afbeelding](https://github.com/ppy/osu/assets/75315940/3dd7a2d1-056a-41be-ad3c-8752bf2255ad)



after
![afbeelding](https://github.com/ppy/osu/assets/75315940/d70a6c20-6d7d-44e2-8da7-e31e7e8d0012)
