### PR TITLE
Add additional gameplay metadata to room score request

### DIFF
--- a/osu.Game/Online/Rooms/CreateRoomScoreRequest.cs
+++ b/osu.Game/Online/Rooms/CreateRoomScoreRequest.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using System.Net.Http;
 using osu.Framework.IO.Network;
+using osu.Game.Beatmaps;
 using osu.Game.Online.API;
 
 namespace osu.Game.Online.Rooms
@@ -11,12 +13,16 @@ namespace osu.Game.Online.Rooms
     {
         private readonly long roomId;
         private readonly long playlistItemId;
+        private readonly BeatmapInfo beatmapInfo;
+        private readonly int rulesetId;
         private readonly string versionHash;
 
-        public CreateRoomScoreRequest(long roomId, long playlistItemId, string versionHash)
+        public CreateRoomScoreRequest(long roomId, long playlistItemId, BeatmapInfo beatmapInfo, int rulesetId, string versionHash)
         {
             this.roomId = roomId;
             this.playlistItemId = playlistItemId;
+            this.beatmapInfo = beatmapInfo;
+            this.rulesetId = rulesetId;
             this.versionHash = versionHash;
         }
 
@@ -25,6 +31,8 @@ namespace osu.Game.Online.Rooms
             var req = base.CreateWebRequest();
             req.Method = HttpMethod.Post;
             req.AddParameter("version_hash", versionHash);
+            req.AddParameter("beatmap_hash", beatmapInfo.MD5Hash);
+            req.AddParameter("ruleset_id", rulesetId.ToString(CultureInfo.InvariantCulture));
             return req;
         }
 

--- a/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/RoomSubmittingPlayer.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Diagnostics;
+using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Scoring;
@@ -30,7 +31,16 @@ namespace osu.Game.Screens.Play
             if (!(Room.RoomID.Value is long roomId))
                 return null;
 
-            return new CreateRoomScoreRequest(roomId, PlaylistItem.ID, Game.VersionHash);
+            int beatmapId = Beatmap.Value.BeatmapInfo.OnlineID;
+            int rulesetId = Ruleset.Value.OnlineID;
+
+            if (beatmapId <= 0)
+                return null;
+
+            if (!Ruleset.Value.IsLegacyRuleset())
+                return null;
+
+            return new CreateRoomScoreRequest(roomId, PlaylistItem.ID, Beatmap.Value.BeatmapInfo, rulesetId, Game.VersionHash);
         }
 
         protected override APIRequest<MultiplayerScore> CreateSubmissionRequest(Score score, long token)


### PR DESCRIPTION
Noticed that this implementation differs from the solo score request, and it probably shouldn't.