### PR TITLE
Fix score conversion incorrectly assuming zero combo score in certain cases

### DIFF
--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -311,13 +311,22 @@ namespace osu.Game.Database
             long maximumLegacyBonusScore = attributes.BonusScore;
 
             double legacyAccScore = maximumLegacyAccuracyScore * score.Accuracy;
-            // We can not separate the ComboScore from the BonusScore, so we keep the bonus in the ratio.
-            // Note that `maximumLegacyComboScore + maximumLegacyBonusScore` can actually be 0
-            // when playing a beatmap with no bonus objects, with mods that have a 0.0x multiplier on stable (relax/autopilot).
-            // In such cases, just assume 0.
-            double comboProportion = maximumLegacyComboScore + maximumLegacyBonusScore > 0
-                ? Math.Max((double)score.LegacyTotalScore - legacyAccScore, 0) / (maximumLegacyComboScore + maximumLegacyBonusScore)
-                : 0;
+
+            double comboProportion;
+
+            if (maximumLegacyComboScore + maximumLegacyBonusScore > 0)
+            {
+                // We can not separate the ComboScore from the BonusScore, so we keep the bonus in the ratio.
+                comboProportion = Math.Max((double)score.LegacyTotalScore - legacyAccScore, 0) / (maximumLegacyComboScore + maximumLegacyBonusScore);
+            }
+            else
+            {
+                // Two possible causes:
+                // the beatmap has no bonus objects *AND*
+                // either the active mods have a zero mod multiplier, in which case assume 0,
+                // or the *beatmap* has a zero `difficultyPeppyStars` (or just no combo-giving objects), in which case assume 1.
+                comboProportion = legacyModMultiplier == 0 ? 0 : 1;
+            }
 
             // We assume the bonus proportion only makes up the rest of the score that exceeds maximumLegacyBaseScore.
             long maximumLegacyBaseScore = maximumLegacyAccuracyScore + maximumLegacyComboScore;


### PR DESCRIPTION
This fell out during work on https://github.com/ppy/osu/pull/26405.

Turns out the assumption of "if combo score plus bonus score is zero then relax / autopilot must have been on" from https://github.com/ppy/osu/pull/26082 is overreaching. https://osu.ppy.sh/beatmapsets/675779#osu/1431549 is a beatmap which has a `difficultyPeppyStars` of zero (0), which means that it doesn't *get* any combo score (and also happens to have no bonus score), which means that going by

https://github.com/ppy/osu/blob/70ba5dd0d3702fc7825fa2eca13222e54c356d52/osu.Game/Rulesets/Scoring/ScoreProcessor.cs#L369

there's not really anything smart to do other than give it the full combo portion of score for free. And yes this probably helps some bad scores too much, but also makes SSes actually worth 960k score rather than 96% of accuracy portion.

This affects all rulesets, but judging from the osu! spreadsheet that I ran (https://docs.google.com/spreadsheets/d/1PmtF9maLl2WAc9BGDx02yv_YqU-2N9wftr0JOZk0m_k/edit#gid=469242467), there is only one beatmap affected by this.

I intentionally am not bumping `LegacyScoreEncoder.LATEST_VERSION` because I already have 2 other pulls open that touch it. It'll fall in there too is what I'm thinking.