### PR TITLE
Force minimum cursor size for `OsuResumeOverlay`

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -70,10 +70,10 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             };
 
             userCursorScale = config.GetBindable<float>(OsuSetting.GameplayCursorSize);
-            userCursorScale.ValueChanged += _ => calculateCursorScale();
+            userCursorScale.ValueChanged += _ => cursorScale.Value = CalculateCursorScale();
 
             autoCursorScale = config.GetBindable<bool>(OsuSetting.AutoCursorSize);
-            autoCursorScale.ValueChanged += _ => calculateCursorScale();
+            autoCursorScale.ValueChanged += _ => cursorScale.Value = CalculateCursorScale();
 
             cursorScale.BindValueChanged(e => cursorScaleContainer.Scale = new Vector2(e.NewValue), true);
         }
@@ -81,10 +81,10 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            calculateCursorScale();
+            cursorScale.Value = CalculateCursorScale();
         }
 
-        private void calculateCursorScale()
+        protected virtual float CalculateCursorScale()
         {
             float scale = userCursorScale.Value;
 
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 scale *= GetScaleForCircleSize(state.Beatmap.Difficulty.CircleSize);
             }
 
-            cursorScale.Value = scale;
+            return scale;
         }
 
         protected override void SkinChanged(ISkinSource skin)

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -71,6 +71,12 @@ namespace osu.Game.Rulesets.Osu.UI
                 RelativePositionAxes = Axes.Both;
             }
 
+            protected override float CalculateCursorScale()
+            {
+                // Force minimum cursor size so it's easily clickable
+                return Math.Max(1f, base.CalculateCursorScale());
+            }
+
             protected override bool OnHover(HoverEvent e)
             {
                 updateColour();


### PR DESCRIPTION
On cursor sizes below 0.3x it becomes exceedingly difficult to quickly locate and then accurately click the resume cursor on the pause overlay as it could as big as a handful of pixels. In the event the cursor aligns somewhere on top of or close to the text, it becomes nearly impossible to find it as it's even the same color. 

This clamps the minimum cursor size to 1x for the resume overlay, which is way more comfortable and less likely to cause the player to miss afterwards (note that not the entire cursor aura is interactable, only about 2/3s) and more closely resembles stable.

0.1x:
![image](https://github.com/ppy/osu/assets/33725716/02fa40b1-fe60-4350-a348-018fe68f74e9)

clamped to 1x:
![image](https://github.com/ppy/osu/assets/33725716/6ea5b6ad-ce9a-4702-a76b-67addc42b967)
