### PR TITLE
Improve song select search performance

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -34,13 +34,17 @@ namespace osu.Game.Beatmaps
             foreach (var filter in filters)
             {
                 if (filter.Matches(beatmapInfo.DifficultyName))
-                    return true;
+                    continue;
 
-                if (BeatmapMetadataInfoExtensions.Match(beatmapInfo.Metadata, filters))
-                    return true;
+                if (BeatmapMetadataInfoExtensions.Match(beatmapInfo.Metadata, filter))
+                    continue;
+
+                // failed to match a single filter at all - fail the whole match.
+                return false;
             }
 
-            return false;
+            // got through all filters without failing any - pass the whole match.
+            return true;
         }
 
         private static string getVersionString(IBeatmapInfo beatmapInfo) => string.IsNullOrEmpty(beatmapInfo.DifficultyName) ? string.Empty : $"[{beatmapInfo.DifficultyName}]";

--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Localisation;
+using osu.Game.Screens.Select;
 
 namespace osu.Game.Beatmaps
 {
@@ -29,20 +29,18 @@ namespace osu.Game.Beatmaps
             return new RomanisableString($"{metadata.GetPreferred(true)}".Trim(), $"{metadata.GetPreferred(false)}".Trim());
         }
 
-        public static List<string> GetSearchableTerms(this IBeatmapInfo beatmapInfo)
+        public static bool Match(this IBeatmapInfo beatmapInfo, params FilterCriteria.OptionalTextFilter[] filters)
         {
-            var termsList = new List<string>(BeatmapMetadataInfoExtensions.MAX_SEARCHABLE_TERM_COUNT + 1);
-
-            addIfNotNull(beatmapInfo.DifficultyName);
-
-            BeatmapMetadataInfoExtensions.CollectSearchableTerms(beatmapInfo.Metadata, termsList);
-            return termsList;
-
-            void addIfNotNull(string? s)
+            foreach (var filter in filters)
             {
-                if (!string.IsNullOrEmpty(s))
-                    termsList.Add(s);
+                if (filter.Matches(beatmapInfo.DifficultyName))
+                    return true;
+
+                if (BeatmapMetadataInfoExtensions.Match(beatmapInfo.Metadata, filters))
+                    return true;
             }
+
+            return false;
         }
 
         private static string getVersionString(IBeatmapInfo beatmapInfo) => string.IsNullOrEmpty(beatmapInfo.DifficultyName) ? string.Empty : $"[{beatmapInfo.DifficultyName}]";

--- a/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
@@ -3,11 +3,14 @@
 
 using System.Collections.Generic;
 using osu.Framework.Localisation;
