### PR TITLE
Fade hold-for-menu button out completely on non-touch devices

### DIFF
--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -16,6 +16,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -44,6 +45,8 @@ namespace osu.Game.Screens.Play.HUD
             Direction = FillDirection.Horizontal;
             Spacing = new Vector2(20, 0);
             Margin = new MarginPadding(10);
+
+            AlwaysPresent = true;
         }
 
         [BackgroundDependencyLoader(true)]
@@ -66,8 +69,14 @@ namespace osu.Game.Screens.Play.HUD
                     Action = () => Action(),
                 }
             };
+
             AutoSizeAxes = Axes.Both;
         }
+
+        [Resolved]
+        private SessionStatics sessionStatics { get; set; }
+
+        private Bindable<bool> touchActive;
 
         protected override void LoadComplete()
         {
@@ -78,7 +87,20 @@ namespace osu.Game.Screens.Play.HUD
                     : "press for menu";
             }, true);
 
-            text.FadeInFromZero(500, Easing.OutQuint).Delay(1500).FadeOut(500, Easing.OutQuint);
+            touchActive = sessionStatics.GetBindable<bool>(Static.TouchInputActive);
+
+            if (touchActive.Value)
+            {
+                Alpha = 1f;
+                text.FadeInFromZero(500, Easing.OutQuint)
+                    .Delay(1500)
+                    .FadeOut(500, Easing.OutQuint);
+            }
+            else
+            {
+                Alpha = 0;
+                text.Alpha = 0f;
+            }
 
             base.LoadComplete();
         }
@@ -99,9 +121,11 @@ namespace osu.Game.Screens.Play.HUD
                 Alpha = 1;
             else
             {
+                float minAlpha = touchActive.Value ? .08f : 0;
+
                 Alpha = Interpolation.ValueAt(
                     Math.Clamp(Clock.ElapsedFrameTime, 0, 200),
-                    Alpha, Math.Clamp(1 - positionalAdjust, 0.04f, 1), 0, 200, Easing.OutQuint);
+                    Alpha, Math.Clamp(1 - positionalAdjust, minAlpha, 1), 0, 200, Easing.OutQuint);
             }
         }
 


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu/pull/26128.
Addresses https://discord.com/channels/188630481301012481/188630652340404224/1187604735574954014

I re-PR'd this because the other attempt is a bit incorrect and fixing would be higher effort.