### PR TITLE
Change key overlay to use the ordering provided by rulesets

### DIFF
--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -69,11 +69,11 @@ namespace osu.Game.Rulesets.Taiko
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]
         {
-            new KeyBinding(InputKey.D, TaikoAction.LeftRim),
-            new KeyBinding(InputKey.F, TaikoAction.LeftCentre),
-            new KeyBinding(InputKey.MouseLeft, TaikoAction.LeftCentre),
-            new KeyBinding(InputKey.J, TaikoAction.RightCentre),
             new KeyBinding(InputKey.MouseRight, TaikoAction.LeftRim),
+            new KeyBinding(InputKey.D, TaikoAction.LeftRim),
+            new KeyBinding(InputKey.MouseLeft, TaikoAction.LeftCentre),
+            new KeyBinding(InputKey.F, TaikoAction.LeftCentre),
+            new KeyBinding(InputKey.J, TaikoAction.RightCentre),
             new KeyBinding(InputKey.K, TaikoAction.RightRim),
         };
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -69,11 +69,11 @@ namespace osu.Game.Rulesets.Taiko
 
         public override IEnumerable<KeyBinding> GetDefaultKeyBindings(int variant = 0) => new[]
         {
-            new KeyBinding(InputKey.MouseLeft, TaikoAction.LeftCentre),
-            new KeyBinding(InputKey.MouseRight, TaikoAction.LeftRim),
             new KeyBinding(InputKey.D, TaikoAction.LeftRim),
             new KeyBinding(InputKey.F, TaikoAction.LeftCentre),
+            new KeyBinding(InputKey.MouseLeft, TaikoAction.LeftCentre),
             new KeyBinding(InputKey.J, TaikoAction.RightCentre),
+            new KeyBinding(InputKey.MouseRight, TaikoAction.LeftRim),
             new KeyBinding(InputKey.K, TaikoAction.RightRim),
         };
 

--- a/osu.Game/Rulesets/UI/RulesetInputManager.cs
+++ b/osu.Game/Rulesets/UI/RulesetInputManager.cs
@@ -167,7 +167,6 @@ namespace osu.Game.Rulesets.UI
             var triggers = KeyBindingContainer.DefaultKeyBindings
                                               .Select(b => b.GetAction<T>())
                                               .Distinct()
-                                              .OrderBy(action => action)
                                               .Select(action => new KeyCounterActionTrigger<T>(action))
                                               .ToArray();
 


### PR DESCRIPTION
osu!mania already goes out of its way to order things correctly. Arguably, osu!taiko just did it wrong.

See commit which fixes the original reason for adding `Order` (https://github.com/ppy/osu/pull/10553).

Addresses https://github.com/ppy/osu/discussions/25944.