### PR TITLE
Fix crash when clicking osu! logo in song select immediately after exiting

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -938,6 +938,35 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("touch device mod still active", () => Game.SelectedMods.Value, () => Has.One.InstanceOf<ModTouchDevice>());
         }
 
+        [Test]
+        public void TestExitSongSelectAndImmediatelyClickLogo()
+        {
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("press escape and then click logo immediately", () =>
+            {
+                InputManager.Key(Key.Escape);
+                clickLogoWhenNotCurrent();
+            });
+
+            void clickLogoWhenNotCurrent()
+            {
+                if (songSelect.IsCurrentScreen())
+                    Scheduler.AddOnce(clickLogoWhenNotCurrent);
+                else
+                {
+                    InputManager.MoveMouseTo(Game.ChildrenOfType<OsuLogo>().Single());
+                    InputManager.Click(MouseButton.Left);
+                }
+            }
+        }
+
         private Func<Player> playToResults()
         {
             var player = playToCompletion();

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -92,6 +92,9 @@ namespace osu.Game.Screens.Select
         {
             if (playerLoader != null) return false;
 
+            if (!this.IsCurrentScreen())
+                return false;
+
             modsAtGameplayStart = Mods.Value;
 
             // Ctrl+Enter should start map with autoplay enabled.

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -92,9 +92,6 @@ namespace osu.Game.Screens.Select
         {
             if (playerLoader != null) return false;
 
-            if (!this.IsCurrentScreen())
-                return false;
-
             modsAtGameplayStart = Mods.Value;
 
             // Ctrl+Enter should start map with autoplay enabled.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -660,7 +660,8 @@ namespace osu.Game.Screens.Select
 
             logo.Action = () =>
             {
-                FinaliseSelection();
+                if (this.IsCurrentScreen())
+                    FinaliseSelection();
                 return false;
             };
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26415.

The crash report with incomplete log was backwards, the exit comes first. Sentry events and the reproducing test in https://github.com/ppy/osu/commit/8a87301c55262f888017cb2ce5ed23d04429ab05 confirm this.