### PR TITLE
update the current activity when the multiplayer room updates

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -349,6 +349,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             addItemButton.Alpha = localUserCanAddItem ? 1 : 0;
 
             Scheduler.AddOnce(UpdateMods);
+
+            Activity.Value = new UserActivity.InLobby(Room);
         }
 
         private bool localUserCanAddItem => client.IsHost || Room.QueueMode.Value != QueueMode.HostOnly;


### PR DESCRIPTION
Currently, if you create a multiplayer room and change its name from the default, the current user activity does not reflect that change, as seen in the Discord presence.
![image](https://github.com/ppy/osu/assets/46694241/7f66ee1c-2e63-459c-8b41-6451188617ef)

This same behavior occurs with playlists too, but i wasn't able to find a way fix it in `PlaylistsRoomSubScreen` because playlists are set as not editable

https://github.com/ppy/osu/blob/16c7c14602c4575c302e3495587c5b7f23369e4d/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs#L41-L42

Ideally should be done at the `RoomSubScreen` level, but since both `PlaylistsRoomSubScreen` and `MultiplayerRoomSubScreen` handle the activity themselves in their constructors, i didn't wanna change that