### PR TITLE
Update github actions to resolve most node deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install .NET 8.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 
@@ -27,7 +27,7 @@ jobs:
         run: dotnet restore osu.Desktop.slnf
 
       - name: Restore inspectcode cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/inspectcode
           key: inspectcode-${{ hashFiles('.config/dotnet-tools.json', '.github/workflows/ci.yml', 'osu.sln*', 'osu*.slnf', '.editorconfig', '.globalconfig', 'CodeAnalysis/*', '**/*.csproj', '**/*.props') }}
@@ -70,10 +70,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install .NET 8.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 
@@ -99,16 +99,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: microsoft
           java-version: 11
 
       - name: Install .NET 8.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 
@@ -126,10 +126,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install .NET 8.0.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "8.0.x"
 

--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -140,7 +140,7 @@ jobs:
       GOOGLE_CREDS_FILE: ${{ steps.set-outputs.outputs.GOOGLE_CREDS_FILE }}
     steps:
       - name: Checkout diffcalc-sheet-generator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.EXECUTION_ID }}
           repository: 'smoogipoo/diffcalc-sheet-generator'

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Annotate CI run with test results
-        uses: dorny/test-reporter@v1.6.0
+        uses: dorny/test-reporter@v1.8.0
         with:
           artifact: osu-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           name: Test Results (${{matrix.os.prettyname}}, ${{matrix.threadingMode}})

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-web-mod-definitions.yml
+++ b/.github/workflows/update-web-mod-definitions.yml
@@ -13,23 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install .NET 8.0.x
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: "8.0.x"
 
     - name: Checkout ppy/osu
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: osu
 
     - name: Checkout ppy/osu-tools
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ppy/osu-tools
         path: osu-tools
 
     - name: Checkout ppy/osu-web
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ppy/osu-web
         path: osu-web
@@ -43,7 +43,7 @@ jobs:
       working-directory: ./osu-tools
 
     - name: Create pull request with changes
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       with:
         title: Update mod definitions
         body: "This PR has been auto-generated to update the mod definitions to match ppy/osu@${{ github.ref_name }}."


### PR DESCRIPTION
As is github tradition, workflows started yelling about running on a node version that was getting sunset, so here we go again.

Relevant bumps:

- https://github.com/actions/checkout/releases/tag/v4.0.0
- https://github.com/actions/setup-dotnet/releases/tag/v4.0.0
- https://github.com/actions/cache/releases/tag/v4.0.0
- https://github.com/actions/setup-java/releases/tag/v4.0.0
- https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.0
- https://github.com/dorny/test-reporter/releases/tag/v1.8.0

Notably, `actions/upload-artifact` is _not_ bumped to v4, although it should be to resolve the node deprecation warnings, because it has more breaking changes and bumping would break `dorny/test-reporter` (see https://github.com/dorny/test-reporter/issues/363).

Only tested basic CI workflow. [Evidence it still works here.](https://github.com/bdach/osu/actions/runs/8007633660/job/21872227672)