### PR TITLE
Reduce mania editor allocations with many objects selected

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -149,7 +148,18 @@ namespace osu.Game.Rulesets.Mania.UI
         /// <summary>
         /// Retrieves the total amount of columns across all stages in this playfield.
         /// </summary>
-        public int TotalColumns => stages.Sum(s => s.Columns.Length);
+        public int TotalColumns
+        {
+            get
+            {
+                int sum = 0;
+
+                foreach (var stage in stages)
+                    sum += stage.Columns.Length;
+
+                return sum;
+            }
+        }
 
         private Stage getStageByColumn(int column)
         {

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -97,11 +97,14 @@ namespace osu.Game.Screens.Edit.Components
                 editorClock.Start();
         }
 
+        private static readonly IconUsage play_icon = FontAwesome.Regular.PlayCircle;
+        private static readonly IconUsage pause_icon = FontAwesome.Regular.PauseCircle;
+
         protected override void Update()
         {
             base.Update();
 
-            playButton.Icon = editorClock.IsRunning ? FontAwesome.Regular.PauseCircle : FontAwesome.Regular.PlayCircle;
+            playButton.Icon = editorClock.IsRunning ? pause_icon : play_icon;
         }
 
         private partial class PlaybackTabControl : OsuTabControl<double>

--- a/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
+++ b/osu.Game/Screens/Edit/Components/TimeInfoContainer.cs
@@ -47,11 +47,26 @@ namespace osu.Game.Screens.Edit.Components
             };
         }
 
+        private double? lastTime;
+        private double? lastBPM;
+
         protected override void Update()
         {
             base.Update();
-            trackTimer.Text = editorClock.CurrentTime.ToEditorFormattedString();
-            bpm.Text = @$"{editorBeatmap.ControlPointInfo.TimingPointAt(editorClock.CurrentTime).BPM:0} BPM";
+
+            if (lastTime != editorClock.CurrentTime)
+            {
+                lastTime = editorClock.CurrentTime;
+                trackTimer.Text = editorClock.CurrentTime.ToEditorFormattedString();
+            }
+
+            double newBPM = editorBeatmap.ControlPointInfo.TimingPointAt(editorClock.CurrentTime).BPM;
+
+            if (lastBPM != newBPM)
+            {
+                lastBPM = newBPM;
+                bpm.Text = @$"{newBPM:0} BPM";
+            }
         }
     }
 }


### PR DESCRIPTION
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/9ce30267-5a2e-4d18-a8fc-0efd0e94ccc1)|![pr](https://github.com/ppy/osu/assets/22874522/162cecbf-b75d-4e03-bd95-c57ebc11162a)|


Last big one is caused by `.Reverse()` in https://github.com/ppy/osu/blob/ef413c08f19a0743a2aa7020aa72047118828adb/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs#L130 since it allocates a new array under the hood. Needs rethinking probably.