### PR TITLE
Fix lag when dragging first slider control point in editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -51,12 +51,24 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             base.LoadComplete();
 
             hitObjectPosition = hitObject.PositionBindable.GetBoundCopy();
-            hitObjectPosition.BindValueChanged(_ => updateConnectingPath());
+            hitObjectPosition.BindValueChanged(_ => pathRequiresUpdate = true);
 
             pathVersion = hitObject.Path.Version.GetBoundCopy();
-            pathVersion.BindValueChanged(_ => updateConnectingPath());
+            pathVersion.BindValueChanged(_ => pathRequiresUpdate = true);
 
             updateConnectingPath();
+        }
+
+        private bool pathRequiresUpdate;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!pathRequiresUpdate) return;
+
+            updateConnectingPath();
+            pathRequiresUpdate = false;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -51,24 +51,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             base.LoadComplete();
 
             hitObjectPosition = hitObject.PositionBindable.GetBoundCopy();
-            hitObjectPosition.BindValueChanged(_ => pathRequiresUpdate = true);
+            hitObjectPosition.BindValueChanged(_ => Scheduler.AddOnce(updateConnectingPath));
 
             pathVersion = hitObject.Path.Version.GetBoundCopy();
-            pathVersion.BindValueChanged(_ => pathRequiresUpdate = true);
+            pathVersion.BindValueChanged(_ => Scheduler.AddOnce(updateConnectingPath));
 
             updateConnectingPath();
-        }
-
-        private bool pathRequiresUpdate;
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (!pathRequiresUpdate) return;
-
-            updateConnectingPath();
-            pathRequiresUpdate = false;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -244,7 +244,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 else if (slidingSample.IsPlaying)
                     slidingSample.Stop();
             }
+        }
 
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            // It's important that this is done in UpdateAfterChildren so that the SliderBody has a chance to update its Size and PathOffset on Update.
             double completionProgress = Math.Clamp((Time.Current - HitObject.StartTime) / HitObject.Duration, 0, 1);
 
             Ball.UpdateProgress(completionProgress);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -250,7 +250,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateAfterChildren();
 
-            // It's important that this is done in UpdateAfterChildren so that the SliderBody has a chance to update its Size and PathOffset on Update.
+            // During slider path editing, the PlaySliderBody is scheduled to refresh once in the Update phase.
+            // It is crucial to perform the code below in UpdateAfterChildren. This ensures that the SliderBody has the opportunity
+            // to update its Size and PathOffset beforehand, ensuring correct placement.
+
             double completionProgress = Math.Clamp((Time.Current - HitObject.StartTime) / HitObject.Duration, 0, 1);
 
             Ball.UpdateProgress(completionProgress);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateAfterChildren();
 
-            // During slider path editing, the PlaySliderBody is scheduled to refresh once in the Update phase.
+            // During slider path editing, the PlaySliderBody is scheduled to refresh once on Update.
             // It is crucial to perform the code below in UpdateAfterChildren. This ensures that the SliderBody has the opportunity
             // to update its Size and PathOffset beforehand, ensuring correct placement.
 

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -218,6 +218,7 @@ namespace osu.Game.Rulesets.Osu.Objects
                         {
                             RepeatIndex = e.SpanIndex,
                             StartTime = e.Time,
+                            Position = EndPosition,
                             StackHeight = StackHeight,
                             ClassicSliderBehaviour = ClassicSliderBehaviour,
                         });
@@ -244,6 +245,9 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             if (HeadCircle != null)
                 HeadCircle.Position = Position;
+
+            if (TailCircle != null)
+                TailCircle.Position = EndPosition;
         }
 
         protected void UpdateNestedSamples()

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             set
             {
                 repeatCount = value;
-                updateNestedPositions();
+                endPositionCache.Invalidate();
             }
         }
 
@@ -165,7 +165,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public Slider()
         {
             SamplesBindable.CollectionChanged += (_, _) => UpdateNestedSamples();
-            Path.Version.ValueChanged += _ => updateNestedPositions();
+            Path.Version.ValueChanged += _ => endPositionCache.Invalidate();
         }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
@@ -218,7 +218,6 @@ namespace osu.Game.Rulesets.Osu.Objects
                         {
                             RepeatIndex = e.SpanIndex,
                             StartTime = e.Time,
-                            Position = EndPosition,
                             StackHeight = StackHeight,
                             ClassicSliderBehaviour = ClassicSliderBehaviour,
                         });
