### PR TITLE
Adjust some mod multipliers for initial leaderboard sanity

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -787,7 +787,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                 InputManager.MoveMouseTo(this.ChildrenOfType<ModPresetPanel>().Single(preset => preset.Preset.Value.Name == "Half Time 0.5x"));
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("difficulty multiplier display shows correct value", () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.5));
+            AddAssert("difficulty multiplier display shows correct value",
+                () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.1).Within(Precision.DOUBLE_EPSILON));
 
             // this is highly unorthodox in a test, but because the `ModSettingChangeTracker` machinery heavily leans on events and object disposal and re-creation,
             // it is instrumental in the reproduction of the failure scenario that this test is supposed to cover.
@@ -796,7 +797,8 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("open customisation area", () => modSelectOverlay.CustomisationButton!.TriggerClick());
             AddStep("reset half time speed to default", () => modSelectOverlay.ChildrenOfType<ModSettingsArea>().Single()
                                                                               .ChildrenOfType<RevertToDefaultButton<double>>().Single().TriggerClick());
-            AddUntilStep("difficulty multiplier display shows correct value", () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.7));
+            AddUntilStep("difficulty multiplier display shows correct value",
+                () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.3).Within(Precision.DOUBLE_EPSILON));
         }
 
         private void waitForColumnLoad() => AddUntilStep("all column content loaded", () =>

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Acronym => "CL";
 
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.5;
 
         public override IconUsage? Icon => FontAwesome.Solid.History;
 

--- a/osu.Game/Rulesets/Mods/ModSynesthesia.cs
+++ b/osu.Game/Rulesets/Mods/ModSynesthesia.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Name => "Synesthesia";
         public override string Acronym => "SY";
         public override LocalisableString Description => "Colours hit objects based on the rhythm.";
-        public override double ScoreMultiplier => 1;
+        public override double ScoreMultiplier => 0.8;
         public override ModType Type => ModType.Fun;
     }
 }

--- a/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
+++ b/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
@@ -32,9 +32,9 @@ namespace osu.Game.Rulesets.Mods
                 value -= 1;
 
                 if (SpeedChange.Value >= 1)
-                    value /= 5;
-
-                return 1 + value;
+                    return 1 + value / 5;
+                else
+                    return 0.6 + value;
             }
         }
 


### PR DESCRIPTION
There may be others we want to adjust. Note that these are basically placeholder safe values (lower is better) so we can allow these scores on the leaderboard without people complaining about unfairness... unless they are complaining the multiplier is too low (which is fine for now).

RFC, mainly to identify any other mods which need to be adjusted.