### PR TITLE
Fix judgement pooling not working correctly in osu!taiko and osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -1,22 +1,23 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Rulesets.Mania.UI.Components;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
@@ -40,13 +41,15 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly ColumnFlow<Column> columnFlow;
 
         private readonly JudgementContainer<DrawableManiaJudgement> judgements;
-        private readonly DrawablePool<DrawableManiaJudgement> judgementPool;
+        private readonly JudgementPooler<DrawableManiaJudgement> judgementPooler;
 
         private readonly Drawable barLineContainer;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Columns.Any(c => c.ReceivePositionalInputAt(screenSpacePos));
 
         private readonly int firstColumnIndex;
+
+        private ISkinSource currentSkin = null!;
 
         public Stage(int firstColumnIndex, StageDefinition definition, ref ManiaAction normalColumnStartAction, ref ManiaAction specialColumnStartAction)
         {
@@ -65,7 +68,6 @@ namespace osu.Game.Rulesets.Mania.UI
 
             InternalChildren = new Drawable[]
             {
-                judgementPool = new DrawablePool<DrawableManiaJudgement>(2),
                 new Container
                 {
                     Anchor = Anchor.TopCentre,
@@ -104,7 +106,7 @@ namespace osu.Game.Rulesets.Mania.UI
                         {
                             RelativeSizeAxes = Axes.Y,
                         },
-                        new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.StageForeground), _ => null)
+                        new SkinnableDrawable(new ManiaSkinComponentLookup(ManiaSkinComponents.StageForeground))
                         {
                             RelativeSizeAxes = Axes.Both
                         },
@@ -137,10 +139,12 @@ namespace osu.Game.Rulesets.Mania.UI
                 AddNested(column);
             }
 
+            var hitWindows = new ManiaHitWindows();
+
+            AddInternal(judgementPooler = new JudgementPooler<DrawableManiaJudgement>(Enum.GetValues<HitResult>().Where(r => hitWindows.IsHitResultAllowed(r))));
+
             RegisterPool<BarLine, DrawableBarLine>(50, 200);
         }
-
-        private ISkinSource currentSkin;
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)
@@ -170,7 +174,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             base.Dispose(isDisposing);
 
-            if (currentSkin != null)
+            if (currentSkin.IsNotNull())
                 currentSkin.SourceChanged -= onSkinChanged;
         }
 
@@ -196,13 +200,13 @@ namespace osu.Game.Rulesets.Mania.UI
                 return;
 
             judgements.Clear(false);
-            judgements.Add(judgementPool.Get(j =>
+            judgements.Add(judgementPooler.Get(result.Type, j =>
             {
                 j.Apply(result, judgedObject);
 
                 j.Anchor = Anchor.Centre;
                 j.Origin = Anchor.Centre;
-            }));
+            })!);
         }
 
         protected override void Update()

--- a/osu.Game/Rulesets/UI/JudgementPooler.cs
+++ b/osu.Game/Rulesets/UI/JudgementPooler.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.UI
+{
+    /// <summary>
+    /// Handles the task of preparing poolable drawable judgements for gameplay usage.
+    /// </summary>
+    /// <typeparam name="T">The drawable judgement type.</typeparam>
+    public partial class JudgementPooler<T> : CompositeComponent
+        where T : DrawableJudgement, new()
+    {
+        private readonly IDictionary<HitResult, DrawablePool<T>> poolDictionary = new Dictionary<HitResult, DrawablePool<T>>();
+
+        private readonly IEnumerable<HitResult> usableHitResults;
+        private readonly Action<T>? onJudgementInitialLoad;
+
+        public JudgementPooler(IEnumerable<HitResult> usableHitResults, Action<T>? onJudgementInitialLoad = null)
+        {
+            this.usableHitResults = usableHitResults;
+            this.onJudgementInitialLoad = onJudgementInitialLoad;
+        }
+
+        public T? Get(HitResult result, Action<T>? setupAction)
+        {
+            if (!poolDictionary.TryGetValue(result, out var pool))
+                return null;
+
+            return pool.Get(setupAction);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            foreach (HitResult result in usableHitResults)
+            {
+                var pool = new DrawableJudgementPool(result, onJudgementInitialLoad);
+                poolDictionary.Add(result, pool);
+                AddInternal(pool);
+            }
+        }
+
+        private partial class DrawableJudgementPool : DrawablePool<T>
+        {
+            private readonly HitResult result;
+            private readonly Action<T>? onLoaded;
+
+            public DrawableJudgementPool(HitResult result, Action<T>? onLoaded)
+                : base(20)
+            {
+                this.result = result;
+                this.onLoaded = onLoaded;
+            }
+
+            protected override T CreateNewDrawable()
+            {
+                var judgement = base.CreateNewDrawable();
+
+                // just a placeholder to initialise the correct drawable hierarchy for this pool.
+                judgement.Apply(new JudgementResult(new HitObject(), new Judgement()) { Type = result }, null);
+
+                onLoaded?.Invoke(judgement);
+
+                return judgement;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reduces potential stutters when loading initial textures, plus should decrease gameplay overhead quite considerably (until now, each time a pool was requested for a different judgement type it would have to reinitialise the judgement's internal drawables).

Closes https://github.com/ppy/osu/issues/26535 (the remaining portion).