### PR TITLE
Fix dropdown colour not updating correctly on enabled state changes

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -384,6 +384,9 @@ namespace osu.Game.Graphics.UserInterface
                 var hoveredColour = colourProvider?.Light4 ?? colours.PinkDarker;
                 var unhoveredColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
 
+                Colour = Color4.White;
+                Alpha = Enabled.Value ? 1 : 0.3f;
+
                 if (SearchBar.State.Value == Visibility.Visible)
                 {
                     Icon.Colour = hovered ? hoveredColour.Lighten(0.5f) : Colour4.White;

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -363,6 +363,7 @@ namespace osu.Game.Graphics.UserInterface
                 base.LoadComplete();
 
                 SearchBar.State.ValueChanged += _ => updateColour();
+                Enabled.BindValueChanged(_ => updateColour());
                 updateColour();
             }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25909#event-11330847362

Also changes the visual look of a disabled dropdown to match with other UI components (applying 0.3 alpha).

Before:

![CleanShot 2023-12-29 at 05 33 38@2x](https://github.com/ppy/osu/assets/22781491/a70a12f3-42e1-4f5e-9844-9d4dd41b098a)

After:

![CleanShot 2023-12-29 at 05 34 32@2x](https://github.com/ppy/osu/assets/22781491/9b5a535a-0615-4059-8f4a-74dcab6a5048)
