### PR TITLE
Adjust menu buttons

### DIFF
--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.Menu
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Size = new Vector2(32),
-                            Position = new Vector2(0, 0),
+                            Position = new Vector2(0, -4),
                             Icon = symbol
                         },
                         new OsuSpriteText
@@ -186,7 +186,7 @@ namespace osu.Game.Screens.Menu
         {
             icon.ClearTransforms();
             icon.RotateTo(0, 500, Easing.Out);
-            icon.MoveTo(Vector2.Zero, 500, Easing.Out);
+            icon.MoveTo(new Vector2(0, -4), 500, Easing.Out);
             icon.ScaleTo(Vector2.One, 200, Easing.Out);
 
             if (State == ButtonState.Expanded)

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -129,7 +129,8 @@ namespace osu.Game.Screens.Menu
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Size = new Vector2(32),
-                            Position = new Vector2(0, -4),
+                            Position = new Vector2(0, 0),
+                            Margin = new MarginPadding { Top = -4 },
                             Icon = symbol
                         },
                         new OsuSpriteText
@@ -138,7 +139,8 @@ namespace osu.Game.Screens.Menu
                             AllowMultiline = false,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Position = new Vector2(-3, 35),
+                            Position = new Vector2(0, 35),
+                            Margin = new MarginPadding { Left = -3 },
                             Text = text
                         }
                     }
@@ -189,7 +191,7 @@ namespace osu.Game.Screens.Menu
         {
             icon.ClearTransforms();
             icon.RotateTo(0, 500, Easing.Out);
-            icon.MoveTo(new Vector2(0, -4), 500, Easing.Out);
+            icon.MoveTo(Vector2.Zero, 500, Easing.Out);
             icon.ScaleTo(Vector2.One, 200, Easing.Out);
 
             if (State == ButtonState.Expanded)

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Screens.Menu
                             AllowMultiline = false,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Position = new Vector2(0, 35),
+                            Position = new Vector2(-3, 35),
                             Text = text
                         }
                     }

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -125,7 +125,7 @@ namespace osu.Game.Screens.Menu
                             Shadow = true,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            Size = new Vector2(30),
+                            Size = new Vector2(32),
                             Position = new Vector2(0, 0),
                             Icon = symbol
                         },

--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -31,6 +31,9 @@ namespace osu.Game.Screens.Menu
     /// </summary>
     public partial class MainMenuButton : BeatSyncedContainer, IStateful<ButtonState>
     {
+        public const float BOUNCE_COMPRESSION = 0.9f;
+        public const float HOVER_SCALE = 1.2f;
+        public const float BOUNCE_ROTATION = 8;
         public event Action<ButtonState>? StateChanged;
 
         public readonly Key[] TriggerKeys;
@@ -153,14 +156,14 @@ namespace osu.Game.Screens.Menu
 
             double duration = timingPoint.BeatLength / 2;
 
-            icon.RotateTo(rightward ? 10 : -10, duration * 2, Easing.InOutSine);
+            icon.RotateTo(rightward ? BOUNCE_ROTATION : -BOUNCE_ROTATION, duration * 2, Easing.InOutSine);
 
             icon.Animate(
                 i => i.MoveToY(-10, duration, Easing.Out),
-                i => i.ScaleTo(1, duration, Easing.Out)
+                i => i.ScaleTo(HOVER_SCALE, duration, Easing.Out)
             ).Then(
                 i => i.MoveToY(0, duration, Easing.In),
-                i => i.ScaleTo(new Vector2(1, 0.9f), duration, Easing.In)
+                i => i.ScaleTo(new Vector2(HOVER_SCALE, HOVER_SCALE * BOUNCE_COMPRESSION), duration, Easing.In)
             );
 
             rightward = !rightward;
@@ -177,8 +180,8 @@ namespace osu.Game.Screens.Menu
             double duration = TimeUntilNextBeat;
 
             icon.ClearTransforms();
-            icon.RotateTo(rightward ? -10 : 10, duration, Easing.InOutSine);
-            icon.ScaleTo(new Vector2(1, 0.9f), duration, Easing.Out);
+            icon.RotateTo(rightward ? -BOUNCE_ROTATION : BOUNCE_ROTATION, duration, Easing.InOutSine);
+            icon.ScaleTo(new Vector2(HOVER_SCALE, HOVER_SCALE * BOUNCE_COMPRESSION), duration, Easing.Out);
             return true;
         }
 


### PR DESCRIPTION
this pull request slightly updates the sizes and positions of the main menu buttons' children to improve the visual balance of the buttons.

current:
![image](https://github.com/ppy/osu/assets/20297536/63ab8b24-e7a5-4f37-bedf-ca524ac0324a)

updated:
![image](https://github.com/ppy/osu/assets/20297536/f07b903b-fe9e-473f-82fc-1c90c6d5b4e5)


as a consequence of the very slight size increase, the rotation of the bounce was tweaked a bit lower.

![6eTgkg9Tcap4](https://github.com/ppy/osu/assets/20297536/5e764bae-91c5-4046-b059-5639ef340b6c)
![YqEzbAGhvSsH](https://github.com/ppy/osu/assets/20297536/ae9b33bc-48fa-4005-a5df-896a37f2fa77)
