### PR TITLE
Fix `Argon` and `Triangles` spinner freeze at low replay speed

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -122,14 +122,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         private void updateSpmAlpha()
         {
             if (drawableSpinner.Result?.TimeStarted is double startTime)
-            {
-                double timeOffset = Math.Clamp(Clock.CurrentTime, startTime, startTime + drawableSpinner.HitObject.TimeFadeIn) - startTime;
-                spmContainer.Alpha = (float)(timeOffset / drawableSpinner.HitObject.TimeFadeIn);
-            }
+                spmContainer.Alpha = (float)Math.Clamp((Clock.CurrentTime - startTime) / drawableSpinner.HitObject.TimeFadeIn, 0, 1);
             else
-            {
                 spmContainer.Alpha = 0;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
@@ -111,42 +110,26 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             {
                 spmCounter.Text = Math.Truncate(spm.NewValue).ToString(@"#0");
             }, true);
-
-            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
         protected override void Update()
         {
             base.Update();
 
-            if (spmContainer.Alpha == 0)
-                fadeCounterOnTimeStart();
+            updateSpmAlpha();
         }
 
-        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
-        {
-            if (!(drawableHitObject is DrawableSpinner))
-                return;
-
-            fadeCounterOnTimeStart();
-        }
-
-        private void fadeCounterOnTimeStart()
+        private void updateSpmAlpha()
         {
             if (drawableSpinner.Result?.TimeStarted is double startTime)
             {
-                using (BeginAbsoluteSequence(startTime))
-                    spmContainer.FadeIn(drawableSpinner.HitObject.TimeFadeIn);
+                double timeOffset = Math.Clamp(Clock.CurrentTime, startTime, startTime + drawableSpinner.HitObject.TimeFadeIn) - startTime;
+                spmContainer.Alpha = (float)(timeOffset / drawableSpinner.HitObject.TimeFadeIn);
             }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableSpinner.IsNotNull())
-                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+            else
+            {
+                spmContainer.Alpha = 0;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         {
             base.Update();
 
-            if (spmContainer.Alpha == 0 && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha == 0)
                 fadeCounterOnTimeStart();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         {
             base.Update();
 
-            if (!spmContainer.IsPresent && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha != 0 && drawableSpinner.Result?.TimeStarted != null)
                 fadeCounterOnTimeStart();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonSpinner.cs
@@ -120,7 +120,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
         {
             base.Update();
 
-            if (spmContainer.Alpha != 0 && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha == 0 && drawableSpinner.Result?.TimeStarted != null)
                 fadeCounterOnTimeStart();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -5,7 +5,6 @@ using System;
 using System.Globalization;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
@@ -117,42 +116,26 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             {
                 spmCounter.Text = Math.Truncate(spm.NewValue).ToString(@"#0");
             }, true);
-
-            drawableSpinner.ApplyCustomUpdateState += updateStateTransforms;
-            updateStateTransforms(drawableSpinner, drawableSpinner.State.Value);
         }
 
         protected override void Update()
         {
             base.Update();
 
-            if (spmContainer.Alpha == 0)
-                fadeCounterOnTimeStart();
+            updateSpmAlpha();
         }
 
-        private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
-        {
-            if (!(drawableHitObject is DrawableSpinner))
-                return;
-
-            fadeCounterOnTimeStart();
-        }
-
-        private void fadeCounterOnTimeStart()
+        private void updateSpmAlpha()
         {
             if (drawableSpinner.Result?.TimeStarted is double startTime)
             {
-                using (BeginAbsoluteSequence(startTime))
-                    spmContainer.FadeIn(drawableSpinner.HitObject.TimeFadeIn);
+                double timeOffset = Math.Clamp(Clock.CurrentTime, startTime, startTime + drawableSpinner.HitObject.TimeFadeIn) - startTime;
+                spmContainer.Alpha = (float)(timeOffset / drawableSpinner.HitObject.TimeFadeIn);
             }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableSpinner.IsNotNull())
-                drawableSpinner.ApplyCustomUpdateState -= updateStateTransforms;
+            else
+            {
+                spmContainer.Alpha = 0;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -128,14 +128,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         private void updateSpmAlpha()
         {
             if (drawableSpinner.Result?.TimeStarted is double startTime)
-            {
-                double timeOffset = Math.Clamp(Clock.CurrentTime, startTime, startTime + drawableSpinner.HitObject.TimeFadeIn) - startTime;
-                spmContainer.Alpha = (float)(timeOffset / drawableSpinner.HitObject.TimeFadeIn);
-            }
+                spmContainer.Alpha = (float)Math.Clamp((Clock.CurrentTime - startTime) / drawableSpinner.HitObject.TimeFadeIn, 0, 1);
             else
-            {
                 spmContainer.Alpha = 0;
-            }
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             base.Update();
 
-            if (spmContainer.Alpha == 0 && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha == 0)
                 fadeCounterOnTimeStart();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             base.Update();
 
-            if (!spmContainer.IsPresent && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha != 0 && drawableSpinner.Result?.TimeStarted != null)
                 fadeCounterOnTimeStart();
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSpinner.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             base.Update();
 
-            if (spmContainer.Alpha != 0 && drawableSpinner.Result?.TimeStarted != null)
+            if (spmContainer.Alpha == 0 && drawableSpinner.Result?.TimeStarted != null)
                 fadeCounterOnTimeStart();
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27261

Spm counter fade transform for these spinners is being added in case if it wasn't present already. However `IsPresent` wasn't enough of a check for that since drawable isn't considered present before [0.0001f alpha](https://github.com/ppy/osu-framework/blob/82cc94410c5738e356a8f0d3d7626c3f0777067b/osu.Framework/Graphics/Drawable.cs#L1316). And since replay is played slowly (and so is the transform), even if transform was already added to the hierarchy - alpha was still below the `visibility_cutoff` value so with that we are adding many new transforms on top.