### PR TITLE
Hide `HoldForMenuButton` on non-touch devices

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHoldForMenuButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHoldForMenuButton.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private HoldForMenuButton holdForMenuButton;
 
-        private void setupSteps(bool autoHide)
+        private void setupSteps(bool alwaysShow)
         {
             AddStep("create button", () =>
             {
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     Origin = Anchor.CentreRight,
                     Anchor = Anchor.CentreRight,
                     Action = () => exitAction = true,
-                    AutoHide = { Value = autoHide },
+                    AlwaysShow = { Value = alwaysShow },
                 };
             });
         }
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestFullMovementAndTrigger()
         {
-            setupSteps(autoHide: false);
+            setupSteps(alwaysShow: true);
             AddStep("Trigger text fade in", () => InputManager.MoveMouseTo(holdForMenuButton));
             AddUntilStep("Text visible", () => getSpriteText().IsPresent && !exitAction);
             AddStep("Trigger text fade out", () => InputManager.MoveMouseTo(Vector2.One));
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestAutoHide()
         {
-            setupSteps(autoHide: true);
+            setupSteps(alwaysShow: false);
             AddAssert("Container initially invisible", () => holdForMenuButton.Alpha < .01f);
             AddStep("Trigger fade in", () => InputManager.MoveMouseTo(holdForMenuButton));
             AddUntilStep("Container visible", () => holdForMenuButton.Alpha >= 1f && !exitAction);
@@ -86,10 +86,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestPartialFadeOnNoInput()
         {
-            setupSteps(autoHide: false);
+            setupSteps(alwaysShow: true);
             AddStep("move mouse away", () => InputManager.MoveMouseTo(Vector2.One));
             AddUntilStep("wait for text fade out", () => !getSpriteText().IsPresent);
-            AddUntilStep("wait for button fade out", () => holdForMenuButton.Alpha < 1f);
+            AddUntilStep("wait for button fade out", () => holdForMenuButton.Alpha < 0.1f);
         }
 
         private SpriteText getSpriteText() => holdForMenuButton.Children.OfType<SpriteText>().First();

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -34,9 +34,9 @@ namespace osu.Game.Screens.Play.HUD
         public readonly Bindable<bool> ReplayLoaded = new Bindable<bool>();
 
         /// <summary>
-        /// Disable the entering animation and stay fully hidden until the cursor is nearby.
+        /// When enabled, show an enter animation and afterwards stay partially faded, otherwise be completely hidden until cursor is nearby.
         /// </summary>
-        public readonly Bindable<bool> AutoHide = new Bindable<bool>();
+        public readonly Bindable<bool> AlwaysShow = new Bindable<bool>(true);
 
         private HoldButton button;
 
@@ -85,8 +85,9 @@ namespace osu.Game.Screens.Play.HUD
                     : "press for menu";
             }, true);
 
-            if (!AutoHide.Value)
+            if (AlwaysShow.Value)
             {
+                Alpha = 1f;
                 text.FadeInFromZero(500, Easing.OutQuint)
                     .Delay(1500)
                     .FadeOut(500, Easing.OutQuint);
@@ -111,7 +112,7 @@ namespace osu.Game.Screens.Play.HUD
                 Alpha = 1;
             else
             {
-                float minAlpha = AutoHide.Value ? .001f : .07f;
+                float minAlpha = AlwaysShow.Value ? .08f : .001f;
 
                 Alpha = Interpolation.ValueAt(
                     Math.Clamp(Clock.ElapsedFrameTime, 0, 200),

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Screens.Play.HUD
 
         public readonly Bindable<bool> ReplayLoaded = new Bindable<bool>();
 
+        /// <summary>
+        /// Disable the entering animation and stay fully hidden until the cursor is nearby.
+        /// </summary>
+        public readonly Bindable<bool> AutoHide = new Bindable<bool>();
+
         private HoldButton button;
 
         public Action Action { get; set; }
@@ -41,6 +46,7 @@ namespace osu.Game.Screens.Play.HUD
 
         public HoldForMenuButton()
         {
+            Alpha = .001f;
             Direction = FillDirection.Horizontal;
             Spacing = new Vector2(20, 0);
             Margin = new MarginPadding(10);
@@ -53,6 +59,7 @@ namespace osu.Game.Screens.Play.HUD
             {
                 text = new OsuSpriteText
                 {
+                    Alpha = 0f,
                     Font = OsuFont.GetFont(weight: FontWeight.Bold),
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft
@@ -78,7 +85,12 @@ namespace osu.Game.Screens.Play.HUD
                     : "press for menu";
             }, true);
 
-            text.FadeInFromZero(500, Easing.OutQuint).Delay(1500).FadeOut(500, Easing.OutQuint);
+            if (!AutoHide.Value)
+            {
+                text.FadeInFromZero(500, Easing.OutQuint)
+                    .Delay(1500)
+                    .FadeOut(500, Easing.OutQuint);
+            }
 
             base.LoadComplete();
         }
@@ -99,9 +111,11 @@ namespace osu.Game.Screens.Play.HUD
                 Alpha = 1;
             else
             {
+                float minAlpha = AutoHide.Value ? .001f : .07f;
+
                 Alpha = Interpolation.ValueAt(
                     Math.Clamp(Clock.ElapsedFrameTime, 0, 200),
-                    Alpha, Math.Clamp(1 - positionalAdjust, 0.04f, 1), 0, 200, Easing.OutQuint);
+                    Alpha, Math.Clamp(1 - positionalAdjust, minAlpha, 1), 0, 200, Easing.OutQuint);
             }
         }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.Play
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        HoldToQuit = CreateHoldForMenuButton(),
+                        HoldToQuit = CreateHoldForMenuButton(touchDevice: mods.Any(m => m is ModTouchDevice)),
                     }
                 },
                 LeaderboardFlow = new FillFlowContainer
