### PR TITLE
Fix a few issues in metadata hub's disconnection requested flow

### DIFF
--- a/osu.Game/Online/IStatefulUserHubClient.cs
+++ b/osu.Game/Online/IStatefulUserHubClient.cs
@@ -13,6 +13,18 @@ namespace osu.Game.Online
     /// </summary>
     public interface IStatefulUserHubClient
     {
+        /// <summary>
+        /// Invoked when the server requests a client to disconnect.
+        /// </summary>
+        /// <remarks>
+        /// When this request is received, the client must presume any and all further requests to the server
+        /// will either fail or be ignored.
+        /// This method is ONLY to be used for the purposes of:
+        /// <list type="bullet">
+        /// <item>actually physically disconnecting from the server,</item>
+        /// <item>cleaning up / setting up any and all required local client state.</item>
+        /// </list>
+        /// </remarks>
         Task DisconnectRequested();
     }
 }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -233,6 +233,8 @@ namespace osu.Game.Online.Metadata
         {
             await base.DisconnectRequested().ConfigureAwait(false);
             await EndWatchingUserPresence().ConfigureAwait(false);
+            if (connector != null)
+                await connector.Disconnect().ConfigureAwait(false);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Online.Metadata
                     // https://github.com/dotnet/aspnetcore/issues/15198
                     connection.On<BeatmapUpdates>(nameof(IMetadataClient.BeatmapSetsUpdated), ((IMetadataClient)this).BeatmapSetsUpdated);
                     connection.On<int, UserPresence?>(nameof(IMetadataClient.UserPresenceUpdated), ((IMetadataClient)this).UserPresenceUpdated);
+                    connection.On(nameof(IStatefulUserHubClient.DisconnectRequested), ((IMetadataClient)this).DisconnectRequested);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -232,7 +232,6 @@ namespace osu.Game.Online.Metadata
         public override async Task DisconnectRequested()
         {
             await base.DisconnectRequested().ConfigureAwait(false);
-            await EndWatchingUserPresence().ConfigureAwait(false);
             if (connector != null)
                 await connector.Disconnect().ConfigureAwait(false);
         }


### PR DESCRIPTION
Before you read on: as far as I can tell the current effect of the flaws I'm about to describe on current client / production is _zero_, because all of the issues are masked by the fact that currently being told to disconnect by the server via any other hub will fully log the user out, implicitly severing the connection to the metadata hub too.

That said this might be changing soon (in certain circumstances, at least) as I work on https://github.com/ppy/osu-server-spectator/issues/52, which is how I found this out.

To test, you can disable the aforementioned masking behaviour by applying:

```diff
diff --git a/osu.Game/Online/HubClientConnector.cs b/osu.Game/Online/HubClientConnector.cs
index 9d414deade..ad71038732 100644
--- a/osu.Game/Online/HubClientConnector.cs
+++ b/osu.Game/Online/HubClientConnector.cs
@@ -103,7 +103,6 @@ protected override Task<PersistentEndpointClient> BuildConnectionAsync(Cancellat
         async Task IHubClientConnector.Disconnect()
         {
             await Disconnect().ConfigureAwait(false);
-            API.Logout();
         }
 
         protected override string ClientName { get; }

```

After applying the above, you can perform the following test scenario on master:

- Log onto client instance no. 1
- Log onto client instance no. 2. Client instance no. 1 will be disconnected from multiplayer and spectator hubs but not logged out. You should still see the notification saying that you "were logged out" still, though.
- On client instance no. 1, change the user's status via the login overlay, or do anything that would change the user's current activity.
- On `master` you should see unobserved errors on every change; on this branch you should see no errors.

As for the actual description of the changes:

## [Fix missing RPC method mapping](https://github.com/ppy/osu/commit/171270d99c21f1f620150cd119489bf40e8fa80c)

Pretty obvious what went wrong there.

## [Actually disconnect from metadata hub when requested to](https://github.com/ppy/osu/commit/9fa60b169e6bc887b64236775fece8ecc936356c)

Nothing in this override, on in the base implementation, would actually attempt to disconnect.

## [Do not attempt to stop watching user presence when requested to disconnect](https://github.com/ppy/osu/commit/b4aa24703239da3b5e81fe834b06fe661662dbfd)

First of all, this sort of cleanup isn't really the client's responsibility, and secondly, at the point the client received this
request to disconnect, *none of its requests will be honored anymore* (currently the only scenario of this if another client has connected - the server-side concurrency filter will reject this request).

When disconnection is requested, the only valid thing to do with respect to talking to the server is to _stop doing it_.

This will probably be moved server-side in a follow-up change, although I'm not even strictly sure that's required - I'd like to think signalr would know to clean up a disconnecting client from all groups they were in.

## [Add extended xmldoc to `DisconnectRequested()`](https://github.com/ppy/osu/commit/1049be7d724565ba61da9f18ddb825366affd723)

Just expounds on what the previous commit message said.