### PR TITLE
Fix cursor ripple pool not loading pooled drawables ahead of time

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorRippleVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorRippleVisualiser.cs
@@ -33,6 +33,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private void load(OsuRulesetConfigManager? rulesetConfig)
         {
             rulesetConfig?.BindWith(OsuRulesetSetting.ShowCursorRipples, showRipples);
+
+            AddInternal(ripplePool);
         }
 
         public bool OnPressed(KeyBindingPressEvent<OsuAction> e)


### PR DESCRIPTION
Increment the counter over at https://github.com/ppy/osu-framework/pull/6136.