### PR TITLE
Fix skin editor crashing in some circumstances when opened in main menu

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -283,15 +283,17 @@ namespace osu.Game.Tests.Visual.Navigation
             openSkinEditor();
         }
 
-        [Test]
-        public void TestOpenSkinEditorGameplaySceneWhenDifferentRulesetActive()
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public void TestOpenSkinEditorGameplaySceneWhenDifferentRulesetActive(int rulesetId)
         {
             BeatmapSetInfo beatmapSet = null!;
 
             AddStep("import beatmap", () => beatmapSet = BeatmapImportHelper.LoadQuickOszIntoOsu(Game).GetResultSafely());
-            AddStep("select mania difficulty", () =>
+            AddStep($"select difficulty for ruleset w/ ID {rulesetId}", () =>
             {
-                var beatmap = beatmapSet.Beatmaps.First(b => b.Ruleset.OnlineID == 3);
+                var beatmap = beatmapSet.Beatmaps.First(b => b.Ruleset.OnlineID == rulesetId);
                 Game.Beatmap.Value = Game.BeatmapManager.GetWorkingBeatmap(beatmap);
             });
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -17,6 +17,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
 using osu.Game.Input.Bindings;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens;
@@ -57,6 +58,9 @@ namespace osu.Game.Overlays.SkinEditor
 
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
+
+        [Resolved]
+        private Bindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
@@ -153,7 +157,11 @@ namespace osu.Game.Overlays.SkinEditor
                 if (screen is Player)
                     return;
 
-                var replayGeneratingMod = beatmap.Value.BeatmapInfo.Ruleset.CreateInstance().GetAutoplayMod();
+                // the validity of the current game-wide beatmap + ruleset combination is enforced by song select.
+                // if we're anywhere else, the state is unknown and may not make sense, so forcibly set something that does.
+                if (screen is not PlaySongSelect)
+                    ruleset.Value = beatmap.Value.BeatmapInfo.Ruleset;
+                var replayGeneratingMod = ruleset.Value.CreateInstance().GetAutoplayMod();
 
                 IReadOnlyList<Mod> usableMods = mods.Value;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25663 (again).

As it turns out, in some scenarios it can be the case that the current game-global `Beatmap` is not valid for the current game-global `Ruleset`. The validity of one and the other in conjunction is only really validated by the song select screen; elsewhere there is no guarantee that the global beatmap is playable using the global ruleset.

However, this only comes up in very specific circumstances, namely one: when trying to autoplay a catch beatmap with osu! ruleset globally active via the skin editor flow.

`Player` is responsible for retrieving the beatmap to be played. It does so by invoking the appropriate beatmap converter and asking it if the beatmap can be converted:

https://github.com/ppy/osu/blob/6d64538d7a3130df63574eb75a8ebe044154c799/osu.Game/Beatmaps/WorkingBeatmap.cs#L262-L266

If the code above throws, `Player` actually silently covers for this, by trying the beatmap's default ruleset instead:

https://github.com/ppy/osu/blob/6d64538d7a3130df63574eb75a8ebe044154c799/osu.Game/Screens/Play/Player.cs#L529-L536

However, for the pairing of osu! ruleset and catch beatmap, this fails, as `OsuBeatmapConverter`'s condition necessary for permitting conversion is that the objects have a defined position:

https://github.com/ppy/osu/blob/6d64538d7a3130df63574eb75a8ebe044154c799/osu.Game.Rulesets.Osu/Beatmaps/OsuBeatmapConverter.cs#L25

which they will do, due to the fact that all catch beatmaps are really just osu! beatmaps but with conversion steps applied, and thus `Player` succeeds to load the catch beatmap _in osu! ruleset_.

In the skin editor scenario, this would lead to the secondary failure of the skin editor trying to apply `CatchModAutoplay` on top of all of that, which would fail at the hard-cast of the beatmap to `CatchBeatmap`.

The proposed fix is crude but simple - the correct ruleset is forcibly set before entering gameplay.