### PR TITLE
Fix save & export failed replay hotkeys handling repeated keypresses

### DIFF
--- a/osu.Game/Screens/Play/SaveFailedScoreButton.cs
+++ b/osu.Game/Screens/Play/SaveFailedScoreButton.cs
@@ -102,6 +102,9 @@ namespace osu.Game.Screens.Play
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            if (e.Repeat)
+                return false;
+
             switch (e.Action)
             {
                 case GlobalAction.SaveReplay:


### PR DESCRIPTION
This was already handled in ReplayDownloadButton
https://github.com/ppy/osu/blob/98efff0bd61ea6cc5d6a884aeda1614d81592b9d/osu.Game/Screens/Ranking/ReplayDownloadButton.cs#L114-L115
but seemingly missed for SaveFailedScoreButton allowing replays to keep being re-exported as long as the key is held down


https://github.com/ppy/osu/assets/33725716/9b0ffb28-fb77-4d13-9c9e-e7d421dbc90a

