### PR TITLE
Only cast `BaseObject` to ruleset-specific object on difficulty hit objects once

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
@@ -13,9 +13,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
     {
         private const float normalized_hitobject_radius = 41.0f;
 
-        public new PalpableCatchHitObject BaseObject;
-
-        public new PalpableCatchHitObject LastObject;
+        public new readonly PalpableCatchHitObject LastObject;
 
         public readonly float NormalizedPosition;
         public readonly float LastNormalizedPosition;
@@ -28,13 +26,14 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
         public CatchDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, float halfCatcherWidth, List<DifficultyHitObject> objects, int index)
             : base(hitObject, lastObject, clockRate, objects, index)
         {
-            BaseObject = (PalpableCatchHitObject)base.BaseObject;
             LastObject = (PalpableCatchHitObject)base.LastObject;
+
+            var baseObject = (PalpableCatchHitObject)BaseObject;
 
             // We will scale everything by this factor, so we can assume a uniform CircleSize among beatmaps.
             float scalingFactor = normalized_hitobject_radius / halfCatcherWidth;
 
-            NormalizedPosition = BaseObject.EffectiveX * scalingFactor;
+            NormalizedPosition = baseObject.EffectiveX * scalingFactor;
             LastNormalizedPosition = LastObject.EffectiveX * scalingFactor;
 
             // Every strain interval is hard capped at the equivalent of 375 BPM streaming speed as a safety measure

--- a/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Preprocessing/CatchDifficultyHitObject.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
     {
         private const float normalized_hitobject_radius = 41.0f;
 
-        public new PalpableCatchHitObject BaseObject => (PalpableCatchHitObject)base.BaseObject;
+        public new PalpableCatchHitObject BaseObject;
 
-        public new PalpableCatchHitObject LastObject => (PalpableCatchHitObject)base.LastObject;
+        public new PalpableCatchHitObject LastObject;
 
         public readonly float NormalizedPosition;
         public readonly float LastNormalizedPosition;
@@ -28,6 +28,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Preprocessing
         public CatchDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, float halfCatcherWidth, List<DifficultyHitObject> objects, int index)
             : base(hitObject, lastObject, clockRate, objects, index)
         {
+            BaseObject = (PalpableCatchHitObject)base.BaseObject;
+            LastObject = (PalpableCatchHitObject)base.LastObject;
+
             // We will scale everything by this factor, so we can assume a uniform CircleSize among beatmaps.
             float scalingFactor = normalized_hitobject_radius / halfCatcherWidth;
 

--- a/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Preprocessing/ManiaDifficultyHitObject.cs
@@ -10,11 +10,12 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Preprocessing
 {
     public class ManiaDifficultyHitObject : DifficultyHitObject
     {
-        public new ManiaHitObject BaseObject => (ManiaHitObject)base.BaseObject;
+        public new ManiaHitObject BaseObject;
 
         public ManiaDifficultyHitObject(HitObject hitObject, HitObject lastObject, double clockRate, List<DifficultyHitObject> objects, int index)
             : base(hitObject, lastObject, clockRate, objects, index)
         {
+            BaseObject = (ManiaHitObject)base.BaseObject;
         }
     }
 }


### PR DESCRIPTION
More optimising. This one is mostly beneficial for the osu! ruleset as it utilises `BaseObject` a lot more than the other rulesets, but no reason to not do this across the board.

This one is small but especially for maps with a lot of objects this can benefit quite a bit of time on the flashlight evaluator

## Before (osu!)
![image](https://github.com/ppy/osu/assets/51536154/78cc5848-556d-40c1-9c2b-5cbdbed40636)

## After (osu!)
![image](https://github.com/ppy/osu/assets/51536154/1e5d541b-db31-475d-8fa1-26b22148f7bc)

(Benchmarked on [The Unforgiving](https://osu.ppy.sh/beatmapsets/29157#osu/156352))