### PR TITLE
Fix toolbar buttons not being clickable at screen edges

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -26,6 +26,8 @@ namespace osu.Game.Overlays.Toolbar
 {
     public abstract partial class ToolbarButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>
     {
+        public const float PADDING = 3;
+
         protected GlobalAction? Hotkey { get; set; }
 
         public void SetIcon(Drawable icon)
@@ -90,7 +92,7 @@ namespace osu.Game.Overlays.Toolbar
                 {
                     Width = Toolbar.HEIGHT,
                     RelativeSizeAxes = Axes.Y,
-                    Padding = new MarginPadding(3),
+                    Padding = new MarginPadding(PADDING),
                     Children = new Drawable[]
                     {
                         BackgroundContent = new Container

--- a/osu.Game/Overlays/Toolbar/ToolbarButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarButton.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Overlays.Toolbar
 
         protected virtual Anchor TooltipAnchor => Anchor.TopLeft;
 
+        protected readonly Container ButtonContent;
         protected ConstrainedIconContainer IconContainer;
         protected SpriteText DrawableText;
         protected Box HoverBackground;
@@ -80,59 +81,66 @@ namespace osu.Game.Overlays.Toolbar
 
         protected ToolbarButton()
         {
-            Width = Toolbar.HEIGHT;
+            AutoSizeAxes = Axes.X;
             RelativeSizeAxes = Axes.Y;
-
-            Padding = new MarginPadding(3);
 
             Children = new Drawable[]
             {
-                BackgroundContent = new Container
+                ButtonContent = new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 6,
-                    CornerExponent = 3f,
-                    Children = new Drawable[]
-                    {
-                        HoverBackground = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = OsuColour.Gray(80).Opacity(180),
-                            Blending = BlendingParameters.Additive,
-                            Alpha = 0,
-                        },
-                        flashBackground = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Alpha = 0,
-                            Colour = Color4.White.Opacity(100),
-                            Blending = BlendingParameters.Additive,
-                        },
-                    }
-                },
-                Flow = new FillFlowContainer
-                {
-                    Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(5),
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
-                    Padding = new MarginPadding { Left = Toolbar.HEIGHT / 2, Right = Toolbar.HEIGHT / 2 },
+                    Width = Toolbar.HEIGHT,
                     RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
+                    Padding = new MarginPadding(3),
                     Children = new Drawable[]
                     {
-                        IconContainer = new ConstrainedIconContainer
+                        BackgroundContent = new Container
                         {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Size = new Vector2(20),
-                            Alpha = 0,
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = 6,
+                            CornerExponent = 3f,
+                            Children = new Drawable[]
+                            {
+                                HoverBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = OsuColour.Gray(80).Opacity(180),
+                                    Blending = BlendingParameters.Additive,
+                                    Alpha = 0,
+                                },
+                                flashBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Colour = Color4.White.Opacity(100),
+                                    Blending = BlendingParameters.Additive,
+                                },
+                            }
                         },
-                        DrawableText = new OsuSpriteText
+                        Flow = new FillFlowContainer
                         {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(5),
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Padding = new MarginPadding { Left = Toolbar.HEIGHT / 2, Right = Toolbar.HEIGHT / 2 },
+                            RelativeSizeAxes = Axes.Y,
+                            AutoSizeAxes = Axes.X,
+                            Children = new Drawable[]
+                            {
+                                IconContainer = new ConstrainedIconContainer
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Size = new Vector2(20),
+                                    Alpha = 0,
+                                },
+                                DrawableText = new OsuSpriteText
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                },
+                            },
                         },
                     },
                 },

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -42,52 +42,59 @@ namespace osu.Game.Overlays.Toolbar
             clockDisplayMode = config.GetBindable<ToolbarClockDisplayMode>(OsuSetting.ToolbarClockDisplayMode);
             prefer24HourTime = config.GetBindable<bool>(OsuSetting.Prefer24HourTime);
 
