### PR TITLE
Fix blueprint container not handling right clicks correctly while moving a blueprint

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected override bool OnMouseDown(MouseDownEvent e)
         {
             bool selectionPerformed = performMouseDownActions(e);
-            bool movementPossible = prepareSelectionMovement();
+            bool movementPossible = prepareSelectionMovement(e);
 
             // check if selection has occurred
             if (selectionPerformed)
@@ -536,9 +536,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <summary>
         /// Attempts to begin the movement of any selected blueprints.
         /// </summary>
+        /// <param name="e">The <see cref="MouseDownEvent"/> defining the beginning of a movement.</param>
         /// <returns>Whether a movement is possible.</returns>
-        private bool prepareSelectionMovement()
+        private bool prepareSelectionMovement(MouseDownEvent e)
         {
+            if (e.Button == MouseButton.Right)
+                return false;
+
             if (!SelectionHandler.SelectedBlueprints.Any())
                 return false;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26640

While a blueprint is being dragged, pressing right click would trigger a `prepareSelectionMovement` call, which incorrectly changes the `movementBlueprintsOriginalPositions` array, causing the next drag event to calculate the movement delta incorrectly, leading to the blueprint jumping to an unexpected position.

The guard added here is intentionally checking only for `Right` mouse buttons, to match with the other guard in `OnDragStart`.

Before:

https://github.com/ppy/osu/assets/22781491/771031d0-ceb5-4c18-8dc5-c15851250dd8

After:

https://github.com/ppy/osu/assets/22781491/f4815044-5cbd-40fa-86fa-847c9b83fe1a

