### PR TITLE
Fix `AdjustedAttributesTooltip` being broken by design

### DIFF
--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Overlays.Mods
     /// On the mod select overlay, this provides a local updating view of BPM, star rating and other
     /// difficulty attributes so the user can have a better insight into what mods are changing.
     /// </summary>
-    public partial class BeatmapAttributesDisplay : ModFooterInformationDisplay, IHasCustomTooltip
+    public partial class BeatmapAttributesDisplay : ModFooterInformationDisplay, IHasCustomTooltip<AdjustedAttributesTooltip.Data?>
     {
         private StarRatingDisplay starRatingDisplay = null!;
         private BPMDisplay bpmDisplay = null!;
@@ -57,11 +57,9 @@ namespace osu.Game.Overlays.Mods
         private CancellationTokenSource? cancellationSource;
         private IBindable<StarDifficulty?> starDifficulty = null!;
 
-        private AdjustedAttributesTooltip rateAdjustTooltip = null!;
+        public ITooltip<AdjustedAttributesTooltip.Data?> GetCustomTooltip() => new AdjustedAttributesTooltip();
 
-        public ITooltip GetCustomTooltip() => rateAdjustTooltip;
-
-        public object TooltipContent => this;
+        public AdjustedAttributesTooltip.Data? TooltipContent { get; private set; }
 
         private const float transition_duration = 250;
 
@@ -69,8 +67,6 @@ namespace osu.Game.Overlays.Mods
         private void load()
         {
             const float shear = ShearedOverlayContainer.SHEAR;
-
-            rateAdjustTooltip = new AdjustedAttributesTooltip();
 
             LeftContent.AddRange(new Drawable[]
             {
@@ -182,7 +178,7 @@ namespace osu.Game.Overlays.Mods
             Ruleset ruleset = gameRuleset.Value.CreateInstance();
             BeatmapDifficulty adjustedDifficulty = ruleset.GetRateAdjustedDisplayDifficulty(originalDifficulty, rate);
 
-            rateAdjustTooltip.UpdateAttributes(originalDifficulty, adjustedDifficulty);
+            TooltipContent = new AdjustedAttributesTooltip.Data(originalDifficulty, adjustedDifficulty);
 
             approachRateDisplay.AdjustType.Value = VerticalAttributeDisplay.CalculateEffect(originalDifficulty.ApproachRate, adjustedDifficulty.ApproachRate);
             overallDifficultyDisplay.AdjustType.Value = VerticalAttributeDisplay.CalculateEffect(originalDifficulty.OverallDifficulty, adjustedDifficulty.OverallDifficulty);

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -30,7 +30,7 @@ using osu.Game.Overlays.Mods;
 
 namespace osu.Game.Screens.Select.Details
 {
-    public partial class AdvancedStats : Container, IHasCustomTooltip
+    public partial class AdvancedStats : Container, IHasCustomTooltip<AdjustedAttributesTooltip.Data>
     {
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; }
@@ -46,9 +46,8 @@ namespace osu.Game.Screens.Select.Details
         protected readonly StatisticRow FirstValue, HpDrain, Accuracy, ApproachRate;
         private readonly StatisticRow starDifficulty;
 
-        private AdjustedAttributesTooltip rateAdjustTooltip;
-        public ITooltip GetCustomTooltip() => rateAdjustTooltip;
-        public object TooltipContent => this;
+        public ITooltip<AdjustedAttributesTooltip.Data> GetCustomTooltip() => new AdjustedAttributesTooltip();
+        public AdjustedAttributesTooltip.Data TooltipContent { get; private set; }
 
         private IBeatmapInfo beatmapInfo;
 
@@ -86,7 +85,6 @@ namespace osu.Game.Screens.Select.Details
         private void load(OsuColour colours)
         {
             starDifficulty.AccentColour = colours.Yellow;
-            rateAdjustTooltip = new AdjustedAttributesTooltip();
         }
 
         protected override void LoadComplete()
@@ -144,7 +142,7 @@ namespace osu.Game.Screens.Select.Details
 
                     adjustedDifficulty = ruleset.CreateInstance().GetRateAdjustedDisplayDifficulty(originalDifficulty, rate);
 
-                    rateAdjustTooltip.UpdateAttributes(originalDifficulty, adjustedDifficulty);
+                    TooltipContent = new AdjustedAttributesTooltip.Data(originalDifficulty, adjustedDifficulty);
                 }
             }
 


### PR DESCRIPTION
Fixes issue described in the following comment:
https://github.com/ppy/osu/pull/25759#issuecomment-1855954637

That is just not how the tooltip system is supposed to be used.

To name the individual sins:

- Caching and returning a tooltip instance like the classes that used tooltips is incorrect. The lifetime of tooltip instances is managed by the tooltip container. `GetCustomTooltip()` is called by it exclusively. It should return a fresh instance every time.

- Not putting actual data in `IHasCustomTooltip.TooltipContent` is wrong.

- Having `Tooltip.SetContent()` be a no-op is *grossly and flagrantly* wrong.

I'm not even sure which particular combination of the above transgressions caused the issue as it presented itself, but at this time I frankly do not care.

---

@Givikap120 for your consideration.