### PR TITLE
Add support for removing mods on entering gameplay

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModDifficultyAdjust.cs
@@ -1,0 +1,144 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Catch.Mods;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Catch.Tests.Mods
+{
+    public partial class TestSceneCatchModDifficultyAdjust : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new CatchRuleset();
+
+        [Test]
+        public void TestRedundancyOnNullValues() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust(),
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestRedundancyOnSameValues() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust { CircleSize = { Value = 8 }, ApproachRate = { Value = 8 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8,
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnDifferentCircleSize() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust { CircleSize = { Value = 10 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnDifferentApproachRate() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust { ApproachRate = { Value = 10 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnHardRockOffsetsTrue() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust { HardRockOffsets = { Value = true } },
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnSameCSAndARButHardRockOffsetsTrue() => CreateModTest(new ModTestData
+        {
+            Mod = new CatchModDifficultyAdjust { CircleSize = { Value = 8 }, ApproachRate = { Value = 8 }, HardRockOffsets = { Value = true } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8,
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new Fruit { StartTime = 1000 },
+                    new Fruit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        private bool checkRedundancy()
+        {
+            return CurrentTestData.Mods.Single(mod => mod.GetType() == typeof(CatchModDifficultyAdjust)).IsRedundant(CurrentTestData.Beatmap);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModDifficultyAdjust.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
@@ -59,6 +60,29 @@ namespace osu.Game.Rulesets.Catch.Mods
 
             if (CircleSize.Value != null) difficulty.CircleSize = CircleSize.Value.Value;
             if (ApproachRate.Value != null) difficulty.ApproachRate = ApproachRate.Value.Value;
+        }
+
+        public override bool IsRedundant(IBeatmap beatmap)
+        {
+            if (!base.IsRedundant(beatmap)) return false;
+
+            var difficulty = beatmap.Difficulty;
+
+            if (CircleSize.Value != null)
+            {
+                float roundedCircleSize = (float)Math.Round(CircleSize.Value.Value, 1);
+
+                if (roundedCircleSize != difficulty.CircleSize) return false;
+            }
+
+            if (ApproachRate.Value != null)
+            {
+                float roundedApproachRate = (float)Math.Round(ApproachRate.Value.Value, 1);
+
+                if (roundedApproachRate != difficulty.ApproachRate) return false;
+            }
+
+            return !HardRockOffsets.Value;
         }
 
         public void ApplyToBeatmapProcessor(IBeatmapProcessor beatmapProcessor)

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
@@ -72,6 +72,111 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             PassCondition = () => checkSomeHit() && checkObjectsPreempt(450)
         });
 
+        [Test]
+        public void TestRedundancyOnNullValues() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModDifficultyAdjust(),
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestRedundancyOnSameValues() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModDifficultyAdjust { CircleSize = { Value = 8 }, ApproachRate = { Value = 8 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8,
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnDifferentCircleSize() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModDifficultyAdjust { CircleSize = { Value = 10 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnDifferentApproachRate() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModDifficultyAdjust { ApproachRate = { Value = 10 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnSameCSButDifferentAR() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModDifficultyAdjust { CircleSize = { Value = 8 }, ApproachRate = { Value = 10 } },
+            Beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        CircleSize = 8,
+                        ApproachRate = 8
+                    }
+                },
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
         private bool checkObjectsPreempt(double target)
         {
             var objects = Player.ChildrenOfType<DrawableHitCircle>();
@@ -93,6 +198,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         private bool checkSomeHit()
         {
             return Player.ScoreProcessor.JudgedHits >= 2;
+        }
+
+        private bool checkRedundancy()
+        {
+            return CurrentTestData.Mods.Single(mod => mod.GetType() == typeof(OsuModDifficultyAdjust)).IsRedundant(CurrentTestData.Beatmap);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -59,6 +60,29 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             if (CircleSize.Value != null) difficulty.CircleSize = CircleSize.Value.Value;
             if (ApproachRate.Value != null) difficulty.ApproachRate = ApproachRate.Value.Value;
+        }
+
+        public override bool IsRedundant(IBeatmap beatmap)
+        {
+            if (!base.IsRedundant(beatmap)) return false;
+
+            var difficulty = beatmap.Difficulty;
+
+            if (CircleSize.Value != null)
+            {
+                float roundedCircleSize = (float)Math.Round(CircleSize.Value.Value, 1);
+
+                if (roundedCircleSize != difficulty.CircleSize) return false;
+            }
+
+            if (ApproachRate.Value != null)
+            {
+                float roundedApproachRate = (float)Math.Round(ApproachRate.Value.Value, 1);
+
+                if (roundedApproachRate != difficulty.ApproachRate) return false;
+            }
+
+            return true;
         }
 
         private partial class ApproachRateSettingsControl : DifficultyAdjustSettingsControl

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModDifficultyAdjust.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Mods
+{
+    public partial class TestSceneTaikoModDifficultyAdjust : TaikoModTestScene
+    {
+        [Test]
+        public void TestRedundancyOnNullValues() => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModDifficultyAdjust(),
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestRedundancyOnScrollSpeed1() => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModDifficultyAdjust { ScrollSpeed = { Value = 1 } },
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => checkRedundancy()
+        });
+
+        [Test]
+        public void TestNonRedundancyOnScrollSpeed4() => CreateModTest(new ModTestData
+        {
+            Mod = new TaikoModDifficultyAdjust { ScrollSpeed = { Value = 4 } },
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 }
+                }
+            },
+            PassCondition = () => !checkRedundancy()
+        });
+
+        private bool checkRedundancy()
+        {
+            return CurrentTestData.Mods.Single(mod => mod.GetType() == typeof(TaikoModDifficultyAdjust)).IsRedundant(CurrentTestData.Beatmap);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModDifficultyAdjust.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
@@ -38,6 +39,20 @@ namespace osu.Game.Rulesets.Taiko.Mods
             base.ApplySettings(difficulty);
 
             if (ScrollSpeed.Value != null) difficulty.SliderMultiplier *= ScrollSpeed.Value.Value;
+        }
+
+        public override bool IsRedundant(IBeatmap beatmap)
+        {
+            if (!base.IsRedundant(beatmap)) return false;
+
+            if (ScrollSpeed.Value != null)
+            {
+                float roundedScrollSpeed = (float)Math.Round(ScrollSpeed.Value.Value, 2);
+
+                if (roundedScrollSpeed != 1) return false;
+            }
+
+            return true;
         }
     }
 }

--- a/osu.Game.Tests/Mods/ModDifficultyAdjustTest.cs
+++ b/osu.Game.Tests/Mods/ModDifficultyAdjustTest.cs
@@ -119,6 +119,98 @@ namespace osu.Game.Tests.Mods
             Assert.That(applied.OverallDifficulty, Is.EqualTo(10));
         }
 
+        [Test]
+        public void TestRedundancyOnNullValues()
+        {
+            Beatmap beatmap = new Beatmap();
+
+            Assert.That(testMod.DrainRate.Value, Is.Null);
+
+            Assert.That(testMod.OverallDifficulty.Value, Is.Null);
+
+            Assert.True(testMod.IsRedundant(beatmap));
+        }
+
+        [Test]
+        public void TestRedundancyOnSameValuesApplied()
+        {
+            Beatmap beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        DrainRate = 8,
+                        OverallDifficulty = 8
+                    }
+                }
+            };
+
+            testMod.DrainRate.Value = 8;
+            testMod.OverallDifficulty.Value = 8;
+
+            Assert.True(testMod.IsRedundant(beatmap));
+        }
+
+        [Test]
+        public void TestNonRedundancyOnDifferentDrainRate()
+        {
+            Beatmap beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        DrainRate = 8
+                    }
+                }
+            };
+
+            testMod.DrainRate.Value = 10;
+
+            Assert.False(testMod.IsRedundant(beatmap));
+        }
+
+        [Test]
+        public void TestNonRedundancyOnDifferentOverallDifficulty()
+        {
+            Beatmap beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        OverallDifficulty = 8
+                    }
+                }
+            };
+
+            testMod.OverallDifficulty.Value = 10;
+
+            Assert.False(testMod.IsRedundant(beatmap));
+        }
+
+        [Test]
+        public void TestNonRedundancyOnSameDrainRateButDifferentOverallDifficulty()
+        {
+            Beatmap beatmap = new Beatmap
+            {
+                BeatmapInfo = new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty
+                    {
+                        DrainRate = 8,
+                        OverallDifficulty = 8
+                    }
+                }
+            };
+
+            testMod.DrainRate.Value = 8;
+            testMod.OverallDifficulty.Value = 10;
+
+            Assert.False(testMod.IsRedundant(beatmap));
+        }
+
         /// <summary>
         /// Applies a <see cref="BeatmapDifficulty"/> to the mod and returns a new <see cref="BeatmapDifficulty"/>
         /// representing the result if the mod were applied to a fresh <see cref="BeatmapDifficulty"/> instance.

