### PR TITLE
Add Snap colours to skin.ini and change default ones

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNote.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.Skinning.Default;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Screens.Edit;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
     /// <summary>
     /// Visualises a <see cref="Note"/> hit object.
     /// </summary>
-    public partial class DrawableNote : DrawableManiaHitObject<Note>, IKeyBindingHandler<ManiaAction>
+    public partial class DrawableNote : DrawableManiaHitObject<Note>, IKeyBindingHandler<ManiaAction>, IHasSnapInformation
     {
         [Resolved]
         private OsuColour colours { get; set; }
@@ -42,6 +43,10 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         private DrawableNotePerfectBonus perfectBonus;
 
+        protected ISkinSource skin { get; private set; }
+        public int SnapIndex { get; set; }
+
+
         public DrawableNote()
             : this(null)
         {
@@ -54,7 +59,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(ManiaRulesetConfigManager rulesetConfig)
+        private void load(ManiaRulesetConfigManager rulesetConfig, ISkinSource skinSource)
         {
             rulesetConfig?.BindWith(ManiaRulesetSetting.TimingBasedNoteColouring, configTimingBasedNoteColouring);
 
@@ -63,6 +68,7 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y
             });
+            skin = skinSource;
         }
 
         protected override void LoadComplete()
@@ -169,7 +175,59 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
             int snapDivisor = beatmap.ControlPointInfo.GetClosestBeatDivisor(HitObject.StartTime);
 
-            Colour = configTimingBasedNoteColouring.Value ? BindableBeatDivisor.GetColourFor(snapDivisor, colours) : Color4.White;
+
+            if (configTimingBasedNoteColouring.Value) {
+                switch (snapDivisor) {
+                    case 1:
+                        SnapIndex = 1;
+                        break;
+
+                    case 2:
+                        SnapIndex = 2;
+                        break;
+
+                    case 3:
+                        SnapIndex = 3;
+                        break;
+
+                    case 4:
+                        SnapIndex = 4;
+                        break;
+
+                    case 5:
+                        SnapIndex = 5;
+                        break;
+
+                    case 6:
+                        SnapIndex = 6;
+                        break;
+
+                    case 8:
+                        SnapIndex = 7;
+                        break;
+
+                    case 12:
+                        SnapIndex = 8;
+                        break;
+
+                    case 16:
+                        SnapIndex = 9;
+                        break;
+
+                    case 20:
+                        SnapIndex = 10;
+                        break;
+
+                    case 24:
+                        SnapIndex = 11;
+                        break;
+
+                    default:
+                        SnapIndex = 0;
+                        break;
+                }
+                Colour = ((IHasSnapInformation)this).GetSnapColour(skin);
+            }
         }
     }
 }

--- a/osu.Game/Beatmaps/Formats/IHasSnapColours.cs
+++ b/osu.Game/Beatmaps/Formats/IHasSnapColours.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osuTK.Graphics;
+
+namespace osu.Game.Beatmaps.Formats
+{
+    public interface IHasSnapColours
+    {
+        /// <summary>
+        /// Retrieves the list of snap colours for presentation only.
+        /// </summary>
+        IReadOnlyList<Color4>? SnapColours { get; }
+
+        /// <summary>
+        /// The list of custom snap colours.
+        /// If non-empty, <see cref="SnapColours"/> will return these colours;
+        /// if empty, <see cref="SnapColours"/> will fall back to default snap colours.
+        /// </summary>
+        List<Color4> CustomSnapColours { get; }
+    }
+}

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -98,6 +98,7 @@ namespace osu.Game.Beatmaps.Formats
             var pair = SplitKeyVal(line);
 
             bool isCombo = pair.Key.StartsWith(@"Combo", StringComparison.Ordinal);
+            bool isSnap = pair.Key.StartsWith(@"Snap", StringComparison.Ordinal);
 
             string[] split = pair.Value.Split(',');
 
@@ -121,6 +122,12 @@ namespace osu.Game.Beatmaps.Formats
                 if (!(output is IHasComboColours tHasComboColours)) return;
 
                 tHasComboColours.CustomComboColours.Add(colour);
+            }
+            else if (isCombo)
+            {
+                if (!(output is IHasSnapColours tHasSnapColours)) return;
+
+                tHasSnapColours.CustomSnapColours.Add(colour);
             }
             else
             {

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Beatmaps.Formats
 
                 tHasComboColours.CustomComboColours.Add(colour);
             }
