### PR TITLE
Fix IgnoreMiss judgements not updating accuracy

### DIFF
--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -356,6 +356,27 @@ namespace osu.Game.Tests.Rulesets.Scoring
             Assert.That(actual, Is.EqualTo(expected).Within(Precision.FLOAT_EPSILON));
         }
 
+        [TestCase(HitResult.Great)]
+        [TestCase(HitResult.LargeTickHit)]
+        public void TestAccuracyUpdateFromIgnoreMiss(HitResult maxResult)
+        {
+            scoreProcessor.ApplyBeatmap(new Beatmap
+            {
+                HitObjects =
+                {
+                    new TestHitObject(maxResult, HitResult.IgnoreMiss)
+                }
+            });
+
+            var judgementResult = new JudgementResult(beatmap.HitObjects.Single(), new TestJudgement(maxResult, HitResult.IgnoreMiss))
+            {
+                Type = HitResult.IgnoreMiss
+            };
+            scoreProcessor.ApplyResult(judgementResult);
+
+            Assert.That(scoreProcessor.Accuracy.Value, Is.Not.EqualTo(1));
+        }
+
         private class TestJudgement : Judgement
         {
             public override HitResult MaxResult { get; }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -218,9 +218,6 @@ namespace osu.Game.Rulesets.Scoring
 
             scoreResultCounts[result.Type] = scoreResultCounts.GetValueOrDefault(result.Type) + 1;
 
-            if (!result.Type.IsScorable())
-                return;
-
             if (result.Type.IncreasesCombo())
                 Combo.Value++;
             else if (result.Type.BreaksCombo())
@@ -228,16 +225,18 @@ namespace osu.Game.Rulesets.Scoring
 
             result.ComboAfterJudgement = Combo.Value;
 
-            if (result.Type.AffectsAccuracy())
+            if (result.Judgement.MaxResult.AffectsAccuracy())
             {
                 currentMaximumBaseScore += Judgement.ToNumericResult(result.Judgement.MaxResult);
-                currentBaseScore += Judgement.ToNumericResult(result.Type);
                 currentAccuracyJudgementCount++;
             }
 
+            if (result.Type.AffectsAccuracy())
+                currentBaseScore += Judgement.ToNumericResult(result.Type);
+
             if (result.Type.IsBonus())
                 currentBonusPortion += GetBonusScoreChange(result);
-            else
+            else if (result.Type.IsScorable())
                 currentComboPortion += GetComboScoreChange(result);
 
             ApplyScoreChange(result);
@@ -275,19 +274,18 @@ namespace osu.Game.Rulesets.Scoring
 
             scoreResultCounts[result.Type] = scoreResultCounts.GetValueOrDefault(result.Type) - 1;
 
-            if (!result.Type.IsScorable())
-                return;
-
-            if (result.Type.AffectsAccuracy())
+            if (result.Judgement.MaxResult.AffectsAccuracy())
             {
                 currentMaximumBaseScore -= Judgement.ToNumericResult(result.Judgement.MaxResult);
-                currentBaseScore -= Judgement.ToNumericResult(result.Type);
                 currentAccuracyJudgementCount--;
             }
 
+            if (result.Type.AffectsAccuracy())
+                currentBaseScore -= Judgement.ToNumericResult(result.Type);
+
             if (result.Type.IsBonus())
                 currentBonusPortion -= GetBonusScoreChange(result);
-            else
+            else if (result.Type.IsScorable())
                 currentComboPortion -= GetComboScoreChange(result);
 
             RemoveScoreChange(result);

--- a/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayAccuracyCounter.cs
@@ -23,11 +23,11 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            AccuracyDisplay.BindValueChanged(mod =>
+            AccuracyDisplay.BindValueChanged(mode =>
             {
                 Current.UnbindBindings();
 
-                switch (mod.NewValue)
+                switch (mode.NewValue)
                 {
                     case AccuracyDisplayMode.Standard:
                         Current.BindTo(scoreProcessor.Accuracy);


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/25492 (whoops, but this PR at least implements `RevertResult`)

Fixes the issue mentioned in https://github.com/ppy/osu/discussions/25739

We historically didn't allow `IgnoreMiss` to be used for anything other than bonus. Now that it can be used as the minimum result for `Great` or `LargeTickHit` judgements, it needs to actually update accuracy. 