### PR TITLE
Fix timing point changes not applying after selecting another one

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -202,7 +202,7 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.MoveMouseTo(timeSignatureTextBox);
                 InputManager.Click(MouseButton.Left);
 
-                Debug.Assert(!timeSignatureTextBox.Current.Value.Equals("1"));
+                Debug.Assert(!timeSignatureTextBox.Current.Value.Equals("1", StringComparison.Ordinal));
                 timeSignatureTextBox.Current.Value = "1";
             });
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -4,11 +4,13 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
@@ -175,6 +177,43 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("Seek to last point", () => EditorClock.Seek(101 * 1000));
 
             AddUntilStep("Scrolled to end", () => timingScreen.ChildrenOfType<OsuScrollContainer>().First().IsScrolledToEnd());
+        }
+
+        [Test]
+        public void TestEditThenClickAway()
+        {
+            AddStep("Add two control points", () =>
+            {
+                editorBeatmap.ControlPointInfo.Clear();
+                editorBeatmap.ControlPointInfo.Add(1000, new TimingControlPoint());
+                editorBeatmap.ControlPointInfo.Add(2000, new TimingControlPoint());
+            });
+
+            AddStep("Select second timing point", () =>
+            {
+                InputManager.MoveMouseTo(Child.ChildrenOfType<TimingRowAttribute>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("Scroll to end", () => timingScreen.ChildrenOfType<ControlPointSettings>().Single().ChildrenOfType<OsuScrollContainer>().Single().ScrollToEnd(false));
+            AddStep("Modify time signature", () =>
+            {
+                var timeSignatureTextBox = Child.ChildrenOfType<LabelledTimeSignature.TimeSignatureBox>().Single().ChildrenOfType<TextBox>().Single();
+                InputManager.MoveMouseTo(timeSignatureTextBox);
+                InputManager.Click(MouseButton.Left);
+
+                Debug.Assert(!timeSignatureTextBox.Current.Value.Equals("1"));
+                timeSignatureTextBox.Current.Value = "1";
+            });
+
+            AddStep("Select first timing point", () =>
+            {
+                InputManager.MoveMouseTo(Child.ChildrenOfType<TimingRowAttribute>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("Second timing point changed time signature", () => editorBeatmap.ControlPointInfo.TimingPoints.Last().TimeSignature.Numerator == 1);
+            AddAssert("First timing point preserved time signature", () => editorBeatmap.ControlPointInfo.TimingPoints.First().TimeSignature.Numerator == 4);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestEditThenClickAway()
+        public void TestEditThenClickAwayAppliesChanges()
         {
             AddStep("Add two control points", () =>
             {

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -44,11 +44,12 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     BackgroundFlow.Add(new RowBackground(group)
                     {
-                        Action = () =>
+                        // schedule to give time for any modified focused text box to lose focus and commit changes (e.g. BPM / time signature textboxes) before switching to new point.
+                        Action = () => Schedule(() =>
                         {
                             SetSelectedRow(group);
                             clock.SeekSmoothlyTo(group.Time);
-                        }
+                        })
                     });
                 }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26581

This is resolved by scheduling the switch in control point selection, since, at the moment that the user clicks and `RowBackground` handles the click (returning true in `OnClick`), focus lost event is rolled out to any focused text box and commit calls are made. 

In master, control points are switched before the focus lost event is dispatched, causing the text box to commit to the new control point rather than the previously selected one.

By scheduling, focus lost events are dispatched first, then the control point is switched in the next frame.

Before:

https://github.com/ppy/osu/assets/22781491/bca608a9-1dbd-4626-a59e-d5292c1b0323

After:

https://github.com/ppy/osu/assets/22781491/94b9ad55-c34e-43c9-81ad-e81fe8cf0a84
