### PR TITLE
Add progressive coverage for mania's Hidden and FadeIn mods

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -7,8 +7,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests.Mods
@@ -62,6 +66,21 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
 
             AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
             AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        [Test]
+        public void TestNoCoverageDuringBreak()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                Beatmap = new Beatmap
+                {
+                    HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
+                    Breaks = { new BreakPeriod(2000, 28000) }
+                },
+                PassCondition = () => Player.IsBreakTime.Value && checkCoverage(0)
+            });
         }
 
         private bool checkCoverage(float expected)

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -1,8 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests.Mods
@@ -11,9 +17,65 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.5f)]
-        [TestCase(0.1f)]
-        [TestCase(0.7f)]
-        public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModFadeIn { Coverage = { Value = coverage } }, PassCondition = () => true });
+        [Test]
+        public void TestMinCoverageFullWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MIN_COVERAGE)
+            });
+        }
+
+        [Test]
+        public void TestMinCoverageHalfWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MIN_COVERAGE)
+            });
+
+            AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        [Test]
+        public void TestMaxCoverageFullWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MAX_COVERAGE)
+            });
+
+            AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
+        }
+
+        [Test]
+        public void TestMaxCoverageHalfWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MAX_COVERAGE)
+            });
+
+            AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
+            AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        private bool checkCoverage(float expected)
+        {
+            Drawable? cover = this.ChildrenOfType<PlayfieldCoveringWrapper>().FirstOrDefault();
+            Drawable? filledArea = cover?.ChildrenOfType<Box>().LastOrDefault();
+
+            if (filledArea == null)
+                return false;
+
+            float scale = cover!.DrawHeight / (768 - Stage.HIT_TARGET_POSITION);
+
+            // A bit of lenience because the test may end up hitting hitobjects before any assertions.
+            return Precision.AlmostEquals(filledArea.DrawHeight / scale, expected, 0.1);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -7,8 +7,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests.Mods
@@ -62,6 +66,21 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
 
             AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
             AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        [Test]
+        public void TestNoCoverageDuringBreak()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                Beatmap = new Beatmap
+                {
+                    HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
+                    Breaks = { new BreakPeriod(2000, 28000) }
+                },
+                PassCondition = () => Player.IsBreakTime.Value && checkCoverage(0)
+            });
         }
 
         private bool checkCoverage(float expected)

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -1,8 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Rulesets.Mania.Tests.Mods
@@ -11,9 +17,65 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
     {
         protected override Ruleset CreatePlayerRuleset() => new ManiaRuleset();
 
-        [TestCase(0.5f)]
-        [TestCase(0.2f)]
-        [TestCase(0.8f)]
-        public void TestCoverage(float coverage) => CreateModTest(new ModTestData { Mod = new ManiaModHidden { Coverage = { Value = coverage } }, PassCondition = () => true });
+        [Test]
+        public void TestMinCoverageFullWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MIN_COVERAGE)
+            });
+        }
+
+        [Test]
+        public void TestMinCoverageHalfWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MIN_COVERAGE)
+            });
+
+            AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        [Test]
+        public void TestMaxCoverageFullWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MAX_COVERAGE)
+            });
+
+            AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
+        }
+
+        [Test]
+        public void TestMaxCoverageHalfWidth()
+        {
+            CreateModTest(new ModTestData
+            {
+                Mod = new ManiaModHidden(),
+                PassCondition = () => checkCoverage(ManiaModHidden.MAX_COVERAGE)
+            });
+
+            AddStep("set combo to 480", () => Player.ScoreProcessor.Combo.Value = 480);
+            AddStep("set playfield width to 0.5", () => Player.Width = 0.5f);
+        }
+
+        private bool checkCoverage(float expected)
+        {
+            Drawable? cover = this.ChildrenOfType<PlayfieldCoveringWrapper>().FirstOrDefault();
+            Drawable? filledArea = cover?.ChildrenOfType<Box>().LastOrDefault();
+
+            if (filledArea == null)
+                return false;
+
+            float scale = cover!.DrawHeight / (768 - Stage.HIT_TARGET_POSITION);
+
+            // A bit of lenience because the test may end up hitting hitobjects before any assertions.
+            return Precision.AlmostEquals(filledArea.DrawHeight / scale, expected, 0.1);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/TestScenePlayfieldCoveringContainer.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestScenePlayfieldCoveringContainer.cs
@@ -39,18 +39,18 @@ namespace osu.Game.Rulesets.Mania.Tests
         public void TestScrollingDownwards()
         {
             AddStep("set down scroll", () => scrollingContainer.Direction = ScrollingDirection.Down);
-            AddStep("set coverage = 0.5", () => cover.Coverage = 0.5f);
-            AddStep("set coverage = 0.8f", () => cover.Coverage = 0.8f);
-            AddStep("set coverage = 0.2f", () => cover.Coverage = 0.2f);
+            AddStep("set coverage = 0.5", () => cover.Coverage.Value = 0.5f);
+            AddStep("set coverage = 0.8f", () => cover.Coverage.Value = 0.8f);
+            AddStep("set coverage = 0.2f", () => cover.Coverage.Value = 0.2f);
         }
 
         [Test]
         public void TestScrollingUpwards()
         {
             AddStep("set up scroll", () => scrollingContainer.Direction = ScrollingDirection.Up);
-            AddStep("set coverage = 0.5", () => cover.Coverage = 0.5f);
-            AddStep("set coverage = 0.8f", () => cover.Coverage = 0.8f);
-            AddStep("set coverage = 0.2f", () => cover.Coverage = 0.2f);
+            AddStep("set coverage = 0.5", () => cover.Coverage.Value = 0.5f);
+            AddStep("set coverage = 0.8f", () => cover.Coverage.Value = 0.8f);
+            AddStep("set coverage = 0.2f", () => cover.Coverage.Value = 0.2f);
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -247,7 +247,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModHardRock(),
                         new MultiMod(new ManiaModSuddenDeath(), new ManiaModPerfect()),
                         new MultiMod(new ManiaModDoubleTime(), new ManiaModNightcore()),
-                        new MultiMod(new ManiaModFadeIn(), new ManiaModHidden()),
+                        new MultiMod(new ManiaModFadeIn(), new ManiaModHidden(), new ManiaModCover()),
                         new ManiaModFlashlight(),
                         new ModAccuracyChallenge(),
                     };

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Localisation;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Mania.UI;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModCover : ManiaModWithPlayfieldCover
+    {
+        public override string Name => "Cover";
+        public override string Acronym => "CO";
+
+        public override LocalisableString Description => @"Decrease the playfield's viewing area.";
+
+        public override double ScoreMultiplier => 1;
+
+        protected override CoverExpandDirection ExpandDirection => Direction.Value;
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
+        {
+            typeof(ManiaModHidden),
+            typeof(ManiaModFadeIn)
+        }).ToArray();
+
+        public override bool Ranked => false;
+
+        [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
+        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
+        {
+            Precision = 0.1f,
+            MinValue = 0.2f,
+            MaxValue = 0.8f,
+            Default = 0.5f,
+        };
+
+        [SettingSource("Direction", "The direction on which the cover is applied")]
+        public Bindable<CoverExpandDirection> Direction { get; } = new Bindable<CoverExpandDirection>();
+    }
+}

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -15,7 +15,11 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override LocalisableString Description => @"Keys appear out of nowhere!";
         public override double ScoreMultiplier => 1;
 
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModHidden)).ToArray();
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
+        {
+            typeof(ManiaModHidden),
+            typeof(ManiaModCover)
+        }).ToArray();
 
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AlongScroll;
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModFadeIn.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mania.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModFadeIn : ManiaModPlayfieldCover
+    public class ManiaModFadeIn : ManiaModHidden
     {
         public override string Name => "Fade In";
         public override string Acronym => "FI";
@@ -19,13 +18,5 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModHidden)).ToArray();
 
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AlongScroll;
-
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
-        {
-            Precision = 0.1f,
-            MinValue = 0.1f,
-            MaxValue = 0.7f,
-            Default = 0.5f,
-        };
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -10,7 +10,7 @@ using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModHidden : ManiaModPlayfieldCover
+    public class ManiaModHidden : ManiaModWithPlayfieldCover
     {
         /// <summary>
         /// osu!stable is referenced to 480px.
@@ -23,7 +23,12 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
-        public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
+
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[]
+        {
+            typeof(ManiaModFadeIn),
+            typeof(ManiaModCover)
+        }).ToArray();
 
         public override BindableNumber<float> Coverage { get; } = new BindableFloat(min_coverage);
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModHidden : ManiaModWithPlayfieldCover
     {
         /// <summary>
-        /// osu!stable is referenced to 480px.
+        /// osu!stable is referenced to 768px.
         /// </summary>
-        private const float playfield_height = 480;
+        private const float playfield_height = 768;
 
         private const float min_coverage = 160f / playfield_height;
         private const float max_coverage = 400f / playfield_height;

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -21,9 +21,9 @@ namespace osu.Game.Rulesets.Mania.Mods
         /// </summary>
         private const float reference_playfield_height = 768;
 
-        private const float min_coverage = 160f / reference_playfield_height;
-        private const float max_coverage = 400f / reference_playfield_height;
-        private const float coverage_increase_per_combo = 0.5f / reference_playfield_height;
+        public const float MIN_COVERAGE = 160f;
+        public const float MAX_COVERAGE = 400f;
+        private const float coverage_increase_per_combo = 0.5f;
 
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             typeof(ManiaModCover)
         }).ToArray();
 
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(min_coverage);
+        public override BindableNumber<float> Coverage { get; } = new BindableFloat(MIN_COVERAGE);
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
 
         private readonly BindableInt combo = new BindableInt();
