### PR TITLE
Fix relax mod not respecting tracking state of sliders when triggering actions

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                         if (!slider.HeadCircle.IsHit)
                             handleHitCircle(slider.HeadCircle);
 
-                        requiresHold |= slider.SliderInputManager.IsMouseInFollowArea(true);
+                        requiresHold |= slider.SliderInputManager.IsMouseInFollowArea(slider.Tracking.Value);
                         break;
 
                     case DrawableSpinner spinner:


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26746

This issue is best explained with the video below, which showcases a replay attached in the issue thread above running under relax's mod implementation (using local diffs):

https://github.com/ppy/osu/assets/22781491/f1c4df9f-b89e-4980-b118-e2b757537833

(the "Meh" judgement in the second playback of that replay is misleading/stale, as nothing showed up on the hit error meter and the sliders were held at correct times)

Notice in the above video, the mod triggered a press action prematurely on the next slider because it's within the region of the previous slider's follow area, but the previous slider is no longer in a tracked state)

Much similarly for https://github.com/ppy/osu/issues/26746#issuecomment-1913429757, the mod triggered an incorrect press action (that landed in a hit circle) before reaching the slider's head due to being within the follow area of that slider, despite that slider not in a tracking state yet.

<details>
<summary>diff to make replay run under relax mod implementation instead of replay actions</summary>

```diff
diff --git a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
index 3679425389..fdf2b80556 100644
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -38,8 +38,6 @@ public class OsuModRelax : ModRelax, IUpdatableByPlayfield, IApplicableToDrawabl
         private ReplayState<OsuAction> state = null!;
         private double lastStateChangeTime;
 
-        private bool hasReplay;
-
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
             // grab the input manager for future use.
@@ -48,20 +46,17 @@ public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset
 
         public void ApplyToPlayer(Player player)
         {
-            if (osuInputManager.ReplayInputHandler != null)
-            {
-                hasReplay = true;
-                return;
-            }
+            // if (osuInputManager.ReplayInputHandler != null)
+            // {
+            //     hasReplay = true;
+            //     return;
+            // }
 
             osuInputManager.AllowGameplayInputs = false;
         }
 
         public void Update(Playfield playfield)
         {
-            if (hasReplay)
-                return;
-
             bool requiresHold = false;
             bool requiresHit = false;
 
@@ -125,7 +120,7 @@ void changeState(bool down)
                 isDownState = down;
                 lastStateChangeTime = time;
 
-                state = new ReplayState<OsuAction>
+                state = new ReplayState<OsuAction>(true)
                 {
                     PressedActions = new List<OsuAction>()
                 };
diff --git a/osu.Game/Input/Handlers/ReplayInputHandler.cs b/osu.Game/Input/Handlers/ReplayInputHandler.cs
index 712e0acb60..847aede02a 100644
--- a/osu.Game/Input/Handlers/ReplayInputHandler.cs
+++ b/osu.Game/Input/Handlers/ReplayInputHandler.cs
@@ -10,6 +10,7 @@
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.UI;
@@ -39,6 +40,12 @@ public class ReplayState<T> : IInput
             where T : struct
         {
             public List<T> PressedActions;
+            private bool works;
+
+            public ReplayState(bool works = false)
+            {
+                this.works = works;
+            }
 
             public void Apply(InputState state, IInputStateChangeHandler handler)
             {
@@ -48,20 +55,23 @@ public void Apply(InputState state, IInputStateChangeHandler handler)
                 T[] released = Array.Empty<T>();
                 T[] pressed = Array.Empty<T>();
 
-                var lastPressed = inputState.LastReplayState?.PressedActions;
-
-                if (lastPressed == null || lastPressed.Count == 0)
-                {
-                    pressed = PressedActions.ToArray();
-                }
-                else if (PressedActions.Count == 0)
-                {
-                    released = lastPressed.ToArray();
-                }
-                else if (!lastPressed.SequenceEqual(PressedActions))
+                if (works)
                 {
-                    released = lastPressed.Except(PressedActions).ToArray();
-                    pressed = PressedActions.Except(lastPressed).ToArray();
+                    var lastPressed = inputState.LastReplayState?.PressedActions;
+
+                    if (lastPressed == null || lastPressed.Count == 0)
+                    {
+                        pressed = PressedActions.ToArray();
+                    }
+                    else if (PressedActions.Count == 0)
+                    {
+                        released = lastPressed.ToArray();
+                    }
+                    else if (!lastPressed.SequenceEqual(PressedActions))
+                    {
+                        released = lastPressed.Except(PressedActions).ToArray();
+                        pressed = PressedActions.Except(lastPressed).ToArray();
+                    }
                 }
 
                 inputState.LastReplayState = this;
```

</details>

I wasn't sure how to go about making test coverage for this due to its precision on time, but I wrote the following while I was looking at the issue:
<details>
<summary>test</summary>

```cs
// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
// See the LICENCE file in the repository root for full licence text.

using System.Collections.Generic;
using System.Linq;
using NUnit.Framework;
using osu.Game.Rulesets.Objects;
using osu.Game.Rulesets.Osu.Beatmaps;
using osu.Game.Rulesets.Osu.Mods;
using osu.Game.Rulesets.Osu.Objects;
using osu.Game.Rulesets.Scoring;
using osuTK;

namespace osu.Game.Rulesets.Osu.Tests.Mods
{
    public partial class TestSceneOsuModRelax : OsuModTestScene
    {
        [Test]
        public void TestSliderPriority()
        {
            CreateModTest(new ModTestData
            {
                Autoplay = false,
                Mod = new OsuModRelax(),
                Beatmap = new OsuBeatmap
                {
                    HitObjects = new List<OsuHitObject>
                    {
                        new Slider
                        {
                            StartTime = 1000,
                            Position = new Vector2(128, 192),
                            Path = new SliderPath(new[]
                            {
                                new PathControlPoint(new Vector2(0, 0)),
                                new PathControlPoint(new Vector2(50, 0)),
                            })
                        },
                        new Slider
                        {
                            StartTime = 1500,
                            Position = new Vector2(250, 192),
                            Path = new SliderPath(new[]
                            {
                                new PathControlPoint(new Vector2(0, 0)),
                                new PathControlPoint(new Vector2(50, 0)),
                            })
                        },
                    }
                },
                PassCondition = () => Player.Results.Count == 4 && Player.Results.All(r => r.Type == r.Judgement.MaxResult),
            });

            AddUntilStep("wait for time = 500ms", () => Player.GameplayClockContainer.CurrentTime, () => Is.GreaterThanOrEqualTo(500));
            AddStep("move mouse to first slider", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.GamefieldToScreenSpace(new Vector2(128, 192))));
            AddUntilStep("wait for time = 1050ms", () => Player.GameplayClockContainer.CurrentTime, () => Is.GreaterThanOrEqualTo(1050));
            AddStep("move mouse to next slider", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.GamefieldToScreenSpace(new Vector2(250, 192))));
        }
    }
}
```

</details>