### PR TITLE
Fix selected room bindable being set to null regardless of the removed room

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneLoungeRoomsContainer.cs
@@ -64,6 +64,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("select first room", () => container.Rooms.First().TriggerClick());
             AddAssert("first spotlight selected", () => checkRoomSelected(RoomManager.Rooms.First(r => r.Category.Value == RoomCategory.Spotlight)));
+
+            AddStep("remove last room", () => RoomManager.RemoveRoom(RoomManager.Rooms.MinBy(r => r.RoomID?.Value)));
+            AddAssert("first spotlight still selected", () => checkRoomSelected(RoomManager.Rooms.First(r => r.Category.Value == RoomCategory.Spotlight)));
+
+            AddStep("remove spotlight room", () => RoomManager.RemoveRoom(RoomManager.Rooms.Single(r => r.Category.Value == RoomCategory.Spotlight)));
+            AddAssert("selection vacated", () => checkRoomSelected(null));
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -146,7 +146,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 roomFlow.RemoveAll(d => d.Room == r, true);
 
                 // selection may have a lease due to being in a sub screen.
-                if (!SelectedRoom.Disabled)
+                if (SelectedRoom.Value == r && !SelectedRoom.Disabled)
                     SelectedRoom.Value = null;
             }
         }


### PR DESCRIPTION
Briefly discussed in [discord](https://discord.com/channels/188630481301012481/188630652340404224/1203699646833365045). The bindable was supposed to be updated only when the selected room matches a removed room (therefore clearing selection), but was refactored at some point and the conditions appeared to be incorrectly removed (see https://github.com/ppy/osu/commit/822225577b8f072501fde2959691f94d98ead5b7#diff-6641e1f909bc58c5179c3c0b386be672449b434087378a72ee99557118db305aL103-R102). I cannot seem to find any positive/negative behavioural change caused by this.