-            else if (isCombo)
+            else if (isSnap)
             {
                 if (!(output is IHasSnapColours tHasSnapColours)) return;
 

--- a/osu.Game/Rulesets/Objects/Types/IHasSnapInformation.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasSnapInformation.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Objects.Types
+{
+
+    /// <summary>
+    /// A HitObject that is part of a snap and has extended information about its position relative to other snap objects.
+    /// </summary>
+    public interface IHasSnapInformation
+    {
+
+        int SnapIndex { get; set; }
+        /// <summary>
+        /// Retrieves the colour of the snap described by this <see cref="IHasSnapInformation"/> object.
+        /// </summary>
+        /// <param name="skin">The skin to retrieve the snap colour from, if wanted.</param>
+        Color4 GetSnapColour(ISkin skin) => GetSkinSnapColour(this, skin, SnapIndex);
+
+        /// <summary>
+        /// Retrieves the colour of the snap described by a given <see cref="IHasSnapInformation"/> object from a given skin.
+        /// </summary>
+        /// <param name="snap">The snap information, should be <c>this</c>.</param>
+        /// <param name="skin">The skin to retrieve the snap colour from.</param>
+        /// <param name="snapIndex">The index to retrieve the snap colour with.</param>
+        /// <returns></returns>
+        protected static Color4 GetSkinSnapColour(IHasSnapInformation snap, ISkin skin, int snapIndex)
+        {
+            return skin.GetConfig<SkinSnapColourLookup, Color4>(new SkinSnapColourLookup(snapIndex, snap))?.Value ?? Color4.White;
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -97,18 +97,31 @@ namespace osu.Game.Screens.Edit
             switch (beatDivisor)
             {
                 case 1:
+                    return Color4.White;
 
                 case 2:
+                    return colours.Red;
 
                 case 4:
+                    return colours.Blue;
 
                 case 8:
+                    return colours.Yellow;
 
                 case 16:
+                    return colours.PurpleDark;
 
+                case 3:
+                    return colours.Purple;
 
+                case 6:
+                    return colours.YellowDark;
+
+                case 12:
+                    return colours.YellowDarker;
 
                 default:
+                    return Color4.Red;
             }
         }
 

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -97,31 +97,18 @@ namespace osu.Game.Screens.Edit
             switch (beatDivisor)
             {
                 case 1:
-                    return Color4.White;
 
                 case 2:
-                    return colours.Red;
 
                 case 4:
-                    return colours.Blue;
 
                 case 8:
-                    return colours.Yellow;
 
                 case 16:
-                    return colours.PurpleDark;
 
-                case 3:
-                    return colours.Purple;
 
-                case 6:
-                    return colours.YellowDark;
-
-                case 12:
-                    return colours.YellowDarker;
 
                 default:
-                    return Color4.Red;
             }
         }
 

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -43,6 +43,22 @@ namespace osu.Game.Skinning
                 new Color4(242, 24, 57, 255)
             };
 
+            Configuration.CustomSnapColours = new List<Color4>
+            {
+                new Color4(255, 192, 0, 255),
+                new Color4(0, 202, 0, 255),
+                new Color4(18, 124, 255, 255),
+                new Color4(242, 24, 57, 255),
+                new Color4(255, 192, 0, 255),
+                new Color4(0, 202, 0, 255),
+                new Color4(18, 124, 255, 255),
+                new Color4(242, 24, 57, 255),
+                new Color4(255, 192, 0, 255),
+                new Color4(0, 202, 0, 255),
+                new Color4(18, 124, 255, 255),
+                new Color4(242, 24, 57, 255)
+            };
+
             Configuration.ConfigDictionary[nameof(SkinConfiguration.LegacySetting.AllowSliderBallTint)] = @"true";
 
             Configuration.LegacyVersion = 2.7m;

--- a/osu.Game/Skinning/GlobalSkinColours.cs
+++ b/osu.Game/Skinning/GlobalSkinColours.cs
@@ -6,6 +6,7 @@ namespace osu.Game.Skinning
     public enum GlobalSkinColours
     {
         ComboColours,
+        SnapColours,
         MenuGlow
     }
 }

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -90,6 +90,12 @@ namespace osu.Game.Skinning
                                     return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(comboColours));
 
                                 break;
+                            case GlobalSkinColours.SnapColours:
+                                var snapColours = Configuration.SnapColours;
+                                if (snapColours != null)
+                                    return SkinUtils.As<TValue>(new Bindable<IReadOnlyList<Color4>>(snapColours));
+
+                                break;
 
                             default:
                                 return SkinUtils.As<TValue>(getCustomColour(Configuration, colour.ToString()));

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -100,6 +100,9 @@ namespace osu.Game.Skinning
                     case SkinComboColourLookup comboColour:
                         return SkinUtils.As<TValue>(GetComboColour(Configuration, comboColour.ColourIndex, comboColour.Combo));
 
