### PR TITLE
Fix taiko maps containing only drum rolls / swells not being passable without mods

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
@@ -106,5 +106,71 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 Assert.That(healthProcessor.HasFailed, Is.True);
             });
         }
+
+        [Test]
+        public void TestDrumRollOnly()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new DrumRoll { Duration = 2000 }
+                }
+            };
+
+            foreach (var ho in beatmap.HitObjects)
+                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var healthProcessor = new TaikoHealthProcessor();
+            healthProcessor.ApplyBeatmap(beatmap);
+
+            foreach (var nested in beatmap.HitObjects[0].NestedHitObjects)
+            {
+                var nestedJudgement = nested.CreateJudgement();
+                healthProcessor.ApplyResult(new JudgementResult(nested, nestedJudgement) { Type = nestedJudgement.MaxResult });
+            }
+
+            var judgement = beatmap.HitObjects[0].CreateJudgement();
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], judgement) { Type = judgement.MaxResult });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(healthProcessor.Health.Value, Is.EqualTo(1));
+                Assert.That(healthProcessor.HasFailed, Is.False);
+            });
+        }
+
+        [Test]
+        public void TestSwellOnly()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new DrumRoll { Duration = 2000 }
+                }
+            };
+
+            foreach (var ho in beatmap.HitObjects)
+                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var healthProcessor = new TaikoHealthProcessor();
+            healthProcessor.ApplyBeatmap(beatmap);
+
+            foreach (var nested in beatmap.HitObjects[0].NestedHitObjects)
+            {
+                var nestedJudgement = nested.CreateJudgement();
+                healthProcessor.ApplyResult(new JudgementResult(nested, nestedJudgement) { Type = nestedJudgement.MaxResult });
+            }
+
+            var judgement = beatmap.HitObjects[0].CreateJudgement();
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], judgement) { Type = judgement.MaxResult });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(healthProcessor.Health.Value, Is.EqualTo(1));
+                Assert.That(healthProcessor.HasFailed, Is.False);
+            });
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
@@ -1,0 +1,110 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Judgements;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Scoring;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    [TestFixture]
+    public class TaikoHealthProcessorTest
+    {
+        [Test]
+        public void TestHitsOnlyGreat()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Hit(),
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 },
+                    new Hit { StartTime = 3000 },
+                    new Hit { StartTime = 4000 },
+                }
+            };
+
+            var healthProcessor = new TaikoHealthProcessor();
+            healthProcessor.ApplyBeatmap(beatmap);
+
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new TaikoJudgement()) { Type = HitResult.Great });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], new TaikoJudgement()) { Type = HitResult.Great });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[2], new TaikoJudgement()) { Type = HitResult.Great });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[3], new TaikoJudgement()) { Type = HitResult.Great });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[4], new TaikoJudgement()) { Type = HitResult.Great });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(healthProcessor.Health.Value, Is.EqualTo(1));
+                Assert.That(healthProcessor.HasFailed, Is.False);
+            });
+        }
+
+        [Test]
+        public void TestHitsAboveThreshold()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Hit(),
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 },
+                    new Hit { StartTime = 3000 },
+                    new Hit { StartTime = 4000 },
+                }
+            };
+
+            var healthProcessor = new TaikoHealthProcessor();
+            healthProcessor.ApplyBeatmap(beatmap);
+
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new TaikoJudgement()) { Type = HitResult.Great });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[2], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[3], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[4], new TaikoJudgement()) { Type = HitResult.Miss });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(healthProcessor.Health.Value, Is.GreaterThan(0.5));
+                Assert.That(healthProcessor.HasFailed, Is.False);
+            });
+        }
+
+        [Test]
+        public void TestHitsBelowThreshold()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Hit(),
+                    new Hit { StartTime = 1000 },
+                    new Hit { StartTime = 2000 },
+                    new Hit { StartTime = 3000 },
+                    new Hit { StartTime = 4000 },
+                }
+            };
+
+            var healthProcessor = new TaikoHealthProcessor();
+            healthProcessor.ApplyBeatmap(beatmap);
+
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[0], new TaikoJudgement()) { Type = HitResult.Miss });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[1], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[2], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[3], new TaikoJudgement()) { Type = HitResult.Ok });
+            healthProcessor.ApplyResult(new JudgementResult(beatmap.HitObjects[4], new TaikoJudgement()) { Type = HitResult.Miss });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(healthProcessor.Health.Value, Is.LessThan(0.5));
+                Assert.That(healthProcessor.HasFailed, Is.True);
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Scoring/TaikoHealthProcessor.cs
+++ b/osu.Game.Rulesets.Taiko/Scoring/TaikoHealthProcessor.cs
@@ -31,9 +31,37 @@ namespace osu.Game.Rulesets.Taiko.Scoring
         /// </summary>
         private double hpMissMultiplier;
 
+        /// <summary>
+        /// Sum of all achievable health increases throughout the map.
+        /// Used to determine if there are any objects that give health.
+        /// If there are none, health will be forcibly pulled up to 1 to avoid cases of impassable maps.
+        /// </summary>
+        private double sumOfMaxHealthIncreases;
+
         public TaikoHealthProcessor()
             : base(0.5)
         {
+        }
+
+        protected override void ApplyResultInternal(JudgementResult result)
+        {
+            base.ApplyResultInternal(result);
+            sumOfMaxHealthIncreases += result.Judgement.MaxHealthIncrease;
+        }
+
+        protected override void RevertResultInternal(JudgementResult result)
+        {
+            base.RevertResultInternal(result);
+            sumOfMaxHealthIncreases -= result.Judgement.MaxHealthIncrease;
+        }
+
+        protected override void Reset(bool storeResults)
+        {
+            base.Reset(storeResults);
+
+            if (storeResults && sumOfMaxHealthIncreases == 0)
+                Health.Value = 1;
+            sumOfMaxHealthIncreases = 0;
         }
 
         public override void ApplyBeatmap(IBeatmap beatmap)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26370.

As was noted in the issue thread stable does not attempt to account for such maps, and the maps are impassable in stable without No Fail. Nevertheless that seems like a pretty anti-player behaviour and I honestly believe (maybe foolishly) that it is fine to change this in lazer.