### PR TITLE
Fix incorrect ordering of items at song select when certain sort modes are used

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Screens.Select.Carousel
             items.ForEach(c => c.Filter(criteria));
 
             // Sorting is expensive, so only perform if it's actually changed.
-            if (lastCriteria?.Sort != criteria.Sort)
+            if (lastCriteria?.RequiresSorting(criteria) != false)
             {
                 criteriaComparer = Comparer<CarouselItem>.Create((x, y) =>
                 {

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -253,7 +253,7 @@ namespace osu.Game.Screens.Select
                     return true;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(Sort), Sort, "Unknown sort mode");
             }
         }
 

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -219,6 +219,44 @@ namespace osu.Game.Screens.Select
             public bool Equals(OptionalTextFilter other) => SearchTerm == other.SearchTerm;
         }
 
+        /// <summary>
+        /// Given a new filter criteria, decide whether a full sort needs to be performed.
+        /// </summary>
+        /// <param name="newCriteria"></param>
+        /// <returns></returns>
+        public bool RequiresSorting(FilterCriteria newCriteria)
+        {
+            if (Sort != newCriteria.Sort)
+                return true;
+
+            switch (Sort)
+            {
+                // Some sorts are stable across all other changes.
+                // Running these sorts will sort all items, including currently hidden items.
+                case SortMode.Artist:
+                case SortMode.Author:
+                case SortMode.DateSubmitted:
+                case SortMode.DateAdded:
+                case SortMode.DateRanked:
+                case SortMode.Source:
+                case SortMode.Title:
+                    return false;
+
+                // Some sorts use aggregate max comparisons, which will change based on filtered items.
+                // These sorts generally ignore items hidden by filtered state, so we must force a sort under all circumstances here.
+                //
+                // This makes things very slow when typing a text search, and we probably want to consider a way to optimise things going forward.
+                case SortMode.LastPlayed:
+                case SortMode.BPM:
+                case SortMode.Length:
+                case SortMode.Difficulty:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
         public enum MatchMode
         {
             /// <summary>


### PR DESCRIPTION
This is quite an unfortunate one, but I can't see a good way of fixing beyond a "revert" for now. Which is to say, it reverts behaviour for the sort modes which will obviously fail due to oversights, but keeps the optimisation in place for the others. Unfortunately this affects most of the commonly used sort modes.

Basically, some sort modes rely on aggregating a "max" value for each `CarouselBeatmapSet`, which is then used to sort the full carousel. The value of this "max" will change as a constraining filter is applied, since it only aggregates visible beatmaps:

https://github.com/ppy/osu/blob/87d0bef313fc9e5563dc3d368f3daf59b437c6aa/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs#L127-L142

The optimisation applied in https://github.com/ppy/osu/pull/25679 assumed that sorting was applied to all sets (even filtered ones), but the above smashes a hole in this theory. Here are two failing cases:

---

https://github.com/ppy/osu/issues/25820

- Ruleset is changed while difficulty sort is enabled

In this case, we actually need to run a full sort, specifically for the difficulty sort type. I haven't special-cased this for now, but if we ever re-apply optimisation in the future it will need to be considered.

---

https://github.com/ppy/osu/issues/25820#issuecomment-1860392556

- Difficulty sort is enabled
- Text criteria entered, filtering (hiding) some panels
- Current beatmap is updated, causing a `Carousel.UpdateBeatmapSet` – this is common when playing the beatmap as the `LastPlayed` will be updated

In this case, the beatmap will be added back to the carousel group using `BinarySearch`:

https://github.com/ppy/osu/blob/44efa2c540c392c998af7cd052a88d35d053aa5b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs#L44-L52

But due to some items being hidden when the last sort was applied, the binary search will not run successfully. I believe this case can be improved with some further thinking (sort could be run more comprehensively on filtered-away sets), but another more amicable path may be to cache the aggregate max value on a `BeatmapSet` (and only invalidating when count of difficulties changes), reducing the overhead of these filter operations massively.

Closes https://github.com/ppy/osu/issues/25820.

Note that I haven't added tests for now. I might get to it later or someone else might beat me. It's not going to be easy to test either of these – one needs fake star rating changes based on ruleset, which as far as i can tell won't be easy, the other needs a test crafted specifically to break `BinarySearch`, which I couldn't make happpen on a quick attempt.