### PR TITLE
Fix mania score conversion using score V1 accuracy

### DIFF
--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -444,9 +444,14 @@ namespace osu.Game.Database
                     break;
 
                 case 3:
+                    // in the mania case accuracy actually changes between score V1 and score V2 / standardised
+                    // (PERFECT weighting changes from 300 to 305),
+                    // so for better accuracy recompute accuracy locally based on hit statistics and use that instead,
+                    double scoreV2Accuracy = ComputeAccuracy(score);
+
                     convertedTotalScore = (long)Math.Round((
                         850000 * comboProportion
-                        + 150000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
+                        + 150000 * Math.Pow(scoreV2Accuracy, 2 + 2 * scoreV2Accuracy)
                         + bonusProportion) * modMultiplier);
                     break;
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -36,9 +36,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000007: Adjust osu!mania combo and accuracy portions and judgement scoring values. Reconvert all scores.</description></item>
         /// <item><description>30000008: Add accuracy conversion. Reconvert all scores.</description></item>
         /// <item><description>30000009: Fix edge cases in conversion for scores which have 0.0x mod multiplier on stable. Reconvert all scores.</description></item>
+        /// <item><description>30000010: Fix mania score V1 conversion using score V1 accuracy rather than V2 accuracy. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000009;
+        public const int LATEST_VERSION = 30000010;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
Partially addresses https://github.com/ppy/osu/discussions/26416

As pointed out in the discussion thread above, the total score conversion process for mania was using accuracy directly from the replay. In mania accuracy is calculated differently in score V1 than in score V2, which meant that scores coming from stable were treated more favourably (due to weighting GREAT and PERFECT equally).

To fix, recompute accuracy locally and use that for the accuracy portion.

Note that this will still not be (and cannot be made) 100% accurate, as in stable score V2, as well as in lazer, hold notes are *two* judgements, not one as in stable score V1, meaning that full and correct score statistics are not available without playing back the replay.

The effects of the change can be previewed on the following spreadsheet:

https://docs.google.com/spreadsheets/d/1wxD4UwLjwcr7n9y5Yq7EN0lgiLBN93kpd4gBnAlG-E0/edit#gid=1711190356

Top 5 changed scores with replays:

| score                                                                                                                            | master  | this PR | replay  |
| :------------------------------------------------------------------------------------------------------------------------------- | ------: | ------: | ------: |
| [Outlasted on Uwa!! So Holiday by toby fox [[4K] easy] (0.71\*)](https://osu.ppy.sh/scores/mania/460404716)                      | 935,917 | 927,269 | 920,579 |
| [ag0 on Emotional Uplifting Orchestral by bradbreeck [[4K] Rocket's Normal] (0.76\*)](https://osu.ppy.sh/scores/mania/453133066) | 921,636 | 913,535 | 875,549 |
| [rlarkgus on Zen Zen Zense by Gom (HoneyWorks) [[5K] Normal] (1.68\*)](https://osu.ppy.sh/scores/mania/458368312)                | 934,340 | 926,787 | 918,855 |
| [YuJJun on Harumachi Clover by R3 Music Box [4K Catastrophe] (1.80\*)](https://osu.ppy.sh/scores/mania/548215786)                | 918,606 | 911,111 | 885,454 |
| [Fritte on 45-byou by respon feat. Hatsune Miku & Megpoid [[5K] Normal] (1.52\*)](https://osu.ppy.sh/scores/mania/516079410)     | 900,024 | 892,569 | 907,456 |

4/5 cases are closer to the "actual" score as indicated by replay than the previous conversion was (although that is a somewhat shaky reference due to differences in hitwindow handling, but it'll do for now).

---

This will 10000% conflict with https://github.com/ppy/osu/pull/26405 if both pulls are accepted. I will deal with that as that comes.

I didn't do what I described [here](https://github.com/ppy/osu/discussions/26416#discussioncomment-8038289) exactly because I dunno it felt safer to preserve the original accuracy I guess. I'm not exactly sure that for other rulesets recomputing accuracy from statistics is lossless (or matches actual lazer gameplay mechanics either).

Classic mod multiplier is deliberately not touched. It will remain 0.96x for all rulesets for the foreseeable future. That may change if the community feedback after release indicates that it is required, but for now it stays. Changing multiplier is a much easier operation to apply retroactively than adjusting the conversion which is why this is being PRed and that isn't.