### PR TITLE
Fix incorrect score conversion on selected beatmaps due to incorrect `difficultyPeppyStars` rounding

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchLegacyScoreSimulator.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.Scoring;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
@@ -62,13 +63,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                 drainLength = ((int)Math.Round(baseBeatmap.HitObjects[^1].StartTime) - (int)Math.Round(baseBeatmap.HitObjects[0].StartTime) - breakLength) / 1000;
             }
 
-            int difficultyPeppyStars = (int)Math.Round(
-                (baseBeatmap.Difficulty.DrainRate
-                 + baseBeatmap.Difficulty.OverallDifficulty
-                 + baseBeatmap.Difficulty.CircleSize
-                 + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
-
-            scoreMultiplier = difficultyPeppyStars;
+            scoreMultiplier = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(baseBeatmap.Difficulty, objectCount, drainLength);
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreSimulator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
@@ -62,13 +63,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 drainLength = ((int)Math.Round(baseBeatmap.HitObjects[^1].StartTime) - (int)Math.Round(baseBeatmap.HitObjects[0].StartTime) - breakLength) / 1000;
             }
 
-            int difficultyPeppyStars = (int)Math.Round(
-                (baseBeatmap.Difficulty.DrainRate
-                 + baseBeatmap.Difficulty.OverallDifficulty
-                 + baseBeatmap.Difficulty.CircleSize
-                 + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
-
-            scoreMultiplier = difficultyPeppyStars;
+            scoreMultiplier = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(baseBeatmap.Difficulty, objectCount, drainLength);
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
@@ -65,11 +66,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 drainLength = ((int)Math.Round(baseBeatmap.HitObjects[^1].StartTime) - (int)Math.Round(baseBeatmap.HitObjects[0].StartTime) - breakLength) / 1000;
             }
 
-            difficultyPeppyStars = (int)Math.Round(
-                (baseBeatmap.Difficulty.DrainRate
-                 + baseBeatmap.Difficulty.OverallDifficulty
-                 + baseBeatmap.Difficulty.CircleSize
-                 + Math.Clamp((float)objectCount / drainLength * 8, 0, 16)) / 38 * 5);
+            difficultyPeppyStars = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(baseBeatmap.Difficulty, objectCount, drainLength);
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
@@ -57,5 +57,40 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1);
         }
+
+        public static int CalculateDifficultyPeppyStars(BeatmapDifficulty difficulty, int objectCount, int drainLength)
+        {
+            /*
+             * WARNING: DO NOT TOUCH IF YOU DO NOT KNOW WHAT YOU ARE DOING
+             *
+             * It so happens that in stable, due to .NET Framework internals, float math would be performed
+             * using x87 registers and opcodes.
+             * .NET (Core) however uses SSE instructions on 32- and 64-bit words.
+             * x87 registers are _80 bits_ wide. Which is notably wider than _both_ float and double.
+             * Therefore, on a significant number of beatmaps, the rounding would not produce correct values.
+             *
+             * Thus, to crudely - but, seemingly *mostly* accurately, after checking across all ranked maps - emulate this,
+             * use `decimal`, which is slow, but has bigger precision than `double`.
+             * At the time of writing, there is _one_ ranked exception to this - namely https://osu.ppy.sh/beatmapsets/1156087#osu/2625853 -
+             * but it is considered an "acceptable casualty", since in that case scores aren't inflated by _that_ much compared to others.
+             */
+
+            decimal objectToDrainRatio = drainLength != 0
+                ? Math.Clamp((decimal)objectCount / drainLength * 8, 0, 16)
+                : 16;
+
+            /*
+             * Notably, THE `double` CASTS BELOW ARE IMPORTANT AND MUST REMAIN.
+             * Their goal is to trick the compiler / runtime into NOT promoting from single-precision float, as doing so would prompt it
+             * to attempt to "silently" fix the single-precision values when converting to decimal,
+             * which is NOT what the x87 FPU does.
+             */
+
+            decimal drainRate = (decimal)(double)difficulty.DrainRate;
+            decimal overallDifficulty = (decimal)(double)difficulty.OverallDifficulty;
+            decimal circleSize = (decimal)(double)difficulty.CircleSize;
+
+            return (int)Math.Round((drainRate + overallDifficulty + circleSize + objectToDrainRatio) / 38 * 5);
+        }
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -13,6 +13,7 @@ using osu.Game.Extensions;
 using osu.Game.IO.Legacy;
 using osu.Game.IO.Serialization;
 using osu.Game.Replays.Legacy;
+using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using SharpCompress.Compressors.LZMA;
@@ -38,9 +39,13 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000009: Fix edge cases in conversion for scores which have 0.0x mod multiplier on stable. Reconvert all scores.</description></item>
         /// <item><description>30000010: Fix mania score V1 conversion using score V1 accuracy rather than V2 accuracy. Reconvert all scores.</description></item>
         /// <item><description>30000011: Re-do catch scoring to mirror stable Score V2 as closely as feasible. Reconvert all scores.</description></item>
