### PR TITLE
Replace recently-added HP drain density calculation with combo-end bonus

### DIFF
--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -17,8 +17,6 @@ namespace osu.Game.Rulesets.Osu.Scoring
         {
         }
 
-        protected override int? GetDensityGroup(HitObject hitObject) => (hitObject as IHasComboInformation)?.ComboIndex;
-
         protected override double GetHealthIncreaseFor(JudgementResult result)
         {
             switch (result.Type)

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Objects;

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     break;
             }
 
-            // The tail has a special IgnoreMiss judgement
+            // The slider tail has a special judgement that can't accurately be described above.
             if (result.HitObject is SliderTailCircle && !result.IsHit)
                 setComboResult(ComboResult.Good);
 

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Rulesets.Scoring
         protected readonly double DrainLenience;
 
         private readonly List<HealthIncrease> healthIncreases = new List<HealthIncrease>();
-        private readonly Dictionary<int, double> densityMultiplierByGroup = new Dictionary<int, double>();
 
         private double gameplayEndTime;
         private double targetMinimumHealth;
@@ -139,28 +138,13 @@ namespace osu.Game.Rulesets.Scoring
             {
                 healthIncreases.Add(new HealthIncrease(
                     result.HitObject.GetEndTime() + result.TimeOffset,
-                    GetHealthIncreaseFor(result),
-                    GetDensityGroup(result.HitObject)));
+                    GetHealthIncreaseFor(result)));
             }
         }
-
-        protected override double GetHealthIncreaseFor(JudgementResult result) => base.GetHealthIncreaseFor(result) * getDensityMultiplier(GetDensityGroup(result.HitObject));
-
-        private double getDensityMultiplier(int? group)
-        {
-            if (group == null)
-                return 1;
-
-            return densityMultiplierByGroup.TryGetValue(group.Value, out double multiplier) ? multiplier : 1;
-        }
-
-        protected virtual int? GetDensityGroup(HitObject hitObject) => null;
 
         protected override void Reset(bool storeResults)
         {
             base.Reset(storeResults);
-
-            densityMultiplierByGroup.Clear();
 
             if (storeResults)
                 DrainRate = ComputeDrainRate();
@@ -172,24 +156,6 @@ namespace osu.Game.Rulesets.Scoring
         {
             if (healthIncreases.Count <= 1)
                 return 0;
-
-            // Normalise the health gain during sections with higher densities.
-            (int group, double avgIncrease)[] avgIncreasesByGroup = healthIncreases
-                                                                    .Where(i => i.Group != null)
-                                                                    .GroupBy(i => i.Group)
-                                                                    .Select(g => ((int)g.Key!, g.Sum(i => i.Amount) / (g.Max(i => i.Time) - g.Min(i => i.Time) + 1)))
-                                                                    .ToArray();
-
-            if (avgIncreasesByGroup.Length > 1)
-            {
-                double overallAverageIncrease = avgIncreasesByGroup.Average(g => g.avgIncrease);
-
-                foreach ((int group, double avgIncrease) in avgIncreasesByGroup)
-                {
-                    // Reduce the health increase for groups that return more health than average.
-                    densityMultiplierByGroup[group] = Math.Min(1, overallAverageIncrease / avgIncrease);
-                }
-            }
 
             int adjustment = 1;
             double result = 1;
@@ -216,12 +182,10 @@ namespace osu.Game.Rulesets.Scoring
                         currentBreak++;
                     }
 
-                    double multiplier = getDensityMultiplier(healthIncreases[i].Group);
-
                     // Apply health adjustments
                     currentHealth -= (currentTime - lastTime) * result;
                     lowestHealth = Math.Min(lowestHealth, currentHealth);
-                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].Amount * multiplier);
+                    currentHealth = Math.Min(1, currentHealth + healthIncreases[i].Amount);
 
                     // Common scenario for when the drain rate is definitely too harsh
                     if (lowestHealth < 0)
@@ -240,6 +204,6 @@ namespace osu.Game.Rulesets.Scoring
             return result;
         }
 
-        private record struct HealthIncrease(double Time, double Amount, int? Group);
+        private record struct HealthIncrease(double Time, double Amount);
     }
 }


### PR DESCRIPTION
When maps have very _consistent_ density, HP drain is as harsh as it can get to the point that it feels like if you miss a note you can never regain HP.

I don't know how to maths enough to fix this just from just the hp increase / hp drain side of things, so I'm taking another approach by adding combo-end bonuses similar to stable.

Stable gives one of three bonuses at the time combo:
- ["Geki"](https://osu.ppy.sh/wiki/en/Gameplay/Judgement/Geki) if every object was hit with a 300.
- ["Katu"](https://osu.ppy.sh/wiki/en/Gameplay/Judgement/Katu) if every object was hit with 100 or above.
- "Mu" if any object was hit with 50 or below.

The slider tick/slider tail cases are a bit special in lazer due to judgement differences from stable.

[Replays.zip](https://github.com/ppy/osu/files/13759423/Replays.zip) (5. is most relevant to this PR)