### PR TITLE
add check for ShiftPressed when moving tablet area

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -240,8 +240,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         protected override void OnDrag(DragEvent e)
         {
-            var newPos = Position + e.Delta;
-            this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size));
+            if (e.ShiftPressed)
+            {
+                var newPos = Position + e.Delta;
+                this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size));
+            }
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -240,6 +240,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         protected override void OnDrag(DragEvent e)
         {
+            // only allow dragging of the tablet area if the Shift key is being pressed.
             if (e.ShiftPressed)
             {
                 var newPos = Position + e.Delta;


### PR DESCRIPTION
resolves https://github.com/ppy/osu/issues/26157

I added a simple `if` check (`UIEvent.ShiftPressed`) for the OnDrag method of the TabletAreaSelection to avoid unintentional moving of the tablet area when dragging within the settings UI. 

A small text in the UI maybe below/above the tablet area to indicate that the Shift key needs to be pressed down to move the tablet area might be useful here too. 