### PR TITLE
Bail from score submission if audio playback rate is too far from reality

### DIFF
--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -227,8 +227,10 @@ namespace osu.Game.Screens.Play
             {
                 elapsedGameplayClockTime += GameplayClock.ElapsedFrameTime;
 
-                elapsedValidationTime ??= elapsedGameplayClockTime;
-                elapsedValidationTime += GameplayClock.Rate * Time.Elapsed;
+                if (elapsedValidationTime == null)
+                    elapsedValidationTime = elapsedGameplayClockTime;
+                else
+                    elapsedValidationTime += GameplayClock.Rate * Time.Elapsed;
 
                 if (Math.Abs(elapsedGameplayClockTime - elapsedValidationTime!.Value) > 300)
                 {

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -38,6 +39,14 @@ namespace osu.Game.Screens.Play
             MaxValue = 2,
             Precision = 0.1,
         };
+
+        /// <summary>
+        /// Whether the audio playback is within acceptable ranges.
+        /// Will become false if audio playback is not going as expected.
+        /// </summary>
+        public IBindable<bool> PlaybackRateValid => playbackRateValid;
+
+        private readonly Bindable<bool> playbackRateValid = new Bindable<bool>(true);
 
         private readonly WorkingBeatmap beatmap;
 
@@ -128,6 +137,7 @@ namespace osu.Game.Screens.Play
         {
             // Safety in case the clock is seeked while stopped.
             LastStopTime = null;
+            elapsedValidationTime = null;
 
             base.Seek(time);
         }
@@ -196,6 +206,51 @@ namespace osu.Game.Screens.Play
 
             addAdjustmentsToTrack();
         }
+
+        protected override void Update()
+        {
+            base.Update();
+            checkPlaybackValidity();
+        }
+
+        #region Clock validation (ensure things are running correctly for local gameplay)
+
+        private double elapsedGameplayClockTime;
+        private double? elapsedValidationTime;
+        private int playbackDiscrepancyCount;
+
+        private const int allowed_playback_discrepancies = 5;
+
+        private void checkPlaybackValidity()
+        {
+            if (GameplayClock.IsRunning)
+            {
+                elapsedGameplayClockTime += GameplayClock.ElapsedFrameTime;
+
+                elapsedValidationTime ??= elapsedGameplayClockTime;
+                elapsedValidationTime += GameplayClock.Rate * Time.Elapsed;
+
+                if (Math.Abs(elapsedGameplayClockTime - elapsedValidationTime!.Value) > 300)
+                {
+                    if (playbackDiscrepancyCount++ > allowed_playback_discrepancies)
+                    {
+                        if (playbackRateValid.Value)
+                        {
+                            playbackRateValid.Value = false;
+                            Logger.Log("System audio playback is not working as expected. Some online functionality will not work.\n\nPlease check your audio drivers.", level: LogLevel.Important);
+                        }
+                    }
+                    else
+                    {
+                        Logger.Log($"Playback discrepancy detected ({playbackDiscrepancyCount} of allowed {allowed_playback_discrepancies}): {elapsedGameplayClockTime:N1} vs {elapsedValidationTime:N1}");
+                    }
+
+                    elapsedValidationTime = null;
+                }
+            }
+        }
+
+        #endregion
 
         private bool speedAdjustmentsApplied;
 

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -208,6 +208,14 @@ namespace osu.Game.Screens.Play
 
         private Task submitScore(Score score)
         {
+            var masterClock = GameplayClockContainer as MasterGameplayClockContainer;
+
+            if (masterClock?.PlaybackRateValid.Value != true)
+            {
+                Logger.Log("Score submission cancelled due to audio playback rate discrepancy.");
+                return Task.CompletedTask;
+            }
+
             // token may be null if the request failed but gameplay was still allowed (see HandleTokenRetrievalFailure).
             if (token == null)
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23149.

Values are ballparked (will trigger with ~1% rate difference over a 2.5 minute beatmap, ie. `300 * 5` total discrepancy). The count is added to avoid once-off discrepancies to not immediately cancel submission, ie. a large lag spike. This mostly matches how stable handles this.

Can be tested using:

```diff
diff --git a/osu.Game/Beatmaps/FramedBeatmapClock.cs b/osu.Game/Beatmaps/FramedBeatmapClock.cs
index 587e6bbeed..b1ed3235d6 100644
--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -61,9 +61,11 @@ public FramedBeatmapClock(bool applyOffsets, bool requireDecoupling, IClock? sou
 
             decoupledTrack = new DecouplingFramedClock(source) { AllowDecoupling = requireDecoupling };
 
+            var veryBadClock = new VeryBadClock(decoupledTrack);
+
             // An interpolating clock is used to ensure precise time values even when the host audio subsystem is not reporting
             // high precision times (on windows there's generally only 5-10ms reporting intervals, as an example).
-            var interpolatedTrack = new InterpolatingFramedClock(decoupledTrack);
+            var interpolatedTrack = new InterpolatingFramedClock(veryBadClock);
 
             if (applyOffsets)
             {
@@ -196,4 +198,29 @@ protected override void Dispose(bool isDisposing)
             beatmapOffsetSubscription?.Dispose();
         }
     }
+
+    public class VeryBadClock : IFrameBasedClock
+    {
+        private readonly IFrameBasedClock source;
+
+        public VeryBadClock(IFrameBasedClock source)
+        {
+            this.source = source;
+        }
+
+        public double CurrentTime => source.CurrentTime * 1.2;
+
+        public double Rate => source.Rate;
+
+        public bool IsRunning => source.IsRunning;
+
+        public void ProcessFrame()
+        {
+            source.ProcessFrame();
+        }
+
+        public double ElapsedFrameTime => source.ElapsedFrameTime;
+
+        public double FramesPerSecond => source.FramesPerSecond;
+    }
 }

```

Dunno how to make automated testing for this. Probably not required?