### PR TITLE
Allow interacting with playlist item buttons when not selected

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -19,8 +19,10 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Models;
 using osu.Game.Online.API;
+using osu.Game.Online.Chat;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -300,6 +302,36 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 p.AllowShowingResults = true;
                 p.AllowEditing = true;
             });
+        }
+
+        [Test]
+        public void TestSelectableMouseHandling()
+        {
+            bool resultsRequested = false;
+
+            AddStep("reset flag", () => resultsRequested = false);
+            createPlaylist(p =>
+            {
+                p.AllowSelection = true;
+                p.AllowShowingResults = true;
+                p.RequestResults = _ => resultsRequested = true;
+            });
+
+            AddStep("move mouse to first item title", () =>
+            {
+                var drawQuad = playlist.ChildrenOfType<LinkFlowContainer>().First().ScreenSpaceDrawQuad;
+                var location = (drawQuad.TopLeft + drawQuad.BottomLeft) / 2 + new Vector2(drawQuad.Width * 0.2f, 0);
+                InputManager.MoveMouseTo(location);
+            });
+            AddAssert("first item title not hovered", () => playlist.ChildrenOfType<DrawableLinkCompiler>().First().IsHovered, () => Is.False);
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddUntilStep("first item selected", () => playlist.ChildrenOfType<DrawableRoomPlaylistItem>().First().IsSelectedItem, () => Is.True);
+            // implies being clickable.
+            AddUntilStep("first item title hovered", () => playlist.ChildrenOfType<DrawableLinkCompiler>().First().IsHovered, () => Is.True);
+
+            AddStep("move mouse to second item results button", () => InputManager.MoveMouseTo(playlist.ChildrenOfType<GrayButton>().ElementAt(5)));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddUntilStep("results requested", () => resultsRequested);
         }
 
         private void moveToItem(int index, Vector2? offset = null)

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoomPlaylist.cs
@@ -323,6 +323,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 var location = (drawQuad.TopLeft + drawQuad.BottomLeft) / 2 + new Vector2(drawQuad.Width * 0.2f, 0);
                 InputManager.MoveMouseTo(location);
             });
+            AddUntilStep("wait for text load", () => playlist.ChildrenOfType<DrawableLinkCompiler>().Any());
             AddAssert("first item title not hovered", () => playlist.ChildrenOfType<DrawableLinkCompiler>().First().IsHovered, () => Is.False);
             AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
             AddUntilStep("first item selected", () => playlist.ChildrenOfType<DrawableRoomPlaylistItem>().First().IsSelectedItem, () => Is.True);

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylist.cs
@@ -165,7 +165,11 @@ namespace osu.Game.Screens.OnlinePlay
         {
             d.SelectedItem.BindTarget = SelectedItem;
             d.RequestDeletion = i => RequestDeletion?.Invoke(i);
-            d.RequestResults = i => RequestResults?.Invoke(i);
+            d.RequestResults = i =>
+            {
+                SelectedItem.Value = i;
+                RequestResults?.Invoke(i);
+            };
             d.RequestEdit = i => RequestEdit?.Invoke(i);
             d.AllowReordering = AllowReordering;
             d.AllowDeletion = AllowDeletion;

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -118,8 +118,6 @@ namespace osu.Game.Screens.OnlinePlay
         [Resolved(CanBeNull = true)]
         private ManageCollectionsDialog manageCollectionsDialog { get; set; }
 
-        protected override bool ShouldBeConsideredForInput(Drawable child) => AllowReordering || AllowDeletion || !AllowSelection || SelectedItem.Value == Model;
-
         public DrawableRoomPlaylistItem(PlaylistItem item)
             : base(item)
         {
@@ -367,7 +365,7 @@ namespace osu.Game.Screens.OnlinePlay
                                     AutoSizeAxes = Axes.Both,
                                     Margin = new MarginPadding { Left = 8, Right = 8 },
                                 },
-                                mainFillFlow = new FillFlowContainer
+                                mainFillFlow = new MainFlow(() => SelectedItem.Value == Model)
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -668,6 +666,18 @@ namespace osu.Game.Screens.OnlinePlay
                 }
 
                 public LocalisableString TooltipText => avatar.TooltipText;
+            }
+        }
+
+        public partial class MainFlow : FillFlowContainer
+        {
+            private readonly Func<bool> isSelected;
+
+            public override bool PropagatePositionalInputSubTree => isSelected();
+
+            public MainFlow(Func<bool> isSelected)
+            {
+                this.isSelected = isSelected;
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
+++ b/osu.Game/Screens/OnlinePlay/DrawableRoomPlaylistItem.cs
@@ -365,7 +365,7 @@ namespace osu.Game.Screens.OnlinePlay
                                     AutoSizeAxes = Axes.Both,
                                     Margin = new MarginPadding { Left = 8, Right = 8 },
                                 },
-                                mainFillFlow = new MainFlow(() => SelectedItem.Value == Model)
+                                mainFillFlow = new MainFlow(() => SelectedItem.Value == Model || !AllowSelection)
                                 {
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
@@ -671,13 +671,13 @@ namespace osu.Game.Screens.OnlinePlay
 
         public partial class MainFlow : FillFlowContainer
         {
-            private readonly Func<bool> isSelected;
+            private readonly Func<bool> allowInteraction;
 
-            public override bool PropagatePositionalInputSubTree => isSelected();
+            public override bool PropagatePositionalInputSubTree => allowInteraction();
 
-            public MainFlow(Func<bool> isSelected)
+            public MainFlow(Func<bool> allowInteraction)
             {
-                this.isSelected = isSelected;
+                this.allowInteraction = allowInteraction;
             }
         }
     }


### PR DESCRIPTION
Originally interaction was limited to fix clicking title/creator links when trying to select the panel. But this also meant that buttons became unresponsive, which is quite anti-user.

I've fixed this by localising the input restrictions to the hyperlink text rather than the full panel.

Addresses https://github.com/ppy/osu/discussions/26403.


https://github.com/ppy/osu/assets/191335/90ea231c-3cb2-4e81-996f-f544323aa816


