### PR TITLE
Fix slider tick / end misses displaying with full size on legacy skins with animated misses

### DIFF
--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -50,17 +50,16 @@ namespace osu.Game.Skinning
 
             // legacy judgements don't play any transforms if they are an animation.... UNLESS they are the temporary displayed judgement from new piece.
             if (animation?.FrameCount > 1 && !forceTransforms)
+            {
+                if (isMissedTick())
+                    applyMissedTickScaling();
                 return;
+            }
 
             if (result.IsMiss())
             {
-                bool isTick = result != HitResult.Miss;
-
-                if (isTick)
-                {
-                    this.ScaleTo(0.6f);
-                    this.ScaleTo(0.3f, 100, Easing.In);
-                }
+                if (isMissedTick())
+                    applyMissedTickScaling();
                 else
                 {
                     this.ScaleTo(1.6f);
@@ -93,6 +92,14 @@ namespace osu.Game.Skinning
                     // second half of the transform.
                     .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f); // t = 1.4
             }
+        }
+
+        private bool isMissedTick() => result.IsMiss() && result != HitResult.Miss;
+
+        private void applyMissedTickScaling()
+        {
+            this.ScaleTo(0.6f);
+            this.ScaleTo(0.3f, 100, Easing.In);
         }
 
         public Drawable GetAboveHitObjectsProxiedContent() => CreateProxy();


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/25987.

Structure is a bit clumsy but I'm not sure how to do better...

Before:

https://github.com/ppy/osu/assets/20418176/da59c256-74ca-4c9c-acde-6c665fd12ebf

After:

https://github.com/ppy/osu/assets/20418176/3e0d1a75-0860-4394-9d3e-f4fb4922e73e
