### PR TITLE
Keep editor in frame stable mode when possible

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneEditorAutoplayFastStreams.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneEditorAutoplayFastStreams.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    /// <summary>
+    /// This test covers autoplay working correctly in the editor on fast streams.
+    /// Might seem like a weird test, but frame stability being toggled can cause autoplay to operation incorrectly.
+    /// This is clearly a bug with the autoplay algorithm, but is worked around at an editor level for now.
+    /// </summary>
+    public partial class TestSceneEditorAutoplayFastStreams : EditorTestScene
+    {
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var testBeatmap = new TestBeatmap(ruleset, false);
+            testBeatmap.HitObjects.AddRange(new[]
+            {
+                new HitCircle { StartTime = 500 },
+                new HitCircle { StartTime = 530 },
+                new HitCircle { StartTime = 560 },
+                new HitCircle { StartTime = 590 },
+                new HitCircle { StartTime = 620 },
+            });
+
+            return testBeatmap;
+        }
+
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestAllHit()
+        {
+            AddStep("start playback", () => EditorClock.Start());
+            AddUntilStep("wait for all hit", () =>
+            {
+                DrawableHitCircle[] hitCircles = Editor.ChildrenOfType<DrawableHitCircle>().OrderBy(s => s.HitObject.StartTime).ToArray();
+
+                return hitCircles.Length == 5 && hitCircles.All(h => h.IsHit);
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
@@ -46,10 +46,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             moveMouseToObject(() => slider);
 
             AddStep("seek after end", () => EditorClock.Seek(750));
+            AddUntilStep("wait for seek", () => !EditorClock.IsSeeking);
             AddStep("left click", () => InputManager.Click(MouseButton.Left));
             AddAssert("slider not selected", () => EditorBeatmap.SelectedHitObjects.Count == 0);
 
             AddStep("seek to visible", () => EditorClock.Seek(650));
+            AddUntilStep("wait for seek", () => !EditorClock.IsSeeking);
             AddStep("left click", () => InputManager.Click(MouseButton.Left));
             AddUntilStep("slider selected", () => EditorBeatmap.SelectedHitObjects.Single() == slider);
         }


### PR DESCRIPTION
This is intended to be a catch-all fix for frame stable related issues in the editor.

This works around https://github.com/ppy/osu/issues/22353 (renamed issue to cover the remaining portion better), and could help https://github.com/ppy/osu/issues/10455 (but doesn't really in practice because the lenience is too small.. spinners just need fixes locally).

I'm open to adjusting the lenience from 1000 if a better number is arrived on. Going too high causes frame stability to remain on during smooth seeks, though.