### PR TITLE
Add replay playback controls

### DIFF
--- a/osu.Game/Localisation/PlayerSettingsOverlayStrings.cs
+++ b/osu.Game/Localisation/PlayerSettingsOverlayStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class PlayerSettingsOverlayStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.PlaybackSettings";
+
+        /// <summary>
+        /// "Seek backward {0} seconds"
+        /// </summary>
+        public static LocalisableString SeekBackwardSeconds(double arg0) => new TranslatableString(getKey(@"seek_backward_seconds"), @"Seek backward {0} seconds", arg0);
+
+        /// <summary>
+        /// "Seek forward {0} seconds"
+        /// </summary>
+        public static LocalisableString SeekForwardSeconds(double arg0) => new TranslatableString(getKey(@"seek_forward_seconds"), @"Seek forward {0} seconds", arg0);
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -41,5 +41,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override void PopIn() => this.FadeIn(fade_duration);
         protected override void PopOut() => this.FadeOut(fade_duration);
+
+        public void Insert(int i, PlayerSettingsGroup drawable) => content.Insert(i, drawable);
     }
 }

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -42,6 +42,6 @@ namespace osu.Game.Screens.Play.HUD
         protected override void PopIn() => this.FadeIn(fade_duration);
         protected override void PopOut() => this.FadeOut(fade_duration);
 
-        public void Insert(int i, PlayerSettingsGroup drawable) => content.Insert(i, drawable);
+        public void AddAtStart(PlayerSettingsGroup drawable) => content.Insert(-1, drawable);
     }
 }

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -12,9 +12,11 @@ namespace osu.Game.Screens.Play.HUD
     {
         private const int fade_duration = 200;
 
-        public readonly PlaybackSettings PlaybackSettings;
-
         public readonly VisualSettings VisualSettings;
+
+        protected override Container<Drawable> Content => content;
+
+        private readonly FillFlowContainer content;
 
         public PlayerSettingsOverlay()
         {
@@ -22,7 +24,7 @@ namespace osu.Game.Screens.Play.HUD
             Origin = Anchor.TopRight;
             AutoSizeAxes = Axes.Both;
 
-            Child = new FillFlowContainer<PlayerSettingsGroup>
+            InternalChild = content = new FillFlowContainer
             {
                 Anchor = Anchor.TopRight,
                 Origin = Anchor.TopRight,
@@ -31,7 +33,6 @@ namespace osu.Game.Screens.Play.HUD
                 Spacing = new Vector2(0, 20),
                 Children = new PlayerSettingsGroup[]
                 {
-                    PlaybackSettings = new PlaybackSettings { Expanded = { Value = false } },
                     VisualSettings = new VisualSettings { Expanded = { Value = false } },
                     new AudioSettings { Expanded = { Value = false } }
                 }

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -274,7 +274,7 @@ namespace osu.Game.Screens.Play
 
             track.BindAdjustments(AdjustmentsFromMods);
             track.AddAdjustment(AdjustableProperty.Frequency, GameplayClock.ExternalPauseFrequencyAdjust);
-            track.AddAdjustment(AdjustableProperty.Tempo, UserPlaybackRate);
+            track.AddAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
 
             speedAdjustmentsApplied = true;
         }
@@ -286,7 +286,7 @@ namespace osu.Game.Screens.Play
 
             track.UnbindAdjustments(AdjustmentsFromMods);
             track.RemoveAdjustment(AdjustableProperty.Frequency, GameplayClock.ExternalPauseFrequencyAdjust);
-            track.RemoveAdjustment(AdjustableProperty.Tempo, UserPlaybackRate);
+            track.RemoveAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
 
             speedAdjustmentsApplied = false;
         }

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -35,9 +35,9 @@ namespace osu.Game.Screens.Play
 
         public readonly BindableNumber<double> UserPlaybackRate = new BindableDouble(1)
         {
-            MinValue = 0.5,
+            MinValue = 0.05,
             MaxValue = 2,
-            Precision = 0.1,
+            Precision = 0.01,
         };
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -476,9 +476,6 @@ namespace osu.Game.Screens.Play
                 skipOutroOverlay.Expire();
             }
 
