### PR TITLE
Stop blocking player load when hovering over osu! logo

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -106,8 +106,8 @@ namespace osu.Game.Screens.Play
             && ReadyForGameplay;
 
         protected virtual bool ReadyForGameplay =>
-            // not ready if the user is hovering one of the panes, unless they are idle.
-            (IsHovered || idleTracker.IsIdle.Value)
+            // not ready if the user is hovering one of the panes (logo is excluded), unless they are idle.
+            (IsHovered || osuLogo?.IsHovered == true || idleTracker.IsIdle.Value)
             // not ready if the user is dragging a slider or otherwise.
             && inputManager.DraggedDrawable == null
             // not ready if a focused overlay is visible, like settings.
@@ -306,9 +306,13 @@ namespace osu.Game.Screens.Play
             return base.OnExiting(e);
         }
 
+        private OsuLogo? osuLogo;
+
         protected override void LogoArriving(OsuLogo logo, bool resuming)
         {
             base.LogoArriving(logo, resuming);
+
+            osuLogo = logo;
 
             const double duration = 300;
 
@@ -328,6 +332,7 @@ namespace osu.Game.Screens.Play
         {
             base.LogoExiting(logo);
             content.StopTracking();
+            osuLogo = null;
         }
 
         protected override void LogoSuspending(OsuLogo logo)
@@ -338,6 +343,8 @@ namespace osu.Game.Screens.Play
             logo
                 .FadeOut(CONTENT_OUT_DURATION / 2, Easing.OutQuint)
                 .ScaleTo(logo.Scale * 0.8f, CONTENT_OUT_DURATION * 2, Easing.OutQuint);
+
+            osuLogo = null;
         }
 
         #endregion


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26803
- Addresses https://github.com/ppy/osu/discussions/26351

The issue can simply be reproduced by hovering over the osu! logo while not getting the game into an idle state (i.e. you make subtle cursor movements within the logo, or randomly press keys).

I've chose to fix this one because it annoyed me personally. That being said, solution here is a bit too basic but works well without complicating matters.