-            Padding = new MarginPadding(3);
-
             Children = new Drawable[]
             {
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 6,
-                    CornerExponent = 3f,
-                    Children = new Drawable[]
-                    {
-                        hoverBackground = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = OsuColour.Gray(80).Opacity(180),
-                            Blending = BlendingParameters.Additive,
-                            Alpha = 0,
-                        },
-                        flashBackground = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Alpha = 0,
-                            Colour = Color4.White.Opacity(100),
-                            Blending = BlendingParameters.Additive,
-                        },
-                    }
-                },
-                new FillFlowContainer
-                {
                     RelativeSizeAxes = Axes.Y,
                     AutoSizeAxes = Axes.X,
-                    Direction = FillDirection.Horizontal,
-                    Spacing = new Vector2(5),
-                    Padding = new MarginPadding(10),
+                    Padding = new MarginPadding(3),
                     Children = new Drawable[]
                     {
-                        analog = new AnalogClockDisplay
+                        new Container
                         {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = 6,
+                            CornerExponent = 3f,
+                            Children = new Drawable[]
+                            {
+                                hoverBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = OsuColour.Gray(80).Opacity(180),
+                                    Blending = BlendingParameters.Additive,
+                                    Alpha = 0,
+                                },
+                                flashBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Colour = Color4.White.Opacity(100),
+                                    Blending = BlendingParameters.Additive,
+                                },
+                            }
                         },
-                        digital = new DigitalClockDisplay
+                        new FillFlowContainer
                         {
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
+                            RelativeSizeAxes = Axes.Y,
+                            AutoSizeAxes = Axes.X,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(5),
+                            Padding = new MarginPadding(10),
+                            Children = new Drawable[]
+                            {
+                                analog = new AnalogClockDisplay
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                },
+                                digital = new DigitalClockDisplay
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                }
+                            }
                         }
                     }
                 }

--- a/osu.Game/Overlays/Toolbar/ToolbarClock.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarClock.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Toolbar
                 {
                     RelativeSizeAxes = Axes.Y,
                     AutoSizeAxes = Axes.X,
-                    Padding = new MarginPadding(3),
+                    Padding = new MarginPadding(ToolbarButton.PADDING),
                     Children = new Drawable[]
                     {
                         new Container

--- a/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarHomeButton.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Overlays.Toolbar
     {
         public ToolbarHomeButton()
         {
-            Width *= 1.4f;
+            ButtonContent.Width *= 1.4f;
             Hotkey = GlobalAction.Home;
         }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Overlays.Toolbar
         public ToolbarMusicButton()
         {
             Hotkey = GlobalAction.ToggleNowPlaying;
-            AutoSizeAxes = Axes.X;
+            ButtonContent.AutoSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Toolbar
 
             public RulesetButton()
             {
-                ButtonContent.Padding = new MarginPadding(3)
+                ButtonContent.Padding = new MarginPadding(PADDING)
                 {
                     Bottom = 5
                 };

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Toolbar
 
             public RulesetButton()
             {
-                Padding = new MarginPadding(3)
+                ButtonContent.Padding = new MarginPadding(3)
                 {
                     Bottom = 5
                 };

--- a/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarSettingsButton.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Overlays.Toolbar
     {
         public ToolbarSettingsButton()
         {
-            Width *= 1.4f;
+            ButtonContent.Width *= 1.4f;
             Hotkey = GlobalAction.ToggleSettings;
         }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarUserButton.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Overlays.Toolbar
 
         public ToolbarUserButton()
         {
-            AutoSizeAxes = Axes.X;
+            ButtonContent.AutoSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
https://github.com/ppy/osu/assets/16479013/8f5794f2-75ac-43a5-9aad-de5f8095651d

- As discussed in https://github.com/ppy/osu/discussions/26198#discussioncomment-8115555

The buttons are expanded so the currently padded region is also clickable. With this change, the buttons can be clicked at the very edge of the screen.

The PR simply nests the button content into a container and applies the padding there.

The only visual change is the position of the position of the tooltip text. I the new position aligns better with the button (I'm guessing the tooltip position change in the new design was unintentional):

| `master` | This PR |
|--------|--------|
| ![image](https://github.com/ppy/osu/assets/16479013/9478519d-7ac9-4221-9c7e-bf32968b883f) | ![image](https://github.com/ppy/osu/assets/16479013/b1db5852-ea24-4dc3-8982-703f23ffcf9c) |

Also, on `master`, the text is misaligned as the gamemode buttons have different padding (3f vs 5f).

![image](https://github.com/ppy/osu/assets/16479013/78474981-ab35-47d6-a8c3-158c2d2d98e7)