--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Moq;
 using NUnit.Framework;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Utils;
@@ -131,6 +132,24 @@ namespace osu.Game.Tests.Mods
         {
             var mod = new Mock<CustomMod1>();
             Assert.That(ModUtils.CheckAllowed(new[] { mod.Object }, new[] { typeof(Mod) }), Is.False);
+        }
+
+        [Test]
+        public void TestRemoveRedundantMods()
+        {
+            var mod1 = new OsuModAutoplay();
+            var mod2 = new OsuModDifficultyAdjust();
+
+            Assert.That(ModUtils.RemoveRedundantMods(new Mod[] { mod1, mod2 }, out var removed, new Beatmap()), Is.True);
+            Assert.That(removed, Is.Not.Null);
+            if (removed != null)
+            {
+                Assert.That(removed.Contains(mod1), Is.False);
+                Assert.That(removed.Contains(mod2), Is.True);
+            }
+
+            Assert.That(ModUtils.RemoveRedundantMods(new Mod[] { mod1 }, out var removed2, new Beatmap()), Is.False);
+            Assert.That(removed2, Is.Null);
         }
 
         private static readonly object[] invalid_mod_test_scenarios =

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -96,6 +96,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddUntilStep("wait for no notifications", () => notificationOverlay.UnreadCount.Value, () => Is.EqualTo(0));
+
+            AddStep("reset mods", () => SelectedMods.Value = Array.Empty<Mod>());
         }
 
         /// <summary>
