### PR TITLE
Remove scores from song select leaderboard when leaving the screen

### DIFF
--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -153,6 +153,15 @@ namespace osu.Game.Online.Leaderboards
         public void RefetchScores() => Scheduler.AddOnce(refetchScores);
 
         /// <summary>
+        /// Clear all scores from the display.
+        /// </summary>
+        public void ClearScores()
+        {
+            cancelPendingWork();
+            SetScores(null);
+        }
+
+        /// <summary>
         /// Call when a retrieval or display failure happened to show a relevant message to the user.
         /// </summary>
         /// <param name="state">The state to display.</param>
@@ -220,9 +229,7 @@ namespace osu.Game.Online.Leaderboards
         {
             Debug.Assert(ThreadSafety.IsUpdateThread);
 
-            cancelPendingWork();
-
-            SetScores(null);
+            ClearScores();
             setState(LeaderboardState.Retrieving);
 
             currentFetchCancellationSource = new CancellationTokenSource();

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -146,6 +146,14 @@ namespace osu.Game.Screens.Select
             }
         }
 
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            // Scores will be refreshed on arriving at this screen.
+            // Clear them to avoid animation overload on returning to song select.
+            playBeatmapDetailArea.Leaderboard.ClearScores();
+            base.OnSuspending(e);
+        }
+
         public override void OnResuming(ScreenTransitionEvent e)
         {
             base.OnResuming(e);


### PR DESCRIPTION
Noticed they would disappear-then-appear after visiting the ranking screen. Which feels very weird.