### PR TITLE
Change initial scroll effect to mod columns

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -346,7 +346,7 @@ namespace osu.Game.Overlays.Mods
             ScheduleAfterChildren(() =>
             {
                 columnScroll.ScrollToEnd(false);
-                columnScroll.ScrollTo(0, true, 0.0055);
+                columnScroll.ScrollTo(0);
             });
         }
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -341,12 +341,12 @@ namespace osu.Game.Overlays.Mods
                     column.SearchTerm = query.NewValue;
             }, true);
 
-            // Start scrolled slightly to the right to give the user a sense that
+            // Start scrolling from the end, to give the user a sense that
             // there is more horizontal content available.
             ScheduleAfterChildren(() =>
             {
-                columnScroll.ScrollTo(200, false);
-                columnScroll.ScrollToStart();
+                columnScroll.ScrollToEnd(false);
+                columnScroll.ScrollTo(0, true, 0.0055);
             });
         }
 


### PR DESCRIPTION
I've realized that, under certain circumstances, it can still happen that you don't quite understand the presence of scrolling in the overlay (even though you should sense it with the presence of a scrollbar, but whatever). It also happened recently that in the game chat, someone asked why there was no AutoPlay mod.

I also often noticed this in general, seeing the presence of an initial scrolling effect - but it's so sneaky/subtle that you can barely sense it, and wonder if it could have any effect.

This is the best result easily achieved by changing almost nothing. I don't know if I should use the `distanceDecay` in another way though, and **its value is completely arbitrary** after trying several of them.
This scroll effect starts from the end (which should be fine with the current number of columns, even on different/wider screen resolutions).

Even personally, changing this animation to a different/slower one can seem disorienting, but it is just a matter of habit and trying to forget the previous one.

- Before:
  
  https://github.com/ppy/osu/assets/43073074/b971de8c-7be8-416d-bbdc-3d3c31b9b035
  
- After:
  
  https://github.com/ppy/osu/assets/43073074/469be3e7-122d-4cad-86cf-723376adad8f
  