### PR TITLE
Only validate playback rate when in submission context

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -21,7 +21,6 @@ using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Scoring;
-using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Beatmaps;
 
@@ -359,11 +358,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 AllowImportCompletion = new SemaphoreSlim(1);
             }
-
-            protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart)
-            {
-                ShouldValidatePlaybackRate = false,
-            };
 
             protected override async Task ImportScore(Score score)
             {

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Play
         /// Whether the audio playback rate should be validated.
         /// Mostly disabled for tests.
         /// </summary>
-        internal bool ShouldValidatePlaybackRate { get; init; } = true;
+        internal bool ShouldValidatePlaybackRate { get; init; }
 
         /// <summary>
         /// Whether the audio playback is within acceptable ranges.

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -61,6 +61,11 @@ namespace osu.Game.Screens.Play
             AddInternal(new PlayerTouchInputDetector());
         }
 
+        protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart)
+        {
+            ShouldValidatePlaybackRate = true,
+        };
+
         protected override void LoadAsyncComplete()
         {
             base.LoadAsyncComplete();


### PR DESCRIPTION
Temporary workaround for https://github.com/ppy/osu/issues/26404.

It appears that some audio files do not behave well with BASS, leading BASS to report a contradictory state of affairs (i.e. a track that is in playing state but also not progressing; see explanation [here](https://github.com/ppy/osu/issues/26404#issuecomment-1889238149)). This appears to be related to seeking specifically, therefore only enable the validation of playback rate in the most sensitive contexts, namely when any sort of score submission is involved.

This is not a very strong workaround, as it still is possible for the player to get stuck at the replay screen when seeking, but again, I'm not sure we're fixing that without either some very far-reaching framework-side heuristics to detect broken playback state or hoping that this can be fixed in bass.