### PR TITLE
Relocate numeric HitResult values, add accuracy conversion

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.Mods;
 using osu.Game.Rulesets.Catch.Objects;
-using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Catch.Scoring;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 {
     internal class CatchLegacyScoreSimulator : ILegacyScoreSimulator
     {
+        private readonly ScoreProcessor scoreProcessor = new CatchScoreProcessor();
+
         private int legacyBonusScore;
         private int standardisedBonusScore;
         private int combo;
@@ -134,7 +136,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += Judgement.ToNumericResult(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetBaseScoreForResult(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Scoring
         }
 
         protected override double GetComboScoreChange(JudgementResult result)
-            => GetRawComboScore(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
+            => GetBaseScoreForResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
 
         public override ScoreRank RankFromAccuracy(double accuracy)
         {

--- a/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchScoreProcessor.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Catch.Scoring
         }
 
         protected override double GetComboScoreChange(JudgementResult result)
-            => GetNumericResultFor(result) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
+            => GetRawComboScore(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(combo_cap, combo_base));
 
         public override ScoreRank RankFromAccuracy(double accuracy)
         {

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -31,7 +31,12 @@ namespace osu.Game.Rulesets.Mania.Scoring
                    + bonusPortion;
         }
 
-        public override int GetRawAccuracyScore(HitResult result)
+        protected override double GetComboScoreChange(JudgementResult result)
+        {
+            return getBaseComboScoreForResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
+        }
+
+        public override int GetBaseScoreForResult(HitResult result)
         {
             switch (result)
             {
@@ -39,10 +44,10 @@ namespace osu.Game.Rulesets.Mania.Scoring
                     return 305;
             }
 
-            return base.GetRawAccuracyScore(result);
+            return base.GetBaseScoreForResult(result);
         }
 
-        public override int GetRawComboScore(HitResult result)
+        private int getBaseComboScoreForResult(HitResult result)
         {
             switch (result)
             {
@@ -50,11 +55,8 @@ namespace osu.Game.Rulesets.Mania.Scoring
                     return 300;
             }
 
-            return base.GetRawComboScore(result);
+            return GetBaseScoreForResult(result);
         }
-
-        protected override double GetComboScoreChange(JudgementResult result)
-            => GetRawComboScore(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
 
         private class JudgementOrderComparer : IComparer<HitObject>
         {

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -31,45 +31,30 @@ namespace osu.Game.Rulesets.Mania.Scoring
                    + bonusPortion;
         }
 
-        protected override double GetNumericResultFor(JudgementResult result)
+        public override int GetRawAccuracyScore(HitResult result)
         {
-            switch (result.Type)
+            switch (result)
             {
                 case HitResult.Perfect:
                     return 305;
             }
 
-            return base.GetNumericResultFor(result);
+            return base.GetRawAccuracyScore(result);
         }
 
-        protected override double GetMaxNumericResultFor(JudgementResult result)
+        public override int GetRawComboScore(HitResult result)
         {
-            switch (result.Judgement.MaxResult)
+            switch (result)
             {
                 case HitResult.Perfect:
-                    return 305;
+                    return 300;
             }
 
-            return base.GetMaxNumericResultFor(result);
+            return base.GetRawComboScore(result);
         }
 
         protected override double GetComboScoreChange(JudgementResult result)
-        {
-            double numericResult;
-
-            switch (result.Type)
-            {
-                case HitResult.Perfect:
-                    numericResult = 300;
-                    break;
-
-                default:
-                    numericResult = GetNumericResultFor(result);
-                    break;
-            }
-
-            return numericResult * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
-        }
+            => GetRawComboScore(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
 
         private class JudgementOrderComparer : IComparer<HitObject>
         {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
                 long totalScore = scoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.Result.TotalRotation / 360) * scoreProcessor.GetRawBonusScore(new SpinnerTick().CreateJudgement().MaxResult);
+                return totalScore == (int)(drawableSpinner.Result.TotalRotation / 360) * scoreProcessor.GetBaseScoreForResult(new SpinnerTick().CreateJudgement().MaxResult);
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerRotation.cs
@@ -58,10 +58,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             double trackerRotationTolerance = 0;
 
             addSeekStep(5000);
-            AddStep("calculate rotation tolerance", () =>
-            {
-                trackerRotationTolerance = Math.Abs(drawableSpinner.RotationTracker.Rotation * 0.1f);
-            });
+            AddStep("calculate rotation tolerance", () => { trackerRotationTolerance = Math.Abs(drawableSpinner.RotationTracker.Rotation * 0.1f); });
             AddAssert("is disc rotation not almost 0", () => drawableSpinner.RotationTracker.Rotation, () => Is.Not.EqualTo(0).Within(100));
             AddAssert("is disc rotation absolute not almost 0", () => drawableSpinner.Result.TotalRotation, () => Is.Not.EqualTo(0).Within(100));
 
@@ -133,9 +130,11 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddAssert("player score matching expected bonus score", () =>
             {
+                var scoreProcessor = ((ScoreExposedPlayer)Player).ScoreProcessor;
+
                 // multipled by 2 to nullify the score multiplier. (autoplay mod selected)
-                long totalScore = ((ScoreExposedPlayer)Player).ScoreProcessor.TotalScore.Value * 2;
-                return totalScore == (int)(drawableSpinner.Result.TotalRotation / 360) * new SpinnerTick().CreateJudgement().MaxNumericResult;
+                long totalScore = scoreProcessor.TotalScore.Value * 2;
+                return totalScore == (int)(drawableSpinner.Result.TotalRotation / 360) * scoreProcessor.GetRawBonusScore(new SpinnerTick().CreateJudgement().MaxResult);
             });
 
             addSeekStep(0);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
@@ -5,12 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
 
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     internal class OsuLegacyScoreSimulator : ILegacyScoreSimulator
     {
+        private readonly ScoreProcessor scoreProcessor = new OsuScoreProcessor();
+
         private int legacyBonusScore;
         private int standardisedBonusScore;
         private int combo;
@@ -171,7 +173,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += Judgement.ToNumericResult(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetBaseScoreForResult(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -313,7 +313,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             updateBonusScore();
         }
 
-        private static readonly int score_per_tick = new OsuScoreProcessor().GetRawBonusScore(new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxResult);
+        private static readonly int score_per_tick = new OsuScoreProcessor().GetBaseScoreForResult(new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxResult);
 
         private void updateBonusScore()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -17,6 +17,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Judgements;
+using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
@@ -312,7 +313,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             updateBonusScore();
         }
 
-        private static readonly int score_per_tick = new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxNumericResult;
+        private static readonly int score_per_tick = new OsuScoreProcessor().GetRawBonusScore(new SpinnerBonusTick.OsuSpinnerBonusTickJudgement().MaxResult);
 
         private void updateBonusScore()
         {

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -13,11 +12,14 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Scoring;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty
 {
     internal class TaikoLegacyScoreSimulator : ILegacyScoreSimulator
     {
+        private readonly ScoreProcessor scoreProcessor = new TaikoScoreProcessor();
+
         private int legacyBonusScore;
         private int standardisedBonusScore;
         private int combo;
@@ -191,7 +193,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += Judgement.ToNumericResult(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (isBonus)
             {
                 legacyBonusScore += scoreIncrease;
-                standardisedBonusScore += scoreProcessor.GetRawBonusScore(bonusResult);
+                standardisedBonusScore += scoreProcessor.GetBaseScoreForResult(bonusResult);
             }
             else
                 attributes.AccuracyScore += scoreIncrease;

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -28,20 +28,31 @@ namespace osu.Game.Rulesets.Taiko.Scoring
 
         protected override double GetComboScoreChange(JudgementResult result)
         {
-            return GetNumericResultFor(result)
+            return GetRawComboScore(result.Type)
                    * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base))
                    * strongScaleValue(result);
         }
 
-        protected override double GetNumericResultFor(JudgementResult result)
+        public override int GetRawAccuracyScore(HitResult result)
         {
-            switch (result.Type)
+            switch (result)
             {
                 case HitResult.Ok:
                     return 150;
             }
 
-            return base.GetNumericResultFor(result);
+            return base.GetRawAccuracyScore(result);
+        }
+
+        public override int GetRawComboScore(HitResult result)
+        {
+            switch (result)
+            {
+                case HitResult.Ok:
+                    return 150;
+            }
+
+            return base.GetRawComboScore(result);
         }
 
         private double strongScaleValue(JudgementResult result)

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoScoreProcessor.cs
@@ -28,12 +28,12 @@ namespace osu.Game.Rulesets.Taiko.Scoring
 
         protected override double GetComboScoreChange(JudgementResult result)
         {
-            return GetRawComboScore(result.Type)
+            return GetBaseScoreForResult(result.Type)
                    * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base))
                    * strongScaleValue(result);
         }
 
-        public override int GetRawAccuracyScore(HitResult result)
+        public override int GetBaseScoreForResult(HitResult result)
         {
             switch (result)
             {
@@ -41,18 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Scoring
                     return 150;
             }
 
-            return base.GetRawAccuracyScore(result);
-        }
-
-        public override int GetRawComboScore(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Ok:
-                    return 150;
-            }
-
-            return base.GetRawComboScore(result);
+            return base.GetBaseScoreForResult(result);
         }
 
         private double strongScaleValue(JudgementResult result)

--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Gameplay
             // Apply a judgement
             scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new TestJudgement(HitResult.LargeBonus)) { Type = HitResult.LargeBonus });
 
-            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(Judgement.LARGE_BONUS_SCORE));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(scoreProcessor.GetRawBonusScore(HitResult.LargeBonus)));
         }
 
         [Test]

--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Gameplay
             // Apply a judgement
             scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new TestJudgement(HitResult.LargeBonus)) { Type = HitResult.LargeBonus });
 
