### PR TITLE
Make the Ruleset buttons as the color of their mascots

### DIFF
--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -266,7 +266,7 @@ namespace osu.Game.Graphics
         public readonly Color4 Yellow = Color4Extensions.FromHex(@"ffcc22");
         public readonly Color4 YellowDark = Color4Extensions.FromHex(@"eeaa00");
         public readonly Color4 YellowDarker = Color4Extensions.FromHex(@"cc6600");
-
+        public readonly Color4 GreenLightest = Color4Extensions.FromHex(@"00ffaa");
         public readonly Color4 GreenLighter = Color4Extensions.FromHex(@"eeffcc");
         public readonly Color4 GreenLight = Color4Extensions.FromHex(@"b3d944");
         public readonly Color4 Green = Color4Extensions.FromHex(@"88b300");

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.UserInterface;
@@ -11,6 +10,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Rulesets;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Toolbar
 {
@@ -26,8 +26,8 @@ namespace osu.Game.Overlays.Toolbar
             Child = ruleset = new RulesetButton
             {
                 Active = false,
+                TooltipMainText = value.CreateInstance().Description
             };
-
             var rInstance = value.CreateInstance();
 
             ruleset.TooltipMain = rInstance.Description;
@@ -41,6 +41,8 @@ namespace osu.Game.Overlays.Toolbar
 
         private partial class RulesetButton : ToolbarButton
         {
+            private Color4 rulesetcolour;
+
             protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
 
             [Resolved]
@@ -53,6 +55,7 @@ namespace osu.Game.Overlays.Toolbar
                     Bottom = 5
                 };
             }
+            public string TooltipMainText { get; set; } = "";
 
             public bool Active
             {
@@ -60,7 +63,24 @@ namespace osu.Game.Overlays.Toolbar
                 {
                     if (value)
                     {
-                        IconContainer.Colour = Color4Extensions.FromHex("#00FFAA");
+                        string tooltipMainText = TooltipMainText;
+                        if (tooltipMainText == "osu!")
+                        {
+                            rulesetcolour = colours.PinkLight;
+                        }
+                        else if (tooltipMainText == "osu!mania")
+                        {
+                            rulesetcolour = colours.Purple1;
+                        }
+                        else if (tooltipMainText == "osu!catch")
+                        {
+                            rulesetcolour = colours.Blue;
+                        }
+                        else
+                        {
+                            rulesetcolour = colours.GreenLightest;
+                        }
+                        IconContainer.Colour = rulesetcolour;
                     }
                     else
                     {

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -70,11 +70,11 @@ namespace osu.Game.Overlays.Toolbar
                         }
                         else if (tooltipMainText == "osu!mania")
                         {
-                            rulesetcolour = colours.Purple1;
+                            rulesetcolour = colours.Purple0;
                         }
                         else if (tooltipMainText == "osu!catch")
                         {
-                            rulesetcolour = colours.Blue;
+                            rulesetcolour = colours.Blue0;
                         }
                         else
                         {


### PR DESCRIPTION
This pull request makes the ruleset buttons have their color as their mascot's color instead of having all of the buttons as the default light green color. This will not mess with custom rulesets as they will have the same color as osu!taiko

also I have put the color that was inside the `ToolbarRulesetTabButton.cs` to `OsuColour.cs` for in case the color can be reused if necessary

btw this is my first time coding in C# so my code might not be the best so feel free to edit it to your liking.