### PR TITLE
Fix recent collection initialiser inspection

### DIFF
--- a/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneRulesetSkinProvidingContainer.cs
@@ -43,13 +43,13 @@ namespace osu.Game.Tests.Rulesets
 
             AddStep("setup provider", () =>
             {
-                var rulesetSkinProvider = new RulesetSkinProvidingContainer(Ruleset.Value.CreateInstance(), Beatmap.Value.Beatmap, Beatmap.Value.Skin);
-
-                rulesetSkinProvider.Add(requester = new SkinRequester());
-
+                requester = new SkinRequester();
                 requester.OnLoadAsync += () => textureOnLoad = requester.GetTexture("test-image");
 
-                Child = rulesetSkinProvider;
+                Child = new RulesetSkinProvidingContainer(Ruleset.Value.CreateInstance(), Beatmap.Value.Beatmap, Beatmap.Value.Skin)
+                {
+                    requester
+                };
             });
 
             AddAssert("requester got correct initial texture", () => textureOnLoad != null);


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/7896613956/job/21550875129?pr=27147

This appears to have come up because .NET `8.0.200` has been made available to the CI runner, and we've only been using `.100`.

It looks like what the inspection wants us to do here is something like...
```
new RulesetSkinProvidingContainer(...)
{
    (skinRequester = new ...)
};
```
Which is pretty 🤮 