### PR TITLE
Create key-presses when watching legacy Relax replays

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         private double lastStateChangeTime;
 
         private DrawableOsuRuleset ruleset = null!;
-        private PressHandler pressHandler = null!;
+        private IPressHandler pressHandler = null!;
 
         private bool hasReplay;
         private bool legacyReplay;
@@ -155,44 +155,52 @@ namespace osu.Game.Rulesets.Osu.Mods
             }
         }
 
-        private class PressHandler
+        private interface IPressHandler
         {
-            protected readonly OsuModRelax Mod;
+            void HandlePress(bool wasLeft);
+            void HandleRelease(bool wasLeft);
+        }
+
+        private class PressHandler : IPressHandler
+        {
+            private readonly OsuModRelax mod;
 
             public PressHandler(OsuModRelax mod)
             {
-                Mod = mod;
+                this.mod = mod;
             }
 
-            public virtual void HandlePress(bool wasLeft)
+            public void HandlePress(bool wasLeft)
             {
-                Mod.state.PressedActions.Add(wasLeft ? OsuAction.LeftButton : OsuAction.RightButton);
-                Mod.state.Apply(Mod.osuInputManager.CurrentState, Mod.osuInputManager);
+                mod.state.PressedActions.Add(wasLeft ? OsuAction.LeftButton : OsuAction.RightButton);
+                mod.state.Apply(mod.osuInputManager.CurrentState, mod.osuInputManager);
             }
 
-            public virtual void HandleRelease(bool wasLeft)
+            public void HandleRelease(bool wasLeft)
             {
-                Mod.state.Apply(Mod.osuInputManager.CurrentState, Mod.osuInputManager);
+                mod.state.Apply(mod.osuInputManager.CurrentState, mod.osuInputManager);
             }
         }
 
         // legacy replays do not contain key-presses with Relax mod, so they need to be triggered by themselves.
-        private class LegacyReplayPressHandler : PressHandler
+        private class LegacyReplayPressHandler : IPressHandler
         {
+            private readonly OsuModRelax mod;
+
             public LegacyReplayPressHandler(OsuModRelax mod)
-                : base(mod)
             {
+                this.mod = mod;
             }
 
-            public override void HandlePress(bool wasLeft)
+            public void HandlePress(bool wasLeft)
             {
-                Mod.osuInputManager.KeyBindingContainer.TriggerPressed(wasLeft ? OsuAction.LeftButton : OsuAction.RightButton);
+                mod.osuInputManager.KeyBindingContainer.TriggerPressed(wasLeft ? OsuAction.LeftButton : OsuAction.RightButton);
             }
 
-            public override void HandleRelease(bool wasLeft)
+            public void HandleRelease(bool wasLeft)
             {
                 // this intentionally releases right when `wasLeft` is true because `wasLeft` is set at point of press and not at point of release
-                Mod.osuInputManager.KeyBindingContainer.TriggerReleased(wasLeft ? OsuAction.RightButton : OsuAction.LeftButton);
+                mod.osuInputManager.KeyBindingContainer.TriggerReleased(wasLeft ? OsuAction.RightButton : OsuAction.LeftButton);
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -191,6 +191,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             public override void HandleRelease(bool wasLeft)
             {
+                // this intentionally releases right when `wasLeft` is true because `wasLeft` is set at point of press and not at point of release
                 Mod.osuInputManager.KeyBindingContainer.TriggerReleased(wasLeft ? OsuAction.RightButton : OsuAction.LeftButton);
             }
         }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModRelax.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 Debug.Assert(ruleset.ReplayScore != null);
                 legacyReplay = ruleset.ReplayScore.ScoreInfo.IsLegacyScore;
 
-                pressHandler = new LegacyReplayPressHandler(this);
+                pressHandler = legacyReplay ? new LegacyReplayPressHandler(this) : new PressHandler(this);
 
                 return;
             }


### PR DESCRIPTION
Resolves #9560

osu!stable does not record key presses onto replays with Relax, so attempting to watch them back in lazer didn't work historically.

## master

https://github.com/ppy/osu/assets/51536154/aa73886a-4aa6-4c97-a72f-1e6a92a136c0

## PR

https://github.com/ppy/osu/assets/51536154/4353ba36-e706-4914-b720-fbfda334caef



