### PR TITLE
Fix strict tracking mod forcefully missing tail before slider start time

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests.Mods
+{
+    public partial class TestSceneOsuModStrictTracking : OsuModTestScene
+    {
+        [Test]
+        public void TestSliderInput() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(0, new Vector2(), OsuAction.LeftButton),
+                new OsuReplayFrame(500, new Vector2(200, 0), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(200, 0)),
+                new OsuReplayFrame(1000, new Vector2(), OsuAction.LeftButton),
+                new OsuReplayFrame(1750, new Vector2(0, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(1751, new Vector2(0, 100)),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
+        });
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -36,6 +36,9 @@ namespace osu.Game.Rulesets.Osu.Mods
                 {
                     if (e.NewValue || slider.Judged) return;
 
+                    if (slider.Time.Current < slider.HitObject.StartTime)
+                        return;
+
                     var tail = slider.NestedHitObjects.OfType<StrictTrackingDrawableSliderTail>().First();
 
                     if (!tail.Judged)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25816.

Regressed in https://github.com/ppy/osu/pull/25748.

The reason this broke is that allowing the state of `Tracking` to change before the slider's start time to support the early hit scenario causes strict tracking to consider loss of tracking before the slider's start time as an actual miss, and thus forcefully miss the tail (see test case in https://github.com/ppy/osu/commit/6cb82310549a73ca2657efe65c9528da8367f1ab).