### PR TITLE
Improve search performance at song select when a collection is selected

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using System;
-using System.Linq;
+using System.Collections.Immutable;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -65,7 +65,7 @@ namespace osu.Game.Screens.Select
                 Sort = sortMode.Value,
                 AllowConvertedBeatmaps = showConverted.Value,
                 Ruleset = ruleset.Value,
-                CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToList()
+                CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet()
             };
 
             if (!minimumStars.IsDefault)

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -64,7 +65,7 @@ namespace osu.Game.Screens.Select
                 Sort = sortMode.Value,
                 AllowConvertedBeatmaps = showConverted.Value,
                 Ruleset = ruleset.Value,
-                CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes)
+                CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToList()
             };
 
             if (!minimumStars.IsDefault)


### PR DESCRIPTION
Without this, there's a large overhead to do a realm-live `Contains` search when a collection is selected.

This may also help considerably alleviate https://github.com/ppy/osu/discussions/27298#discussioncomment-8552508 as we will be performing the native realm search much less.

I've tested that this handled items being added/removed from collections correctly, so it seems like an oversight from the outset:

![2024-02-23 11 19 29@2x](https://github.com/ppy/osu/assets/191335/c6dbdbee-f3be-46a6-8f38-f0a5777af88b)

Closes https://github.com/ppy/osu/issues/27322.