-            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(scoreProcessor.GetRawBonusScore(HitResult.LargeBonus)));
+            Assert.That(scoreProcessor.TotalScore.Value, Is.EqualTo(scoreProcessor.GetBaseScoreForResult(HitResult.LargeBonus)));
         }
 
         [Test]

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -340,15 +340,12 @@ namespace osu.Game
 
                 try
                 {
-                    var score = scoreManager.Query(s => s.ID == id);
-                    long newTotalScore = StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore(score, beatmapManager);
-
                     // Can't use async overload because we're not on the update thread.
                     // ReSharper disable once MethodHasAsyncOverload
                     realmAccess.Write(r =>
                     {
                         ScoreInfo s = r.Find<ScoreInfo>(id)!;
-                        s.TotalScore = newTotalScore;
+                        StandardisedScoreMigrationTools.UpdateFromLegacy(s, beatmapManager);
                         s.TotalScoreVersion = LegacyScoreEncoder.LATEST_VERSION;
                     });
 

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -57,14 +57,14 @@ namespace osu.Game.Database
             // We are constructing a "best possible" score from the statistics provided because it's the best we can do.
             List<HitResult> sortedHits = score.Statistics
                                               .Where(kvp => kvp.Key.AffectsCombo())
-                                              .OrderByDescending(kvp => processor.GetRawComboScore(kvp.Key))
+                                              .OrderByDescending(kvp => processor.GetBaseScoreForResult(kvp.Key))
                                               .SelectMany(kvp => Enumerable.Repeat(kvp.Key, kvp.Value))
                                               .ToList();
 
             // Attempt to use maximum statistics from the database.
             var maximumJudgements = score.MaximumStatistics
                                          .Where(kvp => kvp.Key.AffectsCombo())
-                                         .OrderByDescending(kvp => processor.GetRawComboScore(kvp.Key))
+                                         .OrderByDescending(kvp => processor.GetBaseScoreForResult(kvp.Key))
                                          .SelectMany(kvp => Enumerable.Repeat(new FakeJudgement(kvp.Key), kvp.Value))
                                          .ToList();
 

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -12,16 +12,6 @@ namespace osu.Game.Rulesets.Judgements
     public class Judgement
     {
         /// <summary>
-        /// The score awarded for a small bonus.
-        /// </summary>
-        public const int SMALL_BONUS_SCORE = 10;
-
-        /// <summary>
-        /// The score awarded for a large bonus.
-        /// </summary>
-        public const int LARGE_BONUS_SCORE = 50;
-
-        /// <summary>
         /// The default health increase for a maximum judgement, as a proportion of total health.
         /// By default, each maximum judgement restores 5% of total health.
         /// </summary>
@@ -92,21 +82,9 @@ namespace osu.Game.Rulesets.Judgements
         }
 
         /// <summary>
-        /// The numeric score representation for the maximum achievable result.
-        /// </summary>
-        public int MaxNumericResult => ToNumericResult(MaxResult);
-
-        /// <summary>
         /// The health increase for the maximum achievable result.
         /// </summary>
         public double MaxHealthIncrease => HealthIncreaseFor(MaxResult);
-
-        /// <summary>
-        /// Retrieves the numeric score representation of a <see cref="JudgementResult"/>.
-        /// </summary>
-        /// <param name="result">The <see cref="JudgementResult"/> to find the numeric score representation for.</param>
-        /// <returns>The numeric score representation of <paramref name="result"/>.</returns>
-        public int NumericResultFor(JudgementResult result) => ToNumericResult(result.Type);
 
         /// <summary>
         /// Retrieves the numeric health increase of a <see cref="HitResult"/>.
@@ -165,41 +143,6 @@ namespace osu.Game.Rulesets.Judgements
         /// <returns>The numeric health increase of <paramref name="result"/>.</returns>
         public double HealthIncreaseFor(JudgementResult result) => HealthIncreaseFor(result.Type);
 
-        public override string ToString() => $"MaxResult:{MaxResult} MaxScore:{MaxNumericResult}";
-
-        public static int ToNumericResult(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.SmallTickHit:
-                    return 10;
-
-                case HitResult.LargeTickHit:
-                    return 30;
-
-                case HitResult.Meh:
-                    return 50;
-
-                case HitResult.Ok:
-                    return 100;
-
-                case HitResult.Good:
-                    return 200;
-
-                case HitResult.Great:
-                // Perfect doesn't actually give more score / accuracy directly.
-                case HitResult.Perfect:
-                    return 300;
-
-                case HitResult.SmallBonus:
-                    return SMALL_BONUS_SCORE;
-
-                case HitResult.LargeBonus:
-                    return LARGE_BONUS_SCORE;
-            }
-        }
+        public override string ToString() => $"MaxResult:{MaxResult}";
     }
 }

