### PR TITLE
Fix `SettingsToolboxGroup` allocating excessively due to missing cache validation

### DIFF
--- a/osu.Game/Overlays/SettingsToolboxGroup.cs
+++ b/osu.Game/Overlays/SettingsToolboxGroup.cs
@@ -151,9 +151,12 @@ namespace osu.Game.Overlays
             base.Update();
 
             if (!headerTextVisibilityCache.IsValid)
+            {
                 // These toolbox grouped may be contracted to only show icons.
                 // For now, let's hide the header to avoid text truncation weirdness in such cases.
                 headerText.FadeTo(headerText.DrawWidth < DrawWidth ? 1 : 0, 150, Easing.OutQuint);
+                headerTextVisibilityCache.Validate();
+            }
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)


### PR DESCRIPTION
![CleanShot 2024-01-09 at 09 34 52](https://github.com/ppy/osu/assets/191335/cf3c9700-a346-4a08-9a9a-e39576a9694d)
