### PR TITLE
Display which mods grant pp

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1; // TODO: Implement the mania key mod score multiplier
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -8,5 +8,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModHardRock : ModHardRock
     {
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -11,5 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "One Key";
         public override string Acronym => "1K";
         public override LocalisableString Description => @"Play with one key.";
+        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -11,5 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Ten Keys";
         public override string Acronym => "10K";
         public override LocalisableString Description => @"Play with ten keys.";
+        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -11,5 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Two Keys";
         public override string Acronym => "2K";
         public override LocalisableString Description => @"Play with two keys.";
+        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -11,5 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Three Keys";
         public override string Acronym => "3K";
         public override LocalisableString Description => @"Play with three keys.";
+        public override bool Ranked => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModMirror : ModMirror, IApplicableToBeatmap
     {
         public override LocalisableString Description => "Notes are flipped horizontally.";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"Spinners will be automatically completed.";
         public override double ScoreMultiplier => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot), typeof(OsuModTargetPractice) };
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToDrawableHitObject(DrawableHitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
@@ -10,5 +10,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModTouchDevice : ModTouchDevice
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot) }).ToArray();
+        public override bool Ranked => UsesDefaultConfiguration;
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
@@ -67,6 +68,15 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert(@"Check empty multiplier", () => assertModsMultiplier(Array.Empty<Mod>()));
         }
 
