### PR TITLE
Adjust difference in playback rate for latency assumption.

### DIFF
--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Beatmaps
         private readonly bool applyOffsets;
 
         private readonly OffsetCorrectionClock? userGlobalOffsetClock;
-        private readonly OffsetCorrectionClock? platformOffsetClock;
+        private readonly LatencyAssumptionClock? platformOffsetClock;
         private readonly OffsetCorrectionClock? userBeatmapOffsetClock;
 
         private readonly IFrameBasedClock finalClockSource;
@@ -64,7 +64,7 @@ namespace osu.Game.Beatmaps
             {
                 // Audio timings in general with newer BASS versions don't match stable.
                 // This only seems to be required on windows. We need to eventually figure out why, with a bit of luck.
-                platformOffsetClock = new OffsetCorrectionClock(interpolatedTrack) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
+                platformOffsetClock = new LatencyAssumptionClock(interpolatedTrack) { Offset = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? 15 : 0 };
 
                 // User global offset (set in settings) should also be applied.
                 userGlobalOffsetClock = new OffsetCorrectionClock(platformOffsetClock);

--- a/osu.Game/Screens/Play/LatencyAssumptionClock.cs
+++ b/osu.Game/Screens/Play/LatencyAssumptionClock.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Timing;
+using osu.Game.Screens.Edit;
+
+namespace osu.Game.Screens.Play
+{
+    public class LatencyAssumptionClock : FramedOffsetClock
+    {
+        public new double Offset => base.Offset;
+
+        public LatencyAssumptionClock(IClock source)
+            : base(source)
+        {
+        }
+
+        public override void ProcessFrame()
+        {
+            base.ProcessFrame();
+            updateOffset();
+        }
+
+        private void updateOffset()
+        {
+            // The latency assumption baked into beatmaps should be adjusted by the difference in playback rate.
+            // There should only need to be one clock that performs this calculation.
+            base.Offset = Editor.WAVEFORM_VISUAL_OFFSET * (Rate - 1.0);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/OffsetCorrectionClock.cs
+++ b/osu.Game/Screens/Play/OffsetCorrectionClock.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Timing;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Screens.Play
 {
@@ -36,10 +37,31 @@ namespace osu.Game.Screens.Play
             updateOffset();
         }
 
-        private void updateOffset()
+        protected virtual void updateOffset()
         {
             // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
             base.Offset = Offset * Rate;
+        }
+
+        protected void updateLatencyAssumption()
+        {
+            // The latency assumption baked into beatmaps should also be adjusted by the difference in playback rate.
+            // There should only be one clock that does this.
+            base.Offset += Editor.WAVEFORM_VISUAL_OFFSET * (Rate - 1.0);
+        }
+    }
+
+    public class LatencyAssumptionClock : OffsetCorrectionClock
+    {
+        public LatencyAssumptionClock(IClock source)
+            : base(source)
+        {
+        }
+
+        protected override void updateOffset()
+        {
+            base.updateOffset();
+            updateLatencyAssumption();
         }
     }
 }

--- a/osu.Game/Screens/Play/OffsetCorrectionClock.cs
+++ b/osu.Game/Screens/Play/OffsetCorrectionClock.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Timing;
-using osu.Game.Screens.Edit;
 
 namespace osu.Game.Screens.Play
 {
@@ -20,7 +19,7 @@ namespace osu.Game.Screens.Play
 
                 offset = value;
 
-                UpdateOffset();
+                updateOffset();
             }
         }
 
@@ -34,34 +33,13 @@ namespace osu.Game.Screens.Play
         public override void ProcessFrame()
         {
             base.ProcessFrame();
-            UpdateOffset();
+            updateOffset();
         }
 
-        protected virtual void UpdateOffset()
+        private void updateOffset()
         {
             // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
             base.Offset = Offset * Rate;
-        }
-
-        protected void UpdateLatencyAssumption()
-        {
-            // The latency assumption baked into beatmaps should also be adjusted by the difference in playback rate.
-            // There should only be one clock that does this.
-            base.Offset += Editor.WAVEFORM_VISUAL_OFFSET * (Rate - 1.0);
-        }
-    }
-
-    public class LatencyAssumptionClock : OffsetCorrectionClock
-    {
-        public LatencyAssumptionClock(IClock source)
-            : base(source)
-        {
-        }
-
-        protected override void UpdateOffset()
-        {
-            base.UpdateOffset();
-            UpdateLatencyAssumption();
         }
     }
 }

--- a/osu.Game/Screens/Play/OffsetCorrectionClock.cs
+++ b/osu.Game/Screens/Play/OffsetCorrectionClock.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Screens.Play
 
                 offset = value;
 
-                updateOffset();
+                UpdateOffset();
             }
         }
 
@@ -34,16 +34,16 @@ namespace osu.Game.Screens.Play
         public override void ProcessFrame()
         {
             base.ProcessFrame();
-            updateOffset();
+            UpdateOffset();
         }
 
-        protected virtual void updateOffset()
+        protected virtual void UpdateOffset()
         {
             // we always want to apply the same real-time offset, so it should be adjusted by the difference in playback rate (from realtime) to achieve this.
             base.Offset = Offset * Rate;
         }
 
-        protected void updateLatencyAssumption()
+        protected void UpdateLatencyAssumption()
         {
             // The latency assumption baked into beatmaps should also be adjusted by the difference in playback rate.
             // There should only be one clock that does this.
@@ -58,10 +58,10 @@ namespace osu.Game.Screens.Play
         {
         }
 
-        protected override void updateOffset()
+        protected override void UpdateOffset()
         {
-            base.updateOffset();
-            updateLatencyAssumption();
+            base.UpdateOffset();
+            UpdateLatencyAssumption();
         }
     }
 }


### PR DESCRIPTION
When the rate of playback is slowed down, audio offsets are shrunk so that when the slower rate stretches out a track's real-time duration, the offset will also be stretched, but back to its originally intended size.

For example, if we have a global audio offset of 10ms, and a 50% playback rate, the 10ms gets shrunk to 5ms of virtual time, or `10 * 0.5`:

https://github.com/ppy/osu/blob/7bc571dd517bdcc5493eac8e28b2ea5309726591/osu.Game/Screens/Play/OffsetCorrectionClock.cs#L42

which ultimately ends up turning back into 10ms of real time. This is important because latency is relatively consistent regardless of playback rate.

However, the latency assumption of 20ms that is baked into all beatmap time codes is not accounted for in this way. As a result, the track rushes relative to the metronome when sped up, and drags when slowed down. We can determine the exact amount by which it rushes or drags in milliseconds with the following formula:

```py
assumption = (time - latency) / rate # real time with baked-in latency assumption
correction = (time / rate) - latency # real time with correct order of operations

# positive = rush (relative to metronome), negative = drag
# can be simplified to: latency - latency / rate
difference = assumption - correction
```

For example, let's say a beatmap has a timing point at 980ms (or what would be 1000ms without the baked-in latency assumption), and the playback rate is 25%

```py
real_time = ((1000 - 20) / 0.25) - (1000 / 0.25 - 20) = 3920 - 3980 = -60
virtual_time = (assumption * rate) - (correction * rate) = 980 - 995 = -15
```

To account for this, all we have to do is add the difference in virtual time to the total audio offset, which can be done by promoting one of the `OffsetCorrectionClock`'s to a derived class that performs the additional calculation.

I gave this role to `platformOffsetClock` because it's not a calculation that needs to be performed every time the user changes global or beatmap offsets, only on playback rate changes.
