### PR TITLE
Disable pausing music during intro sequence

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Tests.Visual.Menus
         {
             AddUntilStep("Wait for music", () => Game?.MusicController.IsPlaying == true);
 
-            // Check that pause dosesn't work during intro sequence.
+            // Check that pause doesn't work during intro sequence.
             AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
             AddAssert("Still playing before menu", () => Game?.MusicController.IsPlaying == true);
             AddUntilStep("Wait for main menu", () => Game?.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
@@ -9,39 +9,31 @@ using osu.Game.Screens.Menu;
 
 namespace osu.Game.Tests.Visual.Menus
 {
-    public partial class TestSceneIntroMusicActionHandling : OsuTestScene
+    public partial class TestSceneIntroMusicActionHandling : OsuGameTestScene
     {
-        private OsuGameTestScene.TestOsuGame? game;
+        private GlobalActionContainer globalActionContainer => Game.ChildrenOfType<GlobalActionContainer>().First();
 
-        private GlobalActionContainer globalActionContainer => game.ChildrenOfType<GlobalActionContainer>().First();
+        public override void SetUpSteps()
+        {
+            CreateNewGame();
+            // we do not want to progress to main menu immediately, hence the override and lack of `ConfirmAtMainMenu()` call here.
+        }
 
         [Test]
         public void TestPauseDuringIntro()
         {
-            AddStep("Create new game instance", () =>
-            {
-                if (game?.Parent != null)
-                    Remove(game, true);
-
-                RecycleLocalStorage(false);
-
-                AddGame(game = new OsuGameTestScene.TestOsuGame(LocalStorage, API));
-            });
-
-            AddUntilStep("Wait for load", () => game?.IsLoaded ?? false);
-            AddUntilStep("Wait for intro", () => game?.ScreenStack.CurrentScreen is IntroScreen);
-            AddUntilStep("Wait for music", () => game?.MusicController.IsPlaying == true);
+            AddUntilStep("Wait for music", () => Game?.MusicController.IsPlaying == true);
 
             // Check that pause dosesn't work during intro sequence.
             AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
-            AddAssert("Still playing before menu", () => game?.MusicController.IsPlaying == true);
-            AddUntilStep("Wait for main menu", () => game?.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);
+            AddAssert("Still playing before menu", () => Game?.MusicController.IsPlaying == true);
+            AddUntilStep("Wait for main menu", () => Game?.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);
 
             // Check that toggling after intro still works.
             AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
-            AddUntilStep("Music paused", () => game?.MusicController.IsPlaying == false && game?.MusicController.UserPauseRequested == true);
+            AddUntilStep("Music paused", () => Game?.MusicController.IsPlaying == false && Game?.MusicController.UserPauseRequested == true);
             AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
-            AddUntilStep("Music resumed", () => game?.MusicController.IsPlaying == true && game?.MusicController.UserPauseRequested == false);
+            AddUntilStep("Music resumed", () => Game?.MusicController.IsPlaying == true && Game?.MusicController.UserPauseRequested == false);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroMusicActionHandling.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Input.Bindings;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Tests.Visual.Menus
+{
+    public partial class TestSceneIntroMusicActionHandling : OsuTestScene
+    {
+        private OsuGameTestScene.TestOsuGame? game;
+
+        private GlobalActionContainer globalActionContainer => game.ChildrenOfType<GlobalActionContainer>().First();
+
+        [Test]
+        public void TestPauseDuringIntro()
+        {
+            AddStep("Create new game instance", () =>
+            {
+                if (game?.Parent != null)
+                    Remove(game, true);
+
+                RecycleLocalStorage(false);
+
+                AddGame(game = new OsuGameTestScene.TestOsuGame(LocalStorage, API));
+            });
+
+            AddUntilStep("Wait for load", () => game?.IsLoaded ?? false);
+            AddUntilStep("Wait for intro", () => game?.ScreenStack.CurrentScreen is IntroScreen);
+            AddUntilStep("Wait for music", () => game?.MusicController.IsPlaying == true);
+
+            // Check that pause dosesn't work during intro sequence.
+            AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
+            AddAssert("Still playing before menu", () => game?.MusicController.IsPlaying == true);
+            AddUntilStep("Wait for main menu", () => game?.ScreenStack.CurrentScreen is MainMenu menu && menu.IsLoaded);
+
+            // Check that toggling after intro still works.
+            AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
+            AddUntilStep("Music paused", () => game?.MusicController.IsPlaying == false && game?.MusicController.UserPauseRequested == true);
+            AddStep("Toggle playback", () => globalActionContainer.TriggerPressed(GlobalAction.MusicPlay));
+            AddUntilStep("Music resumed", () => game?.MusicController.IsPlaying == true && game?.MusicController.UserPauseRequested == false);
+        }
+    }
+}

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Whether user control of the global track should be allowed.
         /// </summary>
-        public readonly BindableBool AllowTrackControl = new BindableBool(true);
+        public readonly BindableBool AllowTrackControl = new BindableBool(false);
 
         /// <summary>
         /// Fired when the global <see cref="WorkingBeatmap"/> has changed.

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Whether user control of the global track should be allowed.
         /// </summary>
-        public readonly BindableBool AllowTrackControl = new BindableBool(false);
+        public readonly BindableBool AllowTrackControl = new BindableBool(true);
 
         /// <summary>
         /// Fired when the global <see cref="WorkingBeatmap"/> has changed.

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -109,6 +109,8 @@ namespace osu.Game.Screens.Menu
             // prevent user from changing beatmap while the intro is still running.
             beatmap = Beatmap.BeginLease(false);
 
+            musicController.AllowTrackControl.Value = false;
+
             MenuVoice = config.GetBindable<bool>(OsuSetting.MenuVoice);
             MenuMusic = config.GetBindable<bool>(OsuSetting.MenuMusic);
 

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -95,6 +95,8 @@ namespace osu.Game.Screens.Menu
             Colour = Color4.Black
         };
 
+        public override bool? AllowGlobalTrackControl => false;
+
         protected IntroScreen([CanBeNull] Func<MainMenu> createNextScreen = null)
         {
             this.createNextScreen = createNextScreen;
@@ -108,8 +110,6 @@ namespace osu.Game.Screens.Menu
         {
             // prevent user from changing beatmap while the intro is still running.
             beatmap = Beatmap.BeginLease(false);
-
-            musicController.AllowTrackControl.Value = false;
 
             MenuVoice = config.GetBindable<bool>(OsuSetting.MenuVoice);
             MenuMusic = config.GetBindable<bool>(OsuSetting.MenuMusic);

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Screens.Menu
 
         public override bool AllowExternalScreenChange => true;
 
+        public override bool? AllowGlobalTrackControl => true;
+
         private Screen songSelect;
 
         private MenuSideFlashes sideFlashes;
@@ -240,8 +242,6 @@ namespace osu.Game.Screens.Menu
             if (e.Last is IntroScreen && musicController.TrackLoaded)
             {
                 var track = musicController.CurrentTrack;
-
-                musicController.AllowTrackControl.Value = true;
 
                 // presume the track is the current beatmap's track. not sure how correct this assumption is but it has worked until now.
                 if (!track.IsRunning)

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -241,6 +241,8 @@ namespace osu.Game.Screens.Menu
             {
                 var track = musicController.CurrentTrack;
 
+                musicController.AllowTrackControl.Value = true;
+
                 // presume the track is the current beatmap's track. not sure how correct this assumption is but it has worked until now.
                 if (!track.IsRunning)
                 {

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -59,6 +59,12 @@ namespace osu.Game.Tests.Visual
         [SetUpSteps]
         public virtual void SetUpSteps()
         {
+            CreateNewGame();
+            ConfirmAtMainMenu();
+        }
+
+        protected void CreateNewGame()
+        {
             AddStep("Create new game instance", () =>
             {
                 if (Game?.Parent != null)
@@ -71,8 +77,6 @@ namespace osu.Game.Tests.Visual
 
             AddUntilStep("Wait for load", () => Game.IsLoaded);
             AddUntilStep("Wait for intro", () => Game.ScreenStack.CurrentScreen is IntroScreen);
-
-            ConfirmAtMainMenu();
         }
 
         [TearDownSteps]


### PR DESCRIPTION
Resolves #25999 

This disables the track playback from being controlled when the intro sequence begins, and allows control to the user again when the main menu appears.

Previously the intro sequence music was able to be paused, and after would suddenly resume to the one of the intro tracks or a beatmap track suddenly.

Before:

https://github.com/ppy/osu/assets/17349626/e199272d-1ae0-4924-810b-5c950ebfa86f

After:

https://github.com/ppy/osu/assets/17349626/1a01ae96-404a-4776-9baf-8e84149510b3



Just a heads up... The test does it's job, but I'm not 100% confident in the code quality of the test. I've tried my best and did digging around with other tests for understanding, but got a little lost when it seemed like I should use `OsuGameTestScene` but needed an input during it's intro sequence.
So I'm ready to learn if I wrote the test poorly. 👍 