### PR TITLE
Fix profile current location and interests icons not matching web

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -206,6 +206,12 @@ namespace osu.Game.Tests.Visual.Online
                 Total = 50
             },
             SupportLevel = 2,
+            Location = "Somewhere",
+            Interests = "Rhythm games",
+            Occupation = "Gamer",
+            Twitter = "test_user",
+            Discord = "test_user",
+            Website = "https://google.com",
         };
     }
 }

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Overlays.Profile.Header
 
             bottomLinkContainer.AddIcon(icon, text =>
             {
-                text.Font = text.Font.With(size: 10);
+                text.Font = text.Font.With(icon.Family, 10, icon.Weight);
                 text.Colour = iconColour;
             });
 

--- a/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
+++ b/osu.Game/Overlays/Profile/Header/BottomHeaderContainer.cs
@@ -144,8 +144,8 @@ namespace osu.Game.Overlays.Profile.Header
 
             bool anyInfoAdded = false;
 
-            anyInfoAdded |= tryAddInfo(FontAwesome.Solid.MapMarker, user.Location);
-            anyInfoAdded |= tryAddInfo(FontAwesome.Solid.Heart, user.Interests);
+            anyInfoAdded |= tryAddInfo(FontAwesome.Solid.MapMarkerAlt, user.Location);
+            anyInfoAdded |= tryAddInfo(FontAwesome.Regular.Heart, user.Interests);
             anyInfoAdded |= tryAddInfo(FontAwesome.Solid.Suitcase, user.Occupation);
 
             if (anyInfoAdded)


### PR DESCRIPTION
| Before | After | Web |
| --- | --- | --- |
| <img width="187" alt="Screenshot 2024-02-09 at 2 36 07 PM" src="https://github.com/ppy/osu/assets/35318437/a57146c4-8453-46c0-ac62-1add9b38fbb9"> | <img width="183" alt="Screenshot 2024-02-09 at 2 34 32 PM" src="https://github.com/ppy/osu/assets/35318437/1094b9e2-15ea-4ed4-b167-06f323782691"> | <img width="260" alt="Screenshot 2024-02-09 at 2 36 38 PM" src="https://github.com/ppy/osu/assets/35318437/298cc885-c97e-4960-9ba4-ba8696ff9835"> |