### PR TITLE
Switch leaderboard category button arrangement

### DIFF
--- a/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
+++ b/osu.Game/Screens/Select/PlayBeatmapDetailArea.cs
@@ -80,8 +80,8 @@ namespace osu.Game.Screens.Select
         protected override BeatmapDetailAreaTabItem[] CreateTabItems() => base.CreateTabItems().Concat(new BeatmapDetailAreaTabItem[]
         {
             new BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Local),
-            new BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Country),
             new BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Global),
+            new BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Country),
             new BeatmapDetailAreaLeaderboardTabItem<BeatmapLeaderboardScope>(BeatmapLeaderboardScope.Friend),
         }).ToArray();
 


### PR DESCRIPTION
This is a small change about this:
![image](https://github.com/ppy/osu/assets/52874570/7c1f66fc-f2c1-49ec-9f7e-5057df594211)
To This:
![image](https://github.com/ppy/osu/assets/52874570/469fd0ed-064c-4f47-a206-124eafde0ba9)


The `Country` and `Friend` category are osu!supportor only.
Why not switch the `Global` and `Country` position?

For player didn't have osu!supportor, the `Country` category is there made `Global` and `Country` hard to click (I mean required a little bit more afford to click)
Alt+Tab/Shift+Alt+Tab also need to click 2 times to switch between these common used leaderboard