### PR TITLE
Allow a few new mods and mod settings for pp

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -31,6 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
+        public override bool Ranked => true;
 
         private DrawableOsuBlinds blinds = null!;
 

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool RequiresConfiguration => false;
 
+        public override bool Ranked => true;
+
         public override string SettingDescription => base.SettingDescription.Replace(MinimumAccuracy.ToString(), MinimumAccuracy.Value.ToString("##%", NumberFormatInfo.InvariantInfo));
 
         [SettingSource("Minimum accuracy", "Trigger a failure if your accuracy goes below this value.", SettingControlType = typeof(SettingsPercentageSlider<double>))]

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Zoooooooooom...";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => SpeedChange.IsDefault;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHalftime;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Less zoom...";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => SpeedChange.IsDefault;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.Fun;
         public override IconUsage? Icon => FontAwesome.Solid.EyeSlash;
         public override double ScoreMultiplier => 1;
+        public override bool Ranked => true;
 
         /// <summary>
         /// Slightly higher than the cutoff for <see cref="Drawable.IsPresent"/>.

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override double ScoreMultiplier => 1;
         public override LocalisableString Description => "SS or quit.";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModSuddenDeath), typeof(ModAccuracyChallenge) }).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).ToArray();
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/26934
- Will take effect with https://github.com/ppy/osu-queue-score-statistics/pull/218

## Allow pp for "Restart on fail" setting of Sudden Death & Perfect (c114fd8f8963f28b06df951145486689ad0084db)

Closes https://github.com/ppy/osu/issues/26844.

## Allow pp for Accuracy Challenge (96f66aaa2e4eaa44c167e32af51fde84ad1e6a27)

Addresses https://github.com/ppy/osu/discussions/26919.

## Allow pp for "Adjust pitch" setting of Half Time / Double Time (ea76f7a5d88a3060369db0529330c3c28ea35752)

Addresses https://discord.com/channels/188630481301012481/1097318920991559880/1202606638951825459.

## Allow pp for Blinds (https://github.com/ppy/osu/pull/26935/commits/a84f53b1693892973535250163d13dfe8981ee9c)

The mod does impact pp, but it requires no extra difficulty attributes (https://github.com/ppy/osu/pull/26935#issuecomment-1925734171).

## Allow pp for No Scope (https://github.com/ppy/osu/pull/26935/commits/8df593a8e6734f59e9c3dc81b903e8e6dc5f20e7)

As per https://github.com/ppy/osu/pull/26935#issuecomment-1925644008.