### PR TITLE
Fix `ColourHitErrorMeter` not loading pooled drawables ahead of time

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -15,7 +15,6 @@ using osu.Game.Localisation.HUD;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 {
@@ -42,16 +41,21 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
         [SettingSource(typeof(ColourHitErrorMeterStrings), nameof(ColourHitErrorMeterStrings.JudgementShape), nameof(ColourHitErrorMeterStrings.JudgementShapeDescription))]
         public Bindable<ShapeStyle> JudgementShape { get; } = new Bindable<ShapeStyle>();
 
+        private readonly DrawablePool<HitErrorShape> judgementShapePool;
         private readonly JudgementFlow judgementsFlow;
 
         public ColourHitErrorMeter()
         {
             AutoSizeAxes = Axes.Both;
-            InternalChild = judgementsFlow = new JudgementFlow
+            InternalChildren = new Drawable[]
             {
-                JudgementShape = { BindTarget = JudgementShape },
-                JudgementSpacing = { BindTarget = JudgementSpacing },
-                JudgementCount = { BindTarget = JudgementCount }
+                judgementShapePool = new DrawablePool<HitErrorShape>(50),
+                judgementsFlow = new JudgementFlow
+                {
+                    JudgementShape = { BindTarget = JudgementShape },
+                    JudgementSpacing = { BindTarget = JudgementSpacing },
+                    JudgementCount = { BindTarget = JudgementCount }
+                }
             };
         }
 
@@ -60,7 +64,7 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
             if (!judgement.Type.IsScorable() || judgement.Type.IsBonus())
                 return;
 
-            judgementsFlow.Push(GetColourForHitResult(judgement.Type));
+            judgementsFlow.Push(judgementShapePool.Get(shape => shape.Colour = GetColourForHitResult(judgement.Type)));
         }
 
         public override void Clear()
@@ -105,15 +109,10 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
             private readonly DrawablePool<HitErrorShape> judgementLinePool = new DrawablePool<HitErrorShape>(50);
 
-            public void Push(Color4 colour)
+            public void Push(HitErrorShape shape)
             {
-                judgementLinePool.Get(shape =>
-                {
-                    shape.Colour = colour;
-                    Add(shape);
-
-                    removeExtraJudgements();
-                });
+                Add(shape);
+                removeExtraJudgements();
             }
 
             private void removeExtraJudgements()


### PR DESCRIPTION
Another casualty of https://github.com/ppy/osu-framework/pull/6136.