### PR TITLE
Fix beatmap carousel not preloading panels when off-screen

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -96,12 +96,12 @@ namespace osu.Game.Screens.Select
         /// <summary>
         /// Extend the range to retain already loaded pooled drawables.
         /// </summary>
-        private const float distance_offscreen_before_unload = 1024;
+        private const float distance_offscreen_before_unload = 2048;
 
         /// <summary>
         /// Extend the range to update positions / retrieve pooled drawables outside of visible range.
         /// </summary>
-        private const float distance_offscreen_to_preload = 512; // todo: adjust this appropriately once we can make set panel contents load while off-screen.
+        private const float distance_offscreen_to_preload = 768;
 
         /// <summary>
         /// Whether carousel items have completed asynchronously loaded.

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -108,6 +108,7 @@ namespace osu.Game.Screens.Select
         /// </summary>
         public bool BeatmapSetsLoaded { get; private set; }
 
+        [Cached]
         protected readonly CarouselScrollContainer Scroll;
 
         private readonly NoResultsPlaceholder noResultsPlaceholder;
@@ -1251,7 +1252,7 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        protected partial class CarouselScrollContainer : UserTrackingScrollContainer<DrawableCarouselItem>
+        public partial class CarouselScrollContainer : UserTrackingScrollContainer<DrawableCarouselItem>
         {
             private bool rightMouseScrollBlocked;
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -213,6 +213,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             LoadComponentsAsync(new CompositeDrawable[]
             {
+                // Choice of background image matches BSS implementation (always uses the lowest `beatmap_id` from the set).
                 new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID)))
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Something I noticed in passing that felt like it deserved 45 minutes of attention.

Before:

https://github.com/ppy/osu/assets/191335/6cd5b98b-0170-486c-b83e-c94ef257b02a


After:

https://github.com/ppy/osu/assets/191335/ccf0f103-2ece-415b-9bee-b8b578b6955f

The preload numbers are still on the conservative side. We can probably adjust these based on the system the game is running on in the future. Or across the board. But this should improve the overall responsiveness of carousel loading, something that's been bugging me for quite a while now (and [not just me](https://github.com/ppy/osu/discussions/26243))

For testing purposes (to see when loads are triggered):

```diff
diff --git a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
index 119818242e..328678cd2b 100644
--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -13,6 +13,7 @@
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -20,6 +21,7 @@
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -203,6 +205,14 @@ private void loadContentIfRequired()
             {
                 loadCancellation = new CancellationTokenSource();
 
+                var drawable = new Box
+                {
+                    Colour = Color4.Red,
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                Header.Add(drawable);
+
                 LoadComponentsAsync(new CompositeDrawable[]
                 {
                     new SetPanelBackground(manager.GetWorkingBeatmap(beatmapSet.Beatmaps.MinBy(b => b.OnlineID)))
@@ -218,6 +228,7 @@ private void loadContentIfRequired()
                 {
                     Header.AddRange(drawables);
                     drawables.ForEach(d => d.FadeInFromZero(150));
+                    drawable.Colour = Color4.White;
                 }, loadCancellation.Token);
             }
         }

```