+using osu.Game.Screens.Select;
 
 namespace osu.Game.Beatmaps
 {
     public static class BeatmapMetadataInfoExtensions
     {
+        internal const int MAX_SEARCHABLE_TERM_COUNT = 7;
+
         /// <summary>
         /// An array of all searchable terms provided in contained metadata.
         /// </summary>
@@ -18,7 +21,21 @@ namespace osu.Game.Beatmaps
             return termsList.ToArray();
         }
 
-        internal const int MAX_SEARCHABLE_TERM_COUNT = 7;
+        public static bool Match(IBeatmapMetadataInfo metadataInfo, FilterCriteria.OptionalTextFilter[] filters)
+        {
+            foreach (var filter in filters)
+            {
+                if (filter.Matches(metadataInfo.Author.Username)) return true;
+                if (filter.Matches(metadataInfo.Artist)) return true;
+                if (filter.Matches(metadataInfo.ArtistUnicode)) return true;
+                if (filter.Matches(metadataInfo.Title)) return true;
+                if (filter.Matches(metadataInfo.TitleUnicode)) return true;
+                if (filter.Matches(metadataInfo.Source)) return true;
+                if (filter.Matches(metadataInfo.Tags)) return true;
+            }
+
+            return false;
+        }
 
         internal static void CollectSearchableTerms(IBeatmapMetadataInfo metadataInfo, IList<string> termsList)
         {

--- a/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapMetadataInfoExtensions.cs
@@ -21,18 +21,15 @@ namespace osu.Game.Beatmaps
             return termsList.ToArray();
         }
 
-        public static bool Match(IBeatmapMetadataInfo metadataInfo, FilterCriteria.OptionalTextFilter[] filters)
+        public static bool Match(IBeatmapMetadataInfo metadataInfo, FilterCriteria.OptionalTextFilter filter)
         {
-            foreach (var filter in filters)
-            {
-                if (filter.Matches(metadataInfo.Author.Username)) return true;
-                if (filter.Matches(metadataInfo.Artist)) return true;
-                if (filter.Matches(metadataInfo.ArtistUnicode)) return true;
-                if (filter.Matches(metadataInfo.Title)) return true;
-                if (filter.Matches(metadataInfo.TitleUnicode)) return true;
-                if (filter.Matches(metadataInfo.Source)) return true;
-                if (filter.Matches(metadataInfo.Tags)) return true;
-            }
+            if (filter.Matches(metadataInfo.Author.Username)) return true;
+            if (filter.Matches(metadataInfo.Artist)) return true;
+            if (filter.Matches(metadataInfo.ArtistUnicode)) return true;
+            if (filter.Matches(metadataInfo.Title)) return true;
+            if (filter.Matches(metadataInfo.TitleUnicode)) return true;
+            if (filter.Matches(metadataInfo.Source)) return true;
+            if (filter.Matches(metadataInfo.Tags)) return true;
 
             return false;
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -66,26 +66,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (criteria.SearchTerms.Length > 0)
             {
-                var searchableTerms = BeatmapInfo.GetSearchableTerms();
-
-                foreach (FilterCriteria.OptionalTextFilter criteriaTerm in criteria.SearchTerms)
-                {
-                    bool any = false;
-
-                    // ReSharper disable once ForeachCanBeConvertedToQueryUsingAnotherGetEnumerator
-                    foreach (string searchTerm in searchableTerms)
-                    {
-                        if (!criteriaTerm.Matches(searchTerm)) continue;
-
-                        any = true;
-                        break;
-                    }
-
-                    if (any) continue;
-
-                    match = false;
-                    break;
-                }
+                match = BeatmapInfo.Match(criteria.SearchTerms);
 
                 // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
                 // this should be done after text matching so we can prioritise matching numbers in metadata.

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -41,6 +41,21 @@ namespace osu.Game.Screens.Select.Carousel
                 return match;
             }
 
+            if (criteria.SearchTerms.Length > 0)
+            {
+                match = BeatmapInfo.Match(criteria.SearchTerms);
+
+                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
+                // this should be done after text matching so we can prioritise matching numbers in metadata.
+                if (!match && criteria.SearchNumber.HasValue)
+                {
+                    match = (BeatmapInfo.OnlineID == criteria.SearchNumber.Value) ||
+                            (BeatmapInfo.BeatmapSet?.OnlineID == criteria.SearchNumber.Value);
+                }
+            }
+
+            if (!match) return false;
+
             match &= !criteria.StarDifficulty.HasFilter || criteria.StarDifficulty.IsInRange(BeatmapInfo.StarRating);
             match &= !criteria.ApproachRate.HasFilter || criteria.ApproachRate.IsInRange(BeatmapInfo.Difficulty.ApproachRate);
             match &= !criteria.DrainRate.HasFilter || criteria.DrainRate.IsInRange(BeatmapInfo.Difficulty.DrainRate);
@@ -61,21 +76,6 @@ namespace osu.Game.Screens.Select.Carousel
                      criteria.Title.Matches(BeatmapInfo.Metadata.TitleUnicode);
             match &= !criteria.DifficultyName.HasFilter || criteria.DifficultyName.Matches(BeatmapInfo.DifficultyName);
             match &= !criteria.UserStarDifficulty.HasFilter || criteria.UserStarDifficulty.IsInRange(BeatmapInfo.StarRating);
-
-            if (!match) return false;
-
-            if (criteria.SearchTerms.Length > 0)
-            {
-                match = BeatmapInfo.Match(criteria.SearchTerms);
-
-                // if a match wasn't found via text matching of terms, do a second catch-all check matching against online IDs.
-                // this should be done after text matching so we can prioritise matching numbers in metadata.
-                if (!match && criteria.SearchNumber.HasValue)
-                {
-                    match = (BeatmapInfo.OnlineID == criteria.SearchNumber.Value) ||
-                            (BeatmapInfo.BeatmapSet?.OnlineID == criteria.SearchNumber.Value);
-                }
-            }
 
             if (!match) return false;
 

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -86,16 +86,20 @@ namespace osu.Game.Screens.Select.Carousel
 
             items.ForEach(c => c.Filter(criteria));
 
-            criteriaComparer = Comparer<CarouselItem>.Create((x, y) =>
+            // Sorting is expensive, so only perform if it's actually changed.
+            if (lastCriteria?.Sort != criteria.Sort)
             {
-                int comparison = x.CompareTo(criteria, y);
-                if (comparison != 0)
-                    return comparison;
+                criteriaComparer = Comparer<CarouselItem>.Create((x, y) =>
+                {
+                    int comparison = x.CompareTo(criteria, y);
+                    if (comparison != 0)
+                        return comparison;
 
-                return x.ItemID.CompareTo(y.ItemID);
-            });
+                    return x.ItemID.CompareTo(y.ItemID);
+                });
 
-            items.Sort(criteriaComparer);
+                items.Sort(criteriaComparer);
+            }
 
             lastCriteria = criteria;
         }

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -176,13 +176,15 @@ namespace osu.Game.Screens.Select
                 {
                     default:
                     case MatchMode.Substring:
-                        return value.Contains(SearchTerm, StringComparison.InvariantCultureIgnoreCase);
+                        // Note that we are using ordinal here to avoid performance issues caused by globalisation concerns.
+                        // See https://github.com/ppy/osu/issues/11571 / https://github.com/dotnet/docs/issues/18423.
+                        return value.Contains(SearchTerm, StringComparison.OrdinalIgnoreCase);
 
                     case MatchMode.IsolatedPhrase:
                         return Regex.IsMatch(value, $@"(^|\s){Regex.Escape(searchTerm)}($|\s)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
                     case MatchMode.FullPhrase:
-                        return CultureInfo.InvariantCulture.CompareInfo.Compare(value, searchTerm, CompareOptions.IgnoreCase) == 0;
+                        return CultureInfo.InvariantCulture.CompareInfo.Compare(value, searchTerm, CompareOptions.OrdinalIgnoreCase) == 0;
                 }
             }
 


