### PR TITLE
Fix slider end judgements appearing at incorrect locations when mods that flip playfield are active

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
@@ -45,7 +45,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 128, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderHeadCircle>().Single().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 128, 128)));
             Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 0, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderTailCircle>().Single().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X, 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),
@@ -62,7 +64,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(128, OsuPlayfield.BASE_SIZE.Y - 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderHeadCircle>().Single().Position, Is.EqualTo(new Vector2(128, OsuPlayfield.BASE_SIZE.Y - 128)));
             Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(0, OsuPlayfield.BASE_SIZE.Y - 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderTailCircle>().Single().Position, Is.EqualTo(new Vector2(0, OsuPlayfield.BASE_SIZE.Y - 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),
@@ -79,7 +83,9 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.FlipSliderInPlaceHorizontally(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(128, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderHeadCircle>().Single().Position, Is.EqualTo(new Vector2(128, 128)));
             Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(256, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderTailCircle>().Single().Position, Is.EqualTo(new Vector2(256, 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),

--- a/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuHitObjectGenerationUtilsTest.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                         new PathControlPoint(new Vector2(-128, 0), PathType.LINEAR) // absolute position: (0, 128)
                     }
                 },
-                RepeatCount = 1
+                RepeatCount = 2
             };
             slider.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
             return slider;
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.ReflectHorizontallyAlongPlayfield(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 128, 128)));
-            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 0, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(OsuPlayfield.BASE_SIZE.X - 0, 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.ReflectVerticallyAlongPlayfield(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(128, OsuPlayfield.BASE_SIZE.Y - 128)));
-            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(0, OsuPlayfield.BASE_SIZE.Y - 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(0, OsuPlayfield.BASE_SIZE.Y - 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),
@@ -79,7 +79,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             OsuHitObjectGenerationUtils.FlipSliderInPlaceHorizontally(slider);
 
             Assert.That(slider.Position, Is.EqualTo(new Vector2(128, 128)));
-            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().Single().Position, Is.EqualTo(new Vector2(256, 128)));
+            Assert.That(slider.NestedHitObjects.OfType<SliderRepeat>().First().Position, Is.EqualTo(new Vector2(256, 128)));
             Assert.That(slider.Path.ControlPoints.Select(point => point.Position), Is.EquivalentTo(new[]
             {
                 new Vector2(),

--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Objects
             set
             {
                 repeatCount = value;
-                endPositionCache.Invalidate();
+                updateNestedPositions();
             }
         }
 
@@ -165,7 +165,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         public Slider()
         {
             SamplesBindable.CollectionChanged += (_, _) => UpdateNestedSamples();
-            Path.Version.ValueChanged += _ => endPositionCache.Invalidate();
+            Path.Version.ValueChanged += _ => updateNestedPositions();
         }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26867
- Reverts https://github.com/ppy/osu/commit/882f49039029b7dc3e287ccc302d04de89de10df and https://github.com/ppy/osu/commit/ce643aa68f35369be1a975bb1ceb69fb54192cf2.

The applied optimisation may have been valid as long as it was constrained to `Slider`. But it is not, as `SliderTailCircle` stores a local copy of the object position. And as the commit message of https://github.com/ppy/osu/commit/ce643aa68f35369be1a975bb1ceb69fb54192cf2 states, this could be bypassed by some pretty hacky delegation from `SliderTailCircle.Position` to the slider, but it'd also be pretty hacky because it would make flows like `PositionBindable` break down.

Long-term solution is to probably remove bindables from hitobjects.

cc @OliBomby