### PR TITLE
Update `EditorBeatmap`'s preview time after Undo(Redo)

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePreviewTime.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePreviewTime.cs
@@ -31,5 +31,15 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("set preview time to 1000", () => EditorBeatmap.PreviewTime.Value = 1000);
             AddAssert("preview time line should show", () => Editor.ChildrenOfType<PreviewTimePart>().Single().Children.Single().Alpha == 1);
         }
+
+        [Test]
+        public void TestScenePreviewTimeRollbackAfterUndo()
+        {
+            AddStep("set preview time to -1", () => EditorBeatmap.PreviewTime.Value = -1);
+            AddStep("seek to 1000", () => EditorClock.Seek(1000));
+            AddStep("set current time as preview point", () => Editor.SetPreviewPointToCurrentTime());
+            AddStep("Do undo", () => Editor.Undo());
+            AddAssert("preview time is -1", () => EditorBeatmap.PreviewTime.Value == -1);
+        }
     }
 }

--- a/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
+++ b/osu.Game/Screens/Edit/LegacyEditorBeatmapPatcher.cs
@@ -73,6 +73,8 @@ namespace osu.Game.Screens.Edit
                         editorBeatmap.ControlPointInfo.Add(newGroup.Time, point);
                 }
             }
+
+            editorBeatmap.PreviewTime.Value = getNewBeatmap().Metadata.PreviewTime;
         }
 
         private void processHitObjects(DiffResult result, Func<IBeatmap> getNewBeatmap)


### PR DESCRIPTION
In fact, [preview time can be undo](https://github.com/ppy/osu/blob/8324b75fa455a5a0e2b5accc98cf158591307769/osu.Game/Screens/Edit/EditorBeatmap.cs#L114-L119), but it just does nothing.



this is because `LegacyEditorBeatmapPatcher` will not update preview time in `EditorBeatmap`.

this pr will update preview time in `EditorBeatmap`