### PR TITLE
Fix editor displaying combo colours in effectively incorrect order

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using osu.Framework.Audio.Sample;
@@ -20,7 +18,7 @@ namespace osu.Game.Screens.Edit
     /// </summary>
     public class EditorBeatmapSkin : ISkin
     {
-        public event Action BeatmapSkinChanged;
+        public event Action? BeatmapSkinChanged;
 
         /// <summary>
         /// The underlying beatmap skin.
@@ -65,10 +63,14 @@ namespace osu.Game.Screens.Edit
 
         #region Delegated ISkin implementation
 
-        public Drawable GetDrawableComponent(ISkinComponentLookup lookup) => Skin.GetDrawableComponent(lookup);
-        public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
-        public ISample GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
-        public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => Skin.GetConfig<TLookup, TValue>(lookup);
+        public Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => Skin.GetDrawableComponent(lookup);
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
+        public ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
+
+        public IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+            where TLookup : notnull
+            where TValue : notnull
+            => Skin.GetConfig<TLookup, TValue>(lookup);
 
         #endregion
     }

--- a/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapSkin.cs
@@ -4,7 +4,7 @@
 #nullable disable
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -38,8 +38,17 @@ namespace osu.Game.Screens.Edit
             Skin = skin;
 
             ComboColours = new BindableList<Colour4>();
-            if (Skin.Configuration.ComboColours != null)
-                ComboColours.AddRange(Skin.Configuration.ComboColours.Select(c => (Colour4)c));
+
+            if (Skin.Configuration.ComboColours is IReadOnlyList<Color4> comboColours)
+            {
+                // due to the foibles of how `IHasComboInformation` / `ComboIndexWithOffsets` work,
+                // the actual effective first combo colour that will be used on the beatmap is the one with index 1, not 0.
+                // see also: `IHasComboInformation.UpdateComboInformation`,
+                // https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Edit/Forms/SongSetup.cs#L233-L234.
+                for (int i = 0; i < comboColours.Count; ++i)
+                    ComboColours.Add(comboColours[(i + 1) % comboColours.Count]);
+            }
+
             ComboColours.BindCollectionChanged((_, _) => updateColours());
         }
 
@@ -47,7 +56,10 @@ namespace osu.Game.Screens.Edit
 
         private void updateColours()
         {
-            Skin.Configuration.CustomComboColours = ComboColours.Select(c => (Color4)c).ToList();
+            // performs the inverse of the index rotation operation described in the ctor.
+            Skin.Configuration.CustomComboColours.Clear();
+            for (int i = 0; i < ComboColours.Count; ++i)
+                Skin.Configuration.CustomComboColours.Add(ComboColours[(ComboColours.Count + i - 1) % ComboColours.Count]);
             invokeSkinChanged();
         }
 


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/27316.

Stable lies about the first combo colour being first; in the `.osu` file it is actually second. [It does a thing in editor itself to correct
for this.](https://github.com/peppy/osu-stable-reference/blob/master/osu!/GameModes/Edit/Forms/SongSetup.cs#L233-L234)

I don't particularly like this solution but don't see a better one. No tests because the cost of writing tests properly is higher than the cost of fixing, and I'm not sure this'll pass scrutiny to begin with, but can add if you figure it's worthwhile.