### PR TITLE
Show maximum achievable combo in leaderboard scores

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -293,7 +293,7 @@ namespace osu.Game.Online.Leaderboards
 
         protected virtual IEnumerable<LeaderboardScoreStatistic> GetStatistics(ScoreInfo model) => new[]
         {
-            new LeaderboardScoreStatistic(FontAwesome.Solid.Link, BeatmapsetsStrings.ShowScoreboardHeadersCombo, model.MaxCombo.ToString()),
+            new LeaderboardScoreStatistic(FontAwesome.Solid.Link, BeatmapsetsStrings.ShowScoreboardHeadersCombo, $"{model.MaxCombo}/{model.GetMaximumAchievableCombo()}"),
             new LeaderboardScoreStatistic(FontAwesome.Solid.Crosshairs, BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, model.DisplayAccuracy)
         };
 


### PR DESCRIPTION
Very simple change.

Adds the maximum achievable combo to leaderboards in the form of “XXX/YYY” where XXX is the maximum *achieved* combo (i.e. the number that was shown before this change) and YYY is the maximum *possible* combo for that score.

![2023-12-29_14-39-30](https://github.com/ppy/osu/assets/68816703/1e6eeb71-a240-408a-b72b-657b11df2165)

## Rationale
I've heard several times that people are unhappy with the fact that in lazer an S Rank can be achieved even with a combobreak. This argument in itself is kinda silly because sliderbreaks already used to behave in this way since forever, but knowing whether a score was an FC or not is still very important (imo at least) and this change aims to help with this.

With this change it's now possible for users to gauge at a glance whether a score is an FC or not.

### Disclaimer
I *think* this change works for older scores (where the maximum achievable combo is different from today), but I can't test it because I can't currently log into the dev build to see online scores for whatever reason. It should work though. I think...

### Note
I think the text in the tooltip should be changed from “Max Combo” to just “Combo”. I know it's technically the maximum achieved combo but I think it's just confusing for users.