### PR TITLE
Add keybind for cycling grid type

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -170,6 +170,29 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
+        public void TestGridSizeToggling()
+        {
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+            AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
+            gridSizeIs(4);
+
+            nextGridSizeIs(8);
+            nextGridSizeIs(16);
+            nextGridSizeIs(32);
+            nextGridSizeIs(4);
+        }
+
+        private void nextGridSizeIs(int size)
+        {
+            AddStep("toggle to next grid size", () => InputManager.Key(Key.G));
+            gridSizeIs(size);
+        }
+
+        private void gridSizeIs(int size)
+            => AddAssert($"grid size is {size}", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Single().Spacing.Value == new Vector2(size)
+                                                       && EditorBeatmap.BeatmapInfo.GridSize == size);
+
+        [Test]
         public void TestGridTypeToggling()
         {
             AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
@@ -183,7 +206,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void nextGridTypeIs<T>() where T : PositionSnapGrid
         {
-            AddStep("toggle to next grid type", () => InputManager.Key(Key.G));
+            AddStep("toggle to next grid type", () => InputManager.Key(Key.H));
             gridActive<T>(true);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -9,6 +9,7 @@ using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Tests.Visual;
 using osu.Game.Utils;
@@ -161,7 +162,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             return grid switch
             {
                 RectangularPositionSnapGrid rectangular => rectangular.StartPosition.Value + GeometryUtils.RotateVector(rectangular.Spacing.Value, -rectangular.GridLineRotation.Value),
-                TriangularPositionSnapGrid triangular => triangular.StartPosition.Value + GeometryUtils.RotateVector(new Vector2(triangular.Spacing.Value / 2, triangular.Spacing.Value / 2 * MathF.Sqrt(3)), -triangular.GridLineRotation.Value),
+                TriangularPositionSnapGrid triangular => triangular.StartPosition.Value + GeometryUtils.RotateVector(
+                    new Vector2(triangular.Spacing.Value / 2, triangular.Spacing.Value / 2 * MathF.Sqrt(3)), -triangular.GridLineRotation.Value),
                 CircularPositionSnapGrid circular => circular.StartPosition.Value + GeometryUtils.RotateVector(new Vector2(circular.Spacing.Value, 0), -45),
                 _ => Vector2.Zero
             };
@@ -183,6 +185,71 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             AddStep("toggle to next grid type", () => InputManager.Key(Key.G));
             gridActive<T>(true);
+        }
+
+        [Test]
+        public void TestGridFromPoints()
+        {
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+
+            AddStep("initiate grid from points", () => InputManager.Key(Key.B));
+            AddStep("move cursor to slider head + (1, 1)", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                InputManager.MoveMouseTo(composer.ToScreenSpace(((Slider)EditorBeatmap.HitObjects.First()).Position + new Vector2(1, 1)));
+            });
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            AddStep("move cursor to slider tail + (1, 1)", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                InputManager.MoveMouseTo(composer.ToScreenSpace(((Slider)EditorBeatmap.HitObjects.First()).EndPosition + new Vector2(1, 1)));
+            });
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+
+            gridActive<RectangularPositionSnapGrid>(true);
+            AddAssert("grid position at slider head", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                return Precision.AlmostEquals(((Slider)EditorBeatmap.HitObjects.First()).Position, composer.StartPosition.Value);
+            });
+            AddAssert("grid spacing is distance to slider tail", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.01)
+                       && Precision.AlmostEquals(composer.Spacing.Value.X, composer.Spacing.Value.Y);
+            });
+            AddAssert("grid rotation points to slider tail", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                return Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.01);
+            });
+
+            AddStep("initiate grid from points", () => InputManager.Key(Key.B));
+            AddStep("move cursor to slider tail + (1, 1)", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                InputManager.MoveMouseTo(composer.ToScreenSpace(((Slider)EditorBeatmap.HitObjects.First()).EndPosition + new Vector2(1, 1)));
+            });
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddStep("move cursor to (0, 0)", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                InputManager.MoveMouseTo(composer.ToScreenSpace(Vector2.Zero));
+            });
+
+            gridActive<RectangularPositionSnapGrid>(true);
+            AddAssert("grid position at slider tail", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                return Precision.AlmostEquals(((Slider)EditorBeatmap.HitObjects.First()).EndPosition, composer.StartPosition.Value);
+            });
+            AddAssert("grid spacing and rotation unchanged", () =>
+            {
+                var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
+                return Precision.AlmostEquals(composer.Spacing.Value.X, 32.05, 0.01)
+                       && Precision.AlmostEquals(composer.Spacing.Value.X, composer.Spacing.Value.Y)
+                       && Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.01);
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -206,7 +206,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void nextGridTypeIs<T>() where T : PositionSnapGrid
         {
-            AddStep("toggle to next grid type", () => InputManager.Key(Key.H));
+            AddStep("toggle to next grid type", () =>
+            {
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+            });
             gridActive<T>(true);
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -168,26 +168,21 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
-        public void TestGridSizeToggling()
+        public void TestGridTypeToggling()
         {
             AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
             AddUntilStep("rectangular grid visible", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Any());
-            gridSizeIs(4);
+            gridActive<RectangularPositionSnapGrid>(true);
 
-            nextGridSizeIs(8);
-            nextGridSizeIs(16);
-            nextGridSizeIs(32);
-            nextGridSizeIs(4);
+            nextGridTypeIs<TriangularPositionSnapGrid>();
+            nextGridTypeIs<CircularPositionSnapGrid>();
+            nextGridTypeIs<RectangularPositionSnapGrid>();
         }
 
-        private void nextGridSizeIs(int size)
+        private void nextGridTypeIs<T>() where T : PositionSnapGrid
         {
-            AddStep("toggle to next grid size", () => InputManager.Key(Key.G));
-            gridSizeIs(size);
+            AddStep("toggle to next grid type", () => InputManager.Key(Key.G));
+            gridActive<T>(true);
         }
-
-        private void gridSizeIs(int size)
-            => AddAssert($"grid size is {size}", () => this.ChildrenOfType<RectangularPositionSnapGrid>().Single().Spacing.Value == new Vector2(size)
-                                                       && EditorBeatmap.BeatmapInfo.GridSize == size);
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -211,11 +211,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
-        public void TestGridFromPoints()
+        public void TestGridPlacementTool()
         {
-            AddStep("enable rectangular grid", () => InputManager.Key(Key.Y));
+            AddStep("enable rectangular grid", () => InputManager.Key(Key.T));
 
-            AddStep("initiate grid from points", () => InputManager.Key(Key.B));
+            AddStep("start grid placement", () => InputManager.Key(Key.Number5));
             AddStep("move cursor to slider head + (1, 1)", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
@@ -247,13 +247,17 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 return Precision.AlmostEquals(composer.GridLineRotation.Value, 0.09, 0.01);
             });
 
-            AddStep("initiate grid from points", () => InputManager.Key(Key.B));
+            AddStep("start grid placement", () => InputManager.Key(Key.Number5));
             AddStep("move cursor to slider tail + (1, 1)", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();
                 InputManager.MoveMouseTo(composer.ToScreenSpace(((Slider)EditorBeatmap.HitObjects.First()).EndPosition + new Vector2(1, 1)));
             });
-            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+            AddStep("double click", () =>
+            {
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+            });
             AddStep("move cursor to (0, 0)", () =>
             {
                 var composer = Editor.ChildrenOfType<RectangularPositionSnapGrid>().Single();

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -130,6 +130,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private void gridActive<T>(bool active) where T : PositionSnapGrid
         {
+            AddAssert($"grid type is {typeof(T).Name}", () => this.ChildrenOfType<T>().Any());
             AddStep("choose placement tool", () => InputManager.Key(Key.Number2));
             AddStep("move cursor to spacing + (1, 1)", () =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -215,6 +215,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 GridLinesRotation.Disabled = v.NewValue == PositionSnapGridType.Circle;
 
+                gridTypeButtons.Items[(int)v.NewValue].Select();
+
                 switch (v.NewValue)
                 {
                     case PositionSnapGridType.Square:
@@ -243,28 +245,16 @@ namespace osu.Game.Rulesets.Osu.Edit
             return ((rotation + 360 + period * 0.5f) % period) - period * 0.5f;
         }
 
-        private void nextGridSize()
-        {
-            Spacing.Value = Spacing.Value * 2 >= max_automatic_spacing ? Spacing.Value / 8 : Spacing.Value * 2;
-        }
-
-        private void nextGridType()
-        {
-            int nextGridTypeIndex = (Array.IndexOf(grid_types, GridType.Value) + 1) % grid_types.Length;
-            GridType.Value = grid_types[nextGridTypeIndex];
-            gridTypeButtons.Items[nextGridTypeIndex].Select();
-        }
-
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {
             switch (e.Action)
             {
                 case GlobalAction.EditorCycleGridSpacing:
-                    nextGridSize();
+                    Spacing.Value = Spacing.Value * 2 >= max_automatic_spacing ? Spacing.Value / 8 : Spacing.Value * 2;
                     return true;
 
                 case GlobalAction.EditorCycleGridType:
-                    nextGridType();
+                    GridType.Value = (PositionSnapGridType)(((int)GridType.Value + 1) % Enum.GetValues<PositionSnapGridType>().Length);
                     return true;
             }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -264,6 +264,10 @@ namespace osu.Game.Rulesets.Osu.Edit
                 case GlobalAction.EditorCycleGridDisplayMode:
                     nextGridSize();
                     return true;
+
+                case GlobalAction.EditorCycleGridType:
+                    nextGridType();
+                    return true;
             }
 
             return false;

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public partial class OsuGridToolboxGroup : EditorToolboxGroup, IKeyBindingHandler<GlobalAction>
     {
-        private static readonly PositionSnapGridType[] grid_types = Enum.GetValues(typeof(PositionSnapGridType)).Cast<PositionSnapGridType>().ToArray();
-
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -25,6 +25,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public partial class OsuGridToolboxGroup : EditorToolboxGroup, IKeyBindingHandler<GlobalAction>
     {
+        private static readonly PositionSnapGridType[] grid_types = Enum.GetValues(typeof(PositionSnapGridType)).Cast<PositionSnapGridType>().ToArray();
+
+        private int currentGridTypeIndex;
+
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
 
@@ -244,6 +248,13 @@ namespace osu.Game.Rulesets.Osu.Edit
         private void nextGridSize()
         {
             Spacing.Value = Spacing.Value * 2 >= max_automatic_spacing ? Spacing.Value / 8 : Spacing.Value * 2;
+        }
+
+        private void nextGridType()
+        {
+            currentGridTypeIndex = (currentGridTypeIndex + 1) % grid_types.Length;
+            GridType.Value = grid_types[currentGridTypeIndex];
+            gridTypeButtons.Items[currentGridTypeIndex].Select();
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -27,8 +27,6 @@ namespace osu.Game.Rulesets.Osu.Edit
     {
         private static readonly PositionSnapGridType[] grid_types = Enum.GetValues(typeof(PositionSnapGridType)).Cast<PositionSnapGridType>().ToArray();
 
-        private int currentGridTypeIndex;
-
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
 
@@ -252,9 +250,9 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void nextGridType()
         {
-            currentGridTypeIndex = (currentGridTypeIndex + 1) % grid_types.Length;
-            GridType.Value = grid_types[currentGridTypeIndex];
-            gridTypeButtons.Items[currentGridTypeIndex].Select();
+            int nextGridTypeIndex = (Array.IndexOf(grid_types, GridType.Value) + 1) % grid_types.Length;
+            GridType.Value = grid_types[nextGridTypeIndex];
+            gridTypeButtons.Items[nextGridTypeIndex].Select();
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -259,7 +259,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             switch (e.Action)
             {
-                case GlobalAction.EditorCycleGridDisplayMode:
+                case GlobalAction.EditorCycleGridSpacing:
                     nextGridSize();
                     return true;
 

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -135,6 +135,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
+            new KeyBinding(new[] { InputKey.H }, GlobalAction.EditorCycleGridType),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
             new KeyBinding(new[] { InputKey.T }, GlobalAction.EditorTapForBPM),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),
@@ -370,6 +371,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridDisplayMode))]
         EditorCycleGridDisplayMode,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridType))]
+        EditorCycleGridType,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestGameplay))]
         EditorTestGameplay,

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -372,9 +372,6 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridSpacing))]
         EditorCycleGridSpacing,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridType))]
