### PR TITLE
Fix incorrect standardised score estimation on selected beatmaps in osu! ruleset

### DIFF
--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -382,7 +382,7 @@ namespace osu.Game.Database
 
             HashSet<Guid> scoreIds = realmAccess.Run(r => new HashSet<Guid>(
                 r.All<ScoreInfo>()
-                 .Where(s => s.TotalScoreVersion < LegacyScoreEncoder.LATEST_VERSION)
+                 .Where(s => s.TotalScoreVersion < 30000013) // last total score version with a significant change to ranks
                  .AsEnumerable()
                  // must be done after materialisation, as realm doesn't support
                  // filtering on nested property predicates or projection via `.Select()`

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -365,6 +365,17 @@ namespace osu.Game.Database
                             + bonusProportion) * modMultiplier);
                     }
 
+                    // see similar check above.
+                    // if there is no legacy combo score, all combo conversion operations below
+                    // are either pointless or wildly wrong.
+                    if (maximumLegacyComboScore + maximumLegacyBonusScore == 0)
+                    {
+                        return (long)Math.Round((
+                            500000 * comboProportion // as above, zero if mods result in zero multiplier, one otherwise
+                            + 500000 * Math.Pow(score.Accuracy, 5)
+                            + bonusProportion) * modMultiplier);
+                    }
+
                     // Assumptions:
                     // - sliders and slider ticks are uniformly distributed in the beatmap, and thus can be ignored without losing much precision.
                     //   We thus consider a map of hit-circles only, which gives objectCount == maximumCombo.

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -44,9 +44,10 @@ namespace osu.Game.Scoring.Legacy
         /// <see cref="LegacyRulesetExtensions.CalculateDifficultyPeppyStars"/> method. Reconvert all scores.
         /// </description></item>
         /// <item><description>30000013: All local scores will use lazer definitions of ranks for consistency. Recalculates the rank of all scores.</description></item>
+        /// <item><description>30000014: Fix edge cases in conversion for osu! scores on selected beatmaps. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000013;
+        public const int LATEST_VERSION = 30000014;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-web/issues/11027

Spreadsheet: https://docs.google.com/spreadsheets/d/1dA-6du-vES56ztI7vqXRI7Xmlf_CYI3jPO902OvZBE0/edit#gid=1289988190

Can only realistically affect beatmaps with `difficultyPeppyStars = 0`, of which there are known 2:
- https://osu.ppy.sh/beatmapsets/675779#osu/1431549
- https://osu.ppy.sh/beatmapsets/325158#osu/741477