### PR TITLE
Fix score submission test failures due to checking audio playback validity (again)

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -23,6 +23,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.Play;
 using osu.Game.Screens.Ranking;
 using osu.Game.Tests.Beatmaps;
 
@@ -382,6 +383,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 AllowImportCompletion = new SemaphoreSlim(1);
             }
+
+            protected override GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart)
+            {
+                ShouldValidatePlaybackRate = false,
+            };
 
             protected override async Task ImportScore(Score score)
             {


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/7607899979/job/20716013982?pr=26662#step:5:75

In https://github.com/ppy/osu/pull/26484, I went "well if I'm moving the enabling of validation of playback rate to `SubmittingPlayer` context, then surely I can remove the local override in the test scene, right?"

Reader: Apparently I did not notice that `FakeImportingPlayer : TestPlayer : SoloPlayer : SubmittingPlayer`. So no, I could not remove the local override in the test scene.

You could probably attempt to conjure up some excuse about deep inheritance hierarchies here but nah. Really just a failure to read on my behalf as usual.