### PR TITLE
Reduce allocations when `ModSelectOverlay` is visible

### DIFF
--- a/osu.Game/Overlays/Mods/ModColumn.cs
+++ b/osu.Game/Overlays/Mods/ModColumn.cs
@@ -67,8 +67,25 @@ namespace osu.Game.Overlays.Mods
         private IModHotkeyHandler hotkeyHandler = null!;
 
         private Task? latestLoadTask;
-        private ICollection<ModPanel>? latestLoadedPanels;
-        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true && latestLoadedPanels?.All(panel => panel.Parent != null) == true;
+        private ModPanel[]? latestLoadedPanels;
+        internal bool ItemsLoaded => latestLoadTask?.IsCompleted == true && allPanelsLoaded;
+
+        private bool allPanelsLoaded
+        {
+            get
+            {
+                if (latestLoadedPanels == null)
+                    return false;
+
+                foreach (var panel in latestLoadedPanels)
+                {
+                    if (panel.Parent == null)
+                        return false;
+                }
+
+                return true;
+            }
+        }
 
         public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -361,12 +361,7 @@ namespace osu.Game.Overlays.Mods
 
             if (beatmapAttributesDisplay != null)
             {
-                ShearedButton lastFooterButton = null!;
-
-                foreach (var b in footerButtonFlow)
-                    lastFooterButton = b;
-
-                float rightEdgeOfLastButton = lastFooterButton.ScreenSpaceDrawQuad.TopRight.X;
+                float rightEdgeOfLastButton = footerButtonFlow[^1].ScreenSpaceDrawQuad.TopRight.X;
 
                 // this is cheating a bit; the 640 value is hardcoded based on how wide the expanded panel _generally_ is.
                 // due to the transition applied, the raw screenspace quad of the panel cannot be used, as it will trigger an ugly feedback cycle of expanding and collapsing.

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -349,15 +350,23 @@ namespace osu.Game.Overlays.Mods
             });
         }
 
+        private static readonly LocalisableString input_search_placeholder = Resources.Localisation.Web.CommonStrings.InputSearch;
+        private static readonly LocalisableString tab_to_search_placeholder = ModSelectOverlayStrings.TabToSearch;
+
         protected override void Update()
         {
             base.Update();
 
-            SearchTextBox.PlaceholderText = SearchTextBox.HasFocus ? Resources.Localisation.Web.CommonStrings.InputSearch : ModSelectOverlayStrings.TabToSearch;
+            SearchTextBox.PlaceholderText = SearchTextBox.HasFocus ? input_search_placeholder : tab_to_search_placeholder;
 
             if (beatmapAttributesDisplay != null)
             {
-                float rightEdgeOfLastButton = footerButtonFlow.Last().ScreenSpaceDrawQuad.TopRight.X;
+                ShearedButton lastFooterButton = null!;
+
+                foreach (var b in footerButtonFlow)
+                    lastFooterButton = b;
+
+                float rightEdgeOfLastButton = lastFooterButton.ScreenSpaceDrawQuad.TopRight.X;
 
                 // this is cheating a bit; the 640 value is hardcoded based on how wide the expanded panel _generally_ is.
                 // due to the transition applied, the raw screenspace quad of the panel cannot be used, as it will trigger an ugly feedback cycle of expanding and collapsing.


### PR DESCRIPTION
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/bdeb1851-de6d-45f3-9ac1-6b75d126a29c)|![pr](https://github.com/ppy/osu/assets/22874522/27f2d021-3493-4488-85f3-b934cb328d67)|