### PR TITLE
Fix column sizing exceeding screen width on tablets

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
@@ -100,16 +99,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                         return SkinUtils.As<TValue>(new Bindable<float>(30));
 
                     case LegacyManiaSkinConfigurationLookups.ColumnWidth:
-
-                        float width;
-
                         bool isSpecialColumn = stage.IsSpecialColumn(columnIndex);
 
-                        // Best effort until we have better mobile support.
-                        if (RuntimeInfo.IsMobile)
-                            width = 170 * Math.Min(1, 7f / beatmap.TotalColumns) * (isSpecialColumn ? 1.8f : 1);
-                        else
-                            width = 60 * (isSpecialColumn ? 2 : 1);
+                        float width = 60 * (isSpecialColumn ? 2 : 1);
 
                         return SkinUtils.As<TValue>(new Bindable<float>(width));
 

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -118,8 +118,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
             float aspectRatio = containingCell.Value.X / containingCell.Value.Y;
 
-            // These numbers are based on mobile phones, aspect ~1.92.
+            // 2.83 is a mostly arbitrary scale-up (170 / 60, based on original implementation for argon)
             float mobileAdjust = 2.83f * Math.Min(1, 7f / stageDefinition.Columns);
+            // 1.92 is a "reference" mobile screen aspect ratio for phones.
             // We should scale it back for cases like tablets which aren't so extreme.
             mobileAdjust *= aspectRatio / 1.92f;
 

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -109,22 +109,23 @@ namespace osu.Game.Rulesets.Mania.UI
             if (!IsLoaded || !RuntimeInfo.IsMobile)
                 return;
 
+            // GridContainer+CellContainer containing this stage (gets split up for dual stages).
+            Vector2? containingCell = this.FindClosestParent<Stage>()?.Parent?.DrawSize;
+
+            // Will be null in tests.
+            if (containingCell == null)
+                return;
+
+            float aspectRatio = containingCell.Value.X / containingCell.Value.Y;
+
+            // These numbers are based on mobile phones, aspect ~1.92.
+            float mobileAdjust = 2.83f * Math.Min(1, 7f / stageDefinition.Columns);
+            // We should scale it back for cases like tablets which aren't so extreme.
+            mobileAdjust *= aspectRatio / 1.92f;
+
+            // Best effort until we have better mobile support.
             for (int i = 0; i < stageDefinition.Columns; i++)
-            {
-                // GridContainer+CellContainer containing this stage (gets split up for dual stages).
-                Vector2 containingCell = this.FindClosestParent<Stage>().Parent!.DrawSize;
-
-                // Best effort until we have better mobile support.
-                if (RuntimeInfo.IsMobile)
-                {
-                    // These numbers are based on mobile phones, aspect ~1.92.
-                    float mobileAdjust = 2.83f * Math.Min(1, 7f / stageDefinition.Columns);
-                    // We should scale it back for cases like tablets which aren't so extreme.
-                    mobileAdjust *= (containingCell.X / containingCell.Y) / 1.92f;
-
-                    columns[i].Width *= mobileAdjust;
-                }
-            }
+                columns[i].Width *= mobileAdjust;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private void updateMobileSizing()
         {
-            if (!IsLoaded)
+            if (!IsLoaded || !RuntimeInfo.IsMobile)
                 return;
 
             for (int i = 0; i < stageDefinition.Columns; i++)


### PR DESCRIPTION
This now applies to all skins. I removed the special column adjust because it'd be a bit hard to get right across different skins. Hopefully this doesn't throw people off too much (we could probably just adjust argon across *all* devices back to 1.8 if so?).

Intentionally not running on invalidation to keep things simple.

Closes https://github.com/ppy/osu/issues/25440#issuecomment-1857354098.