### PR TITLE
Remove opaque background from toolbar user button

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -40,8 +40,6 @@ namespace osu.Game.Overlays.Toolbar
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, IAPIProvider api, LoginOverlay? login)
         {
-            BackgroundContent.Add(new OpaqueBackground { Depth = 1 });
-
             Flow.Add(new Container
             {
                 Masking = true,


### PR DESCRIPTION
Would close https://github.com/ppy/osu/issues/26223, and generally seems more consistent with the rest of toolbar anyhow?

| before | after |
| :-: | :-: |
| ![osu_2023-12-29_13-49-55](https://github.com/ppy/osu/assets/20418176/fbc2cba5-883e-45c4-b0fa-9f45922a53b1) | ![osu_2023-12-29_13-50-29](https://github.com/ppy/osu/assets/20418176/e8c37f49-94c9-42e8-bce5-0eca6d3d25a5) |
| ![osu_2023-12-29_13-50-03](https://github.com/ppy/osu/assets/20418176/5daa08b5-83d6-48d7-9ca9-4516cf36439d) | ![osu_2023-12-29_13-50-33](https://github.com/ppy/osu/assets/20418176/26574b0b-c0f8-4d75-9138-ef446c4f4f49) |
