### PR TITLE
Made Taiko judgement snapping configurable by the user

### DIFF
--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
@@ -18,11 +18,13 @@ namespace osu.Game.Rulesets.Taiko.Configuration
             base.InitialiseDefaults();
 
             SetDefault(TaikoRulesetSetting.TouchControlScheme, TaikoTouchControlScheme.KDDK);
+            SetDefault(TaikoRulesetSetting.SnapJudgementLocation, false);
         }
     }
 
     public enum TaikoRulesetSetting
     {
-        TouchControlScheme
+        TouchControlScheme,
+        SnapJudgementLocation
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -10,18 +10,12 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>, IApplicableToDrawableHitObject
+    public class TaikoModClassic : ModClassic, IApplicableToDrawableRuleset<TaikoHitObject>
     {
         public void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
             var drawableTaikoRuleset = (DrawableTaikoRuleset)drawableRuleset;
             drawableTaikoRuleset.LockPlayfieldAspectRange.Value = false;
-        }
-
-        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
-        {
-            if (drawable is DrawableTaikoHitObject hit)
-                hit.SnapJudgementLocation = true;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModClassic.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -41,6 +41,13 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private readonly Bindable<HitType> type = new Bindable<HitType>();
 
+        /// <summary>
+        /// Whether the location of the hit should be snapped to the hit target before animating.
+        /// </summary>
+        /// <remarks>
+        /// This is how osu-stable worked, but notably is not how TnT works.
+        /// Not snapping results in less visual feedback on hit accuracy.
+        /// </remarks>
         private readonly Bindable<bool> snapJudgementLocation = new Bindable<bool>();
 
         public DrawableHit()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -7,12 +7,14 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
+using osu.Game.Rulesets.Taiko.Configuration;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
@@ -39,6 +41,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private readonly Bindable<HitType> type = new Bindable<HitType>();
 
+        private readonly Bindable<bool> snapJudgementLocation = new Bindable<bool>();
+
         public DrawableHit()
             : this(null)
         {
@@ -48,6 +52,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             : base(hit)
         {
             FillMode = FillMode.Fit;
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(TaikoRulesetConfigManager rulesetConfig)
+        {
+            rulesetConfig?.BindWith(TaikoRulesetSetting.SnapJudgementLocation, snapJudgementLocation);
         }
 
         protected override void OnApply()
@@ -163,7 +173,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     const float gravity_time = 300;
                     const float gravity_travel_height = 200;
 
-                    if (SnapJudgementLocation)
+                    if (snapJudgementLocation.Value)
                         MainPiece.MoveToX(-X);
 
                     this.ScaleTo(0.8f, gravity_time * 2, Easing.OutQuad);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -25,15 +25,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private readonly Container nonProxiedContent;
 
-        /// <summary>
-        /// Whether the location of the hit should be snapped to the hit target before animating.
-        /// </summary>
-        /// <remarks>
-        /// This is how osu-stable worked, but notably is not how TnT works.
-        /// Not snapping results in less visual feedback on hit accuracy.
-        /// </remarks>
-        public bool SnapJudgementLocation { get; set; }
-
         protected DrawableTaikoHitObject([CanBeNull] TaikoHitObject hitObject)
             : base(hitObject)
         {

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -30,6 +30,11 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     LabelText = RulesetSettingsStrings.TouchControlScheme,
                     Current = config.GetBindable<TaikoTouchControlScheme>(TaikoRulesetSetting.TouchControlScheme)
+                },
+                new SettingsCheckbox
+                {
+                    LabelText = "Snap notes to judgement location",
+                    Current = config.GetBindable<bool>(TaikoRulesetSetting.SnapJudgementLocation),
                 }
             };
         }


### PR DESCRIPTION
Taiko's Classic mod has a visual effect that was present in Stable where the hit objects will snap to the judgement area when hit.

I am proposing that this visual effect should be moved to a user-configurable setting. This is due to the effect being very similar in nature to other visual effects that don't affect which can be toggled by the user, such as the scrolling direction in Mania, and the slider snaking animations in Standard.

The use of this effect should be decided by personal preference, because there are benefits and disadvantages to both options depending on the player.
When the snapping effect is disabled, it increases visual feedback to the user, and can more easily show how early or late the note was hit. This can help newer players to get their bearings with the game, and can help improve a player's accuracy.

On the other hand, having snapping enabled can be beneficial as well. At higher levels of play, you rarely look at the judgement area, instead focusing on reading the upcoming notes. This can make it difficult to tell where the judgement area is when there is a high density of notes. Having all of the notes come out of the same location gives a clear visual indicator in the player's peripheral vision as to where the judgement area is, and having all notes animate with the same path prevents the animation from being distracting when there is a large number of notes being hit in quick succession as the notes animate in a consistent arc instead of flying in several directions.

As it is now, users who want this visual effect are stuck with the Classic mod's PP penalty along with any other potential future nerfs to Classic/Stable, and they can't do anything about it. This issue will become worse as Lazer becomes more heavily adopted.

---
The name for the setting can be considered a placeholder, as I was unsure what the correct terminology was. I opted to use the phrase "Note" to refer to Taiko hit objects, as that's the term the wiki uses, but this can be changed.
![image](https://github.com/ppy/osu/assets/48618519/b8b94d63-c419-456e-ace6-0ee27526ef16)

---
<details>
  <summary><b>Side-tangent about a seemingly incorrect xmldoc stating that TnT doesn't have snapping</b></summary>
When making this PR, I noticed an xmldoc relating to judgement snapping which stated that Taiko no Tatsujin doesn't include the feature:
<img src=https://github.com/ppy/osu/assets/48618519/1cd6551a-aaa7-49cf-8716-dce31cd52cb0></img>

From my memory, TnT did include this visual effect, so I was a little confused. To double check, I went through footage from several different TnT games, and I struggled to find a single game that *doesn't* implement this form of snapping.

I've kept the xmldoc present in this PR, but I'm unsure what's being referred to here.

Here are a few of the pieces of footage I looked at to check this:

https://youtu.be/ulYGx6FlKJ8?si=rzzxT8J3asTsXZWi&t=33

https://youtu.be/ZcdFbrzeqiY?si=tQUJJEErp3wBT9pb&t=751

https://youtu.be/oMKZ-Qpgjtc?si=5DE2FUnwyxj0m8GJ&t=42

https://youtu.be/KgFrdvfZGEY?si=bw5vta0ovTx0MV4T&t=190
</details>