### PR TITLE
Fix `DrawableLinkCompiler` allocations

### DIFF
--- a/osu.Game/Online/Chat/DrawableLinkCompiler.cs
+++ b/osu.Game/Online/Chat/DrawableLinkCompiler.cs
@@ -4,9 +4,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Lists;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -23,12 +25,21 @@ namespace osu.Game.Online.Chat
         /// <summary>
         /// Each word part of a chat link (split for word-wrap support).
         /// </summary>
-        public readonly List<Drawable> Parts;
+        public readonly SlimReadOnlyListWrapper<Drawable> Parts;
 
         [Resolved]
         private OverlayColourProvider? overlayColourProvider { get; set; }
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Parts.Any(d => d.ReceivePositionalInputAt(screenSpacePos));
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            foreach (var part in Parts)
+            {
+                if (part.ReceivePositionalInputAt(screenSpacePos))
+                    return true;
+            }
+
+            return false;
+        }
 
         protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new LinkHoverSounds(sampleSet, Parts);
 
@@ -39,7 +50,7 @@ namespace osu.Game.Online.Chat
 
         public DrawableLinkCompiler(IEnumerable<Drawable> parts)
         {
-            Parts = parts.ToList();
+            Parts = parts.ToList().AsSlimReadOnly();
         }
 
         [BackgroundDependencyLoader]
@@ -52,15 +63,24 @@ namespace osu.Game.Online.Chat
 
         private partial class LinkHoverSounds : HoverClickSounds
         {
-            private readonly List<Drawable> parts;
+            private readonly SlimReadOnlyListWrapper<Drawable> parts;
 
-            public LinkHoverSounds(HoverSampleSet sampleSet, List<Drawable> parts)
+            public LinkHoverSounds(HoverSampleSet sampleSet, SlimReadOnlyListWrapper<Drawable> parts)
                 : base(sampleSet)
             {
                 this.parts = parts;
             }
 
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => parts.Any(d => d.ReceivePositionalInputAt(screenSpacePos));
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+            {
+                foreach (var part in parts)
+                {
+                    if (part.ReceivePositionalInputAt(screenSpacePos))
+                        return true;
+                }
+
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Similar fix to https://github.com/ppy/osu/pull/26790

Values have been taken while idling in `BeatmapOverlay` and looking at the leaderboard (it has many user links).
![pr](https://github.com/ppy/osu/assets/22874522/b5317107-dc2e-4613-a3ef-3ddefb647ac1)
