### PR TITLE
Fix multiplayer/playlists lounge screen disposing rooms synchronously

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -126,7 +126,11 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 case NotifyCollectionChangedAction.Remove:
                     Debug.Assert(args.OldItems != null);
 
-                    removeRooms(args.OldItems.Cast<Room>());
+                    if (args.OldItems.Count == roomFlow.Count)
+                        clearRooms();
+                    else
+                        removeRooms(args.OldItems.Cast<Room>());
+
                     break;
             }
         }
@@ -141,23 +145,23 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void removeRooms(IEnumerable<Room> rooms)
         {
-            foreach (var room in rooms)
+            foreach (var r in rooms)
             {
-                var drawableRoom = roomFlow.SingleOrDefault(d => d.Room == room);
-                if (drawableRoom == null)
-                    continue;
-
-                // expire to trigger async disposal. the room still has to exist somewhere so we move it to internal content of RoomsContainer until next frame.
-                drawableRoom.Hide();
-                drawableRoom.Expire();
-
-                roomFlow.Remove(drawableRoom, false);
-                AddInternal(drawableRoom);
+                roomFlow.RemoveAll(d => d.Room == r, true);
 
                 // selection may have a lease due to being in a sub screen.
                 if (!SelectedRoom.Disabled)
                     SelectedRoom.Value = null;
             }
+        }
+
+        private void clearRooms()
+        {
+            roomFlow.Clear();
+
+            // selection may have a lease due to being in a sub screen.
+            if (!SelectedRoom.Disabled)
+                SelectedRoom.Value = null;
         }
 
         private void updateSorting()

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -126,6 +126,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 case NotifyCollectionChangedAction.Remove:
                     Debug.Assert(args.OldItems != null);
 
+                    // clear operations have a separate path that benefits from async disposal,
+                    // since disposing is quite expensive when performed on a high number of drawables synchronously.
                     if (args.OldItems.Count == roomFlow.Count)
                         clearRooms();
                     else

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -141,9 +141,18 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void removeRooms(IEnumerable<Room> rooms)
         {
-            foreach (var r in rooms)
+            foreach (var room in rooms)
             {
-                roomFlow.RemoveAll(d => d.Room == r, true);
+                var drawableRoom = roomFlow.SingleOrDefault(d => d.Room == room);
+                if (drawableRoom == null)
+                    continue;
+
+                // expire to trigger async disposal. the room still has to exist somewhere so we move it to internal content of RoomsContainer until next frame.
+                drawableRoom.Hide();
+                drawableRoom.Expire();
+
+                roomFlow.Remove(drawableRoom, false);
+                AddInternal(drawableRoom);
 
                 // selection may have a lease due to being in a sub screen.
                 if (!SelectedRoom.Disabled)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26893

This starts to become noticeable as players began to create more rooms and playlists in osu!lazer. When changing the ruleset, `RoomManager` removes the previously existing rooms, signaling `RoomsContainer` to remove and dispose all existing rooms *synchronously*. This gets bad very quickly when the number of rooms exceeds about 10.

Before:

https://github.com/ppy/osu/assets/22781491/2bf6d0bb-d14c-465c-9f68-75ad617c4565

After:

https://github.com/ppy/osu/assets/22781491/a2f7b6bd-0562-4a3c-8b22-ef028af725a8

(the delay between the loading layer hiding and the rooms actually appearing is an issue that occurs on master as well. not entirely sure what's going on there.)