### PR TITLE
Fix fallback column colors for legacy split stage mania skins

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaColumnElement.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaColumnElement.cs
@@ -34,7 +34,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                 FallbackColumnIndex = "S";
             else
             {
-                int distanceToEdge = Math.Min(Column.Index, (stage.Columns - 1) - Column.Index);
+                // Account for cases like dual-stage (assume that all stages have the same column count for now).
+                int columnInStage = Column.Index % stage.Columns;
+                int distanceToEdge = Math.Min(columnInStage, (stage.Columns - 1) - columnInStage);
                 FallbackColumnIndex = distanceToEdge % 2 == 0 ? "1" : "2";
             }
         }


### PR DESCRIPTION
the comment is copied from https://github.com/ppy/osu/blob/7caca905e37de78d8b5fd0b186953e2ce23d66f2/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs#L121-L122

this can be tested in the Skinning > Playfield mania visual test. the expected behavior is that each stage will have the same column coloring