### PR TITLE
Change legacy beatmap skins to not handle `@2x` textures (to match stable)

### DIFF
--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -138,10 +138,31 @@ namespace osu.Game.Tests.NonVisual.Skinning
             Assert.IsNotNull(texture);
             Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
 
-            texture = legacySkin.GetTexture("hitcircle@2x");
+            var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
+
+            Assert.IsNotNull(twoTimesTexture);
+            Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(1));
+
+            Assert.AreNotEqual(texture, twoTimesTexture);
+        }
+
+        [Test]
+        public void TestAllowHighResolutionSprites()
+        {
+            var textureStore = new TestTextureStore("hitcircle", "hitcircle@2x");
+            var legacySkin = new TestLegacySkin(textureStore) { HighResolutionSprites = true };
+
+            var texture = legacySkin.GetTexture("hitcircle");
 
             Assert.IsNotNull(texture);
-            Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
+            Assert.That(texture.ScaleAdjust, Is.EqualTo(2));
+
+            var twoTimesTexture = legacySkin.GetTexture("hitcircle@2x");
+
+            Assert.IsNotNull(twoTimesTexture);
+            Assert.That(twoTimesTexture.ScaleAdjust, Is.EqualTo(2));
+
+            Assert.AreEqual(texture, twoTimesTexture);
         }
 
         private class TestLegacySkin : LegacySkin

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -127,8 +127,29 @@ namespace osu.Game.Tests.NonVisual.Skinning
             Assert.IsNull(texture);
         }
 
+        [Test]
+        public void TestDisallowHighResolutionSprites()
+        {
+            var textureStore = new TestTextureStore("hitcircle", "hitcircle@2x");
+            var legacySkin = new TestLegacySkin(textureStore) { HighResolutionSprites = false };
+
+            var texture = legacySkin.GetTexture("hitcircle");
+
+            Assert.IsNotNull(texture);
+            Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
+
+            texture = legacySkin.GetTexture("hitcircle@2x");
+
+            Assert.IsNotNull(texture);
+            Assert.That(texture.ScaleAdjust, Is.EqualTo(1));
+        }
+
         private class TestLegacySkin : LegacySkin
         {
+            public bool HighResolutionSprites { get; set; } = true;
+
+            protected override bool AllowHighResolutionSprites => HighResolutionSprites;
+
             public TestLegacySkin(IResourceStore<TextureUpload> textureStore)
                 : base(new SkinInfo(), new TestResourceProvider(textureStore), null, string.Empty)
             {

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -22,6 +22,11 @@ namespace osu.Game.Skinning
         protected override bool AllowManiaConfigLookups => false;
         protected override bool UseCustomSampleBanks => true;
 
+        // matches stable. references:
+        //  1. https://github.com/peppy/osu-stable-reference/blob/dc0994645801010d4b628fff5ff79cd3c286ca83/osu!/Graphics/Textures/TextureManager.cs#L115-L137 (beatmap skin textures lookup)
+        //  2. https://github.com/peppy/osu-stable-reference/blob/dc0994645801010d4b628fff5ff79cd3c286ca83/osu!/Graphics/Textures/TextureManager.cs#L158-L196 (user skin textures lookup)
+        protected override bool AllowHighResolutionSprites => false;
+
         /// <summary>
         /// Construct a new legacy beatmap skin instance.
         /// </summary>

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -477,6 +477,11 @@ namespace osu.Game.Skinning
             return null;
         }
 
+        /// <summary>
+        /// Whether high-resolution textures ("@2x"-suffixed) are allowed to be used by <see cref="GetTexture"/> when available.
+        /// </summary>
+        protected virtual bool AllowHighResolutionSprites => true;
+
         public override Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             switch (componentName)
@@ -488,15 +493,22 @@ namespace osu.Game.Skinning
 
             foreach (string name in getFallbackNames(componentName))
             {
-                // some component names (especially user-controlled ones, like `HitX` in mania)
-                // may contain `@2x` scale specifications.
-                // stable happens to check for that and strip them, so do the same to match stable behaviour.
-                string lookupName = name.Replace(@"@2x", string.Empty);
+                string lookupName = name;
+                Texture? texture = null;
+                float ratio = 1;
 
-                float ratio = 2;
-                string twoTimesFilename = $"{Path.ChangeExtension(lookupName, null)}@2x{Path.GetExtension(lookupName)}";
+                if (AllowHighResolutionSprites)
+                {
+                    // some component names (especially user-controlled ones, like `HitX` in mania)
+                    // may contain `@2x` scale specifications.
+                    // stable happens to check for that and strip them, so do the same to match stable behaviour.
+                    lookupName = name.Replace(@"@2x", string.Empty);
 
-                var texture = Textures?.Get(twoTimesFilename, wrapModeS, wrapModeT);
+                    string twoTimesFilename = $"{Path.ChangeExtension(lookupName, null)}@2x{Path.GetExtension(lookupName)}";
+
+                    texture = Textures?.Get(twoTimesFilename, wrapModeS, wrapModeT);
+                    ratio = 2;
+                }
 
                 if (texture == null)
                 {


### PR DESCRIPTION
- Resolves part of https://github.com/ppy/osu/issues/26239

In stable, when looking up a texture in beatmap skin, the `@2x` suffix does not mean anything and the texture is returned normally with no adjustment to scale.

This only resolves the issue above when beatmap skin is enabled. When disabled, a whole other set of issues arise (see [discord](https://discord.com/channels/188630481301012481/188630652340404224/1197101872033574932) for quick summary). PR'ing this in the mean time while I look at the rest of the issues.