### PR TITLE
Add basic density consideration to HP drain

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Rulesets.Osu
 
         public override ScoreProcessor CreateScoreProcessor() => new OsuScoreProcessor();
 
+        public override HealthProcessor CreateHealthProcessor(double drainStartTime) => new OsuHealthProcessor(drainStartTime);
+
         public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap) => new OsuBeatmapConverter(beatmap, this);
 
         public override IBeatmapProcessor CreateBeatmapProcessor(IBeatmap beatmap) => new OsuBeatmapProcessor(beatmap);

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -3,6 +3,8 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
@@ -14,6 +16,8 @@ namespace osu.Game.Rulesets.Osu.Scoring
             : base(drainStartTime, drainLenience)
         {
         }
+
+        protected override int? GetDensityGroup(HitObject hitObject) => (hitObject as IHasComboInformation)?.ComboIndex;
 
         protected override double GetHealthIncreaseFor(JudgementResult result)
         {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Scoring
+{
+    public partial class OsuHealthProcessor : DrainingHealthProcessor
+    {
+        public OsuHealthProcessor(double drainStartTime, double drainLenience = 0)
+            : base(drainStartTime, drainLenience)
+        {
+        }
+
+        protected override double GetHealthIncreaseFor(JudgementResult result)
+        {
+            switch (result.Type)
+            {
+                case HitResult.SmallTickMiss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.02, -0.075, -0.14);
+
+                case HitResult.LargeTickMiss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.02, -0.075, -0.14);
+
+                case HitResult.Miss:
+                    return IBeatmapDifficultyInfo.DifficultyRange(Beatmap.Difficulty.DrainRate, -0.03, -0.125, -0.2);
+
+                case HitResult.SmallTickHit:
+                    // When classic slider mechanics are enabled, this result comes from the tail.
+                    return 0.02;
+
+                case HitResult.LargeTickHit:
+                    switch (result.HitObject)
+                    {
+                        case SliderTick:
+                            return 0.015;
+
+                        case SliderHeadCircle:
+                        case SliderTailCircle:
+                        case SliderRepeat:
+                            return 0.02;
+                    }
+
+                    break;
+
+                case HitResult.Meh:
+                    return 0.002;
+
+                case HitResult.Ok:
+                    return 0.011;
+
+                case HitResult.Great:
+                    return 0.03;
+
+                case HitResult.SmallBonus:
+                    return 0.0085;
+
+                case HitResult.LargeBonus:
+                    return 0.01;
+            }
+
+            return base.GetHealthIncreaseFor(result);
+        }
+    }
+}


### PR DESCRIPTION
Builds upon https://github.com/ppy/osu/pull/26012 to add some basic form of density consideration.

I need more time to test this, but PRing for review for now.

The idea I'm going for is to normalise higher-density sections back to more reasonable values so that they don't skew the algorithm too much, while preserving some effects of density. Basically - taking the edge off.

In this implementation, a "section" refers to, at least for the osu! ruleset, a combo colour. This is completely theoretical at this point and I haven't tested the effect of applying the normalisation per-hitobject, but this may lead to more interesting effects around things like 1-combo bursts. Definitely needs more testing.

[Replays.zip](https://github.com/ppy/osu/files/13744562/Replays.zip) (compare vs PR above)