### PR TITLE
Fix `FollowPointConnection` pool filling up when follow points are hidden

### DIFF
--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -153,6 +153,9 @@ namespace osu.Game.Rulesets.Objects.Pooling
 
         protected override bool CheckChildrenLife()
         {
+            if (!IsPresent)
+                return false;
+
             bool aliveChanged = base.CheckChildrenLife();
             aliveChanged |= lifetimeManager.Update(Time.Current - PastLifetimeExtension, Time.Current + FutureLifetimeExtension);
             return aliveChanged;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26642.

I think this applied to all pooling cases here.
