### PR TITLE
Store user online state in config for next launch

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -20,6 +20,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osu.Game.Skinning;
+using osu.Game.Users;
 
 namespace osu.Game.Configuration
 {
@@ -193,6 +194,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LastProcessedMetadataId, -1);
 
             SetDefault(OsuSetting.ComboColourNormalisationAmount, 0.2f, 0f, 1f, 0.01f);
+            SetDefault<UserStatus?>(OsuSetting.UserOnlineStatus, null);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -420,5 +422,6 @@ namespace osu.Game.Configuration
         EditorShowSpeedChanges,
         TouchDisableGameplayTaps,
         ModSelectTextSearchStartsActive,
+        UserOnlineStatus,
     }
 }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -23,7 +23,6 @@ namespace osu.Game.Online.Metadata
         public override IBindable<bool> IsWatchingUserPresence => isWatchingUserPresence;
         private readonly BindableBool isWatchingUserPresence = new BindableBool();
 
-        // ReSharper disable once InconsistentlySynchronizedField
         public override IBindableDictionary<int, UserPresence> UserStates => userStates;
         private readonly BindableDictionary<int, UserPresence> userStates = new BindableDictionary<int, UserPresence>();
 
@@ -192,7 +191,7 @@ namespace osu.Game.Online.Metadata
         {
             Schedule(() =>
             {
-                if (presence != null)
+                if (presence?.Status != null)
                     userStates[userId] = presence.Value;
                 else
                     userStates.Remove(userId);

--- a/osu.Game/Overlays/Login/LoginPanel.cs
+++ b/osu.Game/Overlays/Login/LoginPanel.cs
@@ -143,6 +143,8 @@ namespace osu.Game.Overlays.Login
                     panel.Status.BindTo(api.LocalUser.Value.Status);
                     panel.Activity.BindTo(api.LocalUser.Value.Activity);
 
+                    panel.Status.BindValueChanged(_ => updateDropdownCurrent(), true);
+
                     dropdown.Current.BindValueChanged(action =>
                     {
                         switch (action.NewValue)
@@ -173,6 +175,24 @@ namespace osu.Game.Overlays.Login
             if (form != null)
                 ScheduleAfterChildren(() => GetContainingInputManager()?.ChangeFocus(form));
         });
+
+        private void updateDropdownCurrent()
+        {
+            switch (panel.Status.Value)
+            {
+                case UserStatus.Online:
+                    dropdown.Current.Value = UserAction.Online;
+                    break;
+
+                case UserStatus.DoNotDisturb:
+                    dropdown.Current.Value = UserAction.DoNotDisturb;
+                    break;
+
+                case UserStatus.Offline:
+                    dropdown.Current.Value = UserAction.AppearOffline;
+                    break;
+            }
+        }
 
         public override bool AcceptsFocus => true;
 


### PR DESCRIPTION
Closes remainder of https://github.com/ppy/osu/issues/12635.

Stored status is reset on logout, so that it doesn't persist across multiple users logging in on one machine.

No tests because `APIAccess` is not directly testable, so I'd have to implement this logic on `DummyAPIAccess`, in order to test a test component (i.e. pointless).