### PR TITLE
Fix `WorkingBeatmapCache` caching beatmap in wrong state leading to crash

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmapCache.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmapCache.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Dummy;
 using osu.Framework.Graphics.Textures;
@@ -143,13 +144,17 @@ namespace osu.Game.Beatmaps
                 {
                     string fileStorePath = BeatmapSetInfo.GetPathForFile(BeatmapInfo.Path);
 
-                    // TODO: check validity of file
-
                     var stream = GetStream(fileStorePath);
 
                     if (stream == null)
                     {
                         Logger.Log($"Beatmap failed to load (file {BeatmapInfo.Path} not found on disk at expected location {fileStorePath}).", level: LogLevel.Error);
+                        return null;
+                    }
+
+                    if (stream.ComputeMD5Hash() != BeatmapInfo.MD5Hash)
+                    {
+                        Logger.Log($"Beatmap failed to load (file {BeatmapInfo.Path} does not have the expected hash).", level: LogLevel.Error);
                         return null;
                     }
 

--- a/osu.Game/Tests/Visual/OsuGameTestScene.cs
+++ b/osu.Game/Tests/Visual/OsuGameTestScene.cs
@@ -153,6 +153,8 @@ namespace osu.Game.Tests.Visual
 
             public new Bindable<IReadOnlyList<Mod>> SelectedMods => base.SelectedMods;
 
+            public new Storage Storage => base.Storage;
+
             public new SpectatorClient SpectatorClient => base.SpectatorClient;
 
             // if we don't apply these changes, when running under nUnit the version that gets populated is that of nUnit.
@@ -166,7 +168,7 @@ namespace osu.Game.Tests.Visual
             public TestOsuGame(Storage storage, IAPIProvider api, string[] args = null)
                 : base(args)
             {
-                Storage = storage;
+                base.Storage = storage;
                 API = api;
             }
 


### PR DESCRIPTION
Over-caching could mean that a beatmap could load and cause a late crash after editing. Let's catch it early to avoid such a crash occurring.