### PR TITLE
Fix star counter decrease animation being delayed when current is over displayed star count

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStarCounter.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -14,39 +15,47 @@ namespace osu.Game.Tests.Visual.Gameplay
     public partial class TestSceneStarCounter : OsuTestScene
     {
         private readonly StarCounter starCounter;
+        private readonly StarCounter twentyStarCounter;
         private readonly OsuSpriteText starsLabel;
 
         public TestSceneStarCounter()
         {
-            starCounter = new StarCounter
+            Add(new FillFlowContainer
             {
-                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
-            };
-
-            Add(starCounter);
-
-            starsLabel = new OsuSpriteText
-            {
                 Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Scale = new Vector2(2),
-                Y = 50,
-            };
-
-            Add(starsLabel);
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(20),
+                Children = new Drawable[]
+                {
+                    starCounter = new StarCounter(),
+                    twentyStarCounter = new StarCounter(20),
+                    starsLabel = new OsuSpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Scale = new Vector2(2),
+                    },
+                }
+            });
 
             setStars(5);
 
-            AddRepeatStep("random value", () => setStars(RNG.NextSingle() * (starCounter.StarCount + 1)), 10);
-            AddSliderStep("exact value", 0f, 10f, 5f, setStars);
-            AddStep("stop animation", () => starCounter.StopAnimation());
+            AddRepeatStep("random value", () => setStars(RNG.NextSingle() * (twentyStarCounter.StarCount + 1)), 10);
+            AddSliderStep("exact value", 0f, 20f, 5f, setStars);
+            AddStep("stop animation", () =>
+            {
+                starCounter.StopAnimation();
+                twentyStarCounter.StopAnimation();
+            });
             AddStep("reset", () => setStars(0));
         }
 
         private void setStars(float stars)
         {
             starCounter.Current = stars;
+            twentyStarCounter.Current = stars;
             starsLabel.Text = starCounter.Current.ToString("0.00");
         }
     }

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 star.ClearTransforms(true);
 
-                double delay = (current <= newValue ? Math.Max(i - current, 0) : Math.Max(current - 1 - i, 0)) * AnimationDelay;
+                double delay = Math.Max(current <= newValue ? i - current : current - 1 - i, 0) * AnimationDelay;
 
                 using (star.BeginDelayedSequence(delay))
                     star.DisplayAt(getStarScale(i, newValue));

--- a/osu.Game/Graphics/UserInterface/StarCounter.cs
+++ b/osu.Game/Graphics/UserInterface/StarCounter.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 star.ClearTransforms(true);
 
-                double delay = Math.Max(current <= newValue ? i - current : current - 1 - i, 0) * AnimationDelay;
+                double delay = Math.Max(current <= newValue ? i - current : Math.Min(current, StarCount) - 1 - i, 0) * AnimationDelay;
 
                 using (star.BeginDelayedSequence(delay))
                     star.DisplayAt(getStarScale(i, newValue));


### PR DESCRIPTION
Noticed on wedge v2 (not in-game yet) when going from an aspire map with high star rating (100+) to a regular map. The animation would be delayed:

| Before | After |
| --- | --- |
| ![Kapture 2024-02-16 at 22 28 46](https://github.com/ppy/osu/assets/35318437/52b010c1-79b6-46ab-9c31-52a219d2c1e0) | ![Kapture 2024-02-16 at 22 27 42](https://github.com/ppy/osu/assets/35318437/bd19fbf6-9760-4634-a747-487008ce7061) |

Was bundled with my upcoming implementation of wedge statistics, but can be separated.