### PR TITLE
Change rolling counters to use quicker easing types

### DIFF
--- a/osu.Game/Graphics/UserInterface/PercentageCounter.cs
+++ b/osu.Game/Graphics/UserInterface/PercentageCounter.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Graphics.UserInterface
     /// </summary>
     public partial class PercentageCounter : RollingCounter<double>
     {
-        protected override double RollingDuration => 750;
+        protected override double RollingDuration => 375;
 
         private float epsilon => 1e-10f;
 

--- a/osu.Game/Graphics/UserInterface/RollingCounter.cs
+++ b/osu.Game/Graphics/UserInterface/RollingCounter.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Graphics.UserInterface
         /// <summary>
         /// Easing for the counter rollover animation.
         /// </summary>
-        protected virtual Easing RollingEasing => Easing.OutQuint;
+        protected virtual Easing RollingEasing => Easing.OutQuad;
 
         private T displayedCount;
 

--- a/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
+++ b/osu.Game/Overlays/Mods/BeatmapAttributesDisplay.cs
@@ -196,7 +196,7 @@ namespace osu.Game.Overlays.Mods
 
         private partial class BPMDisplay : RollingCounter<double>
         {
-            protected override double RollingDuration => 500;
+            protected override double RollingDuration => 250;
 
             protected override LocalisableString FormatCount(double count) => count.ToLocalisableString("0 BPM");
 

--- a/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
+++ b/osu.Game/Overlays/Mods/ScoreMultiplierDisplay.cs
@@ -145,7 +145,7 @@ namespace osu.Game.Overlays.Mods
 
         private partial class EffectCounter : RollingCounter<double>
         {
-            protected override double RollingDuration => 500;
+            protected override double RollingDuration => 250;
 
             protected override LocalisableString FormatCount(double count) => ModUtils.FormatScoreMultiplier(count);
 

--- a/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
+++ b/osu.Game/Overlays/Mods/VerticalAttributeDisplay.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Overlays.Mods
 
         private partial class EffectCounter : RollingCounter<double>
         {
-            protected override double RollingDuration => 500;
+            protected override double RollingDuration => 250;
 
             protected override LocalisableString FormatCount(double count) => count.ToLocalisableString("0.0#");
 

--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -17,8 +17,7 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class ArgonAccuracyCounter : GameplayAccuracyCounter, ISerialisableDrawable
     {
-        protected override double RollingDuration => 500;
-        protected override Easing RollingEasing => Easing.OutQuint;
+        protected override double RollingDuration => 250;
 
         [SettingSource("Wireframe opacity", "Controls the opacity of the wire frames behind the digits.")]
         public BindableFloat WireframeOpacity { get; } = new BindableFloat(0.25f)

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -21,8 +21,7 @@ namespace osu.Game.Screens.Play.HUD
     {
         private ArgonCounterTextComponent text = null!;
 
-        protected override double RollingDuration => 500;
-        protected override Easing RollingEasing => Easing.OutQuint;
+        protected override double RollingDuration => 250;
 
         [SettingSource("Wireframe opacity", "Controls the opacity of the wire frames behind the digits.")]
         public BindableFloat WireframeOpacity { get; } = new BindableFloat(0.25f)

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -18,8 +18,7 @@ namespace osu.Game.Screens.Play.HUD
     {
         private ArgonScoreTextComponent scoreText = null!;
 
-        protected override double RollingDuration => 500;
-        protected override Easing RollingEasing => Easing.OutQuint;
+        protected override double RollingDuration => 250;
 
         [SettingSource("Wireframe opacity", "Controls the opacity of the wire frames behind the digits.")]
         public BindableFloat WireframeOpacity { get; } = new BindableFloat(0.25f)

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class BPMCounter : RollingCounter<double>, ISerialisableDrawable
     {
-        protected override double RollingDuration => 750;
+        protected override double RollingDuration => 375;
 
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;

--- a/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
         [Resolved]
         private ClicksPerSecondController controller { get; set; } = null!;
 
-        protected override double RollingDuration => 350;
+        protected override double RollingDuration => 175;
 
         public bool UsesFixedAnchor { get; set; }
 

--- a/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
+++ b/osu.Game/Screens/Play/HUD/PerformancePointsCounter.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
 
         protected override bool IsRollingProportional => true;
 
-        protected override double RollingDuration => 1000;
+        protected override double RollingDuration => 500;
 
         private const float alpha_when_invalid = 0.3f;
 

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Play.HUD
     {
         public bool UsesFixedAnchor { get; set; }
 
-        protected override double RollingDuration => 750;
+        protected override double RollingDuration => 375;
 
         private const float alpha_when_invalid = 0.3f;
         private readonly Bindable<bool> valid = new Bindable<bool>();

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
@@ -44,9 +44,10 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
         private partial class Counter : RollingCounter<double>
         {
-            protected override double RollingDuration => AccuracyCircle.ACCURACY_TRANSFORM_DURATION;
-
-            protected override Easing RollingEasing => AccuracyCircle.ACCURACY_TRANSFORM_EASING;
+            // FormatAccuracy doesn't round, which means if we use the OutPow10 easing the number will stick 0.01% short for some time.
+            // To avoid that let's use a shorter easing which looks roughly the same.
+            protected override double RollingDuration => AccuracyCircle.ACCURACY_TRANSFORM_DURATION / 2;
+            protected override Easing RollingEasing => Easing.OutQuad;
 
             protected override LocalisableString FormatCount(double count) => count.FormatAccuracy();
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/26553.

Most changes are from `OutQuint` to `OutQuad` with half length (see https://github.com/ppy/osu/discussions/26553#discussioncomment-8153954). I can't notice the difference visually.

Of note, the two cases pointed out in the linked discussion are due to rounding ([intentionally](https://github.com/ppy/osu/blob/ee18123fc2f1a5ec79b39d7fd4eeea23d969bc94/osu.Game/Utils/FormatUtils.cs#L20-L24)) not being applied to mod multipliers and accuracy. But it's probably fine to apply this across the board to cause less text updates. These counters are actually quite expensive to update.