### PR TITLE
Fix editor test not waiting for editor to load

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Editing
 {
     public partial class TestSceneOpenEditorTimestamp : OsuGameTestScene
     {
-        private Editor editor => (Editor)Game.ScreenStack.CurrentScreen;
+        private Editor? editor => Game.ScreenStack.CurrentScreen as Editor;
         private EditorBeatmap editorBeatmap => editor.ChildrenOfType<EditorBeatmap>().Single();
         private EditorClock editorClock => editor.ChildrenOfType<EditorClock>().Single();
 
@@ -111,18 +111,18 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         private void addStepScreenModeTo(EditorScreenMode screenMode) =>
-            AddStep("change screen to " + screenMode, () => editor.Mode.Value = screenMode);
+            AddStep("change screen to " + screenMode, () => editor!.Mode.Value = screenMode);
 
         private void assertOnScreenAt(EditorScreenMode screen, double time)
         {
             AddAssert($"stayed on {screen} at {time}", () =>
-                editor.Mode.Value == screen
+                editor!.Mode.Value == screen
                 && editorClock.CurrentTime == time
             );
         }
 
         private void assertMovedScreenTo(EditorScreenMode screen, string text = "moved to") =>
-            AddAssert($"{text} {screen}", () => editor.Mode.Value == screen);
+            AddAssert($"{text} {screen}", () => editor!.Mode.Value == screen);
 
         private void setUpEditor(RulesetInfo ruleset)
         {
@@ -145,7 +145,7 @@ namespace osu.Game.Tests.Visual.Editing
                 ((PlaySongSelect)Game.ScreenStack.CurrentScreen)
                 .Edit(beatmapSet.Beatmaps.Last(beatmap => beatmap.Ruleset.Name == ruleset.Name))
             );
-            AddUntilStep("Wait for editor open", () => editor.ReadyForUse);
+            AddUntilStep("Wait for editor open", () => editor?.ReadyForUse == true);
         }
     }
 }


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/7190432363/job/19583540780?pr=22499

```diff
diff --git a/osu.Game/Screens/Edit/EditorLoader.cs b/osu.Game/Screens/Edit/EditorLoader.cs
index 8bcfa7b9f0..3f8a0dcc02 100644
--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -4,6 +4,7 @@
 #nullable disable

 using System;
+using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -53,6 +54,8 @@ public partial class EditorLoader : ScreenWithBeatmapBackground
         [BackgroundDependencyLoader]
         private void load()
         {
+            Thread.Sleep(2000);
+
             AddRangeInternal(new Drawable[]
             {
                 new LoadingSpinner(true)
```
