### PR TITLE
Fix crash when dragging rotation control in editor with both mouse buttons

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -62,6 +62,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override bool OnDragStart(DragStartEvent e)
         {
+            if (e.Button != MouseButton.Left)
+                return false;
+
             if (rotationHandler == null) return false;
 
             rotationHandler.Begin();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26325.
