### PR TITLE
Add `IsLegacyScore` to `SoloScoreInfo`

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -150,6 +150,12 @@ namespace osu.Game.Online.API.Requests.Responses
 
         #endregion
 
+        /// <summary>
+        /// Whether this <see cref="ScoreInfo"/> represents a legacy (osu!stable) score.
+        /// </summary>
+        [JsonIgnore]
+        public bool IsLegacyScore => LegacyScoreId != null;
+
         public override string ToString() => $"score_id: {ID} user_id: {UserID}";
 
         /// <summary>
@@ -191,6 +197,7 @@ namespace osu.Game.Online.API.Requests.Responses
             {
                 OnlineID = OnlineID,
                 LegacyOnlineID = (long?)LegacyScoreId ?? -1,
+                IsLegacyScore = IsLegacyScore,
                 User = User ?? new APIUser { Id = UserID },
                 BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
                 Ruleset = new RulesetInfo { OnlineID = RulesetID },


### PR DESCRIPTION
Intended to be used as a catch-all to resolve https://github.com/ppy/osu-queue-score-statistics/pull/180#discussion_r1424905707

Note that I'm not changing the `ScoreInfo` one into a get-only property for now because it potentially has quirks around the score decoder (e.g. scores that were set offline but are still legacy scores).

Also... Has anyone looked into the layout of this class in recent times? 🤣 
<img width="365" alt="image" src="https://github.com/ppy/osu/assets/1329837/2be35505-4498-44db-9e80-4f6c54e7866c">
(time for a round 2 pass of cleaning this up?)