### PR TITLE
Reduce string allocations during beatmap/storyboard parsing

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -498,10 +498,6 @@ namespace osu.Game.Beatmaps.Formats
                 omitFirstBarSignature = effectFlags.HasFlagFast(LegacyEffectFlags.OmitFirstBarLine);
             }
 
-            string stringSampleSet = sampleSet.ToString().ToLowerInvariant();
-            if (stringSampleSet == @"none")
-                stringSampleSet = HitSampleInfo.BANK_NORMAL;
-
             if (timingChange)
             {
                 if (double.IsNaN(beatLength))
@@ -537,7 +533,7 @@ namespace osu.Game.Beatmaps.Formats
 
             addControlPoint(time, new LegacySampleControlPoint
             {
-                SampleBank = stringSampleSet,
+                SampleBank = sampleSet == LegacySampleBank.None ? HitSampleInfo.BANK_NORMAL : sampleSet.ToString().ToLowerInvariant(),
                 SampleVolume = sampleVolume,
                 CustomSampleBank = customSampleBank,
             }, timingChange);

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -87,10 +87,7 @@ namespace osu.Game.Beatmaps.Formats
         protected string StripComments(string line)
         {
             int index = line.AsSpan().IndexOf("//".AsSpan());
-            if (index > 0)
-                return line.Substring(0, index);
-
-            return line;
+            return index > 0 ? line[..index] : line;
         }
 
         protected void HandleColours<TModel>(TModel output, string line, bool allowAlpha)
@@ -132,12 +129,14 @@ namespace osu.Game.Beatmaps.Formats
 
         protected KeyValuePair<string, string> SplitKeyVal(string line, char separator = ':', bool shouldTrim = true)
         {
-            string[] split = line.Split(separator, 2, shouldTrim ? StringSplitOptions.TrimEntries : StringSplitOptions.None);
+            var span = line.AsSpan();
+            Span<Range> ranges = stackalloc Range[2];
+            span.Split(ranges, separator, shouldTrim ? StringSplitOptions.TrimEntries : StringSplitOptions.None);
 
             return new KeyValuePair<string, string>
             (
-                split[0],
-                split.Length > 1 ? split[1] : string.Empty
+                span.Slice(ranges[0]).ToString(),
+                ranges.Length > 1 ? span.Slice(ranges[1]).ToString() : string.Empty
             );
         }
 

--- a/osu.Game/Beatmaps/Formats/Parsing.cs
+++ b/osu.Game/Beatmaps/Formats/Parsing.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Beatmaps.Formats
 
         public const double MAX_PARSE_VALUE = int.MaxValue;
 
-        public static float ParseFloat(string input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
+        public static float ParseFloat(ReadOnlySpan<char> input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
         {
             float output = float.Parse(input, CultureInfo.InvariantCulture);
 
@@ -27,7 +27,7 @@ namespace osu.Game.Beatmaps.Formats
             return output;
         }
 
-        public static double ParseDouble(string input, double parseLimit = MAX_PARSE_VALUE, bool allowNaN = false)
+        public static double ParseDouble(ReadOnlySpan<char> input, double parseLimit = MAX_PARSE_VALUE, bool allowNaN = false)
         {
             double output = double.Parse(input, CultureInfo.InvariantCulture);
 
@@ -39,7 +39,7 @@ namespace osu.Game.Beatmaps.Formats
             return output;
         }
 
-        public static int ParseInt(string input, int parseLimit = (int)MAX_PARSE_VALUE)
+        public static int ParseInt(ReadOnlySpan<char> input, int parseLimit = (int)MAX_PARSE_VALUE)
         {
             int output = int.Parse(input, CultureInfo.InvariantCulture);
 

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyConverterExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyConverterExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Objects.Legacy
+{
+    public static class LegacyConverterExtensions
+    {
+        public static int GetSplitCount(this ReadOnlySpan<char> text, char separator)
+        {
+            int count = 0;
+
+            foreach (char c in text)
+            {
+                if (c == separator)
+                    count++;
+            }
+
+            return count + 1;
+        }
+
+        public static ReadOnlySpan<char> Slice(this ReadOnlySpan<char> text, Range range)
+            => text.Slice(range.Start.Value, range.Length());
+
+        public static int Length(this Range range) => range.End.Value - range.Start.Value;
+    }
+}


### PR DESCRIPTION
Making a draft pr before spending any more time on it. It will be split into multiple prs down the line, so you can call this one just a reference/proof of concept/whatever.

`string.Split` allocates an array of new sub-strings which can be avoided by using `ReadonlySpan<char>.Split`. However this method acts a bit differently: it needs a `Span<Range>` to store indexes of resulting substrings within the source string, which we can allocate on a stack.
The main question is: is this an acceptable way to proceed?

Example of parsing world.execute(me) (Can be improved even further)
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/533b6d6a-0a1b-4dce-9fd2-973cb75aae04)|![pr](https://github.com/ppy/osu/assets/22874522/333e1dd9-e2f9-42b7-afc7-55e7968070a1)|