### PR TITLE
Add control to allow changing offset from gameplay

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -160,6 +160,8 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Enter, GlobalAction.ToggleChatFocus),
             new KeyBinding(InputKey.F1, GlobalAction.SaveReplay),
             new KeyBinding(InputKey.F2, GlobalAction.ExportReplay),
+            new KeyBinding(InputKey.Plus, GlobalAction.IncreaseOffset),
+            new KeyBinding(InputKey.Minus, GlobalAction.DecreaseOffset),
         };
 
         private static IEnumerable<KeyBinding> replayKeyBindings => new[]
@@ -404,6 +406,12 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorToggleRotateControl))]
         EditorToggleRotateControl,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.IncreaseOffset))]
+        IncreaseOffset,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.DecreaseOffset))]
+        DecreaseOffset
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -345,6 +345,16 @@ namespace osu.Game.Localisation
         public static LocalisableString ExportReplay => new TranslatableString(getKey(@"export_replay"), @"Export replay");
 
         /// <summary>
+        /// "Increase offset"
+        /// </summary>
+        public static LocalisableString IncreaseOffset => new TranslatableString(getKey(@"increase_offset"), @"Increase offset");
+
+        /// <summary>
+        /// "Decrease offset"
+        /// </summary>
+        public static LocalisableString DecreaseOffset => new TranslatableString(getKey(@"decrease_offset"), @"Decrease offset");
+
+        /// <summary>
         /// "Toggle rotate control"
         /// </summary>
         public static LocalisableString EditorToggleRotateControl => new TranslatableString(getKey(@"editor_toggle_rotate_control"), @"Toggle rotate control");

--- a/osu.Game/Screens/Play/GameplayOffsetControl.cs
+++ b/osu.Game/Screens/Play/GameplayOffsetControl.cs
@@ -25,6 +25,9 @@ namespace osu.Game.Screens.Play
 
         public override bool PropagateNonPositionalInputSubTree => true;
 
+        // Disable interaction for now to avoid any funny business with slider bar dragging.
+        public override bool PropagatePositionalInputSubTree => false;
+
         private BeatmapOffsetControl offsetControl = null!;
 
         private OsuTextFlowContainer text = null!;

--- a/osu.Game/Screens/Play/GameplayOffsetControl.cs
+++ b/osu.Game/Screens/Play/GameplayOffsetControl.cs
@@ -1,0 +1,104 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+using osu.Game.Screens.Play.PlayerSettings;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Play
+{
+    /// <summary>
+    /// This provides the ability to change the offset while in gameplay.
+    /// Eventually this should be replaced with all settings from PlayerLoader being accessible from the game.
+    /// </summary>
+    internal partial class GameplayOffsetControl : VisibilityContainer
+    {
+        protected override bool StartHidden => true;
+
+        public override bool PropagateNonPositionalInputSubTree => true;
+
+        private BeatmapOffsetControl offsetControl = null!;
+
+        private OsuTextFlowContainer text = null!;
+
+        private ScheduledDelegate? hideOp;
+
+        public GameplayOffsetControl()
+        {
+            AutoSizeAxes = Axes.Y;
+            Width = SettingsToolboxGroup.CONTAINER_WIDTH;
+
+            Masking = true;
+            CornerRadius = 5;
+
+            // Allow BeatmapOffsetControl to handle keyboard input.
+            AlwaysPresent = true;
+
+            Anchor = Anchor.CentreRight;
+            Origin = Anchor.CentreRight;
+
+            X = 100;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider? colourProvider)
+        {
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.8f,
+                    Colour = colourProvider?.Background4 ?? Color4.Black,
+                },
+                new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding(10),
+                    Spacing = new Vector2(5),
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        offsetControl = new BeatmapOffsetControl(),
+                        text = new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(weight: FontWeight.SemiBold))
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            TextAnchor = Anchor.TopCentre,
+                        }
+                    }
+                },
+            };
+
+            offsetControl.Current.BindValueChanged(val =>
+            {
+                text.Text = BeatmapOffsetControl.GetOffsetExplanatoryText(val.NewValue);
+                Show();
+
+                hideOp?.Cancel();
+                hideOp = Scheduler.AddDelayed(Hide, 500);
+            });
+        }
+
+        protected override void PopIn()
+        {
+            this.FadeIn(500, Easing.OutQuint)
+                .MoveToX(0, 500, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(500, Easing.InQuint)
+                .MoveToX(100, 500, Easing.InQuint);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -461,6 +461,12 @@ namespace osu.Game.Screens.Play
                         OnRetry = () => Restart(),
                         OnQuit = () => PerformExit(true),
                     },
+                    new GameplayOffsetControl
+                    {
+                        Margin = new MarginPadding(20),
+                        Anchor = Anchor.CentreRight,
+                        Origin = Anchor.CentreRight,
+                    }
                 },
             };
 

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -51,6 +51,12 @@ namespace osu.Game.Screens.Play.PlayerSettings
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
+        [Resolved]
+        private Player? player { get; set; }
+
+        [Resolved]
+        private IGameplayClock? gameplayClock { get; set; }
+
         private double lastPlayAverage;
         private double lastPlayBeatmapOffset;
         private HitEventTimingDistributionGraph? lastPlayGraph;