@@ -45,7 +45,12 @@ namespace osu.Game.Rulesets.Mania.Mods
 
             combo.UnbindAll();
             combo.BindTo(scoreProcessor.Combo);
-            combo.BindValueChanged(c => Coverage.Value = Math.Min(max_coverage, min_coverage + c.NewValue * coverage_increase_per_combo), true);
+            combo.BindValueChanged(c =>
+            {
+                Coverage.Value = Math.Min(
+                    MAX_COVERAGE / reference_playfield_height,
+                    MIN_COVERAGE / reference_playfield_height + c.NewValue * coverage_increase_per_combo / reference_playfield_height);
+            }, true);
         }
 
         protected override PlayfieldCoveringWrapper CreateCover(Drawable content) => new LegacyPlayfieldCover(content);

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -6,24 +6,37 @@ using System.Linq;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModHidden : ManiaModPlayfieldCover
     {
+        /// <summary>
+        /// osu!stable is referenced to 480px.
+        /// </summary>
+        private const float playfield_height = 480;
+
+        private const float min_coverage = 160f / playfield_height;
+        private const float max_coverage = 400f / playfield_height;
+        private const float coverage_increase_per_combo = 0.5f / playfield_height;
+
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
-
-        public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)
-        {
-            Precision = 0.1f,
-            MinValue = 0.2f,
-            MaxValue = 0.8f,
-            Default = 0.5f,
-        };
-
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ManiaModFadeIn)).ToArray();
 
