### PR TITLE
Fix revert-to-default button appearing on disabled settings regardless of value

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsItem.cs
@@ -40,8 +40,15 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("change value from default", () => textBox.Current.Value = "non-default");
             AddUntilStep("restore button shown", () => revertToDefaultButton.Alpha > 0);
 
+            AddStep("disable setting", () => textBox.Current.Disabled = true);
+            AddUntilStep("restore button still shown", () => revertToDefaultButton.Alpha > 0);
+
+            AddStep("enable setting", () => textBox.Current.Disabled = false);
             AddStep("restore default", () => textBox.Current.SetDefault());
             AddUntilStep("restore button hidden", () => revertToDefaultButton.Alpha == 0);
+
+            AddStep("disable setting", () => textBox.Current.Disabled = true);
+            AddUntilStep("restore button still hidden", () => revertToDefaultButton.Alpha == 0);
         }
 
         [Test]

--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -115,7 +115,12 @@ namespace osu.Game.Overlays
 
             Enabled.Value = !current.Disabled;
 
-            this.FadeTo(current.Disabled ? 0.2f : (current.IsDefault ? 0 : 1), fade_duration, Easing.OutQuint);
+            if (current.IsDefault)
+                this.FadeTo(0, fade_duration, Easing.OutQuint);
+            else if (current.Disabled)
+                this.FadeTo(0.2f, fade_duration, Easing.OutQuint);
+            else
+                this.FadeTo(1, fade_duration, Easing.OutQuint);
 
             if (IsHovered && Enabled.Value)
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26597

Whether the revert-to-default button should be visible when a setting is disabled is up to debate. I chose to keep it visible, but maybe it shouldn't?