### PR TITLE
Update .NET version on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can see some examples of custom rulesets by visiting the [custom ruleset dir
 
 Please make sure you have the following prerequisites:
 
-- A desktop platform with the [.NET 6.0 SDK](https://dotnet.microsoft.com/download) installed.
+- A desktop platform with the [.NET 8.0 SDK](https://dotnet.microsoft.com/download) installed.
 
 When working with the codebase, we recommend using an IDE with intelligent code completion and syntax highlighting, such as the latest version of [Visual Studio](https://visualstudio.microsoft.com/vs/), [JetBrains Rider](https://www.jetbrains.com/rider/), or [Visual Studio Code](https://code.visualstudio.com/) with the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) plugin installed.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are just looking to give the game a whirl, you can grab the latest releas
 
 You can also generally download a version for your current device from the [osu! site](https://osu.ppy.sh/home/download).
 
-If your platform is not listed above, there is still a chance you can manually build it by following the instructions below.
+If your platform is unsupported or not listed above, there is still a chance you can run the release or manually build it by following the instructions below.
 
 **For iOS/iPadOS users**: The iOS testflight link fills up very fast (Apple has a hard limit of 10,000 users). We reset it occasionally. Please do not ask about this. Check back regularly for link resets or follow [peppy](https://twitter.com/ppy) on twitter for announcements. Our goal is to get the game on mobile app stores in early 2024.
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -47,8 +47,8 @@ namespace osu.Desktop
             {
                 var windowsVersion = Environment.OSVersion.Version;
 
-                // While .NET 6 still supports Windows 7 and above, we are limited by realm currently, as they choose to only support 8.1 and higher.
-                // See https://www.mongodb.com/docs/realm/sdk/dotnet/#supported-platforms
+                // While .NET 8 only supports Windows 10 and above, running on Windows 7/8.1 may still work. We are limited by realm currently, as they choose to only support 8.1 and higher.
+                // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
                     // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider


### PR DESCRIPTION
And other relevant stuff.

Unsure of the stance of unsupported platforms. Readme shows Windows 10+, but startup doesn't block Windows 8.1. Windows 8.1 seems to still build/run as of 8.0.201 though.

What we're doing right now is like .NET is doing, not outright blocking unsupported platforms but could break at any time.