### PR TITLE
Fix collections dropdown crashing during storage migration

### DIFF
--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Collections
         {
             if (changes == null)
             {
+                filters.Clear();
                 filters.Add(allBeatmapsItem);
                 filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
                 if (ShowManageCollectionsItem)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25815.

`CollectionDropdown.collectionsChanged()` was assuming that if it received `null` changes, then it must mean that the change subscription is being initialised and the `filters` list will not contain any items.

However, that is not the only circumstance wherein a realm subscription can fire with `null` changes; that can also happen after the main realm instance gets recycled via the notification registration flow:

https://github.com/ppy/osu/blob/2f28a92f0a03c8aed6fac2ec7fb41f7ed865f798/osu.Game/Database/RealmAccess.cs#L545-L549

https://github.com/ppy/osu/blob/2f28a92f0a03c8aed6fac2ec7fb41f7ed865f798/osu.Game/Database/RealmAccess.cs#L1228-L1251

Therefore, to fix the crash, just ensure that the list is cleared every time.