### PR TITLE
Fix glitchy path type correction for sliders in the editor

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -37,8 +37,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         public Action<DragEvent> DragInProgress;
         public Action DragEnded;
 
-        public List<PathControlPoint> PointsInSegment;
-
         public readonly BindableBool IsSelected = new BindableBool();
         public readonly PathControlPoint ControlPoint;
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -76,23 +76,12 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
             controlPoints.CollectionChanged += onControlPointsChanged;
             controlPoints.BindTo(hitObject.Path.ControlPoints);
-
-            // schedule ensure that updates are only applied after all operations from a single frame are applied.
-            // this avoids inadvertently changing the hit object path type for batch operations.
-            hitObject.Path.Validating += ensureValidPathTypes;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            hitObject.Path.Validating -= ensureValidPathTypes;
         }
 
         /// <summary>
         /// Handles correction of invalid path types.
         /// </summary>
-        private void ensureValidPathTypes()
+        public void EnsureValidPathTypes()
         {
             List<PathControlPoint> pointsInCurrentSegment = new List<PathControlPoint>();
 
@@ -113,6 +102,9 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private void ensureValidPathType(IReadOnlyList<PathControlPoint> segment)
         {
+            if (segment.Count == 0)
+                return;
+
             var first = segment[0];
 
             if (first.Type != PathType.PERFECT_CURVE)
@@ -394,6 +386,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             // Maintain the path types in case they got defaulted to bezier at some point during the drag.
             for (int i = 0; i < hitObject.Path.ControlPoints.Count; i++)
                 hitObject.Path.ControlPoints[i].Type = dragPathTypes[i];
+
+            EnsureValidPathTypes();
         }
 
         public void DragEnded() => changeHandler?.EndChange();
@@ -467,6 +461,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             {
                 foreach (var p in Pieces.Where(p => p.IsSelected.Value))
                     updatePathType(p, type);
+
+                EnsureValidPathTypes();
             });
 
             if (countOfState == totalCount)

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -316,6 +316,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSlider()
         {
+            controlPointVisualiser.EnsureValidPathTypes();
+
             if (state == SliderPlacementState.Drawing)
                 HitObject.Path.ExpectedDistance.Value = (float)HitObject.Path.CalculatedDistance;
             else

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -267,6 +267,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
                     segmentStart.Type = PathType.BEZIER;
                     break;
             }
+
+            controlPointVisualiser.EnsureValidPathTypes();
         }
 
         private void updateCursor()
@@ -316,8 +318,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
         private void updateSlider()
         {
-            controlPointVisualiser.EnsureValidPathTypes();
-
             if (state == SliderPlacementState.Drawing)
                 HitObject.Path.ExpectedDistance.Value = (float)HitObject.Path.CalculatedDistance;
             else

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -254,6 +254,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             // Move the control points from the insertion index onwards to make room for the insertion
             controlPoints.Insert(insertionIndex, pathControlPoint);
 
+            ControlPointVisualiser?.EnsureValidPathTypes();
+
             HitObject.SnapTo(distanceSnapProvider);
 
             return pathControlPoint;
@@ -274,6 +276,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
 
                 controlPoints.Remove(c);
             }
+
+            ControlPointVisualiser?.EnsureValidPathTypes();
 
             // Snap the slider to the current beat divisor before checking length validity.
             HitObject.SnapTo(distanceSnapProvider);

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -25,6 +25,8 @@ namespace osu.Game.Rulesets.Objects
 
         private readonly Bindable<int> version = new Bindable<int>();
 
+        public event Action? Validating;
+
         /// <summary>
         /// The user-set distance of the path. If non-null, <see cref="Distance"/> will match this value,
         /// and the path will be shortened/lengthened to match this length.
@@ -232,6 +234,8 @@ namespace osu.Game.Rulesets.Objects
         {
             if (pathCache.IsValid)
                 return;
+
+            Validating?.Invoke();
 
             calculatePath();
             calculateLength();

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -25,8 +25,6 @@ namespace osu.Game.Rulesets.Objects
 
         private readonly Bindable<int> version = new Bindable<int>();
 
-        public event Action? Validating;
-
         /// <summary>
         /// The user-set distance of the path. If non-null, <see cref="Distance"/> will match this value,
         /// and the path will be shortened/lengthened to match this length.
@@ -234,8 +232,6 @@ namespace osu.Game.Rulesets.Objects
         {
             if (pathCache.IsValid)
                 return;
-
-            Validating?.Invoke();
 
             calculatePath();
             calculateLength();


### PR DESCRIPTION
Fixes an issue in the mechanism responsible for turning the path type to bezier when the perfect curve circle radius is too large.

Right now it triggers the correction at the end of the frame which is after the slider body is drawn which causes a flickering behaviour. Also it could result in retaining the slider length of the perfect curve slider which makes the slider go way off-screen.

The fix is to explicitly apply the correction immediately after each batch operation on the slider path. The timing for this is quite precise because if you do it after the slider path recalculates, it will cause the slider length issue.

Potential other solution is to allow batching of operations right in `SliderPath` itself, so the `Version` only changes after your whole batch operation is done. However I dislike complicating `SliderPath` even further.

https://github.com/ppy/osu/assets/17460441/89480d18-2d5e-4eaf-9d04-d396ce0b70b0

After

https://github.com/ppy/osu/assets/17460441/135b1715-26f9-45b9-a6cc-92b72099e11d

