### PR TITLE
Change legacy version checks to account for users specifying incorrect versions

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -160,7 +160,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                         {
                             decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
 
-                            if (legacyVersion >= 2.0m)
+                            if (legacyVersion > 1.0m)
                                 // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
                                 hitCircleText.FadeOut(legacy_fade_duration / 4);
                             else

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Skinning
 
                     decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
 
-                    if (legacyVersion >= 2.0m)
+                    if (legacyVersion > 1.0m)
                     {
                         this.MoveTo(new Vector2(0, -5));
                         this.MoveToOffset(new Vector2(0, 80), fade_out_delay + fade_out_length, Easing.In);


### PR DESCRIPTION
https://twitter.com/emyl___/status/1738356704742355144 and countless others have reported this. Turns out they are using versions like 1.5, which don't even exist.

Sample broken skin: [eml_-_eml_-_1.5_emil.osk.zip](https://github.com/ppy/osu/files/13758043/eml_-_eml_-_1.5_emil.osk.zip)
