### PR TITLE
Fix song select realm refresh performance

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -464,6 +464,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 manager.Import(testBeatmapSetInfo);
             }, 10);
 
+            AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
+
             AddUntilStep("has selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID == originalOnlineSetID);
 
             Task<Live<BeatmapSetInfo>?> updateTask = null!;
@@ -475,6 +477,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                 updateTask = manager.ImportAsUpdate(new ProgressNotification(), new ImportTask(TestResources.GetQuickTestBeatmapForImport()), original.Value);
             });
             AddUntilStep("wait for update completion", () => updateTask.IsCompleted);
+
+            AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
 
             AddUntilStep("retained selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID == originalOnlineSetID);
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -464,8 +464,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                 manager.Import(testBeatmapSetInfo);
             }, 10);
 
-            AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
-
             AddUntilStep("has selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID, () => Is.EqualTo(originalOnlineSetID));
 
             Task<Live<BeatmapSetInfo>?> updateTask = null!;
@@ -477,8 +475,6 @@ namespace osu.Game.Tests.Visual.SongSelect
                 updateTask = manager.ImportAsUpdate(new ProgressNotification(), new ImportTask(TestResources.GetQuickTestBeatmapForImport()), original.Value);
             });
             AddUntilStep("wait for update completion", () => updateTask.IsCompleted);
-
-            AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
 
             AddUntilStep("retained selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID, () => Is.EqualTo(originalOnlineSetID));
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -466,7 +466,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
 
-            AddUntilStep("has selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID == originalOnlineSetID);
+            AddUntilStep("has selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID, () => Is.EqualTo(originalOnlineSetID));
 
             Task<Live<BeatmapSetInfo>?> updateTask = null!;
 
@@ -480,7 +480,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("Force realm refresh", () => Realm.Run(r => r.Refresh()));
 
-            AddUntilStep("retained selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID == originalOnlineSetID);
+            AddUntilStep("retained selection", () => songSelect!.Carousel.SelectedBeatmapInfo?.BeatmapSet?.OnlineID, () => Is.EqualTo(originalOnlineSetID));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.Select
             applyActiveCriteria(false);
 
             if (loadedTestBeatmaps)
-                invalidateAfterChange(true);
+                invalidateAfterChange();
 
             // Restore selection
             if (selectedBeatmapBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedBeatmapBefore.BeatmapSet!.ID, out var newSelectionCandidates))
@@ -298,7 +298,7 @@ namespace osu.Game.Screens.Select
                         removeBeatmapSet(id);
                 }
 
-                invalidateAfterChange(!BeatmapSetsLoaded);
+                invalidateAfterChange();
                 BeatmapSetsLoaded = true;
                 return;
             }
@@ -349,7 +349,7 @@ namespace osu.Game.Screens.Select
                 }
             }
 
-            invalidateAfterChange(!BeatmapSetsLoaded);
+            invalidateAfterChange();
         }
 
         private void beatmapsChanged(IRealmCollection<BeatmapInfo> sender, ChangeSet? changes)
@@ -378,7 +378,7 @@ namespace osu.Game.Screens.Select
             }
 
             if (changed)
-                invalidateAfterChange(true);
+                invalidateAfterChange();
         }
 
         private IQueryable<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);
@@ -386,7 +386,7 @@ namespace osu.Game.Screens.Select
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
         {
             removeBeatmapSet(beatmapSet.ID);
-            invalidateAfterChange(true);
+            invalidateAfterChange();
         });
 
         private void removeBeatmapSet(Guid beatmapSetID)
@@ -409,7 +409,7 @@ namespace osu.Game.Screens.Select
         public void UpdateBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
         {
             updateBeatmapSet(beatmapSet);
-            invalidateAfterChange(true);
+            invalidateAfterChange();
         });
 
         private void updateBeatmapSet(BeatmapSetInfo beatmapSet)
@@ -752,15 +752,14 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void invalidateAfterChange(bool invokeSetsChangedEvent)
+        private void invalidateAfterChange()
         {
             itemsCache.Invalidate();
 
             if (!Scroll.UserScrolling)
                 ScrollToSelected(true);
 
-            if (invokeSetsChangedEvent)
-                BeatmapSetsChanged?.Invoke();
+            BeatmapSetsChanged?.Invoke();
         }
 
         private float? scrollTarget;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -168,7 +168,10 @@ namespace osu.Game.Screens.Select
             applyActiveCriteria(false);
 
             if (loadedTestBeatmaps)
