### PR TITLE
Fix wireframe misalignment in argon accuracy counter

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonAccuracyCounter.cs
@@ -75,21 +75,21 @@ namespace osu.Game.Screens.Play.HUD
                             AutoSizeAxes = Axes.Both,
                             Child = wholePart = new ArgonCounterTextComponent(Anchor.TopRight, BeatmapsetsStrings.ShowScoreboardHeadersAccuracy.ToUpper())
                             {
-                                RequiredDisplayDigits = { Value = 3 },
                                 WireframeOpacity = { BindTarget = WireframeOpacity },
+                                WireframeTemplate = @"###",
                                 ShowLabel = { BindTarget = ShowLabel },
                             }
                         },
                         fractionPart = new ArgonCounterTextComponent(Anchor.TopLeft)
                         {
-                            RequiredDisplayDigits = { Value = 2 },
                             WireframeOpacity = { BindTarget = WireframeOpacity },
+                            WireframeTemplate = @".##",
                             Scale = new Vector2(0.5f),
                         },
                         percentText = new ArgonCounterTextComponent(Anchor.TopLeft)
                         {
                             Text = @"%",
-                            RequiredDisplayDigits = { Value = 1 },
+                            WireframeTemplate = @"#",
                             WireframeOpacity = { BindTarget = WireframeOpacity }
                         },
                     }

--- a/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonComboCounter.cs
@@ -68,7 +68,10 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateWireframe()
         {
-            text.RequiredDisplayDigits.Value = getDigitsRequiredForDisplayCount();
+            int digitsRequiredForDisplayCount = getDigitsRequiredForDisplayCount();
+
+            if (digitsRequiredForDisplayCount != text.WireframeTemplate.Length)
+                text.WireframeTemplate = new string('#', digitsRequiredForDisplayCount);
         }
 
         private int getDigitsRequiredForDisplayCount()

--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Screens.Play.HUD
         private readonly OsuSpriteText labelText;
 
         public IBindable<float> WireframeOpacity { get; } = new BindableFloat();
-        public Bindable<int> RequiredDisplayDigits { get; } = new BindableInt();
         public Bindable<bool> ShowLabel { get; } = new BindableBool();
 
         public Container NumberContainer { get; private set; }
@@ -35,6 +34,18 @@ namespace osu.Game.Screens.Play.HUD
             get => textPart.Text;
             set => textPart.Text = value;
         }
+
+        /// <summary>
+        /// The template for the wireframe displayed behind the <see cref="Text"/>.
+        /// Any character other than a dot is interpreted to mean a full segmented display "wireframe".
+        /// </summary>
+        public string WireframeTemplate
+        {
+            get => wireframeTemplate;
+            set => wireframesPart.Text = wireframeTemplate = value;
+        }
+
+        private string wireframeTemplate = string.Empty;
 
         public ArgonCounterTextComponent(Anchor anchor, LocalisableString? label = null)
         {
@@ -69,8 +80,6 @@ namespace osu.Game.Screens.Play.HUD
                     }
                 }
             };
-
-            RequiredDisplayDigits.BindValueChanged(digits => wireframesPart.Text = new string('#', digits.NewValue));
         }
 
         private string textLookup(char c)

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Play.HUD
             int digitsRequiredForDisplayCount = Math.Max(RequiredDisplayDigits.Value, getDigitsRequiredForDisplayCount());
 
             if (digitsRequiredForDisplayCount != scoreText.WireframeTemplate.Length)
-                scoreText.WireframeTemplate = new string('#', Math.Max(RequiredDisplayDigits.Value, digitsRequiredForDisplayCount));
+                scoreText.WireframeTemplate = new string('#', digitsRequiredForDisplayCount);
         }
 
         private int getDigitsRequiredForDisplayCount()

--- a/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonScoreCounter.cs
@@ -58,8 +58,10 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateWireframe()
         {
-            scoreText.RequiredDisplayDigits.Value =
-                Math.Max(RequiredDisplayDigits.Value, getDigitsRequiredForDisplayCount());
+            int digitsRequiredForDisplayCount = Math.Max(RequiredDisplayDigits.Value, getDigitsRequiredForDisplayCount());
+
+            if (digitsRequiredForDisplayCount != scoreText.WireframeTemplate.Length)
+                scoreText.WireframeTemplate = new string('#', Math.Max(RequiredDisplayDigits.Value, digitsRequiredForDisplayCount));
         }
 
         private int getDigitsRequiredForDisplayCount()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27385.
- Supersedes / closes https://github.com/ppy/osu/pull/27392.

Basically the same as the patch in https://github.com/ppy/osu/pull/27392#issuecomment-1964207504, but with some unnecessary alloc trimming.