### PR TITLE
Adjust classic slider mechanics to better mimic osu!stable

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderJudgement.cs
@@ -1,0 +1,429 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public partial class TestSceneSliderJudgement : RateAdjustedBeatmapTestScene
+    {
+        private const double time_slider_start = 1000;
+        private const double time_slider_tick = 2000;
+        private const double time_slider_end = 3000;
+
+        private static readonly Vector2 slider_start_position = new Vector2(256 - slider_path_length / 2, 192);
+        private static readonly Vector2 slider_end_position = new Vector2(256 + slider_path_length / 2, 192);
+
+        private ScoreAccessibleReplayPlayer currentPlayer = null!;
+
+        private const float slider_path_length = 200;
+
+        private readonly List<JudgementResult> judgementResults = new List<JudgementResult>();
+
+        #region Nomod
+
+        [Test]
+        public void TestHitAll()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            });
+
+            assertHeadJudgement(HitResult.Great);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestImperfectlyHitHead()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 100, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            });
+
+            assertHeadJudgement(HitResult.Ok);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestMissHead()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 500, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            });
+
+            assertHeadJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestMissTick()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_tick - 200)),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            });
+
+            assertHeadJudgement(HitResult.Great);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestMissTail()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200)),
+                new OsuReplayFrame(time_slider_end, slider_end_position),
+            });
+
+            assertHeadJudgement(HitResult.Great);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.IgnoreMiss);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestMissHeadAndTick()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 500, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_tick - 200)),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position),
+            });
+
+            assertHeadJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        [Test]
+        public void TestMissAll()
+        {
+            performTest(new List<ReplayFrame>());
+
+            assertHeadJudgement(HitResult.Miss);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.IgnoreMiss);
+            assertSliderJudgement(HitResult.IgnoreMiss);
+        }
+
+        [Test]
+        public void TestMissRepeat()
+        {
+            // This adjusts the slider so that the repeat is at time_slider_tick.
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_end - 400)),
+                new OsuReplayFrame(time_slider_tick, slider_end_position),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_end - 400), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_start_position, OsuAction.LeftButton),
+            }, s =>
+            {
+                s.RepeatCount = 1;
+                s.SliderVelocityMultiplier = 2;
+                s.TickDistanceMultiplier = 10;
+            });
+
+            assertHeadJudgement(HitResult.Great);
+            assertRepeatJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.IgnoreHit);
+        }
+
+        #endregion
+
+        #region Classic
+
+        [Test]
+        public void TestHitAllClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickHit);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Great);
+        }
+
+        [Test]
+        public void TestImperfectlyHitHeadClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 100, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickHit);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Great);
+        }
+
+        [Test]
+        public void TestMissHeadClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 500, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickMiss);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Ok);
+        }
+
+        [Test]
+        public void TestMissTickClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_tick - 200)),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position, OsuAction.LeftButton),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickHit);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Ok);
+        }
+
+        [Test]
+        public void TestMissTailClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200)),
+                new OsuReplayFrame(time_slider_end, slider_end_position),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickHit);
+            assertTickJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.IgnoreMiss);
+            assertSliderJudgement(HitResult.Ok);
+        }
+
+        [Test]
+        public void TestMissHeadAndTickClassic()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 500, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_tick - 200)),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_tick + 200), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_end_position),
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickMiss);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Meh);
+        }
+
+        [Test]
+        public void TestMissAllClassic()
+        {
+            performTest(new List<ReplayFrame>(), classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickMiss);
+            assertTickJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.IgnoreMiss);
+            assertSliderJudgement(HitResult.Miss);
+        }
+
+        [Test]
+        public void TestMissRepeatClassic()
+        {
+            // This adjusts the slider so that the repeat is at time_slider_tick.
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_tick - 200, computePositionFromTime(time_slider_end - 400)),
+                new OsuReplayFrame(time_slider_tick, slider_end_position),
+                new OsuReplayFrame(time_slider_tick + 200, computePositionFromTime(time_slider_end - 400), OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_end, slider_start_position, OsuAction.LeftButton),
+            }, s =>
+            {
+                s.RepeatCount = 1;
+                s.SliderVelocityMultiplier = 2;
+                s.TickDistanceMultiplier = 10;
+            }, classic: true);
+
+            assertHeadJudgement(HitResult.LargeTickHit);
+            assertRepeatJudgement(HitResult.LargeTickMiss);
+            assertTailJudgement(HitResult.LargeTickHit);
+            assertSliderJudgement(HitResult.Ok);
+        }
+
+        #endregion
+
+        private void assertHeadJudgement(HitResult result)
+        {
+            AddAssert(
+                "check head result",
+                () => judgementResults.SingleOrDefault(r => r.HitObject is SliderHeadCircle)?.Type,
+                () => Is.EqualTo(result));
+        }
+
+        private void assertTickJudgement(HitResult result)
+        {
+            AddAssert(
+                "check tick result",
+                () => judgementResults.SingleOrDefault(r => r.HitObject is SliderTick)?.Type,
+                () => Is.EqualTo(result));
+        }
+
+        private void assertRepeatJudgement(HitResult result)
+        {
+            AddAssert(
+                "check tick result",
+                () => judgementResults.SingleOrDefault(r => r.HitObject is SliderRepeat)?.Type,
+                () => Is.EqualTo(result));
+        }
+
+        private void assertTailJudgement(HitResult result)
+        {
+            AddAssert(
+                "check tail result",
+                () => judgementResults.SingleOrDefault(r => r.HitObject is SliderTailCircle)?.Type,
+                () => Is.EqualTo(result));
+        }
+
+        private void assertSliderJudgement(HitResult result)
+        {
+            AddAssert(
+                "check slider result",
+                () => judgementResults.SingleOrDefault(r => r.HitObject is Slider)?.Type,
+                () => Is.EqualTo(result));
+        }
+
+        private Vector2 computePositionFromTime(double time)
+        {
+            Vector2 dist = slider_end_position - slider_start_position;
+            double t = (time - time_slider_start) / (time_slider_end - time_slider_start);
+            return slider_start_position + dist * (float)t;
+        }
+
+        private void performTest(List<ReplayFrame> frames, Action<Slider>? adjustSliderFunc = null, bool classic = false)
+        {
+            Slider slider = new Slider
+            {
+                StartTime = time_slider_start,
+                Position = new Vector2(256 - slider_path_length / 2, 192),
+                TickDistanceMultiplier = 3,
+                ClassicSliderBehaviour = classic,
+                Path = new SliderPath(PathType.LINEAR, new[]
+                {
+                    Vector2.Zero,
+                    new Vector2(slider_path_length, 0),
+                }, slider_path_length),
+            };
+
+            adjustSliderFunc?.Invoke(slider);
+
+            AddStep("load player", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(new Beatmap<OsuHitObject>
+                {
+                    HitObjects = { slider },
+                    BeatmapInfo =
+                    {
+                        Difficulty = new BeatmapDifficulty
+                        {
+                            SliderMultiplier = 1,
+                            SliderTickRate = 3
+                        },
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                    }
+                });
+
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+
+                p.OnLoadComplete += _ =>
+                {
+                    p.ScoreProcessor.NewJudgement += result =>
+                    {
+                        if (currentPlayer == p) judgementResults.Add(result);
+                    };
+                };
+
+                LoadScreen(currentPlayer = p);
+                judgementResults.Clear();
+            });
+
+            AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
+        }
+
+        private partial class ScoreAccessibleReplayPlayer : ReplayPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            protected override bool PauseOnFocusLost => false;
+
+            public ScoreAccessibleReplayPlayer(Score score)
+                : base(score, new PlayerConfiguration
+                {
+                    AllowPause = false,
+                    ShowResults = false,
+                })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderHead.cs
@@ -68,10 +68,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             if (HitObject.ClassicSliderBehaviour)
             {
                 // With classic slider behaviour, heads are considered fully hit if in the largest hit window.
-                // We can't award a full Great because the true Great judgement is awarded on the Slider itself,
-                // reduced based on number of ticks hit,
-                // so we use the most suitable LargeTick judgement here instead.
-                return base.ResultFor(timeOffset).IsHit() ? HitResult.LargeTickHit : HitResult.LargeTickMiss;
+                return base.ResultFor(timeOffset).IsHit() ? Result.Judgement.MaxResult : Result.Judgement.MinResult;
             }
 
             return base.ResultFor(timeOffset);

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -135,8 +135,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                 classicSliderBehaviour = value;
                 if (HeadCircle != null)
                     HeadCircle.ClassicSliderBehaviour = value;
