### PR TITLE
Add visual offset to better align editor waveforms with expectations

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -141,7 +141,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
 
             track.BindTo(editorClock.Track);
-            track.BindValueChanged(_ => waveform.Waveform = beatmap.Value.Waveform, true);
+            track.BindValueChanged(_ =>
+            {
+                waveform.Waveform = beatmap.Value.Waveform;
+                waveform.RelativePositionAxes = Axes.X;
+                waveform.X = -(float)(Editor.WAVEFORM_VISUAL_OFFSET / beatmap.Value.Track.Length);
+            }, true);
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
         }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -60,6 +60,19 @@ namespace osu.Game.Screens.Edit
     [Cached]
     public partial class Editor : ScreenWithBeatmapBackground, IKeyBindingHandler<GlobalAction>, IKeyBindingHandler<PlatformAction>, IBeatSnapProvider, ISamplePlaybackDisabler, IBeatSyncProvider
     {
+        /// <summary>
+        /// An offset applied to waveform visuals to align them with expectations.
+        /// </summary>
+        /// <remarks>
+        /// Historically, osu! beatmaps have an assumption of full system latency baked in.
+        /// This comes from a culmination of stable's platform offset, average hardware playback
+        /// latency, and users having their universal offsets tweaked to previous beatmaps.
+        ///
+        /// Coming to this value involved running various tests with existing users / beatmaps.
+        /// This included both visual and audible comparisons. Ballpark confidence is ≈2 ms.
+        /// </remarks>
+        public const float WAVEFORM_VISUAL_OFFSET = 20;
+
         public override float BackgroundParallaxAmount => 0.1f;
 
         public override bool AllowBackButton => false;

--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Edit.Timing
                 // offset to the required beat index.
                 double time = selectedGroupStartTime + index * timingPoint.BeatLength;
 
-                float offset = (float)(time - visible_width / 2) / trackLength * scale;
+                float offset = (float)(time - visible_width / 2 + Editor.WAVEFORM_VISUAL_OFFSET) / trackLength * scale;
 
                 row.Alpha = time < selectedGroupStartTime || time > selectedGroupEndTime ? 0.2f : 1;
                 row.WaveformOffsetTo(-offset, animated);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21947.

Discussion and testing happened [on discord](https://discord.com/channels/188630481301012481/1189078742555951214), although I wouldn't recommend reading that as part of the review, just noting that it did happen and should be pretty accurate.

Testing was done

- Visually (having users try and align based on waveform only) then confirmation via audio checks
- Audibly (having users re-time mistimed beatmaps) then confirming visually

---

In preparation for locking in better audio constants in lazer, let's fix the editor waveform looking completely misaligned.

This adds a visual-only offset to better align the editor waveform (in the timeline and on the timing screen) with osu! community expectations. With this change, visual-based timing is feasible, and assuming done correctly, should be accurate within 2 ms.

