### PR TITLE
Show offset explanation tooltip on settings offset adjust slider bar

### DIFF
--- a/osu.Game/Localisation/BeatmapOffsetControlStrings.cs
+++ b/osu.Game/Localisation/BeatmapOffsetControlStrings.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.BeatmapOffsetControl";
 
         /// <summary>
-        /// "Beatmap offset"
+        /// "Audio offset (this beatmap)"
         /// </summary>
-        public static LocalisableString BeatmapOffset => new TranslatableString(getKey(@"beatmap_offset"), @"Beatmap offset");
+        public static LocalisableString AudioOffsetThisBeatmap => new TranslatableString(getKey(@"beatmap_offset"), @"Audio offset (this beatmap)");
 
         /// <summary>
         /// "Previous play:"

--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -12,12 +12,14 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Screens.Play.PlayerSettings;
 using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
@@ -67,7 +69,7 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        new TimeSlider
+                        new OffsetSliderBar
                         {
                             RelativeSizeAxes = Axes.X,
                             Current = { BindTarget = Current },
@@ -156,6 +158,11 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     ? @"Play a few beatmaps to receive a suggested offset!"
                     : $@"Based on the last {averageHitErrorHistory.Count} play(s), the suggested offset is {SuggestedOffset.Value:N0} ms.";
                 applySuggestion.Enabled.Value = SuggestedOffset.Value != null;
+            }
+
+            private partial class OffsetSliderBar : RoundedSliderBar<double>
+            {
+                public override LocalisableString TooltipText => BeatmapOffsetControl.GetOffsetExplanatoryText(Current.Value);
             }
         }
     }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -307,7 +307,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             }
         }
 
-        public partial class OffsetSliderBar : PlayerSliderBar<double>
+        private partial class OffsetSliderBar : PlayerSliderBar<double>
         {
             protected override Drawable CreateControl() => new CustomSliderBar();
 

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     new OffsetSliderBar
                     {
                         KeyboardStep = 5,
-                        LabelText = BeatmapOffsetControlStrings.BeatmapOffset,
+                        LabelText = BeatmapOffsetControlStrings.AudioOffsetThisBeatmap,
                         Current = Current,
                     },
                     referenceScoreContainer = new FillFlowContainer


### PR DESCRIPTION
Also adjusts the text on beatmap offset. Because every time I see "beatmap offset" I want to change the directionality of adjustment to match. This next text should also help users understand that both the global and per beatmap offset are in the same direction.

Addresses https://github.com/ppy/osu/discussions/26230.