### PR TITLE
De-dupe displayed hits in judgement counter

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private int hiddenCount()
         {
-            var num = counterDisplay.CounterFlow.Children.First(child => child.Result.Type == HitResult.LargeTickHit);
+            var num = counterDisplay.CounterFlow.Children.First(child => child.Result.Types.Contains(HitResult.LargeTickHit));
             return num.Result.ResultCount.Value;
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneJudgementCounter.cs
@@ -148,6 +148,16 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
+        public void TestNoDuplicates()
+        {
+            AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());
+            AddStep("Show all judgements", () => counterDisplay.Mode.Value = JudgementCounterDisplay.DisplayMode.All);
+            AddAssert("Check no duplicates",
+                () => counterDisplay.CounterFlow.ChildrenOfType<JudgementCounter>().Count(),
+                () => Is.EqualTo(counterDisplay.CounterFlow.ChildrenOfType<JudgementCounter>().Select(c => c.ResultName.Text).Distinct().Count()));
+        }
+
+        [Test]
         public void TestCycleDisplayModes()
         {
             AddStep("create counter", () => Child = counterDisplay = new TestJudgementCounterDisplay());

--- a/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounter.cs
+++ b/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -44,14 +45,14 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
                     {
                         Alpha = 0,
                         Font = OsuFont.Numeric.With(size: 8),
-                        Text = ruleset.Value.CreateInstance().GetDisplayNameForHitResult(Result.Type)
+                        Text = Result.DisplayName,
                     }
                 }
             };
 
-            var result = Result.Type;
+            var result = Result.Types.First();
 
-            Colour = result.IsBasic() ? colours.ForHitResult(Result.Type) : !result.IsBonus() ? colours.PurpleLight : colours.PurpleLighter;
+            Colour = result.IsBasic() ? colours.ForHitResult(result) : !result.IsBonus() ? colours.PurpleLight : colours.PurpleLighter;
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -49,7 +50,7 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
                 AutoSizeAxes = Axes.Both
             };
 
-            foreach (var result in judgementCountController.Results)
+            foreach (var result in judgementCountController.Counters)
                 CounterFlow.Add(createCounter(result));
         }
 
@@ -88,7 +89,9 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
                 if (index == 0 && !ShowMaxJudgement.Value)
                     return false;
 
-                if (counter.Result.Type.IsBasic())
+                var hitResult = counter.Result.Types.First();
+
+                if (hitResult.IsBasic())
                     return true;
 
                 switch (Mode.Value)
@@ -97,7 +100,7 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
                         return false;
 
                     case DisplayMode.Normal:
-                        return !counter.Result.Type.IsBonus();
+                        return !hitResult.IsBonus();
 
                     case DisplayMode.All:
                         return true;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26514.

Not sure how useful showing slider end hits is when misses isn't shown... but hey.

This also reduces LINQ overhead that was present previously.