### PR TITLE
Fix scale of skin element bounding box

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -136,9 +136,10 @@ namespace osu.Game.Overlays.SkinEditor
         {
             base.Update();
 
+            Vector2 scale = drawable.DrawInfo.MatrixInverse.ExtractScale().Xy;
             drawableQuad = drawable.ToScreenSpace(
                 drawable.DrawRectangle
-                        .Inflate(SkinSelectionHandler.INFLATE_SIZE));
+                        .Inflate(SkinSelectionHandler.INFLATE_SIZE * scale));
 
             var localSpaceQuad = ToLocalSpace(drawableQuad);
 


### PR DESCRIPTION
- Resolves #25049
- Supersedes / closes https://github.com/ppy/osu/pull/25168

This PR introduces the change suggested by @Tom94 here: https://github.com/ppy/osu/pull/25168#issuecomment-1807152371

## Testing notes

Tested the following elements:
- ArgonAccuracyCounter
- ArgonHealthDisplay
- BarHitErrorMeter
- ArgonComboCounter
- ArgonKeyCounterDisplay
- ArgonSongProgress
- ArgonWedgePiece

Tested scaling elements arbitrarily large and small.
Tested rotation and flipping.
Tested group selections.

### Reproduction and fix demonstration with hot reload
[Screencast_20231221_085141-1.webm](https://github.com/ppy/osu/assets/12166320/09b0e6f8-a9c9-45b8-b550-e0482226df26)

## Known Issues

ArgonWedgePiece's bounding box is still incorrect regardless of scaling. This seems to be a separate issue.
