### PR TITLE
Reduce localisation overhead in `ScoreCounter`

### DIFF
--- a/osu.Game/Graphics/UserInterface/ScoreCounter.cs
+++ b/osu.Game/Graphics/UserInterface/ScoreCounter.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
@@ -39,7 +38,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override double GetProportionalDuration(long currentValue, long newValue) =>
             currentValue > newValue ? currentValue - newValue : newValue - currentValue;
 
-        protected override LocalisableString FormatCount(long count) => count.ToLocalisableString(formatString);
+        protected override LocalisableString FormatCount(long count) => count.ToString(formatString);
 
         protected override OsuSpriteText CreateSpriteText()
             => base.CreateSpriteText().With(s => s.Font = s.Font.With(fixedWidth: true));

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Play.HUD
 
         public bool UsesFixedAnchor { get; set; }
 
-        protected override LocalisableString FormatCount(long count) => count.ToLocalisableString();
+        protected override LocalisableString FormatCount(long count) => count.ToString();
 
         protected override IHasText CreateText() => scoreText = new ArgonScoreTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersScore.ToUpper())
         {


### PR DESCRIPTION
HUD score does not contain any characters which may differ per localisation, so I guess there's no reason to localise it.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/6d4a71da-b75d-4e90-a634-c17dd2daf6dc)|![pr](https://github.com/ppy/osu/assets/22874522/17012681-ca94-4f2a-a911-14d9b79e45a1)|