@@ -272,6 +274,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for non-null player", () => player != null);
             AddAssert("redundant mods have been removed", () => !player.Mods.Value.Contains(playerMod));
+
+            clickNotification();
         }
 
         [Test]
@@ -282,6 +286,19 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddUntilStep("wait for non-null player", () => player != null);
             AddAssert("redundant mods have been removed", () => !player.Mods.Value.Contains(playerMod));
+
+            clickNotification();
+        }
+
+        [Test]
+        public void TestRedundantModsNotification()
+        {
+            AddStep("load player", () => { resetPlayer(true, () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() }); });
+
+            AddUntilStep("wait for non-null player", () => player != null);
+            AddAssert("check for notification", () => notificationOverlay.UnreadCount.Value, () => Is.EqualTo(1));
+
+            clickNotification();
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -265,6 +265,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestRemovingRedundantModsOnEnteringGameplay()
+        {
+            OsuModDifficultyAdjust playerMod = null;
+            AddStep("load player", () => { resetPlayer(true, () => SelectedMods.Value = new[] { playerMod = new OsuModDifficultyAdjust() }); });
+
+            AddUntilStep("wait for player to become current", () => player.IsCurrentScreen());
+            AddAssert("player mods has been removed", () => !player.Mods.Value.Contains(playerMod));
+        }
+
+        [Test]
         public void TestMutedNotificationMasterVolume()
         {
             addVolumeSteps("master volume", () => audioManager.Volume.Value = 0, () => audioManager.Volume.Value == 0.5);

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -270,8 +270,18 @@ namespace osu.Game.Tests.Visual.Gameplay
             OsuModDifficultyAdjust playerMod = null;
             AddStep("load player", () => { resetPlayer(true, () => SelectedMods.Value = new[] { playerMod = new OsuModDifficultyAdjust() }); });
 
-            AddUntilStep("wait for player to become current", () => player.IsCurrentScreen());
-            AddAssert("player mods has been removed", () => !player.Mods.Value.Contains(playerMod));
+            AddUntilStep("wait for non-null player", () => player != null);
+            AddAssert("redundant mods have been removed", () => !player.Mods.Value.Contains(playerMod));
+        }
+
+        [Test]
+        public void TestRemovingRedundantModsWithAutoplayMod()
+        {
+            OsuModDifficultyAdjust playerMod = null;
+            AddStep("load player with autoplay mod", () => { resetPlayer(true, () => SelectedMods.Value = new Mod[] { playerMod = new OsuModDifficultyAdjust(), new OsuModAutoplay() }); });
+
+            AddUntilStep("wait for non-null player", () => player != null);
+            AddAssert("redundant mods have been removed", () => !player.Mods.Value.Contains(playerMod));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayer.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayPlayer.cs
@@ -7,7 +7,9 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Beatmaps;
@@ -155,6 +157,24 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
 
             AddAssert("Jumped forwards", () => Player.GameplayClockContainer.CurrentTime - lastTime > 500);
+        }
+
+        [Test]
+        public void TestNotRemovingRedundantMods()
+        {
+            var redundantMod = new OsuModDifficultyAdjust();
+
+            AddStep("create player with redundant mod", () =>
+            {
+                var ruleset = new OsuRuleset();
+                Beatmap.Value = CreateWorkingBeatmap(ruleset.RulesetInfo);
+                SelectedMods.Value = new Mod[] { redundantMod, new OsuModAutoplay() };
+                Player = new TestReplayPlayer(false);
+            });
+
+            AddStep("load player", () => LoadScreen(Player));
+
+            AddAssert("redundant mod was not removed", () => Player.Mods.Value.Contains(redundantMod));
         }
 
         private void loadPlayerWithBeatmap(IBeatmap? beatmap = null)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -115,6 +115,22 @@ namespace osu.Game.Tests.Visual.Multiplayer
             assertFreeModNotShown(requiredMod);
         }
 
