### PR TITLE
Add "displayable attributes" for rulesets and display as a tooltip on `StarRatingDisplay`

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             if (FlashlightDifficulty > 0.0)
             {
-                dictionary["Flashlight"] = FlashlightDifficulty.ToString("F");
+                dictionary["Flashlight"] = FlashlightDifficulty.ToLocalisableString("0.00");
             }
 
             return dictionary;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
@@ -83,6 +85,22 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         /// The number of spinners in the beatmap.
         /// </summary>
         public int SpinnerCount { get; set; }
+
+        public override IReadOnlyDictionary<string, LocalisableString> ToDisplayableAttributes()
+        {
+            var dictionary = new Dictionary<string, LocalisableString>
+            {
+                { "Aim", AimDifficulty.ToLocalisableString("0.00") },
+                { "Speed", SpeedDifficulty.ToLocalisableString("0.00") }
+            };
+
+            if (FlashlightDifficulty > 0.0)
+            {
+                dictionary["Flashlight"] = FlashlightDifficulty.ToString("F");
+            }
+
+            return dictionary;
+        }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -40,7 +40,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimRatingNoSliders = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
             double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
             double speedNotes = ((Speed)skills[2]).RelevantNoteCount();
-            double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
+            double flashlightRating = 0.0;
+
+            if (mods.Any(m => m is OsuModFlashlight))
+                flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
 
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 
@@ -42,6 +44,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         /// </remarks>
         [JsonProperty("great_hit_window")]
         public double GreatHitWindow { get; set; }
+
+        public override IReadOnlyDictionary<string, LocalisableString> ToDisplayableAttributes() => new Dictionary<string, LocalisableString>
+        {
+            { "Stamina", StaminaDifficulty.ToLocalisableString("0.00") },
+            { "Rhythm", RhythmDifficulty.ToLocalisableString("0.00") },
+            { "Colour", ColourDifficulty.ToLocalisableString("0.00") }
+        };
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {

--- a/osu.Game/Overlays/Difficulty/DisplayableAttributesTooltip.cs
+++ b/osu.Game/Overlays/Difficulty/DisplayableAttributesTooltip.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+
+namespace osu.Game.Overlays.Difficulty
+{
+    public partial class DisplayableAttributesTooltip : VisibilityContainer, ITooltip<IReadOnlyDictionary<string, LocalisableString>?>
+    {
+        private FillFlowContainer attributesFillFlow = null!;
+
+        private Container content = null!;
+        private IReadOnlyDictionary<string, LocalisableString>? displayableAttributes { get; set; }
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            Masking = true;
+            CornerRadius = 5;
+
+            InternalChildren = new Drawable[]
+            {
+                content = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colours.Gray3,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Vertical = 10, Horizontal = 15 },
+                            Direction = FillDirection.Vertical,
+                            Children = new Drawable[]
+                            {
+                                attributesFillFlow = new FillFlowContainer
+                                {
+                                    Direction = FillDirection.Vertical,
+                                    AutoSizeAxes = Axes.Both
+                                }
+                            }
+                        }
+                    }
+                },
+            };
+
+            updateDisplay();
+        }
+
+        protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
+        protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
+
+        public void Move(Vector2 pos) => Position = pos;
+
+        public void SetContent(IReadOnlyDictionary<string, LocalisableString>? attributes)
+        {
+            if (displayableAttributes != null && attributes != null && displayableAttributes.SequenceEqual(attributes))
+            {
+                return;
+            }
+
+            displayableAttributes = attributes;
+            updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            attributesFillFlow.Clear();
+
+            if (displayableAttributes != null)
+            {
+                attributesFillFlow.AddRange(displayableAttributes.Select(kv => new DisplayableAttributeDisplay(kv.Key, kv.Value)));
+            }
+
+            if (attributesFillFlow.Any())
+                content.Show();
+            else
+                content.Hide();
+        }
+
+        private partial class DisplayableAttributeDisplay : CompositeDrawable
+        {
+            public DisplayableAttributeDisplay(string name, LocalisableString value)
+            {
+                AutoSizeAxes = Axes.Both;
+
+                InternalChild = new OsuSpriteText
+                {
+                    Text = $"{name}: {value}"
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 
@@ -61,6 +62,11 @@ namespace osu.Game.Rulesets.Difficulty
             Mods = mods;
             StarRating = starRating;
         }
+
+        /// <summary>
+        /// Converts this <see cref="DifficultyAttributes"/> to a key-value pair of attributes for public display.
+        /// </summary>
+        public virtual IReadOnlyDictionary<string, LocalisableString> ToDisplayableAttributes() => new Dictionary<string, LocalisableString>();
 
         /// <summary>
         /// Converts this <see cref="DifficultyAttributes"/> to osu-web compatible database attribute mappings.


### PR DESCRIPTION
Idea previously discussed [here](https://github.com/peppy/osu-stable-reference/issues/9).

This uses the `DifficultyAttributes` stored for `StarRatingDisplay` to render a tooltip with a breakdown of the difficulty values per skill for each ruleset.

This is only implemented for osu! and Taiko rulesets, since Catch and Mania do not have separated difficulty values (only one skill).

This works by allowing each ruleset's `DifficultyAttributes` to define a dictionary of "displayable attributes". This intentionally uses `LocalisableString` as the value over `double` so that if extra attributes have differing number types that they can still be easily displayed.

The choice to use `Bindable<IReadOnlyDictionary<string, LocalisableString>>` over `BindableDictionary<string, LocalisableString>` is because `BindableDictionary` doesn't allow me to assign an updated dictionary (only a collection) and I can also only bind to an updated collection rather than the updated dictionary. If there's some misuse here or it's fixable then I'm happy to change it but I don't see how to make it work.

The change to `OsuDifficultyCalculator` regarding flashlight rating is done in order to be able to avoid confusion by only displaying the flashlight difficulty when the mod is actually enabled. This won't change the output star rating as it's only used for calculations when flashlight is enabled anyway.

<sup>(This is also a really tiny optimisation (not noticable) as it otherwise runs flashlight calculations even when unnecessary.)</sup>

---

## osu! example (without flashlight):
![image](https://github.com/ppy/osu/assets/51536154/02440002-eb5b-4812-8c22-3e1e69d800f9)

## osu! example (with flashlight):
![image](https://github.com/ppy/osu/assets/51536154/e71a32ce-9a56-42d6-84b6-e1c7b4325c91)

## Taiko example:
![image](https://github.com/ppy/osu/assets/51536154/3e4d89e1-51ff-44ab-9236-c26f2e938a6d)