### PR TITLE
Fix low pass filter getting stuck in multiple locations

### DIFF
--- a/osu.Game/Audio/Effects/AudioFilter.cs
+++ b/osu.Game/Audio/Effects/AudioFilter.cs
@@ -17,11 +17,14 @@ namespace osu.Game.Audio.Effects
         /// </summary>
         public const int MAX_LOWPASS_CUTOFF = 22049; // nyquist - 1hz
 
+        /// <summary>
+        /// Whether this filter is currently attached to the audio track and thus applying an adjustment.
+        /// </summary>
+        public bool IsAttached { get; private set; }
+
         private readonly AudioMixer mixer;
         private readonly BQFParameters filter;
         private readonly BQFType type;
-
-        private bool isAttached;
 
         private readonly Cached filterApplication = new Cached();
 
@@ -132,22 +135,22 @@ namespace osu.Game.Audio.Effects
 
         private void ensureAttached()
         {
-            if (isAttached)
+            if (IsAttached)
                 return;
 
             Debug.Assert(!mixer.Effects.Contains(filter));
             mixer.Effects.Add(filter);
-            isAttached = true;
+            IsAttached = true;
         }
 
         private void ensureDetached()
         {
-            if (!isAttached)
+            if (!IsAttached)
                 return;
 
             Debug.Assert(mixer.Effects.Contains(filter));
             mixer.Effects.Remove(filter);
-            isAttached = false;
+            IsAttached = false;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Collections
             };
         }
 
+        public override bool IsPresent => base.IsPresent
+                                          // Safety for low pass filter potentially getting stuck in applied state due to
+                                          // transforms on `this` causing children to no longer be updated.
+                                          || lowPassFilter.IsAttached;
+
         protected override void PopIn()
         {
             lowPassFilter.CutoffTo(300, 100, Easing.OutCubic);

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -27,6 +27,12 @@ namespace osu.Game.Overlays
 
         public PopupDialog CurrentDialog { get; private set; }
 
+        public override bool IsPresent => Scheduler.HasPendingTasks
+                                          || dialogContainer.Children.Count > 0
+                                          // Safety for low pass filter potentially getting stuck in applied state due to
+                                          // transforms on `this` causing children to no longer be updated.
+                                          || lowPassFilter.IsAttached;
+
         public DialogOverlay()
         {
             AutoSizeAxes = Axes.Y;
@@ -94,8 +100,6 @@ namespace osu.Game.Overlays
                 CurrentDialog = null;
             }
         }
-
-        public override bool IsPresent => Scheduler.HasPendingTasks || dialogContainer.Children.Count > 0;
 
         protected override bool BlockNonPositionalInput => true;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/24100 using some local workarounds on all usages of filters which are held at a class level. As described in the issue, fixing this in a better way is not within reach, so let's just add safeties against it for now.

Can be tested using:

```diff
diff --git a/osu.Game/Collections/ManageCollectionsDialog.cs b/osu.Game/Collections/ManageCollectionsDialog.cs
index 16645d6796..794766a6fa 100644
--- a/osu.Game/Collections/ManageCollectionsDialog.cs
+++ b/osu.Game/Collections/ManageCollectionsDialog.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
@@ -138,6 +139,8 @@ protected override void PopOut()
 
             // Ensure that textboxes commit
             GetContainingInputManager()?.TriggerFocusContention(this);
+
+            Thread.Sleep(1000);
         }
     }
 }
diff --git a/osu.Game/Screens/Play/PlayerLoader.cs b/osu.Game/Screens/Play/PlayerLoader.cs
index aef7a0739e..1319e238fe 100644
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using ManagedBass.Fx;
 using osu.Framework.Allocation;
@@ -459,6 +460,8 @@ protected virtual void ContentOut()
 
             lowPassFilter?.CutoffTo(AudioFilter.MAX_LOWPASS_CUTOFF, CONTENT_OUT_DURATION);
             highPassFilter?.CutoffTo(0, CONTENT_OUT_DURATION);
+
+            Thread.Sleep(2000);
         }
 
         private void pushWhenLoaded()

```