### PR TITLE
Ensure the assumed latency in beatmaps is the same at different speeds

### DIFF
--- a/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
+++ b/osu.Game/Graphics/Containers/BeatSyncedContainer.cs
@@ -108,16 +108,19 @@ namespace osu.Game.Graphics.Containers
 
             double beatLength = timingPoint.BeatLength / Divisor;
 
+            // ensure the assumed latency in beatmaps is the same at different playback rates
+            double time = timingPoint.Time + 20 - (20 * Clock.Rate);
+
             while (beatLength < MinimumBeatLength)
                 beatLength *= 2;
 
-            int beatIndex = (int)((currentTrackTime - timingPoint.Time) / beatLength) - (timingPoint.OmitFirstBarLine ? 1 : 0);
+            int beatIndex = (int)((currentTrackTime - time) / beatLength) - (timingPoint.OmitFirstBarLine ? 1 : 0);
 
             // The beats before the start of the first control point are off by 1, this should do the trick
-            if (currentTrackTime < timingPoint.Time)
+            if (currentTrackTime < time)
                 beatIndex--;
 
-            TimeUntilNextBeat = (timingPoint.Time - currentTrackTime) % beatLength;
+            TimeUntilNextBeat = (time - currentTrackTime) % beatLength;
             if (TimeUntilNextBeat <= 0)
                 TimeUntilNextBeat += beatLength;
 


### PR DESCRIPTION
Beatmaps have an assumption of 20ms of latency baked in, meaning that when a user is making a beatmap, the timing points created will be roughly 20ms earlier than what they would actually be if one were looking at the track in an audio editing program. The variable that holds this value can be seen here:
https://github.com/ppy/osu/blob/da29faffd0bcf80ae361a22683c5b705b5b45037/osu.Game/Screens/Edit/Editor.cs#L63-L74

This works fine when the track is playing at normal speed. However, at speeds other than 100%, the assumed 20ms difference changes in size. At slower speeds, it stretches (or is expected to be smaller relative to the speed) and causes hit objects to occur too early, and at faster speeds, it shrinks (or is expected to be larger relative to the speed) and causes hit objects to occur a bit late.

To fix this, we can add back the 20ms to timing points and then subtract (20 * Clock.Rate).