### PR TITLE
Fix mod search textbox having focus while settings are visible

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -572,7 +572,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestTextSearchActiveByDefault()
         {
-            configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, true);
+            AddStep("text search starts active", () => configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, true));
             createScreen();
 
             AddUntilStep("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
@@ -587,7 +587,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestTextSearchNotActiveByDefault()
         {
-            configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, false);
+            AddStep("text search does not start active", () => configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, false));
             createScreen();
 
             AddUntilStep("search text box not focused", () => !modSelectOverlay.SearchTextBox.HasFocus);
@@ -597,6 +597,31 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("press tab", () => InputManager.Key(Key.Tab));
             AddAssert("search text box unfocused", () => !modSelectOverlay.SearchTextBox.HasFocus);
+        }
+
+        [Test]
+        public void TestTextSearchDoesNotBlockCustomisationPanelKeyboardInteractions()
+        {
+            AddStep("text search starts active", () => configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, true));
+            createScreen();
+
+            AddUntilStep("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+
+            AddStep("select DT", () => SelectedMods.Value = new Mod[] { new OsuModDoubleTime() });
+            AddAssert("DT selected", () => modSelectOverlay.ChildrenOfType<ModPanel>().Count(panel => panel.Active.Value), () => Is.EqualTo(1));
+
+            AddStep("open customisation area", () => modSelectOverlay.CustomisationButton!.TriggerClick());
+            assertCustomisationToggleState(false, true);
+            AddStep("hover over mod settings slider", () =>
+            {
+                var slider = modSelectOverlay.ChildrenOfType<ModSettingsArea>().Single().ChildrenOfType<OsuSliderBar<double>>().First();
+                InputManager.MoveMouseTo(slider);
+            });
+            AddStep("press right arrow", () => InputManager.PressKey(Key.Right));
+            AddAssert("DT speed changed", () => !SelectedMods.Value.OfType<OsuModDoubleTime>().Single().SpeedChange.IsDefault);
+
+            AddStep("close customisation area", () => InputManager.PressKey(Key.Escape));
+            AddUntilStep("search text box reacquired focus", () => modSelectOverlay.SearchTextBox.HasFocus);
         }
 
         [Test]

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -132,6 +132,8 @@ namespace osu.Game.Overlays.Mods
         protected ShearedToggleButton? CustomisationButton { get; private set; }
         protected SelectAllModsButton? SelectAllModsButton { get; set; }
 
+        private bool textBoxShouldFocus;
+
         private Sample? columnAppearSample;
 
         private WorkingBeatmap? beatmap;
@@ -510,9 +512,9 @@ namespace osu.Game.Overlays.Mods
             TopLevelContent.MoveToY(-modAreaHeight, transition_duration, Easing.InOutCubic);
 
             if (customisationVisible.Value)
-                GetContainingInputManager().ChangeFocus(modSettingsArea);
+                SearchTextBox.KillFocus();
             else
-                Scheduler.Add(() => GetContainingInputManager().ChangeFocus(null));
+                setTextBoxFocus(textBoxShouldFocus);
         }
 
         /// <summary>
@@ -626,8 +628,7 @@ namespace osu.Game.Overlays.Mods
                 nonFilteredColumnCount += 1;
             }
 
-            if (textSearchStartsActive.Value)
-                SearchTextBox.HoldFocus = true;
+            setTextBoxFocus(textSearchStartsActive.Value);
         }
 
         protected override void PopOut()
@@ -766,10 +767,18 @@ namespace osu.Game.Overlays.Mods
                 return false;
 
             // TODO: should probably eventually support typical platform search shortcuts (`Ctrl-F`, `/`)
-            SearchTextBox.HoldFocus = !SearchTextBox.HoldFocus;
-            if (SearchTextBox.HoldFocus)
-                SearchTextBox.TakeFocus();
+            setTextBoxFocus(!textBoxShouldFocus);
             return true;
+        }
+
+        private void setTextBoxFocus(bool keepFocus)
+        {
+            textBoxShouldFocus = keepFocus;
+
+            if (textBoxShouldFocus)
+                SearchTextBox.TakeFocus();
+            else
+                SearchTextBox.KillFocus();
         }
 
         #endregion

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -508,6 +508,11 @@ namespace osu.Game.Overlays.Mods
 
             modSettingsArea.ResizeHeightTo(modAreaHeight, transition_duration, Easing.InOutCubic);
             TopLevelContent.MoveToY(-modAreaHeight, transition_duration, Easing.InOutCubic);
+
+            if (customisationVisible.Value)
+                GetContainingInputManager().ChangeFocus(modSettingsArea);
+            else
+                Scheduler.Add(() => GetContainingInputManager().ChangeFocus(null));
         }
 
         /// <summary>
@@ -622,7 +627,7 @@ namespace osu.Game.Overlays.Mods
             }
 
             if (textSearchStartsActive.Value)
-                SearchTextBox.TakeFocus();
+                SearchTextBox.HoldFocus = true;
         }
 
         protected override void PopOut()
@@ -761,11 +766,9 @@ namespace osu.Game.Overlays.Mods
                 return false;
 
             // TODO: should probably eventually support typical platform search shortcuts (`Ctrl-F`, `/`)
-            if (SearchTextBox.HasFocus)
-                SearchTextBox.KillFocus();
-            else
+            SearchTextBox.HoldFocus = !SearchTextBox.HoldFocus;
+            if (SearchTextBox.HoldFocus)
                 SearchTextBox.TakeFocus();
-
             return true;
         }
 

--- a/osu.Game/Overlays/Mods/ModSettingsArea.cs
+++ b/osu.Game/Overlays/Mods/ModSettingsArea.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        public override bool AcceptsFocus => true;
+
         public ModSettingsArea()
         {
             RelativeSizeAxes = Axes.X;


### PR DESCRIPTION
Stopped arrow key adjust on slider bars from working.

Also just felt wrong that you could type into an off-screen textbox.


Closes https://github.com/ppy/osu/issues/25842