@@ -227,6 +233,18 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
+            // General limitations to ensure players don't do anything too weird.
+            // These match stable for now.
+            if (player is SubmittingPlayer)
+            {
+                // TODO: the blocking conditions should probably display a message.
+                if (player?.IsBreakTime.Value == false && gameplayClock?.CurrentTime - gameplayClock?.StartTime > 10000)
+                    return false;
+
+                if (gameplayClock?.IsPaused.Value == true)
+                    return false;
+            }
+
             // To match stable, this should adjust by 5 ms, or 1 ms when holding alt.
             // But that is hard to make work with global actions due to the operating mode.
             // Let's use the more precise as a default for now.

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -9,6 +9,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -16,6 +18,7 @@ using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
@@ -26,7 +29,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
-    public partial class BeatmapOffsetControl : CompositeDrawable
+    public partial class BeatmapOffsetControl : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         public Bindable<ScoreInfo?> ReferenceScore { get; } = new Bindable<ScoreInfo?>();
 
@@ -86,28 +89,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     },
                 }
             };
-        }
-
-        public partial class OffsetSliderBar : PlayerSliderBar<double>
-        {
-            protected override Drawable CreateControl() => new CustomSliderBar();
-
-            protected partial class CustomSliderBar : SliderBar
-            {
-                public override LocalisableString TooltipText =>
-                    Current.Value == 0
-                        ? LocalisableString.Interpolate($@"{base.TooltipText} ms")
-                        : LocalisableString.Interpolate($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
-
-                private LocalisableString getEarlyLateText(double value)
-                {
-                    Debug.Assert(value != 0);
-
-                    return value > 0
-                        ? BeatmapOffsetControlStrings.HitObjectsAppearEarlier
-                        : BeatmapOffsetControlStrings.HitObjectsAppearLater;
-                }
-            }
         }
 
         protected override void LoadComplete()
@@ -242,6 +223,52 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             base.Dispose(isDisposing);
             beatmapOffsetSubscription?.Dispose();
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            double amount = e.AltPressed ? 1 : 5;
+
+            switch (e.Action)
+            {
+                case GlobalAction.IncreaseOffset:
+                    Current.Value += amount;
+
+                    return true;
+
+                case GlobalAction.DecreaseOffset:
+                    Current.Value -= amount;
+
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+
+        public partial class OffsetSliderBar : PlayerSliderBar<double>
+        {
+            protected override Drawable CreateControl() => new CustomSliderBar();
+
+            protected partial class CustomSliderBar : SliderBar
+            {
+                public override LocalisableString TooltipText =>
+                    Current.Value == 0
+                        ? LocalisableString.Interpolate($@"{base.TooltipText} ms")
+                        : LocalisableString.Interpolate($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
+
+                private LocalisableString getEarlyLateText(double value)
+                {
+                    Debug.Assert(value != 0);
+
+                    return value > 0
+                        ? BeatmapOffsetControlStrings.HitObjectsAppearEarlier
+                        : BeatmapOffsetControlStrings.HitObjectsAppearLater;
+                }
+            }
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -227,7 +227,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
-            double amount = e.AltPressed ? 1 : 5;
+            // To match stable, this should adjust by 5 ms, or 1 ms when holding alt.
+            // But that is hard to make work with global actions due to the operating mode.
+            // Let's use the more precise as a default for now.
+            const double amount = 1;
 
             switch (e.Action)
             {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -233,12 +233,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
             {
                 case GlobalAction.IncreaseOffset:
                     Current.Value += amount;
-
                     return true;
 
                 case GlobalAction.DecreaseOffset:
                     Current.Value -= amount;
-
                     return true;
             }
 
@@ -249,25 +247,29 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
         }
 
+        public static LocalisableString GetOffsetExplanatoryText(double offset)
+        {
+            return offset == 0
+                ? LocalisableString.Interpolate($@"{offset:0.0} ms")
+                : LocalisableString.Interpolate($@"{offset:0.0} ms {getEarlyLateText(offset)}");
+
+            LocalisableString getEarlyLateText(double value)
+            {
+                Debug.Assert(value != 0);
+
+                return value > 0
+                    ? BeatmapOffsetControlStrings.HitObjectsAppearEarlier
+                    : BeatmapOffsetControlStrings.HitObjectsAppearLater;
+            }
+        }
+
         public partial class OffsetSliderBar : PlayerSliderBar<double>
         {
             protected override Drawable CreateControl() => new CustomSliderBar();
 
             protected partial class CustomSliderBar : SliderBar
             {
-                public override LocalisableString TooltipText =>
-                    Current.Value == 0
-                        ? LocalisableString.Interpolate($@"{base.TooltipText} ms")
-                        : LocalisableString.Interpolate($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
-
-                private LocalisableString getEarlyLateText(double value)
-                {
-                    Debug.Assert(value != 0);
-
-                    return value > 0
-                        ? BeatmapOffsetControlStrings.HitObjectsAppearEarlier
-                        : BeatmapOffsetControlStrings.HitObjectsAppearLater;
-                }
+                public override LocalisableString TooltipText => GetOffsetExplanatoryText(Current.Value);
             }
         }
     }


### PR DESCRIPTION
Intended to be a very rough implementation, because I'm not supposed to be spending time on these things right now (although arguably, this is in the project sooo...)

In the future, I would see the `PlayerLoader` settings being moved into gameplay and having a better display method. I'd also hope to load the current score as reference so the user could get immediate feedback on their adjustment, but `HitEvents` are currently not populated in realtime.

Also yes, it is intended that this displays initially if the offset is non-zero. Stable also does this to inform the user that there's a local override.

- [x] Note that I haven't tested the alt+key support, as my keyboard layers don't allow that combination >_<.

Closes https://github.com/ppy/osu/issues/25007.

---

This behaves how you'd expect it to coming from stable. It's intended to be a very quick implementation just to get the functionality back, and will improve in the future. Controls are configurable but default to `+`/`-`. Hold `Alt` to get more precise control.

https://github.com/ppy/osu/assets/191335/659934e8-22ec-4e81-98a6-3d76e465cdee

