### PR TITLE
Reduce allocation overhead in `ScrollingHitObjectContainer`

### DIFF
--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -184,9 +184,12 @@ namespace osu.Game.Rulesets.UI.Scrolling
 
             // We need to calculate hit object positions (including nested hit objects) as soon as possible after lifetimes
             // to prevent hit objects displayed in a wrong position for one frame.
-            // Only AliveObjects need to be considered for layout (reduces overhead in the case of scroll speed changes).
-            foreach (var obj in AliveObjects)
+            // Only AliveEntries need to be considered for layout (reduces overhead in the case of scroll speed changes).
+            // We are not using AliveObjects directly to avoid selection/sorting overhead since we don't care about the order at which positions will be updated.
+            foreach (var entry in AliveEntries)
             {
+                var obj = entry.Drawable;
+
                 updatePosition(obj, Time.Current);
 
                 if (layoutComputed.Contains(obj))


### PR DESCRIPTION
Added comment should be self-explanatory. I've tested some sv taiko/mania maps and everything works as expected as far as I can tell.

This solution isn't perfect either since `AliveEntries` is allocating by itself by selecting items from underlying dictionary (top 2 item on 2nd screenshot), so may be `PooledDrawableWithLifetimeContainer` should expose more ways to retrieve hitobjects (I guess in the best scenario we want to loop over the dictionary itself, so in that case making it `protected` would make more sense)

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/11a7a15f-b9fc-4e24-b422-0d4a098d0914)|![pr](https://github.com/ppy/osu/assets/22874522/de441f78-503f-4aae-9f9e-afa345210a4b)|