### PR TITLE
Fix flashlight not dimming if slider head is hit early

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -116,5 +116,44 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 Autoplay = false,
             });
         }
+
+        [Test]
+        public void TestSliderDoesDimAfterStartTimeIfHitLate()
+        {
+            bool sliderDimmed = false;
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new OsuModFlashlight(),
+                PassCondition = () =>
+                {
+                    sliderDimmed |=
+                        Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
+                    return Player.GameplayState.HasPassed && sliderDimmed;
+                },
+                Beatmap = new OsuBeatmap
+                {
+                    HitObjects = new List<OsuHitObject>
+                    {
+                        new Slider
+                        {
+                            StartTime = 1000,
+                            Path = new SliderPath(new[]
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(100))
+                            })
+                        }
+                    },
+                },
+                ReplayFrames = new List<ReplayFrame>
+                {
+                    new OsuReplayFrame(1100, new Vector2(), OsuAction.LeftButton),
+                    new OsuReplayFrame(2000, new Vector2(100), OsuAction.LeftButton),
+                    new OsuReplayFrame(2001, new Vector2(100)),
+                },
+                Autoplay = false,
+            });
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -77,5 +77,44 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 Autoplay = false,
             });
         }
+
+        [Test]
+        public void TestSliderDoesDimAfterStartTimeIfHitEarly()
+        {
+            bool sliderDimmed = false;
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new OsuModFlashlight(),
+                PassCondition = () =>
+                {
+                    sliderDimmed |=
+                        Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
+                    return Player.GameplayState.HasPassed && sliderDimmed;
+                },
+                Beatmap = new OsuBeatmap
+                {
+                    HitObjects = new List<OsuHitObject>
+                    {
+                        new Slider
+                        {
+                            StartTime = 1000,
+                            Path = new SliderPath(new[]
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(100))
+                            })
+                        }
+                    },
+                },
+                ReplayFrames = new List<ReplayFrame>
+                {
+                    new OsuReplayFrame(990, new Vector2(), OsuAction.LeftButton),
+                    new OsuReplayFrame(2000, new Vector2(100), OsuAction.LeftButton),
+                    new OsuReplayFrame(2001, new Vector2(100)),
+                },
+                Autoplay = false,
+            });
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
             if (drawable is DrawableSlider s)
-                s.Tracking.ValueChanged += _ => flashlight.OnSliderTrackingChange(s);
+                s.OnUpdate += _ => flashlight.OnSliderTrackingChange(s);
         }
 
         private partial class OsuFlashlight : Flashlight, IRequireHighFrequencyMousePosition


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26551

\>_<

Fix is a bit nuclear (`OnUpdate` should be considered last resort), but I don't see many better alternatives here as `ApplyCustomUpdateState` does not work...