### PR TITLE
Fix spinner not restoring HP after bonus cap

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
@@ -277,7 +277,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void assertTicksHit(int count)
         {
-            AddAssert($"{count} ticks hit", () => judgementResults.Where(r => r.HitObject is SpinnerTick).Count(r => r.IsHit), () => Is.EqualTo(count));
+            AddAssert($"{count} ticks hit", () => judgementResults.Where(r => r.HitObject is SpinnerTick && !(r.HitObject is SpinnerHealthTick)).Count(r => r.IsHit), () => Is.EqualTo(count));
         }
 
         private void assertSpinnerHit(bool shouldBeHit)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerInput.cs
@@ -277,7 +277,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private void assertTicksHit(int count)
         {
-            AddAssert($"{count} ticks hit", () => judgementResults.Where(r => r.HitObject is SpinnerTick && !(r.HitObject is SpinnerHealthTick)).Count(r => r.IsHit), () => Is.EqualTo(count));
+            AddAssert($"{count} ticks hit", () => judgementResults.Where(r => r.HitObject is SpinnerTick && r.HitObject is not SpinnerHealthTick).Count(r => r.IsHit), () => Is.EqualTo(count));
         }
 
         private void assertSpinnerHit(bool shouldBeHit)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private void assertResult<T>(int index, HitResult expectedResult)
         {
             AddAssert($"{typeof(T).ReadableName()} ({index}) judged as {expectedResult}",
-                () => judgementResults.Where(j => j.HitObject is T && !(j.HitObject is SpinnerHealthTick)).OrderBy(j => j.HitObject.StartTime).ElementAt(index).Type,
+                () => judgementResults.Where(j => j.HitObject is T && j.HitObject is not SpinnerHealthTick).OrderBy(j => j.HitObject.StartTime).ElementAt(index).Type,
                 () => Is.EqualTo(expectedResult));
         }
 

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             performTest(generateReplay(20));
 