+        /// <item><description>
+        /// 30000012: Fix incorrect total score conversion on selected beatmaps after implementing the more correct
+        /// <see cref="LegacyRulesetExtensions.CalculateDifficultyPeppyStars"/> method. Reconvert all scores.
+        /// </description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000011;
+        public const int LATEST_VERSION = 30000012;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
Fixes issue that occurs on *about* 245 beatmaps[^1] and was first [described by me on discord](https://discord.com/channels/188630481301012481/188630652340404224/1154367700378865715) and then [rediscovered again](https://gist.github.com/bdach/414d5289f65b0399fa8f9732245a4f7c#venenog-on-ultmate-end-by-blacky-overdose-631) during work on https://github.com/ppy/osu/pull/26405.

## Explanation

It so happens that in stable, due to .NET Framework internals, float math would be performed using x87 registers and opcodes. .NET (Core) however uses SSE instructions on 32- and 64-bit words. x87 registers are _80 bits_ wide. Which is notably wider than _both_ float and double. Therefore, on a significant number of beatmaps, the final rounding of `difficultyPeppyStars` would not produce correct values due to insufficient precision. See [following gist](https://gist.github.com/bdach/dcde58d5a3607b0408faa3aa2b67bf10) for corroboration of the above (compare dump of JIT asm calculating the value for [lazer](https://gist.github.com/bdach/dcde58d5a3607b0408faa3aa2b67bf10#file-lazer) and [stable](https://gist.github.com/bdach/dcde58d5a3607b0408faa3aa2b67bf10#file-stable)).

Thus, to crudely - but, seemingly *mostly* accurately, after checking across all ranked maps - emulate this, use `decimal`, which is slow, but has bigger precision than `double`. The _single_ known exception beatmap in whose case this results in an incorrect result is https://osu.ppy.sh/beatmapsets/1156087#osu/2625853, which is considered an "acceptable casualty" of sorts (read: after spending a whole full day of dev on this, I do not consider a single beatmap's stable scores getting buffed by 10% significant enough to matter).

Doing this requires some fooling of the compiler / runtime (see second inline comment in new method). To corroborate that this is required, you can try the following code snippet:

```csharp
Console.WriteLine(string.Join(' ', BitConverter.GetBytes(1.3f).Select(x => x.ToString("X2"))));
Console.WriteLine(string.Join(' ', BitConverter.GetBytes(1.3).Select(x => x.ToString("X2"))));
Console.WriteLine();

decimal d1 = (decimal)1.3f;
decimal d2 = (decimal)1.3;
decimal d3 = (decimal)(double)1.3f;

Console.WriteLine(string.Join(' ', decimal.GetBits(d1).SelectMany(BitConverter.GetBytes).Select(x => x.ToString("X2"))));
Console.WriteLine(string.Join(' ', decimal.GetBits(d2).SelectMany(BitConverter.GetBytes).Select(x => x.ToString("X2"))));
Console.WriteLine(string.Join(' ', decimal.GetBits(d3).SelectMany(BitConverter.GetBytes).Select(x => x.ToString("X2"))));
```

which will print

    66 66 A6 3F
    CD CC CC CC CC CC F4 3F

    0D 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00
    0D 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00
    8C 5D 89 FB 3B 76 00 00 00 00 00 00 00 00 0E 00

Note that despite `d1` being converted from a less-precise floating-point value than `d2`, it still is represented 100% accurately as a decimal number.

Yes, this is a hack. Yes, it doesn't work _completely_. I think it's better to start with this rather than consider the alternatives, though (which is having something hard-stuck on windows+x86 just to compute this one value for correct score conversion until stable can't submit scores anymore, i.e. forevermore).

## Implications

A catch sheet showing the effects of this change is available for preview [here](https://docs.google.com/spreadsheets/d/1udSguj1XFKIeLaMUKMtupQzIIUsOjnV_V-vTGfiL6Bw/edit#gid=709239638), although this really impacts all rulesets. Some sampling of scores from there shows the change having the desired effect:

- Most gains, except for the one known-broken beatmap mentioned above (https://osu.ppy.sh/beatmapsets/1156087#osu/2625853), are happening because the combo score was previously _overestimated_, thus capping the following expression

  https://github.com/ppy/osu/blob/7d5e8ff241ba1598bbd8cf8ef9a4767ac8b1c68c/osu.Game/Database/StandardisedScoreMigrationTools.cs#L333

  to 0, and thus _underestimating_ the bonus portion.
- The losses are 200% expected and what this PR is primarily intending to fix (scores _way_ in excess of 1M).

> [!WARNING]
> **Note that after applying this change, recomputation of legacy scoring attributes for *all* rulesets will be required for the change to take the desired effect.**

[^1]: An *approximate* list of affected maps can be found [here](https://gist.github.com/bdach/dcde58d5a3607b0408faa3aa2b67bf10#file-maps_affected-csv). The list is approximate because the source of data used to compare computation of `difficultyPeppyStars` between .NET Framework and .NET (Core) was a data dump provided by @peppy, which unfortunately was not 100% accurate due to `drainTime` sometimes being off by one.