### PR TITLE
Replace linq usage in `Previous` and `Next` on `DifficultyHitObject` with more direct computation

### DIFF
--- a/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
+++ b/osu.Game/Rulesets/Difficulty/Preprocessing/DifficultyHitObject.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Linq;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Difficulty.Preprocessing
@@ -65,8 +64,16 @@ namespace osu.Game.Rulesets.Difficulty.Preprocessing
             EndTime = hitObject.GetEndTime() / clockRate;
         }
 
-        public DifficultyHitObject Previous(int backwardsIndex) => difficultyHitObjects.ElementAtOrDefault(Index - (backwardsIndex + 1));
+        public DifficultyHitObject Previous(int backwardsIndex)
+        {
+            int index = Index - (backwardsIndex + 1);
+            return index >= 0 && index < difficultyHitObjects.Count ? difficultyHitObjects[index] : default;
+        }
 
-        public DifficultyHitObject Next(int forwardsIndex) => difficultyHitObjects.ElementAtOrDefault(Index + (forwardsIndex + 1));
+        public DifficultyHitObject Next(int forwardsIndex)
+        {
+            int index = Index + (forwardsIndex + 1);
+            return index >= 0 && index < difficultyHitObjects.Count ? difficultyHitObjects[index] : default;
+        }
     }
 }


### PR DESCRIPTION
Another optimisation PR. Behaviour is the same as this is what `ElementAtOrDefault` does for lists, however it has extra logic to check enumerable types etc - we know what we're working with so this is quicker.

# Before
![image](https://github.com/ppy/osu/assets/51536154/e7bf1d42-fc54-40b6-a080-5c123a35e474)

# After
![image](https://github.com/ppy/osu/assets/51536154/48c707fb-ad9a-4548-9550-80497850f397)

(Benchmarks done on [The Unforgiving](https://osu.ppy.sh/beatmapsets/29157#osu/156352))