### PR TITLE
Truncate long dropdown menu item text and show tooltip

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Testing;
-using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 
@@ -18,12 +17,21 @@ namespace osu.Game.Tests.Visual.UserInterface
     public partial class TestSceneOsuDropdown : ThemeComparisonTestScene
     {
         protected override Drawable CreateContent() =>
-            new OsuEnumDropdown<BeatmapOnlineStatus>
+            new OsuEnumDropdown<TestEnum>
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.TopCentre,
                 Width = 150
             };
+
+        private enum TestEnum
+        {
+            [System.ComponentModel.Description("Option")]
+            Option,
+
+            [System.ComponentModel.Description("Really lonnnnnnng option")]
+            ReallyLongOption,
+        }
 
         [Test]
         // todo: this can be written much better if ThemeComparisonTestScene has a manual input manager
@@ -43,7 +51,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("press back", () => dropdown().OnPressed(new KeyBindingPressEvent<GlobalAction>(new InputState(), GlobalAction.Back)));
             AddAssert("closed", () => dropdown().ChildrenOfType<Menu>().Single().State == MenuState.Closed);
 
-            OsuEnumDropdown<BeatmapOnlineStatus> dropdown() => this.ChildrenOfType<OsuEnumDropdown<BeatmapOnlineStatus>>().First();
+            OsuEnumDropdown<TestEnum> dropdown() => this.ChildrenOfType<OsuEnumDropdown<TestEnum>>().First();
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -186,6 +186,8 @@ namespace osu.Game.Graphics.UserInterface
                     : base(item)
                 {
                     Foreground.Padding = new MarginPadding(2);
+                    Foreground.AutoSizeAxes = Axes.Y;
+                    Foreground.RelativeSizeAxes = Axes.X;
 
                     Masking = true;
                     CornerRadius = corner_radius;
@@ -247,11 +249,12 @@ namespace osu.Game.Graphics.UserInterface
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
                             },
-                            Label = new OsuSpriteText
+                            Label = new TruncatingSpriteText
                             {
-                                X = 15,
+                                Padding = new MarginPadding { Left = 15 },
                                 Origin = Anchor.CentreLeft,
                                 Anchor = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.X,
                             },
                         };
                     }


### PR DESCRIPTION
- Addresses part of https://github.com/ppy/osu/discussions/27161 (there's search, but doesn't really help with similar text as seen in the videos)

| Before | After |
| --- | --- |
| <img width="274" alt="Screenshot 2024-02-14 at 11 03 04 PM" src="https://github.com/ppy/osu/assets/35318437/2c7a8098-d006-4de6-b88f-ba4ac76a996a"> | <img width="431" alt="Screenshot 2024-02-14 at 11 01 11 PM" src="https://github.com/ppy/osu/assets/35318437/2952bc48-a892-4de3-8b45-ee9b88807885"> |