-            AddAssert("all max judgements", () => judgementResults.All(result => result.Type == result.Judgement.MaxResult));
+            AddAssert("all max judgements", () => judgementResults.All(result => result.HitObject is SpinnerHealthTick || result.Type == result.Judgement.MaxResult));
         }
 
         private static List<ReplayFrame> generateReplay(int spins) => new SpinFramesGenerator(time_spinner_start)

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSpinnerJudgement.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         private void assertResult<T>(int index, HitResult expectedResult)
         {
             AddAssert($"{typeof(T).ReadableName()} ({index}) judged as {expectedResult}",
-                () => judgementResults.Where(j => j.HitObject is T).OrderBy(j => j.HitObject.StartTime).ElementAt(index).Type,
+                () => judgementResults.Where(j => j.HitObject is T && !(j.HitObject is SpinnerHealthTick)).OrderBy(j => j.HitObject.StartTime).ElementAt(index).Type,
                 () => Is.EqualTo(expectedResult));
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -210,6 +210,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             switch (hitObject)
             {
+                case SpinnerHealthTick hpTick:
+                    return new DrawableSpinnerHealthTick(hpTick);
+
                 case SpinnerBonusTick bonusTick:
                     return new DrawableSpinnerBonusTick(bonusTick);
 
@@ -291,7 +294,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             // Ticks can theoretically be judged at any point in the spinner's duration.
             // A tick must be alive to correctly play back samples,
             // but for performance reasons, we only want to keep the next tick alive.
-            var next = NestedHitObjects.FirstOrDefault(h => !h.Judged);
+            var next = NestedHitObjects.FirstOrDefault(h => !h.Judged && !(h is DrawableSpinnerHealthTick));
 
             // See default `LifetimeStart` as set in `DrawableSpinnerTick`.
             if (next?.LifetimeStart == double.MaxValue)
@@ -331,7 +334,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             while (completedFullSpins.Value != spins)
             {
-                var tick = ticks.FirstOrDefault(t => !t.Result.HasResult);
+                var tick = ticks.FirstOrDefault(t => !t.Result.HasResult && !(t is DrawableSpinnerHealthTick));
 
                 // tick may be null if we've hit the spin limit.
                 if (tick == null)
@@ -342,6 +345,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 }
                 else
                     tick.TriggerResult(true);
+
+                // Find and trigger the next HP tick
+                var hpTick = ticks.FirstOrDefault(t => !t.Result.HasResult && t is DrawableSpinnerHealthTick);
+                hpTick?.TriggerResult(true);
 
                 completedFullSpins.Value++;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             // Ticks can theoretically be judged at any point in the spinner's duration.
             // A tick must be alive to correctly play back samples,
             // but for performance reasons, we only want to keep the next tick alive.
-            var next = NestedHitObjects.FirstOrDefault(h => !h.Judged && !(h is DrawableSpinnerHealthTick));
+            var next = NestedHitObjects.FirstOrDefault(h => !h.Judged && h is not DrawableSpinnerHealthTick);
 
             // See default `LifetimeStart` as set in `DrawableSpinnerTick`.
             if (next?.LifetimeStart == double.MaxValue)
@@ -334,21 +334,21 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             while (completedFullSpins.Value != spins)
             {
-                var tick = ticks.FirstOrDefault(t => !t.Result.HasResult && !(t is DrawableSpinnerHealthTick));
+                var tick = ticks.FirstOrDefault(t => !t.Result.HasResult && t is not DrawableSpinnerHealthTick);
 
                 // tick may be null if we've hit the spin limit.
                 if (tick == null)
                 {
+                    // Find and trigger the next HP tick
+                    var hpTick = ticks.FirstOrDefault(t => !t.Result.HasResult && Time.Current >= t.StartTimeBindable.Value);
+                    hpTick?.TriggerResult(true);
+
                     // we still want to play a sound. this will probably be a new sound in the future, but for now let's continue playing the bonus sound.
                     // TODO: this doesn't concurrency. i can't figure out how to make it concurrency. samples are bad and need a refactor.
                     maxBonusSample.Play();
                 }
                 else
                     tick.TriggerResult(true);
-
-                // Find and trigger the next HP tick
-                var hpTick = ticks.FirstOrDefault(t => !t.Result.HasResult && t is DrawableSpinnerHealthTick);
-                hpTick?.TriggerResult(true);
 
                 completedFullSpins.Value++;
             }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerHealthTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinnerHealthTick.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Osu.Objects.Drawables
+{
+    public partial class DrawableSpinnerHealthTick : DrawableSpinnerTick
+    {
+        public DrawableSpinnerHealthTick()
+            : base(null)
+        {
+        }
+
+        public DrawableSpinnerHealthTick(SpinnerHealthTick spinnerTick)
+            : base(spinnerTick)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -52,6 +52,11 @@ namespace osu.Game.Rulesets.Osu.Objects
         private const int bonus_spins_gap = 2;
 
         /// <summary>
+        /// The maximum RPM at which HP will be restored.
+        /// </summary>
+        private const int hp_ticks_per_minute = 500;
+
+        /// <summary>
         /// Number of spins available to give bonus, beyond <see cref="SpinsRequired"/>.
         /// </summary>
         public int MaximumBonusSpins { get; protected set; } = 1;
@@ -92,6 +97,16 @@ namespace osu.Game.Rulesets.Osu.Objects
                 AddNested(i < SpinsRequiredForBonus
                     ? new SpinnerTick { StartTime = startTime, SpinnerDuration = Duration }
                     : new SpinnerBonusTick { StartTime = startTime, SpinnerDuration = Duration, Samples = new[] { CreateHitSampleInfo("spinnerbonus") } });
+            }
+
+            // Add ticks that give HP across the whole spinner duration
+            int maxSpinsForHp = (int)(hp_ticks_per_minute * Duration / 60000);
+
+            for (int i = 0; i < maxSpinsForHp; i++)
+            {
+                double startTime = StartTime + (float)(i + 1) / maxSpinsForHp * Duration;
+
+                AddNested(new SpinnerHealthTick { StartTime = startTime, SpinnerDuration = Duration });
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Spinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Spinner.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             // Add ticks that give HP across the whole spinner duration
             int maxSpinsForHp = (int)(hp_ticks_per_minute * Duration / 60000);
 
-            for (int i = 0; i < maxSpinsForHp; i++)
+            for (int i = totalSpins; i < maxSpinsForHp; i++)
             {
                 double startTime = StartTime + (float)(i + 1) / maxSpinsForHp * Duration;
 

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerHealthTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerHealthTick.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Objects
+{
+    public class SpinnerHealthTick : SpinnerTick
+    {
+        public override Judgement CreateJudgement() => new OsuSpinnerHealthTickJudgement();
+
+        public class OsuSpinnerHealthTickJudgement : OsuSpinnerTickJudgement
+        {
+            public override HitResult MaxResult => HitResult.IgnoreHit;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Objects/SpinnerHealthTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SpinnerHealthTick.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public class OsuSpinnerHealthTickJudgement : OsuSpinnerTickJudgement
         {
-            public override HitResult MaxResult => HitResult.IgnoreHit;
+            public override HitResult MaxResult => HitResult.HealthBonus;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 case HitResult.Great:
                     return 0.03;
 
-                case HitResult.IgnoreHit:
+                case HitResult.HealthBonus:
                 case HitResult.SmallBonus:
                     return 0.0085;
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuHealthProcessor.cs
@@ -115,6 +115,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 case HitResult.Great:
                     return 0.03;
 
+                case HitResult.IgnoreHit:
                 case HitResult.SmallBonus:
                     return 0.0085;
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     increase = 0.01;
                     break;
 
-                case HitResult.IgnoreHit:
+                case HitResult.HealthBonus:
                     increase = 0.05;
                     break;
             }

--- a/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     break;
 
                 case Spinner spinner:
-                    foreach (var nested in spinner.NestedHitObjects.Where(t => t is not SpinnerBonusTick))
+                    foreach (var nested in spinner.NestedHitObjects.Where(t => t is not SpinnerBonusTick && t is not SpinnerHealthTick))
                         yield return nested;
 
                     break;
@@ -71,6 +71,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
                     increase = 0.011;
                     break;
 
+                case HitResult.HealthBonus:
                 case HitResult.Great:
                     increase = 0.03;
                     break;
@@ -81,10 +82,6 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
                 case HitResult.LargeBonus:
                     increase = 0.01;
-                    break;
-
-                case HitResult.HealthBonus:
-                    increase = 0.05;
                     break;
             }
 

--- a/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuLegacyHealthProcessor.cs
@@ -82,6 +82,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
                 case HitResult.LargeBonus:
                     increase = 0.01;
                     break;
+
+                case HitResult.IgnoreHit:
+                    increase = 0.05;
+                    break;
             }
 
             return HpMultiplierNormal * increase;

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -158,6 +158,7 @@ namespace osu.Game.Rulesets.Osu.UI
             RegisterPool<Spinner, DrawableSpinner>(2, 20);
             RegisterPool<SpinnerTick, DrawableSpinnerTick>(10, 200);
             RegisterPool<SpinnerBonusTick, DrawableSpinnerBonusTick>(10, 200);
+            RegisterPool<SpinnerHealthTick, DrawableSpinnerHealthTick>(10, 200);
         }
 
         protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new OsuHitObjectLifetimeEntry(hitObject);

--- a/osu.Game.Tests/Rulesets/Scoring/HitResultTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/HitResultTest.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(new[] { HitResult.Perfect, HitResult.Great, HitResult.Good, HitResult.Ok, HitResult.Meh }, new[] { HitResult.Miss, HitResult.IgnoreMiss })]
         [TestCase(new[] { HitResult.LargeTickHit }, new[] { HitResult.LargeTickMiss, HitResult.IgnoreMiss })]
         [TestCase(new[] { HitResult.SmallTickHit }, new[] { HitResult.SmallTickMiss, HitResult.IgnoreMiss })]
-        [TestCase(new[] { HitResult.LargeBonus, HitResult.SmallBonus }, new[] { HitResult.IgnoreMiss })]
+        [TestCase(new[] { HitResult.LargeBonus, HitResult.SmallBonus, HitResult.HealthBonus }, new[] { HitResult.IgnoreMiss })]
         [TestCase(new[] { HitResult.IgnoreHit }, new[] { HitResult.IgnoreMiss, HitResult.ComboBreak })]
         public void TestValidResultPairs(HitResult[] maxResults, HitResult[] minResults)
         {

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -238,7 +238,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, false)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
-        [TestCase(HitResult.HealthBonus, false)]
+        [TestCase(HitResult.HealthBonus, true)]
         public void TestIsBonus(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsBonus());

--- a/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
+++ b/osu.Game.Tests/Rulesets/Scoring/ScoreProcessorTest.cs
@@ -172,6 +172,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, HitResult.LargeTickMiss)]
         [TestCase(HitResult.SmallBonus, HitResult.IgnoreMiss)]
         [TestCase(HitResult.LargeBonus, HitResult.IgnoreMiss)]
+        [TestCase(HitResult.HealthBonus, HitResult.IgnoreMiss)]
         public void TestMinResults(HitResult hitResult, HitResult expectedMinResult)
         {
             Assert.AreEqual(expectedMinResult, new TestJudgement(hitResult).MinResult);
@@ -193,6 +194,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
+        [TestCase(HitResult.HealthBonus, false)]
         public void TestAffectsCombo(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.AffectsCombo());
@@ -214,6 +216,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, false)]
         [TestCase(HitResult.LargeBonus, false)]
+        [TestCase(HitResult.HealthBonus, false)]
         public void TestAffectsAccuracy(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.AffectsAccuracy());
@@ -235,6 +238,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, false)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.HealthBonus, false)]
         public void TestIsBonus(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsBonus());
