### PR TITLE
Fix multiple issues with `GlowingSpriteText`

### DIFF
--- a/osu.Game/Online/Leaderboards/LeaderboardScore.cs
+++ b/osu.Game/Online/Leaderboards/LeaderboardScore.cs
@@ -358,14 +358,12 @@ namespace osu.Game.Online.Leaderboards
                                 },
                             },
                         },
-                        new GlowingSpriteText
+                        new OsuSpriteText
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            TextColour = Color4.White,
-                            GlowColour = Color4Extensions.FromHex(@"83ccfa"),
                             Text = statistic.Value,
-                            Font = OsuFont.GetFont(size: 17, weight: FontWeight.Bold),
+                            Font = OsuFont.GetFont(size: 17, weight: FontWeight.Bold, fixedWidth: true)
                         },
                     },
                 };


### PR DESCRIPTION
At first I was considering removing this component from the leaderboard since it's barely noticeable, but decided to check old designs to see how it supposed to look like.
| design in question | master | pr |
|---|---|---|
|![design](https://github.com/ppy/osu/assets/22874522/6669ecab-3f8d-4ef0-9d15-7eb6e5ca4f35)|![current](https://github.com/ppy/osu/assets/22874522/86325fa6-2a04-4a2f-971c-54c77d661873)|![pr](https://github.com/ppy/osu/assets/22874522/d5815a27-46b1-4cd7-b8fc-d742807b5283)|

**Overall structure**
Previously `GlowingSpriteText` is a container with a `BufferendContainer` inside and another copy of the text. First things first: there's no reason to hold another copy since `BufferedContainer` provides `DrawOriginal` property. And now we can directly inherit from `BufferedContainer`.

**Texture size**
This is a bad one. Previously to prevent glow from trimming `BufferendContainer`'s scale was set to 3x, so textures were way bigger than needed. Now that we are directly inheriting from it we can just inflate `ScreenSpaceDrawQuad` by the required amount.
|master|pr|
|---|---|
|![score-texture-old](https://github.com/ppy/osu/assets/22874522/92fb087a-a169-4dc1-ba2f-4d483b7384a7)|![score-texture-new](https://github.com/ppy/osu/assets/22874522/0a86034c-ef86-40b9-9fe2-0480f367292a)|
|![result-texture-old](https://github.com/ppy/osu/assets/22874522/1f5f51cb-024b-4edf-b3df-2b9e2ad8fa43)|![result-texture-new](https://github.com/ppy/osu/assets/22874522/f6d67331-e145-4dde-a385-9e46bcf1e435)|

**Better looking glow**
Previously mixing was happening with transparent black colour, but now we can utilize `BackgroundColour` property to fix that.

**`ScoreComponentLabel` doesn't need glow at all**
Looking at the (outdated) design it looks like we don't need to use glow for this component. Including the fact that currently it's barely visible (if at all) it felt safe to remove that usage.

**End result**
|master|pr|
|---|---|
|![song-select-old](https://github.com/ppy/osu/assets/22874522/92679509-0245-423f-9615-6e88c3f86cc0)|![song-select-new](https://github.com/ppy/osu/assets/22874522/634cd710-2044-4322-9556-2d7c59a4d055)|
|![results-old](https://github.com/ppy/osu/assets/22874522/d5de1b37-16ce-4a02-a16f-36ede918e8a5)|![results-new](https://github.com/ppy/osu/assets/22874522/24b7fc27-efc8-4b43-9074-a0990ccef6ce)|