### PR TITLE
Increase slider tails' worth to 150 points (up from 30)

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEarlyHitJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEarlyHitJudgement.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             assertHeadJudgement(HitResult.Meh);
             assertTickJudgement(HitResult.LargeTickHit);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderInput.cs
@@ -467,13 +467,13 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void assertHeadMissTailTracked()
         {
-            AddAssert("Tracking retained", () => judgementResults[^2].Type, () => Is.EqualTo(HitResult.LargeTickHit));
+            AddAssert("Tracking retained", () => judgementResults[^2].Type, () => Is.EqualTo(HitResult.SliderTailHit));
             AddAssert("Slider head missed", () => judgementResults.First().IsHit, () => Is.False);
         }
 
         private void assertMidSliderJudgements()
         {
-            AddAssert("Tracking acquired", () => judgementResults[^2].Type, () => Is.EqualTo(HitResult.LargeTickHit));
+            AddAssert("Tracking acquired", () => judgementResults[^2].Type, () => Is.EqualTo(HitResult.SliderTailHit));
         }
 
         private void assertMidSliderJudgementFail()

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderLateHitJudgement.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
 
             assertHeadJudgement(HitResult.Ok);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertTickJudgement(1, HitResult.LargeTickHit);
             assertTickJudgement(2, HitResult.LargeTickHit);
             assertTickJudgement(3, HitResult.LargeTickHit);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertHeadJudgement(HitResult.Meh);
             assertAllTickJudgements(HitResult.LargeTickHit);
             assertRepeatJudgement(HitResult.LargeTickHit);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 
@@ -210,7 +210,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             assertHeadJudgement(HitResult.Meh);
             assertRepeatJudgement(HitResult.LargeTickHit);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 
@@ -245,7 +245,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertAllTickJudgements(HitResult.LargeTickMiss);
 
             // This particular test actually starts tracking the slider just before the end, so the tail should be hit because of its leniency.
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
 
             assertSliderJudgement(HitResult.IgnoreHit);
         }
@@ -276,7 +276,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             assertHeadJudgement(HitResult.Meh);
             assertTickJudgement(0, HitResult.LargeTickMiss);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 
@@ -307,7 +307,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             assertHeadJudgement(HitResult.Meh);
             assertTickJudgement(0, HitResult.LargeTickMiss);
             assertTickJudgement(1, HitResult.LargeTickMiss);
-            assertTailJudgement(HitResult.LargeTickHit);
+            assertTailJudgement(HitResult.SliderTailHit);
             assertSliderJudgement(HitResult.IgnoreHit);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class TailJudgement : SliderEndJudgement
         {
-            public override HitResult MaxResult => HitResult.LargeTickHit;
+            public override HitResult MaxResult => HitResult.SliderTailHit;
             public override HitResult MinResult => HitResult.IgnoreMiss;
         }
     }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -277,6 +277,7 @@ namespace osu.Game.Rulesets.Osu
 
                 HitResult.LargeTickHit,
                 HitResult.SmallTickHit,
+                HitResult.SliderTailHit,
                 HitResult.SmallBonus,
                 HitResult.LargeBonus,
             };
@@ -289,6 +290,7 @@ namespace osu.Game.Rulesets.Osu
                 case HitResult.LargeTickHit:
                     return "slider tick";
 
+                case HitResult.SliderTailHit:
                 case HitResult.SmallTickHit:
                     return "slider end";
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -91,6 +91,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     // When classic slider mechanics are enabled, this result comes from the tail.
                     return 0.02;
 
+                case HitResult.SliderTailHit:
                 case HitResult.LargeTickHit:
                     switch (result.HitObject)
                     {

--- a/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     increase = 0.02;
                     break;
 
+                case HitResult.SliderTailHit:
                 case HitResult.LargeTickHit:
                     // This result comes from either a slider tick or repeat.
                     increase = hitObject is SliderTick ? 0.015 : 0.02;

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(ScoringMode.Standardised, HitResult.SmallTickHit, HitResult.SmallTickHit, 493_652)]
         [TestCase(ScoringMode.Standardised, HitResult.LargeTickMiss, HitResult.LargeTickHit, 0)]
         [TestCase(ScoringMode.Standardised, HitResult.LargeTickHit, HitResult.LargeTickHit, 326_963)]
