### PR TITLE
Make osu! ruleset once again use the lazer default HP drain

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuHealthProcessor.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestNoBreak()
         {
-            OsuHealthProcessor hp = new OsuHealthProcessor(-1000);
+            OsuLegacyHealthProcessor hp = new OsuLegacyHealthProcessor(-1000);
             hp.ApplyBeatmap(new Beatmap<OsuHitObject>
             {
                 HitObjects =
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestSingleBreak()
         {
-            OsuHealthProcessor hp = new OsuHealthProcessor(-1000);
+            OsuLegacyHealthProcessor hp = new OsuLegacyHealthProcessor(-1000);
             hp.ApplyBeatmap(new Beatmap<OsuHitObject>
             {
                 HitObjects =
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestOverlappingBreak()
         {
-            OsuHealthProcessor hp = new OsuHealthProcessor(-1000);
+            OsuLegacyHealthProcessor hp = new OsuLegacyHealthProcessor(-1000);
             hp.ApplyBeatmap(new Beatmap<OsuHitObject>
             {
                 HitObjects =
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestSequentialBreak()
         {
-            OsuHealthProcessor hp = new OsuHealthProcessor(-1000);
+            OsuLegacyHealthProcessor hp = new OsuLegacyHealthProcessor(-1000);
             hp.ApplyBeatmap(new Beatmap<OsuHitObject>
             {
                 HitObjects =

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneOsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneOsuLegacyHealthProcessor.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Osu.Scoring;
 namespace osu.Game.Rulesets.Osu.Tests
 {
     [TestFixture]
-    public class TestSceneOsuHealthProcessor
+    public class TestSceneOsuLegacyHealthProcessor
     {
         [Test]
         public void TestNoBreak()

--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -18,7 +18,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableHitObject, IApplicableToDrawableRuleset<OsuHitObject>
+    public class OsuModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableHitObject, IApplicableToDrawableRuleset<OsuHitObject>, IApplicableHealthProcessor
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModStrictTracking)).ToArray();
 
@@ -33,6 +33,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         [SettingSource("Fade out hit circles earlier", "Make hit circles fade out into a miss, rather than after it.")]
         public Bindable<bool> FadeHitCircleEarly { get; } = new Bindable<bool>(true);
+
+        [SettingSource("Classic health", "More closely resembles the original HP drain mechanics.")]
+        public Bindable<bool> ClassicHealth { get; } = new Bindable<bool>(true);
 
         private bool usingHiddenFading;
 
@@ -115,5 +118,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 }
             };
         }
+
+        public HealthProcessor? CreateHealthProcessor(double drainStartTime) => ClassicHealth.Value ? new OsuLegacyHealthProcessor(drainStartTime) : null;
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -48,8 +48,6 @@ namespace osu.Game.Rulesets.Osu
 
         public override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor();
 
-        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new OsuHealthProcessor(drainStartTime);
-
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new OsuBeatmapConverter(beatmap, this);
 
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new OsuBeatmapProcessor(beatmap);

--- a/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
@@ -10,9 +10,9 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Osu.Scoring
 {
-    public partial class OsuHealthProcessor : LegacyDrainingHealthProcessor
+    public partial class OsuLegacyHealthProcessor : LegacyDrainingHealthProcessor
     {
-        public OsuHealthProcessor(double drainStartTime)
+        public OsuLegacyHealthProcessor(double drainStartTime)
             : base(drainStartTime)
         {
         }

--- a/osu.Game/Rulesets/Mods/IApplicableHealthProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableHealthProcessor.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    /// <summary>
+    /// Interface for a <see cref="Mod"/> that provides its own health processor.
+    /// </summary>
+    public interface IApplicableHealthProcessor
+    {
+        /// <summary>
+        /// Creates the <see cref="HealthProcessor"/>.
+        /// </summary>
+        HealthProcessor CreateHealthProcessor(double drainStartTime);
+    }
+}

--- a/osu.Game/Rulesets/Mods/IApplicableHealthProcessor.cs
+++ b/osu.Game/Rulesets/Mods/IApplicableHealthProcessor.cs
@@ -11,8 +11,8 @@ namespace osu.Game.Rulesets.Mods
     public interface IApplicableHealthProcessor
     {
         /// <summary>
-        /// Creates the <see cref="HealthProcessor"/>.
+        /// Creates the <see cref="HealthProcessor"/>. May be null to use the ruleset default.
         /// </summary>
-        HealthProcessor CreateHealthProcessor(double drainStartTime);
+        HealthProcessor? CreateHealthProcessor(double drainStartTime);
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -227,7 +227,8 @@ namespace osu.Game.Screens.Play
 
             dependencies.CacheAs(ScoreProcessor);
 
-            HealthProcessor = ruleset.CreateHealthProcessor(playableBeatmap.HitObjects[0].StartTime);
+            HealthProcessor = gameplayMods.OfType<IApplicableHealthProcessor>().FirstOrDefault()?.CreateHealthProcessor(playableBeatmap.HitObjects[0].StartTime);
+            HealthProcessor ??= ruleset.CreateHealthProcessor(playableBeatmap.HitObjects[0].StartTime);
             HealthProcessor.ApplyBeatmap(playableBeatmap);
 
             dependencies.CacheAs(HealthProcessor);


### PR DESCRIPTION
Playing around since the re-introduction of osu!stable's HP drain mechanics, I've become uncertain about using the osu!stable drain by default since it doesn't quite match the "feel" of osu!stable.

Most of my issues appear at higher HP drain rates, but with HR even on old maps the minimum is usually HP 8.4, which falls into the problematic region. I believe the difference is mostly where the judgements are placed - in osu!stable sliders have a big judgement at the end (300 + tick), whereas in lazer they have a medium-high judgement at the start (300) and a small judgement at the end (tick).  
The raw HP drain rate seems to be quite similar, and if anything osu!stable should be harsher on the cases I've found.

I've also attempted to make lazer stable better, but I haven't been able to get it "just right".

There are others that have wanted the old algorithm back, which pretty much echo what I've said above: https://github.com/ppy/osu/discussions/25631

So... This PR moves the osu!stable algorithm to the classic mod.

Here's a replay demonstrating this: https://drive.google.com/file/d/1-AEIhaVF2YfXVR9GYc8UFAnV7zfFFHvA/view?usp=sharing
Note that osu!stable will play with V1 mechanics, but V1 and V2 feel about the same (just accuracy is slightly worse on V2).