### PR TITLE
Fix catch drawable objects not being clamped to playfield bounds

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneOutOfBoundsObjects.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneOutOfBoundsObjects.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Catch.Objects.Drawables;
+using osu.Game.Rulesets.Catch.UI;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osuTK;
+
+namespace osu.Game.Rulesets.Catch.Tests
+{
+    public partial class TestSceneOutOfBoundsObjects : TestSceneCatchPlayer
+    {
+        protected override bool Autoplay => true;
+
+        [Test]
+        public void TestNoOutOfBoundsObjects()
+        {
+            bool anyObjectOutOfBounds = false;
+
+            AddStep("reset flag", () => anyObjectOutOfBounds = false);
+
+            AddUntilStep("check for out-of-bounds objects",
+                () =>
+                {
+                    anyObjectOutOfBounds |= Player.ChildrenOfType<DrawableCatchHitObject>().Any(dho => dho.X < 0 || dho.X > CatchPlayfield.WIDTH);
+                    return Player.ScoreProcessor.HasCompleted.Value;
+                });
+
+            AddAssert("no out of bound objects found", () => !anyObjectOutOfBounds);
+        }
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            BeatmapInfo = new BeatmapInfo
+            {
+                Ruleset = ruleset,
+            },
+            HitObjects = new List<HitObject>
+            {
+                new Fruit { StartTime = 1000, X = -50 },
+                new Fruit { StartTime = 1200, X = CatchPlayfield.WIDTH + 50 },
+                new JuiceStream
+                {
+                    StartTime = 1500,
+                    X = 10,
+                    Path = new SliderPath(PathType.LINEAR, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(-200, 0)
+                    })
+                },
+                new JuiceStream
+                {
+                    StartTime = 3000,
+                    X = CatchPlayfield.WIDTH - 10,
+                    Path = new SliderPath(PathType.LINEAR, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(200, 0)
+                    })
+                },
+            }
+        };
+    }
+}

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Catch.UI;
 using osuTK;
 using osuTK.Graphics;
 
@@ -70,7 +72,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         private void updateXPosition(ValueChangedEvent<float> _)
         {
-            X = OriginalXBindable.Value + XOffsetBindable.Value;
+            // same as `CatchHitObject.EffectiveX`.
+            // not using that property directly to support scenarios where `HitObject` may not necessarily be present
+            // for this pooled drawable.
+            X = Math.Clamp(OriginalXBindable.Value + XOffsetBindable.Value, 0, CatchPlayfield.WIDTH);
         }
 
         protected override void OnApply()


### PR DESCRIPTION
Addresses first issue mentioned in https://github.com/ppy/osu/discussions/26145

Can be tested using supplied test scene, and on https://osu.ppy.sh/beatmapsets/1062804#fruits/2234731 - see juice stream @ 01:58:172:

| stable | master | this PR |
| :-: | :-: | :-: |
| ![screenshot017](https://github.com/ppy/osu/assets/20418176/1aa21cac-8f55-4c4d-b556-ec165c6869a8) | ![osu_2023-12-27_11-13-49](https://github.com/ppy/osu/assets/20418176/04ab09ca-d1d3-4da0-9516-1aeec567d16b) | ![osu_2023-12-27_11-13-06](https://github.com/ppy/osu/assets/20418176/94538c3d-f1dd-4ae0-8721-4c7753883530) |

Notably, only fruits and droplets are affected. Small droplets aren't affected, because of

https://github.com/ppy/osu/blob/e9f350e763b2251c29f4d2061a6a67c107163a6a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs#L104

(the offset clamp ensures that `OriginalXBindable.Value + XOffsetBindable.Value` is always inside [0, 512]), and bananas aren't affected as

https://github.com/ppy/osu/blob/e9f350e763b2251c29f4d2061a6a67c107163a6a/osu.Game.Rulesets.Catch/Beatmaps/CatchBeatmapProcessor.cs#L83