### PR TITLE
Fix being able to change ruleset / beatmap when opening skin editor from main menu

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -290,6 +290,10 @@ namespace osu.Game.Overlays.SkinEditor
         {
             protected override UserActivity? InitialActivity => null;
 
+            public override bool DisallowExternalBeatmapRulesetChanges => true;
+
+            public override bool? AllowGlobalTrackControl => false;
+
             public EndlessPlayer(Func<IBeatmap, IReadOnlyList<Mod>, Score> createScore)
                 : base(createScore, new PlayerConfiguration
                 {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -59,6 +59,10 @@ namespace osu.Game.Screens.Play
 
         protected override bool PlayExitSound => !isRestarting;
 
+        public override bool DisallowExternalBeatmapRulesetChanges => true;
+
+        public override bool? AllowGlobalTrackControl => false;
+
         protected override UserActivity InitialActivity => new UserActivity.InSoloGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
 
         public override float BackgroundParallaxAmount => 0.1f;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -59,10 +59,6 @@ namespace osu.Game.Screens.Play
 
         protected override bool PlayExitSound => !isRestarting;
 
-        public override bool DisallowExternalBeatmapRulesetChanges => true;
-
-        public override bool? AllowGlobalTrackControl => false;
-
         protected override UserActivity InitialActivity => new UserActivity.InSoloGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
 
         public override float BackgroundParallaxAmount => 0.1f;


### PR DESCRIPTION
No tests because it would be silly to test this – it's already a well established behaviour and was just initialised incorrectly.

Closes https://github.com/ppy/osu/issues/25680.
