### PR TITLE
Expose `Mod.UsesDefaultConfiguration()` as public

### DIFF
--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Whether all settings in this mod are set to their default state.
         /// </summary>
-        protected virtual bool UsesDefaultConfiguration => SettingsBindables.All(s => s.IsDefault);
+        public bool UsesDefaultConfiguration => SettingsBindables.All(s => s.IsDefault);
 
         /// <summary>
         /// Creates a copy of this <see cref="Mod"/> initialised to a default state.


### PR DESCRIPTION
Intended for consumption with https://github.com/ppy/osu-queue-score-statistics/issues/191.

Also make it not-virtual. I don't see a world where it should be legal to override this.