### PR TITLE
Reduce enumerator overhead in `GameplayLeaderboard`

### DIFF
--- a/osu.Desktop.slnf
+++ b/osu.Desktop.slnf
@@ -16,15 +16,14 @@
       "osu.Game.Tournament.Tests\\osu.Game.Tournament.Tests.csproj",
       "osu.Game.Tournament\\osu.Game.Tournament.csproj",
       "osu.Game\\osu.Game.csproj",
-
-      "Templates\\Rulesets\\ruleset-empty\\osu.Game.Rulesets.EmptyFreeform\\osu.Game.Rulesets.EmptyFreeform.csproj",
       "Templates\\Rulesets\\ruleset-empty\\osu.Game.Rulesets.EmptyFreeform.Tests\\osu.Game.Rulesets.EmptyFreeform.Tests.csproj",
-      "Templates\\Rulesets\\ruleset-example\\osu.Game.Rulesets.Pippidon\\osu.Game.Rulesets.Pippidon.csproj",
+      "Templates\\Rulesets\\ruleset-empty\\osu.Game.Rulesets.EmptyFreeform\\osu.Game.Rulesets.EmptyFreeform.csproj",
       "Templates\\Rulesets\\ruleset-example\\osu.Game.Rulesets.Pippidon.Tests\\osu.Game.Rulesets.Pippidon.Tests.csproj",
-      "Templates\\Rulesets\\ruleset-scrolling-empty\\osu.Game.Rulesets.EmptyScrolling\\osu.Game.Rulesets.EmptyScrolling.csproj",
+      "Templates\\Rulesets\\ruleset-example\\osu.Game.Rulesets.Pippidon\\osu.Game.Rulesets.Pippidon.csproj",
       "Templates\\Rulesets\\ruleset-scrolling-empty\\osu.Game.Rulesets.EmptyScrolling.Tests\\osu.Game.Rulesets.EmptyScrolling.Tests.csproj",
-      "Templates\\Rulesets\\ruleset-scrolling-example\\osu.Game.Rulesets.Pippidon\\osu.Game.Rulesets.Pippidon.csproj",
-      "Templates\\Rulesets\\ruleset-scrolling-example\\osu.Game.Rulesets.Pippidon.Tests\\osu.Game.Rulesets.Pippidon.Tests.csproj"
+      "Templates\\Rulesets\\ruleset-scrolling-empty\\osu.Game.Rulesets.EmptyScrolling\\osu.Game.Rulesets.EmptyScrolling.csproj",
+      "Templates\\Rulesets\\ruleset-scrolling-example\\osu.Game.Rulesets.Pippidon.Tests\\osu.Game.Rulesets.Pippidon.Tests.csproj",
+      "Templates\\Rulesets\\ruleset-scrolling-example\\osu.Game.Rulesets.Pippidon\\osu.Game.Rulesets.Pippidon.csproj"
     ]
   }
 }

