### PR TITLE
Fix spinner max bonus sound playing when seeking in replay

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private const float spinning_sample_initial_frequency = 1.0f;
         private const float spinning_sample_modulated_base_frequency = 0.5f;
 
-        private SkinnableSound maxBonusSample;
+        private PausableSkinnableSound maxBonusSample;
 
         /// <summary>
         /// The amount of bonus score gained from spinning after the required number of spins, for display purposes.
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     Looping = true,
                     Frequency = { Value = spinning_sample_initial_frequency }
                 },
-                maxBonusSample = new SkinnableSound
+                maxBonusSample = new PausableSkinnableSound
                 {
                     MinimumSampleVolume = MINIMUM_SAMPLE_VOLUME,
                 }


### PR DESCRIPTION
Fixes #26164

Originally the spinner max bonus sound was loaded through `SkinnableSound` instead of `PausableSkinnableSound`, leading to it not respecting the case where sample playback is globally disabled through `ISamplePlaybackDisabler`, and can be easily heard in situations like during the catchup period when seeking a replay.