+        [TestCase(ScoringMode.Standardised, HitResult.SliderTailHit, HitResult.SliderTailHit, 326_963)]
         [TestCase(ScoringMode.Standardised, HitResult.SmallBonus, HitResult.SmallBonus, 1_000_030)]
         [TestCase(ScoringMode.Standardised, HitResult.LargeBonus, HitResult.LargeBonus, 1_000_150)]
         [TestCase(ScoringMode.Classic, HitResult.Miss, HitResult.Great, 0)]
@@ -96,6 +97,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(ScoringMode.Classic, HitResult.SmallTickHit, HitResult.SmallTickHit, 49_365)]
         [TestCase(ScoringMode.Classic, HitResult.LargeTickMiss, HitResult.LargeTickHit, 0)]
         [TestCase(ScoringMode.Classic, HitResult.LargeTickHit, HitResult.LargeTickHit, 32_696)]
+        [TestCase(ScoringMode.Classic, HitResult.SliderTailHit, HitResult.SliderTailHit, 32_696)]
         [TestCase(ScoringMode.Classic, HitResult.SmallBonus, HitResult.SmallBonus, 100_003)]
         [TestCase(ScoringMode.Classic, HitResult.LargeBonus, HitResult.LargeBonus, 100_015)]
         public void TestFourVariousResultsOneMiss(ScoringMode scoringMode, HitResult hitResult, HitResult maxResult, int expectedScore)
@@ -167,6 +169,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.Perfect, HitResult.Miss)]
         [TestCase(HitResult.SmallTickHit, HitResult.SmallTickMiss)]
         [TestCase(HitResult.LargeTickHit, HitResult.LargeTickMiss)]
+        [TestCase(HitResult.SliderTailHit, HitResult.LargeTickMiss)]
         [TestCase(HitResult.SmallBonus, HitResult.IgnoreMiss)]
         [TestCase(HitResult.LargeBonus, HitResult.IgnoreMiss)]
         public void TestMinResults(HitResult hitResult, HitResult expectedMinResult)
@@ -187,6 +190,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SmallTickHit, false)]
         [TestCase(HitResult.LargeTickMiss, true)]
         [TestCase(HitResult.LargeTickHit, true)]
+        [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
         public void TestAffectsCombo(HitResult hitResult, bool expectedReturnValue)
@@ -207,6 +211,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SmallTickHit, true)]
         [TestCase(HitResult.LargeTickMiss, true)]
         [TestCase(HitResult.LargeTickHit, true)]
+        [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
         public void TestAffectsAccuracy(HitResult hitResult, bool expectedReturnValue)
@@ -227,6 +232,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SmallTickHit, false)]
         [TestCase(HitResult.LargeTickMiss, false)]
         [TestCase(HitResult.LargeTickHit, false)]
+        [TestCase(HitResult.SliderTailHit, false)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsBonus(HitResult hitResult, bool expectedReturnValue)
@@ -247,6 +253,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SmallTickHit, true)]
         [TestCase(HitResult.LargeTickMiss, false)]
         [TestCase(HitResult.LargeTickHit, true)]
+        [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsHit(HitResult hitResult, bool expectedReturnValue)
@@ -267,6 +274,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SmallTickHit, true)]
         [TestCase(HitResult.LargeTickMiss, true)]
         [TestCase(HitResult.LargeTickHit, true)]
