### PR TITLE
Do not attempt to stop preview tracks when arriving from a "track completed" sync

### DIFF
--- a/osu.Game/Audio/PreviewTrack.cs
+++ b/osu.Game/Audio/PreviewTrack.cs
@@ -96,10 +96,13 @@ namespace osu.Game.Audio
 
             hasStarted = false;
 
-            Track.Stop();
+            if (!Track.HasCompleted)
+            {
+                Track.Stop();
 
-            // Ensure the track is reset immediately on stopping, so the next time it is started it has a correct time value.
-            Track.Seek(0);
+                // Ensure the track is reset immediately on stopping, so the next time it is started it has a correct time value.
+                Track.Seek(0);
+            }
 
             Stopped?.Invoke();
         }

--- a/osu.Game/Audio/PreviewTrack.cs
+++ b/osu.Game/Audio/PreviewTrack.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Audio
 
             hasStarted = false;
 
+            // This pre-check is important, fixes a BASS deadlock in some scenarios.
             if (!Track.HasCompleted)
             {
                 Track.Stop();


### PR DESCRIPTION
This fixes an issue identified with the WASAPI implementation in https://github.com/ppy/osu-framework/pull/6088. It appears to have no real effect on current `master`, but fixes a deadlock that occurs with the aforementioned framework branch when one lets a preview track play out to the end - at this point all audio will stop and an attempt to perform any synchronous BASS operation (playing another track, seeking) will result in a deadlock.

See [discord conversation](https://discord.com/channels/188630481301012481/589331078574112768/1188731899686957197) and [later continuation](https://discord.com/channels/188630481301012481/589331078574112768/1188861382196727891) for paper trail.

It isn't terribly clear as to why this is happening precisely, but there does not appear to be any need to stop and seek at that point, so this feels like a decent workaround even if the actual issue is upstream (and will unblock pushing out WASAPI support to users).