### PR TITLE
Fix `DrawableManiaRuleset` performing skin lookup every frame

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -61,9 +59,9 @@ namespace osu.Game.Rulesets.Mania.UI
         // Stores the current speed adjustment active in gameplay.
         private readonly Track speedAdjustmentTrack = new TrackVirtual(0);
 
-        private ISkinSource currentSkin;
+        private ISkinSource currentSkin = null!;
 
-        public DrawableManiaRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods = null)
+        public DrawableManiaRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
             : base(ruleset, beatmap, mods)
         {
             BarLines = new BarLineGenerator<BarLine>(Beatmap).BarLines;
@@ -114,7 +112,7 @@ namespace osu.Game.Rulesets.Mania.UI
             updateTimeRange();
         }
 
-        private ScheduledDelegate pendingSkinChange;
+        private ScheduledDelegate? pendingSkinChange;
         private float hitPosition;
 
         private void onSkinChange()
@@ -160,7 +158,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         protected override PassThroughInputManager CreateInputManager() => new ManiaInputManager(Ruleset.RulesetInfo, Variant);
 
-        public override DrawableHitObject<ManiaHitObject> CreateDrawableRepresentation(ManiaHitObject h) => null;
+        public override DrawableHitObject<ManiaHitObject>? CreateDrawableRepresentation(ManiaHitObject h) => null;
 
         protected override ReplayInputHandler CreateReplayInputHandler(Replay replay) => new ManiaFramedReplayInputHandler(replay);
 


### PR DESCRIPTION
Used [SkinReloadableDrawable](https://github.com/ppy/osu/blob/master/osu.Game/Skinning/SkinReloadableDrawable.cs) as a reference.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/a43f852b-85f9-4435-a6a0-9bcb07b26d12)|![pr](https://github.com/ppy/osu/assets/22874522/80216ccf-e085-4db9-8a23-cec37b9ee522)|
