### PR TITLE
Fix legacy animated judgements not fading out correctly

### DIFF
--- a/osu.Game/Skinning/LegacyJudgementPieceOld.cs
+++ b/osu.Game/Skinning/LegacyJudgementPieceOld.cs
@@ -46,6 +46,7 @@ namespace osu.Game.Skinning
             const double fade_out_length = 600;
 
             this.FadeInFromZero(fade_in_length);
+            this.Delay(fade_out_delay).FadeOut(fade_out_length);
 
             // legacy judgements don't play any transforms if they are an animation.... UNLESS they are the temporary displayed judgement from new piece.
             if (animation?.FrameCount > 1 && !forceTransforms)
@@ -79,8 +80,6 @@ namespace osu.Game.Skinning
                     this.RotateTo(0);
                     this.RotateTo(rotation, fade_in_length)
                         .Then().RotateTo(rotation * 2, fade_out_delay + fade_out_length - fade_in_length, Easing.In);
-
-                    this.Delay(fade_out_delay).FadeOut(fade_out_length);
                 }
             }
             else
@@ -94,8 +93,6 @@ namespace osu.Game.Skinning
                     // so we need to force the current value to be correct at 1.2 (0.95) then complete the
                     // second half of the transform.
                     .ScaleTo(0.95f).ScaleTo(finalScale, fade_in_length * 0.2f); // t = 1.4
-
-                this.Delay(fade_out_delay).FadeOut(fade_out_length);
             }
         }
 


### PR DESCRIPTION
This reverts commit d0421fe20667530bf1bca1a5c8e3f387dde0cf6a and fixes https://github.com/ppy/osu/issues/26801.

https://github.com/ppy/osu/pull/26703#discussion_r1469409667 was correct in saying that the early fade-out needs to be restored, and that's because of the early-return. Legacy judgements that are the temporary displayed judgement from new piece should also receive the fade-out, and d0421fe20667530bf1bca1a5c8e3f387dde0cf6a broke that.