+            {
                 invalidateAfterChange();
+                BeatmapSetsLoaded = true;
+            }
 
             // Restore selection
             if (selectedBeatmapBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedBeatmapBefore.BeatmapSet!.ID, out var newSelectionCandidates))

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -168,7 +168,7 @@ namespace osu.Game.Screens.Select
             applyActiveCriteria(false);
 
             if (loadedTestBeatmaps)
-                signalBeatmapsLoaded();
+                invalidateAfterChange(true);
 
             // Restore selection
             if (selectedBeatmapBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedBeatmapBefore.BeatmapSet!.ID, out var newSelectionCandidates))
@@ -298,7 +298,8 @@ namespace osu.Game.Screens.Select
                         removeBeatmapSet(id);
                 }
 
-                signalBeatmapsLoaded();
+                invalidateAfterChange(!BeatmapSetsLoaded);
+                BeatmapSetsLoaded = true;
                 return;
             }
 
@@ -393,12 +394,7 @@ namespace osu.Game.Screens.Select
                 root.RemoveItem(set);
             }
 
-            itemsCache.Invalidate();
-
-            if (!Scroll.UserScrolling)
-                ScrollToSelected(true);
-
-            BeatmapSetsChanged?.Invoke();
+            invalidateAfterChange(true);
         });
 
         public void UpdateBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
@@ -465,12 +461,7 @@ namespace osu.Game.Screens.Select
                 }
             }
 
-            itemsCache.Invalidate();
-
-            if (!Scroll.UserScrolling)
-                ScrollToSelected(true);
-
-            BeatmapSetsChanged?.Invoke();
+            invalidateAfterChange(true);
         });
 
         /// <summary>
@@ -748,15 +739,15 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private void signalBeatmapsLoaded()
+        private void invalidateAfterChange(bool invokeSetsChangedEvent)
         {
-            if (!BeatmapSetsLoaded)
-            {
-                BeatmapSetsChanged?.Invoke();
-                BeatmapSetsLoaded = true;
-            }
-
             itemsCache.Invalidate();
+
+            if (!Scroll.UserScrolling)
+                ScrollToSelected(true);
+
+            if (invokeSetsChangedEvent)
+                BeatmapSetsChanged?.Invoke();
         }
 
         private float? scrollTarget;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -290,6 +290,8 @@ namespace osu.Game.Screens.Select
             {
                 foreach (var set in removeableSets)
                     removeBeatmapSet(set);
+
+                invalidateAfterChange();
             });
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -320,7 +320,7 @@ namespace osu.Game.Screens.Select
                 // To handle the beatmap update flow, attempt to track selection changes across delete-insert transactions.
                 // When an update occurs, the previous beatmap set is either soft or hard deleted.
                 // Check if the current selection was potentially deleted by re-querying its validity.
-                bool selectedSetMarkedDeleted = realm.Run(r => r.Find<BeatmapSetInfo>(SelectedBeatmapSet.ID))?.DeletePending != false;
+                bool selectedSetMarkedDeleted = sender.Realm.Find<BeatmapSetInfo>(SelectedBeatmapSet.ID)?.DeletePending != false;
 
                 int[] modifiedAndInserted = changes.NewModifiedIndices.Concat(changes.InsertedIndices).ToArray();
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Select
         /// <summary>
         /// The total count of non-filtered beatmaps displayed.
         /// </summary>
-        public int CountDisplayed => beatmapSets.Where(s => !s.Filtered.Value).Sum(s => s.Beatmaps.Count(b => !b.Filtered.Value));
+        public int CountDisplayed => beatmapSets.Where(s => !s.Filtered.Value).Sum(s => s.TotalItemsNotFiltered);
 
         /// <summary>
         /// The currently selected beatmap set.

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Screens.Select.Carousel
 
         public IReadOnlyList<CarouselItem> Items => items;
 
+        public int TotalItemsNotFiltered { get; private set; }
+
         private readonly List<CarouselItem> items = new List<CarouselItem>();
 
         /// <summary>
