### PR TITLE
Use classic HP values for non-classic osu! HP drain

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Rulesets.Osu
 
         public override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor();
 
+        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new OsuHealthProcessor(drainStartTime);
+
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new OsuBeatmapConverter(beatmap, this);
 
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new OsuBeatmapProcessor(beatmap);

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Scoring
+{
+    public partial class OsuHealthProcessor : DrainingHealthProcessor
+    {
+        public OsuHealthProcessor(double drainStartTime, double drainLenience = 0)
+            : base(drainStartTime, drainLenience)
+        {
+        }
+
+        protected override double GetHealthIncreaseFor(JudgementResult result)
+        {
+            switch (result.Type)
+            {
+                case HitResult.SmallTickMiss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.02, -0.075, -0.14);
+
+                case HitResult.LargeTickMiss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.02, -0.075, -0.14);
+
+                case HitResult.Miss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.03, -0.125, -0.2);
+
+                case HitResult.SmallTickHit:
+                    // When classic slider mechanics are enabled, this result comes from the tail.
+                    return 0.02;
+
+                case HitResult.LargeTickHit:
+                    switch (result.HitObject)
+                    {
+                        case SliderTick:
+                            return 0.015;
+
+                        case SliderHeadCircle:
+                        case SliderTailCircle:
+                        case SliderRepeat:
+                            return 0.02;
+                    }
+
+                    break;
+
+                case HitResult.Meh:
+                    return 0.002;
+
+                case HitResult.Ok:
+                    return 0.011;
+
+                case HitResult.Great:
+                    return 0.03;
+
+                case HitResult.SmallBonus:
+                    return 0.0085;
+
+                case HitResult.LargeBonus:
+                    return 0.01;
+            }
+
+            return base.GetHealthIncreaseFor(result);
+        }
+    }
+}


### PR DESCRIPTION
The main issue here, is that the default HP increase of `LargeTickHit`, as defined by `Judgement`, is equal to that of a `Great`. This seems to be way too lenient on slider-heavy maps.

But, the path I took to fixing this is via adding an `OsuHealthProcessor` that uses the same raw values as `OsuLegacyHealthProcessor`. It means that some values and their relative increases are a bit different and may need further adjustment.

Here's a few replays:

[Replays.zip](https://github.com/ppy/osu/files/13744562/Replays.zip)

The `Izutsumi` and `Crone` replays fail now but both players indicated their scores shouldn't have been passes.

I still don't think that my replay should be a fail, and it feels about as harsh as if not worse than classic mod now, but I want to get this out for wider feedback before further adjustments are made.