### PR TITLE
Update argon and triangles slider tick/end miss to match display style

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
@@ -62,7 +62,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         /// </remarks>
         public virtual void PlayAnimation()
         {
-            if (Result.IsMiss())
+            if (Result == HitResult.IgnoreMiss || Result == HitResult.LargeTickMiss)
+            {
+                this.RotateTo(-45);
+                this.ScaleTo(1.8f);
+                this.ScaleTo(1.2f, 100, Easing.In);
+
+                this.MoveTo(Vector2.Zero);
+                this.MoveToOffset(new Vector2(0, 10), 800, Easing.InQuint);
+            }
+            else if (Result.IsMiss())
             {
                 this.ScaleTo(1.6f);
                 this.ScaleTo(1, 100, Easing.In);

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -38,7 +38,20 @@ namespace osu.Game.Rulesets.Judgements
         /// </remarks>
         public virtual void PlayAnimation()
         {
-            if (Result != HitResult.None && !Result.IsHit())
+            // TODO: make these better. currently they are using a text `-` and it's not centered properly.
+            // Should be an explicit drawable.
+            //
+            // When this is done, remove the [Description] attributes from HitResults which were added for this purpose.
+            if (Result == HitResult.IgnoreMiss || Result == HitResult.LargeTickMiss)
+            {
+                this.RotateTo(-45);
+                this.ScaleTo(1.8f);
+                this.ScaleTo(1.2f, 100, Easing.In);
+
+                this.MoveTo(Vector2.Zero);
+                this.MoveToOffset(new Vector2(0, 10), 800, Easing.InQuint);
+            }
+            else if (Result.IsMiss())
             {
                 this.ScaleTo(1.6f);
                 this.ScaleTo(1, 100, Easing.In);

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a large tick miss.
         /// </summary>
         [EnumMember(Value = "large_tick_miss")]
-        [Description(@"x")]
+        [Description("-")]
         [Order(10)]
         LargeTickMiss,
 
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a miss that should be ignored for scoring purposes.
         /// </summary>
         [EnumMember(Value = "ignore_miss")]
-        [Description("x")]
+        [Description("-")]
         [Order(13)]
         IgnoreMiss,
 


### PR DESCRIPTION
https://github.com/ppy/osu/assets/191335/780b0a80-a25c-4948-ab0e-29edf019edbe

https://github.com/ppy/osu/assets/191335/a0d17443-0103-4c1e-8e4a-bcfde9ea7c15

