### PR TITLE
Corrected hit circle behavior.

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
@@ -40,8 +40,16 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void updateState()
         {
-            var quad = GeometryUtils.GetSurroundingQuad(selectedMovableObjects);
-            CanRotate.Value = quad.Width > 0 || quad.Height > 0;
+            if (selectedMovableObjects.Count() == 1 && selectedMovableObjects.First() is HitCircle)
+            {
+                // Allow rotation for a single hit circle
+                CanRotate.Value = true;
+            }
+            else
+            {
+                var quad = GeometryUtils.GetSurroundingQuad(selectedMovableObjects);
+                CanRotate.Value = quad.Width > 0 || quad.Height > 0;
+            }
         }
 
         private OsuHitObject[]? objectsInRotation;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -173,9 +173,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (rotationHandler != null)
-                canRotate.BindTo(rotationHandler.CanRotate);
-
             canRotate.BindValueChanged(_ => recreate(), true);
         }
 


### PR DESCRIPTION
Rotates the hit circle as intended.

Shows the selection box but without the rotation handlers in composer. also pop over is accessible, and is by default selecting playfield centre as opposed to selection centre