### PR TITLE
Make `ModClassic` ranked in default configuration

### DIFF
--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -19,5 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Feeling nostalgic?";
 
         public override ModType Type => ModType.Conversion;
+
+        public override bool Ranked => UsesDefaultConfiguration;
     }
 }


### PR DESCRIPTION
Related to #25350

Rationale is that in default configuration (Osu)ModClassic has all settings _enabled_ which should equal to osu!stable gameplay. Taiko CL doesn't have any settings so there's no problem with enabling it as well.

Ideally all settings should be ranked and dealt in diff/pp calc accordingly, but I think this is a good first step