### PR TITLE
Clamp logo triangles along both axes

### DIFF
--- a/osu.Game/Screens/Menu/OsuLogo.cs
+++ b/osu.Game/Screens/Menu/OsuLogo.cs
@@ -187,7 +187,6 @@ namespace osu.Game.Screens.Menu
                                                                         },
                                                                         triangles = new TrianglesV2
                                                                         {
-                                                                            ClampAxes = Axes.X,
                                                                             Anchor = Anchor.Centre,
                                                                             Origin = Anchor.Centre,
                                                                             Thickness = 0.009f,


### PR DESCRIPTION
Same pr as https://github.com/ppy/osu/pull/26647
This was probably left from previous attempts to improve their looks, however due to some limitations the idea was postponed/dropped. And with the current implementation there's no reason to not clamp them along both axes.