### PR TITLE
Add offset to taiko hit area to more correctly align with expectations

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -16,9 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
             drawableTaikoRuleset.LockPlayfieldAspectRange.Value = false;
-
-            var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
-            playfield.ClassicHitTargetPosition.Value = true;
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -222,7 +222,8 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             // Padding is required to be updated for elements which are based on "absolute" X sized elements.
             // This is basically allowing for correct alignment as relative pieces move around them.
-            rightArea.Padding = new MarginPadding { Left = inputDrum.Width };
+            // 24px offset was obtained via visual comparison with stable.
+            rightArea.Padding = new MarginPadding { Left = inputDrum.Width - 24 };
             barLineContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
             hitObjectContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
             overlayContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -31,11 +30,6 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// Default height of a <see cref="TaikoPlayfield"/> when inside a <see cref="DrawableTaikoRuleset"/>.
         /// </summary>
         public const float DEFAULT_HEIGHT = 200;
-
-        /// <summary>
-        /// Whether the hit target should be nudged further towards the left area, matching the stable "classic" position.
-        /// </summary>
-        public Bindable<bool> ClassicHitTargetPosition = new BindableBool();
 
         public Container UnderlayElements { get; private set; } = null!;
 

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -222,8 +222,10 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             // Padding is required to be updated for elements which are based on "absolute" X sized elements.
             // This is basically allowing for correct alignment as relative pieces move around them.
+            //
+            // 180px is input drum size on classic skin.
             // 24px offset was obtained via visual comparison with stable.
-            rightArea.Padding = new MarginPadding { Left = inputDrum.Width - 24 };
+            rightArea.Padding = new MarginPadding { Left = 180 - 24 };
             barLineContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
             hitObjectContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };
             overlayContent.Padding = new MarginPadding { Left = HitTarget.DrawWidth / 2 };


### PR DESCRIPTION
This was supposed to be achieved via #17622. Unfortunately, that PR regressed its own behaviour [halfway through](https://github.com/ppy/osu/pull/17622/commits/ec5ad995f830bd74b8f4ecae8d8e5f7898250948#diff-da95ba59b0b0ece21a5e869b2dbd950c0a1a01f761762d366a468a4174f8dc56R210), leaving the classic skin setting bindable unused.

I've removed the bindable and updated the location to match in all cases. I think we can match stable without classic mod being applied for something like this.

| stable | lazer |
| :---: | :---: |
| ![CleanShot 2024-01-18 at 09 08 15](https://github.com/ppy/osu/assets/191335/4c6729fe-0916-4297-977d-4dca87d96431) | ![CleanShot 2024-01-18 at 09 08 07](https://github.com/ppy/osu/assets/191335/886eb044-634d-4f6f-a503-92676d7ff009) |

other skins:

| triangles | argon |
| :---: | :---: |
| ![CleanShot 2024-01-18 at 09 14 39](https://github.com/ppy/osu/assets/191335/20d90d63-fa24-448f-9c92-d97bfd3ee551) | ![CleanShot 2024-01-18 at 09 14 56](https://github.com/ppy/osu/assets/191335/d62d87d6-73f6-41b0-84a7-3ef467400048) |