### PR TITLE
Rewrite osu!taiko's time range computation logic to match 1:1 with stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -16,7 +16,6 @@ using osu.Game.Replays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Game.Rulesets.Timing;
@@ -35,6 +34,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         public readonly BindableBool LockPlayfieldAspectRange = new BindableBool(true);
 
         public new TaikoInputManager KeyBindingInputManager => (TaikoInputManager)base.KeyBindingInputManager;
+
+        protected new TaikoPlayfieldAdjustmentContainer PlayfieldAdjustmentContainer => (TaikoPlayfieldAdjustmentContainer)base.PlayfieldAdjustmentContainer;
 
         protected override bool UserScrollSpeedAdjustment => false;
 
@@ -68,22 +69,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             TimeRange.Value = ComputeTimeRange();
         }
 
-        protected virtual double ComputeTimeRange()
-        {
-            // Taiko scrolls at a constant 100px per 1000ms. More notes become visible as the playfield is lengthened.
-            const float scroll_rate = 10;
-
-            // Since the time range will depend on a positional value, it is referenced to the x480 pixel space.
-            // Width is used because it defines how many notes fit on the playfield.
-            // We clamp the ratio to the maximum aspect ratio to keep scroll speed consistent on widths lower than the default.
-            float ratio = Math.Max(DrawSize.X / 768f, TaikoPlayfieldAdjustmentContainer.MAXIMUM_ASPECT);
-
-            // Stable internally increased the slider velocity of objects by a factor of `VELOCITY_MULTIPLIER`.
-            // To simulate this, we shrink the time range by that factor here.
-            // This, when combined with the rest of the scrolling ruleset machinery (see `MultiplierControlPoint` et al.),
-            // has the effect of increasing each multiplier control point's multiplier by `VELOCITY_MULTIPLIER`, ensuring parity with stable.
-            return (Playfield.HitObjectContainer.DrawWidth / ratio) * scroll_rate / TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
-        }
+        protected virtual double ComputeTimeRange() => PlayfieldAdjustmentContainer.ComputeTimeRange();
 
         protected override void UpdateAfterChildren()
         {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfieldAdjustmentContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Taiko.Beatmaps;
 using osu.Game.Rulesets.UI;
 using osuTK;
 
@@ -14,6 +15,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         public const float MAXIMUM_ASPECT = 16f / 9f;
         public const float MINIMUM_ASPECT = 5f / 4f;
 
+        private const float stable_gamefield_height = 480f;
+
         public readonly IBindable<bool> LockPlayfieldAspectRange = new BindableBool(true);
 
         public TaikoPlayfieldAdjustmentContainer()
@@ -21,6 +24,9 @@ namespace osu.Game.Rulesets.Taiko.UI
             RelativeSizeAxes = Axes.X;
             RelativePositionAxes = Axes.Y;
             Height = TaikoPlayfield.BASE_HEIGHT;
+
+            // Matches stable, see https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L514
+            Y = 135f / stable_gamefield_height;
         }
 
         protected override void Update()
@@ -28,8 +34,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             base.Update();
 
             const float base_relative_height = TaikoPlayfield.BASE_HEIGHT / 768;
-            // Matches stable, see https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L514
-            const float base_position = 135f / 480f;
 
             float relativeHeight = base_relative_height;
 
@@ -51,10 +55,38 @@ namespace osu.Game.Rulesets.Taiko.UI
             // Limit the maximum relative height of the playfield to one-third of available area to avoid it masking out on extreme resolutions.
             relativeHeight = Math.Min(relativeHeight, 1f / 3f);
 
-            Y = base_position;
-
             Scale = new Vector2(Math.Max((Parent!.ChildSize.Y / 768f) * (relativeHeight / base_relative_height), 1f));
             Width = 1 / Scale.X;
