### PR TITLE
Fix excessive allocation overheads during realm startup cleanup

### DIFF
--- a/osu.Game/Database/RealmFileStore.cs
+++ b/osu.Game/Database/RealmFileStore.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -99,9 +98,7 @@ namespace osu.Game.Database
             realm.Write(r =>
             {
                 // TODO: consider using a realm native query to avoid iterating all files (https://github.com/realm/realm-dotnet/issues/2659#issuecomment-927823707)
-                var files = r.All<RealmFile>().ToList();
-
-                foreach (var file in files)
+                foreach (var file in r.All<RealmFile>())
                 {
                     totalFiles++;
 


### PR DESCRIPTION
I'd still want to move this to a native query, but it doesn't seem to work. That said, removing the `ToList` somehow massively improves this.

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-09 at 06 25 08](https://github.com/ppy/osu/assets/191335/5ecf86ad-b905-40f9-8119-99dc145ffba1) | ![CleanShot 2024-01-09 at 06 25 32](https://github.com/ppy/osu/assets/191335/5a2c9b96-a1fb-4cc6-a5a9-82d490eeec7d) |