### PR TITLE
Change osu!taiko's scrolling time range to match stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -69,12 +69,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected virtual double ComputeTimeRange()
         {
-            float aspectRatio = Math.Clamp(
-                DrawWidth / DrawHeight,
-                TaikoPlayfieldAdjustmentContainer.MINIMUM_ASPECT,
-                TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
-
-            return TaikoPlayfieldAdjustmentContainer.AspectRatioToTimeRange(aspectRatio);
+            return ((TaikoPlayfieldAdjustmentContainer)PlayfieldAdjustmentContainer).ComputeTimeRange();
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -16,7 +16,6 @@ using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Game.Rulesets.Timing;
@@ -70,19 +69,12 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected virtual double ComputeTimeRange()
         {
-            // Taiko scrolls at a constant 100px per 1000ms. More notes become visible as the playfield is lengthened.
-            const float scroll_rate = 10;
+            float aspectRatio = Math.Clamp(
+                DrawWidth / DrawHeight,
+                TaikoPlayfieldAdjustmentContainer.MINIMUM_ASPECT,
+                TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
 
-            // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
-            // Width is used because it defines how many notes fit on the playfield.
-            // We clamp the ratio to the maximum aspect ratio to keep scroll speed consistent on widths lower than the default.
-            float ratio = Math.Max(DrawSize.X / 768f, TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
-
-            // Stable internally increased the slider velocity of objects by a factor of `VELOCITY_MULTIPLIER`.
-            // To simulate this, we shrink the time range by that factor here.
-            // This, when combined with the rest of the scrolling ruleset machinery (see `MultiplierControlPoint` et al.),
-            // has the effect of increasing each multiplier control point's multiplier by `VELOCITY_MULTIPLIER`, ensuring parity with stable.
-            return (Playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
+            return TaikoPlayfieldAdjustmentContainer.AspectRatioToTimeRange(aspectRatio);
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -13,20 +13,28 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
 
-        public const float DEFAULT_ASPECT = 16f / 9f;
-        public const float MAXIMUM_ASPECT = 16f / 9f;
-        public const float MINIMUM_ASPECT = 5f / 4f;
+        private const float MAXIMUM_ASPECT = 16f / 9f;
+        private const float MINIMUM_ASPECT = 5f / 4f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
-        public static double AspectRatioToTimeRange(float aspectRatio)
+        private static double aspectRatioToTimeRange(float aspectRatio)
         {
+            const float default_aspect = 16f / 9f;
+
+            // This value is taken by visual comparison with stable
             const float default_time_range = 7000 / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
 
             // This is the fraction of the width that should not contribute to time range.
-            const float ratio_compensator = 380f / 1366f;
+            const float non_playable_portion = 380f / 1366f;
 
-            return (aspectRatio - ratio_compensator) / (DEFAULT_ASPECT - ratio_compensator) * default_time_range;
+            return (aspectRatio - non_playable_portion) / (default_aspect - non_playable_portion) * default_time_range;
+        }
+
+        public double ComputeTimeRange()
+        {
+            float aspectRatio = Math.Clamp(Parent!.ChildSize.X / Parent!.ChildSize.Y, MINIMUM_ASPECT, MAXIMUM_ASPECT);
+            return aspectRatioToTimeRange(aspectRatio);
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
 
-        private const float MAXIMUM_ASPECT = 16f / 9f;
-        private const float MINIMUM_ASPECT = 5f / 4f;
+        private const float maximum_aspect = 16f / 9f;
+        private const float minimum_aspect = 5f / 4f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         public double ComputeTimeRange()
         {
-            float aspectRatio = Math.Clamp(Parent!.ChildSize.X / Parent!.ChildSize.Y, MINIMUM_ASPECT, MAXIMUM_ASPECT);
+            float aspectRatio = Math.Clamp(Parent!.ChildSize.X / Parent!.ChildSize.Y, minimum_aspect, maximum_aspect);
             return aspectRatioToTimeRange(aspectRatio);
         }
 
@@ -52,10 +52,10 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 float currentAspect = Parent!.ChildSize.X / Parent!.ChildSize.Y;
 
-                if (currentAspect > MAXIMUM_ASPECT)
-                    height *= currentAspect / MAXIMUM_ASPECT;
-                else if (currentAspect < MINIMUM_ASPECT)
-                    height *= currentAspect / MINIMUM_ASPECT;
+                if (currentAspect > maximum_aspect)
+                    height *= currentAspect / maximum_aspect;
+                else if (currentAspect < minimum_aspect)
+                    height *= currentAspect / minimum_aspect;
             }
 
             // Limit the maximum relative height of the playfield to one-third of available area to avoid it masking out on extreme resolutions.

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.UI
@@ -12,10 +13,21 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         private const float default_relative_height = TaikoPlayfield.DEFAULT_HEIGHT / 768;
 
+        public const float DEFAULT_ASPECT = 16f / 9f;
         public const float MAXIMUM_ASPECT = 16f / 9f;
         public const float MINIMUM_ASPECT = 5f / 4f;
 
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
+
+        public static double AspectRatioToTimeRange(float aspectRatio)
+        {
+            const float default_time_range = 7000 / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
+
+            // This is the fraction of the width that should not contribute to time range.
+            const float ratio_compensator = 380f / 1366f;
+
+            return (aspectRatio - ratio_compensator) / (DEFAULT_ASPECT - ratio_compensator) * default_time_range;
+        }
 
         protected override void Update()
         {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -21,11 +21,9 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             const float default_aspect = 16f / 9f;
 
-            // This value is taken by visual comparison with stable
-            const float default_time_range = 7000 / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
-
-            // This is the fraction of the width that should not contribute to time range.
-            const float non_playable_portion = 380f / 1366f;
+            // These values are taken purely by visual comparison with stable
+            const float default_time_range = 6933 / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
+            const float non_playable_portion = 1f / 3f;
 
             return (aspectRatio - non_playable_portion) / (default_aspect - non_playable_portion) * default_time_range;
         }


### PR DESCRIPTION
This PR aims to address the time range difference of nomod between current lazer and stable (issue #25919). I'm also planning to base further changes for (classic) mods on this in a future PR, as this provides an easy way to convert between aspect ratio and time range matching stable's algorithm. I'm opening this as a separate PR as it seems to be easier to deal with this way.

## To note:

- The value of `default_time_range` is pretty much found by manually comparing with stable (which iirc was also the case for #19604)
- The 380px value of `ratio_compensator` is calculated from 200px (drum display) and 180px (input drum, taken from #26632)
- `DEFAULT_ASPECT` is only used by `AspectRatioToTimeRange` so it could be moved into there. It's placed on the class for now since it seems to fit there next to `MAXIMUM_ASPECT` and `MINIMUM ASPECT`

## Comparisons

Note that because of display differences, note overlap and apparent velocity may be different. But time range (amount of notes shown on screen, or the time that a note appears from the right side) should be matching.

These issues should be alleviated by the other existing PRs aiming to match stable's display.

_Apologies for the stuttery lazer recordings, I have no idea what's the cause (already using release build) but it doesn't seem to affect timings after notes start playing._

### 1920x1080 (16:9)

- Stable on top and lazer at the bottom

https://youtu.be/R7yaJFNhxQE

### 1280x1024 (5:4)

- Stable on top and lazer at the bottom

https://youtu.be/31CHiWGj1dE

### 1024x768 (4:3)

- Stable on top and lazer at the bottom

https://youtu.be/znIjYMx4Esk

### Aspect ratio wider than 16:9

- Time range should match each other (aspect ratio limited to <16:9)
- Reference on top (lazer 16:9) and wide ratio at the bottom

https://youtu.be/tSo2bz07JGY

### Aspect ratio narrower than 5:4

- Time range should match each other (aspect ratio limited to >5:4)
- Reference on top (lazer 5:4) and narrow ratio at the bottom

https://youtu.be/WaaIMkHn66k

