### PR TITLE
Change `userBeatmapOffsetClock` to a `FramedOffsetClock`

### DIFF
--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Beatmaps
 
         private readonly OffsetCorrectionClock? userGlobalOffsetClock;
         private readonly OffsetCorrectionClock? platformOffsetClock;
-        private readonly OffsetCorrectionClock? userBeatmapOffsetClock;
+        private readonly FramedOffsetClock? userBeatmapOffsetClock;
 
         private readonly IFrameBasedClock finalClockSource;
 
@@ -70,7 +70,7 @@ namespace osu.Game.Beatmaps
                 userGlobalOffsetClock = new OffsetCorrectionClock(platformOffsetClock);
 
                 // User per-beatmap offset will be applied to this final clock.
-                finalClockSource = userBeatmapOffsetClock = new OffsetCorrectionClock(userGlobalOffsetClock);
+                finalClockSource = userBeatmapOffsetClock = new FramedOffsetClock(userGlobalOffsetClock);
             }
             else
             {
@@ -122,7 +122,7 @@ namespace osu.Game.Beatmaps
                 Debug.Assert(userBeatmapOffsetClock != null);
                 Debug.Assert(platformOffsetClock != null);
 
-                return userGlobalOffsetClock.RateAdjustedOffset + userBeatmapOffsetClock.RateAdjustedOffset + platformOffsetClock.RateAdjustedOffset;
+                return userGlobalOffsetClock.RateAdjustedOffset + userBeatmapOffsetClock.Offset + platformOffsetClock.RateAdjustedOffset;
             }
         }
 


### PR DESCRIPTION
Real-time offsets are good for latency correction, since the latency does not change in size relative to the rate of playback, but there is another type of timing inaccuracy that is not caused by latency. It occurs when there is a misalignment in the beatmap itself, between its track and its timestamps.

Currently, we can use a beatmap-specific offset to correct these misalignments. The type of offset used for this is a real-time offset, the exact same type of offset that the global audio offset uses for latency correction.

The problem with this approach is that timing inaccuracies caused by misalignment are not of the same nature as those caused by latency. Unlike with latency, this type of timing inaccuracy **does** change in size (in real-time) relative to the rate of playback. It should therefore be corrected with a virtual-time offset.

A real-time beatmap offset will only correct the misalignment for one specific playback rate, whereas a virtual-time offset would correct the misalignment for every conceivable playback rate.

***Will this break the beatmap offsets already set by users?***

If the offset amount was intended to work alongside a normal playback rate of 100%, then it will work just as well as it did before. If it wasn't intended for a normal playback rate, then a new amount will need to be specified, but once a virtual-time beatmap offset works for one playback rate, it will work for every other playback rate as well, which means that fewer adjustments overall will need to be made in the long run.

Here are some examples:

### Before (beatmap offset is an `OffsetCorrectionClock`)

https://github.com/ppy/osu/assets/3401272/bc09a744-f364-4152-8b4a-ae4c2a9b2c6f

You'll notice that at 100% playback rate, timing sounds perfectly fine, but the more it deviates from 100%, the larger the delay becomes, especially at slower speeds. There's also a slight delay at faster speeds, but it's less pronounced.

### After (beatmap offset is a `FramedOffsetClock`)

https://github.com/ppy/osu/assets/3401272/ce8695db-3696-4bf6-a2a4-d2e1e6e7bb80

After offsetting with virtual time, the delay disappears.