### PR TITLE
Fix padding on dropdown search bar

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -397,7 +397,7 @@ namespace osu.Game.Graphics.UserInterface
 
             protected override DropdownSearchBar CreateSearchBar() => new OsuDropdownSearchBar
             {
-                Padding = new MarginPadding { Right = 36 },
+                Padding = new MarginPadding { Right = 26 },
             };
 
             private partial class OsuDropdownSearchBar : DropdownSearchBar


### PR DESCRIPTION
Reduces the padding on the dropdown search bar by 10 pixels, hiding the previously visible ellipsis on long dropdown items (e.g. skin names)

Closes #25779.