### PR TITLE
Update song select to always show difficulty stats

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.Ruleset, string.Empty);
             SetDefault(OsuSetting.Skin, SkinInfo.ARGON_SKIN.ToString());
 
-            SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Details);
+            SetDefault(OsuSetting.BeatmapDetailTab, PlayBeatmapDetailArea.TabType.Local);
             SetDefault(OsuSetting.BeatmapDetailModsFilter, false);
 
             SetDefault(OsuSetting.ShowConvertedBeatmaps, true);

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -19,7 +18,6 @@ using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Screens.Select.Details;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Select
 {
@@ -70,21 +68,12 @@ namespace osu.Game.Screens.Select
             CornerRadius = 10;
             Masking = true;
 
-            EdgeEffect = new EdgeEffectParameters
-            {
-                Type = EdgeEffectType.Glow,
-                Hollow = true,
-                Colour = new Color4(130, 204, 255, 15),
-                Radius = 10,
-            };
-
             Children = new Drawable[]
             {
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = new Color4(130, 204, 255, 40),
-                    Blending = BlendingParameters.Additive,
+                    Colour = Colour4.Black.Opacity(0.3f),
                 },
                 new Container
                 {

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -28,7 +28,6 @@ namespace osu.Game.Screens.Select
         private const float spacing = 10;
         private const float transition_duration = 250;
 
-        private readonly AdvancedStats advanced;
         private readonly UserRatings ratingsDisplay;
         private readonly MetadataSection description, source, tags;
         private readonly Container failRetryContainer;
@@ -109,12 +108,6 @@ namespace osu.Game.Screens.Select
                                                 Padding = new MarginPadding { Right = spacing / 2 },
                                                 Children = new[]
                                                 {
-                                                    new DetailBox().WithChild(advanced = new AdvancedStats
-                                                    {
-                                                        RelativeSizeAxes = Axes.X,
-                                                        AutoSizeAxes = Axes.Y,
-                                                        Padding = new MarginPadding { Horizontal = spacing, Top = spacing * 2, Bottom = spacing },
-                                                    }),
                                                     new DetailBox().WithChild(new OnlineViewContainer(string.Empty)
                                                     {
                                                         RelativeSizeAxes = Axes.X,
@@ -180,7 +173,6 @@ namespace osu.Game.Screens.Select
 
         private void updateStatistics()
         {
-            advanced.BeatmapInfo = BeatmapInfo;
             description.Metadata = BeatmapInfo?.DifficultyName ?? string.Empty;
             source.Metadata = BeatmapInfo?.Metadata.Source ?? string.Empty;
             tags.Metadata = BeatmapInfo?.Metadata.Tags ?? string.Empty;

--- a/osu.Game/Screens/Select/BeatmapDetails.cs
+++ b/osu.Game/Screens/Select/BeatmapDetails.cs
@@ -3,9 +3,9 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -67,12 +67,24 @@ namespace osu.Game.Screens.Select
 
         public BeatmapDetails()
         {
+            CornerRadius = 10;
+            Masking = true;
+
+            EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Hollow = true,
+                Colour = new Color4(130, 204, 255, 15),
+                Radius = 10,
+            };
+
             Children = new Drawable[]
             {
                 new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.Black.Opacity(0.5f),
+                    Colour = new Color4(130, 204, 255, 40),
+                    Blending = BlendingParameters.Additive,
                 },
                 new Container
                 {
@@ -122,7 +134,8 @@ namespace osu.Game.Screens.Select
                                             },
                                             new OsuScrollContainer
                                             {
-                                                RelativeSizeAxes = Axes.Both,
+                                                RelativeSizeAxes = Axes.X,
+                                                Height = 250,
                                                 Width = 0.5f,
                                                 ScrollbarVisible = false,
                                                 Padding = new MarginPadding { Left = spacing / 2 },
@@ -271,11 +284,6 @@ namespace osu.Game.Screens.Select
 
                 InternalChildren = new Drawable[]
                 {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.Black.Opacity(0.5f),
-                    },
                     content = new Container
                     {
                         RelativeSizeAxes = Axes.X,

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -305,7 +305,7 @@ namespace osu.Game.Screens.Select
                             },
                             infoLabelContainer = new FillFlowContainer
                             {
-                                Margin = new MarginPadding { Top = 20 },
+                                Margin = new MarginPadding { Top = 8 },
                                 Spacing = new Vector2(20, 0),
                                 AutoSizeAxes = Axes.Both,
                             }

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Select
             {
                 Type = EdgeEffectType.Glow,
                 Colour = new Color4(130, 204, 255, 150),
-                Radius = 20,
+                Radius = 15,
                 Roundness = 15,
             };
         }

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -311,23 +311,36 @@ namespace osu.Game.Screens.Select.Details
                             Font = OsuFont.GetFont(size: 12)
                         },
                     },
-                    bar = new Bar
+                    new Container
                     {
-                        Origin = Anchor.CentreLeft,
-                        Anchor = Anchor.CentreLeft,
-                        RelativeSizeAxes = Axes.X,
-                        Height = 5,
-                        BackgroundColour = Color4.White.Opacity(0.5f),
+                        RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding { Left = name_width + 10, Right = value_width + 10 },
-                    },
-                    ModBar = new Bar
-                    {
-                        Origin = Anchor.CentreLeft,
-                        Anchor = Anchor.CentreLeft,
-                        RelativeSizeAxes = Axes.X,
-                        Alpha = 0.5f,
-                        Height = 5,
-                        Padding = new MarginPadding { Left = name_width + 10, Right = value_width + 10 },
+                        Children = new Drawable[]
+                        {
+                            new Container
+                            {
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.X,
+                                Height = 5,
+
+                                CornerRadius = 2,
+                                Masking = true,
+                                Children = new Drawable[]
+                                {
+                                    bar = new Bar
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        BackgroundColour = Color4.White.Opacity(0.5f),
+                                    },
+                                    ModBar = new Bar
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Alpha = 0.5f,
+                                    },
+                                }
+                            },
+                        }
                     },
                     new Container
                     {

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -92,11 +92,35 @@ namespace osu.Game.Screens.Select.Details
                         Direction = FillDirection.Full,
                         Children = new[]
                         {
-                            FirstValue = new StatisticRow { Width = 0.5f }, // circle size/key amount
-                            HpDrain = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsDrain, Width = 0.5f },
-                            Accuracy = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAccuracy, Width = 0.5f },
-                            ApproachRate = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAr, Width = 0.5f },
-                            starDifficulty = new StatisticRow(10, true) { Title = BeatmapsetsStrings.ShowStatsStars, Width = 0.5f },
+                            FirstValue = new StatisticRow
+                            {
+                                Width = 0.5f,
+                                Padding = new MarginPadding { Right = 5, Vertical = 2.5f },
+                            }, // circle size/key amount
+                            HpDrain = new StatisticRow
+                            {
+                                Title = BeatmapsetsStrings.ShowStatsDrain,
+                                Width = 0.5f,
+                                Padding = new MarginPadding { Left = 5, Vertical = 2.5f },
+                            },
+                            Accuracy = new StatisticRow
+                            {
+                                Title = BeatmapsetsStrings.ShowStatsAccuracy,
+                                Width = 0.5f,
+                                Padding = new MarginPadding { Right = 5, Vertical = 2.5f },
+                            },
+                            ApproachRate = new StatisticRow
+                            {
+                                Title = BeatmapsetsStrings.ShowStatsAr,
+                                Width = 0.5f,
+                                Padding = new MarginPadding { Left = 5, Vertical = 2.5f },
+                            },
+                            starDifficulty = new StatisticRow(10, true)
+                            {
+                                Title = BeatmapsetsStrings.ShowStatsStars,
+                                Width = 0.5f,
+                                Padding = new MarginPadding { Right = 5, Vertical = 2.5f },
+                            },
                         },
                     };
                     break;

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -64,21 +64,43 @@ namespace osu.Game.Screens.Select.Details
             }
         }
 
