### PR TITLE
Fix touch device mod getting selected as a free mod in playlists

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneFreeModSelectOverlay.cs
@@ -10,12 +10,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay;
+using osu.Game.Utils;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Multiplayer
@@ -23,6 +25,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
     public partial class TestSceneFreeModSelectOverlay : MultiplayerTestScene
     {
         private FreeModSelectOverlay freeModSelectOverlay;
+        private FooterButtonFreeMods footerButtonFreeMods;
         private readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> availableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>();
 
         [BackgroundDependencyLoader]
@@ -119,11 +122,46 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddAssert("select all button enabled", () => this.ChildrenOfType<SelectAllModsButton>().Single().Enabled.Value);
         }
 
+        [Test]
+        public void TestSelectAllViaFooterButtonThenDeselectFromOverlay()
+        {
+            createFreeModSelect();
+
+            AddAssert("overlay select all button enabled", () => freeModSelectOverlay.ChildrenOfType<SelectAllModsButton>().Single().Enabled.Value);
+            AddAssert("footer button displays off", () => footerButtonFreeMods.ChildrenOfType<IHasText>().Any(t => t.Text == "off"));
+
+            AddStep("click footer select all button", () =>
+            {
+                InputManager.MoveMouseTo(footerButtonFreeMods);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddUntilStep("all mods selected", assertAllAvailableModsSelected);
+            AddAssert("footer button displays all", () => footerButtonFreeMods.ChildrenOfType<IHasText>().Any(t => t.Text == "all"));
+
+            AddStep("click deselect all button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DeselectAllModsButton>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddUntilStep("all mods deselected", () => !freeModSelectOverlay.SelectedMods.Value.Any());
+            AddAssert("footer button displays off", () => footerButtonFreeMods.ChildrenOfType<IHasText>().Any(t => t.Text == "off"));
+        }
+
         private void createFreeModSelect()
         {
-            AddStep("create free mod select screen", () => Child = freeModSelectOverlay = new FreeModSelectOverlay
+            AddStep("create free mod select screen", () => Children = new Drawable[]
             {
-                State = { Value = Visibility.Visible }
+                freeModSelectOverlay = new FreeModSelectOverlay
+                {
+                    State = { Value = Visibility.Visible }
+                },
+                footerButtonFreeMods = new FooterButtonFreeMods(freeModSelectOverlay)
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Current = { BindTarget = freeModSelectOverlay.SelectedMods },
+                },
             });
             AddUntilStep("all column content loaded",
                 () => freeModSelectOverlay.ChildrenOfType<ModColumn>().Any()
@@ -134,9 +172,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             var allAvailableMods = availableMods.Value
                                                 .Where(pair => pair.Key != ModType.System)
-                                                .SelectMany(pair => pair.Value)
+                                                .SelectMany(pair => ModUtils.FlattenMods(pair.Value))
                                                 .Where(mod => mod.UserPlayable && mod.HasImplementation)
                                                 .ToList();
+
+            if (freeModSelectOverlay.SelectedMods.Value.Count != allAvailableMods.Count)
+                return false;
 
             foreach (var availableMod in allAvailableMods)
             {

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -447,7 +447,7 @@ namespace osu.Game.Overlays.Mods
         private void filterMods()
         {
             foreach (var modState in AllAvailableMods)
-                modState.ValidForSelection.Value = modState.Mod.HasImplementation && IsValidMod.Invoke(modState.Mod);
+                modState.ValidForSelection.Value = modState.Mod.Type != ModType.System && modState.Mod.HasImplementation && IsValidMod.Invoke(modState.Mod);
         }
 
         private void updateMultiplier()

--- a/osu.Game/Overlays/Mods/SelectAllModsButton.cs
+++ b/osu.Game/Overlays/Mods/SelectAllModsButton.cs
@@ -41,8 +41,8 @@ namespace osu.Game.Overlays.Mods
         private void updateEnabledState()
         {
             Enabled.Value = availableMods.Value
-                                         .Where(pair => pair.Key != ModType.System)
                                          .SelectMany(pair => pair.Value)
+                                         .Where(modState => modState.ValidForSelection.Value)
                                          .Any(modState => !modState.Active.Value && modState.Visible);
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26490

The cause of this issue laid in the way `FooterButtonFreeMods` determines available mods, which is the following code:
https://github.com/ppy/osu/blob/8e5b2e78e58842721478fbf5dd7fdd7c7a1f66ad/osu.Game/Screens/OnlinePlay/FooterButtonFreeMods.cs#L142-L144

Touch device has `ValidForSelection = true`, therefore being included in the above list and becoming selected when clicking the footer button.

At first, I considered removing system mods from being added to `ModSelectOverlay.AvailableMods`, but I'm not confident enough that this won't indirectly result in random issues when interacting with the mod select overlay (causing the touch device mod to be unintentionally deselected).

Instead, I settled down on setting `ValidForSelection = false` and using that as an indicator for both `FooterButtonFreeMods` and `SelectAllModsButton` (select all button in the overlay) to ignore such mods.

@bdach requesting your review as you're more knowledgable in this system. also worthy of note I cannot test on a touch device at the moment.