### PR TITLE
Adjust default min result of SliderTailHit, remove override

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/SliderTailCircle.cs
@@ -30,7 +30,6 @@ namespace osu.Game.Rulesets.Osu.Objects
         public class TailJudgement : SliderEndJudgement
         {
             public override HitResult MaxResult => HitResult.SliderTailHit;
-            public override HitResult MinResult => HitResult.IgnoreMiss;
         }
     }
 }

--- a/osu.Game/Rulesets/Judgements/Judgement.cs
+++ b/osu.Game/Rulesets/Judgements/Judgement.cs
@@ -73,8 +73,10 @@ namespace osu.Game.Rulesets.Judgements
                         return HitResult.SmallTickMiss;
 
                     case HitResult.LargeTickHit:
-                    case HitResult.SliderTailHit:
                         return HitResult.LargeTickMiss;
+
+                    case HitResult.SliderTailHit:
+                        return HitResult.IgnoreMiss;
 
                     default:
                         return HitResult.Miss;

--- a/osu.Game/Rulesets/Scoring/HitResult.cs
+++ b/osu.Game/Rulesets/Scoring/HitResult.cs
@@ -138,7 +138,8 @@ namespace osu.Game.Rulesets.Scoring
         ComboBreak,
 
         /// <summary>
-        /// A special judgement similar to <see cref="LargeTickHit"/> that's used to increase the valuation of the final tick of a slider.
+        /// A special tick judgement to increase the valuation of the final tick of a slider.
+        /// The default minimum result is <see cref="IgnoreMiss"/>, but may be overridden to <see cref="LargeTickMiss"/>.
         /// </summary>
         [EnumMember(Value = "slider_tail_hit")]
         [Order(8)]


### PR DESCRIPTION
Came across this as I was updating the table in https://github.com/ppy/osu/wiki/Scoring

I'd rather avoid overriding except for extreme cases.