### PR TITLE
Fix some elements not showing on leaderboard scores when almost off-screen

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -164,7 +164,8 @@ namespace osu.Game.Online.Leaderboards
                                         {
                                             Anchor = Anchor.BottomLeft,
                                             Origin = Anchor.BottomLeft,
-                                            AutoSizeAxes = Axes.Both,
+                                            AutoSizeAxes = Axes.X,
+                                            Height = 28,
                                             Direction = FillDirection.Horizontal,
                                             Spacing = new Vector2(10f, 0f),
                                             Children = new Drawable[]


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/25996. Fill flow with bottom left anchor. Content not loaded until flow comes on screen, which doesn't happen due to `AutoSize=Y` causing masked away due to zero content loaded.

Adjust UI scale until score is mostly off-screen to test.

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-16 at 07 47 22](https://github.com/ppy/osu/assets/191335/e0671801-7425-4817-973e-4e9e49c8a8e0) | ![CleanShot 2024-01-16 at 07 47 07](https://github.com/ppy/osu/assets/191335/3a33ec9e-f616-4345-8de9-e2d7d51cf2d0) |