### PR TITLE
Further reduce allocation overhead in `ScrollingHitObjectContainer`

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDepth.cs
@@ -75,8 +75,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             double time = playfield.Time.Current;
 
-            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
+            foreach (var entry in playfield.HitObjectContainer.AliveEntries)
             {
+                var drawable = entry.Value;
+
                 switch (drawable)
                 {
                     case DrawableHitCircle circle:

--- a/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModMagnetised.cs
@@ -49,8 +49,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var cursorPos = playfield.Cursor.AsNonNull().ActiveCursor.DrawPosition;
 
-            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
+            foreach (var entry in playfield.HitObjectContainer.AliveEntries)
             {
+                var drawable = entry.Value;
+
                 switch (drawable)
                 {
                     case DrawableHitCircle circle:

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRepel.cs
@@ -48,8 +48,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             var cursorPos = playfield.Cursor.AsNonNull().ActiveCursor.DrawPosition;
 
-            foreach (var drawable in playfield.HitObjectContainer.AliveObjects)
+            foreach (var entry in playfield.HitObjectContainer.AliveEntries)
             {
+                var drawable = entry.Value;
+
                 var destination = Vector2.Clamp(2 * drawable.Position - cursorPos, Vector2.Zero, OsuPlayfield.BASE_SIZE);
 
                 if (drawable.HitObject is Slider thisSlider)

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -2,12 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
+using osu.Framework.Lists;
 
 namespace osu.Game.Rulesets.Objects.Pooling
 {
@@ -36,7 +37,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// <remarks>
         /// The enumeration order is undefined.
         /// </remarks>
-        public readonly ReadOnlyDictionary<TEntry, TDrawable> AliveEntries;
+        public readonly SlimReadOnlyDictionaryWrapper<TEntry, TDrawable> AliveEntries;
 
         /// <summary>
         /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry.LifetimeStart"/>.
@@ -65,7 +66,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
             lifetimeManager.EntryBecameDead += entryBecameDead;
             lifetimeManager.EntryCrossedBoundary += entryCrossedBoundary;
 
-            AliveEntries = new ReadOnlyDictionary<TEntry, TDrawable>(aliveDrawableMap);
+            AliveEntries = aliveDrawableMap.AsSlimReadOnly();
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// <remarks>
         /// The enumeration order is undefined.
         /// </remarks>
-        public IEnumerable<(TEntry Entry, TDrawable Drawable)> AliveEntries => aliveDrawableMap.Select(x => (x.Key, x.Value));
+        public IEnumerable<(TEntry Entry, TDrawable Drawable)> AliveEntries => AliveDrawableMap.Select(x => (x.Key, x.Value));
 
         /// <summary>
         /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry.LifetimeStart"/>.
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </summary>
         internal double FutureLifetimeExtension { get; set; }
 
-        private readonly Dictionary<TEntry, TDrawable> aliveDrawableMap = new Dictionary<TEntry, TDrawable>();
+        public readonly Dictionary<TEntry, TDrawable> AliveDrawableMap = new Dictionary<TEntry, TDrawable>();
         private readonly HashSet<TEntry> allEntries = new HashSet<TEntry>();
 
         private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
@@ -101,10 +101,10 @@ namespace osu.Game.Rulesets.Objects.Pooling
         private void entryBecameAlive(LifetimeEntry lifetimeEntry)
         {
             var entry = (TEntry)lifetimeEntry;
-            Debug.Assert(!aliveDrawableMap.ContainsKey(entry));
+            Debug.Assert(!AliveDrawableMap.ContainsKey(entry));
 
             TDrawable drawable = GetDrawable(entry);
-            aliveDrawableMap[entry] = drawable;
+            AliveDrawableMap[entry] = drawable;
             AddDrawable(entry, drawable);
         }
 
@@ -119,10 +119,10 @@ namespace osu.Game.Rulesets.Objects.Pooling
         private void entryBecameDead(LifetimeEntry lifetimeEntry)
         {
             var entry = (TEntry)lifetimeEntry;
-            Debug.Assert(aliveDrawableMap.ContainsKey(entry));
+            Debug.Assert(AliveDrawableMap.ContainsKey(entry));
 
-            TDrawable drawable = aliveDrawableMap[entry];
-            aliveDrawableMap.Remove(entry);
+            TDrawable drawable = AliveDrawableMap[entry];
+            AliveDrawableMap.Remove(entry);
             RemoveDrawable(entry, drawable);
         }
 
@@ -148,7 +148,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
             foreach (var entry in Entries.ToArray())
                 Remove(entry);
 
-            Debug.Assert(aliveDrawableMap.Count == 0);
+            Debug.Assert(AliveDrawableMap.Count == 0);
         }
 
         protected override bool CheckChildrenLife()

--- a/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
+++ b/osu.Game/Rulesets/UI/GameplaySampleTriggerSource.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Rulesets.UI
                 // If required, we can make this lookup more efficient by adding support to get next-future-entry in LifetimeEntryManager.
                 var candidate =
                     // Use alive entries first as an optimisation.
-                    hitObjectContainer.AliveEntries.Select(tuple => tuple.Entry).Where(e => !isAlreadyHit(e)).MinBy(e => e.HitObject.StartTime)
+                    hitObjectContainer.AliveEntries.Keys.Where(e => !isAlreadyHit(e)).MinBy(e => e.HitObject.StartTime)
                     ?? hitObjectContainer.Entries.Where(e => !isAlreadyHit(e)).MinBy(e => e.HitObject.StartTime);
 
                 // In the case there are no non-judged objects, the last hit object should be used instead.

--- a/osu.Game/Rulesets/UI/HitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/HitObjectContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.UI
     {
         public IEnumerable<DrawableHitObject> Objects => InternalChildren.Cast<DrawableHitObject>().OrderBy(h => h.HitObject.StartTime);
 
-        public IEnumerable<DrawableHitObject> AliveObjects => AliveEntries.Select(pair => pair.Drawable).OrderBy(h => h.HitObject.StartTime);
+        public IEnumerable<DrawableHitObject> AliveObjects => AliveEntries.Values.OrderBy(h => h.HitObject.StartTime);
 
         /// <summary>
         /// Invoked when a <see cref="DrawableHitObject"/> is judged.

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -186,9 +186,9 @@ namespace osu.Game.Rulesets.UI.Scrolling
             // to prevent hit objects displayed in a wrong position for one frame.
             // Only AliveEntries need to be considered for layout (reduces overhead in the case of scroll speed changes).
             // We are not using AliveObjects directly to avoid selection/sorting overhead since we don't care about the order at which positions will be updated.
-            foreach (var entry in AliveEntries)
+            foreach (var entry in AliveDrawableMap)
             {
-                var obj = entry.Drawable;
+                var obj = entry.Value;
 
                 updatePosition(obj, Time.Current);
 

--- a/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/ScrollingHitObjectContainer.cs
@@ -186,7 +186,7 @@ namespace osu.Game.Rulesets.UI.Scrolling
             // to prevent hit objects displayed in a wrong position for one frame.
             // Only AliveEntries need to be considered for layout (reduces overhead in the case of scroll speed changes).
             // We are not using AliveObjects directly to avoid selection/sorting overhead since we don't care about the order at which positions will be updated.
-            foreach (var entry in AliveDrawableMap)
+            foreach (var entry in AliveEntries)
             {
                 var obj = entry.Value;
 

--- a/osu.Game/Screens/Play/FailAnimationContainer.cs
+++ b/osu.Game/Screens/Play/FailAnimationContainer.cs
@@ -198,8 +198,10 @@ namespace osu.Game.Screens.Play
             foreach (var nested in playfield.NestedPlayfields)
                 applyToPlayfield(nested);
 
-            foreach (DrawableHitObject obj in playfield.HitObjectContainer.AliveObjects)
+            foreach (var entry in playfield.HitObjectContainer.AliveEntries)
             {
+                var obj = entry.Value;
+
                 if (appliedObjects.Contains(obj))
                     continue;
 


### PR DESCRIPTION
- [x] Depends on framework package with https://github.com/ppy/osu-framework/pull/6163

Part 2 of https://github.com/ppy/osu/pull/26788

Not sure how safe is making dictionary `public` though. Would've made it protected, however some mods (such as Depth) will benefit from using that instead of `AliveObjects`.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/caeeffd4-51c0-4e6a-976e-bf8489a69c1d)|![pr](https://github.com/ppy/osu/assets/22874522/1a429a48-d5ed-480e-b4f5-0d292d55cdf2)|