### PR TITLE
Fix mania skin array decoder not handling malformed entries rigorously

### DIFF
--- a/osu.Game.Tests/Resources/mania-skin-broken-array.ini
+++ b/osu.Game.Tests/Resources/mania-skin-broken-array.ini
@@ -1,0 +1,3 @@
+[Mania]
+Keys: 4
+ColumnLineWidth: 3,,3,3,3

--- a/osu.Game.Tests/Skins/LegacyManiaSkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacyManiaSkinDecoderTest.cs
@@ -114,5 +114,24 @@ namespace osu.Game.Tests.Skins
                 Assert.That(configs[0].MinimumColumnWidth, Is.EqualTo(16));
             }
         }
+
+        [Test]
+        public void TestParseArrayWithSomeEmptyElements()
+        {
+            var decoder = new LegacyManiaSkinDecoder();
+
+            using (var resStream = TestResources.OpenResource("mania-skin-broken-array.ini"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var configs = decoder.Decode(stream);
+
+                Assert.That(configs.Count, Is.EqualTo(1));
+                Assert.That(configs[0].ColumnLineWidth[0], Is.EqualTo(3));
+                Assert.That(configs[0].ColumnLineWidth[1], Is.EqualTo(0)); // malformed entry, should be parsed as zero
+                Assert.That(configs[0].ColumnLineWidth[2], Is.EqualTo(3));
+                Assert.That(configs[0].ColumnLineWidth[3], Is.EqualTo(3));
+                Assert.That(configs[0].ColumnLineWidth[4], Is.EqualTo(3));
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Skins/LegacyManiaSkinDecoderTest.cs
+++ b/osu.Game.Tests/Skins/LegacyManiaSkinDecoderTest.cs
@@ -126,6 +126,7 @@ namespace osu.Game.Tests.Skins
                 var configs = decoder.Decode(stream);
 
                 Assert.That(configs.Count, Is.EqualTo(1));
+                Assert.That(configs[0].ColumnLineWidth.Length, Is.EqualTo(5));
                 Assert.That(configs[0].ColumnLineWidth[0], Is.EqualTo(3));
                 Assert.That(configs[0].ColumnLineWidth[1], Is.EqualTo(0)); // malformed entry, should be parsed as zero
                 Assert.That(configs[0].ColumnLineWidth[2], Is.EqualTo(3));

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Skinning
                 if (i >= output.Length)
                     break;
 
-                if (!float.TryParse(values[i], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out float parsedValue))
+                if (!float.TryParse(values[i], NumberStyles.Float, CultureInfo.InvariantCulture, out float parsedValue))
                     // some skins may provide incorrect entries in array values. to match stable behaviour, read such entries as zero.
                     // see: https://github.com/ppy/osu/issues/26464, stable code: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Skinning/Components/Section.cs#L134-L137
                     parsedValue = 0;

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -155,7 +155,15 @@ namespace osu.Game.Skinning
                 if (i >= output.Length)
                     break;
 
-                output[i] = float.Parse(values[i], CultureInfo.InvariantCulture) * (applyScaleFactor ? LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR : 1);
+                if (!float.TryParse(values[i], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out float parsedValue))
+                    // some skins may provide incorrect entries in array values. to match stable behaviour, read such entries as zero.
+                    // see: https://github.com/ppy/osu/issues/26464, stable code: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Skinning/Components/Section.cs#L134-L137
+                    parsedValue = 0;
+
+                if (applyScaleFactor)
+                    parsedValue *= LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
+
+                output[i] = parsedValue;
             }
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26464

Not much to say here. Stable code is linked in solution, since it's a very specific behavior defined by stable.