### PR TITLE
Define constant input drum width for osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneInputDrum.cs
@@ -30,8 +30,11 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(200),
-                    Child = new InputDrum()
+                    Size = new Vector2(180f, 200f),
+                    Child = new InputDrum
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    }
                 }
             });
         }

--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonInputDrum.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Argon
 
         public ArgonInputDrum()
         {
-            RelativeSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultInputDrum.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
     {
         public DefaultInputDrum()
         {
-            RelativeSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyInputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyInputDrum.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -18,22 +19,20 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
     /// </summary>
     internal partial class LegacyInputDrum : Container
     {
-        private Container content = null!;
         private LegacyHalfDrum left = null!;
         private LegacyHalfDrum right = null!;
 
         public LegacyInputDrum()
         {
-            RelativeSizeAxes = Axes.Y;
-            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)
         {
-            Child = content = new Container
+            Child = new Container
             {
-                Size = new Vector2(180, 200),
+                RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
                     new Sprite
@@ -66,31 +65,22 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             const float ratio = 1.6f;
 
             // because the right half is flipped, we need to position using width - position to get the true "topleft" origin position
-            float negativeScaleAdjust = content.Width / ratio;
+            const float negative_scale_adjust = TaikoPlayfield.INPUT_DRUM_WIDTH / ratio;
 
             if (skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value >= 2.1m)
             {
                 left.Centre.Position = new Vector2(0, taiko_bar_y) * ratio;
-                right.Centre.Position = new Vector2(negativeScaleAdjust - 56, taiko_bar_y) * ratio;
+                right.Centre.Position = new Vector2(negative_scale_adjust - 56, taiko_bar_y) * ratio;
                 left.Rim.Position = new Vector2(0, taiko_bar_y) * ratio;
-                right.Rim.Position = new Vector2(negativeScaleAdjust - 56, taiko_bar_y) * ratio;
+                right.Rim.Position = new Vector2(negative_scale_adjust - 56, taiko_bar_y) * ratio;
             }
             else
             {
                 left.Centre.Position = new Vector2(18, taiko_bar_y + 31) * ratio;
-                right.Centre.Position = new Vector2(negativeScaleAdjust - 54, taiko_bar_y + 31) * ratio;
+                right.Centre.Position = new Vector2(negative_scale_adjust - 54, taiko_bar_y + 31) * ratio;
                 left.Rim.Position = new Vector2(8, taiko_bar_y + 23) * ratio;
-                right.Rim.Position = new Vector2(negativeScaleAdjust - 53, taiko_bar_y + 23) * ratio;
+                right.Rim.Position = new Vector2(negative_scale_adjust - 53, taiko_bar_y + 23) * ratio;
             }
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // Relying on RelativeSizeAxes.Both + FillMode.Fit doesn't work due to the precise pixel layout requirements.
-            // This is a bit ugly but makes the non-legacy implementations a lot cleaner to implement.
-            content.Scale = new Vector2(DrawHeight / content.Size.Y);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
+++ b/osu.Game.Rulesets.Taiko/UI/InputDrum.cs
@@ -14,12 +14,6 @@ namespace osu.Game.Rulesets.Taiko.UI
     /// </summary>
     internal partial class InputDrum : Container
     {
-        public InputDrum()
-        {
-            AutoSizeAxes = Axes.X;
-            RelativeSizeAxes = Axes.Y;
-        }
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -27,8 +21,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.InputDrum), _ => new DefaultInputDrum())
                 {
-                    RelativeSizeAxes = Axes.Y,
-                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Both,
                 },
             };
         }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// </summary>
         public const float BASE_HEIGHT = 200;
 
+        public const float INPUT_DRUM_WIDTH = 180f;
+
         /// <summary>
         /// Whether the hit target should be nudged further towards the left area, matching the stable "classic" position.
         /// </summary>
@@ -49,7 +51,6 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private ProxyContainer topLevelHitContainer = null!;
         private InputDrum inputDrum = null!;
-        private Container rightArea = null!;
 
         /// <remarks>
         /// <see cref="Playfield.AddNested"/> is purposefully not called on this to prevent i.e. being able to interact
@@ -66,8 +67,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
-                AutoSizeAxes = Axes.X,
                 RelativeSizeAxes = Axes.Y,
+                Width = INPUT_DRUM_WIDTH,
             };
 
             InternalChildren = new[]
@@ -76,8 +77,8 @@ namespace osu.Game.Rulesets.Taiko.UI
                 new Container
                 {
                     Name = "Left overlay",
-                    RelativeSizeAxes = Axes.Both,
-                    FillMode = FillMode.Fit,
+                    RelativeSizeAxes = Axes.Y,
+                    Width = INPUT_DRUM_WIDTH,
                     BorderColour = colours.Gray0,
                     Children = new[]
                     {
@@ -93,10 +94,11 @@ namespace osu.Game.Rulesets.Taiko.UI
                     RelativeSizeAxes = Axes.None,
                     Y = 0.2f
                 },
-                rightArea = new Container
+                new Container
                 {
                     Name = "Right area",
                     RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Left = INPUT_DRUM_WIDTH },
                     Children = new Drawable[]
                     {
                         new Container
@@ -218,14 +220,6 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             var taikoObject = (DrawableTaikoHitObject)drawableHitObject;
             topLevelHitContainer.Add(taikoObject.CreateProxiedContent());
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            // todo: input drum width should be constant.
-            rightArea.Padding = new MarginPadding { Left = inputDrum.DrawWidth };
         }
 
         #region Pooling support


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/26631

Up until now, the input drum width was variable per skin, which results in the overall gameplay width changing based on skin. This has been discussed to be quite bad and must not be the case (see [discord](https://discord.com/channels/188630481301012481/188630652340404224/1197514459695034428)).

The constant width for the input drum has been defined to be 180px, visually matching osu!stable on classic skin. Default skins have been altered slightly to respect that width (basically set its height with respect to width rather than the opposite).

Preview:

https://github.com/ppy/osu/assets/22781491/11d990d1-45a0-4c81-b0ae-a43f882a2e7f