@@ -30,6 +32,9 @@ namespace osu.Game.Screens.Select.Carousel
         public virtual void RemoveItem(CarouselItem i)
         {
             items.Remove(i);
+
+            if (!i.Filtered.Value)
+                TotalItemsNotFiltered--;
 
             // it's important we do the deselection after removing, so any further actions based on
             // State.ValueChanged make decisions post-removal.
@@ -55,6 +60,9 @@ namespace osu.Game.Screens.Select.Carousel
                 // criteria may be null for initial population. the filtering will be applied post-add.
                 items.Add(i);
             }
+
+            if (!i.Filtered.Value)
+                TotalItemsNotFiltered--;
         }
 
         public CarouselGroup(List<CarouselItem>? items = null)
@@ -84,7 +92,14 @@ namespace osu.Game.Screens.Select.Carousel
         {
             base.Filter(criteria);
 
-            items.ForEach(c => c.Filter(criteria));
+            TotalItemsNotFiltered = 0;
+
+            foreach (var c in items)
+            {
+                c.Filter(criteria);
+                if (!c.Filtered.Value)
+                    TotalItemsNotFiltered++;
+            }
 
             // Sorting is expensive, so only perform if it's actually changed.
             if (lastCriteria?.Sort != criteria.Sort)

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             if (!i.Filtered.Value)
-                TotalItemsNotFiltered--;
+                TotalItemsNotFiltered++;
         }
 
         public CarouselGroup(List<CarouselItem>? items = null)

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -101,7 +100,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (State.Value != CarouselItemState.Selected) return;
 
             // we only perform eager selection if none of our items are in a selected state already.
-            if (Items.Any(i => i.State.Value == CarouselItemState.Selected)) return;
+            if (LastSelected?.State.Value == CarouselItemState.Selected || TotalItemsNotFiltered == 0) return;
 
             PerformSelection();
         }

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -100,7 +101,7 @@ namespace osu.Game.Screens.Select.Carousel
             if (State.Value != CarouselItemState.Selected) return;
 
             // we only perform eager selection if none of our items are in a selected state already.
-            if (LastSelected?.State.Value == CarouselItemState.Selected || TotalItemsNotFiltered == 0) return;
+            if (Items.Any(i => i.State.Value == CarouselItemState.Selected)) return;
 
             PerformSelection();
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                FilterApplied = () => Scheduler.Add(updateVisibleBeatmapCount),
+                FilterApplied = () => Scheduler.AddOnce(updateVisibleBeatmapCount),
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,7 +162,7 @@ namespace osu.Game.Screens.Select
                 BleedBottom = Footer.HEIGHT,
                 SelectionChanged = updateSelectedBeatmap,
                 BeatmapSetsChanged = carouselBeatmapsLoaded,
-                FilterApplied = updateVisibleBeatmapCount,
+                FilterApplied = () => Scheduler.Add(updateVisibleBeatmapCount),
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 
@@ -843,7 +843,7 @@ namespace osu.Game.Screens.Select
         private void carouselBeatmapsLoaded()
         {
             bindBindables();
-            updateVisibleBeatmapCount();
+            Scheduler.AddOnce(updateVisibleBeatmapCount);
 
             Carousel.AllowSelection = true;
 
@@ -877,7 +877,8 @@ namespace osu.Game.Screens.Select
         {
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).
-            FilterControl.InformationalText = Carousel.CountDisplayed != 1 ? $"{Carousel.CountDisplayed:#,0} matches" : $"{Carousel.CountDisplayed:#,0} match";
+            int carouselCountDisplayed = Carousel.CountDisplayed;
+            FilterControl.InformationalText = carouselCountDisplayed != 1 ? $"{carouselCountDisplayed:#,0} matches" : $"{carouselCountDisplayed:#,0} match";
         }
 
         private bool boundLocalBindables;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25824

Each commit is basically standalone.

If any are seen as hard-to-merge or break test expectations, we can cherry-pick the good ones for now.

87b7699fcc29ab7e70ec1f632a0341bbe08a23b9 takes things from <1 FPS to a substantially usable frame rate with occasional stutters.

The rest of the commits work to reduce the stutter down to <100ms.

Can be tested using [test database](https://drive.google.com/drive/folders/1SMSR5v2YdbKXd78JiBHrxzKnex76Tgml?usp=sharing)