### PR TITLE
Add aliases "author" and "mapper" for creator results

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -274,10 +274,12 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.IsTrue(filterCriteria.OnlineStatus.IsUpperInclusive);
         }
 
-        [Test]
-        public void TestApplyCreatorQueries()
+        [TestCase("creator")]
+        [TestCase("author")]
+        [TestCase("mapper")]
+        public void TestApplyCreatorQueries(string keyword)
         {
-            const string query = "beatmap specifically by creator=my_fav";
+            string query = $"beatmap specifically by {keyword}=my_fav";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual("beatmap specifically by", filterCriteria.SearchText.Trim());

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -69,6 +69,7 @@ namespace osu.Game.Screens.Select
 
                 case "creator":
                 case "author":
+                case "mapper":
                     return TryUpdateCriteriaText(ref criteria.Creator, op, value);
 
                 case "artist":

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -68,6 +68,7 @@ namespace osu.Game.Screens.Select
                     return TryUpdateCriteriaRange(ref criteria.OnlineStatus, op, value, tryParseEnum);
 
                 case "creator":
+                case "author":
                     return TryUpdateCriteriaText(ref criteria.Creator, op, value);
 
                 case "artist":


### PR DESCRIPTION
Allows "author" and "mapper" to show the results of "creator"


https://github.com/ppy/osu/assets/58333920/5b0ce81e-7f0e-4ef7-88f8-ea153b7dfe27




Resolves #27101