### PR TITLE
Hide osu!taiko scroller when the beatmap has storyboard

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoPlayerScroller.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoPlayerScroller.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Taiko.Skinning.Legacy;
+using osu.Game.Storyboards;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public partial class TestSceneTaikoPlayerScroller : LegacySkinPlayerTestScene
+    {
+        private Storyboard? currentStoryboard;
+
+        protected override bool HasCustomSteps => true;
+
+        [Test]
+        public void TestForegroundSpritesHidesScroller()
+        {
+            AddStep("load storyboard", () =>
+            {
+                currentStoryboard = new Storyboard();
+
+                for (int i = 0; i < 10; i++)
+                    currentStoryboard.GetLayer("Foreground").Add(new StoryboardSprite($"test{i}", Anchor.Centre, Vector2.Zero));
+            });
+
+            CreateTest();
+            AddAssert("taiko scroller not present", () => !this.ChildrenOfType<LegacyTaikoScroller>().Any());
+        }
+
+        [Test]
+        public void TestOverlaySpritesKeepsScroller()
+        {
+            AddStep("load storyboard", () =>
+            {
+                currentStoryboard = new Storyboard();
+
+                for (int i = 0; i < 10; i++)
+                    currentStoryboard.GetLayer("Overlay").Add(new StoryboardSprite($"test{i}", Anchor.Centre, Vector2.Zero));
+            });
+
+            CreateTest();
+            AddAssert("taiko scroller present", () => this.ChildrenOfType<LegacyTaikoScroller>().Single().IsPresent);
+        }
+
+        protected override Ruleset CreatePlayerRuleset() => new TaikoRuleset();
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
+            => base.CreateWorkingBeatmap(beatmap, currentStoryboard ?? storyboard);
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -54,14 +54,14 @@ namespace osu.Game.Rulesets.Taiko.UI
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(GameplayState gameplayState)
+        private void load([CanBeNull] GameplayState gameplayState)
         {
             new BarLineGenerator<BarLine>(Beatmap).BarLines.ForEach(bar => Playfield.Add(bar));
 
-            var spriteElements = gameplayState.Storyboard.Layers.Where(l => l.Name != @"Overlay")
+            var spriteElements = gameplayState?.Storyboard.Layers.Where(l => l.Name != @"Overlay")
                                               .SelectMany(l => l.Elements)
                                               .OfType<StoryboardSprite>()
-                                              .DistinctBy(e => e.Path);
+                                              .DistinctBy(e => e.Path) ?? Enumerable.Empty<StoryboardSprite>();
 
             if (spriteElements.Count() < 10)
             {

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Screens.Play
 {
@@ -41,6 +42,11 @@ namespace osu.Game.Screens.Play
         public readonly ScoreProcessor ScoreProcessor;
 
         /// <summary>
+        /// The storyboard associated with the beatmap.
+        /// </summary>
+        public readonly Storyboard Storyboard;
+
+        /// <summary>
         /// Whether gameplay completed without the user failing.
         /// </summary>
         public bool HasPassed { get; set; }
@@ -62,7 +68,7 @@ namespace osu.Game.Screens.Play
 
         private readonly Bindable<JudgementResult> lastJudgementResult = new Bindable<JudgementResult>();
 
-        public GameplayState(IBeatmap beatmap, Ruleset ruleset, IReadOnlyList<Mod>? mods = null, Score? score = null, ScoreProcessor? scoreProcessor = null)
+        public GameplayState(IBeatmap beatmap, Ruleset ruleset, IReadOnlyList<Mod>? mods = null, Score? score = null, ScoreProcessor? scoreProcessor = null, Storyboard? storyboard = null)
         {
             Beatmap = beatmap;
             Ruleset = ruleset;
@@ -76,6 +82,7 @@ namespace osu.Game.Screens.Play
             };
             Mods = mods ?? Array.Empty<Mod>();
             ScoreProcessor = scoreProcessor ?? ruleset.CreateScoreProcessor();
+            Storyboard = storyboard ?? new Storyboard();
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -255,7 +255,7 @@ namespace osu.Game.Screens.Play
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
             Score.ScoreInfo.Mods = gameplayMods;
 
-            dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor));
+            dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor, Beatmap.Value.Storyboard));
 
             var rulesetSkinProvider = new RulesetSkinProvidingContainer(ruleset, playableBeatmap, Beatmap.Value.Skin);
 
@@ -397,7 +397,7 @@ namespace osu.Game.Screens.Play
         protected virtual GameplayClockContainer CreateGameplayClockContainer(WorkingBeatmap beatmap, double gameplayStart) => new MasterGameplayClockContainer(beatmap, gameplayStart);
 
         private Drawable createUnderlayComponents() =>
-            DimmableStoryboard = new DimmableStoryboard(Beatmap.Value.Storyboard, GameplayState.Mods) { RelativeSizeAxes = Axes.Both };
+            DimmableStoryboard = new DimmableStoryboard(GameplayState.Storyboard, GameplayState.Mods) { RelativeSizeAxes = Axes.Both };
 
         private Drawable createGameplayComponents(IWorkingBeatmap working) => new ScalingContainer(ScalingMode.Gameplay)
         {
@@ -456,7 +456,7 @@ namespace osu.Game.Screens.Play
                     {
                         RequestSkip = performUserRequestedSkip
                     },
-                    skipOutroOverlay = new SkipOverlay(Beatmap.Value.Storyboard.LatestEventTime ?? 0)
+                    skipOutroOverlay = new SkipOverlay(GameplayState.Storyboard.LatestEventTime ?? 0)
                     {
                         RequestSkip = () => progressToResults(false),
                         Alpha = 0
@@ -1088,7 +1088,7 @@ namespace osu.Game.Screens.Play
 
             DimmableStoryboard.IsBreakTime.BindTo(breakTracker.IsBreakTime);
 
-            storyboardReplacesBackground.Value = Beatmap.Value.Storyboard.ReplacesBackground && Beatmap.Value.Storyboard.HasDrawable;
+            storyboardReplacesBackground.Value = GameplayState.Storyboard.ReplacesBackground && GameplayState.Storyboard.HasDrawable;
 
             foreach (var mod in GameplayState.Mods.OfType<IApplicableToPlayer>())
                 mod.ApplyToPlayer(this);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27189

The condition to determine the visibility of the scroller tries to mimic exactly how stable does it, as to not result in any inconvenience. Up to debate, I know we're not meant to copy everything from stable, but I'm not sure of any other solution to this. [Stable code, for reference](https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L747).

Beatmaps of interest:
 - https://dev.ppy.sh/beatmapsets/447342#taiko/960444 (has storyboard, should hide scroller)
 - https://dev.ppy.sh/beatmapsets/7743#osu/32763 (has storyboard, should hide scroller)
 - https://dev.ppy.sh/beatmapsets/10568#osu/41134 (has storyboard, should keep scroller shown)