### PR TITLE
Show back button when spectating

### DIFF
--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Screens.Play
 
         private readonly Score score;
 
+        public override bool AllowBackButton => true;
+
         protected override bool CheckModsAllowFailure()
         {
             if (!allowFail)


### PR DESCRIPTION
Avoids getting stuck at some screens.

It's a bit ugly having the back button visible like this, but is the best approach we have for now.

Closes https://github.com/ppy/osu/issues/25763.