### PR TITLE
Fix osu! standardised score conversion sometimes exceeding bounds

### DIFF
--- a/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
@@ -127,8 +127,11 @@ namespace osu.Game.Tests.Database
             });
         }
 
+        [TestCase(30000001)]
         [TestCase(30000002)]
         [TestCase(30000003)]
+        [TestCase(30000004)]
+        [TestCase(30000005)]
         public void TestScoreUpgradeSuccess(int scoreVersion)
         {
             ScoreInfo scoreInfo = null!;

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -316,8 +316,7 @@ namespace osu.Game
 
             HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(r.All<ScoreInfo>()
                                                                              .Where(s => !s.BackgroundReprocessingFailed && s.BeatmapInfo != null
-                                                                                                                         && (s.TotalScoreVersion == 30000002
-                                                                                                                             || s.TotalScoreVersion == 30000003))
+                                                                                                                         && s.TotalScoreVersion < LegacyScoreEncoder.LATEST_VERSION)
                                                                              .AsEnumerable().Select(s => s.ID)));
 
             Logger.Log($"Found {scoreIds.Count} scores which require total score conversion.");

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -305,11 +305,10 @@ namespace osu.Game.Database
                     // The clamp from below to `comboPortionFromLongestComboInScoreV1` targets near-FC scores wherein
                     // the player had bad accuracy at the end of their longest combo, which causes the division by accuracy
                     // to underestimate the combo portion.
-                    // The clamp from above to `maximumAchievableComboPortionInScoreV1` targets FC scores wherein
-                    // the player had bad accuracy at the start of the map, which causes the division by accuracy
-                    // to overestimate the combo portion.
-                    double comboPortionInScoreV1 = Math.Clamp(maximumAchievableComboPortionInScoreV1 * comboProportion / score.Accuracy,
-                        comboPortionFromLongestComboInScoreV1, maximumAchievableComboPortionInScoreV1);
+                    // Ideally, this would be clamped from above to `maximumAchievableComboPortionInScoreV1` too,
+                    // but in practice this appears to fail for some scores (https://github.com/ppy/osu/pull/25876#issuecomment-1862248413).
+                    // TODO: investigate the above more closely
+                    double comboPortionInScoreV1 = Math.Max(maximumAchievableComboPortionInScoreV1 * comboProportion / score.Accuracy, comboPortionFromLongestComboInScoreV1);
 
                     // Calculate how many times the longest combo the user has achieved in the play can repeat
                     // without exceeding the combo portion in score V1 as achieved by the player.

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Database
             if (score.IsLegacyScore)
                 return false;
 
-            if (score.TotalScoreVersion > 30000004)
+            if (score.TotalScoreVersion > 30000005)
                 return false;
 
             // Recalculate the old-style standardised score to see if this was an old lazer score.

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Database
             if (score.IsLegacyScore)
                 return false;
 
-            if (score.TotalScoreVersion > 30000005)
+            if (score.TotalScoreVersion > 30000002)
                 return false;
 
             // Recalculate the old-style standardised score to see if this was an old lazer score.

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -32,9 +32,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000003: First version after converting legacy total score to standardised.</description></item>
         /// <item><description>30000004: Fixed mod multipliers during legacy score conversion. Reconvert all scores.</description></item>
         /// <item><description>30000005: Introduce combo exponent in the osu! gamemode. Reconvert all scores.</description></item>
+        /// <item><description>30000006: Fix edge cases in conversion after combo exponent introduction that lead to NaNs. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000005;
+        public const int LATEST_VERSION = 30000006;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25860.

Concept of the change provided by @Zyfarok.

Users reported that some stable scores would convert to large negative total scores in lazer after the introduction of combo exponent. Those large negative total scores were actually mangled NaNs.

The root cause of this was the following calculation going below zero unexpectedly:

https://github.com/ppy/osu/blob/8e8d9b2cd96be4c4b3d8f1f01dc013fc9d41f765/osu.Game/Database/StandardisedScoreMigrationTools.cs#L323

which then propagates negative numbers onward until

https://github.com/ppy/osu/blob/8e8d9b2cd96be4c4b3d8f1f01dc013fc9d41f765/osu.Game/Database/StandardisedScoreMigrationTools.cs#L337

which yields a NaN due to attempting to take the square root of a negative number.

To fix, clamp `comboPortionInScoreV1` to sane limits: to `comboPortionFromLongestComboInScoreV1` from below, and to `maximumAchievableComboPortionInScoreV1` from above. This is a less direct fix than perhaps imagined, but it seems like a better one as it will also affect the calculation of both the lower and the upper estimate of the score.