### PR TITLE
Remove LINQ cast in `HUDOverlay`

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -258,14 +258,13 @@ namespace osu.Game.Screens.Play
 
             Vector2? highestBottomScreenSpace = null;
 
-            // cast can be removed when IDrawable interface includes Anchor / RelativeSizeAxes.
             foreach (var element in mainComponents.Components)
-                processDrawable(element as Drawable);
+                processDrawable(element);
 
             if (rulesetComponents != null)
             {
                 foreach (var element in rulesetComponents.Components)
-                    processDrawable(element as Drawable);
+                    processDrawable(element);
             }
 
             if (lowestTopScreenSpaceRight.HasValue)
@@ -283,33 +282,36 @@ namespace osu.Game.Screens.Play
             else
                 bottomRightElements.Y = 0;
 
-            void processDrawable(Drawable element)
+            void processDrawable(ISerialisableDrawable element)
             {
+                // Cast can be removed when IDrawable interface includes Anchor / RelativeSizeAxes.
+                Drawable drawable = (Drawable)element;
+
                 // for now align some top components with the bottom-edge of the lowest top-anchored hud element.
-                if (element.Anchor.HasFlagFast(Anchor.y0))
+                if (drawable.Anchor.HasFlagFast(Anchor.y0))
                 {
                     // health bars are excluded for the sake of hacky legacy skins which extend the health bar to take up the full screen area.
                     if (element is LegacyHealthDisplay)
                         return;
 
-                    float bottom = element.ScreenSpaceDrawQuad.BottomRight.Y;
+                    float bottom = drawable.ScreenSpaceDrawQuad.BottomRight.Y;
 
-                    bool isRelativeX = element.RelativeSizeAxes == Axes.X;
+                    bool isRelativeX = drawable.RelativeSizeAxes == Axes.X;
 
-                    if (element.Anchor.HasFlagFast(Anchor.TopRight) || isRelativeX)
+                    if (drawable.Anchor.HasFlagFast(Anchor.TopRight) || isRelativeX)
                     {
                         if (lowestTopScreenSpaceRight == null || bottom > lowestTopScreenSpaceRight.Value)
                             lowestTopScreenSpaceRight = bottom;
                     }
 
-                    if (element.Anchor.HasFlagFast(Anchor.TopLeft) || isRelativeX)
+                    if (drawable.Anchor.HasFlagFast(Anchor.TopLeft) || isRelativeX)
                     {
                         if (lowestTopScreenSpaceLeft == null || bottom > lowestTopScreenSpaceLeft.Value)
                             lowestTopScreenSpaceLeft = bottom;
                     }
                 }
                 // and align bottom-right components with the top-edge of the highest bottom-anchored hud element.
-                else if (element.Anchor.HasFlagFast(Anchor.BottomRight) || (element.Anchor.HasFlagFast(Anchor.y2) && element.RelativeSizeAxes == Axes.X))
+                else if (drawable.Anchor.HasFlagFast(Anchor.BottomRight) || (drawable.Anchor.HasFlagFast(Anchor.y2) && drawable.RelativeSizeAxes == Axes.X))
                 {
                     var topLeft = element.ScreenSpaceDrawQuad.TopLeft;
                     if (highestBottomScreenSpace == null || topLeft.Y < highestBottomScreenSpace.Value.Y)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -259,14 +258,14 @@ namespace osu.Game.Screens.Play
 
             Vector2? highestBottomScreenSpace = null;
 
-            // LINQ cast can be removed when IDrawable interface includes Anchor / RelativeSizeAxes.
-            foreach (var element in mainComponents.Components.Cast<Drawable>())
-                processDrawable(element);
+            // cast can be removed when IDrawable interface includes Anchor / RelativeSizeAxes.
+            foreach (var element in mainComponents.Components)
+                processDrawable(element as Drawable);
 
             if (rulesetComponents != null)
             {
-                foreach (var element in rulesetComponents.Components.Cast<Drawable>())
-                    processDrawable(element);
+                foreach (var element in rulesetComponents.Components)
+                    processDrawable(element as Drawable);
             }
 
             if (lowestTopScreenSpaceRight.HasValue)


### PR DESCRIPTION
I coundn't find any LINQ-related remarks in [original pr](https://github.com/ppy/osu/pull/12750), only [few crash reports](https://github.com/ppy/osu/pull/12750#issuecomment-840339193) related to it, but these were fixed via other prs. So I guess this should be fine?

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/aaf8b645-0a54-438b-ac65-4de3deb361ae)|![Снимок экрана 2024-01-26 012034](https://github.com/ppy/osu/assets/22874522/7d014657-fdaf-4237-9065-9e1628e9c0fd)|