### PR TITLE
Add missing .olz association to iOS

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -102,6 +102,19 @@
 				<string>osz</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>sh.ppy.osu.items</string>
+			</array>
+			<key>UTTypeIdentifier</key>
+			<string>sh.ppy.osu.olz</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>olz</string>
+			</dict>
+		</dict>
 	</array>
 	<key>CFBundleDocumentTypes</key>
 	<array>


### PR DESCRIPTION
Noticed .olz files weren't showing osu! as an option to Open With through the Files app

![image0](https://github.com/ppy/osu/assets/6813986/d78c80de-638c-4c3a-a6d9-cbc56910e947)


The Info.plist file was missing this extension, this adds it so that it's associated on iOS.