### PR TITLE
Fix allocations in `SliderInputManager.updateTracking`

### DIFF
--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Lists;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu
 {
     public partial class OsuInputManager : RulesetInputManager<OsuAction>
     {
-        public IEnumerable<OsuAction> PressedActions => KeyBindingContainer.PressedActions;
+        public SlimReadOnlyListWrapper<OsuAction> PressedActions => KeyBindingContainer.PressedActions;
 
         /// <summary>
         /// Whether gameplay input buttons should be allowed.


### PR DESCRIPTION
- [x] Depends on framework build with https://github.com/ppy/osu-framework/pull/6185

Removes enumerator allocations in https://github.com/ppy/osu/blob/4d4d69521ff8eac4a6f95b02610cd5f5392678ed/osu.Game.Rulesets.Osu/Objects/Drawables/SliderInputManager.cs#L234

![Снимок экрана 2024-02-19 011818](https://github.com/ppy/osu/assets/22874522/9a10e9f1-ae6c-4061-8e2e-9d9d97359dc2)