### PR TITLE
Fix slider head being incorrectly dimmed twice

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         protected override IEnumerable<Drawable> DimmablePieces => new Drawable[]
         {
-            HeadCircle,
+            // HeadCircle should not be added to this list, as it handles dimming itself
             TailCircle,
             repeatContainer,
             Body,


### PR DESCRIPTION
Resolves #25761.

Notice that the slider heads's approach circles are also dimmed in the footage in the issue. Slider heads are supposed to behave like hit circles, which [dim their body, but not their approach circle](https://github.com/ppy/osu/pull/24968).

The issue is that `DrawableSlider` dims its elements, including its `HeadCircle`, but `DrawableSliderHead`, inheriting from `DrawableHitCircle`, already dims itself (while also not dimming the approach circle), so the slider head is incorrectly being dimmed twice.

Thus, the solution is to remove the slider head from the list of slider elements to dim.

Not sure why it's an issue only most of the time (eg. from a few seconds into the map) and not always. The drawable hit object's state might not always be updating when it should? Either way, the addressed issue is gone now.

<details>
  <summary>some data</summary>

In the footage, the cutoff point seems to be between the orange 5 and the orange 6. Times in the map:
- offset: -16
- first hit object: 18734
- orange 5: 20984
- orange 6: 21265

On my test map (offset 676) it would usually happen at 11497, but usually not at 11568.

Sometimes, moving the slider to a new time, or even just seeking away and back, would resolve or reintroduce the issue on the slider, or removing all objects before the tested slider and existing and re-entering the editor would resolve the issue. Changing offset didn't make a difference.

</details>

| before | after |
| :---: | :---: |
| ![before](https://github.com/ppy/osu/assets/92268414/f00f61f1-ae8c-40ea-9ba7-170e4cf5ad8c) | ![after](https://github.com/ppy/osu/assets/92268414/3b80f0b2-58aa-44c2-86e5-25b9f9473c92) |