+        [Test]
+        public void TestUnrankedBadge()
+        {
+            AddStep(@"Add unranked mod", () => changeMods(new[] { new OsuModDeflate() }));
+            AddAssert("Unranked badge shown", () => footerButtonMods.UnrankedBadge.Alpha == 1);
+            AddStep(@"Clear selected mod", () => changeMods(Array.Empty<Mod>()));
+            AddAssert("Unranked badge not shown", () => footerButtonMods.UnrankedBadge.Alpha == 0);
+        }
+
         private void changeMods(IReadOnlyList<Mod> mods)
         {
             footerButtonMods.Current.Value = mods;
@@ -83,6 +93,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private partial class TestFooterButtonMods : FooterButtonMods
         {
             public new OsuSpriteText MultiplierText => base.MultiplierText;
+            public new Drawable UnrankedBadge => base.UnrankedBadge;
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -119,7 +119,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("mod multiplier correct", () =>
             {
                 double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
-                return Precision.AlmostEquals(multiplier, modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value);
+                return Precision.AlmostEquals(multiplier, modSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
             AddAssert("setting items created", () => modSelectOverlay.ChildrenOfType<ISettingsItem>().Any());
@@ -134,7 +134,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("mod multiplier correct", () =>
             {
                 double multiplier = SelectedMods.Value.Aggregate(1d, (m, mod) => m * mod.ScoreMultiplier);
-                return Precision.AlmostEquals(multiplier, modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value);
+                return Precision.AlmostEquals(multiplier, modSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value);
             });
             assertCustomisationToggleState(disabled: false, active: false);
             AddAssert("setting items created", () => modSelectOverlay.ChildrenOfType<ISettingsItem>().Any());
@@ -846,7 +846,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
             AddAssert("difficulty multiplier display shows correct value",
-                () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.1).Within(Precision.DOUBLE_EPSILON));
+                () => modSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value, () => Is.EqualTo(0.1).Within(Precision.DOUBLE_EPSILON));
 
             // this is highly unorthodox in a test, but because the `ModSettingChangeTracker` machinery heavily leans on events and object disposal and re-creation,
             // it is instrumental in the reproduction of the failure scenario that this test is supposed to cover.
@@ -856,7 +856,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("reset half time speed to default", () => modSelectOverlay.ChildrenOfType<ModSettingsArea>().Single()
                                                                               .ChildrenOfType<RevertToDefaultButton<double>>().Single().TriggerClick());
             AddUntilStep("difficulty multiplier display shows correct value",
-                () => modSelectOverlay.ChildrenOfType<ScoreMultiplierDisplay>().Single().Current.Value, () => Is.EqualTo(0.3).Within(Precision.DOUBLE_EPSILON));
+                () => modSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value, () => Is.EqualTo(0.3).Within(Precision.DOUBLE_EPSILON));
         }
 
         private void waitForColumnLoad() => AddUntilStep("all column content loaded", () =>

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRankingInformationDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRankingInformationDisplay.cs
@@ -11,7 +11,7 @@ using osu.Game.Overlays.Mods;
 namespace osu.Game.Tests.Visual.UserInterface
 {
     [TestFixture]
-    public partial class TestSceneScoreMultiplierDisplay : OsuTestScene
+    public partial class TestSceneRankingInformationDisplay : OsuTestScene
     {
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Green);
@@ -19,22 +19,24 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestBasic()
         {
-            ScoreMultiplierDisplay multiplierDisplay = null!;
+            RankingInformationDisplay onlinePropertiesDisplay = null!;
 
-            AddStep("create content", () => Child = multiplierDisplay = new ScoreMultiplierDisplay
+            AddStep("create content", () => Child = onlinePropertiesDisplay = new RankingInformationDisplay
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre
             });
 
-            AddStep("set multiplier below 1", () => multiplierDisplay.Current.Value = 0.5);
-            AddStep("set multiplier to 1", () => multiplierDisplay.Current.Value = 1);
-            AddStep("set multiplier above 1", () => multiplierDisplay.Current.Value = 1.5);
+            AddToggleStep("toggle ranked", ranked => onlinePropertiesDisplay.Ranked.Value = ranked);
+
+            AddStep("set multiplier below 1", () => onlinePropertiesDisplay.ModMultiplier.Value = 0.5);
+            AddStep("set multiplier to 1", () => onlinePropertiesDisplay.ModMultiplier.Value = 1);
+            AddStep("set multiplier above 1", () => onlinePropertiesDisplay.ModMultiplier.Value = 1.5);
 
             AddSliderStep("set multiplier", 0, 2, 1d, multiplier =>
             {
-                if (multiplierDisplay.IsNotNull())
-                    multiplierDisplay.Current.Value = multiplier;
+                if (onlinePropertiesDisplay.IsNotNull())
+                    onlinePropertiesDisplay.ModMultiplier.Value = multiplier;
             });
         }
     }

--- a/osu.Game/Localisation/ModSelectOverlayStrings.cs
+++ b/osu.Game/Localisation/ModSelectOverlayStrings.cs
@@ -49,6 +49,26 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ScoreMultiplier => new TranslatableString(getKey(@"score_multiplier"), @"Score Multiplier");
 
+        /// <summary>
+        /// "Ranked"
+        /// </summary>
+        public static LocalisableString Ranked => new TranslatableString(getKey(@"ranked"), @"Ranked");
+
+        /// <summary>
+        /// "Performance points can be granted for the active mods."
+        /// </summary>
+        public static LocalisableString RankedExplanation => new TranslatableString(getKey(@"ranked_explanation"), @"Performance points can be granted for the active mods.");
+
+        /// <summary>
+        /// "Unranked"
+        /// </summary>
+        public static LocalisableString Unranked => new TranslatableString(getKey(@"unranked"), @"Unranked");
+
+        /// <summary>
+        /// "Performance points will not be granted due to active mods."
+        /// </summary>
+        public static LocalisableString UnrankedExplanation => new TranslatableString(getKey(@"ranked_explanation"), @"Performance points will not be granted due to active mods.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -125,7 +125,7 @@ namespace osu.Game.Overlays.Mods
         private DeselectAllModsButton deselectAllModsButton = null!;
 
         private Container aboveColumnsContent = null!;
-        private ScoreMultiplierDisplay? multiplierDisplay;
+        private RankingInformationDisplay? rankingInformationDisplay;
         private BeatmapAttributesDisplay? beatmapAttributesDisplay;
 
         protected ShearedButton BackButton { get; private set; } = null!;
@@ -185,7 +185,7 @@ namespace osu.Game.Overlays.Mods
                 aboveColumnsContent = new Container
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = ScoreMultiplierDisplay.HEIGHT,
+                    Height = RankingInformationDisplay.HEIGHT,
                     Padding = new MarginPadding { Horizontal = 100 },
                     Child = SearchTextBox = new ShearedSearchTextBox
                     {
@@ -200,7 +200,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         Padding = new MarginPadding
                         {
-                            Top = ScoreMultiplierDisplay.HEIGHT + PADDING,
+                            Top = RankingInformationDisplay.HEIGHT + PADDING,
                             Bottom = PADDING
                         },
                         RelativeSizeAxes = Axes.Both,
@@ -269,7 +269,7 @@ namespace osu.Game.Overlays.Mods
                     },
                     Children = new Drawable[]
                     {
-                        multiplierDisplay = new ScoreMultiplierDisplay
+                        rankingInformationDisplay = new RankingInformationDisplay
                         {
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight
@@ -315,7 +315,7 @@ namespace osu.Game.Overlays.Mods
 
             SelectedMods.BindValueChanged(_ =>
             {
-                updateMultiplier();
+                updateRankingInformation();
                 updateFromExternalSelection();
                 updateCustomisation();
 
@@ -328,7 +328,7 @@ namespace osu.Game.Overlays.Mods
                     //
                     // See https://github.com/ppy/osu/pull/23284#issuecomment-1529056988
                     modSettingChangeTracker = new ModSettingChangeTracker(SelectedMods.Value);
-                    modSettingChangeTracker.SettingChanged += _ => updateMultiplier();
+                    modSettingChangeTracker.SettingChanged += _ => updateRankingInformation();
                 }
             }, true);
 
@@ -450,9 +450,9 @@ namespace osu.Game.Overlays.Mods
                 modState.ValidForSelection.Value = modState.Mod.Type != ModType.System && modState.Mod.HasImplementation && IsValidMod.Invoke(modState.Mod);
         }
 
-        private void updateMultiplier()
+        private void updateRankingInformation()
         {
-            if (multiplierDisplay == null)
+            if (rankingInformationDisplay == null)
                 return;
 
             double multiplier = 1.0;
@@ -460,7 +460,8 @@ namespace osu.Game.Overlays.Mods
             foreach (var mod in SelectedMods.Value)
                 multiplier *= mod.ScoreMultiplier;
 
-            multiplierDisplay.Current.Value = multiplier;
+            rankingInformationDisplay.ModMultiplier.Value = multiplier;
+            rankingInformationDisplay.Ranked.Value = SelectedMods.Value.All(m => m.Ranked);
         }
 
         private void updateCustomisation()

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -67,6 +67,11 @@ namespace osu.Game.Rulesets.Mods
         bool AlwaysValidForSubmission { get; }
 
         /// <summary>
+        /// Whether scores with this mod active can give performance points.
+        /// </summary>
+        bool Ranked { get; }
+
+        /// <summary>
         /// Create a fresh <see cref="Mod"/> instance based on this mod.
         /// </summary>
         Mod CreateInstance() => (Mod)Activator.CreateInstance(GetType())!;

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -168,6 +168,12 @@ namespace osu.Game.Rulesets.Mods
         public virtual bool RequiresConfiguration => false;
 
         /// <summary>
+        /// Whether scores with this mod active can give performance points.
+        /// </summary>
+        [JsonIgnore]
+        public virtual bool Ranked => false;
+
+        /// <summary>
         /// The mods this mod cannot be enabled with.
         /// </summary>
         [JsonIgnore]

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => null;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Whoaaaaa...";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Zoooooooooom...";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -16,6 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyReduction;
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)
         {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModFlashlight;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Restricted view area.";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public abstract BindableFloat SizeMultiplier { get; }

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHalftime;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Less zoom...";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Everything just got a bit harder...";
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust) };
+        public override bool Ranked => UsesDefaultConfiguration;
 
         protected const float ADJUST_RATIO = 1.4f;
 

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -14,6 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "HD";
         public override IconUsage? Icon => OsuIcon.ModHidden;
         public override ModType Type => ModType.DifficultyIncrease;
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => UsesDefaultConfiguration;
     }
 
     public abstract class ModMuted<TObject> : ModMuted, IApplicableToDrawableRuleset<TObject>, IApplicableToTrack, IApplicableToScoreProcessor

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNightcore;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Uguuuuuuuu...";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "You can't fail, no matter what.";
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
+        public override bool Ranked => UsesDefaultConfiguration;
 
         private readonly Bindable<bool> showHealthBar = new Bindable<bool>();
 

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override double ScoreMultiplier => 1;
         public override LocalisableString Description => "SS or quit.";
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModSuddenDeath), typeof(ModAccuracyChallenge) }).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => UsesDefaultConfiguration;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).ToArray();
 

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -9,6 +9,9 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -16,6 +19,7 @@ using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
 using osu.Game.Utils;
 
 namespace osu.Game.Screens.Select
