### PR TITLE
Fix date failing to display on leaderboard for some scores with weird datetimes

### DIFF
--- a/osu.Game/Extensions/TimeDisplayExtensions.cs
+++ b/osu.Game/Extensions/TimeDisplayExtensions.cs
@@ -59,7 +59,8 @@ namespace osu.Game.Extensions
         /// <returns>A short relative string representing the input time.</returns>
         public static string ToShortRelativeTime(this DateTimeOffset time, TimeSpan lowerCutoff)
         {
-            if (time == default)
+            // covers all `DateTimeOffset` instances with the date portion of 0001-01-01.
+            if (time.Date == default)
                 return "-";
 
             var now = DateTime.Now;


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/26517.

The score reported has a datetime of 0001/1/1 05:00:00 AM.

Bit of a dodge fix but maybe fine?