+        [Test]
+        public void TestRedudantModsRemovalWhenSelectingBeatmap()
+        {
+            BeatmapInfo selectedBeatmap = null;
+            OsuModDifficultyAdjust mod = null;
+
+            AddStep("select beatmap",
+                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = beatmaps.First()));
+            AddUntilStep("wait for selection", () => Beatmap.Value.BeatmapInfo.Equals(selectedBeatmap));
+
+            AddStep("set mods", () => SelectedMods.Value = new Mod[] { mod = new OsuModDifficultyAdjust(), new OsuModHidden() });
+            AddStep("finalise selection", () => songSelect.FinaliseSelection());
+            AddUntilStep("song select exited", () => !songSelect.IsCurrentScreen());
+            AddAssert("mod has been removed", () => SelectedRoom.Value.Playlist.Last().RequiredMods.Length == 1);
+        }
+
         private void assertFreeModNotShown(Type type)
         {
             AddAssert($"{type.ReadableName()} not displayed in freemod overlay",

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -11,13 +11,16 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
@@ -41,6 +44,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private TestMultiplayerMatchSongSelect songSelect;
 
         private Live<BeatmapSetInfo> importedBeatmapSet;
+
+        [Cached(typeof(INotificationOverlay))]
+        private readonly NotificationOverlay notificationOverlay;
+
+        public TestSceneMultiplayerMatchSongSelect()
+        {
+            AddRange(new Drawable[]
+            {
+                notificationOverlay = new NotificationOverlay
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight
+                }
+            });
+        }
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -129,6 +147,34 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("finalise selection", () => songSelect.FinaliseSelection());
             AddUntilStep("song select exited", () => !songSelect.IsCurrentScreen());
             AddAssert("mod has been removed", () => SelectedRoom.Value.Playlist.Last().RequiredMods.Length == 1);
+
+            clickNotification();
+        }
+
+        [Test]
+        public void TestRedundantModsNotification()
+        {
+            BeatmapInfo selectedBeatmap = null;
+
+            AddStep("select beatmap",
+                () => songSelect.Carousel.SelectBeatmap(selectedBeatmap = beatmaps.First()));
+            AddUntilStep("wait for selection", () => Beatmap.Value.BeatmapInfo.Equals(selectedBeatmap));
+
+            AddStep("set redundant mod", () => SelectedMods.Value = new[] { new OsuModDifficultyAdjust() });
+            AddStep("finalise selection", () => songSelect.FinaliseSelection());
+            AddUntilStep("song select exited", () => !songSelect.IsCurrentScreen());
+            AddAssert("check for notification", () => notificationOverlay.UnreadCount.Value, () => Is.EqualTo(1));
+
+            clickNotification();
+        }
+
+        private void clickNotification()
+        {
+            Notification notification = null;
+
+            AddUntilStep("wait for notification", () => (notification = notificationOverlay.ChildrenOfType<Notification>().FirstOrDefault()) != null);
+            AddStep("open notification overlay", () => notificationOverlay.Show());
+            AddStep("click notification", () => notification.TriggerClick());
         }
 
         private void assertFreeModNotShown(Type type)

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -8,11 +8,15 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
@@ -29,6 +33,21 @@ namespace osu.Game.Tests.Visual.Multiplayer
         private BeatmapManager manager;
 
         private TestPlaylistsSongSelect songSelect;
