### PR TITLE
Fix crash when creating collections named "All beatmaps" or "Manage collections..."

### DIFF
--- a/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/Collections/TestSceneManageCollectionsDialog.cs
@@ -167,6 +167,29 @@ namespace osu.Game.Tests.Visual.Collections
         }
 
         [Test]
+        public void TestCollectionNameCollisionsWithBuiltInItems()
+        {
+            AddStep("add dropdown", () =>
+            {
+                Add(new CollectionDropdown
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    RelativeSizeAxes = Axes.X,
+                    Width = 0.4f,
+                });
+            });
+            AddStep("add two collections which collide with default items", () => Realm.Write(r => r.Add(new[]
+            {
+                new BeatmapCollection(name: "All beatmaps"),
+                new BeatmapCollection(name: "Manage collections...")
+                {
+                    BeatmapMD5Hashes = { beatmapManager.GetAllUsableBeatmapSets().First().Beatmaps[0].MD5Hash }
+                },
+            })));
+        }
+
+        [Test]
         public void TestRemoveCollectionViaButton()
         {
             AddStep("add two collections", () => Realm.Write(r => r.Add(new[]

--- a/osu.Game/Collections/CollectionFilterMenuItem.cs
+++ b/osu.Game/Collections/CollectionFilterMenuItem.cs
@@ -37,22 +37,17 @@ namespace osu.Game.Collections
             CollectionName = name;
         }
 
-        public bool Equals(CollectionFilterMenuItem? other)
+        public virtual bool Equals(CollectionFilterMenuItem? other)
         {
-            if (other == null)
-                return false;
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
 
-            // collections may have the same name, so compare first on reference equality.
-            // this relies on the assumption that only one instance of the BeatmapCollection exists game-wide, managed by CollectionManager.
-            if (Collection != null)
-                return Collection.ID == other.Collection?.ID;
+            if (Collection == null) return false;
 
-            // fallback to name-based comparison.
-            // this is required for special dropdown items which don't have a collection (all beatmaps / manage collections items below).
-            return CollectionName == other.CollectionName;
+            return Collection.ID == other.Collection?.ID;
         }
 
-        public override int GetHashCode() => CollectionName.GetHashCode();
+        public override int GetHashCode() => Collection?.ID.GetHashCode() ?? 0;
     }
 
     public class AllBeatmapsCollectionFilterMenuItem : CollectionFilterMenuItem
@@ -61,6 +56,10 @@ namespace osu.Game.Collections
             : base("All beatmaps")
         {
         }
+
+        public override bool Equals(CollectionFilterMenuItem? other) => other is AllBeatmapsCollectionFilterMenuItem;
+
+        public override int GetHashCode() => 1;
     }
 
     public class ManageCollectionsFilterMenuItem : CollectionFilterMenuItem
@@ -69,5 +68,9 @@ namespace osu.Game.Collections
             : base("Manage collections...")
         {
         }
+
+        public override bool Equals(CollectionFilterMenuItem? other) => other is ManageCollectionsFilterMenuItem;
+
+        public override int GetHashCode() => 2;
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25834

The name fallback that was there previously since https://github.com/ppy/osu/pull/11892 was half broken. This way should be a lot less prone to failure.