### PR TITLE
Fix opening log files from notification not presenting the correct file

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1190,7 +1190,7 @@ namespace osu.Game
                 }
                 else if (recentLogCount == short_term_display_limit)
                 {
-                    string logFile = $@"{entry.Target.Value.ToString().ToLowerInvariant()}.log";
+                    string logFile = Logger.GetLogger(entry.Target.Value).Filename;
 
                     Schedule(() => Notifications.Post(new SimpleNotification
                     {
@@ -1198,7 +1198,7 @@ namespace osu.Game
                         Text = NotificationsStrings.SubsequentMessagesLogged,
                         Activated = () =>
                         {
-                            Storage.GetStorageForDirectory(@"logs").PresentFileExternally(logFile);
+                            Logger.Storage.PresentFileExternally(logFile);
                             return true;
                         }
                     }));


### PR DESCRIPTION
- Regressed with https://github.com/ppy/osu-framework/pull/6063

Minor issue. The logs folder would open normally, but the relevant `.log` file would not be selected/highlighted.

Kinda weird how `LogEntry` doesn't include a `Logger` field, but does have `Target` and `LoggerName` which can be used to retrieve the logger.