@@ -256,6 +260,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.HealthBonus, true)]
         public void TestIsHit(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsHit());
@@ -277,6 +282,7 @@ namespace osu.Game.Tests.Rulesets.Scoring
         [TestCase(HitResult.SliderTailHit, true)]
         [TestCase(HitResult.SmallBonus, true)]
         [TestCase(HitResult.LargeBonus, true)]
+        [TestCase(HitResult.HealthBonus, false)]
         public void TestIsScorable(HitResult hitResult, bool expectedReturnValue)
         {
             Assert.AreEqual(expectedReturnValue, hitResult.IsScorable());

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -67,6 +67,7 @@ namespace osu.Game.Rulesets.Judgements
                     case HitResult.SmallBonus:
                     case HitResult.LargeBonus:
                     case HitResult.IgnoreHit:
+                    case HitResult.HealthBonus:
                         return HitResult.IgnoreMiss;
 
                     case HitResult.SmallTickHit:

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.ApplyResultInternal(result);
 
-            if (IsSimulating && !result.Type.IsBonus() && result.Type.IsScorable())
+            if (IsSimulating && !result.Type.IsBonus())
             {
                 healthIncreases.Add(new HealthIncrease(
                     result.HitObject.GetEndTime() + result.TimeOffset,

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -134,7 +134,7 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.ApplyResultInternal(result);
 
-            if (IsSimulating && !result.Type.IsBonus())
+            if (IsSimulating && !result.Type.IsBonus() && result.Type.IsScorable())
             {
                 healthIncreases.Add(new HealthIncrease(
                     result.HitObject.GetEndTime() + result.TimeOffset,

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -399,6 +399,9 @@ namespace osu.Game.Rulesets.Scoring
             if (maxResult.IsBonus() && minResult != HitResult.IgnoreMiss)
                 throw new ArgumentOutOfRangeException(nameof(minResult), $"{HitResult.IgnoreMiss} is the only valid minimum result for a {maxResult} judgement.");
 
+            if (maxResult == HitResult.HealthBonus && minResult != HitResult.IgnoreMiss)
+                throw new ArgumentOutOfRangeException(nameof(minResult), $"{HitResult.IgnoreMiss} is the only valid minimum result for a {maxResult} judgement.");
+
             if (minResult == HitResult.IgnoreMiss)
                 return;
 

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -147,6 +147,13 @@ namespace osu.Game.Rulesets.Scoring
         SliderTailHit,
 
         /// <summary>
+        /// A judgement similar to <see cref="IgnoreHit"/> that's used to give a health bonus to spinners after reaching the bonus cap.
+        /// </summary>
+        [EnumMember(Value = "health_bonus")]
+        [Order(17)]
+        HealthBonus,
+
+        /// <summary>
         /// A special result used as a padding value for legacy rulesets. It is a hit type and affects combo, but does not affect the base score (does not affect accuracy).
         ///
         /// DO NOT USE FOR ANYTHING EVER.

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -278,6 +278,7 @@ namespace osu.Game.Rulesets.Scoring
             {
                 case HitResult.SmallBonus:
                 case HitResult.LargeBonus:
+                case HitResult.HealthBonus:
                     return true;
 
                 default:


### PR DESCRIPTION
Closes #26261.

Implemented as talked about [on discord](https://discord.com/channels/188630481301012481/188630652340404224/1191718123045400627).

Before:

https://github.com/ppy/osu/assets/6898693/484eb86e-8289-42f4-84df-23b2f8269359

After:

https://github.com/ppy/osu/assets/6898693/d77b3c2b-54a3-4aac-8057-72997ce86d94