-        public AdvancedStats()
+        public AdvancedStats(int columns = 1)
         {
-            Child = new FillFlowContainer
+            switch (columns)
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Children = new[]
-                {
-                    FirstValue = new StatisticRow(), // circle size/key amount
-                    HpDrain = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsDrain },
-                    Accuracy = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAccuracy },
-                    ApproachRate = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAr },
-                    starDifficulty = new StatisticRow(10, true) { Title = BeatmapsetsStrings.ShowStatsStars },
-                },
-            };
+                case 1:
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new[]
+                        {
+                            FirstValue = new StatisticRow(), // circle size/key amount
+                            HpDrain = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsDrain },
+                            Accuracy = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAccuracy },
+                            ApproachRate = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAr },
+                            starDifficulty = new StatisticRow(10, true) { Title = BeatmapsetsStrings.ShowStatsStars },
+                        },
+                    };
+                    break;
+
+                case 2:
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Full,
+                        Children = new[]
+                        {
+                            FirstValue = new StatisticRow { Width = 0.5f }, // circle size/key amount
+                            HpDrain = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsDrain, Width = 0.5f },
+                            Accuracy = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAccuracy, Width = 0.5f },
+                            ApproachRate = new StatisticRow { Title = BeatmapsetsStrings.ShowStatsAr, Width = 0.5f },
+                            starDifficulty = new StatisticRow(10, true) { Title = BeatmapsetsStrings.ShowStatsStars, Width = 0.5f },
+                        },
+                    };
+                    break;
+            }
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -13,7 +13,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -274,28 +273,20 @@ namespace osu.Game.Screens.Select
                                                         RelativeSizeAxes = Axes.Both,
                                                         Masking = true,
                                                         CornerRadius = 10,
