### PR TITLE
Reduce allocation overhead in mania's `ColumnFlow`

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             foreach (var stage in stages)
             {
-                for (int i = 0; i < stage.Columns.Count; i++)
+                for (int i = 0; i < stage.Columns.Length; i++)
                 {
                     var obj = new Note { Column = i, StartTime = Time.Current + 2000 };
                     obj.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.Mania.Tests
         {
             foreach (var stage in stages)
             {
-                for (int i = 0; i < stage.Columns.Count; i++)
+                for (int i = 0; i < stage.Columns.Length; i++)
                 {
                     var obj = new HoldNote { Column = i, StartTime = Time.Current + 2000, Duration = 500 };
                     obj.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -4,8 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -28,20 +26,21 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// All contents added to this <see cref="ColumnFlow{TContent}"/>.
         /// </summary>
-        public IReadOnlyList<TContent> Content => columns.Children.Select(c => c.Count == 0 ? null : (TContent)c.Child).ToList();
+        public TContent[] Content { get; }
 
-        private readonly FillFlowContainer<Container> columns;
+        private readonly FillFlowContainer<Container<TContent>> columns;
         private readonly StageDefinition stageDefinition;
 
         public ColumnFlow(StageDefinition stageDefinition)
         {
             this.stageDefinition = stageDefinition;
+            Content = new TContent[stageDefinition.Columns];
 
             AutoSizeAxes = Axes.X;
 
             Masking = true;
 
-            InternalChild = columns = new FillFlowContainer<Container>
+            InternalChild = columns = new FillFlowContainer<Container<TContent>>
             {
                 RelativeSizeAxes = Axes.Y,
                 AutoSizeAxes = Axes.X,
@@ -49,7 +48,7 @@ namespace osu.Game.Rulesets.Mania.UI
             };
 
             for (int i = 0; i < stageDefinition.Columns; i++)
-                columns.Add(new Container { RelativeSizeAxes = Axes.Y });
+                columns.Add(new Container<TContent> { RelativeSizeAxes = Axes.Y });
         }
 
         private ISkinSource currentSkin;
@@ -102,7 +101,10 @@ namespace osu.Game.Rulesets.Mania.UI
         /// </summary>
         /// <param name="column">The index of the column to set the content of.</param>
         /// <param name="content">The content.</param>
-        public void SetContentForColumn(int column, TContent content) => columns[column].Child = content;
+        public void SetContentForColumn(int column, TContent content)
+        {
+            Content[column] = columns[column].Child = content;
+        }
 
         private void updateMobileSizing()
         {

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 stages.Add(newStage);
                 AddNested(newStage);
 
-                firstColumnIndex += newStage.Columns.Count;
+                firstColumnIndex += newStage.Columns.Length;
             }
         }
 
@@ -125,9 +125,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
             foreach (var stage in stages)
             {
-                if (index >= stage.Columns.Count)
+                if (index >= stage.Columns.Length)
                 {
-                    index -= stage.Columns.Count;
+                    index -= stage.Columns.Length;
                     continue;
                 }
 
@@ -140,7 +140,7 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// Retrieves the total amount of columns across all stages in this playfield.
         /// </summary>
-        public int TotalColumns => stages.Sum(s => s.Columns.Count);
+        public int TotalColumns => stages.Sum(s => s.Columns.Length);
 
         private Stage getStageByColumn(int column)
         {
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             foreach (var stage in stages)
             {
-                sum += stage.Columns.Count;
+                sum += stage.Columns.Length;
                 if (sum > column)
                     return stage;
             }

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -42,7 +42,16 @@ namespace osu.Game.Rulesets.Mania.UI
             }
         }
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => stages.Any(s => s.ReceivePositionalInputAt(screenSpacePos));
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            foreach (var s in stages)
+            {
+                if (s.ReceivePositionalInputAt(screenSpacePos))
+                    return true;
+            }
+
+            return false;
+        }
 
         public ManiaPlayfield(List<StageDefinition> stageDefinitions)
         {

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -37,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         public const float HIT_TARGET_POSITION = 110;
 
-        public IReadOnlyList<Column> Columns => columnFlow.Content;
+        public Column[] Columns => columnFlow.Content;
         private readonly ColumnFlow<Column> columnFlow;
 
         private readonly JudgementContainer<DrawableManiaJudgement> judgements;
@@ -184,13 +183,13 @@ namespace osu.Game.Rulesets.Mania.UI
             NewResult += OnNewResult;
         }
 
-        public override void Add(HitObject hitObject) => Columns.ElementAt(((ManiaHitObject)hitObject).Column - firstColumnIndex).Add(hitObject);
+        public override void Add(HitObject hitObject) => Columns[((ManiaHitObject)hitObject).Column - firstColumnIndex].Add(hitObject);
 
-        public override bool Remove(HitObject hitObject) => Columns.ElementAt(((ManiaHitObject)hitObject).Column - firstColumnIndex).Remove(hitObject);
+        public override bool Remove(HitObject hitObject) => Columns[((ManiaHitObject)hitObject).Column - firstColumnIndex].Remove(hitObject);
 
-        public override void Add(DrawableHitObject h) => Columns.ElementAt(((ManiaHitObject)h.HitObject).Column - firstColumnIndex).Add(h);
+        public override void Add(DrawableHitObject h) => Columns[((ManiaHitObject)h.HitObject).Column - firstColumnIndex].Add(h);
 
-        public override bool Remove(DrawableHitObject h) => Columns.ElementAt(((ManiaHitObject)h.HitObject).Column - firstColumnIndex).Remove(h);
+        public override bool Remove(DrawableHitObject h) => Columns[((ManiaHitObject)h.HitObject).Column - firstColumnIndex].Remove(h);
 
         public void Add(BarLine barLine) => base.Add(barLine);
 

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -44,7 +44,16 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly Drawable barLineContainer;
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Columns.Any(c => c.ReceivePositionalInputAt(screenSpacePos));
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            foreach (var c in Columns)
+            {
+                if (c.ReceivePositionalInputAt(screenSpacePos))
+                    return true;
+            }
+
+            return false;
+        }
 
         private readonly int firstColumnIndex;
 


### PR DESCRIPTION
The main hot path is that `ColumnFlow.Content` is used to determine `ReceivePositionalInputAt` and thus being called every frame.
Regressed during refactoring in https://github.com/ppy/osu/commit/018523a43a8c11243b6806fc4c4adf3384e24e6f, before that we were using just plain children of a `FillFlowContainer` without `ToList()`.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/0b9dd58e-6b17-43f0-b2c6-1576ffdad28b)|![pr](https://github.com/ppy/osu/assets/22874522/04363a36-eadf-48f0-9eba-a59e672204af)|