-            if (GameplayClockContainer is MasterGameplayClockContainer master)
-                HUDOverlay.PlayerSettingsOverlay.PlaybackSettings.UserPlaybackRate.BindTarget = master.UserPlaybackRate;
-
             return container;
         }
 

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -11,6 +11,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Screens.Edit.Timing;
 using osuTK;
 
 namespace osu.Game.Screens.Play.PlayerSettings
@@ -64,14 +65,14 @@ namespace osu.Game.Screens.Play.PlayerSettings
                             Spacing = new Vector2(5, 0),
                             Children = new Drawable[]
                             {
-                                new IconButton
+                                new SeekButton
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastBackward,
                                     Action = () => seek(-1, seek_fast_amount),
                                 },
-                                new IconButton
+                                new SeekButton
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
@@ -96,14 +97,14 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                         }
                                     }
                                 },
-                                new IconButton
+                                new SeekButton
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Forward,
                                     Action = () => seek(1, seek_amount),
                                 },
-                                new IconButton
+                                new SeekButton
                                 {
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
@@ -150,6 +151,14 @@ namespace osu.Game.Screens.Play.PlayerSettings
             base.LoadComplete();
             rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.0}x", true);
             gameplayClock?.IsPaused.BindTo(isPaused);
+        }
+
+        private partial class SeekButton : IconButton
+        {
+            public SeekButton()
+            {
+                AddInternal(new RepeatingButtonBehaviour(this));
+            }
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -13,6 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Edit.Timing;
 using osuTK;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -71,6 +72,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastBackward,
                                     Action = () => seek(-1, seek_fast_amount),
+                                    TooltipText = PlayerSettingsOverlayStrings.SeekBackwardSeconds(seek_fast_amount / 1000),
                                 },
                                 new SeekButton
                                 {
@@ -78,6 +80,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Backward,
                                     Action = () => seek(-1, seek_amount),
+                                    TooltipText = PlayerSettingsOverlayStrings.SeekBackwardSeconds(seek_amount / 1000),
                                 },
                                 play = new IconButton
                                 {
@@ -103,6 +106,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Forward,
                                     Action = () => seek(1, seek_amount),
+                                    TooltipText = PlayerSettingsOverlayStrings.SeekForwardSeconds(seek_amount / 1000),
                                 },
                                 new SeekButton
                                 {
@@ -110,6 +114,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastForward,
                                     Action = () => seek(1, seek_fast_amount),
+                                    TooltipText = PlayerSettingsOverlayStrings.SeekForwardSeconds(seek_fast_amount / 1000),
                                 },
                             },
                         },
@@ -137,7 +142,19 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
             };
 
-            isPaused.BindValueChanged(e => play.Icon = !e.NewValue ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle, true);
+            isPaused.BindValueChanged(paused =>
+            {
+                if (!paused.NewValue)
+                {
+                    play.TooltipText = ToastStrings.PauseTrack;
+                    play.Icon = FontAwesome.Regular.PauseCircle;
+                }
+                else
+                {
+                    play.TooltipText = ToastStrings.PlayTrack;
+                    play.Icon = FontAwesome.Regular.PlayCircle;
+                }
+            }, true);
 
             void seek(int direction, double amount)
             {

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private readonly IconButton play;
 
+        private readonly BindableBool isPaused = new BindableBool();
+
         [Resolved]
         private GameplayClockContainer? gameplayClock { get; set; }
 
@@ -134,6 +136,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
             };
 
+            isPaused.BindValueChanged(e => play.Icon = e.NewValue ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle, true);
+
             void seek(int direction, double amount)
             {
                 double target = Math.Clamp((gameplayClock?.CurrentTime ?? 0) + (direction * amount), 0, gameplayState?.Beatmap.GetLastObjectTime() ?? 0);
@@ -145,12 +149,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             base.LoadComplete();
             rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.0}x", true);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-            play.Icon = gameplayClock?.IsRunning == true ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle;
