### PR TITLE
Adjust slider tick / end miss animations to be less busy

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
@@ -65,14 +65,15 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             if (Result == HitResult.IgnoreMiss || Result == HitResult.LargeTickMiss)
             {
                 this.RotateTo(-45);
-                this.ScaleTo(1.8f);
+                this.ScaleTo(1.6f);
                 this.ScaleTo(1.2f, 100, Easing.In);
 
-                this.MoveTo(Vector2.Zero);
-                this.MoveToOffset(new Vector2(0, 10), 800, Easing.InQuint);
+                this.FadeOutFromOne(400);
             }
             else if (Result.IsMiss())
             {
+                this.FadeOutFromOne(800);
+
                 this.ScaleTo(1.6f);
                 this.ScaleTo(1, 100, Easing.In);
 
@@ -84,13 +85,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             }
             else
             {
+                this.FadeOutFromOne(800);
+
                 JudgementText
                     .FadeInFromZero(300, Easing.OutQuint)
                     .ScaleTo(Vector2.One)
                     .ScaleTo(new Vector2(1.2f), 1800, Easing.OutQuint);
             }
-
-            this.FadeOutFromOne(800);
 
             ringExplosion?.PlayAnimation();
         }

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -49,8 +49,10 @@ namespace osu.Game.Rulesets.Judgements
                 this.ScaleTo(1.2f, 100, Easing.In);
 
                 this.FadeOutFromOne(400);
+                return;
             }
-            else if (Result.IsMiss())
+
+            if (Result.IsMiss())
             {
                 this.ScaleTo(1.6f);
                 this.ScaleTo(1, 100, Easing.In);
@@ -60,9 +62,9 @@ namespace osu.Game.Rulesets.Judgements
 
                 this.RotateTo(0);
                 this.RotateTo(40, 800, Easing.InQuint);
-
-                this.FadeOutFromOne(800);
             }
+
+            this.FadeOutFromOne(800);
         }
 
         public Drawable? GetAboveHitObjectsProxiedContent() => null;

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -45,11 +45,10 @@ namespace osu.Game.Rulesets.Judgements
             if (Result == HitResult.IgnoreMiss || Result == HitResult.LargeTickMiss)
             {
                 this.RotateTo(-45);
-                this.ScaleTo(1.8f);
+                this.ScaleTo(1.6f);
                 this.ScaleTo(1.2f, 100, Easing.In);
 
-                this.MoveTo(Vector2.Zero);
-                this.MoveToOffset(new Vector2(0, 10), 800, Easing.InQuint);
+                this.FadeOutFromOne(400);
             }
             else if (Result.IsMiss())
             {
@@ -61,9 +60,9 @@ namespace osu.Game.Rulesets.Judgements
 
                 this.RotateTo(0);
                 this.RotateTo(40, 800, Easing.InQuint);
-            }
 
-            this.FadeOutFromOne(800);
+                this.FadeOutFromOne(800);
+            }
         }
 
         public Drawable? GetAboveHitObjectsProxiedContent() => null;

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -63,14 +63,10 @@ namespace osu.Game.Skinning
                 // missed ticks / slider end don't get the normal animation.
                 if (isMissedTick())
                 {
-                    this.ScaleTo(1.6f);
-                    this.ScaleTo(1, 100, Easing.In);
+                    this.ScaleTo(1.2f);
+                    this.ScaleTo(1f, 100, Easing.In);
 
-                    if (legacyVersion > 1.0m)
-                    {
-                        this.MoveTo(new Vector2(0, -2f));
-                        this.MoveToOffset(new Vector2(0, 10), fade_out_delay + fade_out_length, Easing.In);
-                    }
+                    this.FadeOutFromOne(400);
                 }
                 else
                 {


### PR DESCRIPTION
Attempts to address concerns in https://github.com/ppy/osu/discussions/26653.

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-22 at 09 51 53](https://github.com/ppy/osu/assets/191335/f3625517-533c-4e3a-bb84-41820d3c57c9) | ![CleanShot 2024-01-22 at 09 50 55](https://github.com/ppy/osu/assets/191335/e004d204-78e6-485f-85e6-e4d5bf55650e) |

The classic skin sprite probably needs to be shrunk a touch, but I'll look into that separately.