### PR TITLE
Don't retrieve Username from Settings if SaveUsername is disabled

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Online.API
             authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, APIEndpointUrl);
             log = Logger.GetLogger(LoggingTarget.Network);
 
-            ProvidedUsername = config.Get<string>(OsuSetting.Username);
+            ProvidedUsername = config.Get<bool>(OsuSetting.SaveUsername) ? config.Get<string>(OsuSetting.Username) : string.Empty;
 
             authentication.TokenString = config.Get<string>(OsuSetting.Token);
             authentication.Token.ValueChanged += onTokenChanged;

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Online.API
             authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, APIEndpointUrl);
             log = Logger.GetLogger(LoggingTarget.Network);
 
-            ProvidedUsername = config.Get<bool>(OsuSetting.SaveUsername) ? config.Get<string>(OsuSetting.Username) : string.Empty;
+            ProvidedUsername = config.Get<string>(OsuSetting.Username);
 
             authentication.TokenString = config.Get<string>(OsuSetting.Token);
             authentication.Token.ValueChanged += onTokenChanged;

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -13,11 +13,11 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Overlays.Settings;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Login
 {
@@ -26,6 +26,7 @@ namespace osu.Game.Overlays.Login
         private TextBox username = null!;
         private TextBox password = null!;
         private ShakeContainer shakeSignIn = null!;
+        private SettingsCheckbox rememberUsername = null!;
 
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
@@ -82,7 +83,7 @@ namespace osu.Game.Overlays.Login
                         },
                     },
                 },
-                new SettingsCheckbox
+                rememberUsername = new SettingsCheckbox
                 {
                     LabelText = LoginPanelStrings.RememberUsername,
                     Current = config.GetBindable<bool>(OsuSetting.SaveUsername),
@@ -130,6 +131,7 @@ namespace osu.Game.Overlays.Login
             forgottenPasswordLink.AddLink(LayoutStrings.PopupLoginLoginForgot, $"{api.WebsiteRootUrl}/home/password-reset");
 
             password.OnCommit += (_, _) => performLogin();
+            rememberUsername.SettingChanged += () => onRememberUsernameChanged(config);
 
             if (api.LastLoginError?.Message is string error)
             {
@@ -144,6 +146,13 @@ namespace osu.Game.Overlays.Login
                 api.Login(username.Text, password.Text);
             else
                 shakeSignIn.Shake();
+        }
+
+        private void onRememberUsernameChanged(OsuConfigManager config)
+        {
+            var checkBox = (SettingsCheckbox)rememberUsername.GetUnderlyingSettingValue();
+            if (checkBox.Current.Value == false)
+                config.SetValue(OsuSetting.Username, string.Empty);
         }
 
         protected override bool OnClick(ClickEvent e) => true;

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -150,8 +150,7 @@ namespace osu.Game.Overlays.Login
 
         private void onRememberUsernameChanged(OsuConfigManager config)
         {
-            var checkBox = (SettingsCheckbox)rememberUsername.GetUnderlyingSettingValue();
-            if (checkBox.Current.Value == false)
+            if (rememberUsername.Current.Value == false)
                 config.SetValue(OsuSetting.Username, string.Empty);
         }
 


### PR DESCRIPTION
Resolves #27272 

Prevents any saved Username from being prefilled into the field if the Remember Username setting was disabled after saving a Username. The setting itself will be emptied upon login attempt.