### PR TITLE
Update Accuracy PP to take into account slider judgements if they are present

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -192,6 +192,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             // This percentage only considers HitCircles of any value - in this part of the calculation we focus on hitting the timing hit window.
             double betterAccuracyPercentage;
             int amountHitObjectsWithAccuracy = attributes.HitCircleCount;
+            if (!score.Mods.Any(h => h is OsuModClassic && ((OsuModClassic)h).NoSliderHeadAccuracy.Value))
+                amountHitObjectsWithAccuracy += attributes.SliderCount;
 
             if (amountHitObjectsWithAccuracy > 0)
                 betterAccuracyPercentage = ((countGreat - (totalHits - amountHitObjectsWithAccuracy)) * 6 + countOk * 2 + countMeh) / (double)(amountHitObjectsWithAccuracy * 6);


### PR DESCRIPTION
Accuracy PP in osu! has a length bonus based off of the number of hitcircles, because maintaining accuracy for longer periods is more difficult. This is only based off of hitcircle count, because in stable slider judgements are more lenient. However, lazer slider judgements are the same hitcircle judgements, so it makes no sense to exclude them from accuracy length bonus.