### PR TITLE
Add an option to always expand the gameplay leaderboard

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -144,6 +144,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ReplaySettingsOverlay, true);
             SetDefault(OsuSetting.ReplayPlaybackControlsExpanded, true);
             SetDefault(OsuSetting.GameplayLeaderboard, true);
+            SetDefault(OsuSetting.AlwaysExpandGameplayLeaderboard, false);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
             SetDefault(OsuSetting.FloatingComments, false);
@@ -428,6 +429,7 @@ namespace osu.Game.Configuration
         TouchDisableGameplayTaps,
         ModSelectTextSearchStartsActive,
         UserOnlineStatus,
-        MultiplayerRoomFilter
+        MultiplayerRoomFilter,
+        AlwaysExpandGameplayLeaderboard,
     }
 }

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -85,6 +85,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysShowGameplayLeaderboard => new TranslatableString(getKey(@"gameplay_leaderboard"), @"Always show gameplay leaderboard");
 
         /// <summary>
+        /// "Always show detailed information on gameplay leaderboard"
+        /// </summary>
+        public static LocalisableString AlwaysExpandGameplayLeaderboard => new TranslatableString(getKey(@"always_expand_gameplay_leaderboard"), @"Always show detailed information on gameplay leaderboard");
+
+        /// <summary>
         /// "Always play first combo break sound"
         /// </summary>
         public static LocalisableString AlwaysPlayFirstComboBreak => new TranslatableString(getKey(@"always_play_first_combo_break"), @"Always play first combo break sound");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = GameplaySettingsStrings.AlwaysExpandGameplayLeaderboard,
+                    Current = config.GetBindable<bool>(OsuSetting.AlwaysExpandGameplayLeaderboard),
+                },
+                new SettingsCheckbox
+                {
                     ClassicDefault = false,
                     LabelText = GameplaySettingsStrings.ShowHealthDisplayWhenCantFail,
                     Current = config.GetBindable<bool>(OsuSetting.ShowHealthDisplayWhenCantFail),

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -391,7 +391,7 @@ namespace osu.Game.Screens.Play
             IsBreakTime.BindTo(breakTracker.IsBreakTime);
             IsBreakTime.BindValueChanged(onBreakTimeChanged, true);
 
-            loadLeaderboard();
+            loadLeaderboard(config);
         }
 
         protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart);
@@ -867,8 +867,14 @@ namespace osu.Game.Screens.Play
 
         protected readonly Bindable<bool> LeaderboardExpandedState = new BindableBool();
 
-        private void loadLeaderboard()
+        /// <summary>
+        /// Always show the leaderboard in expanded state. Pulled from config.
+        /// </summary>
+        private Bindable<bool> leaderboardAlwaysExpand;
+
+        private void loadLeaderboard(OsuConfigManager config)
         {
+            leaderboardAlwaysExpand = config.GetBindable<bool>(OsuSetting.AlwaysExpandGameplayLeaderboard);
             HUDOverlay.HoldingForHUD.BindValueChanged(_ => updateLeaderboardExpandedState());
             LocalUserPlaying.BindValueChanged(_ => updateLeaderboardExpandedState(), true);
 
@@ -894,7 +900,7 @@ namespace osu.Game.Screens.Play
         protected virtual void AddLeaderboardToHUD(GameplayLeaderboard leaderboard) => HUDOverlay.LeaderboardFlow.Add(leaderboard);
 
         private void updateLeaderboardExpandedState() =>
-            LeaderboardExpandedState.Value = !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value;
+            LeaderboardExpandedState.Value = leaderboardAlwaysExpand.Value || !LocalUserPlaying.Value || HUDOverlay.HoldingForHUD.Value;
 
         #endregion
 


### PR DESCRIPTION
Something to resolve https://github.com/ppy/osu/discussions/22040.

I am not certain about the option though, especially the wording.
Might also consider:
- Having "Always / during gameplay / never" minimize leaderboard option.
- Merge it with the toggle option.

### Progress

- Add setting to always show expanded gameplay leaderboard
- Add toggle in settings for AlwaysExpandGameplayLeaderboard
- Apply AlwaysExpandGameplayLeaderboard when calculating LeaderboardExpandedState
