### PR TITLE
Fix huge allocation overhead during beatmap texture creation in song-select screen

### DIFF
--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
 
         private TextureUpload limitTextureUploadSize(TextureUpload textureUpload)
         {
-            var image = Image.LoadPixelData(textureUpload.Data.ToArray(), textureUpload.Width, textureUpload.Height);
+            var image = Image.LoadPixelData(textureUpload.Data, textureUpload.Width, textureUpload.Height);
 
             // The original texture upload will no longer be returned or used.
             textureUpload.Dispose();


### PR DESCRIPTION
Values have been taken in song-select screen while pressing F2 to go to a random beatmap

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/6033630a-9e0d-4576-adc5-61ccbdec722d)|![pr](https://github.com/ppy/osu/assets/22874522/da09148d-ab67-42eb-a319-d8dc8ff05ab9)|
|![master-graph](https://github.com/ppy/osu/assets/22874522/7a7dbac6-293a-4292-88a7-d42f45882bd1)|![pr-graph](https://github.com/ppy/osu/assets/22874522/5200f97f-21d3-469e-8e30-ddfe94f954e0)|