### PR TITLE
Fix cursor ripples displaying on release positions in replays

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorRippleVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorRippleVisualiser.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
+using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -39,6 +40,9 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
         {
+            if ((Clock as IGameplayClock)?.IsRewinding == true)
+                return false;
+
             if (showRipples.Value)
             {
                 AddInternal(ripplePool.Get(r =>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27171

When a user rewinds in replay, a press event is triggered at the point which the key was originally released. This causes a cursor ripple to be added at each point a key is released, and the animation of each ripple is suspended until the clock reaches the point which they are added.