### PR TITLE
Fix song select's carousel scroll position getting reset on background processing

### DIFF
--- a/osu.Game/Graphics/Containers/OsuScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/OsuScrollContainer.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Graphics.Containers
 
         private bool shouldPerformRightMouseScroll(MouseButtonEvent e) => RightMouseScrollbar && e.Button == MouseButton.Right;
 
-        private void scrollFromMouseEvent(MouseEvent e) =>
-            ScrollTo(Clamp(ToLocalSpace(e.ScreenSpaceMousePosition)[ScrollDim] / DrawSize[ScrollDim]) * Content.DrawSize[ScrollDim], true, DistanceDecayOnRightMouseScrollbar);
-
         private bool rightMouseDragging;
 
         protected override bool IsDragging => base.IsDragging || rightMouseDragging;
@@ -80,7 +77,7 @@ namespace osu.Game.Graphics.Containers
         {
             if (shouldPerformRightMouseScroll(e))
             {
-                scrollFromMouseEvent(e);
+                ScrollFromMouseEvent(e);
                 return true;
             }
 
@@ -91,7 +88,7 @@ namespace osu.Game.Graphics.Containers
         {
             if (rightMouseDragging)
             {
-                scrollFromMouseEvent(e);
+                ScrollFromMouseEvent(e);
                 return;
             }
 
@@ -128,6 +125,9 @@ namespace osu.Game.Graphics.Containers
 
             return base.OnScroll(e);
         }
+
+        protected virtual void ScrollFromMouseEvent(MouseEvent e) =>
+            ScrollTo(Clamp(ToLocalSpace(e.ScreenSpaceMousePosition)[ScrollDim] / DrawSize[ScrollDim]) * Content.DrawSize[ScrollDim], true, DistanceDecayOnRightMouseScrollbar);
 
         protected override ScrollbarContainer CreateScrollbar(Direction direction) => new OsuScrollbar(direction);
 

--- a/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
+++ b/osu.Game/Graphics/Containers/UserTrackingScrollContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
 
 namespace osu.Game.Graphics.Containers
 {
@@ -44,6 +45,12 @@ namespace osu.Game.Graphics.Containers
         {
             UserScrolling = false;
             base.ScrollIntoView(target, animated);
+        }
+
+        protected override void ScrollFromMouseEvent(MouseEvent e)
+        {
+            UserScrolling = true;
+            base.ScrollFromMouseEvent(e);
         }
 
         public new void ScrollTo(float value, bool animated = true, double? distanceDecay = null)


### PR DESCRIPTION

This only happened for users using absolute right-click scroll.