@@ -29,12 +33,26 @@ namespace osu.Game.Screens.Select
         }
 
         protected OsuSpriteText MultiplierText { get; private set; } = null!;
-        private ModDisplay modDisplay = null!;
+        protected Container UnrankedBadge { get; private set; } = null!;
+
+        private readonly ModDisplay modDisplay;
 
         private ModSettingChangeTracker? modSettingChangeTracker;
 
         private Color4 lowMultiplierColour;
         private Color4 highMultiplierColour;
+
+        public FooterButtonMods()
+        {
+            // must be created in ctor for correct operation of `Current`.
+            modDisplay = new ModDisplay
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Scale = new Vector2(0.8f),
+                ExpansionMode = ExpansionMode.AlwaysContracted,
+            };
+        }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -48,19 +66,38 @@ namespace osu.Game.Screens.Select
 
             ButtonContentContainer.AddRange(new Drawable[]
             {
-                modDisplay = new ModDisplay
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Scale = new Vector2(0.8f),
-                    ExpansionMode = ExpansionMode.AlwaysContracted,
-                },
+                modDisplay,
                 MultiplierText = new OsuSpriteText
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Font = OsuFont.GetFont(weight: FontWeight.Bold),
-                }
+                },
+                UnrankedBadge = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Circle
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Colour = colours.Yellow,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new OsuSpriteText
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Colour = colours.Gray2,
+                            Padding = new MarginPadding(5),
+                            UseFullGlyphHeight = false,
+                            Text = ModSelectOverlayStrings.Unranked.ToLower()
+                        }
+                    }
+                },
             });
         }
 
