### PR TITLE
Remove mania mod multiplier for DT/NC

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModDoubleTime.cs
@@ -10,5 +10,10 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModDoubleTime : ModDoubleTime, IManiaRateAdjustmentMod
     {
         public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
+
+        // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
+        // make the map harder and is more of a personal preference.
+        // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
+        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNightcore.cs
@@ -11,5 +11,10 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModNightcore : ModNightcore<ManiaHitObject>, IManiaRateAdjustmentMod
     {
         public HitWindows HitWindows { get; set; } = new ManiaHitWindows();
+
+        // For now, all rate-increasing mods should be given a 1x multiplier in mania because it doesn't always
+        // make the map any harder and is more of a personal preference.
+        // In the future, we can consider adjusting this by experimenting with not applying the hitwindow leniency.
+        public override double ScoreMultiplier => 1;
     }
 }


### PR DESCRIPTION
Discussed in https://github.com/ppy/osu/discussions/25810#discussioncomment-7897894 and https://discord.com/channels/188630481301012481/1187004935452250132

The general gist of it is that, right now DT and NC are seen more as a personal preference than mods that have any significant impact to scores. The 1M score cap is seen as "sacred" to the degree that these mods, whether the reader agrees with the idea that these are personal preference or not, are not significant enough to justify breaking the score cap.

I believe we've reached the amicable conclusion that we are not adverse to experimenting with mods and their effects, multipliers, and other ways to display scores for showcasing purposes.

One such idea proposed, is to see whether a DT/NC mod with fixed hitwindows becomes more worthy of having a mod multiplier, combined with a separate mod for the current hitwindow-affecting rate adjustment

But, that is for future work. For the time being, I'm satisfied with the conclusion and bringing things to a common ground that everyone can agree with is an objective point of reference.