### PR TITLE
Fix backwards z-ordering of fruits in juice streams and banana showers

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 Mod = new CatchModHidden(),
                 PassCondition = () => Player.Results.Count > 0
                                       && Player.ChildrenOfType<DrawableJuiceStream>().Single().Alpha > 0
-                                      && Player.ChildrenOfType<DrawableFruit>().Last().Alpha > 0
+                                      && Player.ChildrenOfType<DrawableFruit>().First().Alpha > 0
             });
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBananaShower.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             RelativeSizeAxes = Axes.X;
             Origin = Anchor.BottomLeft;
 
-            AddInternal(bananaContainer = new Container { RelativeSizeAxes = Axes.Both });
+            AddInternal(bananaContainer = new NestedFruitContainer { RelativeSizeAxes = Axes.Both });
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableJuiceStream.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             RelativeSizeAxes = Axes.X;
             Origin = Anchor.BottomLeft;
 
-            AddInternal(dropletContainer = new Container { RelativeSizeAxes = Axes.Both, });
+            AddInternal(dropletContainer = new NestedFruitContainer { RelativeSizeAxes = Axes.Both, });
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/NestedFruitContainer.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/NestedFruitContainer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Rulesets.Catch.Objects.Drawables
+{
+    public partial class NestedFruitContainer : Container
+    {
+        /// <remarks>
+        /// This comparison logic is a copy of <see cref="HitObjectContainer"/> comparison logic,
+        /// which can't be easily extracted to a more common place.
+        /// </remarks>
+        /// <seealso cref="HitObjectContainer.Compare"/>
+        protected override int Compare(Drawable x, Drawable y)
+        {
+            if (x is not DrawableCatchHitObject xObj || y is not DrawableCatchHitObject yObj)
+                return base.Compare(x, y);
+
+            int result = yObj.HitObject.StartTime.CompareTo(xObj.HitObject.StartTime);
+            return result == 0 ? CompareReverseChildID(x, y) : result;
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25827.

| master | this PR |
| :-: | :-: |
| ![osu_2024-01-02_12-00-07](https://github.com/ppy/osu/assets/20418176/183409b0-25ea-4dfc-ad06-7668c44a17da) | ![osu_2024-01-02_12-01-24](https://github.com/ppy/osu/assets/20418176/d5a9b185-5e7e-4c8c-b9ec-dcdb1cbee89f) |
| ![osu_2024-01-02_12-00-30](https://github.com/ppy/osu/assets/20418176/b3820a0c-df3a-498d-84b6-171224eae8e5) | ![osu_2024-01-02_12-01-39](https://github.com/ppy/osu/assets/20418176/c694f38a-668d-40a6-bd80-c39b46fdcfef) |

The logic cannot be easily abstracted out (because `CompareReverseChildID()` is protected and non-static on `CompositeDrawable`), so a local copy was applied instead.

No testing as any testing would have been purely visual anyways.