### PR TITLE
Fix `ConstrainedIconContainer` always using masking without a reason

### DIFF
--- a/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
+++ b/osu.Game/Beatmaps/Drawables/DifficultyIcon.cs
@@ -92,7 +92,6 @@ namespace osu.Game.Beatmaps.Drawables
                     EdgeEffect = new EdgeEffectParameters
                     {
                         Colour = Color4.Black.Opacity(0.06f),
-
                         Type = EdgeEffectType.Shadow,
                         Radius = 3,
                     },

--- a/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
+++ b/osu.Game/Graphics/Containers/ConstrainedIconContainer.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osuTK;
 
 namespace osu.Game.Graphics.Containers
@@ -17,19 +16,7 @@ namespace osu.Game.Graphics.Containers
         public Drawable Icon
         {
             get => InternalChild;
-
             set => InternalChild = value;
-        }
-
-        /// <summary>
-        /// Determines an edge effect of this <see cref="Container"/>.
-        /// Edge effects are e.g. glow or a shadow.
-        /// Only has an effect when <see cref="CompositeDrawable.Masking"/> is true.
-        /// </summary>
-        public new EdgeEffectParameters EdgeEffect
-        {
-            get => base.EdgeEffect;
-            set => base.EdgeEffect = value;
         }
 
         protected override void Update()
@@ -48,11 +35,6 @@ namespace osu.Game.Graphics.Containers
                 InternalChild.Anchor = Anchor.Centre;
                 InternalChild.Origin = Anchor.Centre;
             }
-        }
-
-        public ConstrainedIconContainer()
-        {
-            Masking = true;
         }
     }
 }

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
@@ -58,15 +57,7 @@ namespace osu.Game.Overlays.Toolbar
             {
                 set => Scheduler.AddOnce(() =>
                 {
-                    if (value)
-                    {
-                        IconContainer.Colour = Color4Extensions.FromHex("#00FFAA");
-                    }
-                    else
-                    {
-                        IconContainer.Colour = colours.GrayF;
-                        IconContainer.EdgeEffect = new EdgeEffectParameters();
-                    }
+                    IconContainer.Colour = value ? Color4Extensions.FromHex("#00FFAA") : colours.GrayF;
                 });
             }
 


### PR DESCRIPTION
Was trying to investigate the issue mentioned in [this comment](https://github.com/ppy/osu/pull/22197#issuecomment-1384817950), however turned out `ConstrainedIconContainer` isn't the source of this problem: even when using raw icons without this container edge pixels are kinda weird-looking (you can also test that in `OsuIconTestScene` by lowering the icon size).

So at the end this became just a clean-up pr.