### PR TITLE
Reduce allocation overhead in `BeatmapCarousel`

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -899,7 +899,7 @@ namespace osu.Game.Screens.Select
 
             // Update externally controlled state of currently visible items (e.g. x-offset and opacity).
             // This is a per-frame update on all drawable panels.
-            foreach (DrawableCarouselItem item in Scroll.ScrollContent)
+            foreach (DrawableCarouselItem item in Scroll)
             {
                 updateItem(item);
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -868,7 +868,7 @@ namespace osu.Game.Screens.Select
                 {
                     var toDisplay = visibleItems.GetRange(displayedRange.first, displayedRange.last - displayedRange.first + 1);
 
-                    foreach (var panel in Scroll.Children)
+                    foreach (var panel in Scroll)
                     {
                         Debug.Assert(panel.Item != null);
 
@@ -1094,7 +1094,7 @@ namespace osu.Game.Screens.Select
                         // to enter clamp-special-case mode where it animates completely differently to normal.
                         float scrollChange = scrollTarget.Value - Scroll.Current;
                         Scroll.ScrollTo(scrollTarget.Value, false);
-                        foreach (var i in Scroll.Children)
+                        foreach (var i in Scroll)
                             i.Y += scrollChange;
                         break;
                 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -899,7 +899,7 @@ namespace osu.Game.Screens.Select
 
             // Update externally controlled state of currently visible items (e.g. x-offset and opacity).
             // This is a per-frame update on all drawable panels.
-            foreach (DrawableCarouselItem item in Scroll.Children)
+            foreach (DrawableCarouselItem item in Scroll.ScrollContent)
             {
                 updateItem(item);
 


### PR DESCRIPTION
This fix was brought to you by [this comment](https://github.com/ppy/osu-framework/blob/f6feea4b08de3a5182fa15f6913edfcffeceb267/osu.Framework/Graphics/Containers/Container.cs#L77). Basically `Container` has built-in enumerator caching and accessing children directly won't provide such luxury.

Before vs after
![Снимок экрана (456)](https://github.com/ppy/osu/assets/22874522/c4557c83-e06a-4e1e-8601-db6bc52d35f5)