### PR TITLE
Fix wireframe misalignment in `ArgonAccuracyCounter`

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -80,11 +80,15 @@ namespace osu.Game.Screens.Play.HUD
                                 ShowLabel = { BindTarget = ShowLabel },
                             }
                         },
-                        fractionPart = new ArgonCounterTextComponent(Anchor.TopLeft)
+                        new Container
                         {
-                            RequiredDisplayDigits = { Value = 2 },
-                            WireframeOpacity = { BindTarget = WireframeOpacity },
-                            Scale = new Vector2(0.5f),
+                            AutoSizeAxes = Axes.Both,
+                            Child = fractionPart = new ArgonCounterTextComponent(Anchor.TopRight)
+                            {
+                                RequiredDisplayDigits = { Value = 2 },
+                                WireframeOpacity = { BindTarget = WireframeOpacity },
+                                Scale = new Vector2(0.5f),
+                            }
                         },
                         percentText = new ArgonCounterTextComponent(Anchor.TopLeft)
                         {


### PR DESCRIPTION
Resolves #27385

The dot is included in the `textPart`, but not in the `wireframesPart` of `ArgonCounterTextComponent` . 
Setting the Anchor of both to `TopLeft` causes the misalignment due to the different widths.
I used the implementation from the block above and changed the `Anchor` to `TopRight`.

| before | after |
|--------|--------|
| ![before](https://github.com/ppy/osu/assets/112003827/2dd244d3-86c4-4173-8f89-1aaaac97b86a)|![after](https://github.com/ppy/osu/assets/112003827/e19e362e-ad32-4eaf-9004-b8a831aed291) |