+        }
+
+        public double ComputeTimeRange()
+        {
+            float currentAspect = Parent!.ChildSize.X / Parent!.ChildSize.Y;
+
+            if (LockPlayfieldAspectRange.Value)
+                currentAspect = Math.Clamp(currentAspect, MINIMUM_ASPECT, MAXIMUM_ASPECT);
+
+            // in a game resolution of 1024x768, stable's scrolling system consists of objects being placed 600px (widthScaled - 40) away from their hit location.
+            // however, the point at which the object renders at the end of the screen is exactly x=640, but stable makes the object start moving from beyond the screen instead of the boundary point.
+            // therefore, in lazer we have to adjust the "in length" so that it's in a 640px->160px fashion before passing it down as a "time range".
+            // see stable's "in length": https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/GameplayElements/HitObjectManagerTaiko.cs#L168
+            const float stable_hit_location = 160f;
+            float widthScaled = currentAspect * stable_gamefield_height;
+            float inLength = widthScaled - stable_hit_location;
+
+            // also in a game resolution of 1024x768, stable makes hit objects scroll from 760px->160px at a duration of 6000ms, divided by slider velocity (i.e. at a rate of 0.1px/ms)
+            // compare: https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/GameplayElements/HitObjectManagerTaiko.cs#L218
+            // note: the variable "sv", in the linked reference, is equivalent to MultiplierControlPoint.Multiplier * 100, but since time range is agnostic of velocity, we replace "sv" with 100 below.
+            float inMsLength = inLength / 100 * 1000;
+
+            // stable multiplies the slider velocity by 1.4x for certain reasons, divide the time range by that factor to achieve similar result.
+            // for references on how the factor is applied to the time range, see:
+            //  1. https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/GameplayElements/HitObjectManagerTaiko.cs#L79 (DifficultySliderMultiplier multiplied by 1.4x)
+            //  2. https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/GameplayElements/HitObjectManager.cs#L468-L470 (DifficultySliderMultiplier used to calculate SliderScoringPointDistance)
+            //  3. https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/GameplayElements/HitObjectManager.cs#L248-L250 (SliderScoringPointDistance used to calculate slider velocity, i.e. the "sv" variable from above)
+            inMsLength /= TaikoBeatmapConverter.VELOCITY_MULTIPLIER;
+
+            return inMsLength;
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25919
- Supersedes & closes https://github.com/ppy/osu/pull/26681

After cross-comparing against stable, I've found out that the logic in the PR above could be rewritten completely to be based on stable code rather than a linear approximation given by visual comparison (especially when dealing with different aspect ratios).

I have spent some time to get an understanding of how the logic works, so I wrote explanatory comments across the logic in hope that it speeds up the understanding process and keeps the code as close and matching with stable as possible.

| | stable | lazer |
|-|--------|-------|
| 1024x768 | ![CleanShot 2024-01-29 at 20 51 57](https://github.com/ppy/osu/assets/22781491/18d3668c-2a49-42cc-acf5-20c1f9935441) | ![CleanShot 2024-01-29 at 20 51 23](https://github.com/ppy/osu/assets/22781491/dff9e6a5-da76-4d08-a73d-d24178c57146) |
| 1280x1024 | ![CleanShot 2024-01-29 at 20 55 42](https://github.com/ppy/osu/assets/22781491/1816cabd-8958-4147-8b87-c0d4c934c184) | ![CleanShot 2024-01-29 at 20 55 46](https://github.com/ppy/osu/assets/22781491/452c559e-4082-48da-b35f-5b5b7448b80c)
| 1366x768 | ![CleanShot 2024-01-29 at 20 57 52](https://github.com/ppy/osu/assets/22781491/cbd2db8b-b90b-40dd-995d-3483505e5405) | ![CleanShot 2024-01-29 at 20 57 55](https://github.com/ppy/osu/assets/22781491/9d6cb0b7-d04d-4b28-b237-60bf61b0bdcf) |

The beatmap/difficulty above is https://osu.ppy.sh/beatmapsets/847323#taiko/1774604. It uses a base slider velocity of 1.4x. For extra testing, I've changed the slider velocity to 2x and made another comparison:
| stable | lazer |
|--------|-------|
| ![CleanShot 2024-01-29 at 21 49 45](https://github.com/ppy/osu/assets/22781491/a50354d1-71e6-422b-8ea1-b4d693273f55) | ![CleanShot 2024-01-29 at 21 49 41](https://github.com/ppy/osu/assets/22781491/84affac7-a0ac-4a66-b60d-7f66873d2777) |