### PR TITLE
Fix `LegacyApproachCircle` incorrectly applying scaling factor

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultApproachCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultApproachCircle.cs
@@ -25,8 +25,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             Texture = textures.Get(@"Gameplay/osu/approachcircle").WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2);
 
-            // account for the sprite being used for the default approach circle being taken from stable,
-            // when hitcircles have 5px padding on each size. this should be removed if we update the sprite.
+            // In triangles and argon skins, we expanded hitcircles to take up the full 128 px which are clickable,
+            // but still use the old approach circle sprite. To make it feel correct (ie. disappear as it collides
+            // with the hitcircle, *not when it overlaps the border*) we need to expand it slightly.
             Scale = new Vector2(128 / 118f);
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyApproachCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyApproachCircle.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
@@ -26,10 +25,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             var texture = skin.GetTexture(@"approachcircle");
             Debug.Assert(texture != null);
             Texture = texture.WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2);
-
-            // account for the sprite being used for the default approach circle being taken from stable,
-            // when hitcircles have 5px padding on each size. this should be removed if we update the sprite.
-            Scale = new Vector2(128 / 118f);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
Simple way of explaining this: it was only supposed to be applied to default skins, but was incorrectly applied everywhere. This was likely an oversight due to the implementation existing in `LegacyApproachCircle`. But it was in the `CreateDefault` method which is not used because there's always an `approachcircle` sprite.

https://github.com/ppy/osu/blob/ad6f04cfb0030c32797621c896a3eb4a4e65e62a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyApproachCircle.cs#L44-L46

Here's the longer version, which I've also updated the inline comment to:

In triangles and argon, we expanded hitcircles to take up the full 128 px which are clickable, but still use the old approach circle sprite. To make it feel correct (ie. disappear as it collides with the hitcircle, *not when it overlaps the border*) we need to expand it slightly.

This is what the scale adjust exists to do.

Note that this only affects classic and legacy skins.

| Before | After |
| :---: | :---: |
| ![2024-02-21 13 49 47@2x](https://github.com/ppy/osu/assets/191335/507d8e42-1505-40cd-9312-67e7b1d11ef6) | ![2024-02-21 13 50 27@2x](https://github.com/ppy/osu/assets/191335/ce514f72-a37a-4acc-8dc3-b1a158857814) |
| ![2024-02-21 13 47 25@2x](https://github.com/ppy/osu/assets/191335/430c20a1-bb1c-48bc-9ce0-5caba10f41eb) | ![2024-02-21 13 45 42@2x](https://github.com/ppy/osu/assets/191335/e74d22dc-1974-46c2-a262-186d225fefe0) |
| ![2024-02-21 13 46 56@2x](https://github.com/ppy/osu/assets/191335/3ff4ff12-0b65-474b-bf2d-17701b9a009e) | ![2024-02-21 13 45 28@2x](https://github.com/ppy/osu/assets/191335/678bbde2-fa5f-407a-86eb-9705f3299994) |
| ![2024-02-21 13 46 39@2x](https://github.com/ppy/osu/assets/191335/cfa7ac94-83bc-41cf-bda3-0260c573af23) | ![2024-02-21 13 45 50@2x](https://github.com/ppy/osu/assets/191335/da822347-bc4e-4616-9861-a6fa0b51984d) |

Closes https://github.com/ppy/osu/issues/27283.