### PR TITLE
Fix beats being counted incorrectly in the timing editor

### DIFF
--- a/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/WaveformComparisonDisplay.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Screens.Edit.Timing
                 row.Alpha = time < selectedGroupStartTime || time > selectedGroupEndTime ? 0.2f : 1;
                 row.WaveformOffsetTo(-offset, animated);
                 row.WaveformScale = new Vector2(scale, 1);
-                row.BeatIndex = (int)Math.Floor(index);
+                row.BeatIndex = (int)Math.Round(index);
 
                 index++;
             }


### PR DESCRIPTION
Fixes #26263

this PR fixes a bug where the incorrect beat index was showing due to a rounding error

these poor timing variables are getting multiplied and divided and remultiplied and redivided again