### PR TITLE
Fix editor timing mode not handling undo/redo correctly

### DIFF
--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Edit
             return -1;
         }
 
-        protected bool SetSelectedRow(object? item)
+        protected virtual bool SetSelectedRow(object? item)
         {
             bool foundSelection = false;
 

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
@@ -46,15 +47,42 @@ namespace osu.Game.Screens.Edit
             });
         }
 
-        protected void SetSelectedRow(object? item)
+        protected int GetIndexForObject(object? item)
         {
+            for (int i = 0; i < BackgroundFlow.Count; i++)
+            {
+                if (BackgroundFlow[i].Item == item)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        protected bool SetSelectedRow(object? item)
+        {
+            bool foundSelection = false;
+
             foreach (var b in BackgroundFlow)
             {
                 b.Selected = ReferenceEquals(b.Item, item);
 
                 if (b.Selected)
+                {
+                    Debug.Assert(!foundSelection);
                     OnRowSelected?.Invoke(b);
+                    foundSelection = true;
+                }
             }
+
+            return foundSelection;
+        }
+
+        protected object? GetObjectAtIndex(int index)
+        {
+            if (index < 0 || index > BackgroundFlow.Count - 1)
+                return null;
+
+            return BackgroundFlow[index].Item;
         }
 
         protected override Drawable CreateHeader(int index, TableColumn? column) => new HeaderText(column?.Header ?? default);

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -109,8 +109,13 @@ namespace osu.Game.Screens.Edit.Timing
             controlPointGroups.BindTo(Beatmap.ControlPointInfo.Groups);
             controlPointGroups.BindCollectionChanged((_, _) =>
             {
-                table.ControlGroups = controlPointGroups;
-                changeHandler?.SaveState();
+                // This callback can happen many times in a change operation. It gets expensive.
+                // We really should be handling the `CollectionChanged` event properly.
+                Scheduler.AddOnce(() =>
+                {
+                    table.ControlGroups = controlPointGroups;
+                    changeHandler?.SaveState();
+                });
             }, true);
 
             table.OnRowSelected += drawable => scroll.ScrollIntoView(drawable);

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Edit.Timing
     public partial class ControlPointTable : EditorTable
     {
         [Resolved]
-        private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
+        private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
 
         [Resolved]
         private EditorClock clock { get; set; } = null!;
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Edit.Timing
         {
             set
             {
+                int selectedIndex = GetIndexForObject(selectedGroup.Value);
+
                 Content = null;
                 BackgroundFlow.Clear();
 
@@ -53,7 +55,11 @@ namespace osu.Game.Screens.Edit.Timing
                 Columns = createHeaders();
                 Content = value.Select(createContent).ToArray().ToRectangular();
 
-                updateSelectedGroup();
+                if (!SetSelectedRow(selectedGroup.Value))
+                {
+                    // Some operations completely obliterate references, so best-effort reselect based on index.
+                    selectedGroup.Value = GetObjectAtIndex(selectedIndex) as ControlPointGroup;
+                }
             }
         }
 
@@ -61,10 +67,8 @@ namespace osu.Game.Screens.Edit.Timing
         {
             base.LoadComplete();
 
-            selectedGroup.BindValueChanged(_ => updateSelectedGroup(), true);
+            selectedGroup.BindValueChanged(_ => SetSelectedRow(selectedGroup.Value), true);
         }
-
-        private void updateSelectedGroup() => SetSelectedRow(selectedGroup.Value);
 
         private TableColumn[] createHeaders()
         {


### PR DESCRIPTION
When undoing, selection would be lost, and (kind of as a result) the controls on the right of the screen would enter a detached state where they don't update correctly. Quite annoying when you're making changes.