### PR TITLE
Add better submission failure messaging

### DIFF
--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Play
                 Scores = { BindTarget = LeaderboardScores }
             };
 
-        protected override bool HandleTokenRetrievalFailure(Exception exception) => false;
+        protected override bool ShouldExitOnTokenRetrievalFailure(Exception exception) => false;
 
         protected override Task ImportScore(Score score)
         {

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -137,11 +137,11 @@ namespace osu.Game.Screens.Play
                 if (displayNotification || shouldExit)
                 {
                     string whatWillHappen = shouldExit
-                        ? "You are not able to submit a score."
-                        : "The following score will not be submitted.";
+                        ? "Play in this state is not permitted."
+                        : "Your score will not be submitted.";
 
                     if (string.IsNullOrEmpty(exception.Message))
-                        Logger.Error(exception, $"{whatWillHappen} Failed to retrieve a score submission token.");
+                        Logger.Error(exception, $"Failed to retrieve a score submission token.\n\n{whatWillHappen}");
                     else
                     {
                         switch (exception.Message)
@@ -149,11 +149,11 @@ namespace osu.Game.Screens.Play
                             case @"missing token header":
                             case @"invalid client hash":
                             case @"invalid verification hash":
-                                Logger.Log($"{whatWillHappen} Please ensure that you are using the latest version of the official game releases.", level: LogLevel.Important);
+                                Logger.Log($"Please ensure that you are using the latest version of the official game releases.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
                             case @"expired token":
-                                Logger.Log($"{whatWillHappen} Your system clock is set incorrectly. Please check your system time, date and timezone.", level: LogLevel.Important);
+                                Logger.Log($"Your system clock is set incorrectly. Please check your system time, date and timezone.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
                             default:

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -140,7 +140,13 @@ namespace osu.Game.Screens.Play
                     {
                         switch (exception.Message)
                         {
-                            case "expired token":
+                            case @"missing token header":
+                            case @"invalid client hash":
+                            case @"invalid verification hash":
+                                Logger.Log("You are not able to submit a score. Please ensure that you are using the latest version of the official game releases.", level: LogLevel.Important);
+                                break;
+
+                            case @"expired token":
                                 Logger.Log("Score submission failed because your system clock is set incorrectly. Please check your system time, date and timezone.", level: LogLevel.Important);
                                 break;
 

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Tests.Visual
             PauseOnFocusLost = pauseOnFocusLost;
         }
 
-        protected override bool HandleTokenRetrievalFailure(Exception exception) => false;
+        protected override bool ShouldExitOnTokenRetrievalFailure(Exception exception) => false;
 
         protected override APIRequest<APIScoreToken> CreateTokenRequest()
         {


### PR DESCRIPTION
Subjective, so I accept the possibility of this getting dumpstered on sight.

## [Use better messaging for selected submission failure reasons](https://github.com/ppy/osu/commit/95e745c6fbabce01dda192e567546185bfe62e9f)

Some failure reasons related to more stringent integrity checks have been cropping up rather often lately, mostly courtesy of linux users, but not only:

- https://github.com/ppy/osu/issues/26840
- https://github.com/ppy/osu/issues/27008
- https://github.com/ppy/osu/discussions/26962

so this is a proposal for slightly improved messaging for such cases to hopefully get users on the right track.

The original error is still logged to network log, so there's no information loss.

## [Show selected submission failure messages even in solo](https://github.com/ppy/osu/commit/898d5ce88bd4d249f98b8fe7cc6dd5e7cdd635d4)

Previously, if a `SubmittingPlayer` instance deemed it okay to proceed with gameplay despite submission failure, it would silently log all errors and proceed, but the score would still not be submitted. This feels a bit anti-user in the cases wherein something is genuinely wrong with either the client or web, so things like token verification failures or API failures are now shown as notifications to give the user an indication that something went wrong at all.

Selected cases (non-user-playable mod, logged out, beatmap is not online) are still logged silently because those are either known and expected, or someone is messing with things.