-        EditorCycleGridType,
-
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorTestGameplay))]
         EditorTestGameplay,
 
@@ -476,6 +473,9 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorSeekToNextSamplePoint))]
         EditorSeekToNextSamplePoint,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridType))]
+        EditorCycleGridType,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
             new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridSpacing),
-            new KeyBinding(new[] { InputKey.H }, GlobalAction.EditorCycleGridType),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.G }, GlobalAction.EditorCycleGridType),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
             new KeyBinding(new[] { InputKey.T }, GlobalAction.EditorTapForBPM),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.EditorFlipHorizontally),

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.EditorCloneSelection),
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
-            new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridDisplayMode),
+            new KeyBinding(new[] { InputKey.G }, GlobalAction.EditorCycleGridSpacing),
             new KeyBinding(new[] { InputKey.H }, GlobalAction.EditorCycleGridType),
             new KeyBinding(new[] { InputKey.F5 }, GlobalAction.EditorTestGameplay),
             new KeyBinding(new[] { InputKey.T }, GlobalAction.EditorTapForBPM),
@@ -369,8 +369,8 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleChatFocus))]
         ToggleChatFocus,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridDisplayMode))]
-        EditorCycleGridDisplayMode,
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridSpacing))]
+        EditorCycleGridSpacing,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorCycleGridType))]
         EditorCycleGridType,

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -190,9 +190,9 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorCloneSelection => new TranslatableString(getKey(@"editor_clone_selection"), @"Clone selection");
 
         /// <summary>
