### PR TITLE
Allow new common cases when a user is locating a stable osu! install directory for import

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -269,11 +269,11 @@ namespace osu.Game.Overlays.FirstRunSetup
                 if (directory.OldValue?.FullName == directory.NewValue.FullName)
                     return;
 
-                if (directory.NewValue?.GetFiles(@"osu!.*.cfg").Any() ?? false)
+                if (legacyImportManager.IsUsableForStableImport(directory.NewValue, out var stableRoot))
                 {
                     this.HidePopover();
 
-                    string path = directory.NewValue.FullName;
+                    string path = stableRoot.FullName;
 
                     legacyImportManager.UpdateStorage(path);
                     Current.Value = path;

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
@@ -46,6 +46,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         }
 
         private bool shouldUseParentDirectory(DirectoryInfo? info)
-            => info?.Parent != null && (info?.Name == "Songs" || info?.Name == "Skins");
+            => info?.Parent != null && (info.Name == "Songs" || info.Name == "Skins");
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
@@ -15,7 +15,16 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
-        protected override bool IsValidDirectory(DirectoryInfo? info) => info?.GetFiles("osu!.*.cfg").Any() ?? false;
+        protected override bool IsValidDirectory(DirectoryInfo? info) =>
+            // A full stable installation will have a configuration file present.
+            // This is the best case scenario, as it may contain a custom beatmap directory we need to traverse to.
+            info?.GetFiles("osu!.*.cfg").Any() == true ||
+            // The user may only have their songs or skins folders left.
+            // We still want to allow them to import based on this.
+            info?.GetDirectories("Songs").Any() == true ||
+            info?.GetDirectories("Skins").Any() == true ||
+            // The user may have traverse *inside* their songs or skins folders.
+            shouldUseParentDirectory(info);
 
         public override LocalisableString HeaderText => "Please select your osu!stable install location";
 
@@ -26,7 +35,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         protected override void OnSelection(DirectoryInfo directory)
         {
-            taskCompletionSource.TrySetResult(directory.FullName);
+            taskCompletionSource.TrySetResult(shouldUseParentDirectory(directory) ? directory.Parent!.FullName : directory.FullName);
             this.Exit();
         }
 
@@ -35,5 +44,8 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
             taskCompletionSource.TrySetCanceled();
             return base.OnExiting(e);
         }
+
+        private bool shouldUseParentDirectory(DirectoryInfo? info)
+            => info?.Parent != null && (info?.Name == "Songs" || info?.Name == "Skins");
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/StableDirectorySelectScreen.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
+using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Framework.Screens;
+using osu.Game.Database;
 
 namespace osu.Game.Overlays.Settings.Sections.Maintenance
 {
@@ -13,18 +15,12 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
     {
         private readonly TaskCompletionSource<string> taskCompletionSource;
 
+        [Resolved]
+        private LegacyImportManager legacyImportManager { get; set; } = null!;
+
         protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.Disabled;
 
-        protected override bool IsValidDirectory(DirectoryInfo? info) =>
-            // A full stable installation will have a configuration file present.
-            // This is the best case scenario, as it may contain a custom beatmap directory we need to traverse to.
-            info?.GetFiles("osu!.*.cfg").Any() == true ||
-            // The user may only have their songs or skins folders left.
-            // We still want to allow them to import based on this.
-            info?.GetDirectories("Songs").Any() == true ||
-            info?.GetDirectories("Skins").Any() == true ||
-            // The user may have traverse *inside* their songs or skins folders.
-            shouldUseParentDirectory(info);
+        protected override bool IsValidDirectory(DirectoryInfo? info) => legacyImportManager.IsUsableForStableImport(info, out _);
 
         public override LocalisableString HeaderText => "Please select your osu!stable install location";
 
@@ -35,7 +31,10 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         protected override void OnSelection(DirectoryInfo directory)
         {
-            taskCompletionSource.TrySetResult(shouldUseParentDirectory(directory) ? directory.Parent!.FullName : directory.FullName);
+            if (!legacyImportManager.IsUsableForStableImport(directory, out var stableRoot))
+                throw new InvalidOperationException($@"{nameof(OnSelection)} was called on an invalid directory. This should never happen.");
+
+            taskCompletionSource.TrySetResult(stableRoot.FullName);
             this.Exit();
         }
 
@@ -44,8 +43,5 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
             taskCompletionSource.TrySetCanceled();
             return base.OnExiting(e);
         }
-
-        private bool shouldUseParentDirectory(DirectoryInfo? info)
-            => info?.Parent != null && (info.Name == "Songs" || info.Name == "Skins");
     }
 }


### PR DESCRIPTION
Stemmed from [discussion on discord](https://discord.com/channels/188630481301012481/1097318920991559880/1185082171271151646)

---

This allows:

- Selecting a `Songs` or `Skins` folder directly (will automatically use the parent for imports)
- Selecting an `osu!` folder without it containing a `osu!.*.cfg` file (which is the case for some users that have only backed up their `Songs` or `Skins` folders)