### PR TITLE
Fix logo tracking container being behind by one frame

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneLogoTrackingContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneLogoTrackingContainer.cs
@@ -282,7 +282,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             /// <summary>
             /// Check that the logo is tracking the position of the facade, with an acceptable precision lenience.
             /// </summary>
-            public bool IsLogoTracking => Precision.AlmostEquals(Logo.Position, ComputeLogoTrackingPosition());
+            public bool IsLogoTracking => Precision.AlmostEquals(Logo!.Position, ComputeLogoTrackingPosition());
         }
     }
 }

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -19,7 +17,7 @@ namespace osu.Game.Graphics.Containers
     {
         public Facade LogoFacade => facade;
 
-        protected OsuLogo Logo { get; private set; }
+        protected OsuLogo? Logo { get; private set; }
 
         private readonly InternalFacade facade = new InternalFacade();
 
@@ -76,7 +74,7 @@ namespace osu.Game.Graphics.Containers
         /// <remarks>Will only be correct if the logo's <see cref="Drawable.RelativePositionAxes"/> are set to Axes.Both</remarks>
         protected Vector2 ComputeLogoTrackingPosition()
         {
-            var absolutePos = Logo.Parent!.ToLocalSpace(LogoFacade.ScreenSpaceDrawQuad.Centre);
+            var absolutePos = Logo!.Parent!.ToLocalSpace(LogoFacade.ScreenSpaceDrawQuad.Centre);
 
             return new Vector2(absolutePos.X / Logo.Parent!.RelativeToAbsoluteFactor.X,
                 absolutePos.Y / Logo.Parent!.RelativeToAbsoluteFactor.Y);

--- a/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
+++ b/osu.Game/Graphics/Containers/LogoTrackingContainer.cs
@@ -82,9 +82,9 @@ namespace osu.Game.Graphics.Containers
                 absolutePos.Y / Logo.Parent!.RelativeToAbsoluteFactor.Y);
         }
 
-        protected override void Update()
+        protected override void UpdateAfterChildren()
         {
-            base.Update();
+            base.UpdateAfterChildren();
 
             if (Logo == null)
                 return;


### PR DESCRIPTION
This was especially visible at the main menu when running in single thread mode.

| Before | After |
| :---: | :---: |
| ![2024-02-18 23 24 20](https://github.com/ppy/osu/assets/191335/fc970cb2-cb84-46ff-bc22-e48d4b4967ad) | ![2024-02-18 23 22 51](https://github.com/ppy/osu/assets/191335/2be225c7-1f12-44f6-b681-f862a0016888) |