+            gameplayClock?.IsPaused.BindTo(isPaused);
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
             void seek(int direction, double amount)
             {
-                double target = Math.Clamp((gameplayClock?.CurrentTime ?? 0) + (direction * amount), 0, gameplayState.Beatmap.GetLastObjectTime());
+                double target = Math.Clamp((gameplayClock?.CurrentTime ?? 0) + (direction * amount), 0, gameplayState?.Beatmap.GetLastObjectTime() ?? 0);
                 gameplayClock?.Seek(target);
             }
         }

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Precision = 0.1,
         };
 
-
         private readonly PlayerSliderBar<double> rateSlider;
 
         private readonly OsuSpriteText multiplierText;

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -1,11 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osuTK;
 
 namespace osu.Game.Screens.Play.PlayerSettings
 {
@@ -24,40 +30,127 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private readonly OsuSpriteText multiplierText;
 
+        private readonly IconButton play;
+
+        [Resolved]
+        private GameplayClockContainer gameplayClock { get; set; } = null!;
+
+        [Resolved]
+        private GameplayState gameplayState { get; set; } = null!;
+
         public PlaybackSettings()
             : base("playback")
         {
+            const double seek_amount = 5000;
+            const double seek_fast_amount = 10000;
+
             Children = new Drawable[]
             {
-                new Container
+                new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Horizontal = padding },
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, padding),
                     Children = new Drawable[]
                     {
-                        new OsuSpriteText
+                        new FillFlowContainer
                         {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Text = "Playback speed",
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(5, 0),
+                            Children = new Drawable[]
+                            {
+                                new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.FastBackward,
+                                    Action = () => seek(-1, seek_fast_amount),
+                                },
+                                new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.Backward,
+                                    Action = () => seek(-1, seek_amount),
+                                },
+                                play = new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Scale = new Vector2(1.4f),
+                                    IconScale = new Vector2(1.4f),
+                                    Icon = FontAwesome.Regular.PlayCircle,
+                                    Action = () =>
+                                    {
+                                        if (gameplayClock != null)
+                                        {
+                                            if (gameplayClock.IsRunning)
+                                                gameplayClock.Stop();
+                                            else
+                                                gameplayClock.Start();
+                                        }
+                                    }
+                                },
+                                new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.Forward,
+                                    Action = () => seek(1, seek_amount),
+                                },
+                                new IconButton
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Icon = FontAwesome.Solid.FastForward,
+                                    Action = () => seek(1, seek_fast_amount),
+                                },
+                            },
                         },
-                        multiplierText = new OsuSpriteText
+                        new Container
                         {
-                            Anchor = Anchor.CentreRight,
-                            Origin = Anchor.CentreRight,
-                            Font = OsuFont.GetFont(weight: FontWeight.Bold),
-                        }
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Children = new Drawable[]
+                            {
+                                rateSlider = new PlayerSliderBar<double>
+                                {
+                                    LabelText = "Playback speed",
+                                    Current = UserPlaybackRate,
+                                },
+                                multiplierText = new OsuSpriteText
+                                {
+                                    Anchor = Anchor.TopRight,
+                                    Origin = Anchor.TopRight,
+                                    Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                                    Margin = new MarginPadding { Right = 20 },
+                                }
+                            },
+                        },
                     },
                 },
-                rateSlider = new PlayerSliderBar<double> { Current = UserPlaybackRate }
             };
+
+            void seek(int direction, double amount)
+            {
+                double target = Math.Clamp((gameplayClock?.CurrentTime ?? 0) + (direction * amount), 0, gameplayState.Beatmap.GetLastObjectTime());
+                gameplayClock?.Seek(target);
+            }
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
             rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.0}x", true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            play.Icon = gameplayClock.IsRunning ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle;
         }
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -27,7 +27,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Precision = 0.1,
         };
 
-        public readonly Bindable<bool> AllowControls = new BindableBool(true);
 
         private readonly PlayerSliderBar<double> rateSlider;
 