--- a/osu.Game/Rulesets/Judgements/JudgementResult.cs
+++ b/osu.Game/Rulesets/Judgements/JudgementResult.cs
@@ -112,6 +112,6 @@ namespace osu.Game.Rulesets.Judgements
             RawTime = null;
         }
 
-        public override string ToString() => $"{Type} (Score:{Judgement.NumericResultFor(this)} HP:{Judgement.HealthIncreaseFor(this)} {Judgement})";
+        public override string ToString() => $"{Type} ({Judgement})";
     }
 }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -227,12 +227,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore += GetMaxNumericResultFor(result);
+                currentMaximumBaseScore += GetRawAccuracyScore(result.Judgement.MaxResult);
                 currentAccuracyJudgementCount++;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore += GetNumericResultFor(result);
+                currentBaseScore += GetRawAccuracyScore(result.Type);
 
             if (result.Type.IsBonus())
                 currentBonusPortion += GetBonusScoreChange(result);
@@ -276,12 +276,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore -= GetMaxNumericResultFor(result);
+                currentMaximumBaseScore -= GetRawAccuracyScore(result.Judgement.MaxResult);
                 currentAccuracyJudgementCount--;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore -= GetNumericResultFor(result);
+                currentBaseScore -= GetRawAccuracyScore(result.Type);
 
             if (result.Type.IsBonus())
                 currentBonusPortion -= GetBonusScoreChange(result);