### PR DESCRIPTION
Just a quick optimisation pass. Anything further will require more consideration, as the overhead is coming from the raw `IndexTo` operation, and to a lesser extent `CarouselBeatmap.checkMatch()` and other methods with nothing too simple to optimise out:

![CleanShot 2023-12-05 at 06 32 00](https://github.com/ppy/osu/assets/191335/4a0e2d1e-712b-42cb-9303-c842f9dcac1d)

Initial filter is the full load of song select (includes sort). Subsequent are filtering on non-matching strings (ie. "aaaaaaa").

`master`:

[runtime] 2023-12-05 05:23:02 [verbose]: Filter took 8,785.0 ms
[runtime] 2023-12-05 05:23:39 [verbose]: Filter took 9,147.0 ms
[runtime] 2023-12-05 05:23:50 [verbose]: Filter took 9,159.0 ms
[runtime] 2023-12-05 05:24:00 [verbose]: Filter took 9,254.0 ms
[runtime] 2023-12-05 05:24:16 [verbose]: Filter took 9,474.0 ms

after 7fda38d0b02496f4e255e496a73def950deca6a3:

[runtime] 2023-12-05 05:20:36 [verbose]: Filter took 8,739.0 ms
[runtime] 2023-12-05 05:21:40 [verbose]: Filter took 6,354.0 ms
[runtime] 2023-12-05 05:21:47 [verbose]: Filter took 6,471.0 ms
[runtime] 2023-12-05 05:21:53 [verbose]: Filter took 6,437.0 ms
[runtime] 2023-12-05 05:22:02 [verbose]: Filter took 6,753.0 ms

after 27e778ae09364981ce5e2768110efde51b4a3f7b:

[runtime] 2023-12-05 05:18:30 [verbose]: Filter took 8,990.0 ms
[runtime] 2023-12-05 05:19:15 [verbose]: Filter took 1,266.0 ms
[runtime] 2023-12-05 05:19:17 [verbose]: Filter took 1,213.0 ms
[runtime] 2023-12-05 05:19:19 [verbose]: Filter took 1,179.0 ms
[runtime] 2023-12-05 05:19:21 [verbose]: Filter took 1,166.0 ms

after 36eb338f53db580eafc8f2a576fcf8c4153a3173:

[runtime] 2023-12-05 05:54:19 [verbose]: Filter took 8,789.0 ms
[runtime] 2023-12-05 05:54:41 [verbose]: Filter took 1,232.0 ms
[runtime] 2023-12-05 05:54:43 [verbose]: Filter took 1,061.0 ms
[runtime] 2023-12-05 05:54:44 [verbose]: Filter took 1,039.0 ms
[runtime] 2023-12-05 05:54:46 [verbose]: Filter took 1,032.0 ms

Testing done using:

```diff
diff --git a/osu.Game/Screens/Select/BeatmapCarousel.cs b/osu.Game/Screens/Select/BeatmapCarousel.cs
index eb47a7201a..53bfef7d87 100644
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -17,6 +17,7 @@
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Layout;
+using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -131,6 +132,9 @@ private void loadBeatmapSets(IEnumerable<BeatmapSetInfo> beatmapSets)
         {
             originalBeatmapSetsDetached = beatmapSets.Detach();
 
+            while (originalBeatmapSetsDetached.Count < 250000)
+                originalBeatmapSetsDetached.AddRange(originalBeatmapSetsDetached);
+
             if (selectedBeatmapSet != null && !originalBeatmapSetsDetached.Contains(selectedBeatmapSet.BeatmapSet))
                 selectedBeatmapSet = null;
 
@@ -738,6 +742,9 @@ void perform()
                     return;
                 }
 
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
+
                 root.Filter(activeCriteria);
                 itemsCache.Invalidate();
 
@@ -745,6 +752,8 @@ void perform()
                     ScrollToSelected(true);
 
                 FilterApplied?.Invoke();
+
+                Logger.Log($"Filter took {sw.ElapsedMilliseconds:N1} ms");
             }
         }
 

```

Improves https://github.com/ppy/osu/issues/11571 but probably doesn't close yet (would want things to be async still).


---

Reduces time taken to search beatmaps at song select by 88%.