### PR TITLE
Add guard against submitting score with invalid mod instances

### DIFF
--- a/osu.Game.Tests/Mods/ModUtilsTest.cs
+++ b/osu.Game.Tests/Mods/ModUtilsTest.cs
@@ -7,7 +7,9 @@ using Moq;
 using NUnit.Framework;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Utils;
 
 namespace osu.Game.Tests.Mods
@@ -308,6 +310,16 @@ namespace osu.Game.Tests.Mods
                 Assert.IsNull(invalid);
             else
                 Assert.That(invalid?.Select(t => t.GetType()), Is.EquivalentTo(expectedInvalid));
+        }
+
+        [Test]
+        public void TestModBelongsToRuleset()
+        {
+            Assert.That(ModUtils.CheckModsBelongToRuleset(new OsuRuleset(), Array.Empty<Mod>()));
+            Assert.That(ModUtils.CheckModsBelongToRuleset(new OsuRuleset(), new Mod[] { new OsuModDoubleTime() }));
+            Assert.That(ModUtils.CheckModsBelongToRuleset(new OsuRuleset(), new Mod[] { new OsuModDoubleTime(), new OsuModAccuracyChallenge() }));
+            Assert.That(ModUtils.CheckModsBelongToRuleset(new OsuRuleset(), new Mod[] { new OsuModDoubleTime(), new ModAccuracyChallenge() }), Is.False);
+            Assert.That(ModUtils.CheckModsBelongToRuleset(new OsuRuleset(), new Mod[] { new OsuModDoubleTime(), new TaikoModFlashlight() }), Is.False);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -13,7 +13,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Localisation;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -487,13 +486,8 @@ namespace osu.Game.Tests.Visual.Gameplay
             }
         }
 
-        private class TestMod : Mod, IApplicableToScoreProcessor
+        private class TestMod : OsuModDoubleTime, IApplicableToScoreProcessor
         {
-            public override string Name => string.Empty;
-            public override string Acronym => string.Empty;
-            public override double ScoreMultiplier => 1;
-            public override LocalisableString Description => string.Empty;
-
             public bool Applied { get; private set; }
 
             public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -294,6 +294,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             createPlayerTest(createRuleset: () => new OsuRuleset(), createMods: () => new Mod[] { new TaikoModHidden() });
 
             AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+            AddAssert("gameplay not loaded", () => Player.DrawableRuleset == null);
 
             AddStep("exit", () => Player.Exit());
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -15,11 +15,13 @@ using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Beatmaps;
@@ -34,12 +36,19 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private Func<RulesetInfo, IBeatmap> createCustomBeatmap;
         private Func<Ruleset> createCustomRuleset;
+        private Func<Mod[]> createCustomMods;
 
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
         protected override bool HasCustomSteps => true;
 
-        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new FakeImportingPlayer(false);
+        protected override TestPlayer CreatePlayer(Ruleset ruleset)
+        {
+            if (createCustomMods != null)
+                SelectedMods.Value = SelectedMods.Value.Concat(createCustomMods()).ToList();
+
+            return new FakeImportingPlayer(false);
+        }
 
         protected new FakeImportingPlayer Player => (FakeImportingPlayer)base.Player;
 
@@ -277,13 +286,27 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("ensure no submission", () => Player.SubmittedScore == null);
         }
 
-        private void createPlayerTest(bool allowFail = false, Func<RulesetInfo, IBeatmap> createBeatmap = null, Func<Ruleset> createRuleset = null)
+        [Test]
+        public void TestNoSubmissionWithModsOfDifferentRuleset()
+        {
+            prepareTestAPI(true);
+
+            createPlayerTest(createRuleset: () => new OsuRuleset(), createMods: () => new Mod[] { new TaikoModHidden() });
+
+            AddUntilStep("wait for token request", () => Player.TokenCreationRequested);
+
+            AddStep("exit", () => Player.Exit());
+            AddAssert("ensure no submission", () => Player.SubmittedScore == null);
+        }
+
+        private void createPlayerTest(bool allowFail = false, Func<RulesetInfo, IBeatmap> createBeatmap = null, Func<Ruleset> createRuleset = null, Func<Mod[]> createMods = null)
         {
             CreateTest(() => AddStep("set up requirements", () =>
             {
                 this.allowFail = allowFail;
                 createCustomBeatmap = createBeatmap;
                 createCustomRuleset = createRuleset;
+                createCustomMods = createMods;
             }));
         }
 

