### PR TITLE
Update classic mania score import formula

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModClassic.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModClassic.cs
@@ -7,5 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModClassic : ModClassic
     {
+        public override double ScoreMultiplier => 1;
     }
 }

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -444,10 +444,12 @@ namespace osu.Game.Database
                     break;
 
                 case 3:
-                    convertedTotalScore = (long)Math.Round((
-                        850000 * comboProportion
-                        + 150000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
-                        + bonusProportion) * modMultiplier);
+                    // Keep the whole comboProportion (with a Classic mod multiplier of 1.00)
+                    // Nerf high scores' ratio by multiplying by 2 their difference from the score cap
+                    // Keep a max nerf of 95% of the original score
+                    convertedTotalScore = Math.floor(
+                        Math.max(1000000-2*(1000000-(1000000*comboProportion)), comboProportion * 0.95) * modMultiplier
+                    );
                     break;
 
                 default:

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -444,12 +444,10 @@ namespace osu.Game.Database
                     break;
 
                 case 3:
-                    // Keep the whole comboProportion (with a Classic mod multiplier of 1.00)
-                    // Nerf high scores' ratio by multiplying by 2 their difference from the score cap
-                    // Keep a max nerf of 95% of the original score
-                    convertedTotalScore = Math.floor(
-                        Math.max(1000000-2*(1000000-(1000000*comboProportion)), comboProportion * 0.95) * modMultiplier
-                    );
+                    convertedTotalScore = (long)Math.Round((
+                        850000 * comboProportion
+                        + 150000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
+                        + bonusProportion) * modMultiplier);
                     break;
 
                 default:


### PR DESCRIPTION
This preserves the integrity of mania rankings

Since it's provably impossible to statically convert scorev1 to scorev2 in mania, the best we can do is a rough estimation, however a single multiplier is a bit insensible. I'm aware this PR doesn't impact stable score import for leaderboards ; But I can only guess that it is done in the same way in your routines. So this is an attempt at having them match this logic.

As a side effect, this makes the "Classic" mode have no multiplier, due to it being used in the stable import tool. Maybe this isn't necessary? The most important matter being actual online leaderboards.

`Instead of the default 0.96 classic mod multiplier, use a slightly better formula to reflect high scores' transition from v1 to v2. Keep a maximum nerf of around 95% of original score to reflect most scorev2 scores compared to scorev1.`

This is a voluntarily simple change, as it might not be necessary to go in further complications for this matter.

![image](https://github.com/ppy/osu/assets/16978299/119a9e89-0bd3-43a8-907d-f8f269ddbbb5)
