### PR TITLE
Fix some beatmaps being reprocessed each startup

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -59,23 +59,26 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         {
             double roundedCircleSize = Math.Round(difficulty.CircleSize);
 
-            if (new ManiaRuleset().RulesetInfo.Equals(difficulty.SourceRuleset))
+            if (difficulty.SourceRuleset.ShortName == ManiaRuleset.SHORT_NAME)
                 return (int)Math.Max(1, roundedCircleSize);
 
             double roundedOverallDifficulty = Math.Round(difficulty.OverallDifficulty);
 
-            int countSliderOrSpinner = difficulty.EndTimeObjectCount;
+            if (difficulty.TotalObjectCount > 0 && difficulty.EndTimeObjectCount >= 0)
+            {
+                int countSliderOrSpinner = difficulty.EndTimeObjectCount;
 
-            // In osu!stable, this division appears as if it happens on floats, but due to release-mode
-            // optimisations, it actually ends up happening on doubles.
-            double percentSpecialObjects = (double)countSliderOrSpinner / difficulty.TotalObjectCount;
+                // In osu!stable, this division appears as if it happens on floats, but due to release-mode
+                // optimisations, it actually ends up happening on doubles.
+                double percentSpecialObjects = (double)countSliderOrSpinner / difficulty.TotalObjectCount;
 
-            if (percentSpecialObjects < 0.2)
-                return 7;
-            if (percentSpecialObjects < 0.3 || roundedCircleSize >= 5)
-                return roundedOverallDifficulty > 5 ? 7 : 6;
-            if (percentSpecialObjects > 0.6)
-                return roundedOverallDifficulty > 4 ? 5 : 4;
+                if (percentSpecialObjects < 0.2)
+                    return 7;
+                if (percentSpecialObjects < 0.3 || roundedCircleSize >= 5)
+                    return roundedOverallDifficulty > 5 ? 7 : 6;
+                if (percentSpecialObjects > 0.6)
+                    return roundedOverallDifficulty > 4 ? 5 : 4;
+            }
 
             return Math.Max(4, Math.Min((int)roundedOverallDifficulty + 1, 7));
         }

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -196,7 +196,7 @@ namespace osu.Game
 
             realmAccess.Run(r =>
             {
-                foreach (var b in r.All<BeatmapInfo>().Where(b => b.TotalObjectCount == 0))
+                foreach (var b in r.All<BeatmapInfo>().Where(b => b.TotalObjectCount < 0 || b.EndTimeObjectCount < 0))
                     beatmapIds.Add(b.ID);
             });
 

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -120,9 +120,9 @@ namespace osu.Game.Beatmaps
         [JsonIgnore]
         public bool Hidden { get; set; }
 
-        public int EndTimeObjectCount { get; set; }
+        public int EndTimeObjectCount { get; set; } = -1;
 
-        public int TotalObjectCount { get; set; }
+        public int TotalObjectCount { get; set; } = -1;
 
         /// <summary>
         /// Reset any fetched online linking information (and history).

--- a/osu.Game/Beatmaps/IBeatmapInfo.cs
+++ b/osu.Game/Beatmaps/IBeatmapInfo.cs
@@ -59,11 +59,13 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// The basic star rating for this beatmap (with no mods applied).
+        /// Defaults to -1 (meaning not-yet-calculated).
         /// </summary>
         double StarRating { get; }
 
         /// <summary>
         /// The number of hitobjects in the beatmap with a distinct end time.
+        /// Defaults to -1 (meaning not-yet-calculated).
         /// </summary>
         /// <remarks>
         /// Canonically, these are hitobjects are either sliders or spinners.
@@ -72,6 +74,7 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// The total number of hitobjects in the beatmap.
+        /// Defaults to -1 (meaning not-yet-calculated).
         /// </summary>
         int TotalObjectCount { get; }
     }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -89,8 +89,9 @@ namespace osu.Game.Database
         /// 35   2023-10-16    Clear key combinations of keybindings that are assigned to more than one action in a given settings section.
         /// 36   2023-10-26    Add LegacyOnlineID to ScoreInfo. Move osu_scores_*_high IDs stored in OnlineID to LegacyOnlineID. Reset anomalous OnlineIDs.
         /// 38   2023-12-10    Add EndTimeObjectCount and TotalObjectCount to BeatmapInfo.
+        /// 39   2023-12-19    Migrate any EndTimeObjectCount and TotalObjectCount values of 0 to -1 to better identify non-calculated values.
         /// </summary>
-        private const int schema_version = 38;
+        private const int schema_version = 39;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1095,6 +1096,20 @@ namespace osu.Game.Database
 
                     break;
                 }
+
+                case 39:
+                    foreach (var b in migration.NewRealm.All<BeatmapInfo>())
+                    {
+                        // Either actually no objects, or processing ran and failed.
+                        // Reset to -1 so the next time they become zero we know that processing was attempted.
+                        if (b.TotalObjectCount == 0 && b.EndTimeObjectCount == 0)
+                        {
+                            b.TotalObjectCount = -1;
+                            b.EndTimeObjectCount = -1;
+                        }
+                    }
+
+                    break;
             }
 
             Logger.Log($"Migration completed in {stopwatch.ElapsedMilliseconds}ms");


### PR DESCRIPTION
- closes https://github.com/ppy/osu/issues/25910

Had this happen for around 190 beatmaps on every startup. Follows by example (`StarRating` also does similarly use `-1` as default).