@@ -98,6 +135,9 @@ namespace osu.Game.Screens.Select
                 modDisplay.FadeIn();
             else
                 modDisplay.FadeOut();
+
+            bool anyUnrankedMods = Current.Value?.Any(m => !m.Ranked) == true;
+            UnrankedBadge.FadeTo(anyUnrankedMods ? 1 : 0);
         });
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Rulesets.Mods;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.UserInterface;
@@ -31,27 +28,13 @@ namespace osu.Game.Screens.Select
             set => modDisplay.Current = value;
         }
 
-        protected readonly OsuSpriteText MultiplierText;
-        private readonly ModDisplay modDisplay;
+        protected OsuSpriteText MultiplierText { get; private set; } = null!;
+        private ModDisplay modDisplay = null!;
+
+        private ModSettingChangeTracker? modSettingChangeTracker;
+
         private Color4 lowMultiplierColour;
         private Color4 highMultiplierColour;
-
-        public FooterButtonMods()
-        {
-            ButtonContentContainer.Add(modDisplay = new ModDisplay
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Scale = new Vector2(0.8f),
-                ExpansionMode = ExpansionMode.AlwaysContracted,
-            });
-            ButtonContentContainer.Add(MultiplierText = new OsuSpriteText
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Font = OsuFont.GetFont(weight: FontWeight.Bold),
-            });
-        }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
@@ -62,10 +45,24 @@ namespace osu.Game.Screens.Select
             highMultiplierColour = colours.Green;
             Text = @"mods";
             Hotkey = GlobalAction.ToggleModSelection;
-        }
 
-        [CanBeNull]
-        private ModSettingChangeTracker modSettingChangeTracker;
+            ButtonContentContainer.AddRange(new Drawable[]
+            {
+                modDisplay = new ModDisplay
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Scale = new Vector2(0.8f),
+                    ExpansionMode = ExpansionMode.AlwaysContracted,
+                },
+                MultiplierText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.GetFont(weight: FontWeight.Bold),
+                }
+            });
+        }
 
         protected override void LoadComplete()
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26888

In mod select and in song select footer.

https://github.com/ppy/osu/assets/20418176/431e5889-d1e0-4dc5-babd-9a984666ca2d

I'll quote the disclaimer from the issue again:

> - **this is only a temporary UX solution to a real problem of users not knowing what currently gives PP and what doesn't.**
> - The set of mods that will give pp **is subject to change and will change** (for the better) as we see fit.
> - There is **no guarantee that the "ranked" mod concept will function indefinitely.** The original goal was to have as much "ranked" as possible, and as far as I'm aware, this has not changed.

This doesn't work 100% correctly in multiplayer, namely when a user is selecting from free mods, but that is a pre-existing issue that affects the mod multiplier and the beatmap attribute display too so I'd ask to look away for the time being.

Please give f89923aeaee5785aeb4b91b6aaa3dfdf8b8ad791 particular attention when reviewing. And yes for now that commit is written very conservatively to match [the server-side implementation](https://github.com/ppy/osu-queue-score-statistics/blob/2264bfa68e14bb16ec71a7cac2072bdcfaf565b6/osu.Server.Queues.ScoreStatisticsProcessor/Processors/ScorePerformanceProcessor.cs#L197-L252) (which the `Ranked` property will be replacing).