### PR TITLE
Fix slider tails sometimes not dimming correctly

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -81,6 +81,17 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             foreach (var piece in DimmablePieces)
             {
+                // if the specified dimmable piece is a DHO, it is generally not safe to tack transforms onto it directly
+                // as they may be cleared via the `updateState()` DHO flow,
+                // so use `ApplyCustomUpdateState` instead. which does not have this pitfall.
+                if (piece is DrawableHitObject drawableObjectPiece)
+                    drawableObjectPiece.ApplyCustomUpdateState += (dho, _) => applyDim(dho);
+                else
+                    applyDim(piece);
+            }
+
+            void applyDim(Drawable piece)
+            {
                 piece.FadeColour(new Color4(195, 195, 195, 255));
                 using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
                     piece.FadeColour(Color4.White, 100);

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuHitObject.cs
@@ -85,7 +85,12 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 // as they may be cleared via the `updateState()` DHO flow,
                 // so use `ApplyCustomUpdateState` instead. which does not have this pitfall.
                 if (piece is DrawableHitObject drawableObjectPiece)
-                    drawableObjectPiece.ApplyCustomUpdateState += (dho, _) => applyDim(dho);
+                {
+                    // this method can be called multiple times, and we don't want to subscribe to the event more than once,
+                    // so this is what it is going to have to be...
+                    drawableObjectPiece.ApplyCustomUpdateState -= applyDimToDrawableHitObject;
+                    drawableObjectPiece.ApplyCustomUpdateState += applyDimToDrawableHitObject;
+                }
                 else
                     applyDim(piece);
             }
@@ -96,6 +101,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 using (piece.BeginDelayedSequence(InitialLifetimeOffset - OsuHitWindows.MISS_WINDOW))
                     piece.FadeColour(Color4.White, 100);
             }
+
+            void applyDimToDrawableHitObject(DrawableHitObject dho, ArmedState _) => applyDim(dho);
         }
 
         protected sealed override double InitialLifetimeOffset => HitObject.TimePreempt;


### PR DESCRIPTION
Originally noticed during review of another change: https://github.com/ppy/osu/pull/27369#issuecomment-1966140198.

`DrawableOsuHitObject` tries to solve the initial dimming of objects by applying transform to a list of dimmable parts. For plain drawables this is safe, but if one of the parts is a DHO, it is not safe, because drawable transforms can be cleared at will.

In particular, on first use of a drawable slider, `UpdateInitialTransforms()` would fire via `LoadComplete()` on the `DrawableSlider`, but *then*, also via `LoadComplete()`, the `DrawableSliderTail` would update its own state and by doing so inadvertently clear the dim transform just added by the slider.

To fix, ensure dim transforms are applied to DHOs via `ApplyCustomUpdateState`.

https://github.com/ppy/osu/assets/20418176/62b5d3e4-3707-41e2-b516-7031dd434491