### PR TITLE
Fix incorrect accuracy and rank population when decoding lazer replays

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -3,14 +3,18 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Beatmaps.Legacy;
+using osu.Game.IO.Legacy;
 using osu.Game.Replays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -244,6 +248,123 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decodedAfterEncode.ScoreInfo.MaximumStatistics, Is.EqualTo(scoreInfo.MaximumStatistics));
                 Assert.That(decodedAfterEncode.ScoreInfo.Mods, Is.EqualTo(scoreInfo.Mods));
                 Assert.That(decodedAfterEncode.ScoreInfo.ClientVersion, Is.EqualTo("2023.1221.0"));
+            });
+        }
+
+        [Test]
+        public void AccuracyAndRankOfStableScorePreserved()
+        {
+            var memoryStream = new MemoryStream();
+
+            // local partial implementation of legacy score encoder
+            // this is done half for readability, half because `LegacyScoreEncoder` forces `LATEST_VERSION`
+            // and we want to emulate a stable score here
+            using (var sw = new SerializationWriter(memoryStream, true))
+            {
+                sw.Write((byte)0); // ruleset id (osu!)
+                sw.Write(20240116); // version (anything below `LegacyScoreEncoder.FIRST_LAZER_VERSION` is stable)
+                sw.Write(string.Empty.ComputeMD5Hash()); // beatmap hash, irrelevant to this test
+                sw.Write("username"); // irrelevant to this test
+                sw.Write(string.Empty.ComputeMD5Hash()); // score hash, irrelevant to this test
+                sw.Write((ushort)198); // count300
+                sw.Write((ushort)1); // count100
+                sw.Write((ushort)0); // count50
+                sw.Write((ushort)0); // countGeki
+                sw.Write((ushort)0); // countKatu
+                sw.Write((ushort)1); // countMiss
+                sw.Write(12345678); // total score, irrelevant to this test
+                sw.Write((ushort)1000); // max combo, irrelevant to this test
+                sw.Write(false); // full combo, irrelevant to this test
+                sw.Write((int)LegacyMods.Hidden); // mods
+                sw.Write(string.Empty); // hp graph, irrelevant
+                sw.Write(DateTime.Now); // date, irrelevant
+                sw.Write(Array.Empty<byte>()); // replay data, irrelevant
+                sw.Write((long)1234); // legacy online ID, irrelevant
+            }
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            var decoded = new TestLegacyScoreDecoder().Parse(memoryStream);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decoded.ScoreInfo.Accuracy, Is.EqualTo((double)(198 * 300 + 100) / (200 * 300)));
+                Assert.That(decoded.ScoreInfo.Rank, Is.EqualTo(ScoreRank.A));
+            });
+        }
+
+        [Test]
+        public void AccuracyAndRankOfLazerScorePreserved()
+        {
+            var ruleset = new OsuRuleset().RulesetInfo;
+
+            var scoreInfo = TestResources.CreateTestScoreInfo(ruleset);
+            scoreInfo.Mods = new Mod[] { new OsuModFlashlight() };
+            scoreInfo.Statistics = new Dictionary<HitResult, int>
+            {
+                [HitResult.Great] = 199,
+                [HitResult.Miss] = 1,
+                [HitResult.LargeTickHit] = 1,
+            };
+            scoreInfo.MaximumStatistics = new Dictionary<HitResult, int>
+            {
+                [HitResult.Great] = 200,
+                [HitResult.LargeTickHit] = 1,
+            };
+
+            var beatmap = new TestBeatmap(ruleset);
+            var score = new Score
+            {
+                ScoreInfo = scoreInfo,
+            };
+
+            var decodedAfterEncode = encodeThenDecode(LegacyBeatmapDecoder.LATEST_VERSION, score, beatmap);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decodedAfterEncode.ScoreInfo.Accuracy, Is.EqualTo((double)(199 * 300 + 30) / (200 * 300 + 30)));
+                Assert.That(decodedAfterEncode.ScoreInfo.Rank, Is.EqualTo(ScoreRank.SH));
+            });
+        }
+
+        [Test]
+        public void AccuracyAndRankOfLazerScoreWithoutLegacyReplaySoloScoreInfoUsesBestEffortFallbackToLegacy()
+        {
+            var memoryStream = new MemoryStream();
+
+            // local partial implementation of legacy score encoder
+            // this is done half for readability, half because we want to emulate an old lazer score here
+            // that does not have everything that `LegacyScoreEncoder` now writes to the replay
+            using (var sw = new SerializationWriter(memoryStream, true))
+            {
+                sw.Write((byte)0); // ruleset id (osu!)
+                sw.Write(LegacyScoreEncoder.FIRST_LAZER_VERSION); // version
+                sw.Write(string.Empty.ComputeMD5Hash()); // beatmap hash, irrelevant to this test
+                sw.Write("username"); // irrelevant to this test
+                sw.Write(string.Empty.ComputeMD5Hash()); // score hash, irrelevant to this test
+                sw.Write((ushort)198); // count300
+                sw.Write((ushort)0); // count100
+                sw.Write((ushort)1); // count50
+                sw.Write((ushort)0); // countGeki
+                sw.Write((ushort)0); // countKatu
+                sw.Write((ushort)1); // countMiss
+                sw.Write(12345678); // total score, irrelevant to this test
+                sw.Write((ushort)1000); // max combo, irrelevant to this test
+                sw.Write(false); // full combo, irrelevant to this test
+                sw.Write((int)LegacyMods.Hidden); // mods
+                sw.Write(string.Empty); // hp graph, irrelevant
+                sw.Write(DateTime.Now); // date, irrelevant
+                sw.Write(Array.Empty<byte>()); // replay data, irrelevant
+                sw.Write((long)1234); // legacy online ID, irrelevant
+                // importantly, no compressed `LegacyReplaySoloScoreInfo` here
+            }
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+            var decoded = new TestLegacyScoreDecoder().Parse(memoryStream);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(decoded.ScoreInfo.Accuracy, Is.EqualTo((double)(198 * 300 + 50) / (200 * 300)));
+                Assert.That(decoded.ScoreInfo.Rank, Is.EqualTo(ScoreRank.A));
             });
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24061.