-                if (TailCircle != null)
-                    TailCircle.ClassicSliderBehaviour = value;
             }
         }
 
@@ -219,8 +217,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                             RepeatIndex = e.SpanIndex,
                             StartTime = e.Time,
                             Position = EndPosition,
-                            StackHeight = StackHeight,
-                            ClassicSliderBehaviour = ClassicSliderBehaviour,
+                            StackHeight = StackHeight
                         });
                         break;
 
@@ -275,12 +272,19 @@ namespace osu.Game.Rulesets.Osu.Objects
             TailSamples = this.GetNodeSamples(repeatCount + 1);
         }
 
-        public override Judgement CreateJudgement() => ClassicSliderBehaviour
-            // Final combo is provided by the slider itself - see logic in `DrawableSlider.CheckForResult()`
-            ? new OsuJudgement()
-            // Final combo is provided by the tail circle - see `SliderTailCircle`
-            : new OsuIgnoreJudgement();
+        public override Judgement CreateJudgement() => ClassicSliderBehaviour ? new ClassicSliderJudgement() : new OsuIgnoreJudgement();
 
         protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+
+        private class ClassicSliderJudgement : OsuJudgement
+        {
+            public override bool AffectsCombo(HitResult result)
+            {
+                if (result == MinResult)
+                    return base.AffectsCombo(result);
+
+                return false;
+            }
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -2,30 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
     public class SliderTailCircle : SliderEndCircle
     {
-        /// <summary>
-        /// Whether to treat this <see cref="SliderHeadCircle"/> as a normal <see cref="HitCircle"/> for judgement purposes.
-        /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
-        /// </summary>
-        public bool ClassicSliderBehaviour;
-
         public SliderTailCircle(Slider slider)
             : base(slider)
         {
         }
 
-        public override Judgement CreateJudgement() => ClassicSliderBehaviour ? new LegacyTailJudgement() : new TailJudgement();
-
-        public class LegacyTailJudgement : OsuJudgement
-        {
-            public override HitResult MaxResult => HitResult.SmallTickHit;
-        }
+        public override Judgement CreateJudgement() => new TailJudgement();
 
         public class TailJudgement : SliderEndJudgement
         {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -52,11 +52,6 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 case HitResult.Miss:
                     return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.03, -0.125, -0.2);
 
-                case HitResult.SmallTickHit:
-                    // This result always comes from the slider tail, which is judged the same as a repeat.
-                    increase = 0.02;
-                    break;
-
                 case HitResult.LargeTickHit:
                     // This result comes from either a slider tick or repeat.
                     increase = hitObject is SliderTick ? 0.015 : 0.02;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -170,6 +170,9 @@ namespace osu.Game.Rulesets.Osu.UI
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
 
+            if (!result.Type.IsScorable())
+                return;
+
             DrawableOsuJudgement explosion = poolDictionary[result.Type].Get(doj => doj.Apply(result, judgedObject));
 
             judgementLayer.Add(explosion);

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -356,18 +356,43 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(actual, Is.EqualTo(expected).Within(Precision.FLOAT_EPSILON));
         }
 
+        [Test]
+        public void TestJudgementCustomAffectsCombo()
+        {
+            scoreProcessor.ApplyBeatmap(new Beatmap
+            {
+                HitObjects =
+                {
+                    new TestHitObject(HitResult.Great, affectsCombo: false)
+                }
+            });
+
+            var judgementResult = new JudgementResult(beatmap.HitObjects.Single(), new TestJudgement(HitResult.Great, affectsCombo: false))
+            {
+                Type = HitResult.Great
+            };
+            scoreProcessor.ApplyResult(judgementResult);
+
+            Assert.That(scoreProcessor.Combo.Value, Is.EqualTo(0));
+            Assert.That(scoreProcessor.HighestCombo.Value, Is.EqualTo(0));
+        }
+
         private class TestJudgement : Judgement
         {
             public override HitResult MaxResult { get; }
 
             public override HitResult MinResult => minResult ?? base.MinResult;
 
-            private readonly HitResult? minResult;
+            public override bool AffectsCombo(HitResult result) => affectsCombo ?? base.AffectsCombo(result);
 
-            public TestJudgement(HitResult maxResult, HitResult? minResult = null)
+            private readonly HitResult? minResult;
+            private readonly bool? affectsCombo;
+
+            public TestJudgement(HitResult maxResult, HitResult? minResult = null, bool? affectsCombo = null)
             {
                 MaxResult = maxResult;
                 this.minResult = minResult;
+                this.affectsCombo = affectsCombo;
             }
         }
 
@@ -375,16 +400,18 @@ namespace osu.Game.Tests.Rulesets.Scoring
         {
             private readonly HitResult maxResult;
             private readonly HitResult? minResult;
+            private readonly bool? affectsCombo;
 
             public override Judgement CreateJudgement()
             {
-                return new TestJudgement(maxResult, minResult);
+                return new TestJudgement(maxResult, minResult, affectsCombo);
             }
 
-            public TestHitObject(HitResult maxResult, HitResult? minResult = null)
+            public TestHitObject(HitResult maxResult, HitResult? minResult = null, bool? affectsCombo = null)
             {
                 this.maxResult = maxResult;
                 this.minResult = minResult;
+                this.affectsCombo = affectsCombo;
             }
         }
 

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -94,7 +94,9 @@ namespace osu.Game.Beatmaps
 
             static void addCombo(HitObject hitObject, ref int combo)
             {
-                if (hitObject.CreateJudgement().MaxResult.AffectsCombo())
+                var judgement = hitObject.CreateJudgement();
+
+                if (judgement.AffectsCombo(judgement.MaxResult) && judgement.MaxResult.IncreasesCombo())
                     combo++;
 
                 foreach (var nested in hitObject.NestedHitObjects)

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -92,6 +92,12 @@ namespace osu.Game.Rulesets.Judgements
         }
 
         /// <summary>
+        /// Whether the given <see cref="HitResult"/> affects combo in coordination with this <see cref="Judgement"/>.
+        /// </summary>
+        /// <param name="result">The hit result.</param>
+        public virtual bool AffectsCombo(HitResult result) => result.AffectsCombo();
+
+        /// <summary>
         /// The numeric score representation for the maximum achievable result.
         /// </summary>
         public int MaxNumericResult => ToNumericResult(MaxResult);

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -213,10 +213,13 @@ namespace osu.Game.Rulesets.Scoring
             if (!result.Type.IsScorable())
                 return;
 
-            if (result.Type.IncreasesCombo())
-                Combo.Value++;
-            else if (result.Type.BreaksCombo())
-                Combo.Value = 0;
+            if (result.Judgement.AffectsCombo(result.Type))
+            {
+                if (result.Type.IncreasesCombo())
+                    Combo.Value++;
+                else if (result.Type.BreaksCombo())
+                    Combo.Value = 0;
+            }
 
             result.ComboAfterJudgement = Combo.Value;
 


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/25594
Resolves https://github.com/ppy/osu/issues/11769

We're not going to be changing the lazer mechanics for the time being. Even so, it's worth making the classic mod more faithfully reproduce osu!stable's mechanics.

| Object | No mod | Classic Mod |
| --- | --- | --- |
| Head | `Great / Ok / Meh / Miss` | `LargeTickHit / LargeTickMiss` |
| Tick | `LargeTickHit / LargeTickMiss` | `LargeTickHit / LargeTickMiss` |
| Repeat | `LargeTickHit / LargeTickMiss` | `LargeTickHit / LargeTickMiss` |
| Tail | `LargeTickHit / IgnoreMiss` | `LargeTickHit / IgnoreMiss` |
| Slider | `IgnoreHit / IgnoreMiss` | `Great / Ok / Meh / Miss` (no combo gain) |

Note that this does mean the number of slider ticks between NM and CL are different, but I think this is fine. Historically, ticks haven't been displayed on the results screen, and ticks themselves are not used for any calculations.