+        public override BindableNumber<float> Coverage { get; } = new BindableFloat(min_coverage);
         protected override CoverExpandDirection ExpandDirection => CoverExpandDirection.AgainstScroll;
+
+        private readonly BindableInt combo = new BindableInt();
+
+        public override void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        {
+            base.ApplyToScoreProcessor(scoreProcessor);
+
+            combo.UnbindAll();
+            combo.BindTo(scoreProcessor.Combo);
+            combo.BindValueChanged(c => Coverage.Value = Math.Min(max_coverage, min_coverage + c.NewValue * coverage_increase_per_combo), true);
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -6,20 +6,21 @@ using System.Linq;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModHidden : ManiaModWithPlayfieldCover
+    public partial class ManiaModHidden : ManiaModWithPlayfieldCover
     {
         /// <summary>
         /// osu!stable is referenced to 768px.
         /// </summary>
-        private const float playfield_height = 768;
+        private const float reference_playfield_height = 768;
 
-        private const float min_coverage = 160f / playfield_height;
-        private const float max_coverage = 400f / playfield_height;
-        private const float coverage_increase_per_combo = 0.5f / playfield_height;
+        private const float min_coverage = 160 / reference_playfield_height;
+        private const float max_coverage = 400f / reference_playfield_height;
+        private const float coverage_increase_per_combo = 0.5f / reference_playfield_height;
 
         public override LocalisableString Description => @"Keys fade out before you hit them!";
         public override double ScoreMultiplier => 1;
@@ -42,6 +43,24 @@ namespace osu.Game.Rulesets.Mania.Mods
             combo.UnbindAll();
             combo.BindTo(scoreProcessor.Combo);
             combo.BindValueChanged(c => Coverage.Value = Math.Min(max_coverage, min_coverage + c.NewValue * coverage_increase_per_combo), true);
+        }
+
+        protected override PlayfieldCoveringWrapper CreateCover(Drawable content) => new LegacyPlayfieldCover(content);
+
+        private partial class LegacyPlayfieldCover : PlayfieldCoveringWrapper
+        {
+            public LegacyPlayfieldCover(Drawable content)
+                : base(content)
+            {
+            }
+
+            protected override float GetHeight(float coverage)
+            {
+                if (DrawHeight == 0)
+                    return base.GetHeight(coverage);
+
+                return base.GetHeight(coverage) * reference_playfield_height / DrawHeight;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 {
                     c.RelativeSizeAxes = Axes.Both;
                     c.Direction = ExpandDirection;
-                    c.Coverage = Coverage.Value;
+                    c.Coverage.BindTo(Coverage);
                 }));
             }
         }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPlayfieldCover.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Configuration;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