The gist of this change is that if the `LegacyReplaySoloScoreInfo` bolt-on is present in the replay, then it can (and is) used to recompute the accuracy, and rank is computed based on that.

This was the missing part of https://github.com/ppy/osu/issues/24061#issuecomment-1888438151. The accuracy would change on import before that because the encode process is _lossy_ if the `LegacyReplaySoloScoreInfo` bolt-on is not used, as the legacy format only has 6 fields for encoding judgement counts, and some judgements that affect accuracy in lazer do not fit into that.

Note that this _only_ fixes _relatively_ new lazer scores looking wrong after reimport.

- Very old lazer scores, i.e. ones that don't have the `LegacyReplaySoloScoreInfo` bolt-on, obviously can't use it to repopulate.  There's really not much good that can be done there, so the stable pathways are used as a fallback that always works.

- For stable replays, `ScoreImporter` recalculates the accuracy of the score _again_ in

  https://github.com/ppy/osu/blob/15a5fd7e4c8e8e3c38382cfd3d5d676d107d7908/osu.Game/Scoring/ScoreImporter.cs#L106-L110

  as `StandardisedScoreMigrationTools.UpdateFromLegacy()` recomputes _both_ total score and accuracy.

  This makes a _semblance_ of sense as it attempts to make the accuracy of stable and lazer scores comparable. In most cases it also won't matter, as the only ruleset where accuracy changed between the legacy implementation and current lazer accuracy is mania.

  But it is also an inaccurate process (as, again, some of the required data is not in the replay, namely judgement counts of ticks
  and so on). For whatever's worth, a similar thing happens [server-side](https://github.com/ppy/osu-queue-score-statistics/blob/106c2948dbe695efcad5972d32cd46f4b36005cc/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs#L319).

- However, _ranks_ of stable scores will still use the local stable reimplementation of ranks, i.e. a 1-miss stable score in osu! ruleset
  will be an A rather than an S. Compare [server-side score importer](https://github.com/ppy/osu-queue-score-statistics/blob/106c2948dbe695efcad5972d32cd46f4b36005cc/osu.Server.Queues.ScoreStatisticsProcessor/Commands/Queue/BatchInserter.cs#L237)

  (it's the same method which is renamed to `PopulateLegacyAccuracyAndRank()` in this PR).

  That is all a bit of a mess honestly, but I'm not sure where to even begin there...