-        /// "Cycle grid display mode"
+        /// "Cycle grid spacing"
         /// </summary>
-        public static LocalisableString EditorCycleGridDisplayMode => new TranslatableString(getKey(@"editor_cycle_grid_display_mode"), @"Cycle grid display mode");
+        public static LocalisableString EditorCycleGridSpacing => new TranslatableString(getKey(@"editor_cycle_grid_spacing"), @"Cycle grid spacing");
 
         /// <summary>
         /// "Cycle grid type"

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -195,6 +195,11 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorCycleGridDisplayMode => new TranslatableString(getKey(@"editor_cycle_grid_display_mode"), @"Cycle grid display mode");
 
         /// <summary>
+        /// "Cycle grid type"
+        /// </summary>
+        public static LocalisableString EditorCycleGridType => new TranslatableString(getKey(@"editor_cycle_grid_type"), @"Cycle grid type");
+
+        /// <summary>
         /// "Test gameplay"
         /// </summary>
         public static LocalisableString EditorTestGameplay => new TranslatableString(getKey(@"editor_test_gameplay"), @"Test gameplay");


### PR DESCRIPTION
Requires:
- [x] https://github.com/ppy/osu/pull/26309
- [x] https://github.com/ppy/osu/pull/26310
- [x] https://github.com/ppy/osu/pull/26311
- [x] https://github.com/ppy/osu/pull/26313

Using the tool boxes on the right frequently is quite annoying, so I also added a keybind for cycling the grid type (H). I chose this key because its right next to the grid spacing cycle hotkey (G) and unused. It makes sense to group the grid property changing hotkeys physically close on the keyboard. An alternative hotkey could be like Shift+G or Shift+G, Ctrl+G is taken.

There's also a test for the grid placement tool in here which apparently got left behind when I was splitting up this PR into parts. I guess it can't hurt to have it so here it is.

https://github.com/ppy/osu/assets/17460441/cf63348d-0fdc-4170-b497-bae3c69cee7a