+        [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
         public void TestIsScorable(HitResult hitResult, bool expectedReturnValue)

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -73,6 +73,7 @@ namespace osu.Game.Rulesets.Judgements
                         return HitResult.SmallTickMiss;
 
                     case HitResult.LargeTickHit:
+                    case HitResult.SliderTailHit:
                         return HitResult.LargeTickMiss;
 
                     default:
@@ -104,6 +105,7 @@ namespace osu.Game.Rulesets.Judgements
                 case HitResult.SmallTickMiss:
                     return -DEFAULT_MAX_HEALTH_INCREASE * 0.5;
 
+                case HitResult.SliderTailHit:
                 case HitResult.LargeTickHit:
                     return DEFAULT_MAX_HEALTH_INCREASE;
 

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -140,6 +140,13 @@ namespace osu.Game.Rulesets.Scoring
         ComboBreak,
 
         /// <summary>
+        /// A special judgement similar to <see cref="LargeTickHit"/> that's used to increase the valuation of the final tick of a slider.
+        /// </summary>
+        [EnumMember(Value = "slider_tail_hit")]
+        [Order(16)]
+        SliderTailHit,
+
+        /// <summary>
         /// A special result used as a padding value for legacy rulesets. It is a hit type and affects combo, but does not affect the base score (does not affect accuracy).
         ///
         /// DO NOT USE FOR ANYTHING EVER.
@@ -188,6 +195,7 @@ namespace osu.Game.Rulesets.Scoring
                 case HitResult.LargeTickMiss:
                 case HitResult.LegacyComboIncrease:
                 case HitResult.ComboBreak:
+                case HitResult.SliderTailHit:
                     return true;
 
                 default:
@@ -246,6 +254,7 @@ namespace osu.Game.Rulesets.Scoring
                 case HitResult.LargeTickMiss:
                 case HitResult.SmallTickHit:
                 case HitResult.SmallTickMiss:
+                case HitResult.SliderTailHit:
                     return true;
 
                 default:
@@ -329,6 +338,9 @@ namespace osu.Game.Rulesets.Scoring
                 case HitResult.ComboBreak:
                     return true;
 
+                case HitResult.SliderTailHit:
+                    return true;
+
                 default:
                     // Note that IgnoreHit and IgnoreMiss are excluded as they do not affect score.
                     return result >= HitResult.Miss && result < HitResult.IgnoreMiss;
@@ -382,6 +394,9 @@ namespace osu.Game.Rulesets.Scoring
 
             if (minResult == HitResult.IgnoreMiss)
                 return;
+
+            if (maxResult == HitResult.SliderTailHit && minResult != HitResult.LargeTickMiss)
+                throw new ArgumentOutOfRangeException(nameof(minResult), $"{HitResult.LargeTickMiss} is the only valid minimum result for a {maxResult} judgement.");
 
             if (maxResult == HitResult.LargeTickHit && minResult != HitResult.LargeTickMiss)
                 throw new ArgumentOutOfRangeException(nameof(minResult), $"{HitResult.LargeTickMiss} is the only valid minimum result for a {maxResult} judgement.");

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -322,6 +322,9 @@ namespace osu.Game.Rulesets.Scoring
                 case HitResult.LargeTickHit:
                     return 30;
 
+                case HitResult.SliderTailHit:
+                    return 150;
+
                 case HitResult.Meh:
                     return 50;
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -350,6 +350,7 @@ namespace osu.Game.Scoring
                 {
                     case HitResult.SmallTickHit:
                     case HitResult.LargeTickHit:
+                    case HitResult.SliderTailHit:
                     case HitResult.LargeBonus:
                     case HitResult.SmallBonus:
                         if (MaximumStatistics.TryGetValue(r.result, out int count) && count > 0)


### PR DESCRIPTION
@Bubbleman532, @Zyfarok, and others in the community have mentioned that the changes to sliders (tails not affecting the slider's main judgement, because that judgement is now on the head) have made tails not worth as much anymore, and removes the need to aim sliders on higher SR maps that very rarely have any ticks in sliders.

This PR makes tails worth 150 points, compared to the 30 points of a normal tick.

Not sure on the exact value this should be, was given a range anywhere between 100 and 230.