### PR TITLE
Cycle between Daycore and Half Time mod when using classic hotkeys style

### DIFF
--- a/osu.Game/Overlays/Mods/Input/ClassicModHotkeyHandler.cs
+++ b/osu.Game/Overlays/Mods/Input/ClassicModHotkeyHandler.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Overlays.Mods.Input
         {
             [Key.Q] = new[] { typeof(ModEasy) },
             [Key.W] = new[] { typeof(ModNoFail) },
-            [Key.E] = new[] { typeof(ModHalfTime) },
+            [Key.E] = new[] { typeof(ModHalfTime), typeof(ModDaycore) },
             [Key.A] = new[] { typeof(ModHardRock) },
             [Key.S] = new[] { typeof(ModSuddenDeath), typeof(ModPerfect) },
             [Key.D] = new[] { typeof(ModDoubleTime), typeof(ModNightcore) },


### PR DESCRIPTION
Even though this mod is not in Stable, it seems fair that it reflects the same behavior as Double Time and Nightcore using the classic hotkeys.

I noticed it a few days ago when I tried to switch between the two and found no match. It must have been lost over time with the added distinction of the two hotkey styles (or maybe even earlier, during the mod select redesign).

I see that [there's already a test for this](https://github.com/ppy/osu/blob/c2d60006cba819476234bca9a4bdba6300a8e0ec/osu.Game.Tests/Visual/UserInterface/TestSceneModColumn.cs#L185), so I guess there's no need to edit it or add some(?)

(Since this is my first contribution with pull requests here, I hope I don't make any weird mistakes. Or maybe I'm just too paranoid)