### PR TITLE
Only compute flashlight in osu! difficulty calculations when required

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -40,7 +40,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double aimRatingNoSliders = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
             double speedRating = Math.Sqrt(skills[2].DifficultyValue()) * difficulty_multiplier;
             double speedNotes = ((Speed)skills[2]).RelevantNoteCount();
-            double flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
+
+            double flashlightRating = 0.0;
+
+            if (mods.Any(h => h is OsuModFlashlight))
+                flashlightRating = Math.Sqrt(skills[3].DifficultyValue()) * difficulty_multiplier;
 
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
@@ -126,13 +130,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            return new Skill[]
+            var skills = new List<Skill>
             {
                 new Aim(mods, true),
                 new Aim(mods, false),
-                new Speed(mods),
-                new Flashlight(mods)
+                new Speed(mods)
             };
+
+            if (mods.Any(h => h is OsuModFlashlight))
+                skills.Add(new Flashlight(mods));
+
+            return skills.ToArray();
         }
 
         protected override Mod[] DifficultyAdjustmentMods => new Mod[]


### PR DESCRIPTION
I've been looking at speeding up and improving memory usage on difficulty calculation, so this is one of a series of PRs I'll be creating over time to try and improve it.

Thus far the flashlight skill (only used/relevant when flashlight is enabled as a mod) has always been computing in difficulty calculation even when it isn't needed, and flashlight also happens to be the most expensive calculation (from my benchmarks) so this is a good win for most mod combinations.

Guaranteed to have no effect on resulting numbers but you can run the diff calc sheet generator if you want.