### PR TITLE
Reduce allocations during aggregate beatmap sorts in song-select screen

### DIFF
--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -127,12 +127,40 @@ namespace osu.Game.Screens.Select.Carousel
         /// <summary>
         /// All beatmaps which are not filtered and valid for display.
         /// </summary>
-        protected IEnumerable<BeatmapInfo> ValidBeatmaps => Beatmaps.Where(b => !b.Filtered.Value || b.State.Value == CarouselItemState.Selected).Select(b => b.BeatmapInfo);
+        protected IEnumerable<BeatmapInfo> ValidBeatmaps
+        {
+            get
+            {
+                foreach (var item in Items) // iterating over Items directly to not allocate 2 enumerators
+                {
+                    if (item is CarouselBeatmap b && (!b.Filtered.Value || b.State.Value == CarouselItemState.Selected))
+                        yield return b.BeatmapInfo;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether there are available beatmaps which are not filtered and valid for display.
+        /// Cheaper alternative to <see cref="ValidBeatmaps"/>.Any()
+        /// </summary>
+        public bool HasValidBeatmaps
+        {
+            get
+            {
+                foreach (var item in Items) // iterating over Items directly to not allocate 2 enumerators
+                {
+                    if (item is CarouselBeatmap b && (!b.Filtered.Value || b.State.Value == CarouselItemState.Selected))
+                        return true;
+                }
+
+                return false;
+            }
+        }
 
         private int compareUsingAggregateMax(CarouselBeatmapSet other, Func<BeatmapInfo, double> func)
         {
-            bool ourBeatmaps = ValidBeatmaps.Any();
-            bool otherBeatmaps = other.ValidBeatmaps.Any();
+            bool ourBeatmaps = HasValidBeatmaps;
+            bool otherBeatmaps = other.HasValidBeatmaps;
 
             if (!ourBeatmaps && !otherBeatmaps) return 0;
             if (!ourBeatmaps) return -1;

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -91,19 +91,19 @@ namespace osu.Game.Screens.Select.Carousel
                     break;
 
                 case SortMode.LastPlayed:
-                    comparison = -compareUsingAggregateMax(otherSet, b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
+                    comparison = -compareUsingAggregateMax(otherSet, static b => (b.LastPlayed ?? DateTimeOffset.MinValue).ToUnixTimeSeconds());
                     break;
 
                 case SortMode.BPM:
-                    comparison = compareUsingAggregateMax(otherSet, b => b.BPM);
+                    comparison = compareUsingAggregateMax(otherSet, static b => b.BPM);
                     break;
 
                 case SortMode.Length:
-                    comparison = compareUsingAggregateMax(otherSet, b => b.Length);
+                    comparison = compareUsingAggregateMax(otherSet, static b => b.Length);
                     break;
 
                 case SortMode.Difficulty:
-                    comparison = compareUsingAggregateMax(otherSet, b => b.StarRating);
+                    comparison = compareUsingAggregateMax(otherSet, static b => b.StarRating);
                     break;
 
                 case SortMode.DateSubmitted:

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Extensions.ListExtensions;
+using osu.Framework.Lists;
 
 namespace osu.Game.Screens.Select.Carousel
 {
@@ -12,7 +14,7 @@ namespace osu.Game.Screens.Select.Carousel
     {
         public override DrawableCarouselItem? CreateDrawableRepresentation() => null;
 
-        public IReadOnlyList<CarouselItem> Items => items;
+        public SlimReadOnlyListWrapper<CarouselItem> Items => items.AsSlimReadOnly();
 
         public int TotalItemsNotFiltered { get; private set; }
 


### PR DESCRIPTION
Affects `LastPlayed`, `BPM`, `Length`, `Difficulty` sort modes.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/95198901-17b3-407a-ba16-392772a707e1)|![pr](https://github.com/ppy/osu/assets/22874522/213c1c28-532e-480c-bc11-1924fe51cecf)|