@@ -245,9 +244,6 @@ namespace osu.Game.Rulesets.Osu.Objects
 
             if (HeadCircle != null)
                 HeadCircle.Position = Position;
-
-            if (TailCircle != null)
-                TailCircle.Position = EndPosition;
         }
 
         protected void UpdateNestedSamples()

--- a/osu.Game.Rulesets.Osu/Objects/SliderEndCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderEndCircle.cs
@@ -14,16 +14,16 @@ namespace osu.Game.Rulesets.Osu.Objects
     /// </summary>
     public abstract class SliderEndCircle : HitCircle
     {
-        private readonly Slider slider;
+        protected readonly Slider Slider;
 
         protected SliderEndCircle(Slider slider)
         {
-            this.slider = slider;
+            Slider = slider;
         }
 
         public int RepeatIndex { get; set; }
 
-        public double SpanDuration => slider.SpanDuration;
+        public double SpanDuration => Slider.SpanDuration;
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)
         {
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             else
             {
                 // The first end circle should fade in with the slider.
-                TimePreempt += StartTime - slider.StartTime;
+                TimePreempt += StartTime - Slider.StartTime;
             }
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
@@ -16,12 +14,6 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
         /// </summary>
         public bool ClassicSliderBehaviour;
-
-        public override Vector2 Position
-        {
-            get => Slider.EndPosition;
-            set => throw new NotImplementedException();
-        }
 
         public SliderTailCircle(Slider slider)
             : base(slider)

--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
@@ -14,6 +16,12 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// If <c>false</c>, this <see cref="SliderHeadCircle"/> will be judged as a <see cref="SliderTick"/> instead.
         /// </summary>
         public bool ClassicSliderBehaviour;
+
+        public override Vector2 Position
+        {
+            get => Slider.EndPosition;
+            set => throw new NotImplementedException();
+        }
 
         public SliderTailCircle(Slider slider)
             : base(slider)

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -18,8 +18,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         protected IBindable<Color4> AccentColourBindable { get; private set; } = null!;
 
-        private IBindable<int> pathVersion = null!;
-
         [Resolved(CanBeNull = true)]
         private OsuRulesetConfigManager? config { get; set; }
 
@@ -33,8 +31,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             ScaleBindable = drawableSlider.ScaleBindable.GetBoundCopy();
             ScaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
 
-            pathVersion = drawableSlider.PathVersion.GetBoundCopy();
-            pathVersion.BindValueChanged(_ => Refresh());
+            drawableObject.DefaultsApplied += _ => Refresh();
+            drawableObject.HitObjectApplied += _ => Refresh();
 
             AccentColourBindable = drawableObject.AccentColour.GetBoundCopy();
             AccentColourBindable.BindValueChanged(accent => AccentColour = GetBodyAccentColour(skin, accent.NewValue), true);

--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         protected IBindable<Color4> AccentColourBindable { get; private set; } = null!;
 
+        private IBindable<int> pathVersion = null!;
+
         [Resolved(CanBeNull = true)]
         private OsuRulesetConfigManager? config { get; set; }
 
@@ -31,8 +33,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             ScaleBindable = drawableSlider.ScaleBindable.GetBoundCopy();
             ScaleBindable.BindValueChanged(scale => PathRadius = OsuHitObject.OBJECT_RADIUS * scale.NewValue, true);
 
-            drawableObject.DefaultsApplied += _ => Refresh();
-            drawableObject.HitObjectApplied += _ => Refresh();
+            pathVersion = drawableSlider.PathVersion.GetBoundCopy();
+            pathVersion.BindValueChanged(_ => Scheduler.AddOnce(Refresh));
 
             AccentColourBindable = drawableObject.AccentColour.GetBoundCopy();
             AccentColourBindable.BindValueChanged(accent => AccentColour = GetBodyAccentColour(skin, accent.NewValue), true);


### PR DESCRIPTION
Things like dragging the first slider control point move many control points in a single frame, and each time a single control point was moved it would trigger a recalculate of the whole slider, multiple times within a single frame.
I changed the logic in things that bind to changes in the path version to only refresh once per frame, so unnecessary refreshes are avoided.

Before:
https://github.com/ppy/osu/assets/17460441/1a7c780f-79f6-4f06-a314-c46bd069e54c

After:
https://github.com/ppy/osu/assets/17460441/d1bc9f6d-aba7-4f16-95f2-447b059574da

(The flashing is just a glitch with my ShareX recording)