+
+        [Cached(typeof(INotificationOverlay))]
+        private readonly NotificationOverlay notificationOverlay;
+
+        public TestScenePlaylistsSongSelect()
+        {
+            AddRange(new Drawable[]
+            {
+                notificationOverlay = new NotificationOverlay
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight
+                }
+            });
+        }
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
@@ -160,7 +179,29 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("set mods", () => { SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust(), new OsuModHidden() }; });
             AddStep("create item", () => songSelect.BeatmapDetails.CreateNewItem());
             AddAssert("redundant mod has been removed", () => SelectedRoom.Value.Playlist.First().RequiredMods.Length == 1);
+
+            clickNotification();
         }
+
+        [Test]
+        public void TestRedundantModsNotification()
+        {
+            AddStep("set redundant mod", () => { SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust() }; });
+            AddStep("create item", () => songSelect.BeatmapDetails.CreateNewItem());
+            AddAssert("check for notification", () => notificationOverlay.UnreadCount.Value, () => Is.EqualTo(1));
+
+            clickNotification();
+        }
+
+        private void clickNotification()
+        {
+            Notification notification = null;
+
+            AddUntilStep("wait for notification", () => (notification = notificationOverlay.ChildrenOfType<Notification>().FirstOrDefault()) != null);
+            AddStep("open notification overlay", () => notificationOverlay.Show());
+            AddStep("click notification", () => notification.TriggerClick());
+        }
+
         private partial class TestPlaylistsSongSelect : PlaylistsSongSelect
         {
             public new MatchBeatmapDetailArea BeatmapDetails => (MatchBeatmapDetailArea)base.BeatmapDetails;

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -154,6 +154,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
             });
         }
 
+        [Test]
+        public void TestRedudantModsRemovalWhenCreatingItem()
+        {
+            AddStep("set mods", () => { SelectedMods.Value = new Mod[] { new OsuModDifficultyAdjust(), new OsuModHidden() }; });
+            AddStep("create item", () => songSelect.BeatmapDetails.CreateNewItem());
+            AddAssert("redundant mod has been removed", () => SelectedRoom.Value.Playlist.First().RequiredMods.Length == 1);
+        }
         private partial class TestPlaylistsSongSelect : PlaylistsSongSelect
         {
             public new MatchBeatmapDetailArea BeatmapDetails => (MatchBeatmapDetailArea)base.BeatmapDetails;

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -113,6 +113,11 @@ Please try changing your audio device to a working setting.");
         /// </summary>
         public static LocalisableString MismatchingBeatmapForReplay => new TranslatableString(getKey(@"mismatching_beatmap_for_replay"), @"Your local copy of the beatmap for this replay appears to be different than expected. You may need to update or re-download it.");
 
+        /// <summary>
+        /// "It seems you enabled some redundant mods. These mods were removed: {0}"
+        /// </summary>
+        public static LocalisableString RedundantModsRemoved(string removedMods) => new TranslatableString(getKey(@"redundant_mods_removed"), @"It seems you enabled some redundant mods. These mods were removed: {0}.", removedMods);
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -11,6 +11,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Rulesets.UI;
@@ -331,5 +332,18 @@ namespace osu.Game.Rulesets.Mods
 
             public int GetHashCode(IBindable obj) => obj.GetUnderlyingSettingValue().GetHashCode();
         }
