### PR TITLE
Customisable ruleset icon colours

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
@@ -167,6 +169,7 @@ namespace osu.Game.Rulesets.Catch
         public override string PlayingVerb => "Catching fruit";
 
         public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.RulesetCatch };
+        public override ColourInfo RulesetColour => Color4Extensions.FromHex("#00EFEF");
 
         protected override IEnumerable<HitResult> GetValidHitResults()
         {

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
@@ -309,6 +311,7 @@ namespace osu.Game.Rulesets.Mania
         public override string PlayingVerb => "Smashing keys";
 
         public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.RulesetMania };
+        public override ColourInfo RulesetColour => Color4Extensions.FromHex("#a600ff");
 
         public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) => new ManiaDifficultyCalculator(RulesetInfo, beatmap);
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
@@ -229,7 +231,7 @@ namespace osu.Game.Rulesets.Osu
         }
 
         public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.RulesetOsu };
-
+        public override ColourInfo RulesetColour => Color4Extensions.FromHex("#FF67AA");
         public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap) => new OsuDifficultyCalculator(RulesetInfo, beatmap);
 
         public override PerformanceCalculator CreatePerformanceCalculator() => new OsuPerformanceCalculator();

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -36,6 +36,8 @@ using osu.Game.Rulesets.Configuration;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.Taiko.Configuration;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Game.Rulesets.Taiko
 {
@@ -185,6 +187,7 @@ namespace osu.Game.Rulesets.Taiko
         public override string PlayingVerb => "Bashing drums";
 
         public override Drawable CreateIcon() => new SpriteIcon { Icon = OsuIcon.RulesetTaiko };
+        public override ColourInfo RulesetColour => Color4Extensions.FromHex("#0ddd4e");
 
         public override HitObjectComposer CreateHitObjectComposer() => new TaikoHitObjectComposer(this);
 

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -42,7 +42,6 @@ namespace osu.Game.Overlays.Toolbar
 
         private partial class RulesetButton : ToolbarButton
         {
-
             protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
 
             [Resolved]
@@ -55,10 +54,12 @@ namespace osu.Game.Overlays.Toolbar
                     Bottom = 5
                 };
             }
+
             /// <summary>
             /// The icon colour when active
             /// </summary>
             public ColourInfo ActiveColour { get; set; } = Color4Extensions.FromHex("#00FFAA"); //Default colour
+
             public bool Active
             {
                 set => Scheduler.AddOnce(() =>

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
@@ -32,6 +33,7 @@ namespace osu.Game.Overlays.Toolbar
             ruleset.TooltipMain = rInstance.Description;
             ruleset.TooltipSub = ToolbarStrings.PlaySomeRuleset(rInstance.Description);
             ruleset.SetIcon(rInstance.CreateIcon());
+            ruleset.ActiveColour = rInstance.RulesetColour;
         }
 
         protected override void OnActivated() => ruleset.Active = true;
@@ -40,6 +42,7 @@ namespace osu.Game.Overlays.Toolbar
 
         private partial class RulesetButton : ToolbarButton
         {
+
             protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
 
             [Resolved]
@@ -52,12 +55,15 @@ namespace osu.Game.Overlays.Toolbar
                     Bottom = 5
                 };
             }
-
+            /// <summary>
+            /// The icon colour when active
+            /// </summary>
+            public ColourInfo ActiveColour { get; set; } = Color4Extensions.FromHex("#00FFAA"); //Default colour
             public bool Active
             {
                 set => Scheduler.AddOnce(() =>
                 {
-                    IconContainer.Colour = value ? Color4Extensions.FromHex("#00FFAA") : colours.GrayF;
+                    IconContainer.Colour = value ? ActiveColour : colours.GrayF;
                 });
             }
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -6,8 +6,10 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.IO.Stores;
@@ -273,6 +275,11 @@ namespace osu.Game.Rulesets
         public virtual IBeatmapVerifier? CreateBeatmapVerifier() => null;
 
         public virtual Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Solid.QuestionCircle };
+
+        /// <summary>
+        /// The icon colour when active.
+        /// </summary>
+        public virtual ColourInfo RulesetColour => Color4Extensions.FromHex("#00FFAA");
 
         public virtual IResourceStore<byte[]> CreateResourceStore() => new NamespacedResourceStore<byte[]>(new DllResourceStore(GetType().Assembly), @"Resources");
 


### PR DESCRIPTION
Adds a [feature request](https://github.com/ppy/osu/discussions/27203)
I'm not sure whether there's an official colour-code for these rulesets, so I just made some up.

I have not found a way of testing the `ToolbarRulesetTabButton.RulesetButton.IconContainer.Colour` field, which is why I have not added any tests.