### PR TITLE
Fix slider sometimes not updating anchor position of nested objects

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderApplication.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             DrawableSlider dho = null;
 
-            AddStep("create slider", () => Child = dho = new DrawableSlider(prepareObject(new Slider
+            AddStep("create slider", () => Child = dho = new DrawableSlider(applyDefaults(new Slider
             {
                 Position = new Vector2(256, 192),
                 IndexInCurrentCombo = 0,
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddWaitStep("wait for progression", 1);
 
-            AddStep("apply new slider", () => dho.Apply(prepareObject(new Slider
+            AddStep("apply new slider", () => dho.Apply(applyDefaults(new Slider
             {
                 Position = new Vector2(256, 192),
                 ComboIndex = 1,
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                 Child = new SkinProvidingContainer(provider)
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Child = dho = new DrawableSlider(prepareObject(new Slider
+                    Child = dho = new DrawableSlider(applyDefaults(new Slider
                     {
                         Position = new Vector2(256, 192),
                         IndexInCurrentCombo = 0,
@@ -97,7 +97,38 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("ball is red", () => dho.ChildrenOfType<LegacySliderBall>().Single().BallColour == Color4.Red);
         }
 
-        private Slider prepareObject(Slider slider)
+        [Test]
+        public void TestIncreaseRepeatCount()
+        {
+            DrawableSlider dho = null;
+
+            AddStep("create slider", () =>
+            {
+                Child = dho = new DrawableSlider(applyDefaults(new Slider
+                {
+                    Position = new Vector2(256, 192),
+                    IndexInCurrentCombo = 0,
+                    StartTime = Time.Current,
+                    Path = new SliderPath(PathType.LINEAR, new[]
+                    {
+                        Vector2.Zero,
+                        new Vector2(150, 100),
+                        new Vector2(300, 0),
+                    })
+                }));
+            });
+
+            AddStep("increase repeat count", () =>
+            {
+                dho.HitObject.RepeatCount++;
+                applyDefaults(dho.HitObject);
+            });
+
+            AddAssert("repeat got custom anchor", () =>
+                dho.ChildrenOfType<DrawableSliderRepeat>().Single().RelativeAnchorPosition == Vector2.Divide(dho.SliderBody!.PathOffset, dho.DrawSize));
+        }
+
+        private Slider applyDefaults(Slider slider)
         {
             slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
             return slider;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private Container<DrawableSliderRepeat> repeatContainer;
         private PausableSkinnableSound slidingSample;
 
-        private readonly LayoutValue drawSizeLayout;
+        private readonly LayoutValue relativeAnchorPositionLayout;
 
         public DrawableSlider()
             : this(null)
@@ -85,7 +85,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 AlwaysPresent = true,
                 Alpha = 0
             };
-            AddLayout(drawSizeLayout = new LayoutValue(Invalidation.DrawSize | Invalidation.MiscGeometry));
+            AddLayout(relativeAnchorPositionLayout = new LayoutValue(Invalidation.DrawSize | Invalidation.MiscGeometry));
         }
 
         [BackgroundDependencyLoader]
@@ -190,6 +190,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     repeatContainer.Add(repeat);
                     break;
             }
+
+            relativeAnchorPositionLayout.Invalidate();
         }
 
         protected override void ClearNestedHitObjects()
@@ -265,14 +267,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             Size = SliderBody?.Size ?? Vector2.Zero;
             OriginPosition = SliderBody?.PathOffset ?? Vector2.Zero;
 
-            if (!drawSizeLayout.IsValid)
+            if (!relativeAnchorPositionLayout.IsValid)
             {
                 Vector2 pos = Vector2.Divide(OriginPosition, DrawSize);
                 foreach (var obj in NestedHitObjects)
                     obj.RelativeAnchorPosition = pos;
                 Ball.RelativeAnchorPosition = pos;
 
-                drawSizeLayout.Validate();
+                relativeAnchorPositionLayout.Validate();
             }
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26633

For the repeat object to appear correctly, its anchor position is supposed to be updated by `DrawableSlider` in update method. However, there is a layout that needs to be invalidated first for the repeat to be updated, and that does not get invalidated when replacing/adding a repeat or any other nested object.