### PR TITLE
Fix slider sample playing before the slider begins

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     drawableHitObject.AccentColour.Value = colour.NewValue;
             }, true);
 
-            Tracking.BindValueChanged(updateSlidingSample);
+            TrackingInValidTimeRange.BindValueChanged(updateSlidingSample);
         }
 
         protected override void OnApply()
@@ -166,9 +166,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             slidingSample?.Stop();
         }
 
-        private void updateSlidingSample(ValueChangedEvent<bool> tracking)
+        private void updateSlidingSample(ValueChangedEvent<bool> trackingInValidTimeRange)
         {
-            if (tracking.NewValue)
+            if (trackingInValidTimeRange.NewValue)
                 slidingSample?.Play();
             else
                 slidingSample?.Stop();
@@ -231,12 +231,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         }
 
         public readonly Bindable<bool> Tracking = new Bindable<bool>();
+        public readonly Bindable<bool> TrackingInValidTimeRange = new Bindable<bool>();
 
         protected override void Update()
         {
             base.Update();
 
             Tracking.Value = SliderInputManager.Tracking;
+            TrackingInValidTimeRange.Value = SliderInputManager.TrackingInValidTimeRange;
 
             if (Tracking.Value && slidingSample != null)
                 // keep the sliding sample playing at the current tracking position

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/SliderInputManager.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/SliderInputManager.cs
@@ -22,6 +22,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         public bool Tracking { get; private set; }
 
         /// <summary>
+        /// Whether the slider is currently being tracked in valid time range.
+        /// </summary>
+        public bool TrackingInValidTimeRange { get; private set; }
+
+        /// <summary>
         /// The point in time after which we can accept any key for tracking. Before this time, we may need to restrict tracking to the key used to hit the head circle.
         ///
         /// This is a requirement to stop the case where a player holds down one key (from before the slider) and taps the second key while maintaining full scoring (tracking) of sliders.
@@ -235,6 +240,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 && isValidTrackingPosition
                 // valid action
                 && (actions?.Any(isValidTrackingAction) ?? false);
+
+            // whether the sliding sample should be played
+            TrackingInValidTimeRange = Tracking && Time.Current >= slider.HitObject.StartTime;
 
             lastPressedActions.Clear();
             if (actions != null)


### PR DESCRIPTION
Fixes an issue introduced by #25748 whereby the sliding sample sound can be played before the slider begins.

Closes #25870.