### PR TITLE
Add classic skin sprites for slider tick and slider end misses

### DIFF
--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -58,14 +58,24 @@ namespace osu.Game.Skinning
 
             if (result.IsMiss())
             {
+                decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
+
+                // missed ticks / slider end don't get the normal animation.
                 if (isMissedTick())
-                    applyMissedTickScaling();
-                else
                 {
                     this.ScaleTo(1.6f);
                     this.ScaleTo(1, 100, Easing.In);
 
-                    decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
+                    if (legacyVersion > 1.0m)
+                    {
+                        this.MoveTo(new Vector2(0, -2f));
+                        this.MoveToOffset(new Vector2(0, 10), fade_out_delay + fade_out_length, Easing.In);
+                    }
+                }
+                else
+                {
+                    this.ScaleTo(1.6f);
+                    this.ScaleTo(1, 100, Easing.In);
 
                     if (legacyVersion > 1.0m)
                     {

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -461,7 +461,6 @@ namespace osu.Game.Skinning
                 case HitResult.LargeTickMiss:
                     return this.GetAnimation("slidertickmiss", true, false);
 
-                case HitResult.ComboBreak:
                 case HitResult.IgnoreMiss:
                     return this.GetAnimation("sliderendmiss", true, false);
 

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -453,11 +453,18 @@ namespace osu.Game.Skinning
 
         private Drawable? getJudgementAnimation(HitResult result)
         {
-            if (result.IsMiss())
-                return this.GetAnimation("hit0", true, false);
-
             switch (result)
             {
+                case HitResult.Miss:
+                    return this.GetAnimation("hit0", true, false);
+
+                case HitResult.LargeTickMiss:
+                    return this.GetAnimation("slidertickmiss", true, false);
+
+                case HitResult.ComboBreak:
+                case HitResult.IgnoreMiss:
+                    return this.GetAnimation("sliderendmiss", true, false);
+
                 case HitResult.Meh:
                     return this.GetAnimation("hit50", true, false);
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2023.1219.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1215.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2023.1225.0" />
     <PackageReference Include="Sentry" Version="3.40.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.33.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/300

Design feedback was taken in `#general` on discord.

---

A lot of complaints asking for disable on the new elements. Mostly because it was confusing to just downscale the normal miss.

Now they get their own sprites. And as a result it's skinnable for the people that are *really* adverse to change. You can skin via `slidertickmiss@2x.png` and `sliderendmiss@2x.png`.
 
https://github.com/ppy/osu-resources/assets/191335/2a855d02-3a5c-4cd7-9772-fc8fdb484753

https://github.com/ppy/osu-resources/assets/191335/77b928b4-cafb-4c3c-90ef-4be3b2233117
