### PR TITLE
Populate MaxCombo scoring attrib for non-osu rulesets

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             attributes.BonusScoreRatio = legacyBonusScore == 0 ? 0 : (double)standardisedBonusScore / legacyBonusScore;
             attributes.BonusScore = legacyBonusScore;
+            attributes.MaxCombo = combo;
 
             return attributes;
         }

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
@@ -15,7 +15,11 @@ namespace osu.Game.Rulesets.Mania.Difficulty
     {
         public LegacyScoreAttributes Simulate(IWorkingBeatmap workingBeatmap, IBeatmap playableBeatmap)
         {
-            return new LegacyScoreAttributes { ComboScore = 1000000 };
+            return new LegacyScoreAttributes
+            {
+                ComboScore = 1000000,
+                MaxCombo = 0 // Max combo is mod-dependent, so any value here is insufficient.
+            };
         }
 
         public double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             attributes.BonusScoreRatio = legacyBonusScore == 0 ? 0 : (double)standardisedBonusScore / legacyBonusScore;
             attributes.BonusScore = legacyBonusScore;
+            attributes.MaxCombo = combo;
 
             return attributes;
         }


### PR DESCRIPTION
Was told of this IRL, though it isn't actually used anywhere during conversion for any ruleset other than osu!.