### PR TITLE
Fix star rating display changing width depending on number displayed

### DIFF
--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -37,6 +38,8 @@ namespace osu.Game.Beatmaps.Drawables
         }
 
         private readonly Bindable<double> displayedStars = new BindableDouble();
+
+        private readonly Container textContainer;
 
         /// <summary>
         /// The currently displayed stars of this display wrapped in a bindable.
@@ -116,15 +119,19 @@ namespace osu.Game.Beatmaps.Drawables
                                     Size = new Vector2(8f),
                                 },
                                 Empty(),
-                                starsText = new OsuSpriteText
+                                textContainer = new Container
                                 {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Margin = new MarginPadding { Bottom = 1.5f },
-                                    // todo: this should be size: 12f, but to match up with the design, it needs to be 14.4f
-                                    // see https://github.com/ppy/osu-framework/issues/3271.
-                                    Font = OsuFont.Torus.With(size: 14.4f, weight: FontWeight.Bold),
-                                    Shadow = false,
+                                    AutoSizeAxes = Axes.Y,
+                                    Child = starsText = new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Margin = new MarginPadding { Bottom = 1.5f },
+                                        // todo: this should be size: 12f, but to match up with the design, it needs to be 14.4f
+                                        // see https://github.com/ppy/osu-framework/issues/3271.
+                                        Font = OsuFont.Torus.With(size: 14.4f, weight: FontWeight.Bold),
+                                        Shadow = false,
+                                    },
                                 },
                             }
                         }
@@ -155,6 +162,11 @@ namespace osu.Game.Beatmaps.Drawables
 
                 starIcon.Colour = s.NewValue >= 6.5 ? colours.Orange1 : colourProvider?.Background5 ?? Color4Extensions.FromHex("303d47");
                 starsText.Colour = s.NewValue >= 6.5 ? colours.Orange1 : colourProvider?.Background5 ?? Color4.Black.Opacity(0.75f);
+
+                // In order to avoid autosize throwing the width of these displays all over the place,
+                // let's lock in some sane defaults for the text width based on how many digits we're
+                // displaying.
+                textContainer.Width = 24 + Math.Max(starsText.Text.ToString().Length - 4, 0) * 6;
             }, true);
         }
     }

--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -144,8 +144,8 @@ namespace osu.Game.Overlays.Mods
 
         private void startAnimating()
         {
-            Content.AutoSizeEasing = Easing.OutQuint;
-            Content.AutoSizeDuration = transition_duration;
+            LeftContent.AutoSizeEasing = Content.AutoSizeEasing = Easing.OutQuint;
+            LeftContent.AutoSizeDuration = Content.AutoSizeDuration = transition_duration;
         }
 
         private void updateValues() => Scheduler.AddOnce(() =>

--- a/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
+++ b/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
@@ -82,7 +82,8 @@ namespace osu.Game.Overlays.Mods
             {
                 Origin = Anchor.CentreLeft,
                 Anchor = Anchor.CentreLeft,
-                AutoSizeAxes = Axes.Both,
+                AutoSizeAxes = Axes.Y,
+                Width = 50,
                 Direction = FillDirection.Vertical,
                 Children = new Drawable[]
                 {


### PR DESCRIPTION
A few isolated fixes to improve things here. I was looking to completely rewrite `StarRatingDisplay` to not use `GridContainer` (it feels a bit wasteful for such a common element) but this turned out to be high effort. Instead, I've made the width more consistent based on the number of *characters* displayed, rather than *which* characters are displayed.

This still causes a bit of visual awkwardness at the location mentioned in the issue (the attributes display in mod select), so I've also adjusted the `AutoSize` tweening to make that feel slightly better.

Before:

https://github.com/ppy/osu/assets/191335/d41222c7-8e73-4f14-99d8-8284248559e6

After:

https://github.com/ppy/osu/assets/191335/99a1623e-5c9c-4392-bc3e-e54add5ed030



Closes https://github.com/ppy/osu/issues/25772