### PR TITLE
Fix huge allocation overhead in `UnstableRateCounter`

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
+++ b/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Benchmarks
+{
+    public class BenchmarkUnstableRate : BenchmarkTest
+    {
+        private List<HitEvent> events = null!;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            events = new List<HitEvent>();
+
+            for (int i = 0; i < 1000; i++)
+                events.Add(new HitEvent(RNG.NextDouble(-200.0, 200.0), RNG.NextDouble(1.0, 2.0), HitResult.Great, new HitObject(), null, null));
+        }
+
+        [Benchmark]
+        public void CalculateUnstableRate()
+        {
+            _ = events.CalculateUnstableRate();
+        }
+    }
+}

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -11,8 +11,11 @@ namespace osu.Game.Rulesets.Scoring
     public static class HitEventExtensions
     {
         /// <summary>
-        /// Calculates the "unstable rate" for a sequence of <see cref="HitEvent"/>s using Welford's online algorithm.
+        /// Calculates the "unstable rate" for a sequence of <see cref="HitEvent"/>s.
         /// </summary>
+        /// <remarks>
+        /// Uses <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm">Welford's online algorithm</a>.
+        /// </remarks>
         /// <returns>
         /// A non-null <see langword="double"/> value if unstable rate could be calculated,
         /// and <see langword="null"/> if unstable rate cannot be calculated due to <paramref name="hitEvents"/> being empty.

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -22,8 +22,8 @@ namespace osu.Game.Rulesets.Scoring
             Debug.Assert(hitEvents.All(ev => ev.GameplayRate != null));
 
             int count = 0;
-            double m = 0;
-            double s = 0;
+            double mean = 0;
+            double sumOfSquares = 0;
 
             foreach (var e in hitEvents)
             {
@@ -34,15 +34,15 @@ namespace osu.Game.Rulesets.Scoring
 
                 // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
                 double currentValue = e.TimeOffset / e.GameplayRate!.Value;
-                double mNext = m + (currentValue - m) / count;
-                s += (currentValue - m) * (currentValue - mNext);
-                m = mNext;
+                double nextMean = mean + (currentValue - mean) / count;
+                sumOfSquares += (currentValue - mean) * (currentValue - nextMean);
+                mean = nextMean;
             }
 
             if (count == 0)
                 return null;
 
-            return 10.0 * Math.Sqrt(s / count);
+            return 10.0 * Math.Sqrt(sumOfSquares / count);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -21,30 +21,28 @@ namespace osu.Game.Rulesets.Scoring
         {
             Debug.Assert(hitEvents.All(ev => ev.GameplayRate != null));
 
-            double currentValue;
-            int k = 0;
+            int count = 0;
             double m = 0;
             double s = 0;
-            double mNext;
 
             foreach (var e in hitEvents)
             {
                 if (!affectsUnstableRate(e))
                     continue;
 
-                // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
-                currentValue = e.TimeOffset / e.GameplayRate!.Value;
+                count++;
 
-                k++;
-                mNext = m + (currentValue - m) / k;
+                // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
+                double currentValue = e.TimeOffset / e.GameplayRate!.Value;
+                double mNext = m + (currentValue - m) / count;
                 s += (currentValue - m) * (currentValue - mNext);
                 m = mNext;
             }
 
-            if (k == 0)
+            if (count == 0)
                 return null;
 
-            return 10.0 * Math.Sqrt(s / k);
+            return 10.0 * Math.Sqrt(s / count);
         }
 
         /// <summary>

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -1041,4 +1041,5 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unplayed/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unproxy/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unranked/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Welford_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Zoomable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
# Overview
Currently `UnstableRateCounter` is allocationg a new array of size of judged objects on each judgement, which quickly becoming a problem for maps with many objects. By using Welford's online algorithm we can avoid selection and multiple passes over hitEvents and compute UR in a single loop.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/fe92472e-8aaa-4658-a351-1a321edbd11b)|![pr](https://github.com/ppy/osu/assets/22874522/f796ac0a-eb62-4c66-be68-4d7067e3fd3f)|

# Benchmark
| Method         | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------- |---------:|---------:|---------:|-------:|----------:|
| BenchmarkOldUR | 62.75 us | 0.079 us | 0.066 us | 8.0566 |   16968 B |
| BenchmarkNewUR | 29.24 us | 0.033 us | 0.027 us | 0.0305 |      96 B |

<details><summary>Code</summary>

```
// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
// See the LICENCE file in the repository root for full licence text.

using System.Collections.Generic;
using BenchmarkDotNet.Attributes;
using osu.Framework.Utils;
using osu.Game.Rulesets.Objects;
using osu.Game.Rulesets.Scoring;

namespace osu.Game.Benchmarks
{
    public class BenchmarkUR : BenchmarkTest
    {
        private List<HitEvent> events = null!;

        public override void SetUp()
        {
            base.SetUp();
            events = new List<HitEvent>();

            for (int i = 0; i < 1000; i++)
                events.Add(new HitEvent(RNG.NextDouble(-200.0, 200.0), RNG.NextDouble(1.0, 2.0), HitResult.Great, new HitObject(), null, null));
        }

        [Benchmark]
        public void BenchmarkOldUR()
        {
            events.CalculateUnstableRateOld();
        }

        [Benchmark]
        public void BenchmarkNewUR()
        {
            events.CalculateUnstableRate();
        }
    }
}
```

</details>

# Algorithm comparison
There is a `UnstableRateTest` test scene but just in case I compared old and new algo manually, results are basically the same:
![diff](https://github.com/ppy/osu/assets/22874522/d8b64f47-6628-4aeb-812c-d48df57dba6d)