### PR TITLE
Fix tournament beatmap backgrounds occasionally not loading

### DIFF
--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -12,6 +12,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
+using osu.Game.Models;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Menu;
 using osuTK;
@@ -101,11 +102,25 @@ namespace osu.Game.Tournament.Components
 
         private void refreshContent()
         {
-            if (beatmap == null)
+            beatmap ??= new BeatmapInfo
             {
-                flow.Clear();
-                return;
-            }
+                Metadata = new BeatmapMetadata
+                {
+                    Artist = "unknown",
+                    Title = "no beatmap selected",
+                    Author = new RealmUser { Username = "unknown" },
+                },
+                DifficultyName = "unknown",
+                BeatmapSet = new BeatmapSetInfo(),
+                StarRating = 0,
+                Difficulty = new BeatmapDifficulty
+                {
+                    CircleSize = 0,
+                    DrainRate = 0,
+                    OverallDifficulty = 0,
+                    ApproachRate = 0,
+                },
+            };
 
             double bpm = beatmap.BPM;
             double length = beatmap.Length;

--- a/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
+++ b/osu.Game.Tournament/Components/TournamentBeatmapPanel.cs
@@ -194,7 +194,7 @@ namespace osu.Game.Tournament.Components
 
             // Use DelayedLoadWrapper to avoid content unloading when switching away to another screen.
             protected override DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
-                => new DelayedLoadWrapper(createContentFunc, timeBeforeLoad);
+                => new DelayedLoadWrapper(createContentFunc(), timeBeforeLoad);
         }
     }
 }


### PR DESCRIPTION
I don't even know which component should take blame here, or whether any framework changes should be required to resolve this.

Basically, when constructing a `DelayedLoadWrapper` with a `Func<Drawable>`, a different initialisation path is invoked which doesn't copy sizing attributes from the future drawable (to avoid constructing the drawable until required). At first I thought `ModelBackedDrawable` was at fault, but it was working fine in the framework implementation. Turns out it was an oversight in the local override.

The end result is that the `DelayedLoadWrapper` was of size `(0,0)` and placed in the bottom-left corner of the window, ready to floating-point-precifaaaaaaaaill itself to never load.

Closes https://github.com/ppy/osu/issues/26550#issuecomment-1893506530

---

This also shows an empty beatmap instead of nothing when no beatmap is selected.