### PR TITLE
Change hit target position in osu!taiko to always match stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -16,9 +16,6 @@ namespace osu.Game.Rulesets.Taiko.Mods
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
             drawableTaikoRuleset.LockPlayfieldAspectRange.Value = false;
-
-            var playfield = (TaikoPlayfield)drawableRuleset.Playfield;
-            playfield.ClassicHitTargetPosition.Value = true;
         }
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -33,11 +32,6 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public const float INPUT_DRUM_WIDTH = 180f;
 
-        /// <summary>
-        /// Whether the hit target should be nudged further towards the left area, matching the stable "classic" position.
-        /// </summary>
-        public Bindable<bool> ClassicHitTargetPosition = new BindableBool();
-
         public Container UnderlayElements { get; private set; } = null!;
 
         private Container<HitExplosion> hitExplosionContainer = null!;
@@ -62,6 +56,7 @@ namespace osu.Game.Rulesets.Taiko.UI
         private void load(OsuColour colours)
         {
             const float hit_target_width = BASE_HEIGHT;
+            const float hit_target_offset = -24f;
 
             inputDrum = new InputDrum
             {
@@ -106,6 +101,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                             Name = "Elements behind hit objects",
                             RelativeSizeAxes = Axes.Y,
                             Width = hit_target_width,
+                            X = hit_target_offset,
                             Children = new[]
                             {
                                 new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.KiaiGlow), _ => Empty())
@@ -126,7 +122,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                         {
                             Name = "Bar line content",
                             RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = hit_target_width / 2 },
+                            Padding = new MarginPadding { Left = hit_target_width / 2 + hit_target_offset },
                             Children = new Drawable[]
                             {
                                 UnderlayElements = new Container
@@ -140,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                         {
                             Name = "Masked hit objects content",
                             RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = hit_target_width / 2 },
+                            Padding = new MarginPadding { Left = hit_target_width / 2 + hit_target_offset },
                             Masking = true,
                             Child = HitObjectContainer,
                         },
@@ -148,7 +144,7 @@ namespace osu.Game.Rulesets.Taiko.UI
                         {
                             Name = "Overlay content",
                             RelativeSizeAxes = Axes.Both,
-                            Padding = new MarginPadding { Left = hit_target_width / 2 },
+                            Padding = new MarginPadding { Left = hit_target_width / 2 + hit_target_offset },
                             Children = new Drawable[]
                             {
                                 drumRollHitContainer = new DrumRollHitContainer(),


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/26632
- Supersedes / closes https://github.com/ppy/osu/pull/26615

The offset was ballparked / taken from https://github.com/ppy/osu/pull/26615. Comparison between stable and lazer on classic skin:

https://github.com/ppy/osu/assets/22781491/a9c32731-6aa6-43ce-9657-234ebec35951

(used my screenshot utility to ensure the gap between the input drum and the hit target is constant)

Preview on non-classic skins:

| triangles | argon |
|-----------|-------|
| ![CleanShot 2024-01-20 at 02 01 21](https://github.com/ppy/osu/assets/22781491/0b9b9301-7958-446d-9cce-a83e1541fd08) | ![CleanShot 2024-01-20 at 02 01 01](https://github.com/ppy/osu/assets/22781491/267fc90b-71aa-4a22-8694-471760958d5f) |