### PR TITLE
Prevent custom divisor ranges from halting divisor preset cycling

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneBeatDivisorControl.cs
@@ -210,6 +210,13 @@ namespace osu.Game.Tests.Visual.Editing
             switchPresets(-1);
             assertPreset(BeatDivisorType.Custom, 15);
             assertBeatSnap(15);
+
+            setDivisorViaInput(24);
+            assertPreset(BeatDivisorType.Custom, 24);
+            switchPresets(1);
+            assertPreset(BeatDivisorType.Common);
+            switchPresets(-2);
+            assertPreset(BeatDivisorType.Triplets);
         }
 
         private void switchBeatSnap(int direction) => AddRepeatStep($"move snap {(direction > 0 ? "forward" : "backward")}", () =>

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -29,10 +29,11 @@ namespace osu.Game.Screens.Edit
         /// Set a divisor, updating the valid divisor range appropriately.
         /// </summary>
         /// <param name="divisor">The intended divisor.</param>
-        public void SetArbitraryDivisor(int divisor)
+        /// <param name="force">Ignores the current valid divisor range when true.</param>
+        public void SetArbitraryDivisor(int divisor, bool force = false)
         {
             // If the current valid divisor range doesn't contain the proposed value, attempt to find one which does.
-            if (!ValidDivisors.Value.Presets.Contains(divisor))
+            if (force || !ValidDivisors.Value.Presets.Contains(divisor))
             {
                 if (BeatDivisorPresetCollection.COMMON.Presets.Contains(divisor))
                     ValidDivisors.Value = BeatDivisorPresetCollection.COMMON;

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -29,11 +29,11 @@ namespace osu.Game.Screens.Edit
         /// Set a divisor, updating the valid divisor range appropriately.
         /// </summary>
         /// <param name="divisor">The intended divisor.</param>
-        /// <param name="force">Ignores the current valid divisor range when true.</param>
-        public void SetArbitraryDivisor(int divisor, bool force = false)
+        /// <param name="preferKnownPresets">Forces changing the valid divisors to a known preset.</param>
+        public void SetArbitraryDivisor(int divisor, bool preferKnownPresets = false)
         {
             // If the current valid divisor range doesn't contain the proposed value, attempt to find one which does.
-            if (force || !ValidDivisors.Value.Presets.Contains(divisor))
+            if (preferKnownPresets || !ValidDivisors.Value.Presets.Contains(divisor))
             {
                 if (BeatDivisorPresetCollection.COMMON.Presets.Contains(divisor))
                     ValidDivisors.Value = BeatDivisorPresetCollection.COMMON;

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -208,11 +208,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             switch (currentType)
             {
                 case BeatDivisorType.Common:
-                    beatDivisor.SetArbitraryDivisor(4);
+                    beatDivisor.SetArbitraryDivisor(4, true);
                     break;
 
                 case BeatDivisorType.Triplets:
-                    beatDivisor.SetArbitraryDivisor(6);
+                    beatDivisor.SetArbitraryDivisor(6, true);
                     break;
 
                 case BeatDivisorType.Custom:


### PR DESCRIPTION
In the editor, if we enter a custom divisor of 24, it creates a custom divisor preset with the range:

`{1, 2, 3, 4, 6, 8, 12, 24}`

Then, when we try to switch back to the "common" or "triplets" presets, the divisor changes to the default value of those presets, but we're still stuck in the custom preset.

This happens because the custom preset contains both 4 and 6, and the preset will not change if the current valid divisor range already contains the proposed value. So the only way to manually break out of the custom preset is to enter a new custom divisor whose preset range won't contain 4 or 6.

This PR allows the current valid divisor range check to be skipped when cycling through presets.