### PR TITLE
Make mania scroll speed independent of hit position

### DIFF
--- a/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfiguration.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Skinning
         /// </summary>
         public const float DEFAULT_COLUMN_SIZE = 30 * POSITION_SCALE_FACTOR;
 
+        public const float DEFAULT_HIT_POSITION = (480 - 402) * POSITION_SCALE_FACTOR;
+
         public readonly int Keys;
 
         public Dictionary<string, Color4> CustomColours { get; } = new Dictionary<string, Color4>();
@@ -35,7 +37,7 @@ namespace osu.Game.Skinning
         public readonly float[] ExplosionWidth;
         public readonly float[] HoldNoteLightWidth;
 
-        public float HitPosition = (480 - 402) * POSITION_SCALE_FACTOR;
+        public float HitPosition = DEFAULT_HIT_POSITION;
         public float LightPosition = (480 - 413) * POSITION_SCALE_FACTOR;
         public float ScorePosition = 300 * POSITION_SCALE_FACTOR;
         public bool ShowJudgementLine = true;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/20820

Comparisons

| speed | stable | lazer |
| --- | --- | --- |
| 20 | <img width="1512" alt="Screenshot 2023-12-26 at 12 41 10" src="https://github.com/ppy/osu/assets/1329837/5549d825-16dc-45c9-9c96-6e4c02420db5"> | <img width="1512" alt="Screenshot 2023-12-26 at 12 41 05" src="https://github.com/ppy/osu/assets/1329837/6c4dcda7-9776-4f02-b2ab-b01ead225c26"> |
| 40 | <img width="1512" alt="Screenshot 2023-12-26 at 12 42 22" src="https://github.com/ppy/osu/assets/1329837/1dbfcd0d-9070-46e1-8c69-e2a4e8199b59"> | <img width="1512" alt="Screenshot 2023-12-26 at 12 42 19" src="https://github.com/ppy/osu/assets/1329837/60de7dde-c21d-4c36-a003-e73d2b69cecc"> |
| 15 | <img width="1512" alt="Screenshot 2023-12-26 at 12 42 52" src="https://github.com/ppy/osu/assets/1329837/7893a4c5-119d-4b05-afd3-e5c1e69e52a8"> | <img width="1512" alt="Screenshot 2023-12-26 at 12 42 49" src="https://github.com/ppy/osu/assets/1329837/5f726944-563a-4c19-8dbe-850ecaaa2b88"> |