### PR TITLE
Hide ruleset selector when on kudosu ranking

### DIFF
--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -39,5 +39,15 @@ namespace osu.Game.Overlays.Rankings
                 Icon = OsuIcon.Ranking;
             }
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Current.BindValueChanged(scope =>
+            {
+                rulesetSelector.FadeTo(scope.NewValue <= RankingsScope.Country ? 1 : 0, 200, Easing.OutQuint);
+            });
+        }
     }
 }

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
-using osu.Game.Localisation;
-using osu.Game.Resources.Localisation.Web;
 using osu.Framework.Graphics;
 using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
 using osu.Game.Users;
 
@@ -19,8 +17,8 @@ namespace osu.Game.Overlays.Rankings
 
         public Bindable<CountryCode> Country => countryFilter.Current;
 
-        private OverlayRulesetSelector rulesetSelector;
-        private CountryFilter countryFilter;
+        private OverlayRulesetSelector rulesetSelector = null!;
+        private CountryFilter countryFilter = null!;
 
         protected override OverlayTitle CreateTitle() => new RankingsTitle();
 
@@ -46,8 +44,23 @@ namespace osu.Game.Overlays.Rankings
 
             Current.BindValueChanged(scope =>
             {
-                rulesetSelector.FadeTo(scope.NewValue <= RankingsScope.Country ? 1 : 0, 200, Easing.OutQuint);
-            });
+                rulesetSelector.FadeTo(showRulesetSelector(scope.NewValue) ? 1 : 0, 200, Easing.OutQuint);
+            }, true);
+
+            bool showRulesetSelector(RankingsScope scope)
+            {
+                switch (scope)
+                {
+                    case RankingsScope.Performance:
+                    case RankingsScope.Spotlights:
+                    case RankingsScope.Score:
+                    case RankingsScope.Country:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/27061

Did `<= country` to future-proof any future rankings that don't use the ruleset selector (like `multiplayer` and `seasons` in web, but not listed as they can be accessed directly in lazer). Transition duration is arbitrary as I believe there isn't a standard, just put what looked good.

https://github.com/ppy/osu/assets/35318437/e718445b-0d0f-4843-a063-0ca65f4dc720