### PR TITLE
Do not attempt to recalculate non-legacy scores or scores set on custom rulesets

### DIFF
--- a/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -182,9 +183,38 @@ namespace osu.Game.Tests.Database
             AddAssert("Score version not upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(30000002));
         }
 
+        [Test]
+        public void TestCustomRulesetScoreNotSubjectToUpgrades([Values] bool available)
+        {
+            RulesetInfo rulesetInfo = null!;
+            ScoreInfo scoreInfo = null!;
+            TestBackgroundDataStoreProcessor processor = null!;
+
+            AddStep("Add unavailable ruleset", () => Realm.Write(r => r.Add(rulesetInfo = new RulesetInfo
+            {
+                ShortName = Guid.NewGuid().ToString(),
+                Available = available
+            })));
+
+            AddStep("Add score for unavailable ruleset", () => Realm.Write(r => r.Add(scoreInfo = new ScoreInfo(
+                ruleset: rulesetInfo,
+                beatmap: r.All<BeatmapInfo>().First())
+            {
+                TotalScoreVersion = 30000001
+            })));
+
+            AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
+            AddUntilStep("Wait for completion", () => processor.Completed);
+
+            AddAssert("Score not marked as failed", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.BackgroundReprocessingFailed), () => Is.False);
+            AddAssert("Score version not upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(30000001));
+        }
+
         public partial class TestBackgroundDataStoreProcessor : BackgroundDataStoreProcessor
         {
             protected override int TimeToSleepDuringGameplay => 10;
+
+            public bool Completed => ProcessingTask.IsCompleted;
         }
     }
 }

--- a/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
+++ b/osu.Game.Tests/Database/BackgroundDataStoreProcessorTests.cs
@@ -210,6 +210,31 @@ namespace osu.Game.Tests.Database
             AddAssert("Score version not upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(30000001));
         }
 
+        [Test]
+        public void TestNonLegacyScoreNotSubjectToUpgrades()
+        {
+            ScoreInfo scoreInfo = null!;
+            TestBackgroundDataStoreProcessor processor = null!;
+
+            AddStep("Add score which requires upgrade (and has beatmap)", () =>
+            {
+                Realm.Write(r =>
+                {
+                    r.Add(scoreInfo = new ScoreInfo(ruleset: r.All<RulesetInfo>().First(), beatmap: r.All<BeatmapInfo>().First())
+                    {
+                        TotalScoreVersion = 30000005,
+                        LegacyTotalScore = 123456,
+                    });
+                });
+            });
+
+            AddStep("Run background processor", () => Add(processor = new TestBackgroundDataStoreProcessor()));
+            AddUntilStep("Wait for completion", () => processor.Completed);
+
+            AddAssert("Score not marked as failed", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.BackgroundReprocessingFailed), () => Is.False);
+            AddAssert("Score version not upgraded", () => Realm.Run(r => r.Find<ScoreInfo>(scoreInfo.ID)!.TotalScoreVersion), () => Is.EqualTo(30000005));
+        }
+
         public partial class TestBackgroundDataStoreProcessor : BackgroundDataStoreProcessor
         {
             protected override int TimeToSleepDuringGameplay => 10;

--- a/osu.Game/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/BackgroundDataStoreProcessor.cs
@@ -28,6 +28,8 @@ namespace osu.Game
     /// </summary>
     public partial class BackgroundDataStoreProcessor : Component
     {
+        protected Task ProcessingTask = null!;
+
         [Resolved]
         private RulesetStore rulesetStore { get; set; } = null!;
 
@@ -61,7 +63,7 @@ namespace osu.Game
         {
             base.LoadComplete();
 
-            Task.Factory.StartNew(() =>
+            ProcessingTask = Task.Factory.StartNew(() =>
             {
                 Logger.Log("Beginning background data store processing..");
 


### PR DESCRIPTION
Addresses discussions such as https://github.com/ppy/osu/discussions/26407 or https://github.com/ppy/osu/discussions/25914 wherein:
- the game would attempt to convert scores for custom rulesets, which makes no sense, especially so when they're not there,
- the game would also "recalculate" lazer scores, but that was never the intention or was never supported; the game would just increment the score version on those but still include them in the converted tally.