### PR TITLE
Fix beatmap updates causing one extra carousel selection

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -36,13 +36,13 @@ namespace osu.Game.Screens.Select.Carousel
         /// items have been filtered. This bool will be true during the base <see cref="Filter(FilterCriteria)"/>
         /// operation.
         /// </summary>
-        private bool filteringItems;
+        protected bool DisableSelection;
 
         public override void Filter(FilterCriteria criteria)
         {
-            filteringItems = true;
+            DisableSelection = true;
             base.Filter(criteria);
-            filteringItems = false;
+            DisableSelection = false;
 
             attemptSelection();
         }
@@ -95,7 +95,7 @@ namespace osu.Game.Screens.Select.Carousel
 
         private void attemptSelection()
         {
-            if (filteringItems) return;
+            if (DisableSelection) return;
 
             // we only perform eager selection if we are a currently selected group.
             if (State.Value != CarouselItemState.Selected) return;


### PR DESCRIPTION
This fixes the carousel making one unnecessary selection every time the current selection is updated. Basically, on returning from gameplay this will cause the selection sound to no longer (incorrectly) play, but also likely improves smoothness as it's not randomly selecting a beatmap *somewhere* in the carousel before correcting back to the retained selection.

I'd like to let the code speak for itself here. The only reason I did this is that I was already so deep that it seemed worthwhile. The resultant code does seem like an improvement over what we had, but I'll let others be the judge.

- [x] Depends on https://github.com/ppy/osu/pull/25943
