### PR TITLE
Adjust BeatmapInfoWedge's beatmap length field according to mod rate

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -191,6 +192,36 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 var label = infoWedge.DisplayedContent.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == BeatmapsetsStrings.ShowStatsBpm);
                 return label.Statistic.Content == target;
+            });
+        }
+
+        [TestCase]
+        public void TestLengthUpdates()
+        {
+            IBeatmap beatmap = createTestBeatmap(new OsuRuleset().RulesetInfo);
+            double drain = beatmap.CalculateDrainLength();
+            beatmap.BeatmapInfo.Length = drain;
+
+            OsuModDoubleTime doubleTime = null;
+
+            selectBeatmap(beatmap);
+            checkDisplayedLength(drain);
+
+            AddStep("select DT", () => SelectedMods.Value = new[] { doubleTime = new OsuModDoubleTime() });
+            checkDisplayedLength(Math.Round(drain / 1.5f));
+
+            AddStep("change DT rate", () => doubleTime.SpeedChange.Value = 2);
+            checkDisplayedLength(Math.Round(drain / 2));
+        }
+
+        private void checkDisplayedLength(double drain)
+        {
+            var displayedLength = drain.ToFormattedDuration();
+
+            AddUntilStep($"check map drain ({displayedLength})", () =>
+            {
+                var label = infoWedge.DisplayedContent.ChildrenOfType<BeatmapInfoWedge.WedgeInfoText.InfoLabel>().Single(l => l.Statistic.Name == BeatmapsetsStrings.ShowStatsTotalLength(displayedLength));
+                return label.Statistic.Content == displayedLength.ToString();
             });
         }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapInfoWedge.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Extensions;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;

--- a/osu.Game/Screens/Select/BeatmapInfoWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapInfoWedge.cs
@@ -161,6 +161,7 @@ namespace osu.Game.Screens.Select
             private ILocalisedBindableString artistBinding;
             private FillFlowContainer infoLabelContainer;
             private Container bpmLabelContainer;
+            private Container lengthLabelContainer;
 
             private readonly WorkingBeatmap working;
             private readonly RulesetInfo ruleset;
@@ -341,10 +342,10 @@ namespace osu.Game.Screens.Select
                 {
                     settingChangeTracker?.Dispose();
 
-                    refreshBPMLabel();
+                    refreshBPMAndLengthLabel();
 
                     settingChangeTracker = new ModSettingChangeTracker(m.NewValue);
-                    settingChangeTracker.SettingChanged += _ => refreshBPMLabel();
+                    settingChangeTracker.SettingChanged += _ => refreshBPMAndLengthLabel();
                 }, true);
             }
 
@@ -370,12 +371,10 @@ namespace osu.Game.Screens.Select
 
                     infoLabelContainer.Children = new Drawable[]
                     {
-                        new InfoLabel(new BeatmapStatistic
+                        lengthLabelContainer = new Container
                         {
-                            Name = BeatmapsetsStrings.ShowStatsTotalLength(playableBeatmap.CalculateDrainLength().ToFormattedDuration()),
-                            CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
-                            Content = working.BeatmapInfo.Length.ToFormattedDuration().ToString(),
-                        }),
+                            AutoSizeAxes = Axes.Both,
+                        },
                         bpmLabelContainer = new Container
                         {
                             AutoSizeAxes = Axes.Both,
@@ -394,7 +393,7 @@ namespace osu.Game.Screens.Select
                 }
             }
 
-            private void refreshBPMLabel()
+            private void refreshBPMAndLengthLabel()
             {
                 var beatmap = working.Beatmap;
 
@@ -419,6 +418,16 @@ namespace osu.Game.Screens.Select
                     Name = BeatmapsetsStrings.ShowStatsBpm,
                     CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Bpm),
                     Content = labelText
+                });
+
+                double drainLength = Math.Round(beatmap.CalculateDrainLength() / rate);
+                double hitLength = Math.Round(beatmap.BeatmapInfo.Length / rate);
+
+                lengthLabelContainer.Child = new InfoLabel(new BeatmapStatistic
+                {
+                    Name = BeatmapsetsStrings.ShowStatsTotalLength(drainLength.ToFormattedDuration()),
+                    CreateIcon = () => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Length),
+                    Content = hitLength.ToFormattedDuration().ToString(),
                 });
             }
 


### PR DESCRIPTION
I noticed the displayed length of the beatmap didn't change according to the change in rate (BPM does). These changes makes the beatmap length in `BeatmapInfoWedge` refresh the same time as BPM according to the mods rate.