@@ -297,21 +297,100 @@ namespace osu.Game.Rulesets.Scoring
             updateScore();
         }
 
-        protected virtual double GetBonusScoreChange(JudgementResult result) => GetNumericResultFor(result);
-
-        protected virtual double GetComboScoreChange(JudgementResult result) => GetMaxNumericResultFor(result) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
+        /// <summary>
+        /// Gets the final score change to be applied to the bonus portion of the score.
+        /// </summary>
+        /// <param name="result">The judgement result.</param>
+        protected virtual double GetBonusScoreChange(JudgementResult result) => GetRawBonusScore(result.Type);
 
         /// <summary>
-        /// Retrieves the numeric score representation for a <see cref="JudgementResult"/>.
+        /// Gets the final score change to be applied to the combo portion of the score.
         /// </summary>
-        /// <param name="result">The <see cref="JudgementResult"/>.</param>
-        protected virtual double GetNumericResultFor(JudgementResult result) => result.Judgement.NumericResultFor(result);
+        /// <param name="result">The judgement result.</param>
+        protected virtual double GetComboScoreChange(JudgementResult result) => GetRawComboScore(result.Judgement.MaxResult) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
 
         /// <summary>
-        /// Retrieves the maximum numeric score representation for a <see cref="JudgementResult"/>.
+        /// Retrieves the raw score value for a hit result, in order to be applied to the combo portion.
         /// </summary>
