### PR TITLE
Change default slider velocity for new beatmaps to match osu!stable

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneHyperDash.cs
@@ -63,7 +63,11 @@ namespace osu.Game.Rulesets.Catch.Tests
                 BeatmapInfo =
                 {
                     Ruleset = ruleset,
-                    Difficulty = new BeatmapDifficulty { CircleSize = 3.6f }
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 3.6f,
+                        SliderMultiplier = 1,
+                    },
                 }
             };
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -507,7 +507,11 @@ namespace osu.Game.Rulesets.Osu.Tests
                     HitObjects = { slider },
                     BeatmapInfo =
                     {
-                        Difficulty = new BeatmapDifficulty { SliderTickRate = tickRate ?? 3 },
+                        Difficulty = new BeatmapDifficulty
+                        {
+                            SliderTickRate = tickRate ?? 3,
+                            SliderMultiplier = 1,
+                        },
                         Ruleset = new OsuRuleset().RulesetInfo,
                     },
                     ControlPointInfo = cpi,

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -31,11 +31,6 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
         /// </summary>
         private const float osu_base_scoring_distance = 100;
 
-        /// <summary>
-        /// Drum roll distance that results in a duration of 1 speed-adjusted beat length.
-        /// </summary>
-        private const float taiko_base_distance = 100;
-
         private readonly bool isForCurrentRuleset;
 
         public TaikoBeatmapConverter(IBeatmap beatmap, Ruleset ruleset)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         {
             var beatmap = createBeatmap();
             beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = time_range });
-            beatmap.Difficulty.SliderMultiplier = 2;
+            beatmap.BeatmapInfo.Difficulty.SliderMultiplier = 2;
 
             createTest(beatmap);
             AddStep("adjust time range", () => drawableRuleset.TimeRange.Value = 2000);
@@ -237,7 +237,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         });
 
         private void assertPosition(int index, float relativeY) => AddAssert($"hitobject {index} at {relativeY}",
-            () => Precision.AlmostEquals(getDrawableHitObject(index)?.DrawPosition.Y ?? -1, yScale * relativeY));
+            () => getDrawableHitObject(index)?.DrawPosition.Y / yScale ?? -1, () => Is.EqualTo(relativeY).Within(Precision.FLOAT_EPSILON));
 
         private void setTime(double time)
         {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableScrollingRuleset.cs
@@ -251,7 +251,17 @@ namespace osu.Game.Tests.Visual.Gameplay
         /// <returns>The <see cref="IBeatmap"/>.</returns>
         private IBeatmap createBeatmap(Func<int, TestHitObject> createAction = null)
         {
-            var beatmap = new Beatmap<TestHitObject> { BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo } };
+            var beatmap = new Beatmap<TestHitObject>
+            {
+                BeatmapInfo =
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        SliderMultiplier = 1
+                    },
+                    Ruleset = new OsuRuleset().RulesetInfo
+                }
+            };
 
             for (int i = 0; i < 10; i++)
             {

--- a/osu.Game/Beatmaps/BeatmapDifficulty.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficulty.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Beatmaps
         public float OverallDifficulty { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
         public float ApproachRate { get; set; } = IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY;
 
-        public double SliderMultiplier { get; set; } = 1;
+        public double SliderMultiplier { get; set; } = 1.4;
         public double SliderTickRate { get; set; } = 1;
 
         public BeatmapDifficulty()

--- a/osu.Game/Screens/Edit/Setup/DifficultySection.cs
+++ b/osu.Game/Screens/Edit/Setup/DifficultySection.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Edit.Setup
                     Description = EditorSetupStrings.BaseVelocityDescription,
                     Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
                     {
-                        Default = 1,
+                        Default = 1.4,
                         MinValue = 0.4,
                         MaxValue = 3.6,
                         Precision = 0.01f,


### PR DESCRIPTION
This is the default in osu!stable (ie. on creating a new beatmap in the editor) and plays better than `1.0`.