### PR TITLE
Fix 2FA verification via link not working correctly

### DIFF
--- a/osu.Game/Online/PersistentEndpointClientConnector.cs
+++ b/osu.Game/Online/PersistentEndpointClientConnector.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Online
                     break;
 
                 case APIState.Online:
+                case APIState.RequiresSecondFactorAuth:
                     await connect().ConfigureAwait(true);
                     break;
             }
@@ -83,7 +84,7 @@ namespace osu.Game.Online
 
             try
             {
-                while (apiState.Value == APIState.Online)
+                while (apiState.Value == APIState.RequiresSecondFactorAuth || apiState.Value == APIState.Online)
                 {
                     // ensure any previous connection was disposed.
                     // this will also create a new cancellation token source.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26835.

I must have not re-tested this correctly after all the refactors...

Basically the issue is that the websocket connection would only come online when the API state changed to full `Online`. In particular the connector would not attempt to connect when the API state was `RequiresSecondFactorAuth`, giving the link-based flow no chance to actually work.

The change in `WebSocketNotificationsClientConnector` is relevant in that queueing requests does nothing before the API state changes to full `Online`. It also cleans up things a bit code-wise so... win?

And yes, this means that the _other_ `PersistentEndpointClientConnector` implementations (i.e. SignalR connectors) will also come online earlier after this. Based on previous discussions
(https://github.com/ppy/osu/pull/25480#discussion_r1395566545) I think this is fine, but if it is _not_ fine, then it can be fixed by exposing a virtual that lets a connector to decide when to come alive, I guess.