### PR TITLE
Change mania PERFECT back to giving bonus, just smaller

### DIFF
--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNotePerfectBonus.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableNotePerfectBonus.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Mania.Objects.Drawables
+{
+    public partial class DrawableNotePerfectBonus : DrawableManiaHitObject<NotePerfectBonus>
+    {
+        public override bool DisplayResult => false;
+
+        public DrawableNotePerfectBonus()
+            : this(null!)
+        {
+        }
+
+        public DrawableNotePerfectBonus(NotePerfectBonus hitObject)
+            : base(hitObject)
+        {
+        }
+
+        /// <summary>
+        /// Apply a judgement result.
+        /// </summary>
+        /// <param name="hit">Whether this tick was reached.</param>
+        internal void TriggerResult(bool hit) => ApplyResult(r => r.Type = hit ? r.Judgement.MaxResult : r.Judgement.MinResult);
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/Note.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Note.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Judgements;
 
@@ -12,5 +13,12 @@ namespace osu.Game.Rulesets.Mania.Objects
     public class Note : ManiaHitObject
     {
         public override Judgement CreateJudgement() => new ManiaJudgement();
+
+        protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+        {
+            base.CreateNestedHitObjects(cancellationToken);
+
+            AddNested(new NotePerfectBonus { StartTime = StartTime });
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Objects/NotePerfectBonus.cs
+++ b/osu.Game.Rulesets.Mania/Objects/NotePerfectBonus.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Mania.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Objects
+{
+    public class NotePerfectBonus : ManiaHitObject
+    {
+        public override Judgement CreateJudgement() => new NotePerfectBonusJudgement();
+        protected override HitWindows CreateHitWindows() => HitWindows.Empty;
+
+        public class NotePerfectBonusJudgement : ManiaJudgement
+        {
+            public override HitResult MaxResult => HitResult.SmallBonus;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
+++ b/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs
@@ -33,29 +33,18 @@ namespace osu.Game.Rulesets.Mania.Scoring
 
         protected override double GetComboScoreChange(JudgementResult result)
         {
-            return getBaseComboScoreForResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
+            return GetBaseScoreForResult(result.Type) * Math.Min(Math.Max(0.5, Math.Log(result.ComboAfterJudgement, combo_base)), Math.Log(400, combo_base));
         }
 
         public override int GetBaseScoreForResult(HitResult result)
         {
             switch (result)
             {
-                case HitResult.Perfect:
-                    return 305;
+                case HitResult.SmallBonus:
+                    return 1;
             }
 
             return base.GetBaseScoreForResult(result);
-        }
-
-        private int getBaseComboScoreForResult(HitResult result)
-        {
-            switch (result)
-            {
-                case HitResult.Perfect:
-                    return 300;
-            }
-
-            return GetBaseScoreForResult(result);
         }
 
         private class JudgementOrderComparer : IComparer<HitObject>

--- a/osu.Game.Rulesets.Mania/UI/Column.cs
+++ b/osu.Game.Rulesets.Mania/UI/Column.cs
@@ -109,6 +109,7 @@ namespace osu.Game.Rulesets.Mania.UI
             TopLevelContainer.Add(HitObjectArea.Explosions.CreateProxy());
 
             RegisterPool<Note, DrawableNote>(10, 50);
+            RegisterPool<NotePerfectBonus, DrawableNotePerfectBonus>(10, 50);
             RegisterPool<HoldNote, DrawableHoldNote>(10, 50);
             RegisterPool<HeadNote, DrawableHoldNoteHead>(10, 50);
             RegisterPool<TailNote, DrawableHoldNoteTail>(10, 50);

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -444,10 +444,13 @@ namespace osu.Game.Database
                     break;
 
                 case 3:
+                    var scoreProcessor = ruleset.CreateScoreProcessor();
+                    double bonus = score.Statistics.GetValueOrDefault(HitResult.Perfect) * scoreProcessor.GetBaseScoreForResult(HitResult.Perfect);
+
                     convertedTotalScore = (long)Math.Round((
                         850000 * comboProportion
                         + 150000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
-                        + bonusProportion) * modMultiplier);
+                        + bonus) * modMultiplier);
                     break;
 
                 default:


### PR DESCRIPTION
I have not tested this at all. PRing early so I can do a diffcalc comparison.

In theory, this would allow us to preserve 100% == SS, while not impacting the ordering of scores in much of a noticeable impact (4k vs 200k previously, on a 4000 note map).

This is mostly a revert of https://github.com/ppy/osu/pull/25945, with a few changes.