### PR TITLE
Fix overall ranking text overlapping at some aspect ratios

### DIFF
--- a/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SoloStatisticsPanel.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Screens.Ranking.Statistics
                     RelativeSizeAxes = Axes.X,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Width = 0.5f,
                     StatisticsUpdate = { BindTarget = StatisticsUpdate }
                 })).ToArray();
             }


### PR DESCRIPTION
Can't confirm on the actual ranking screen due to stuff not working.

Maybe it'll work tomorrow.

Closes https://github.com/ppy/osu/issues/26341.