### PR TITLE
Allow pp for muted mod for any combination of settings

### DIFF
--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool Ranked => true;
     }
 
     public abstract class ModMuted<TObject> : ModMuted, IApplicableToDrawableRuleset<TObject>, IApplicableToTrack, IApplicableToScoreProcessor


### PR DESCRIPTION
- Adressed https://github.com/ppy/osu/discussions/27130

ModMuted was enable ranked in https://github.com/ppy/osu-queue-score-statistics/pull/9
the reason is "it doesn't change gameplay"
so can we make ModMuted ranked when adjust settings
