### PR TITLE
Adjust "classic" mod multiplier to 0.96x

### DIFF
--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Acronym => "CL";
 
-        public override double ScoreMultiplier => 0.5;
+        public override double ScoreMultiplier => 0.96;
 
         public override IconUsage? Icon => FontAwesome.Solid.History;
 


### PR DESCRIPTION
Following discussions on discord, this seems like the most agreed upon value. Increasing this is important so that imported legacy scores don't lose too much value.
