### PR TITLE
Associate with files & urls on Windows

### DIFF
--- a/osu.Game.Tests/Updater/AssociationManagerTest.cs
+++ b/osu.Game.Tests/Updater/AssociationManagerTest.cs
@@ -15,21 +15,18 @@ namespace osu.Game.Tests.Updater
         AssociationManager manager = new AssociationManager();
 
         [Test]
-        [SupportedOSPlatform("windows")]
         public void TestRemoveAssociations()
         {
             manager.RemoveFileAssociations();
         }
 
         [Test]
-        [SupportedOSPlatform("windows")]
         public void TestSetAssociations()
         {
             manager.InitializeFileAssociations();
         }
 
         [Test]
-        [SupportedOSPlatform("windows")]
         public void TestEnsureAssociations()
         {
             bool isensured = manager.EnsureAssociationsSet();

--- a/osu.Game.Tests/Updater/AssociationManagerTest.cs
+++ b/osu.Game.Tests/Updater/AssociationManagerTest.cs
@@ -9,13 +9,15 @@ using osu.Game.Updater;
 namespace osu.Game.Tests.Updater
 {
     [TestFixture]
+    [SupportedOSPlatform("windows")]
     public class AssociationManagerTest
     {
+        AssociationManager manager = new AssociationManager();
+
         [Test]
         [SupportedOSPlatform("windows")]
         public void TestRemoveAssociations()
         {
-            var manager = new AssociationManager();
             manager.RemoveFileAssociations();
         }
 
@@ -23,7 +25,6 @@ namespace osu.Game.Tests.Updater
         [SupportedOSPlatform("windows")]
         public void TestSetAssociations()
         {
-            var manager = new AssociationManager();
             manager.InitializeFileAssociations();
         }
 
@@ -31,7 +32,6 @@ namespace osu.Game.Tests.Updater
         [SupportedOSPlatform("windows")]
         public void TestEnsureAssociations()
         {
-            var manager = new AssociationManager();
             bool isensured = manager.EnsureAssociationsSet();
 
             if (isensured)

--- a/osu.Game.Tests/Updater/AssociationManagerTest.cs
+++ b/osu.Game.Tests/Updater/AssociationManagerTest.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.Versioning;
+using NUnit.Framework;
+using osu.Game.Updater;
+
+namespace osu.Game.Tests.Updater
+{
+    [TestFixture]
+    public class AssociationManagerTest
+    {
+        [Test]
+        [SupportedOSPlatform("windows")]
+        public void TestRemoveAssociations()
+        {
+            var manager = new AssociationManager();
+            manager.RemoveFileAssociations();
+        }
+
+        [Test]
+        [SupportedOSPlatform("windows")]
+        public void TestSetAssociations()
+        {
+            var manager = new AssociationManager();
+            manager.InitializeFileAssociations();
+        }
+
+        [Test]
+        [SupportedOSPlatform("windows")]
+        public void TestEnsureAssociations()
+        {
+            var manager = new AssociationManager();
+            bool isensured = manager.EnsureAssociationsSet();
+
+            if (isensured)
+            {
+                Console.WriteLine("File associations are set up correctly!");
+            }
+            else
+            {
+                Console.WriteLine("File associations are not set up correctly!");
+            }
+        }
+    }
+}

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1041,6 +1041,9 @@ namespace osu.Game
             // dependency on notification overlay, dependent by settings overlay
             loadComponentSingleFile(CreateUpdateManager(), Add, true);
 
+            // dependency on notification overlay
+            if (OperatingSystem.IsWindows()) loadComponentSingleFile(new AssociationManager(), Add, true);
+
             // overlay elements
             loadComponentSingleFile(FirstRunOverlay = new FirstRunSetupOverlay(), overlayContent.Add, true);
             loadComponentSingleFile(new ManageCollectionsDialog(), overlayContent.Add, true);

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -72,7 +73,7 @@ namespace osu.Game.Updater
         public void InitializeFileAssociations()
         {
             Logger.Log("Setting up file associations!");
-            string programPath = Assembly.GetExecutingAssembly().Location;
+            string programPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\osu!.exe";
 
             foreach (string extension in associated_extensions)
             {

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -100,12 +100,11 @@ namespace osu.Game.Updater
             Logger.Log("Creating file association for " + extension);
 
             // Check if the extension has a file explorer override, if so, delete the override
-            RegistryKey? fileExplorerKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\" + extension, true);
+            using RegistryKey? fileExplorerKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\" + extension, true);
 
             if (fileExplorerKey != null)
             {
                 fileExplorerKey.DeleteSubKey("UserChoice", false);
-                fileExplorerKey.Close();
                 Logger.Log("Deleted file explorer override for " + extension);
             }
             else
@@ -113,17 +112,16 @@ namespace osu.Game.Updater
                 Logger.Log("File explorer override for " + extension + " does not exist!");
             }
 
-            RegistryKey key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{extension}");
+            using RegistryKey key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{extension}");
             key.SetValue("", description);
             key.CreateSubKey(@"shell\open\command").SetValue("", $"\"{programPath}\" \"%1\"");
-            key.Close();
             Logger.Log("Created file association for " + extension);
         }
 
         public void RemoveFileAssociation(string extension)
         {
             Logger.Log("Removing file association for " + extension);
-            RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
+            using RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
 
             if (key != null)
             {
@@ -151,7 +149,7 @@ namespace osu.Game.Updater
 
         public bool IsAssociated(string extension, string programPath)
         {
-            RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
+            using RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
 
             // Check if the value set is equal to the path of the executable
             return key?.OpenSubKey(@"shell\open\command")?.GetValue("")?.ToString() == $"\"{programPath}\" \"%1\"";

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Updater
         public void InitializeFileAssociations()
         {
             Logger.Log("Setting up file associations!");
-            string programPath = Assembly.GetEntryAssembly()?.Location ?? throw new InvalidOperationException("Could not get entry assembly location.");
+            string programPath = Assembly.GetExecutingAssembly().Location;
 
             foreach (string extension in associated_extensions)
             {

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -100,7 +100,7 @@ namespace osu.Game.Updater
             Logger.Log("Creating file association for " + extension);
 
             // Check if the extension has a file explorer override, if so, delete the override
-            RegistryKey? fileExplorerKey = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" + extension, true);
+            RegistryKey? fileExplorerKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\" + extension, true);
 
             if (fileExplorerKey != null)
             {
@@ -113,9 +113,9 @@ namespace osu.Game.Updater
                 Logger.Log("File explorer override for " + extension + " does not exist!");
             }
 
-            RegistryKey key = Registry.CurrentUser.CreateSubKey($"Software\\Classes\\{extension}");
+            RegistryKey key = Registry.CurrentUser.CreateSubKey($@"Software\Classes\{extension}");
             key.SetValue("", description);
-            key.CreateSubKey("shell\\\\open\\\\command").SetValue("", $"\"{programPath}\" \"%1\"");
+            key.CreateSubKey(@"shell\open\command").SetValue("", $"\"{programPath}\" \"%1\"");
             key.Close();
             Logger.Log("Created file association for " + extension);
         }
@@ -123,11 +123,11 @@ namespace osu.Game.Updater
         public void RemoveFileAssociation(string extension)
         {
             Logger.Log("Removing file association for " + extension);
-            RegistryKey? key = Registry.CurrentUser.OpenSubKey($"Software\\Classes\\{extension}");
+            RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
 
             if (key != null)
             {
-                Registry.CurrentUser.DeleteSubKeyTree($"Software\\Classes\\{extension}");
+                Registry.CurrentUser.DeleteSubKeyTree($@"Software\Classes\{extension}");
                 Logger.Log("Removed file association for " + extension);
             }
             else
@@ -151,10 +151,10 @@ namespace osu.Game.Updater
 
         public bool IsAssociated(string extension, string programPath)
         {
-            RegistryKey? key = Registry.CurrentUser.OpenSubKey($"Software\\Classes\\{extension}");
+            RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
 
             // Check if the value set is equal to the path of the executable
-            return key?.OpenSubKey("shell\\\\open\\\\command")?.GetValue("")?.ToString() == $"\"{programPath}\" \"%1\"";
+            return key?.OpenSubKey(@"shell\open\command")?.GetValue("")?.ToString() == $"\"{programPath}\" \"%1\"";
         }
 
         /// <summary>

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -33,7 +33,6 @@ namespace osu.Game.Updater
             { ".osz", "osu! beatmap" },
             { ".osr", "osu! replay" },
             { ".osk", "osu! skin" },
-            { ".osu", "osu! difficulty" },
             { ".olz", "osu! beatmap" }
         };
 

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -93,6 +93,16 @@ namespace osu.Game.Updater
         public void CreateFileAssociation(string extension, string programPath)
         {
             Logger.Log("Creating file association for " + extension);
+
+            // Check if the extension has a file explorer override, if so, delete the override
+            RegistryKey? fileExplorerKey = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\" + extension, true);
+
+            if (fileExplorerKey != null)
+            {
+                fileExplorerKey.DeleteSubKey("UserChoice", false);
+                fileExplorerKey.Close();
+            }
+
             RegistryKey key = Registry.CurrentUser.CreateSubKey($"Software\\Classes\\{extension}");
             key.CreateSubKey("shell\\\\open\\\\command").SetValue("", $"\"{programPath}\" \"%1\"");
             key.Close();

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -101,6 +101,11 @@ namespace osu.Game.Updater
             {
                 fileExplorerKey.DeleteSubKey("UserChoice", false);
                 fileExplorerKey.Close();
+                Logger.Log("Deleted file explorer override for " + extension);
+            }
+            else
+            {
+                Logger.Log("File explorer override for " + extension + " does not exist!");
             }
 
             RegistryKey key = Registry.CurrentUser.CreateSubKey($"Software\\Classes\\{extension}");

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Updater
         public void InitializeFileAssociations()
         {
             Logger.Log("Setting up file associations!");
-            string programPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\osu!.exe";
+            string programPath = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "osu!.exe");
 
             foreach (string extension in associated_extensions.Keys)
             {
@@ -165,7 +165,7 @@ namespace osu.Game.Updater
         /// </returns>
         public bool EnsureAssociationsSet()
         {
-            string programPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\osu!.exe";
+            string programPath = Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "osu!.exe");
 
             // Loop through all of the extensions and check if they are associated
             return associated_extensions.All(extension => IsAssociated(extension.Key, programPath));

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -119,6 +119,8 @@ namespace osu.Game.Updater
 
         public void RemoveFileAssociation(string extension)
         {
+            if (string.IsNullOrWhiteSpace(extension)) throw new ArgumentNullException(nameof(extension));
+
             Logger.Log("Removing file association for " + extension);
             using RegistryKey? key = Registry.CurrentUser.OpenSubKey($@"Software\Classes\{extension}");
 

--- a/osu.Game/Updater/AssociationManager.cs
+++ b/osu.Game/Updater/AssociationManager.cs
@@ -1,0 +1,155 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Game.Updater
+{
+    [SupportedOSPlatform("windows")]
+    public partial class AssociationManager : CompositeDrawable
+    {
+        // Needed so that Explorer windows get refreshed after the registry is updated
+        [DllImport("Shell32.dll")]
+        private static extern int SHChangeNotify(int eventId, int flags, IntPtr item1, IntPtr item2);
+
+        private static readonly string[] associated_extensions =
+        {
+            ".osz",
+            ".osr",
+            ".osk",
+            ".osu",
+            ".osr",
+        };
+
+        [Resolved]
+        protected INotificationOverlay Notifications { get; private set; } = null!;
+
+        // TODO: Somehow make this run on initial setup without prompting the user
+        /// <summary>
+        /// This checks the integrity of the file associations. If they look out of place, it will prompt the user via notifications to fix them.
+        /// </summary>
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Logger.Log("Checking file associations");
+
+            bool fileAssociationStatus = EnsureAssociationsSet();
+
+            if (!fileAssociationStatus)
+            {
+                // Files are not associated, prompt the user to fix them
+                Notifications.Post(new SimpleNotification
+                {
+                    Icon = FontAwesome.Solid.ExclamationCircle,
+                    Text = "File associations are not set up correctly! Do you want to fix them?",
+                    Activated = () =>
+                    {
+                        InitializeFileAssociations();
+                        Notifications.Post(new SimpleNotification
+                        {
+                            Icon = FontAwesome.Solid.CheckCircle,
+                            Text = "File associations have been fixed!",
+                        });
+                        return true;
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Initializes (creates) the file associations
+        /// </summary>
+        public void InitializeFileAssociations()
+        {
+            Logger.Log("Setting up file associations!");
+            string programPath = Assembly.GetEntryAssembly()?.Location ?? throw new InvalidOperationException("Could not get entry assembly location.");
+
+            foreach (string extension in associated_extensions)
+            {
+                CreateFileAssociation(extension, programPath);
+            }
+
+            SHChangeNotify(0x8000000, 0x1000, IntPtr.Zero, IntPtr.Zero); // Notify Explorer that the file associations have changed
+        }
+
+        /// <summary>
+        /// Create an association for a specific extension
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <param name="programPath"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public void CreateFileAssociation(string extension, string programPath)
+        {
+            Logger.Log("Creating file association for " + extension);
+            RegistryKey key = Registry.CurrentUser.CreateSubKey($"Software\\Classes\\{extension}");
+            key.CreateSubKey("shell\\\\open\\\\command").SetValue("", $"\"{programPath}\" \"%1\"");
+            key.Close();
+            Logger.Log("Created file association for " + extension);
+        }
+
+        public void RemoveFileAssociation(string extension)
+        {
+            Logger.Log("Removing file association for " + extension);
+            RegistryKey? key = Registry.CurrentUser.OpenSubKey($"Software\\Classes\\{extension}");
+
+            if (key != null)
+            {
+                Registry.CurrentUser.DeleteSubKeyTree($"Software\\Classes\\{extension}");
+                Logger.Log("Removed file association for " + extension);
+            }
+            else
+            {
+                Logger.Log("File association for " + extension + " does not exist!");
+            }
+        }
+
+        /// <summary>
+        /// Removes all of the file associations
+        /// </summary>
+        public void RemoveFileAssociations()
+        {
+            foreach (string extension in associated_extensions)
+            {
+                RemoveFileAssociation(extension);
+            }
+
+            SHChangeNotify(0x8000000, 0x1000, IntPtr.Zero, IntPtr.Zero); // Notify Explorer that the file associations have changed
+        }
+
+        public bool IsAssociated(string extension)
+        {
+            RegistryKey? key = Registry.CurrentUser.OpenSubKey($"Software\\Classes\\{extension}");
+            return key != null;
+        }
+
+        /// <summary>
+        /// Ensures that the file associations are valid
+        /// </summary>
+        /// <returns>
+        /// Whether the file associations are valid or not
+        /// </returns>
+        public bool EnsureAssociationsSet()
+        {
+            // Loop through all of the extensions and check if they are associated
+            foreach (string extension in associated_extensions)
+            {
+                if (!IsAssociated(extension))
+                {
+                    return false; // If any of them are not associated, return false
+                }
+            }
+
+            return true; // If all of them are associated, return true
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the initial implementation of `AssociationManager.cs`, a module which controls file associations for Windows within Lazer. This PR addresses #14824.

`AssociationManager.cs` is initialized on first time setup & game startup. First, it checks the integrity of the file association registry keys. If they look out of place, it will let the user know about this via notifications. The user can then choose to let lazer create the file associations, otherwise they can simply dismiss the notification.

The file associations are written to a different place than stable. Stable writes to `HKCR` while this implementation writes to `HKCU`. By doing this, we no longer need osu! to ask for admin permissions to set up the associations, and we can also let users manage their associations at any point in time. However, this also results in an issue where stable's registry keys are prioritized over lazer's (at least for me) even though the keys in `HKCU` are supposed to be prioritized. I'll probably try this again in a virtual machine to rule out file explorer overrides having an effect on it.

<hr />

### TODO:
- [ ]  Associate files on first time setup without prompting the user
- [x]  Add names to the registry keys to have files show up in explorer as `osu! beatmap`, `osu! replay`, etc, instead of just `osu! File`
- [ ]  Make file associations take on the proper osu icon
- [ ]  Add URL handler registry key
- [ ]  Address stable's registry keys in `HKCR` being prioritized over lazer's registry keys in `HKCU` (discussion in #14824)
- [ ]  Find a way to actually locate the executable instead of just using `installation directory\osu!.exe`
- [ ]  Fix up docs & code style
- [ ]  Reduce verbosity when using release configuration (or just reduce verbosity once this is ready for review)
- [ ]  Add a way to permanently dismiss the notification (would probably require the below)
- [ ]  Add a setting to the maintenance section of the settings menu to allow users to manage associations at any time (Needs more consideration)
