### PR TITLE
Fix standardised score conversion failing for some taiko scores due to overestimating accuracy portion

### DIFF
--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -316,7 +316,7 @@ namespace osu.Game.Database
             // when playing a beatmap with no bonus objects, with mods that have a 0.0x multiplier on stable (relax/autopilot).
             // In such cases, just assume 0.
             double comboProportion = maximumLegacyComboScore + maximumLegacyBonusScore > 0
-                ? ((double)score.LegacyTotalScore - legacyAccScore) / (maximumLegacyComboScore + maximumLegacyBonusScore)
+                ? Math.Max((double)score.LegacyTotalScore - legacyAccScore, 0) / (maximumLegacyComboScore + maximumLegacyBonusScore)
                 : 0;
 
             // We assume the bonus proportion only makes up the rest of the score that exceeds maximumLegacyBaseScore.


### PR DESCRIPTION
Standardised score conversion would return a negative total score for https://osu.ppy.sh/scores/taiko/182230346.

The underlying reason for this is that the estimation of the accuracy portion for a score can be above the actual accuracy portion in the taiko ruleset.

When calculating the maximum accuracy portion achievable, `TaikoLegacyScoreSimulator` will include the extra 300 points from a double hit on a strong hit, per strong hit. However, this double hit is not factored into accuracy.

Both of the aforementioned facts mean that in taiko

	maximumLegacyAccuracyScore * score.Accuracy

\- which normally in other rulesets can be used pretty reliably as the exact number of points gained from the accuracy portion - is an estimate in the case of taiko, and an _upper_ estimate at that, because it implicitly assumes that the user has also hit `score.Accuracy` percent of all double hits possible in the beatmap. If this assumption is not upheld, then the user will have earned _less_ points than that from the accuracy portion, which means that the combo proportion estimate will go below zero.

It is possible that this has happened on other scores before, but did not result in the total score going negative as the accuracy portion gained would have counteracted the effect of that due to being larger in magnitude than the score loss incurred from the negative combo portion. In the case of the score in question this was not the case due to very low accuracy _and_ very low max combo.

Practically speaking this would mean that for 100% correctness a full reimport of taiko scores would be required, but I don't think it would change many scores in practice, so I don't see it as *strictly* required to go live.