### PR TITLE
Adjust slider tick / end defaults again

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonJudgementPiece.cs
@@ -17,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Mania.Skinning.Argon
 {
-    public partial class ArgonJudgementPiece : JudgementPiece, IAnimatableJudgement
+    public partial class ArgonJudgementPiece : TextJudgementPiece, IAnimatableJudgement
     {
         private const float judgement_y_position = 160;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -88,8 +88,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    this.FadeOut(ANIM_DURATION);
-                    this.TransformBindableTo(AccentColour, Color4.Red, 0);
+                    this.FadeOut(ANIM_DURATION, Easing.OutQuint);
                     break;
 
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTick.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         public const double ANIM_DURATION = 150;
 
-        private const float default_tick_size = 16;
+        public const float DEFAULT_TICK_SIZE = 16;
 
         protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
 
@@ -44,8 +44,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 Masking = true,
                 Origin = Anchor.Centre,
-                Size = new Vector2(default_tick_size),
-                BorderThickness = default_tick_size / 4,
+                Size = new Vector2(DEFAULT_TICK_SIZE),
+                BorderThickness = DEFAULT_TICK_SIZE / 4,
                 BorderColour = Color4.White,
                 Child = new Box
                 {

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -28,6 +28,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Osu.Scoring;
 using osu.Game.Rulesets.Osu.Skinning.Argon;
+using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;
 using osu.Game.Rulesets.Osu.Statistics;
 using osu.Game.Rulesets.Osu.UI;
@@ -254,6 +255,9 @@ namespace osu.Game.Rulesets.Osu
 
                 case ArgonSkin:
                     return new OsuArgonSkinTransformer(skin);
+
+                case TrianglesSkin:
+                    return new OsuTrianglesSkinTransformer(skin);
             }
 
             return null;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPiece.cs
@@ -16,7 +16,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
-    public partial class ArgonJudgementPiece : JudgementPiece, IAnimatableJudgement
+    public partial class ArgonJudgementPiece : TextJudgementPiece, IAnimatableJudgement
     {
         private RingExplosion? ringExplosion;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPieceSliderTickMiss.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonJudgementPieceSliderTickMiss.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Argon
+{
+    public partial class ArgonJudgementPieceSliderTickMiss : CompositeDrawable, IAnimatableJudgement
+    {
+        private readonly HitResult result;
+        private Circle piece = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public ArgonJudgementPieceSliderTickMiss(HitResult result)
+        {
+            this.result = result;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(piece = new Circle
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Blending = BlendingParameters.Additive,
+                Colour = colours.ForHitResult(result),
+                Size = new Vector2(ArgonSliderScorePoint.SIZE)
+            });
+        }
+
+        public void PlayAnimation()
+        {
+            this.ScaleTo(1.4f);
+            this.ScaleTo(1f, 150, Easing.Out);
+
+            this.FadeOutFromOne(400);
+        }
+
+        public Drawable? GetAboveHitObjectsProxiedContent() => piece.CreateProxy();
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderScorePoint.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSliderScorePoint.cs
@@ -16,14 +16,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
     {
         private Bindable<Color4> accentColour = null!;
 
-        private const float size = 12;
+        public const float SIZE = 12;
 
         [BackgroundDependencyLoader]
         private void load(DrawableHitObject hitObject)
         {
             Masking = true;
             Origin = Anchor.Centre;
-            Size = new Vector2(size);
+            Size = new Vector2(SIZE);
             BorderThickness = 3;
             BorderColour = Color4.White;
             Child = new Box

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -19,11 +19,21 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             switch (lookup)
             {
                 case GameplaySkinComponentLookup<HitResult> resultComponent:
+                    HitResult result = resultComponent.Component;
+
                     // This should eventually be moved to a skin setting, when supported.
-                    if (Skin is ArgonProSkin && (resultComponent.Component == HitResult.Great || resultComponent.Component == HitResult.Perfect))
+                    if (Skin is ArgonProSkin && (result == HitResult.Great || result == HitResult.Perfect))
                         return Drawable.Empty();
 
-                    return new ArgonJudgementPiece(resultComponent.Component);
+                    switch (result)
+                    {
+                        case HitResult.IgnoreMiss:
+                        case HitResult.LargeTickMiss:
+                            return new ArgonJudgementPieceSliderTickMiss(result);
+
+                        default:
+                            return new ArgonJudgementPiece(result);
+                    }
 
                 case OsuSkinComponentLookup osuComponent:
                     // TODO: Once everything is finalised, consider throwing UnsupportedSkinComponentException on missing entries.

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultJudgementPieceSliderTickMiss.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultJudgementPieceSliderTickMiss.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public partial class DefaultJudgementPieceSliderTickMiss : CompositeDrawable, IAnimatableJudgement
+    {
+        private readonly HitResult result;
+        private Circle piece = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        public DefaultJudgementPieceSliderTickMiss(HitResult result)
+        {
+            this.result = result;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(piece = new Circle
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Blending = BlendingParameters.Additive,
+                Colour = colours.ForHitResult(result),
+                Size = new Vector2(DrawableSliderTick.DEFAULT_TICK_SIZE)
+            });
+        }
+
+        public void PlayAnimation()
+        {
+            this.ScaleTo(1.4f);
+            this.ScaleTo(1f, 150, Easing.Out);
+
+            this.FadeOutFromOne(400);
+        }
+
+        public Drawable? GetAboveHitObjectsProxiedContent() => piece.CreateProxy();
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Default/OsuTrianglesSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/OsuTrianglesSkinTransformer.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public class OsuTrianglesSkinTransformer : SkinTransformer
+    {
+        public OsuTrianglesSkinTransformer(ISkin skin)
+            : base(skin)
+        {
+        }
+
+        public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+        {
+            switch (lookup)
+            {
+                case GameplaySkinComponentLookup<HitResult> resultComponent:
+                    HitResult result = resultComponent.Component;
+
+                    switch (result)
+                    {
+                        case HitResult.IgnoreMiss:
+                        case HitResult.LargeTickMiss:
+                            // use argon judgement piece for new tick misses because i don't want to design another one for triangles.
+                            return new DefaultJudgementPieceSliderTickMiss(result);
+                    }
+
+                    break;
+            }
+
+            return base.GetDrawableComponent(lookup);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonJudgementPiece.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Argon/ArgonJudgementPiece.cs
@@ -17,7 +17,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Skinning.Argon
 {
-    public partial class ArgonJudgementPiece : JudgementPiece, IAnimatableJudgement
+    public partial class ArgonJudgementPiece : TextJudgementPiece, IAnimatableJudgement
     {
         private RingExplosion? ringExplosion;
 

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Graphics
             {
                 case HitResult.IgnoreMiss:
                 case HitResult.SmallTickMiss:
-                    return Orange1;
+                    return Color4.Gray;
 
                 case HitResult.Miss:
                 case HitResult.LargeTickMiss:

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -10,7 +10,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Judgements
 {
-    public partial class DefaultJudgementPiece : JudgementPiece, IAnimatableJudgement
+    public partial class DefaultJudgementPiece : TextJudgementPiece, IAnimatableJudgement
     {
         public DefaultJudgementPiece(HitResult result)
             : base(result)

--- a/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/DefaultJudgementPiece.cs
@@ -38,20 +38,6 @@ namespace osu.Game.Rulesets.Judgements
         /// </remarks>
         public virtual void PlayAnimation()
         {
-            // TODO: make these better. currently they are using a text `-` and it's not centered properly.
-            // Should be an explicit drawable.
-            //
-            // When this is done, remove the [Description] attributes from HitResults which were added for this purpose.
-            if (Result == HitResult.IgnoreMiss || Result == HitResult.LargeTickMiss)
-            {
-                this.RotateTo(-45);
-                this.ScaleTo(1.6f);
-                this.ScaleTo(1.2f, 100, Easing.In);
-
-                this.FadeOutFromOne(400);
-                return;
-            }
-
             if (Result.IsMiss())
             {
                 this.ScaleTo(1.6f);

--- a/osu.Game/Rulesets/Judgements/TextJudgementPiece.cs
+++ b/osu.Game/Rulesets/Judgements/TextJudgementPiece.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Judgements
 {
-    public abstract partial class JudgementPiece : CompositeDrawable
+    public abstract partial class TextJudgementPiece : CompositeDrawable
     {
         protected readonly HitResult Result;
 
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Judgements
         [Resolved]
         private OsuColour colours { get; set; } = null!;
 
-        protected JudgementPiece(HitResult result)
+        protected TextJudgementPiece(HitResult result)
         {
             Result = result;
         }

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -86,7 +86,6 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a large tick miss.
         /// </summary>
         [EnumMember(Value = "large_tick_miss")]
-        [Description("-")]
         [Order(11)]
         LargeTickMiss,
 
@@ -118,7 +117,6 @@ namespace osu.Game.Rulesets.Scoring
         /// Indicates a miss that should be ignored for scoring purposes.
         /// </summary>
         [EnumMember(Value = "ignore_miss")]
-        [Description("-")]
         [Order(14)]
         IgnoreMiss,
 

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Skinning
             if (!result.IsMiss())
             {
                 //new judgement shows old as a temporary effect
-                AddInternal(temporaryOldStyle = new LegacyJudgementPieceOld(result, createMainDrawable, 1.05f)
+                AddInternal(temporaryOldStyle = new LegacyJudgementPieceOld(result, createMainDrawable, 1.05f, true)
                 {
                     Blending = BlendingParameters.Additive,
                     Anchor = Anchor.Centre,

--- a/osu.Game/Skinning/LegacyJudgementPieceNew.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceNew.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Skinning
             if (!result.IsMiss())
             {
                 //new judgement shows old as a temporary effect
-                AddInternal(temporaryOldStyle = new LegacyJudgementPieceOld(result, createMainDrawable, 1.05f, true)
+                AddInternal(temporaryOldStyle = new LegacyJudgementPieceOld(result, createMainDrawable, 1.05f)
                 {
                     Blending = BlendingParameters.Additive,
                     Anchor = Anchor.Centre,

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -44,7 +44,6 @@ namespace osu.Game.Skinning
             const double fade_out_length = 600;
 
             this.FadeInFromZero(fade_in_length);
-            this.Delay(fade_out_delay).FadeOut(fade_out_length);
 
             if (result.IsMiss())
             {
@@ -74,6 +73,8 @@ namespace osu.Game.Skinning
                     this.RotateTo(0);
                     this.RotateTo(rotation, fade_in_length)
                         .Then().RotateTo(rotation * 2, fade_out_delay + fade_out_length - fade_in_length, Easing.In);
+
+                    this.Delay(fade_out_delay).FadeOut(fade_out_length);
                 }
             }
             else
@@ -87,6 +88,8 @@ namespace osu.Game.Skinning
                     // so we need to force the current value to be correct at 1.2 (0.95) then complete the
                     // second half of the transform.
                     .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f); // t = 1.4
+
+                this.Delay(fade_out_delay).FadeOut(fade_out_length);
             }
         }
 

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -18,16 +18,14 @@ namespace osu.Game.Skinning
         private readonly HitResult result;
 
         private readonly float finalScale;
-        private readonly bool forceTransforms;
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
 
-        public LegacyJudgementPieceOld(HitResult result, Func<Drawable> createMainDrawable, float finalScale = 1f, bool forceTransforms = false)
+        public LegacyJudgementPieceOld(HitResult result, Func<Drawable> createMainDrawable, float finalScale = 1f)
         {
             this.result = result;
             this.finalScale = finalScale;
-            this.forceTransforms = forceTransforms;
 
             AutoSizeAxes = Axes.Both;
             Origin = Anchor.Centre;
@@ -47,14 +45,6 @@ namespace osu.Game.Skinning
 
             this.FadeInFromZero(fade_in_length);
             this.Delay(fade_out_delay).FadeOut(fade_out_length);
-
-            // legacy judgements don't play any transforms if they are an animation.... UNLESS they are the temporary displayed judgement from new piece.
-            if (animation?.FrameCount > 1 && !forceTransforms)
-            {
-                if (isMissedTick())
-                    applyMissedTickScaling();
-                return;
-            }
 
             if (result.IsMiss())
             {

--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -18,14 +18,16 @@ namespace osu.Game.Skinning
         private readonly HitResult result;
 
         private readonly float finalScale;
+        private readonly bool forceTransforms;
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
 
-        public LegacyJudgementPieceOld(HitResult result, Func<Drawable> createMainDrawable, float finalScale = 1f)
+        public LegacyJudgementPieceOld(HitResult result, Func<Drawable> createMainDrawable, float finalScale = 1f, bool forceTransforms = false)
         {
             this.result = result;
             this.finalScale = finalScale;
+            this.forceTransforms = forceTransforms;
 
             AutoSizeAxes = Axes.Both;
             Origin = Anchor.Centre;
@@ -44,6 +46,10 @@ namespace osu.Game.Skinning
             const double fade_out_length = 600;
 
             this.FadeInFromZero(fade_in_length);
+
+            // legacy judgements don't play any transforms if they are an animation.... UNLESS they are the temporary displayed judgement from new piece.
+            if (animation?.FrameCount > 1 && !forceTransforms)
+                return;
 
             if (result.IsMiss())
             {
@@ -94,12 +100,6 @@ namespace osu.Game.Skinning
         }
 
         private bool isMissedTick() => result.IsMiss() && result != HitResult.Miss;
-
-        private void applyMissedTickScaling()
-        {
-            this.ScaleTo(0.6f);
-            this.ScaleTo(0.3f, 100, Easing.In);
-        }
 
         public Drawable GetAboveHitObjectsProxiedContent() => CreateProxy();
     }


### PR DESCRIPTION
The goal is to improve the defaults until less people complain

- [x] Depends on https://github.com/ppy/osu-resources/pull/304

---

More subtle, less noisy, but still should describe the misses quite well.

I toyed with bringing across the stable behaviour of ticks not fading out but people preferred this direction, so let's stick with it.

https://github.com/ppy/osu/assets/191335/7308fd37-5fda-4983-8b12-f9e3d99ea2bd