@@ -73,7 +72,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastBackward,
                                     Action = () => seek(-1, seek_fast_amount),
-                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -81,7 +79,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Backward,
                                     Action = () => seek(-1, seek_amount),
-                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 play = new IconButton
                                 {
@@ -100,7 +97,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                                 gameplayClock.Start();
                                         }
                                     },
-                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -108,7 +104,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Forward,
                                     Action = () => seek(1, seek_amount),
-                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -116,7 +111,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastForward,
                                     Action = () => seek(1, seek_fast_amount),
-                                    Enabled = { BindTarget = AllowControls },
                                 },
                             },
                         },

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -22,9 +22,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public readonly Bindable<double> UserPlaybackRate = new BindableDouble(1)
         {
-            MinValue = 0.5,
+            MinValue = 0.05,
             MaxValue = 2,
-            Precision = 0.1,
+            Precision = 0.01,
         };
 
         private readonly PlayerSliderBar<double> rateSlider;
@@ -149,7 +149,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.0}x", true);
+            rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.00}x", true);
 
             if (gameplayClock != null)
                 isPaused.BindTarget = gameplayClock.IsPaused;

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
             };
 
-            isPaused.BindValueChanged(e => play.Icon = e.NewValue ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle, true);
+            isPaused.BindValueChanged(e => play.Icon = !e.NewValue ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle, true);
 
             void seek(int direction, double amount)
             {

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Precision = 0.1,
         };
 
+        public readonly Bindable<bool> AllowControls = new BindableBool(true);
+
         private readonly PlayerSliderBar<double> rateSlider;
 
         private readonly OsuSpriteText multiplierText;
@@ -71,6 +73,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastBackward,
                                     Action = () => seek(-1, seek_fast_amount),
+                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -78,6 +81,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Backward,
                                     Action = () => seek(-1, seek_amount),
+                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 play = new IconButton
                                 {
@@ -95,7 +99,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                             else
                                                 gameplayClock.Start();
                                         }
-                                    }
+                                    },
+                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -103,6 +108,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.Forward,
                                     Action = () => seek(1, seek_amount),
+                                    Enabled = { BindTarget = AllowControls },
                                 },
                                 new SeekButton
                                 {
@@ -110,6 +116,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                                     Origin = Anchor.Centre,
                                     Icon = FontAwesome.Solid.FastForward,
                                     Action = () => seek(1, seek_fast_amount),
+                                    Enabled = { BindTarget = AllowControls },
                                 },
                             },
                         },
@@ -150,7 +157,9 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             base.LoadComplete();
             rateSlider.Current.BindValueChanged(multiplier => multiplierText.Text = $"{multiplier.NewValue:0.0}x", true);
-            gameplayClock?.IsPaused.BindTo(isPaused);
+
+            if (gameplayClock != null)
+                isPaused.BindTarget = gameplayClock.IsPaused;
         }
 
         private partial class SeekButton : IconButton

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         private readonly OsuSpriteText multiplierText;
 
-        private readonly IconButton play;
-
         private readonly BindableBool isPaused = new BindableBool();
 
         [Resolved]
@@ -46,6 +44,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
         {
             const double seek_amount = 5000;
             const double seek_fast_amount = 10000;
+
+            IconButton play;
 
             Children = new Drawable[]
             {

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -33,10 +33,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly IconButton play;
 
         [Resolved]
-        private GameplayClockContainer gameplayClock { get; set; } = null!;
+        private GameplayClockContainer? gameplayClock { get; set; }
 
         [Resolved]
-        private GameplayState gameplayState { get; set; } = null!;
+        private GameplayState? gameplayState { get; set; }
 
         public PlaybackSettings()
             : base("playback")
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         protected override void Update()
         {
             base.Update();
-            play.Icon = gameplayClock.IsRunning ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle;
+            play.Icon = gameplayClock?.IsRunning == true ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle;
         }
     }
 }

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -50,18 +51,19 @@ namespace osu.Game.Screens.Play
             this.createScore = createScore;
         }
 
