### PR TITLE
Fix mod score multiplier rounding to 1.00x with specific mod combinations

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -310,6 +310,13 @@ namespace osu.Game.Tests.Mods
                 Assert.That(invalid?.Select(t => t.GetType()), Is.EquivalentTo(expectedInvalid));
         }
 
+        [Test]
+        public void TestFormatScoreMultiplier()
+        {
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9999).ToString(), "0.99x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0001).ToString(), "1.01x");
+        }
+
         public abstract class CustomMod1 : Mod, IModCompatibilitySpecification
         {
         }
@@ -337,6 +344,16 @@ namespace osu.Game.Tests.Mods
             public override double ScoreMultiplier => 1;
             public override bool HasImplementation => true;
             public override bool ValidForMultiplayerAsFreeMod => false;
+        }
+
+        public class EditableMod : Mod
+        {
+            public override string Name => string.Empty;
+            public override LocalisableString Description => string.Empty;
+            public override string Acronym => string.Empty;
+            public override double ScoreMultiplier => Multiplier;
+
+            public double Multiplier = 1;
         }
 
         public interface IModCompatibilitySpecification

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -314,11 +314,20 @@ namespace osu.Game.Tests.Mods
         public void TestFormatScoreMultiplier()
         {
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9999).ToString(), "0.99x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0).ToString(), "1.00x");
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0001).ToString(), "1.01x");
+
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.899999999999999).ToString(), "0.90x");
-            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.099999999999999).ToString(), "1.10x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9).ToString(), "0.90x");
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.900000000000001).ToString(), "0.90x");
+
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.099999999999999).ToString(), "1.10x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.1).ToString(), "1.10x");
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.100000000000001).ToString(), "1.10x");
+
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.045).ToString(), "1.05x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.05).ToString(), "1.05x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.055).ToString(), "1.06x");
         }
 
         public abstract class CustomMod1 : Mod, IModCompatibilitySpecification

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -315,6 +315,10 @@ namespace osu.Game.Tests.Mods
         {
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.9999).ToString(), "0.99x");
             Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.0001).ToString(), "1.01x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.899999999999999).ToString(), "0.90x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.099999999999999).ToString(), "1.10x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(0.900000000000001).ToString(), "0.90x");
+            Assert.AreEqual(ModUtils.FormatScoreMultiplier(1.100000000000001).ToString(), "1.10x");
         }
 
         public abstract class CustomMod1 : Mod, IModCompatibilitySpecification

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Select;
+using osu.Game.Utils;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -74,7 +76,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private bool assertModsMultiplier(IEnumerable<Mod> mods)
         {
             double multiplier = mods.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier);
-            string expectedValue = multiplier.Equals(1.0) ? string.Empty : $"{multiplier:N2}x";
+            string expectedValue = multiplier == 1 ? string.Empty : ModUtils.FormatScoreMultiplier(multiplier).ToString();
 
             return expectedValue == footerButtonMods.MultiplierText.Current.Value;
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;

