### PR TITLE
Improve exception logging of unobserved exceptions via `FireAndForget`

### DIFF
--- a/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClientExtensions.cs
@@ -23,9 +23,12 @@ namespace osu.Game.Online.Multiplayer
 
                     Debug.Assert(exception != null);
 
-                    string message = exception.GetHubExceptionMessage() ?? exception.Message;
+                    if (exception.GetHubExceptionMessage() is string message)
+                        // Hub exceptions generally contain something we can show the user directly.
+                        Logger.Log(message, level: LogLevel.Important);
+                    else
+                        Logger.Error(exception, $"Unobserved exception occurred via {nameof(FireAndForget)} call: {exception.Message}");
 
-                    Logger.Log(message, level: LogLevel.Important);
                     onError?.Invoke(exception);
                 }
                 else


### PR DESCRIPTION
Coming from https://github.com/ppy/osu/issues/27076, where the log output makes finding where the exception arrived for nigh impossible.

Example output:

```log
2024-02-07 16:23:25 [error]: Unobserved exception via FireAndForget: Test
2024-02-07 16:23:25 [error]: System.InvalidOperationException: Test
2024-02-07 16:23:25 [error]: at osu.Game.Graphics.ScreenshotManager.<TakeScreenshotAsync>b__25_0() in /Users/dean/Projects/osu/osu.Game/Graphics/ScreenshotManager.cs:line 88
2024-02-07 16:23:25 [error]: at System.Threading.Tasks.Task`1.InnerInvoke()
2024-02-07 16:23:25 [error]: at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
2024-02-07 16:23:25 [error]: --- End of stack trace from previous location ---
2024-02-07 16:23:25 [error]: at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
2024-02-07 16:23:25 [error]: at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
2024-02-07 16:23:26 [debug]: Pressed (HoldForHUD) handled by HUDOverlay.
2024-02-07 16:23:26 [debug]: KeyDownEvent(ControlLeft, False) handled by GlobalActionContainer.
2024-02-07 16:23:26 [debug]: Pressed (Back) handled by HoldForMenuButton+HoldButton.
2024-02-07 16:23:26 [debug]: KeyDownEvent(Escape, False) handled by GlobalActionContainer.
2024-02-07 16:23:26 [debug]: Pressed (HoldForHUD) handled by HUDOverlay.
2024-02-07 16:23:26 [debug]: KeyDownEvent(ControlLeft, False) handled by GlobalActionContainer.
2024-02-07 16:23:26 [debug]: Pressed (Back) handled by HoldForMenuButton+HoldButton.
2024-02-07 16:23:26 [debug]: KeyDownEvent(Escape, False) handled by GlobalActionContainer.
2024-02-07 16:23:26 [debug]: Pressed (Back) handled by HoldForMenuButton+HoldButton.
2024-02-07 16:23:26 [debug]: KeyDownEvent(Escape, False) handled by GlobalActionContainer.
2024-02-07 16:23:27 [verbose]: ⚠️ Unobserved exception via FireAndForget: Test
```