### PR TITLE
Move object counts to BeatmapInfo

### DIFF
--- a/osu.Game.Tournament/Models/TournamentBeatmap.cs
+++ b/osu.Game.Tournament/Models/TournamentBeatmap.cs
@@ -21,6 +21,10 @@ namespace osu.Game.Tournament.Models
 
         public double StarRating { get; set; }
 
+        public int EndTimeObjectCount { get; set; }
+
+        public int TotalObjectCount { get; set; }
+
         public IBeatmapMetadataInfo Metadata { get; set; } = new BeatmapMetadata();
 
         public IBeatmapDifficultyInfo Difficulty { get; set; } = new BeatmapDifficulty();
@@ -41,6 +45,8 @@ namespace osu.Game.Tournament.Models
             Metadata = beatmap.Metadata;
             Difficulty = beatmap.Difficulty;
             Covers = beatmap.BeatmapSet?.Covers ?? new BeatmapSetOnlineCovers();
+            EndTimeObjectCount = beatmap.EndTimeObjectCount;
+            TotalObjectCount = beatmap.TotalObjectCount;
         }
 
         public bool Equals(IBeatmapInfo? other) => other is TournamentBeatmap b && this.MatchesOnlineID(b);

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -20,7 +20,6 @@ using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Screens.Play;
-using Realms;
 
 namespace osu.Game
 {
@@ -177,9 +176,13 @@ namespace osu.Game
         {
             Logger.Log("Querying for beatmaps with missing hitobject counts to reprocess...");
 
-            HashSet<Guid> beatmapIds = realmAccess.Run(r => new HashSet<Guid>(r.All<BeatmapInfo>()
-                                                                               .Filter($"{nameof(BeatmapInfo.Difficulty)}.{nameof(BeatmapDifficulty.TotalObjectCount)} == 0")
-                                                                               .AsEnumerable().Select(b => b.ID)));
+            HashSet<Guid> beatmapIds = new HashSet<Guid>();
+
+            realmAccess.Run(r =>
+            {
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.TotalObjectCount == 0))
+                    beatmapIds.Add(b.ID);
+            });
 
             Logger.Log($"Found {beatmapIds.Count} beatmaps which require reprocessing.");
 

--- a/osu.Game/Beatmaps/BeatmapDifficulty.cs
+++ b/osu.Game/Beatmaps/BeatmapDifficulty.cs
@@ -21,9 +21,6 @@ namespace osu.Game.Beatmaps
         public double SliderMultiplier { get; set; } = 1.4;
         public double SliderTickRate { get; set; } = 1;
 
-        public int EndTimeObjectCount { get; set; }
-        public int TotalObjectCount { get; set; }
-
         public BeatmapDifficulty()
         {
         }
@@ -47,9 +44,6 @@ namespace osu.Game.Beatmaps
 
             difficulty.SliderMultiplier = SliderMultiplier;
             difficulty.SliderTickRate = SliderTickRate;
-
-            difficulty.EndTimeObjectCount = EndTimeObjectCount;
-            difficulty.TotalObjectCount = TotalObjectCount;
         }
 
         public virtual void CopyFrom(IBeatmapDifficultyInfo other)
@@ -61,9 +55,6 @@ namespace osu.Game.Beatmaps
 
             SliderMultiplier = other.SliderMultiplier;
             SliderTickRate = other.SliderTickRate;
-
-            EndTimeObjectCount = other.EndTimeObjectCount;
-            TotalObjectCount = other.TotalObjectCount;
         }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -388,9 +388,7 @@ namespace osu.Game.Beatmaps
                         OverallDifficulty = decodedDifficulty.OverallDifficulty,
                         ApproachRate = decodedDifficulty.ApproachRate,
                         SliderMultiplier = decodedDifficulty.SliderMultiplier,
-                        SliderTickRate = decodedDifficulty.SliderTickRate,
-                        EndTimeObjectCount = decoded.HitObjects.Count(h => h is IHasDuration),
-                        TotalObjectCount = decoded.HitObjects.Count
+                        SliderTickRate = decodedDifficulty.SliderTickRate
                     };
 
                     var metadata = new BeatmapMetadata
@@ -428,6 +426,8 @@ namespace osu.Game.Beatmaps
                         GridSize = decodedInfo.GridSize,
                         TimelineZoom = decodedInfo.TimelineZoom,
                         MD5Hash = memoryStream.ComputeMD5Hash(),
+                        EndTimeObjectCount = decoded.HitObjects.Count(h => h is IHasDuration),
+                        TotalObjectCount = decoded.HitObjects.Count
                     };
 
                     beatmaps.Add(beatmap);

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -120,6 +120,10 @@ namespace osu.Game.Beatmaps
         [JsonIgnore]
         public bool Hidden { get; set; }
 
+        public int EndTimeObjectCount { get; set; }
+
+        public int TotalObjectCount { get; set; }
+
         /// <summary>
         /// Reset any fetched online linking information (and history).
         /// </summary>

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -91,8 +91,8 @@ namespace osu.Game.Beatmaps
             var working = workingBeatmapCache.GetWorkingBeatmap(beatmapInfo);
             var beatmap = working.Beatmap;
 
