### PR TITLE
Fix interests icon no longer visible in user profile

### DIFF
--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Overlays.Profile.Header
             bool anyInfoAdded = false;
 
             anyInfoAdded |= tryAddInfo(FontAwesome.Solid.MapMarker, user.Location);
-            anyInfoAdded |= tryAddInfo(OsuIcon.Heart, user.Interests);
+            anyInfoAdded |= tryAddInfo(FontAwesome.Solid.Heart, user.Interests);
             anyInfoAdded |= tryAddInfo(FontAwesome.Solid.Suitcase, user.Occupation);
 
             if (anyInfoAdded)


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/26258

I'm confused as to why this icon was taken from `OsuIcon` and not from `FontAwesome` (which I don't know anything about yet, but I'm just confused since all the others here are not from the former).

I'm using Visual Studio's git blame, and it shows no changes to this code since 2020, so I don't know what has happened recently as the icon is no longer visible.

Current:
![image](https://github.com/ppy/osu/assets/43073074/507c4675-5b12-41f9-8461-a95437994eb1)

With this fix:
![image](https://github.com/ppy/osu/assets/43073074/01054344-121c-4e73-9800-f6f47f76ff72)
