### PR TITLE
Move osu!taiko playfield down a nudge to match stable visually

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Rulesets.Taiko.UI
             base.Update();
 
             const float base_relative_height = TaikoPlayfield.BASE_HEIGHT / 768;
+            // Matches stable, see https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L514
+            const float base_position = 135f / 480f;
 
             float relativeHeight = base_relative_height;
 
@@ -49,14 +51,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Limit the maximum relative height of the playfield to one-third of available area to avoid it masking out on extreme resolutions.
             relativeHeight = Math.Min(relativeHeight, 1f / 3f);
 
-            // Position the taiko playfield exactly one playfield from the top of the screen, if there is enough space for it.
-            // Note that the relative height cannot exceed one-third - if that limit is hit, the playfield will be exactly centered.
-            float playfieldPosition = relativeHeight;
-
-            // arbitrary offset to make playfield position match stable.
-            playfieldPosition += 0.022f;
-
-            Y = playfieldPosition;
+            Y = base_position;
 
             Scale = new Vector2(Math.Max((Parent!.ChildSize.Y / 768f) * (relativeHeight / base_relative_height), 1f));
             Width = 1 / Scale.X;

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -51,7 +51,12 @@ namespace osu.Game.Rulesets.Taiko.UI
 
             // Position the taiko playfield exactly one playfield from the top of the screen, if there is enough space for it.
             // Note that the relative height cannot exceed one-third - if that limit is hit, the playfield will be exactly centered.
-            Y = relativeHeight;
+            float playfieldPosition = relativeHeight;
+
+            // arbitrary offset to make playfield position match stable.
+            playfieldPosition += 0.022f;
+
+            Y = playfieldPosition;
 
             Scale = new Vector2(Math.Max((Parent!.ChildSize.Y / 768f) * (relativeHeight / base_relative_height), 1f));
             Width = 1 / Scale.X;


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/26631

This one is just something I noticed. I'm not entirely sure where this offset is applied in stable's codebase, and it's quite hard to parse the layout system there, so I went with ballparking it like https://github.com/ppy/osu/pull/26634.

Comparison:

https://github.com/ppy/osu/assets/22781491/ca686664-17dd-4b75-a63b-e4fb0a3a3ffc

(notice playfield position roughly matches 1:1 between stable and lazer)