### PR TITLE
Reduce sliding sample allocations in `DrawableSlider`

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -239,11 +239,11 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 if (Tracking.Value && Time.Current >= HitObject.StartTime)
                 {
                     // keep the sliding sample playing at the current tracking position
-                    if (!slidingSample.IsPlaying)
+                    if (!slidingSample.RequestedPlaying)
                         slidingSample.Play();
                     slidingSample.Balance.Value = CalculateSamplePlaybackBalance(CalculateDrawableRelativePosition(Ball));
                 }
-                else if (slidingSample.IsPlaying)
+                else if (slidingSample.IsPlaying || slidingSample.RequestedPlaying)
                     slidingSample.Stop();
             }
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSpinner.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             if (tracking.NewValue)
             {
-                if (!spinningSample.IsPlaying)
+                if (!spinningSample.RequestedPlaying)
                     spinningSample.Play();
 
                 spinningSample.VolumeTo(1, 300);


### PR DESCRIPTION
For some reason `IsPlaying` isn't reliable enough.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/caa730c7-9965-41e6-84fd-a883355a5f48)|![pr](https://github.com/ppy/osu/assets/22874522/8d852321-846a-4b37-9ae4-08a0550aa522)|