### PR TITLE
Fix crash after changing audio track in editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -25,6 +25,7 @@ using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Storyboards;
 using osu.Game.Tests.Resources;
@@ -94,8 +95,11 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestAddAudioTrack()
         {
-            AddAssert("track is virtual", () => Beatmap.Value.Track is TrackVirtual);
+            AddStep("enter compose mode", () => InputManager.Key(Key.F1));
+            AddUntilStep("wait for timeline load", () => Editor.ChildrenOfType<Timeline>().FirstOrDefault()?.IsLoaded == true);
 
+            AddStep("enter setup mode", () => InputManager.Key(Key.F4));
+            AddAssert("track is virtual", () => Beatmap.Value.Track is TrackVirtual);
             AddAssert("switch track to real track", () =>
             {
                 var setup = Editor.ChildrenOfType<SetupScreen>().First();

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -141,15 +141,27 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
 
             track.BindTo(editorClock.Track);
-            // schedule added as without it, `beatmap.Value.Track.Length` can be 0 immediately after a track switch.
-            track.BindValueChanged(_ => Schedule(() =>
+            track.BindValueChanged(_ =>
             {
                 waveform.Waveform = beatmap.Value.Waveform;
-                waveform.RelativePositionAxes = Axes.X;
-                waveform.X = -(float)(Editor.WAVEFORM_VISUAL_OFFSET / beatmap.Value.Track.Length);
-            }), true);
+                Scheduler.AddOnce(applyVisualOffset, beatmap);
+            }, true);
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
+        }
+
+        private void applyVisualOffset(IBindable<WorkingBeatmap> beatmap)
+        {
+            waveform.RelativePositionAxes = Axes.X;
+
+            if (beatmap.Value.Track.Length > 0)
+                waveform.X = -(float)(Editor.WAVEFORM_VISUAL_OFFSET / beatmap.Value.Track.Length);
+            else
+            {
+                // sometimes this can be the case immediately after a track switch.
+                // reschedule with the hope that the track length eventually populates.
+                Scheduler.AddOnce(applyVisualOffset, beatmap);
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -141,12 +141,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
 
             track.BindTo(editorClock.Track);
-            track.BindValueChanged(_ =>
+            // schedule added as without it, `beatmap.Value.Track.Length` can be 0 immediately after a track switch.
+            track.BindValueChanged(_ => Schedule(() =>
             {
                 waveform.Waveform = beatmap.Value.Waveform;
                 waveform.RelativePositionAxes = Axes.X;
                 waveform.X = -(float)(Editor.WAVEFORM_VISUAL_OFFSET / beatmap.Value.Track.Length);
-            }, true);
+            }), true);
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.BeatmapInfo.TimelineZoom);
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26213.

Reproduction scenario: switch audio track in editor after timeline loads.

Happens because `beatmap.Value.Track.Length` is 0 immediately after a track switch, until BASS computes the actual track length on the audio thread.

Yes this is a hack. No I have no better immediate ideas how to address this otherwise.