### PR TITLE
Make spinner-top and spinner-middle2 spin at different speeds to match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs
@@ -135,7 +135,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         protected override void Update()
         {
             base.Update();
-            spinningMiddle.Rotation = discTop.Rotation = DrawableSpinner.RotationTracker.Rotation;
+
+            float turnRatio = spinningMiddle.Texture != null ? 0.5f : 1;
+            discTop.Rotation = DrawableSpinner.RotationTracker.Rotation * turnRatio;
+            spinningMiddle.Rotation = DrawableSpinner.RotationTracker.Rotation;
+
             discBottom.Rotation = discTop.Rotation / 3;
 
             glow.Alpha = DrawableSpinner.Progress;


### PR DESCRIPTION
Resolves #26094

Like stable, this multiplies a `turnRatio`  with the `discTop` rotation, the ratio is 1 if the `spinningMiddle` texture is null and 0.5 otherwise.

Unlike stable however, mods like DT or HT make the spinner components spin faster/slower. Stable has an `ApplyModsToTime` method to mitigate this but I couldn't find anything similar in the lazer source code (the original rotation logic in lazer also didn't account for speed modifiers either).