--- a/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
+using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -108,13 +109,13 @@ namespace osu.Game.Overlays.Mods
 
             Current.BindValueChanged(e =>
             {
-                if (e.NewValue > Current.Default)
+                if (Precision.DefinitelyBigger(e.NewValue, Current.Default))
                 {
                     MainBackground
                         .FadeColour(colours.ForModType(ModType.DifficultyIncrease), transition_duration, Easing.OutQuint);
                     counter.FadeColour(ColourProvider.Background5, transition_duration, Easing.OutQuint);
                 }
-                else if (e.NewValue < Current.Default)
+                else if (Precision.DefinitelyBigger(Current.Default, e.NewValue))
                 {
                     MainBackground
                         .FadeColour(colours.ForModType(ModType.DifficultyReduction), transition_duration, Easing.OutQuint);
@@ -130,6 +131,11 @@ namespace osu.Game.Overlays.Mods
                     .FadeOutFromOne()
                     .FadeTo(0.15f, 60, Easing.OutQuint)
                     .Then().FadeOut(500, Easing.OutQuint);
+
+                if (Precision.DefinitelyBigger(1.0, Current.Value) && Current.Value >= 0.995)
+                    Current.Value = 0.99;
+                if (Precision.DefinitelyBigger(Current.Value, 1.0) && Current.Value < 1.005)
+                    Current.Value = 1.01;
 
                 const float move_amount = 4;
                 if (e.NewValue > e.OldValue)

--- a/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
@@ -4,18 +4,17 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Overlays.Mods
@@ -109,13 +108,13 @@ namespace osu.Game.Overlays.Mods
 
             Current.BindValueChanged(e =>
             {
-                if (Precision.DefinitelyBigger(e.NewValue, Current.Default))
+                if (e.NewValue > Current.Default)
                 {
                     MainBackground
                         .FadeColour(colours.ForModType(ModType.DifficultyIncrease), transition_duration, Easing.OutQuint);
                     counter.FadeColour(ColourProvider.Background5, transition_duration, Easing.OutQuint);
                 }
-                else if (Precision.DefinitelyBigger(Current.Default, e.NewValue))
+                else if (e.NewValue < Current.Default)
                 {
                     MainBackground
                         .FadeColour(colours.ForModType(ModType.DifficultyReduction), transition_duration, Easing.OutQuint);
@@ -131,11 +130,6 @@ namespace osu.Game.Overlays.Mods
                     .FadeOutFromOne()
                     .FadeTo(0.15f, 60, Easing.OutQuint)
                     .Then().FadeOut(500, Easing.OutQuint);
-
-                if (Precision.DefinitelyBigger(1.0, Current.Value) && Current.Value >= 0.995)
-                    Current.Value = 0.99;
-                if (Precision.DefinitelyBigger(Current.Value, 1.0) && Current.Value < 1.005)
-                    Current.Value = 1.01;
 
                 const float move_amount = 4;
                 if (e.NewValue > e.OldValue)
@@ -153,7 +147,7 @@ namespace osu.Game.Overlays.Mods
         {
             protected override double RollingDuration => 500;
 
-            protected override LocalisableString FormatCount(double count) => count.ToLocalisableString(@"0.00x");
+            protected override LocalisableString FormatCount(double count) => ModUtils.FormatScoreMultiplier(count);
 
             protected override OsuSpriteText CreateSpriteText() => new OsuSpriteText
             {

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -19,7 +19,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Input.Bindings;
-using osu.Framework.Utils;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.Select
 {
@@ -88,17 +88,11 @@ namespace osu.Game.Screens.Select
         private void updateMultiplierText() => Schedule(() =>
         {
             double multiplier = Current.Value?.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier) ?? 1;
+            MultiplierText.Text = multiplier == 1 ? string.Empty : ModUtils.FormatScoreMultiplier(multiplier);
 
-            if (Precision.DefinitelyBigger(1.0, multiplier) && multiplier >= 0.995)
-                MultiplierText.Text = $"{0.99:N2}x";
-            else if (Precision.DefinitelyBigger(multiplier, 1.0) && multiplier < 1.005)
-                MultiplierText.Text = $"{1.01:N2}x";
-            else
-                MultiplierText.Text = multiplier.Equals(1.0) ? string.Empty : $"{multiplier:N2}x";
-
-            if (Precision.DefinitelyBigger(multiplier, 1.0))
+            if (multiplier > 1)
                 MultiplierText.FadeColour(highMultiplierColour, 200);
-            else if (Precision.DefinitelyBigger(1.0, multiplier))
+            else if (multiplier < 1)
                 MultiplierText.FadeColour(lowMultiplierColour, 200);
             else
                 MultiplierText.FadeColour(Color4.White, 200);

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -19,6 +19,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Input.Bindings;
+using osu.Framework.Utils;
 
 namespace osu.Game.Screens.Select
 {
@@ -88,11 +89,16 @@ namespace osu.Game.Screens.Select
         {
             double multiplier = Current.Value?.Aggregate(1.0, (current, mod) => current * mod.ScoreMultiplier) ?? 1;
 
-            MultiplierText.Text = multiplier.Equals(1.0) ? string.Empty : $"{multiplier:N2}x";
+            if (Precision.DefinitelyBigger(1.0, multiplier) && multiplier >= 0.995)
+                MultiplierText.Text = $"{0.99:N2}x";
+            else if (Precision.DefinitelyBigger(multiplier, 1.0) && multiplier < 1.005)
+                MultiplierText.Text = $"{1.01:N2}x";
+            else
+                MultiplierText.Text = multiplier.Equals(1.0) ? string.Empty : $"{multiplier:N2}x";
 
-            if (multiplier > 1.0)
+            if (Precision.DefinitelyBigger(multiplier, 1.0))
                 MultiplierText.FadeColour(highMultiplierColour, 200);
-            else if (multiplier < 1.0)
+            else if (Precision.DefinitelyBigger(1.0, multiplier))
                 MultiplierText.FadeColour(lowMultiplierColour, 200);
             else
                 MultiplierText.FadeColour(Color4.White, 200);

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -225,6 +227,22 @@ namespace osu.Game.Utils
             }
 
             return proposedWereValid;
+        }
+
+        /// <summary>
+        /// Given a value of a score multiplier, returns a string version with special handling for a value near 1.00x.
+        /// </summary>
+        /// <param name="scoreMultiplier">The value of the score multiplier.</param>
+        /// <returns>A formatted score multiplier with a trailing "x" symbol</returns>
+        public static LocalisableString FormatScoreMultiplier(double scoreMultiplier)
+        {
+            // Round multiplier values away from 1.00x to two significant digits.
+            if (scoreMultiplier > 1)
+                scoreMultiplier = Math.Ceiling(scoreMultiplier * 100) / 100;
+            else
+                scoreMultiplier = Math.Floor(scoreMultiplier * 100) / 100;
+
+            return scoreMultiplier.ToLocalisableString("0.00x");
         }
     }
 }

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -238,9 +238,9 @@ namespace osu.Game.Utils
         {
             // Round multiplier values away from 1.00x to two significant digits.
             if (scoreMultiplier > 1)
-                scoreMultiplier = Math.Ceiling(scoreMultiplier * 100) / 100;
+                scoreMultiplier = Math.Ceiling(Math.Round(scoreMultiplier * 100, 12)) / 100;
             else
-                scoreMultiplier = Math.Floor(scoreMultiplier * 100) / 100;
+                scoreMultiplier = Math.Floor(Math.Round(scoreMultiplier * 100, 12)) / 100;
 
             return scoreMultiplier.ToLocalisableString("0.00x");
         }


### PR DESCRIPTION
#  Fix mod score multiplier rounding to 1.00x with specific mod combinations.

## Before

![osu_2023-12-27_00-06-25](https://github.com/ppy/osu/assets/93961902/973f717f-cdc1-40c5-9f97-c647dd821c47)
![osu_2023-12-27_00-06-30](https://github.com/ppy/osu/assets/93961902/1c2b5b37-4ca2-43ce-87cb-40dee368e47e)

## After

![osu_2023-12-27_00-05-09](https://github.com/ppy/osu/assets/93961902/e3dad36d-0271-48ef-a4fb-fb5b99544643)
![osu_2023-12-27_00-05-30](https://github.com/ppy/osu/assets/93961902/e0f7b752-8dc2-410c-958f-9a1646f55a3e)
