### PR TITLE
Fix skin potentially being lost when opening and closing skin editor rapidly

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -35,6 +35,7 @@ using osu.Game.Screens.OnlinePlay.Lounge;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
@@ -832,6 +833,24 @@ namespace osu.Game.Tests.Visual.Navigation
             pushEscape();
 
             AddAssert("exit dialog is shown", () => Game.Dependencies.Get<IDialogOverlay>().CurrentDialog is ConfirmExitDialog);
+        }
+
+        [Test]
+        public void TestQuickSkinEditorDoesntNukeSkin()
+        {
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+
+            AddStep("open", () => InputManager.Key(Key.Space));
+            AddStep("skin", () => InputManager.Key(Key.E));
+            AddStep("editor", () => InputManager.Key(Key.S));
+            AddStep("and close immediately", () => InputManager.Key(Key.Escape));
+
+            AddStep("open again", () => InputManager.Key(Key.S));
+
+            Player player = null;
+
+            AddUntilStep("wait for player", () => (player = Game.ScreenStack.CurrentScreen as Player) != null);
+            AddUntilStep("wait for gameplay still has health bar", () => player.ChildrenOfType<ArgonHealthDisplay>().Any());
         }
 
         [Test]

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected override bool StartHidden => true;
 
-        private Drawable targetScreen = null!;
+        private Drawable? targetScreen;
 
         private OsuTextFlowContainer headerText = null!;
 
@@ -541,7 +541,13 @@ namespace osu.Game.Overlays.SkinEditor
             if (!hasBegunMutating)
                 return;
 
+            if (targetScreen?.IsLoaded != true)
+                return;
+
             SkinComponentsContainer[] targetContainers = availableTargets.ToArray();
+
+            if (!targetContainers.All(c => c.ComponentsLoaded))
+                return;
 
             foreach (var t in targetContainers)
                 currentSkin.Value.UpdateDrawableTarget(t);

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -136,10 +136,15 @@ namespace osu.Game.Overlays.SkinEditor
             globallyReenableBeatmapSkinSetting();
         }
 
-        public void PresentGameplay()
+        public void PresentGameplay() => presentGameplay(false);
+
+        private void presentGameplay(bool attemptedBeatmapSwitch)
         {
             performer?.PerformFromScreen(screen =>
             {
+                if (State.Value != Visibility.Visible)
+                    return;
+
                 if (beatmap.Value is DummyWorkingBeatmap)
                 {
                     // presume we don't have anything good to play and just bail.
@@ -149,8 +154,12 @@ namespace osu.Game.Overlays.SkinEditor
                 // If we're playing the intro, switch away to another beatmap.
                 if (beatmap.Value.BeatmapSetInfo.Protected)
                 {
-                    music.NextTrack();
-                    Schedule(PresentGameplay);
+                    if (!attemptedBeatmapSwitch)
+                    {
+                        music.NextTrack();
+                        Schedule(() => presentGameplay(true));
+                    }
+
                     return;
                 }
 


### PR DESCRIPTION
Test is added, but needs to be tested manually (can't make it fail headless).

451ba1c86131e61245d4d3a9eb232cc47c32ff7e is something i noticed in passing – when I had the test not importing a beatmap it got stuck in an endless loop.

Closes https://github.com/ppy/osu/issues/26092