+                    case SkinSnapColourLookup snapColour:
+                        return SkinUtils.As<TValue>(GetSnapColour(Configuration, snapColour.ColourIndex, snapColour.Snap));
+
                     case SkinCustomColourLookup customColour:
                         return SkinUtils.As<TValue>(getCustomColour(Configuration, customColour.Lookup.ToString() ?? string.Empty));
 
@@ -289,6 +292,12 @@ namespace osu.Game.Skinning
         protected virtual IBindable<Color4>? GetComboColour(IHasComboColours source, int colourIndex, IHasComboInformation combo)
         {
             var colour = source.ComboColours?[colourIndex % source.ComboColours.Count];
+            return colour.HasValue ? new Bindable<Color4>(colour.Value) : null;
+        }
+
+        protected virtual IBindable<Color4>? GetSnapColour(IHasSnapColours source, int colourIndex, IHasSnapInformation snap)
+        {
+            var colour = source.SnapColours?[colourIndex % source.SnapColours.Count];
             return colour.HasValue ? new Bindable<Color4>(colour.Value) : null;
         }
 

--- a/osu.Game/Skinning/SkinConfiguration.cs
+++ b/osu.Game/Skinning/SkinConfiguration.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Skinning
     /// <summary>
     /// An empty skin configuration.
     /// </summary>
-    public class SkinConfiguration : IHasComboColours, IHasCustomColours
+    public class SkinConfiguration : IHasComboColours, IHasCustomColours, IHasSnapColours
     {
         public readonly SkinInfo SkinInfo = new SkinInfo();
 
@@ -20,6 +20,8 @@ namespace osu.Game.Skinning
         /// Whether to allow <see cref="DefaultComboColours"/> as a fallback list for when no combo colours are provided.
         /// </summary>
         internal bool AllowDefaultComboColoursFallback = true;
+
+        internal bool AllowDefaultSnapColoursFallback = true;
 
         /// <summary>
         /// Legacy version of this skin.
@@ -48,7 +50,25 @@ namespace osu.Game.Skinning
             new Color4(242, 24, 57, 255),
         };
 
+        public static List<Color4> DefaultSnapColours { get; } = new List<Color4>
+        {
+            new Color4(255, 255, 255, 255),
+            new Color4(255, 0, 0, 255),
+            new Color4(0, 0, 255, 255),
+            new Color4(102, 45, 145, 255),
+            new Color4(255, 255, 0, 255),
+            new Color4(153, 153, 153, 255),
+            new Color4(255, 0, 255, 255),
+            new Color4(247, 148, 29, 255),
+            new Color4(0, 255, 255, 255),
+            new Color4(0, 198, 0, 255),
+            new Color4(255, 153, 153, 255),
+            new Color4(153, 143, 255, 255)
+        };
+
         public List<Color4> CustomComboColours { get; set; } = new List<Color4>();
+
+        public List<Color4> CustomSnapColours { get; set; } = new List<Color4>();
 
         public IReadOnlyList<Color4>? ComboColours
         {
@@ -59,6 +79,20 @@ namespace osu.Game.Skinning
 
                 if (AllowDefaultComboColoursFallback)
                     return DefaultComboColours;
+
+                return null;
+            }
+        }
+
+        public IReadOnlyList<Color4>? SnapColours
+        {
+            get
+            {
+                if (CustomSnapColours.Count > 0)
+                    return CustomSnapColours;
+
+                if (AllowDefaultSnapColoursFallback)
+                    return DefaultSnapColours;
 
                 return null;
             }

--- a/osu.Game/Skinning/SkinSnapColourLookup.cs
+++ b/osu.Game/Skinning/SkinSnapColourLookup.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Skinning
+{
+    public class SkinSnapColourLookup
+    {
+        /// <summary>
+        /// The index to use for deciding the snap colour.
+        /// </summary>
+        public readonly int ColourIndex;
+
+        /// <summary>
+        /// The snap information requesting the colour.
+        /// </summary>
+        public readonly IHasSnapInformation Snap;
+
+        public SkinSnapColourLookup(int colourIndex, IHasSnapInformation snap)
+        {
+            ColourIndex = colourIndex;
+            Snap = snap;
+        }
+    }
+}


### PR DESCRIPTION
Hi,
There are my currents progress to use skin defined snap colors for mania instead of hardcoded ones.
Actually, I correctly use defaults ones without issue but i didn't find the way to correctly load skin ones. 
Here is where i expected them to be in a skin.ini:
```
[Colours]
Combo1: ...
ComboN:...

Snap0:...
Snap1:...
SnapN:...
Snap11:...
...
```
I hope someone which already did that will clearly see what i miss so thanks for help and i hope i'll be able to does clear enouth modifications for it to be merged.