+
+        /// <summary>
+        /// Checks if this mod is redundant.
+        /// </summary>
+        /// <returns>Whether this mod is redundant.</returns>
+        public virtual bool IsRedundant() => false;
+
+        /// <summary>
+        /// Checks if this mod is redundant based on a <see cref="IBeatmap"/> implementation.
+        /// </summary>
+        /// <param name="beatmap">The <see cref="IBeatmap"/> implementation to test against.</param>
+        /// <returns>Whether this mod is redundant.</returns>
+        public virtual bool IsRedundant(IBeatmap beatmap) => IsRedundant();
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -95,5 +95,27 @@ namespace osu.Game.Rulesets.Mods
             if (DrainRate.Value != null) difficulty.DrainRate = DrainRate.Value.Value;
             if (OverallDifficulty.Value != null) difficulty.OverallDifficulty = OverallDifficulty.Value.Value;
         }
+
+        public override bool IsRedundant(IBeatmap beatmap)
+        {
+            var difficulty = beatmap.Difficulty;
+
+            if (DrainRate.Value != null)
+            {
+                // Rounding due to some float problems
+                float roundedDrainRate = (float)Math.Round(DrainRate.Value.Value, 1);
+
+                if (roundedDrainRate != difficulty.DrainRate) return false;
+            }
+
+            if (OverallDifficulty.Value != null)
+            {
+                float roundedOverallDifficulty = (float)Math.Round(OverallDifficulty.Value.Value, 1);
+
+                if (roundedOverallDifficulty != difficulty.OverallDifficulty) return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -9,10 +9,12 @@ using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer
 {
@@ -70,6 +72,13 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                 Logger.Log($"{nameof(SelectItem)} aborted due to {nameof(operationInProgress)}");
                 return false;
             }
+
+            var validMods = Mods.Value.ToArray();
+
+            if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+                validMods = validMods.Except(removed).ToArray();
+
+            item.RequiredMods = validMods.Select(m => new APIMod(m)).ToArray();
 
             // If the client is already in a room, update via the client.
             // Otherwise, update the playlist directly in preparation for it to be submitted to the API on match creation.

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osu.Game.Utils;
@@ -25,6 +26,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         [Resolved]
         private OngoingOperationTracker operationTracker { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notificationOverlay { get; set; }
 
         private readonly IBindable<bool> operationInProgress = new Bindable<bool>();
         private readonly PlaylistItem? itemToEdit;
@@ -76,7 +80,17 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             var validMods = Mods.Value.ToArray();
 
             if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+            {
                 validMods = validMods.Except(removed).ToArray();
+
+                string[] removedModsNames = new string[removed.Count];
+                for (int i = 0; i < removed.Count; i++)
+                {
+                    removedModsNames[i] = removed[i].Name;
+                }
+
+                notificationOverlay?.Post(new RedundantModsNotification(removedModsNames));
+            }
 
             item.RequiredMods = validMods.Select(m => new APIMod(m)).ToArray();
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.Select;
 using osu.Game.Utils;
@@ -13,6 +15,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 {
     public partial class PlaylistsSongSelect : OnlinePlaySongSelect
     {
+        [Resolved]
+        private INotificationOverlay? notificationOverlay { get; set; }
+
         public PlaylistsSongSelect(Room room)
             : base(room)
         {
@@ -46,7 +51,17 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             var validMods = Mods.Value.ToArray();
 
             if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+            {
                 validMods = validMods.Except(removed).ToArray();
+
+                string[] removedModsNames = new string[removed.Count];
+                for (int i = 0; i < removed.Count; i++)
+                {
+                    removedModsNames[i] = removed[i].Name;
+                }
+
+                notificationOverlay?.Post(new RedundantModsNotification(removedModsNames));
+            }
 
             Mods.Value = validMods;
 

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -7,6 +7,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Screens.Select;
+using osu.Game.Utils;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
@@ -42,6 +43,13 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         private void createNewItem()
         {
+            var validMods = Mods.Value.ToArray();
+
+            if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+                validMods = validMods.Except(removed).ToArray();
+
+            Mods.Value = validMods;
+
             PlaylistItem item = new PlaylistItem(Beatmap.Value.BeatmapInfo)
             {
                 ID = Playlist.Count == 0 ? 0 : Playlist.Max(p => p.ID) + 1,

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -402,7 +402,17 @@ namespace osu.Game.Screens.Play
                 var validMods = Mods.Value.ToArray();
 
                 if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+                {
                     validMods = validMods.Except(removed).ToArray();
+
+                    string[] removedModsNames = new string[removed.Count];
+                    for (int i = 0; i < removed.Count; i++)
+                    {
+                        removedModsNames[i] = removed[i].Name;
+                    }
+
+                    notificationOverlay?.Post(new RedundantModsNotification(removedModsNames));
+                }
 
                 Mods.Value = validMods;
             }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -394,14 +394,18 @@ namespace osu.Game.Screens.Play
             if (!this.IsCurrentScreen())
                 return;
 
-            var validMods = Mods.Value.ToArray();
-
-            if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
-                validMods = validMods.Except(removed).ToArray();
-
-            Mods.Value = validMods;
-
             CurrentPlayer = createPlayer();
+
+            if (CurrentPlayer is not ReplayPlayer)
+            {
+                var validMods = Mods.Value.ToArray();
+
+                if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+                    validMods = validMods.Except(removed).ToArray();
+
+                Mods.Value = validMods;
+            }
+
             CurrentPlayer.Configuration.AutomaticallySkipIntro |= quickRestart;
             CurrentPlayer.RestartCount = restartCount++;
             CurrentPlayer.RestartRequested = restartRequested;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
@@ -392,6 +393,13 @@ namespace osu.Game.Screens.Play
         {
             if (!this.IsCurrentScreen())
                 return;
+
+            var validMods = Mods.Value.ToArray();
+
+            if (ModUtils.RemoveRedundantMods(validMods, out var removed, Beatmap.Value.Beatmap))
+                validMods = validMods.Except(removed).ToArray();
+
+            Mods.Value = validMods;
 
             CurrentPlayer = createPlayer();
             CurrentPlayer.Configuration.AutomaticallySkipIntro |= quickRestart;

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -25,6 +25,7 @@ using osu.Game.Input;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Skinning;
@@ -396,7 +397,7 @@ namespace osu.Game.Screens.Play
 
             CurrentPlayer = createPlayer();
 
-            if (CurrentPlayer is not ReplayPlayer)
+            if (CurrentPlayer is not ReplayPlayer || Mods.Value.OfType<ICreateReplayData>().Any())
             {
                 var validMods = Mods.Value.ToArray();
 

--- a/osu.Game/Screens/RedundantModsNotification.cs
+++ b/osu.Game/Screens/RedundantModsNotification.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Localisation;
+
+namespace osu.Game.Screens
+{
+    public partial class RedundantModsNotification : SimpleNotification
+    {
+        public override bool IsImportant => true;
+
+        public RedundantModsNotification(string[] removedMods)
+        {
+            Text = NotificationsStrings.RedundantModsRemoved(string.Join(", ", removedMods));
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours, INotificationOverlay notificationOverlay)
+        {
+            IconContent.Colour = colours.YellowDark;
+        }
+    }
+}

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Beatmaps;
 
 namespace osu.Game.Utils
 {
@@ -225,6 +226,30 @@ namespace osu.Game.Utils
             }
 
             return proposedWereValid;
+        }
+
+        /// <summary>
+        /// Checks if there are redundant <see cref="Mod"/>s in a combination.
+        /// </summary>
+        /// <param name="combination">The <see cref="Mod"/>s combination to check.</param>
+        /// <param name="removedMods">The set of <see cref="Mod"/>s to be removed.</param>
+        /// <param name="beatmap">The <see cref="IBeatmap"/> implementation to test against.</param>
+        /// <returns>Whether there are redundant <see cref="Mod"/>s in the combination.</returns>
+        public static bool RemoveRedundantMods(IEnumerable<Mod> combination, [NotNullWhen(true)] out List<Mod>? removedMods, IBeatmap beatmap)
+        {
+            var mods = FlattenMods(combination).ToArray();
+            removedMods = null;
+
+            foreach (var mod in mods)
+            {
+                if (mod.IsRedundant(beatmap))
+                {
+                    removedMods ??= new List<Mod>();
+                    removedMods.Add(mod);
+                }
+            }
+
+            return removedMods != null;
         }
     }
 }


### PR DESCRIPTION
Addresses #17835.

Automatically removes mods on entering gameplay when they do nothing (e.g. difficulty adjust mod at default settings). For now, it only supports removing difficulty adjust mods. I'll try to implement the removal for key conversion mods later in another PR.

I'm just unsure about whether I should separate the test for each mod or just use this giant test.