-        /// <param name="result">The <see cref="JudgementResult"/>.</param>
-        protected virtual double GetMaxNumericResultFor(JudgementResult result) => result.Judgement.MaxNumericResult;
+        /// <param name="result">The hit result.</param>
+        public virtual int GetRawComboScore(HitResult result)
+        {
+            switch (result)
+            {
+                default:
+                    return 0;
+
+                case HitResult.SmallTickHit:
+                    return 10;
+
+                case HitResult.LargeTickHit:
+                    return 30;
+
+                case HitResult.Meh:
+                    return 50;
+
+                case HitResult.Ok:
+                    return 100;
+
+                case HitResult.Good:
+                    return 200;
+
+                case HitResult.Great:
+                case HitResult.Perfect: // Perfect doesn't actually give more score / accuracy directly.
+                    return 300;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the raw score value for a hit result, in order to be applied to the accuracy portion.
+        /// </summary>
+        /// <param name="result">The hit result.</param>
+        public virtual int GetRawAccuracyScore(HitResult result)
+        {
+            switch (result)
+            {
+                default:
+                    return 0;
+
+                case HitResult.SmallTickHit:
+                    return 10;
+
+                case HitResult.LargeTickHit:
+                    return 30;
+
+                case HitResult.Meh:
+                    return 50;
+
+                case HitResult.Ok:
+                    return 100;
+
+                case HitResult.Good:
+                    return 200;
+
+                case HitResult.Great:
+                case HitResult.Perfect: // Perfect doesn't actually give more score / accuracy directly.
+                    return 300;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the raw score value for a hit result, in order to be applied to the bonus portion.
+        /// </summary>
+        /// <param name="result">The hit result.</param>
+        public virtual int GetRawBonusScore(HitResult result)
+        {
+            switch (result)
+            {
+                default:
+                    return 0;
+
+                case HitResult.SmallBonus:
+                    return 10;
+
+                case HitResult.LargeBonus:
+                    return 50;
+            }
+        }
 
         protected virtual void ApplyScoreChange(JudgementResult result)
         {
@@ -540,7 +619,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         /// <remarks>
         /// Used to compute accuracy.
-        /// See: <see cref="HitResultExtensions.IsBasic"/> and <see cref="Judgement.ToNumericResult"/>.
+        /// See: <see cref="HitResultExtensions.IsBasic"/> and <see cref="ScoreProcessor.GetRawAccuracyScore"/>.
         /// </remarks>
         [Key(0)]
         public double BaseScore { get; set; }

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -227,12 +227,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore += GetRawAccuracyScore(result.Judgement.MaxResult);
+                currentMaximumBaseScore += GetBaseScoreForResult(result.Judgement.MaxResult);
                 currentAccuracyJudgementCount++;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore += GetRawAccuracyScore(result.Type);
+                currentBaseScore += GetBaseScoreForResult(result.Type);
 
             if (result.Type.IsBonus())
                 currentBonusPortion += GetBonusScoreChange(result);
@@ -276,12 +276,12 @@ namespace osu.Game.Rulesets.Scoring
 
             if (result.Judgement.MaxResult.AffectsAccuracy())
             {
-                currentMaximumBaseScore -= GetRawAccuracyScore(result.Judgement.MaxResult);
+                currentMaximumBaseScore -= GetBaseScoreForResult(result.Judgement.MaxResult);
                 currentAccuracyJudgementCount--;
             }
 
             if (result.Type.AffectsAccuracy())
-                currentBaseScore -= GetRawAccuracyScore(result.Type);
+                currentBaseScore -= GetBaseScoreForResult(result.Type);
 
             if (result.Type.IsBonus())
                 currentBonusPortion -= GetBonusScoreChange(result);
@@ -301,19 +301,15 @@ namespace osu.Game.Rulesets.Scoring
         /// Gets the final score change to be applied to the bonus portion of the score.
         /// </summary>
         /// <param name="result">The judgement result.</param>
-        protected virtual double GetBonusScoreChange(JudgementResult result) => GetRawBonusScore(result.Type);
+        protected virtual double GetBonusScoreChange(JudgementResult result) => GetBaseScoreForResult(result.Type);
 
         /// <summary>
         /// Gets the final score change to be applied to the combo portion of the score.
         /// </summary>
         /// <param name="result">The judgement result.</param>
-        protected virtual double GetComboScoreChange(JudgementResult result) => GetRawComboScore(result.Judgement.MaxResult) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
+        protected virtual double GetComboScoreChange(JudgementResult result) => GetBaseScoreForResult(result.Judgement.MaxResult) * Math.Pow(result.ComboAfterJudgement, COMBO_EXPONENT);
 
-        /// <summary>
-        /// Retrieves the raw score value for a hit result, in order to be applied to the combo portion.
-        /// </summary>
-        /// <param name="result">The hit result.</param>
-        public virtual int GetRawComboScore(HitResult result)
+        public virtual int GetBaseScoreForResult(HitResult result)
         {
             switch (result)
             {
@@ -338,51 +334,6 @@ namespace osu.Game.Rulesets.Scoring
                 case HitResult.Great:
                 case HitResult.Perfect: // Perfect doesn't actually give more score / accuracy directly.
                     return 300;
-            }
-        }
-
-        /// <summary>
-        /// Retrieves the raw score value for a hit result, in order to be applied to the accuracy portion.
-        /// </summary>
-        /// <param name="result">The hit result.</param>
-        public virtual int GetRawAccuracyScore(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
-
-                case HitResult.SmallTickHit:
-                    return 10;
-
-                case HitResult.LargeTickHit:
-                    return 30;
-
-                case HitResult.Meh:
-                    return 50;
-
-                case HitResult.Ok:
-                    return 100;
-
-                case HitResult.Good:
-                    return 200;
-
-                case HitResult.Great:
-                case HitResult.Perfect: // Perfect doesn't actually give more score / accuracy directly.
-                    return 300;
-            }
-        }
-
-        /// <summary>
-        /// Retrieves the raw score value for a hit result, in order to be applied to the bonus portion.
-        /// </summary>
-        /// <param name="result">The hit result.</param>
-        public virtual int GetRawBonusScore(HitResult result)
-        {
-            switch (result)
-            {
-                default:
-                    return 0;
 
                 case HitResult.SmallBonus:
                     return 10;
@@ -619,7 +570,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         /// <remarks>
         /// Used to compute accuracy.
-        /// See: <see cref="HitResultExtensions.IsBasic"/> and <see cref="ScoreProcessor.GetRawAccuracyScore"/>.
+        /// See: <see cref="HitResultExtensions.IsBasic"/> and <see cref="ScoreProcessor.GetBaseScoreForResult"/>.
         /// </remarks>
         [Key(0)]
         public double BaseScore { get; set; }

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -34,9 +34,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000005: Introduce combo exponent in the osu! gamemode. Reconvert all scores.</description></item>
         /// <item><description>30000006: Fix edge cases in conversion after combo exponent introduction that lead to NaNs. Reconvert all scores.</description></item>
         /// <item><description>30000007: Adjust osu!mania combo and accuracy portions and judgement scoring values. Reconvert all scores.</description></item>
+        /// <item><description>30000008: Add accuracy conversion. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000007;
+        public const int LATEST_VERSION = 30000008;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -131,7 +131,7 @@ namespace osu.Game.Scoring
             // Populate the maximum statistics.
             HitResult maxBasicResult = rulesetInstance.GetHitResults()
                                                       .Select(h => h.result)
-                                                      .Where(h => h.IsBasic()).MaxBy(scoreProcessor.GetRawAccuracyScore);
+                                                      .Where(h => h.IsBasic()).MaxBy(scoreProcessor.GetBaseScoreForResult);
 
             foreach ((HitResult result, int count) in score.Statistics)
             {

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -17,7 +17,6 @@ using osu.Game.Scoring.Legacy;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using Realms;
 
@@ -125,13 +124,14 @@ namespace osu.Game.Scoring
             var beatmap = score.BeatmapInfo!.Detach();
             var ruleset = score.Ruleset.Detach();
             var rulesetInstance = ruleset.CreateInstance();
+            var scoreProcessor = rulesetInstance.CreateScoreProcessor();
 
             Debug.Assert(rulesetInstance != null);
 
             // Populate the maximum statistics.
             HitResult maxBasicResult = rulesetInstance.GetHitResults()
                                                       .Select(h => h.result)
-                                                      .Where(h => h.IsBasic()).MaxBy(Judgement.ToNumericResult);
+                                                      .Where(h => h.IsBasic()).MaxBy(scoreProcessor.GetRawAccuracyScore);
 
             foreach ((HitResult result, int count) in score.Statistics)
             {

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Scoring
             else if (model.IsLegacyScore)
             {
                 model.LegacyTotalScore = model.TotalScore;
-                model.TotalScore = StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore(model, beatmaps());
+                StandardisedScoreMigrationTools.UpdateFromLegacy(model, beatmaps());
             }
         }
 


### PR DESCRIPTION
- `Judgement.NumericResultFor()`/`Judgement.ToNumericResult()` et al. have been removed.
- `ScoreProcessor. GetNumericResultFor()`/`ScoreProcessor.GetMaxNumericResultFor()` removed.
- `virtual ScoreProcessor.GetBaseScoreForResult(HitResult)` added as the new method to retrieve the raw scoring values.
- `StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore()` made private.
- `StandardisedScoreMigrationTools.UpdateFromLegacy()` added, which converts totalscore and (now) accuracy.
    - This is something that was previously being done manually inside the highscore importer, but the in-client import didn't do this which felt inconsistent.