### PR TITLE
Bump databased star rating versions

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         private readonly bool isForCurrentRuleset;
         private readonly double originalOverallDifficulty;
 
-        public override int Version => 20220902;
+        public override int Version => 20230817;
 
         public ManiaDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
     {
         private const double difficulty_multiplier = 1.35;
 
-        public override int Version => 20220902;
+        public override int Version => 20221107;
 
         public TaikoDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
             : base(ruleset, beatmap)


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/issues/26929

Bumped to the date at which the relevant PRs were merged:
taiko: https://github.com/ppy/osu/pull/20558
mania: https://github.com/ppy/osu/pull/24109

Refer to https://github.com/orgs/ppy/projects/12/views/1 for all changes that have happened in the last recent while.