@@ -354,10 +354,11 @@ namespace osu.Game.Screens.Play
             ShowHealth = { BindTarget = ShowHealthBar }
         };
 
-        protected HoldForMenuButton CreateHoldForMenuButton() => new HoldForMenuButton
+        protected HoldForMenuButton CreateHoldForMenuButton(bool touchDevice) => new HoldForMenuButton
         {
             Anchor = Anchor.BottomRight,
             Origin = Anchor.BottomRight,
+            AutoHide = { Value = !touchDevice },
         };
 
         protected ModDisplay CreateModsContainer() => new ModDisplay

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Screens.Play
         private Bindable<bool> configSettingsOverlay;
 
         private readonly BindableBool replayLoaded = new BindableBool();
+        private readonly BindableBool touchActive = new BindableBool();
 
         private static bool hasShownNotificationOnce;
 
@@ -158,7 +159,7 @@ namespace osu.Game.Screens.Play
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        HoldToQuit = CreateHoldForMenuButton(touchDevice: mods.Any(m => m is ModTouchDevice)),
+                        HoldToQuit = CreateHoldForMenuButton(),
                     }
                 },
                 LeaderboardFlow = new FillFlowContainer
@@ -177,7 +178,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, INotificationOverlay notificationOverlay)
+        private void load(OsuConfigManager config, INotificationOverlay notificationOverlay, SessionStatics statics)
         {
             if (drawableRuleset != null)
             {
@@ -189,6 +190,8 @@ namespace osu.Game.Screens.Play
             configVisibilityMode = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
             configLeaderboardVisibility = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard);
             configSettingsOverlay = config.GetBindable<bool>(OsuSetting.ReplaySettingsOverlay);
+
+            statics.BindWith(Static.TouchInputActive, touchActive);
 
             if (configVisibilityMode.Value == HUDVisibilityMode.Never && !hasShownNotificationOnce)
             {
@@ -354,11 +357,11 @@ namespace osu.Game.Screens.Play
             ShowHealth = { BindTarget = ShowHealthBar }
         };
 
-        protected HoldForMenuButton CreateHoldForMenuButton(bool touchDevice) => new HoldForMenuButton
+        protected HoldForMenuButton CreateHoldForMenuButton() => new HoldForMenuButton
         {
             Anchor = Anchor.BottomRight,
             Origin = Anchor.BottomRight,
-            AutoHide = { Value = !touchDevice },
+            AlwaysShow = { BindTarget = touchActive },
         };
 
         protected ModDisplay CreateModsContainer() => new ModDisplay


### PR DESCRIPTION
As per [this](https://discord.com/channels/188630481301012481/188630652340404224/1187604735574954014) discussion in the discord, this PR changes the `HoldForMenuButton` to never appear on non-touch devices until the cursor is nearby, and on touch devices it will retain the pop-in animation, fading out to always be slightly visible. Since this component is redundant on devices on devices with a keyboard and hardcoded regardless it should be at least hidden.
