### PR TITLE
Rewrite legacy slider path rendering to match stable better

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/PlaySliderBody.cs
@@ -44,7 +44,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             SnakingOut.BindTo(configSnakingOut);
 
-            BorderSize = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderBorderSize)?.Value ?? 1;
             BorderColour = skin.GetConfig<OsuSkinColour, Color4>(OsuSkinColour.SliderBorder)?.Value ?? Color4.White;
         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -23,29 +23,29 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private partial class LegacyDrawableSliderPath : DrawableSliderPath
         {
-            private const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
-
-            protected new float CalculatedBorderPortion
-                // Roughly matches osu!stable's slider border portions.
-                => base.CalculatedBorderPortion * 0.77f;
-
             protected override Color4 ColourAt(float position)
             {
-                float realBorderPortion = shadow_portion + CalculatedBorderPortion;
-                float realGradientPortion = 1 - realBorderPortion;
+                const float aa_width = 0.5f / 64f;
+                const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
+                const float border_portion = 0.1875f;
 
-                if (position <= shadow_portion)
-                    return new Color4(0f, 0f, 0f, 0.25f * position / shadow_portion);
-
-                if (position <= realBorderPortion)
-                    return BorderColour;
-
-                position -= realBorderPortion;
-
+                Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);
                 Color4 innerColour = lighten(AccentColour, 0.5f);
 
-                return LegacyUtils.InterpolateNonLinear(position / realGradientPortion, outerColour, innerColour, 0, 1);
+                if (position <= shadow_portion - aa_width)
+                    return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion - aa_width);
+
+                if (position <= shadow_portion + aa_width)
+                    return LegacyUtils.InterpolateNonLinear(position, shadow, BorderColour, shadow_portion - aa_width, shadow_portion + aa_width);
+
+                if (position <= border_portion - aa_width)
+                    return BorderColour;
+
+                if (position <= border_portion + aa_width)
+                    return LegacyUtils.InterpolateNonLinear(position, BorderColour, outerColour, border_portion - aa_width, border_portion + aa_width);
+
+                return LegacyUtils.InterpolateNonLinear(position, outerColour, innerColour, border_portion + aa_width, 1);
             }
 
             /// <summary>

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             protected new float CalculatedBorderPortion
                 // Roughly matches osu!stable's slider border portions.
-                => base.CalculatedBorderPortion * 0.84f;
+                => base.CalculatedBorderPortion * 0.77f;
 
             protected override Color4 ColourAt(float position)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,8 +26,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             private const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
 
             protected new float CalculatedBorderPortion
-                // Matches osu!stable's slider border portions.
-                => 0.109375f;
+                // Roughly matches osu!stable's slider border portions.
+                => base.CalculatedBorderPortion * 0.84f;
 
             protected override Color4 ColourAt(float position)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             protected new float CalculatedBorderPortion
                 // Roughly matches osu!stable's slider border portions.
-                => base.CalculatedBorderPortion * 0.77f;
+                => base.CalculatedBorderPortion * 0.84f;
 
             protected override Color4 ColourAt(float position)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             protected override Color4 ColourAt(float position)
             {
                 // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99
-                const float aa_width = 0.5f / 64f;
+                const float aa_width = 3f / 256f;
 
                 Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,8 +26,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             private const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
 
             protected new float CalculatedBorderPortion
-                // Roughly matches osu!stable's slider border portions.
-                => base.CalculatedBorderPortion * 0.84f;
+                // Matches osu!stable's slider border portions.
+                => 0.109375f;
 
             protected override Color4 ColourAt(float position)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -25,13 +25,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             protected override Color4 ColourAt(float position)
             {
+                // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99
                 const float aa_width = 0.5f / 64f;
-                const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
-                const float border_portion = 0.1875f;
 
                 Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);
                 Color4 innerColour = lighten(AccentColour, 0.5f);
+
+                // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L59-L70
+                const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
+                const float border_portion = 0.1875f;
 
                 if (position <= shadow_portion - aa_width)
                     return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion - aa_width);

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,7 +26,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             protected override Color4 ColourAt(float position)
             {
                 // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99
-                const float aa_width = 3f / 256f;
+                // float aaWidth = Math.Min(Math.Max(0.5f / PathRadius, 3.0f / 256.0f), 1.0f / 16.0f);
+                // applying the aa_width constant from stable makes sliders blurry, especially on CS>5. set to zero for now.
+                // this might be related to SmoothPath applying AA internally, but disabling that does not seem to have much of an effect.
+                const float aa_width = 0f;
 
                 Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -5,7 +5,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
 {
     public enum OsuSkinConfiguration
     {
-        SliderBorderSize,
         SliderPathRadius,
         CursorCentre,
         CursorExpand,


### PR DESCRIPTION
Resolves #26000. ~~Found by binary searching on stable-lazer screenshot comparisons on a CS 0 slider. Probably not a theoretically perfect match with stable still, but in reality not that much precision is required, and any value between around 0.776 and 0.8496 worked.~~

See https://github.com/ppy/osu/pull/27383#issuecomment-1965510222 and https://github.com/ppy/osu/pull/27383#issuecomment-1967552676