### PR TITLE
Add setting for mod select search box focusing by default

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -37,6 +38,9 @@ namespace osu.Game.Tests.Visual.UserInterface
         private RulesetStore rulesetStore = null!;
 
         private TestModSelectOverlay modSelectOverlay = null!;
+
+        [Resolved]
+        private OsuConfigManager configManager { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -566,17 +570,33 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestSearchFocusChangeViaKey()
+        public void TestTextSearchActiveByDefault()
         {
+            configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, true);
             createScreen();
 
-            const Key focus_switch_key = Key.Tab;
+            AddUntilStep("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
 
-            AddStep("press tab", () => InputManager.Key(focus_switch_key));
-            AddAssert("focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box unfocused", () => !modSelectOverlay.SearchTextBox.HasFocus);
 
-            AddStep("press tab", () => InputManager.Key(focus_switch_key));
-            AddAssert("lost focus", () => !modSelectOverlay.SearchTextBox.HasFocus);
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+        }
+
+        [Test]
+        public void TestTextSearchNotActiveByDefault()
+        {
+            configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, false);
+            createScreen();
+
+            AddUntilStep("search text box not focused", () => !modSelectOverlay.SearchTextBox.HasFocus);
+
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box unfocused", () => !modSelectOverlay.SearchTextBox.HasFocus);
         }
 
         [Test]

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.RandomSelectAlgorithm, RandomSelectAlgorithm.RandomPermutation);
             SetDefault(OsuSetting.ModSelectHotkeyStyle, ModSelectHotkeyStyle.Sequential);
+            SetDefault(OsuSetting.ModSelectTextSearchStartsActive, true);
 
             SetDefault(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2f, 1f);
 
@@ -416,5 +417,6 @@ namespace osu.Game.Configuration
         AutomaticallyDownloadMissingBeatmaps,
         EditorShowSpeedChanges,
         TouchDisableGameplayTaps,
+        ModSelectTextSearchStartsActive,
     }
 }

--- a/osu.Game/Localisation/UserInterfaceStrings.cs
+++ b/osu.Game/Localisation/UserInterfaceStrings.cs
@@ -105,6 +105,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ModSelectHotkeyStyle => new TranslatableString(getKey(@"mod_select_hotkey_style"), @"Mod select hotkey style");
 
         /// <summary>
+        /// "Automatically focus search text box in mod select"
+        /// </summary>
+        public static LocalisableString ModSelectTextSearchStartsActive => new TranslatableString(getKey(@"mod_select_text_search_starts_active"), @"Automatically focus search text box in mod select");
+
+        /// <summary>
         /// "no limit"
         /// </summary>
         public static LocalisableString NoLimit => new TranslatableString(getKey(@"no_limit"), @"no limit");

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Overlays.Mods
         public IEnumerable<ModState> AllAvailableMods => AvailableMods.Value.SelectMany(pair => pair.Value);
 
         private readonly BindableBool customisationVisible = new BindableBool();
+        private Bindable<bool> textSearchStartsActive = null!;
 
         private ModSettingsArea modSettingsArea = null!;
         private ColumnScrollContainer columnScroll = null!;
@@ -154,7 +155,7 @@ namespace osu.Game.Overlays.Mods
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuGameBase game, OsuColour colours, AudioManager audio)
+        private void load(OsuGameBase game, OsuColour colours, AudioManager audio, OsuConfigManager configManager)
         {
             Header.Title = ModSelectOverlayStrings.ModSelectTitle;
             Header.Description = ModSelectOverlayStrings.ModSelectDescription;
@@ -282,6 +283,8 @@ namespace osu.Game.Overlays.Mods
             }
 
             globalAvailableMods.BindTo(game.AvailableMods);
+
+            textSearchStartsActive = configManager.GetBindable<bool>(OsuSetting.ModSelectTextSearchStartsActive);
         }
 
         public override void Hide()
@@ -617,6 +620,9 @@ namespace osu.Game.Overlays.Mods
 
                 nonFilteredColumnCount += 1;
             }
+
+            if (textSearchStartsActive.Value)
+                SearchTextBox.TakeFocus();
         }
 
         protected override void PopOut()

--- a/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/UserInterface/SongSelectSettings.cs
@@ -43,6 +43,12 @@ namespace osu.Game.Overlays.Settings.Sections.UserInterface
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = UserInterfaceStrings.ModSelectTextSearchStartsActive,
+                    Current = config.GetBindable<bool>(OsuSetting.ModSelectTextSearchStartsActive),
+                    ClassicDefault = false
+                },
+                new SettingsCheckbox
+                {
                     LabelText = GameplaySettingsStrings.BackgroundBlur,
                     Current = config.GetBindable<bool>(OsuSetting.SongSelectBackgroundBlur),
                     ClassicDefault = false,


### PR DESCRIPTION
This is a @peppy request.

---

The _new_ default is to focus the search box by default so that you can type immediately after the overlay pops in. But it is toggleable so that users who are accustomed to hotkeys can continue using hotkeys. As such the "classic" default for the setting is to not focus the search box.

For existing lazer users that want to use classic hotkeys, please adjust the new setting `Automatically focus search text box in mod select`.