### PR TITLE
Suggest to update only if the latest release is available for the current platform

### DIFF
--- a/osu.Game/Updater/SimpleUpdateManager.cs
+++ b/osu.Game/Updater/SimpleUpdateManager.cs
@@ -94,15 +94,18 @@ namespace osu.Game.Updater
                     break;
 
                 case RuntimeInfo.Platform.iOS:
-                    // iOS releases are available via testflight. this link seems to work well enough for now.
-                    // see https://stackoverflow.com/a/32960501
-                    url = "itms-beta://beta.itunes.apple.com/v1/app/1447765923";
+                    if (release.Assets?.Exists(f => f.Name.EndsWith(".ipa", StringComparison.Ordinal)) == true)
+                        // iOS releases are available via testflight. this link seems to work well enough for now.
+                        // see https://stackoverflow.com/a/32960501
+                        url = "itms-beta://beta.itunes.apple.com/v1/app/1447765923";
+
                     break;
 
                 case RuntimeInfo.Platform.Android:
-                    // on our testing device using the .apk URL causes the download to magically disappear.
-                    //bestAsset = release.Assets?.Find(f => f.Name.EndsWith(".apk"));
-                    url = release.HtmlUrl;
+                    if (release.Assets?.Exists(f => f.Name.EndsWith(".apk", StringComparison.Ordinal)) == true)
+                        // on our testing device using the .apk URL causes the download to magically disappear.
+                        url = release.HtmlUrl;
+
                     break;
             }
 

--- a/osu.Game/Updater/SimpleUpdateManager.cs
+++ b/osu.Game/Updater/SimpleUpdateManager.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -22,10 +20,10 @@ namespace osu.Game.Updater
     /// </summary>
     public partial class SimpleUpdateManager : UpdateManager
     {
-        private string version;
+        private string version = null!;
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game)
@@ -76,7 +74,7 @@ namespace osu.Game.Updater
 
         private string getBestUrl(GitHubRelease release)
         {
-            GitHubAsset bestAsset = null;
+            GitHubAsset? bestAsset = null;
 
             switch (RuntimeInfo.OS)
             {


### PR DESCRIPTION
We've had few releases lately where mobile isn't working / is crashing, so the mobile release was pulled. Unfortunately, the game would still send an update notification, leading to many people opening issues about the update not being available for their platform.

This PR changes `SimpleUpdateManager` to only show the update notification if the latest release actually has an update for the current platform (i.e. it wasn't pulled).

For this to work properly, the files need to removed from the release. This is mostly relevant for iOS, as the `osu.iOS.ipa` is available to download even if the update has not been pushed to testflight.