### PR TITLE
Ensure slider end animation plays when a slider is activated close to the slider end time

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
@@ -31,6 +31,9 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 if (ParentObject.Judged)
                     return;
 
+                if (ParentObject.HitObject?.StartTime is null)
+                    return;
+
                 using (BeginAbsoluteSequence(Math.Max(Time.Current, ParentObject.HitObject?.StartTime ?? 0)))
                 {
                     if (tracking.NewValue)

--- a/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/FollowCircle.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 
@@ -40,6 +41,14 @@ namespace osu.Game.Rulesets.Osu.Skinning
                         OnSliderPress();
                     else
                         OnSliderRelease();
+
+                    // calling one of the above after OnSliderEnd() would result in a lack of a slider end animation
+                    // thus, ensure OnSliderEnd() is called again if the tracking value changed after the first call
+                    if (Time.Current >= ParentObject.HitStateUpdateTime + SliderEventGenerator.TAIL_LENIENCY)
+                    {
+                        FinishTransforms();
+                        OnSliderEnd();
+                    }
                 }
             }, true);
         }


### PR DESCRIPTION
Resolves #25981 by calling `OnSliderEnd` again if tracking value changes past the tail leniency region. Also guards against possible null pointer dereferences caused by `OnSliderRelease` being called before `DrawableSlider` is loaded. `FinishTransforms` is needed as replacement for the lack of the 0-36 ms long slider tick animation of the '36ms' tick that is present in stable but isn't in lazer.

Technically, this solution is still not a completely identical match with stable because it doesn't scale the finishing Press/Release animation and defer End animation by `max(0, remainingTime)`. However, the difference is fairly small, and with lazer's new tail leniency, this is even arguably better behavior, because it plays the same animation regardless of time of activation in the tail leniency region. The follow circle will also leave the playfield faster, and thus is an improvement in visibility of other hit objects.

Testing several different slider inputs on stable, exporting to lazer, and then watching them several times, also frame-by-frame, seemed to result in the expected behavior. A 100% accurate analysis would be time-consuming.