### PR TITLE
Fix background dim occasionally getting in a bad state when exiting gameplay

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenBeatmap.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Backgrounds
         /// </summary>
         public readonly Bindable<float> DimWhenUserSettingsIgnored = new Bindable<float>();
 
-        internal readonly IBindable<bool> IsBreakTime = new Bindable<bool>();
+        internal readonly Bindable<bool> IsBreakTime = new Bindable<bool>();
 
         private readonly DimmableBackground dimmable;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1243,7 +1243,7 @@ namespace osu.Game.Screens.Play
                     b.IgnoreUserSettings.Value = true;
 
                     b.IsBreakTime.UnbindFrom(breakTracker.IsBreakTime);
-                    b.IsBreakTime.Value = true;
+                    b.IsBreakTime.Value = false;
                 });
                 storyboardReplacesBackground.Value = false;
             }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1078,7 +1078,7 @@ namespace osu.Game.Screens.Play
                 b.FadeColour(Color4.White, 250);
 
                 // bind component bindables.
-                b.IsBreakTime.BindTo(breakTracker.IsBreakTime);
+                ((IBindable<bool>)b.IsBreakTime).BindTo(breakTracker.IsBreakTime);
 
                 b.StoryboardReplacesBackground.BindTo(storyboardReplacesBackground);
 
@@ -1238,7 +1238,13 @@ namespace osu.Game.Screens.Play
 
             if (this.IsCurrentScreen())
             {
-                ApplyToBackground(b => b.IgnoreUserSettings.Value = true);
+                ApplyToBackground(b =>
+                {
+                    b.IgnoreUserSettings.Value = true;
+
+                    b.IsBreakTime.UnbindFrom(breakTracker.IsBreakTime);
+                    b.IsBreakTime.Value = true;
+                });
                 storyboardReplacesBackground.Value = false;
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26344.

Can confirm that this was the issue by changing the `= false` that I added to an `= true`, will reproduce what was seen in the video.