--- a/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
@@ -8,6 +8,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osuTK;
 
@@ -29,7 +30,7 @@ namespace osu.Game.Tests.Visual.Mods
         public void TestMaximumAchievableAccuracy() =>
             CreateModTest(new ModTestData
             {
-                Mod = new ModAccuracyChallenge
+                Mod = new OsuModAccuracyChallenge
                 {
                     MinimumAccuracy = { Value = 0.6 }
                 },
@@ -49,7 +50,7 @@ namespace osu.Game.Tests.Visual.Mods
         public void TestStandardAccuracy() =>
             CreateModTest(new ModTestData
             {
-                Mod = new ModAccuracyChallenge
+                Mod = new OsuModAccuracyChallenge
                 {
                     MinimumAccuracy = { Value = 0.6 },
                     AccuracyJudgeMode = { Value = ModAccuracyChallenge.AccuracyMode.Standard }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -38,6 +38,7 @@ using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Ranking;
 using osu.Game.Skinning;
 using osu.Game.Users;
+using osu.Game.Utils;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
@@ -213,7 +214,7 @@ namespace osu.Game.Screens.Play
             if (playableBeatmap == null)
                 return;
 
-            if (gameplayMods.Any(m => ruleset.AllMods.All(rulesetMod => m.GetType() != rulesetMod.GetType())))
+            if (!ModUtils.CheckModsBelongToRuleset(ruleset, gameplayMods))
             {
                 Logger.Log($@"Gameplay was started with a mod belonging to a ruleset different than '{ruleset.Description}'.", level: LogLevel.Important);
                 return;

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -213,6 +213,12 @@ namespace osu.Game.Screens.Play
             if (playableBeatmap == null)
                 return;
 
+            if (gameplayMods.Any(m => ruleset.AllMods.All(rulesetMod => m.GetType() != rulesetMod.GetType())))
+            {
+                Logger.Log($@"Gameplay was started with a mod belonging to a ruleset different than '{ruleset.Description}'.", level: LogLevel.Important);
+                return;
+            }
+
             mouseWheelDisabled = config.GetBindable<bool>(OsuSetting.MouseDisableWheel);
 
             if (game != null)

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -255,7 +255,7 @@ namespace osu.Game.Utils
                 }
 
                 if (!found)
-                    return true;
+                    return false;
             }
 
             return true;

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -230,6 +230,38 @@ namespace osu.Game.Utils
         }
 
         /// <summary>
+        /// Verifies all mods provided belong to the given ruleset.
+        /// </summary>
+        /// <param name="ruleset">The ruleset to check the proposed mods against.</param>
+        /// <param name="proposedMods">The mods proposed for checking.</param>
+        /// <returns>Whether all <paramref name="proposedMods"/> belong to the given <paramref name="ruleset"/>.</returns>
+        public static bool CheckModsBelongToRuleset(Ruleset ruleset, IEnumerable<Mod> proposedMods)
+        {
+            var rulesetModsTypes = ruleset.AllMods.Select(m => m.GetType()).ToList();
+
+            foreach (var proposedMod in proposedMods)
+            {
+                bool found = false;
+
+                var proposedModType = proposedMod.GetType();
+
+                foreach (var rulesetModType in rulesetModsTypes)
+                {
+                    if (rulesetModType == proposedModType)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                    return true;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Given a value of a score multiplier, returns a string version with special handling for a value near 1.00x.
         /// </summary>
         /// <param name="scoreMultiplier">The value of the score multiplier.</param>

--- a/osu.Game/Utils/ModUtils.cs
+++ b/osu.Game/Utils/ModUtils.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Utils
 
                 foreach (var rulesetModType in rulesetModsTypes)
                 {
-                    if (rulesetModType == proposedModType)
+                    if (rulesetModType.IsAssignableFrom(proposedModType))
                     {
                         found = true;
                         break;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26498

Preview:

https://github.com/ppy/osu/assets/22781491/e73be747-ea8c-4265-8aff-c250758ee17c

(the mod instances are corrected in https://github.com/ppy/osu/pull/26496, but are being used here for the sake of demonstrating how the guard would act)