-        protected override void LoadComplete()
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            base.LoadComplete();
-
-            if (HUDOverlay != null)
+            var playbackSettings = new PlaybackSettings
             {
-                var playerSettingsOverlay = new PlaybackSettings { Expanded = { Value = false } };
-                HUDOverlay.PlayerSettingsOverlay.Add(playerSettingsOverlay);
+                Depth = float.MaxValue,
+                Expanded = { Value = false }
+            };
 
-                if (GameplayClockContainer is MasterGameplayClockContainer master)
-                    playerSettingsOverlay.UserPlaybackRate.BindTarget = master.UserPlaybackRate;
-            }
+            if (GameplayClockContainer is MasterGameplayClockContainer master)
+                playbackSettings.UserPlaybackRate.BindTo(master.UserPlaybackRate);
+
+            HUDOverlay.PlayerSettingsOverlay.Insert(-1, playbackSettings);
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -54,11 +54,14 @@ namespace osu.Game.Screens.Play
         {
             base.LoadComplete();
 
-            var playerSettingsOverlay = new PlaybackSettings { Expanded = { Value = false } };
-            HUDOverlay.PlayerSettingsOverlay.Add(playerSettingsOverlay);
+            if (HUDOverlay != null)
+            {
+                var playerSettingsOverlay = new PlaybackSettings { Expanded = { Value = false } };
+                HUDOverlay.PlayerSettingsOverlay.Add(playerSettingsOverlay);
 
-            if (GameplayClockContainer is MasterGameplayClockContainer master)
-                playerSettingsOverlay.UserPlaybackRate.BindTarget = master.UserPlaybackRate;
+                if (GameplayClockContainer is MasterGameplayClockContainer master)
+                    playerSettingsOverlay.UserPlaybackRate.BindTarget = master.UserPlaybackRate;
+            }
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -54,6 +54,9 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader]
         private void load()
         {
+            if (!LoadedBeatmapSuccessfully)
+                return;
+
             var playbackSettings = new PlaybackSettings
             {
                 Depth = float.MaxValue,

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -15,6 +15,7 @@ using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
 
@@ -47,6 +48,17 @@ namespace osu.Game.Screens.Play
             : base(configuration)
         {
             this.createScore = createScore;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            var playerSettingsOverlay = new PlaybackSettings { Expanded = { Value = false } };
+            HUDOverlay.PlayerSettingsOverlay.Add(playerSettingsOverlay);
+
+            if (GameplayClockContainer is MasterGameplayClockContainer master)
+                playerSettingsOverlay.UserPlaybackRate.BindTarget = master.UserPlaybackRate;
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Play
             if (GameplayClockContainer is MasterGameplayClockContainer master)
                 playbackSettings.UserPlaybackRate.BindTo(master.UserPlaybackRate);
 
-            HUDOverlay.PlayerSettingsOverlay.Insert(-1, playbackSettings);
+            HUDOverlay.PlayerSettingsOverlay.AddAtStart(playbackSettings);
         }
 
         protected override void PrepareReplay()

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -68,6 +68,8 @@ namespace osu.Game.Screens.Play
                         master.UserPlaybackRate.Value = 1;
                 }
             }, true);
+
+            HUDOverlay.PlayerSettingsOverlay.PlaybackSettings.AllowControls.Value = false;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -68,8 +68,6 @@ namespace osu.Game.Screens.Play
                         master.UserPlaybackRate.Value = 1;
                 }
             }, true);
-
-            HUDOverlay.PlayerSettingsOverlay.PlaybackSettings.AllowControls.Value = false;
         }
 
         /// <summary>


### PR DESCRIPTION
From https://github.com/ppy/osu/discussions/26444.
This adds playback controls to allow controlled seeking and playing/pausing in replays.

---

This also:

- Adjusts playback speed range to allow slower minimum speed (0.05x ~ 2.0x)
- Change replay playback adjustment to skew frequency, not tempo (sounds better)

https://github.com/ppy/osu/assets/20495991/4d7db131-68d5-4839-995a-329ce2fcb05c