-            beatmapInfo.Difficulty.EndTimeObjectCount = beatmap.HitObjects.Count(h => h is IHasDuration);
-            beatmapInfo.Difficulty.TotalObjectCount = beatmap.HitObjects.Count;
+            beatmapInfo.EndTimeObjectCount = beatmap.HitObjects.Count(h => h is IHasDuration);
+            beatmapInfo.TotalObjectCount = beatmap.HitObjects.Count;
 
             // And invalidate again afterwards as re-fetching the most up-to-date database metadata will be required.
             workingBeatmapCache.Invalidate(beatmapInfo);

--- a/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapDifficultyInfo.cs
@@ -45,19 +45,6 @@ namespace osu.Game.Beatmaps
         double SliderTickRate { get; }
 
         /// <summary>
-        /// The number of hitobjects in the beatmap with a distinct end time.
-        /// </summary>
-        /// <remarks>
-        /// Canonically, these are hitobjects are either sliders or spinners.
-        /// </remarks>
-        int EndTimeObjectCount { get; }
-
-        /// <summary>
-        /// The total number of hitobjects in the beatmap.
-        /// </summary>
-        int TotalObjectCount { get; }
-
-        /// <summary>
         /// Maps a difficulty value [0, 10] to a two-piece linear range of values.
         /// </summary>
         /// <param name="difficulty">The difficulty value to be mapped.</param>

--- a/osu.Game/Beatmaps/IBeatmapInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapInfo.cs
@@ -61,5 +61,18 @@ namespace osu.Game.Beatmaps
         /// The basic star rating for this beatmap (with no mods applied).
         /// </summary>
         double StarRating { get; }
+
+        /// <summary>
+        /// The number of hitobjects in the beatmap with a distinct end time.
+        /// </summary>
+        /// <remarks>
+        /// Canonically, these are hitobjects are either sliders or spinners.
+        /// </remarks>
+        int EndTimeObjectCount { get; }
+
+        /// <summary>
+        /// The total number of hitobjects in the beatmap.
+        /// </summary>
+        int TotalObjectCount { get; }
     }
 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -88,9 +88,9 @@ namespace osu.Game.Database
         /// 34   2023-08-21    Add BackgroundReprocessingFailed flag to ScoreInfo to track upgrade failures.
         /// 35   2023-10-16    Clear key combinations of keybindings that are assigned to more than one action in a given settings section.
         /// 36   2023-10-26    Add LegacyOnlineID to ScoreInfo. Move osu_scores_*_high IDs stored in OnlineID to LegacyOnlineID. Reset anomalous OnlineIDs.
-        /// 37   2023-12-10    Add EndTimeObjectCount and TotalObjectCount to BeatmapDifficulty.
+        /// 38   2023-12-10    Add EndTimeObjectCount and TotalObjectCount to BeatmapInfo.
         /// </summary>
-        private const int schema_version = 37;
+        private const int schema_version = 38;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs
@@ -41,6 +41,10 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty(@"difficulty_rating")]
         public double StarRating { get; set; }
 
+        public int EndTimeObjectCount => SliderCount + SpinnerCount;
+
+        public int TotalObjectCount => CircleCount + SliderCount + SpinnerCount;
+
         [JsonProperty(@"drain")]
         public float DrainRate { get; set; }
 
@@ -108,9 +112,7 @@ namespace osu.Game.Online.API.Requests.Responses
             DrainRate = DrainRate,
             CircleSize = CircleSize,
             ApproachRate = ApproachRate,
-            OverallDifficulty = OverallDifficulty,
-            EndTimeObjectCount = SliderCount + SpinnerCount,
-            TotalObjectCount = CircleCount + SliderCount + SpinnerCount
+            OverallDifficulty = OverallDifficulty
         };
 
         IBeatmapSetInfo? IBeatmapInfo.BeatmapSet => BeatmapSet;

--- a/osu.Game/Rulesets/Scoring/Legacy/LegacyBeatmapConversionDifficultyInfo.cs
+++ b/osu.Game/Rulesets/Scoring/Legacy/LegacyBeatmapConversionDifficultyInfo.cs
@@ -62,8 +62,8 @@ namespace osu.Game.Rulesets.Scoring.Legacy
             SourceRuleset = beatmapInfo.Ruleset,
             CircleSize = beatmapInfo.Difficulty.CircleSize,
             OverallDifficulty = beatmapInfo.Difficulty.OverallDifficulty,
-            EndTimeObjectCount = beatmapInfo.Difficulty.EndTimeObjectCount,
-            TotalObjectCount = beatmapInfo.Difficulty.TotalObjectCount
+            EndTimeObjectCount = beatmapInfo.EndTimeObjectCount,
+            TotalObjectCount = beatmapInfo.TotalObjectCount
         };
     }
 }


### PR DESCRIPTION
As mentioned to me IRL, `BeatmapInfo` feels like a better place for this to live. I had mentioned in the original PR that I was unsure about the placement of these properties, so I'm happy to move them.

~~For those that have ran debug builds on the branch/master, they should delete the `client_37.realm` database.~~ Nevermind, miscommunication.