### PR TITLE
Fix old-style legacy spinner fade-in not matching stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyOldStyleSpinner.cs
@@ -92,8 +92,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimePreempt))
                 this.FadeOut();
 
-            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn / 2))
-                this.FadeInFromZero(spinner.TimeFadeIn / 2);
+            using (BeginAbsoluteSequence(spinner.StartTime - spinner.TimeFadeIn))
+                this.FadeInFromZero(spinner.TimeFadeIn);
         }
 
         protected override void Update()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27274

This was supposed to have been adjusted in https://github.com/ppy/osu/pull/20817 alongside `LegacyNewStyleSpinner`, but has been forgotten about.

Compare (`LegacyNewStyleSpinner`):
https://github.com/ppy/osu/blob/e3ab7b1e9fd60ac15ae3e3e838425290512cf517/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyNewStyleSpinner.cs#L108-L109

Also see [stable reference](https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameplayElements/HitObjects/Osu/SpinnerOsu.cs#L78) and notice transformation there is same regardless of spinner style.