-                                                        EdgeEffect = new EdgeEffectParameters
-                                                        {
-                                                            Type = EdgeEffectType.Glow,
-                                                            Hollow = true,
-                                                            Colour = new Color4(130, 204, 255, 15),
-                                                            Radius = 10,
-                                                        },
                                                         Children = new Drawable[]
                                                         {
                                                             new Box
                                                             {
-                                                                Colour = new Color4(130, 204, 255, 40),
-                                                                Blending = BlendingParameters.Additive,
                                                                 RelativeSizeAxes = Axes.Both,
+                                                                Colour = Colour4.Black.Opacity(0.3f),
                                                             },
                                                             advancedStats = new AdvancedStats(2)
                                                             {
                                                                 RelativeSizeAxes = Axes.X,
                                                                 AutoSizeAxes = Axes.Y,
-                                                                Width = 0.8f,
                                                                 Anchor = Anchor.Centre,
                                                                 Origin = Anchor.Centre,
+                                                                Padding = new MarginPadding(10)
                                                             },
                                                         }
                                                     },

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.Select
                                         Origin = Anchor.BottomLeft,
                                         Anchor = Anchor.BottomLeft,
                                         RelativeSizeAxes = Axes.Both,
-                                        Padding = new MarginPadding { Top = left_area_padding },
+                                        Padding = new MarginPadding { Top = 5 },
                                         Children = new Drawable[]
                                         {
                                             new LeftSideInteractionContainer(() => Carousel.ScrollToSelected())
@@ -264,7 +264,7 @@ namespace osu.Game.Screens.Select
                                                 Padding = new MarginPadding(10)
                                                 {
                                                     Left = left_area_padding,
-                                                    Right = left_area_padding * 2,
+                                                    Right = left_area_padding * 2 + 5,
                                                 },
                                                 Y = WEDGE_HEIGHT,
                                                 Children = new Drawable[]

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -13,6 +13,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
@@ -35,6 +37,7 @@ using osu.Game.Screens.Backgrounds;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Select.Details;
 using osu.Game.Screens.Select.Options;
 using osu.Game.Skinning;
 using osuTK;
@@ -45,7 +48,7 @@ namespace osu.Game.Screens.Select
 {
     public abstract partial class SongSelect : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>
     {
-        public static readonly float WEDGE_HEIGHT = 245;
+        public static readonly float WEDGE_HEIGHT = 200;
 
         protected const float BACKGROUND_BLUR = 20;
         private const float left_area_padding = 20;
@@ -131,6 +134,8 @@ namespace osu.Game.Screens.Select
         private double audioFeedbackLastPlaybackTime;
 
         private IDisposable? modSelectOverlayRegistration;
+
+        private AdvancedStats advancedStats = null!;
 
         [Resolved]
         private MusicController music { get; set; } = null!;
@@ -254,11 +259,55 @@ namespace osu.Game.Screens.Select
                                             },
                                             new Container
                                             {
+                                                RelativeSizeAxes = Axes.X,
+                                                Height = 90,
+                                                Padding = new MarginPadding(10)
+                                                {
+                                                    Left = left_area_padding,
+                                                    Right = left_area_padding * 2,
+                                                },
+                                                Y = WEDGE_HEIGHT,
+                                                Children = new Drawable[]
+                                                {
+                                                    new Container
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both,
+                                                        Masking = true,
+                                                        CornerRadius = 10,
+                                                        EdgeEffect = new EdgeEffectParameters
+                                                        {
+                                                            Type = EdgeEffectType.Glow,
+                                                            Hollow = true,
+                                                            Colour = new Color4(130, 204, 255, 15),
+                                                            Radius = 10,
+                                                        },
+                                                        Children = new Drawable[]
+                                                        {
+                                                            new Box
+                                                            {
+                                                                Colour = new Color4(130, 204, 255, 40),
+                                                                Blending = BlendingParameters.Additive,
+                                                                RelativeSizeAxes = Axes.Both,
+                                                            },
+                                                            advancedStats = new AdvancedStats(2)
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                AutoSizeAxes = Axes.Y,
+                                                                Width = 0.8f,
+                                                                Anchor = Anchor.Centre,
+                                                                Origin = Anchor.Centre,
+                                                            },
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            new Container
+                                            {
                                                 RelativeSizeAxes = Axes.Both,
                                                 Padding = new MarginPadding
                                                 {
                                                     Bottom = Footer.HEIGHT,
-                                                    Top = WEDGE_HEIGHT,
+                                                    Top = WEDGE_HEIGHT + 70,
                                                     Left = left_area_padding,
                                                     Right = left_area_padding * 2,
                                                 },
@@ -796,6 +845,8 @@ namespace osu.Game.Screens.Select
             BeatmapDetails.Beatmap = beatmap;
 
             ModSelect.Beatmap = beatmap;
+
+            advancedStats.BeatmapInfo = beatmap.BeatmapInfo;
 
             bool beatmapSelected = beatmap is not DummyWorkingBeatmap;
 


### PR DESCRIPTION
We have a larger redesign planned, but let's just get this in so people can easily see both leaderboards and beatmap stats.

Yes, tags text may have low contrast. No I don't really care at this point (it's still legible in all cases, even pure white background), but I am reluctantly open to better looking colour suggestions.

This also sets the default display mode to local leaderboard, instead of details, as it's a better look.

https://github.com/ppy/osu/assets/191335/42466082-4073-4e43-85c2-c204d68b6d9b


