### PR TITLE
Make mod search box text be selected when a new mod is selected/deselected

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -551,6 +551,14 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("press enter again", () => InputManager.Key(Key.Enter));
             AddAssert("hidden deselected", () => !getPanelForMod(typeof(OsuModHidden)).Active.Value);
 
+            AddStep("apply search matching nothing", () => modSelectOverlay.SearchTerm = "ZZZ");
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+            AddAssert("all text not selected in textbox", () =>
+            {
+                var textBox = modSelectOverlay.ChildrenOfType<SearchTextBox>().Single();
+                return textBox.SelectedText != textBox.Text;
+            });
+
             AddStep("clear search", () => modSelectOverlay.SearchTerm = string.Empty);
             AddStep("press enter", () => InputManager.Key(Key.Enter));
             AddAssert("mod select hidden", () => modSelectOverlay.State.Value == Visibility.Hidden);

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -542,6 +542,11 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("press enter", () => InputManager.Key(Key.Enter));
             AddAssert("hidden selected", () => getPanelForMod(typeof(OsuModHidden)).Active.Value);
+            AddAssert("all text selected in textbox", () =>
+            {
+                var textBox = modSelectOverlay.ChildrenOfType<SearchTextBox>().Single();
+                return textBox.SelectedText == textBox.Text;
+            });
 
             AddStep("press enter again", () => InputManager.Key(Key.Enter));
             AddAssert("hidden deselected", () => !getPanelForMod(typeof(OsuModHidden)).Active.Value);

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -48,6 +48,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public void KillFocus() => textBox.KillFocus();
 
+        public bool SelectAll() => textBox.SelectAll();
+
         public ShearedSearchTextBox()
         {
             Height = 42;

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -565,9 +565,6 @@ namespace osu.Game.Overlays.Mods
                                                      .ToArray();
 
             SelectedMods.Value = ComputeNewModsFromSelection(SelectedMods.Value, candidateSelection);
-
-            if (SearchTextBox.HasFocus)
-                SearchTextBox.SelectAll();
         }
 
         #region Transition handling
@@ -723,6 +720,8 @@ namespace osu.Game.Overlays.Mods
 
                     if (firstMod is not null)
                         firstMod.Active.Value = !firstMod.Active.Value;
+
+                    SearchTextBox.SelectAll();
 
                     return true;
                 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -565,6 +565,9 @@ namespace osu.Game.Overlays.Mods
                                                      .ToArray();
 
             SelectedMods.Value = ComputeNewModsFromSelection(SelectedMods.Value, candidateSelection);
+
+            if (SearchTextBox.HasFocus)
+                SearchTextBox.SelectAll();
         }
 
         #region Transition handling

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -719,9 +719,10 @@ namespace osu.Game.Overlays.Mods
                     ModState? firstMod = columnFlow.Columns.OfType<ModColumn>().FirstOrDefault(m => m.IsPresent)?.AvailableMods.FirstOrDefault(x => x.Visible);
 
                     if (firstMod is not null)
+                    {
                         firstMod.Active.Value = !firstMod.Active.Value;
-
-                    SearchTextBox.SelectAll();
+                        SearchTextBox.SelectAll();
+                    }
 
                     return true;
                 }


### PR DESCRIPTION
Addresses #26142.

This makes the `SelectAll()` method from `SearchTextBox` be triggered when the mod selection is changed and the search box is focused.
I'm just not sure if it's bad practice to include the method trigger for `SelectAll()` inside the mod selection update method. As such, I've made a [second branch](https://github.com/felipemarins/osu/tree/mod-search-text-box-select-all-2) in which the `SelectAll()` method is triggered when the select key is pressed. If this PR gets rejected due to it, I'll continue to work on the second branch and try to include a trigger for when a mod is clicked.