### PR TITLE
Reduce `CursorTrail` allocation overhead

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     return;
                 }
 
-                foreach (Vector2 pos2 in resampler.AddPosition(position))
+                if (resampler.AddPosition(position) is Vector2 pos2)
                 {
                     Trace.Assert(lastPosition.HasValue);
 


### PR DESCRIPTION
- [ ] Depends on framework package with https://github.com/ppy/osu-framework/pull/6172

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/23567906-9388-49ba-bc38-e7c9e4a77363)|![pr](https://github.com/ppy/osu/assets/22874522/22c8a6c4-6cc9-4d22-903f-4c6618f95d51)|
