### PR TITLE
Ensure that `SoloScoreInfo` serialisation result does not contain interface members

### DIFF
--- a/osu.Game.Tests/Online/TestSoloScoreInfoJsonSerialization.cs
+++ b/osu.Game.Tests/Online/TestSoloScoreInfoJsonSerialization.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Game.IO.Serialization;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Scoring;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Online
@@ -35,6 +36,32 @@ namespace osu.Game.Tests.Online
 
             Assert.That(serialised, Contains.Substring("large_tick_hit"));
             Assert.That(serialised, Contains.Substring("\"rank\":\"S\""));
+        }
+
+        /// <summary>
+        /// Ensures that the proxy implementations of <see cref="IScoreInfo"/> by <see cref="SoloScoreInfo"/>
+        /// do not get serialised to JSON.
+        /// </summary>
+        [Test]
+        public void TestScoreSerialisationSkipsInterfaceMembers()
+        {
+            var score = SoloScoreInfo.ForSubmission(TestResources.CreateTestScoreInfo());
+
+            string[] variants =
+            {
+                JsonConvert.SerializeObject(score),
+                score.Serialize()
+            };
+
+            foreach (string serialised in variants)
+            {
+                Assert.That(serialised, Does.Not.Contain("\"online_id\":"));
+                Assert.That(serialised, Does.Not.Contain("\"user\":"));
+                Assert.That(serialised, Does.Not.Contain("\"date\":"));
+                Assert.That(serialised, Does.Not.Contain("\"legacy_online_id\":"));
+                Assert.That(serialised, Does.Not.Contain("\"beatmap\":"));
+                Assert.That(serialised, Does.Not.Contain("\"ruleset\":"));
+            }
         }
     }
 }


### PR DESCRIPTION
This just adds a sanity check test to ensure that when serialising through newtonsoft, the same thing [that caused issues in `osu-elastic-indexer`](https://github.com/ppy/osu-elastic-indexer/pull/148) of attempting to serialise the `IScoreInfo` members does not happen.

Notably, as seen on the screenshot attached in the aforementioned PR, the ES client that `osu-elastic-indexer` was using could not understand newtonsoft and instead appears to be rolling its own serialisation, hence dying of death.