@@ -24,7 +23,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         /// </summary>
         protected abstract CoverExpandDirection ExpandDirection { get; }
 
-        [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
         public abstract BindableNumber<float> Coverage { get; }
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModWithPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModWithPlayfieldCover.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Mania.Mods
                 Container hocParent = (Container)hoc.Parent!;
 
                 hocParent.Remove(hoc, false);
-                hocParent.Add(new PlayfieldCoveringWrapper(hoc).With(c =>
+                hocParent.Add(CreateCover(hoc).With(c =>
                 {
                     c.RelativeSizeAxes = Axes.Both;
                     c.Direction = ExpandDirection;
@@ -46,6 +46,8 @@ namespace osu.Game.Rulesets.Mania.Mods
                 }));
             }
         }
+
+        protected virtual PlayfieldCoveringWrapper CreateCover(Drawable content) => new PlayfieldCoveringWrapper(content);
 
         protected override void ApplyIncreasedVisibilityState(DrawableHitObject hitObject, ArmedState state)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModWithPlayfieldCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModWithPlayfieldCover.cs
@@ -14,7 +14,7 @@ using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public abstract class ManiaModPlayfieldCover : ModHidden, IApplicableToDrawableRuleset<ManiaHitObject>
+    public abstract class ManiaModWithPlayfieldCover : ModHidden, IApplicableToDrawableRuleset<ManiaHitObject>
     {
         public override Type[] IncompatibleMods => new[] { typeof(ModFlashlight<ManiaHitObject>) };
 
@@ -23,6 +23,9 @@ namespace osu.Game.Rulesets.Mania.Mods
         /// </summary>
         protected abstract CoverExpandDirection ExpandDirection { get; }
 
+        /// <summary>
+        /// The relative area that should be completely covered. This does not include the fade.
+        /// </summary>
         public abstract BindableNumber<float> Coverage { get; }
 
         public virtual void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)

--- a/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
@@ -20,6 +20,11 @@ namespace osu.Game.Rulesets.Mania.UI
     public partial class PlayfieldCoveringWrapper : CompositeDrawable
     {
         /// <summary>
+        /// The relative area that should be completely covered. This does not include the fade.
+        /// </summary>
+        public readonly BindableFloat Coverage = new BindableFloat();
+
+        /// <summary>
         /// The complete cover, including gradient and fill.
         /// </summary>
         private readonly Drawable cover;
@@ -94,20 +99,19 @@ namespace osu.Game.Rulesets.Mania.UI
             scrollDirection.BindValueChanged(onScrollDirectionChanged, true);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Coverage.BindValueChanged(c =>
+            {
+                filled.Height = c.NewValue;
+                gradient.Y = -c.NewValue;
+            }, true);
+        }
+
         private void onScrollDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
             => cover.Rotation = direction.NewValue == ScrollingDirection.Up ? 0 : 180f;
-
-        /// <summary>
-        /// The relative area that should be completely covered. This does not include the fade.
-        /// </summary>
-        public float Coverage
-        {
-            set
-            {
-                filled.Height = value;
-                gradient.Y = -value;
-            }
-        }
 
         /// <summary>
         /// The direction in which the cover expands.

--- a/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly IBindable<ScrollingDirection> scrollDirection = new Bindable<ScrollingDirection>();
 
-        private float currentCoverage;
+        private float currentCoverageHeight;
 
         public PlayfieldCoveringWrapper(Drawable content)
         {
@@ -106,23 +106,36 @@ namespace osu.Game.Rulesets.Mania.UI
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            updateHeight(Coverage.Value);
+            updateCoverSize(true);
         }
 
         protected override void Update()
         {
             base.Update();
-
-            updateHeight((float)Interpolation.DampContinuously(currentCoverage, Coverage.Value, 25, Math.Abs(Time.Elapsed)));
+            updateCoverSize(false);
         }
 
-        private void updateHeight(float coverage)
+        private void updateCoverSize(bool instant)
         {
-            filled.Height = GetHeight(coverage);
-            gradient.Y = -GetHeight(coverage);
+            float targetCoverage;
+            float targetAlpha;
 
-            currentCoverage = coverage;
+            if (instant)
+            {
+                targetCoverage = Coverage.Value;
+                targetAlpha = Coverage.Value > 0 ? 1 : 0;
+            }
+            else
+            {
+                targetCoverage = (float)Interpolation.DampContinuously(currentCoverageHeight, Coverage.Value, 25, Math.Abs(Time.Elapsed));
+                targetAlpha = (float)Interpolation.DampContinuously(gradient.Alpha, Coverage.Value > 0 ? 1 : 0, 25, Math.Abs(Time.Elapsed));
+            }
+
+            filled.Height = GetHeight(targetCoverage);
+            gradient.Y = -GetHeight(targetCoverage);
+            gradient.Alpha = targetAlpha;
+
+            currentCoverageHeight = targetCoverage;
         }
 
         protected virtual float GetHeight(float coverage) => coverage;

--- a/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.ComponentModel;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -13,11 +14,12 @@ using osu.Framework.Utils;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Graphics;
+using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
     /// <summary>
-    /// A <see cref="Container"/> that has its contents partially hidden by an adjustable "cover". This is intended to be used in a playfield.
+    /// A <see cref="Framework.Graphics.Containers.Container"/> that has its contents partially hidden by an adjustable "cover". This is intended to be used in a playfield.
     /// </summary>
     public partial class PlayfieldCoveringWrapper : CompositeDrawable
     {
@@ -157,11 +159,13 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// The cover expands along the scrolling direction.
         /// </summary>
+        [Description("Along scroll")]
         AlongScroll,
 
         /// <summary>
         /// The cover expands against the scrolling direction.
         /// </summary>
+        [Description("Against scroll")]
         AgainstScroll
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private readonly IBindable<ScrollingDirection> scrollDirection = new Bindable<ScrollingDirection>();
 
+        private float currentCoverage;
+
         public PlayfieldCoveringWrapper(Drawable content)
         {
             InternalChild = new BufferedContainer
@@ -112,14 +114,18 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             base.Update();
 
-            updateHeight((float)Interpolation.DampContinuously(filled.Height, Coverage.Value, 25, Math.Abs(Time.Elapsed)));
+            updateHeight((float)Interpolation.DampContinuously(currentCoverage, Coverage.Value, 25, Math.Abs(Time.Elapsed)));
         }
 
-        private void updateHeight(float height)
+        private void updateHeight(float coverage)
         {
-            filled.Height = height;
-            gradient.Y = -height;
+            filled.Height = GetHeight(coverage);
+            gradient.Y = -GetHeight(coverage);
+
+            currentCoverage = coverage;
         }
+
+        protected virtual float GetHeight(float coverage) => coverage;
 
         private void onScrollDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)
             => cover.Rotation = direction.NewValue == ScrollingDirection.Up ? 0 : 180f;

--- a/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
+++ b/osu.Game.Rulesets.Mania/UI/PlayfieldCoveringWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -8,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.UI.Scrolling;
 using osuTK;
 using osuTK.Graphics;
@@ -103,11 +105,20 @@ namespace osu.Game.Rulesets.Mania.UI
         {
             base.LoadComplete();
 
-            Coverage.BindValueChanged(c =>
-            {
-                filled.Height = c.NewValue;
-                gradient.Y = -c.NewValue;
-            }, true);
+            updateHeight(Coverage.Value);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            updateHeight((float)Interpolation.DampContinuously(filled.Height, Coverage.Value, 25, Math.Abs(Time.Elapsed)));
+        }
+
+        private void updateHeight(float height)
+        {
+            filled.Height = height;
+            gradient.Y = -height;
         }
 
         private void onScrollDirectionChanged(ValueChangedEvent<ScrollingDirection> direction)

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -16,11 +16,11 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override bool Ranked => UsesDefaultConfiguration;
 
-        public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {
         }
 
-        public ScoreRank AdjustRank(ScoreRank rank, double accuracy)
+        public virtual ScoreRank AdjustRank(ScoreRank rank, double accuracy)
         {
             switch (rank)
             {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/22355
Supersedes / closes https://github.com/ppy/osu/pull/22591

This restores progressive coverage that HD and FI had in osu!stable, and adds a new mod `ManiaModCover` / `CO` which allows setting a custom cover.

I've tested that importing an old score that previously had `Coverage` set to a custom value works.

Not sure whether we want/need to do a score reset at this point.