### PR TITLE
Fix classic skin follow circles animating from incorrect starting point

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             // Note that the scale adjust here is 2 instead of DrawableSliderBall.FOLLOW_AREA to match legacy behaviour.
             // This means the actual tracking area for gameplay purposes is larger than the sprite (but skins may be accounting for this).
-            this.ScaleTo(0.5f).ScaleTo(2f, Math.Min(180f, remainingTime), Easing.Out)
+            this.ScaleTo(1f).ScaleTo(2f, Math.Min(180f, remainingTime), Easing.Out)
                 .FadeTo(0).FadeTo(1f, Math.Min(60f, remainingTime));
         }
 


### PR DESCRIPTION
I don't know how this happened, but it looks completely wrong. The follower was starting from inside the circle.

[Reference](https://github.com/ppy/osu/blob/a137fa548080cf6c5ff5b6d79b427cf23a677d2b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyFollowCircle.cs#L27-L32)