### PR TITLE
Restore taiko accuracy to ScoreV2 values

### DIFF
--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Scoring
         }
 
         protected override double GetComboScoreChange(JudgementResult result)
-            => Judgement.ToNumericResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
+            => GetNumericResultFor(result) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
 
         public override ScoreRank RankFromAccuracy(double accuracy)
         {

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Mania.Scoring
         }
 
         protected override double GetComboScoreChange(JudgementResult result)
-            => Judgement.ToNumericResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
+            => GetNumericResultFor(result) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
 
         private class JudgementOrderComparer : IComparer<HitObject>
         {

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoScoreProcessorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoScoreProcessorTest.cs
@@ -13,7 +13,7 @@ using osu.Game.Rulesets.Taiko.Scoring;
 namespace osu.Game.Rulesets.Taiko.Tests
 {
     [TestFixture]
-    public class TestSceneTaikoScoreProcessor
+    public class TaikoScoreProcessorTest
     {
         [Test]
         public void TestInaccurateHitScore()

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoScoreProcessor.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Judgements;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Scoring;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    [TestFixture]
+    public class TestSceneTaikoScoreProcessor
+    {
+        [Test]
+        public void TestInaccurateHitScore()
+        {
+            var beatmap = new Beatmap<HitObject>
+            {
+                HitObjects =
+                {
+                    new Hit(),
+                    new Hit { StartTime = 1000 }
+                }
+            };
+
+            var scoreProcessor = new TaikoScoreProcessor();
+            scoreProcessor.ApplyBeatmap(beatmap);
+
+            // Apply a miss judgement
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new TaikoJudgement()) { Type = HitResult.Great });
+            scoreProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], new TaikoJudgement()) { Type = HitResult.Ok });
+
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(453745));
+            Assert.That(scoreProcessor.Accuracy.Value, Is.EqualTo(0.75).Within(0.0001));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -33,6 +33,17 @@ namespace osu.Game.Rulesets.Taiko.Scoring
                    * strongScaleValue(result);
         }
 
+        protected override double GetNumericResultFor(JudgementResult result)
+        {
+            switch (result.Type)
+            {
+                case HitResult.Ok:
+                    return 150;
+            }
+
+            return base.GetNumericResultFor(result);
+        }
+
         private double strongScaleValue(JudgementResult result)
         {
             if (result.HitObject is StrongNestedHitObject strong)

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Scoring
 
         protected override double GetComboScoreChange(JudgementResult result)
         {
-            return Judgement.ToNumericResult(result.Type)
+            return GetNumericResultFor(result)
                    * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base))
                    * strongScaleValue(result);
         }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -227,12 +227,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore += Judgement.ToNumericResult(result.Judgement.MaxResult);
+                currentMaximumBaseScore += GetMaxNumericResultFor(result);
                 currentAccuracyJudgementCount++;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore += Judgement.ToNumericResult(result.Type);
+                currentBaseScore += GetNumericResultFor(result);
 
             if (result.Type.IsBonus())
                 currentBonusPortion += GetBonusScoreChange(result);
@@ -276,12 +276,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore -= Judgement.ToNumericResult(result.Judgement.MaxResult);
+                currentMaximumBaseScore -= GetMaxNumericResultFor(result);
                 currentAccuracyJudgementCount--;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore -= Judgement.ToNumericResult(result.Type);
+                currentBaseScore -= GetNumericResultFor(result);
 
             if (result.Type.IsBonus())
                 currentBonusPortion -= GetBonusScoreChange(result);
@@ -297,9 +297,21 @@ namespace osu.Game.Rulesets.Scoring
             updateScore();
         }
 
-        protected virtual double GetBonusScoreChange(JudgementResult result) => Judgement.ToNumericResult(result.Type);
+        protected virtual double GetBonusScoreChange(JudgementResult result) => GetNumericResultFor(result);
 
-        protected virtual double GetComboScoreChange(JudgementResult result) => Judgement.ToNumericResult(result.Judgement.MaxResult) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
+        protected virtual double GetComboScoreChange(JudgementResult result) => GetMaxNumericResultFor(result) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
+
+        /// <summary>
+        /// Retrieves the numeric score representation for a <see cref="JudgementResult"/>.
+        /// </summary>
+        /// <param name="result">The <see cref="JudgementResult"/>.</param>
+        protected virtual double GetNumericResultFor(JudgementResult result) => result.Judgement.NumericResultFor(result);
+
+        /// <summary>
+        /// Retrieves the maximum numeric score representation for a <see cref="JudgementResult"/>.
+        /// </summary>
+        /// <param name="result">The <see cref="JudgementResult"/>.</param>
+        protected virtual double GetMaxNumericResultFor(JudgementResult result) => result.Judgement.MaxNumericResult;
 
         protected virtual void ApplyScoreChange(JudgementResult result)
         {


### PR DESCRIPTION
This has been brought up as an inconsistency several times:
- Closes https://github.com/ppy/osu/discussions/25882
- Fixes https://github.com/ppy/osu/issues/9087

Note that this doesn't fix the accuracy circle/grade issue - that's an issue for all rulesets.