### PR TITLE
Simplify gameplay pause sequence

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             resumeAndConfirm();
 
-            AddAssert("Resumed without seeking forward", () => Player.LastResumeTime, () => Is.LessThanOrEqualTo(Player.LastPauseTime));
+            AddAssert("continued playing forward", () => Player.LastResumeTime, () => Is.GreaterThanOrEqualTo(Player.LastPauseTime));
 
             AddUntilStep("player playing", () => Player.LocalUserPlaying.Value);
         }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePause.cs
@@ -93,15 +93,12 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                     double currentTime = masterClock.CurrentTime;
 
-                    bool goingForward = currentTime >= (masterClock.LastStopTime ?? lastStopTime);
+                    bool goingForward = currentTime >= lastStopTime;
 
                     alwaysGoingForward &= goingForward;
 
                     if (!goingForward)
                         Logger.Log($"Went too far backwards (last stop: {lastStopTime:N1} current: {currentTime:N1})");
-
-                    if (masterClock.LastStopTime != null)
-                        lastStopTime = masterClock.LastStopTime.Value;
                 };
             });
 

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -27,11 +27,6 @@ namespace osu.Game.Beatmaps
     {
         private readonly bool applyOffsets;
 
-        /// <summary>
-        /// The total frequency adjustment from pause transforms. Should eventually be handled in a better way.
-        /// </summary>
-        public readonly BindableDouble ExternalPauseFrequencyAdjust = new BindableDouble(1);
-
         private readonly OffsetCorrectionClock? userGlobalOffsetClock;
         private readonly OffsetCorrectionClock? platformOffsetClock;
         private readonly OffsetCorrectionClock? userBeatmapOffsetClock;
@@ -69,13 +64,13 @@ namespace osu.Game.Beatmaps
             {
                 // Audio timings in general with newer BASS versions don't match stable.
                 // This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
-                platformOffsetClock = new OffsetCorrectionClock(interpolatedTrack, ExternalPauseFrequencyAdjust) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
+                platformOffsetClock = new OffsetCorrectionClock(interpolatedTrack) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
 
                 // User global offset (set in settings) should also be applied.
-                userGlobalOffsetClock = new OffsetCorrectionClock(platformOffsetClock, ExternalPauseFrequencyAdjust);
+                userGlobalOffsetClock = new OffsetCorrectionClock(platformOffsetClock);
 
                 // User per-beatmap offset will be applied to this final clock.
-                finalClockSource = userBeatmapOffsetClock = new OffsetCorrectionClock(userGlobalOffsetClock, ExternalPauseFrequencyAdjust);
+                finalClockSource = userBeatmapOffsetClock = new OffsetCorrectionClock(userGlobalOffsetClock);
             }
             else
             {

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -78,8 +78,6 @@ namespace osu.Game.Screens.Play
 
             isPaused.Value = false;
 
-            PrepareStart();
-
             // The case which caused this to be added is FrameStabilityContainer, which manages its own current and elapsed time.
             // Because we generally update our own current time quicker than children can query it (via Start/Seek/Update),
             // this means that the first frame ever exposed to children may have a non-zero current time.
@@ -97,14 +95,6 @@ namespace osu.Game.Screens.Play
 
                 StartGameplayClock();
             });
-        }
-
-        /// <summary>
-        /// When <see cref="Start"/> is called, this will be run to give an opportunity to prepare the clock at the correct
-        /// start location.
-        /// </summary>
-        protected virtual void PrepareStart()
-        {
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -207,7 +207,6 @@ namespace osu.Game.Screens.Play
             musicController.ResetTrackAdjustments();
 
             track.BindAdjustments(AdjustmentsFromMods);
-            track.AddAdjustment(AdjustableProperty.Frequency, GameplayClock.ExternalPauseFrequencyAdjust);
             track.AddAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
 
             speedAdjustmentsApplied = true;
@@ -219,7 +218,6 @@ namespace osu.Game.Screens.Play
                 return;
 
             track.UnbindAdjustments(AdjustmentsFromMods);
-            track.RemoveAdjustment(AdjustableProperty.Frequency, GameplayClock.ExternalPauseFrequencyAdjust);
             track.RemoveAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
 
             speedAdjustmentsApplied = false;

--- a/osu.Game/Screens/Play/OffsetCorrectionClock.cs
+++ b/osu.Game/Screens/Play/OffsetCorrectionClock.cs
@@ -1,15 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
 using osu.Framework.Timing;
 
 namespace osu.Game.Screens.Play
 {
     public class OffsetCorrectionClock : FramedOffsetClock
     {
-        private readonly BindableDouble pauseRateAdjust;
-
         private double offset;
 
         public new double Offset
@@ -28,10 +25,9 @@ namespace osu.Game.Screens.Play
 
         public double RateAdjustedOffset => base.Offset;
 
-        public OffsetCorrectionClock(IClock source, BindableDouble pauseRateAdjust)
+        public OffsetCorrectionClock(IClock source)
             : base(source)
         {
-            this.pauseRateAdjust = pauseRateAdjust;
         }
 
         public override void ProcessFrame()
@@ -42,12 +38,8 @@ namespace osu.Game.Screens.Play
 
         private void updateOffset()
         {
-            // changing this during the pause transform effect will cause a potentially large offset to be suddenly applied as we approach zero rate.
-            if (pauseRateAdjust.Value == 1)
-            {
-                // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
-                base.Offset = Offset * Rate;
-            }
+            // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
+            base.Offset = Offset * Rate;
         }
     }
 }


### PR DESCRIPTION
This removes the frequency ramp on pausing. This was something I was personally behind implementing and working to keep around, but nuking in favour of simplifying the process for now. In [discussing with nekodex](https://discord.com/channels/188630481301012481/188630652340404224/1197410116329283646) we both agree there is a better way forward than this.

This lays groundwork for doing other things, like allowing seeking during replay pause, and changing the way offsets work without worrying about the weird application considerations from the pause ramp effect.

Closes https://github.com/ppy/osu/issues/26442, closes https://github.com/ppy/osu/issues/26596 and probably other issues.