--- a/osu.Game/Graphics/Containers/WaveContainer.cs
+++ b/osu.Game/Graphics/Containers/WaveContainer.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override void PopIn()
         {
-            foreach (var w in wavesContainer.Children)
+            foreach (var w in wavesContainer)
                 w.Show();
 
             contentContainer.MoveToY(0, APPEAR_DURATION, Easing.OutQuint);
@@ -132,7 +132,7 @@ namespace osu.Game.Graphics.Containers
 
         protected override void PopOut()
         {
-            foreach (var w in wavesContainer.Children)
+            foreach (var w in wavesContainer)
                 w.Hide();
 
             contentContainer.MoveToY(2, DISAPPEAR_DURATION, Easing.In);

--- a/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
+++ b/osu.Game/Graphics/UserInterface/BreadcrumbControl.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Graphics.UserInterface
 
             Current.ValueChanged += index =>
             {
-                foreach (var t in TabContainer.Children.OfType<BreadcrumbTabItem>())
+                foreach (var t in TabContainer.OfType<BreadcrumbTabItem>())
                 {
                     int tIndex = TabContainer.IndexOf(t);
                     int tabIndex = TabContainer.IndexOf(TabMap[index.NewValue]);

--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 if (Dropdown is IHasAccentColour dropdown)
                     dropdown.AccentColour = value;
-                foreach (var i in TabContainer.Children.OfType<IHasAccentColour>())
+                foreach (var i in TabContainer.OfType<IHasAccentColour>())
                     i.AccentColour = value;
             }
         }
@@ -48,7 +48,7 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override TabItem<T> CreateTabItem(T value) => new OsuTabItem(value);
 
-        protected virtual float StripWidth => TabContainer.Children.Sum(c => c.IsPresent ? c.DrawWidth + TabContainer.Spacing.X : 0) - TabContainer.Spacing.X;
+        protected virtual float StripWidth => TabContainer.Sum(c => c.IsPresent ? c.DrawWidth + TabContainer.Spacing.X : 0) - TabContainer.Spacing.X;
 
         /// <summary>
         /// Whether entries should be automatically populated if <typeparamref name="T"/> is an <see cref="Enum"/> type.

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Graphics.UserInterface
         public void StopAnimation()
         {
             animate(current);
-            foreach (var star in stars.Children)
+            foreach (var star in stars)
                 star.FinishTransforms(true);
         }
 

--- a/osu.Game/Online/Leaderboards/Leaderboard.cs
+++ b/osu.Game/Online/Leaderboards/Leaderboard.cs
@@ -287,7 +287,7 @@ namespace osu.Game.Online.Leaderboards
 
                 double delay = 0;
 
-                foreach (var s in scoreFlowContainer.Children)
+                foreach (var s in scoreFlowContainer)
                 {
                     using (s.BeginDelayedSequence(delay))
                         s.Show();
@@ -384,7 +384,7 @@ namespace osu.Game.Online.Leaderboards
             if (scoreFlowContainer == null)
                 return;
 
-            foreach (var c in scoreFlowContainer.Children)
+            foreach (var c in scoreFlowContainer)
             {
                 float topY = c.ToSpaceOfOtherDrawable(Vector2.Zero, scoreFlowContainer).Y;
                 float bottomY = topY + LeaderboardScore.HEIGHT;

--- a/osu.Game/Overlays/Chat/Listing/ChannelListing.cs
+++ b/osu.Game/Overlays/Chat/Listing/ChannelListing.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Overlays.Chat.Listing
             flow.ChildrenEnumerable = newChannels.Where(c => c.Type == ChannelType.Public)
                                                  .Select(c => new ChannelListingItem(c));
 
-            foreach (var item in flow.Children)
+            foreach (var item in flow)
             {
                 item.OnRequestJoin += channel => OnRequestJoin?.Invoke(channel);
                 item.OnRequestLeave += channel => OnRequestLeave?.Invoke(channel);

--- a/osu.Game/Overlays/OverlayStreamControl.cs
+++ b/osu.Game/Overlays/OverlayStreamControl.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Overlays
 
         protected override bool OnHover(HoverEvent e)
         {
-            foreach (var streamBadge in TabContainer.Children.OfType<OverlayStreamItem<T>>())
+            foreach (var streamBadge in TabContainer.OfType<OverlayStreamItem<T>>())
                 streamBadge.UserHoveringArea = true;
 
             return base.OnHover(e);
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            foreach (var streamBadge in TabContainer.Children.OfType<OverlayStreamItem<T>>())
+            foreach (var streamBadge in TabContainer.OfType<OverlayStreamItem<T>>())
                 streamBadge.UserHoveringArea = false;
 
             base.OnHoverLost(e);

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -343,7 +343,7 @@ namespace osu.Game.Screens.Menu
                 {
                     buttonArea.ButtonSystemState = state;
 
-                    foreach (var b in buttonArea.Children.OfType<MainMenuButton>())
+                    foreach (var b in buttonArea.OfType<MainMenuButton>())
                         b.ButtonSystemState = state;
                 }
 

--- a/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/GameplayLeaderboard.cs
@@ -128,7 +128,7 @@ namespace osu.Game.Screens.Play.HUD
             if (!scroll.IsScrolledToEnd()) fadeBottom -= panel_height;
 
             // logic is mostly shared with Leaderboard, copied here for simplicity.
-            foreach (var c in Flow.Children)
+            foreach (var c in Flow)
             {
                 float topY = c.ToSpaceOfOtherDrawable(Vector2.Zero, Flow).Y;
                 float bottomY = topY + panel_height;

--- a/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/JudgementCounter/JudgementCounterDisplay.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Screens.Play.HUD.JudgementCounter
 
                 CounterFlow.Direction = convertedDirection;
 
-                foreach (var counter in CounterFlow.Children)
+                foreach (var counter in CounterFlow)
                     counter.Direction.Value = convertedDirection;
             }, true);
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             bool isSelected = Item?.State.Value == CarouselItemState.Selected;
 
-            foreach (var panel in beatmapContainer.Children)
+            foreach (var panel in beatmapContainer)
             {
                 Debug.Assert(panel.Item != null);
 


### PR DESCRIPTION
In a similar vein to https://github.com/ppy/osu/pull/26660. Noticed the overhead of `GameplayLeaderboard` makes it still a top allocator during gameplay. Probably one of the remaining easy wins (rest is transforms, input and audio samples.....)

Applied in other places because we can.

![2024-01-23 05 34 06@2x](https://github.com/ppy/osu/assets/191335/af88eaf3-5984-4a47-af54-c776ecd46c48)
