### PR TITLE
Fix advanced stats in beatmap info overlay showing "key count" on non-mania beatmaps

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -37,14 +37,8 @@ namespace osu.Game.Tests.Visual.SongSelect
         [SetUp]
         public void Setup() => Schedule(() => Child = advancedStats = new TestAdvancedStats
         {
-            Width = 500
+            Width = 500,
         });
-
-        [SetUpSteps]
-        public void SetUpSteps()
-        {
-            AddStep("reset game ruleset", () => Ruleset.Value = new OsuRuleset().RulesetInfo);
-        }
 
         private BeatmapInfo exampleBeatmapInfo => new BeatmapInfo
         {
@@ -74,45 +68,12 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
-        public void TestManiaFirstBarTextManiaBeatmap()
+        public void TestFirstBarText()
         {
-            AddStep("set game ruleset to mania", () => Ruleset.Value = new ManiaRuleset().RulesetInfo);
-
-            AddStep("set beatmap", () => advancedStats.BeatmapInfo = new BeatmapInfo
-            {
-                Ruleset = rulesets.GetRuleset(3) ?? throw new InvalidOperationException("osu!mania ruleset not found"),
-                Difficulty = new BeatmapDifficulty
-                {
-                    CircleSize = 5,
-                    DrainRate = 4.3f,
-                    OverallDifficulty = 4.5f,
-                    ApproachRate = 3.1f
-                },
-                StarRating = 8
-            });
-
+            AddStep("set ruleset to mania", () => advancedStats.Ruleset.Value = new ManiaRuleset().RulesetInfo);
             AddAssert("first bar text is correct", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == BeatmapsetsStrings.ShowStatsCsMania);
-        }
-
-        [Test]
-        public void TestManiaFirstBarTextConvert()
-        {
-            AddStep("set game ruleset to mania", () => Ruleset.Value = new ManiaRuleset().RulesetInfo);
-
-            AddStep("set beatmap", () => advancedStats.BeatmapInfo = new BeatmapInfo
-            {
-                Ruleset = new OsuRuleset().RulesetInfo,
-                Difficulty = new BeatmapDifficulty
-                {
-                    CircleSize = 5,
-                    DrainRate = 4.3f,
-                    OverallDifficulty = 4.5f,
-                    ApproachRate = 3.1f
-                },
-                StarRating = 8
-            });
-
-            AddAssert("first bar text is correct", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == BeatmapsetsStrings.ShowStatsCsMania);
+            AddStep("set ruleset to osu", () => advancedStats.Ruleset.Value = new OsuRuleset().RulesetInfo);
+            AddAssert("first bar text is correct", () => advancedStats.ChildrenOfType<SpriteText>().First().Text == BeatmapsetsStrings.ShowStatsCs);
         }
 
         [Test]

--- a/osu.Game/Overlays/BeatmapSet/Details.cs
+++ b/osu.Game/Overlays/BeatmapSet/Details.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapSet.Buttons;
+using osu.Game.Rulesets;
 using osu.Game.Screens.Select.Details;
 using osuTK;
 
@@ -33,10 +34,10 @@ namespace osu.Game.Overlays.BeatmapSet
             {
                 if (value == beatmapSet) return;
 
-                beatmapSet = value;
+                basic.BeatmapSet = preview.BeatmapSet = beatmapSet = value;
 
-                basic.BeatmapSet = preview.BeatmapSet = BeatmapSet;
-                updateDisplay();
+                if (IsLoaded)
+                    updateDisplay();
             }
         }
 
@@ -50,13 +51,10 @@ namespace osu.Game.Overlays.BeatmapSet
                 if (value == beatmapInfo) return;
 
                 basic.BeatmapInfo = advanced.BeatmapInfo = beatmapInfo = value;
-            }
-        }
 
-        private void updateDisplay()
-        {
-            Ratings.Ratings = BeatmapSet?.Ratings;
-            ratingBox.Alpha = BeatmapSet?.Status > 0 ? 1 : 0;
+                if (IsLoaded)
+                    updateDisplay();
+            }
         }
 
         public Details()
@@ -101,10 +99,20 @@ namespace osu.Game.Overlays.BeatmapSet
             };
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        [Resolved]
+        private RulesetStore rulesets { get; set; }
+
+        protected override void LoadComplete()
         {
+            base.LoadComplete();
             updateDisplay();
+        }
+
+        private void updateDisplay()
+        {
+            Ratings.Ratings = BeatmapSet?.Ratings;
+            ratingBox.Alpha = BeatmapSet?.Status > 0 ? 1 : 0;
+            advanced.Ruleset.Value = rulesets.GetRuleset(beatmapInfo?.Ruleset.OnlineID ?? 0);
         }
 
         private partial class DetailBox : Container

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -59,6 +59,13 @@ namespace osu.Game.Screens.Select.Details
             }
         }
 
+        /// <summary>
+        /// Ruleset to be used for certain elements of display.
+        /// When set, this will override the set <see cref="Beatmap"/>'s own ruleset.
+        /// </summary>
+        /// <remarks>
+        /// No checks are done as to whether the ruleset specified is valid for the currently <see cref="BeatmapInfo"/>.
+        /// </remarks>
         public Bindable<RulesetInfo> Ruleset { get; } = new Bindable<RulesetInfo>();
 
         public AdvancedStats(int columns = 1)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -286,7 +286,7 @@ namespace osu.Game.Screens.Select
                                                                 AutoSizeAxes = Axes.Y,
                                                                 Anchor = Anchor.Centre,
                                                                 Origin = Anchor.Centre,
-                                                                Padding = new MarginPadding(10)
+                                                                Padding = new MarginPadding(10),
                                                             },
                                                         }
                                                     },
@@ -584,6 +584,11 @@ namespace osu.Game.Screens.Select
 
                 beatmapInfoPrevious = beatmap;
             }
+
+            // we can't run this in the debounced run due to the selected mods bindable not being debounced,
+            // since mods could be updated to the new ruleset instances while the decoupled bindable is held behind,
+            // therefore resulting in performing difficulty calculation with invalid states.
+            advancedStats.Ruleset.Value = ruleset;
 
             void run()
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27371

The component itself was assuming too much. The decision of whether to show the "key count" label should be completely up to each usage instead.