### PR TITLE
Allow choosing "Edit" from any beatmap carousel item

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Select.Carousel
                       .ForEach(AddItem);
         }
 
-        protected override CarouselItem? GetNextToSelect()
+        public override CarouselItem? GetNextToSelect()
         {
             if (LastSelected == null || LastSelected.Filtered.Value)
             {

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Screens.Select.Carousel
         /// Finds the item this group would select next if it attempted selection
         /// </summary>
         /// <returns>An unfiltered item nearest to the last selected one or null if all items are filtered</returns>
-        protected virtual CarouselItem? GetNextToSelect()
+        public virtual CarouselItem? GetNextToSelect()
         {
             if (Items.Count == 0)
                 return null;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (songSelect != null)
             {
-                mainMenuItems = songSelect.CreateForwardNavigationMenuItemsForBeatmap(beatmapInfo);
+                mainMenuItems = songSelect.CreateForwardNavigationMenuItemsForBeatmap(() => beatmapInfo);
                 selectRequested = b => songSelect.FinaliseSelection(b);
             }
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Screens.Select.Carousel
 
         private Task? beatmapsLoadTask;
 
+        private MenuItem[]? mainMenuItems;
+
         [Resolved]
         private BeatmapManager manager { get; set; } = null!;
 
@@ -57,8 +59,11 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapSetOverlay? beatmapOverlay)
+        private void load(BeatmapSetOverlay? beatmapOverlay, SongSelect? songSelect)
         {
+            if (songSelect != null)
+                mainMenuItems = songSelect.CreateForwardNavigationMenuItemsForBeatmap(() => (((CarouselBeatmapSet)Item!).GetNextToSelect() as CarouselBeatmap)!.BeatmapInfo);
+
             restoreHiddenRequested = s =>
             {
                 foreach (var b in s.Beatmaps)
@@ -221,6 +226,9 @@ namespace osu.Game.Screens.Select.Carousel
 
                 if (Item?.State.Value == CarouselItemState.NotSelected)
                     items.Add(new OsuMenuItem("Expand", MenuItemType.Highlighted, () => Item.State.Value = CarouselItemState.Selected));
+
+                if (mainMenuItems != null)
+                    items.AddRange(mainMenuItems);
 
                 if (beatmapSet.OnlineID > 0 && viewDetails != null)
                     items.Add(new OsuMenuItem("Details...", MenuItemType.Standard, () => viewDetails(beatmapSet.OnlineID)));

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -34,10 +35,10 @@ namespace osu.Game.Screens.Select
 
         public override bool AllowExternalScreenChange => true;
 
-        public override MenuItem[] CreateForwardNavigationMenuItemsForBeatmap(BeatmapInfo beatmap) => new MenuItem[]
+        public override MenuItem[] CreateForwardNavigationMenuItemsForBeatmap(Func<BeatmapInfo> getBeatmap) => new MenuItem[]
         {
-            new OsuMenuItem(ButtonSystemStrings.Play.ToSentence(), MenuItemType.Highlighted, () => FinaliseSelection(beatmap)),
-            new OsuMenuItem(ButtonSystemStrings.Edit.ToSentence(), MenuItemType.Standard, () => Edit(beatmap))
+            new OsuMenuItem(ButtonSystemStrings.Play.ToSentence(), MenuItemType.Highlighted, () => FinaliseSelection(getBeatmap())),
+            new OsuMenuItem(ButtonSystemStrings.Edit.ToSentence(), MenuItemType.Standard, () => Edit(getBeatmap()))
         };
 
         protected override UserActivity InitialActivity => new UserActivity.ChoosingBeatmap();

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -89,11 +89,11 @@ namespace osu.Game.Screens.Select
         /// Creates any "action" menu items for the provided beatmap (ie. "Select", "Play", "Edit").
         /// These will always be placed at the top of the context menu, with common items added below them.
         /// </summary>
-        /// <param name="beatmap">The beatmap to create items for.</param>
+        /// <param name="getBeatmap">The beatmap to create items for.</param>
         /// <returns>The menu items.</returns>
-        public virtual MenuItem[] CreateForwardNavigationMenuItemsForBeatmap(BeatmapInfo beatmap) => new MenuItem[]
+        public virtual MenuItem[] CreateForwardNavigationMenuItemsForBeatmap(Func<BeatmapInfo> getBeatmap) => new MenuItem[]
         {
-            new OsuMenuItem(@"Select", MenuItemType.Highlighted, () => FinaliseSelection(beatmap))
+            new OsuMenuItem(@"Select", MenuItemType.Highlighted, () => FinaliseSelection(getBeatmap()))
         };
 
         [Resolved]


### PR DESCRIPTION
Was a bit confusing until now. Even I hit this at least once.

https://twitter.com/ppy/status/1736963119828897883

![CleanShot 2023-12-19 at 11 00 48](https://github.com/ppy/osu/assets/191335/dc8be1c3-c675-40cd-8a78-d1dc0eeece7d)
