### PR TITLE
Fix February 29 test failure

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -538,7 +538,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
             Assert.That(filterCriteria.LastPlayed.Max, Is.Not.Null);
             // the parser internally references `DateTimeOffset.Now`, so to not make things too annoying for tests, just assume some tolerance
             // (irrelevant in proportion to the actual filter proscribed).
-            Assert.That(filterCriteria.LastPlayed.Min, Is.EqualTo(DateTimeOffset.Now.AddYears(-1).AddMonths(-6)).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(filterCriteria.LastPlayed.Min, Is.EqualTo(DateTimeOffset.Now.AddMonths(-6).AddYears(-1)).Within(TimeSpan.FromSeconds(5)));
             Assert.That(filterCriteria.LastPlayed.Max, Is.EqualTo(DateTimeOffset.Now.AddMonths(-3)).Within(TimeSpan.FromSeconds(5)));
         }
 

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -402,19 +402,19 @@ namespace osu.Game.Screens.Select
                 // we'll want to flip the operator, such that `>5d` means "more than five days ago", as in "*before* five days ago",
                 // as intended by the user.
                 case Operator.Less:
-                    op = Operator.GreaterOrEqual;
-                    break;
-
-                case Operator.LessOrEqual:
                     op = Operator.Greater;
                     break;
 
+                case Operator.LessOrEqual:
+                    op = Operator.GreaterOrEqual;
+                    break;
+
                 case Operator.Greater:
-                    op = Operator.LessOrEqual;
+                    op = Operator.Less;
                     break;
 
                 case Operator.GreaterOrEqual:
-                    op = Operator.Less;
+                    op = Operator.LessOrEqual;
                     break;
             }
 

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -402,19 +402,19 @@ namespace osu.Game.Screens.Select
                 // we'll want to flip the operator, such that `>5d` means "more than five days ago", as in "*before* five days ago",
                 // as intended by the user.
                 case Operator.Less:
-                    op = Operator.Greater;
-                    break;
-
-                case Operator.LessOrEqual:
                     op = Operator.GreaterOrEqual;
                     break;
 
+                case Operator.LessOrEqual:
+                    op = Operator.Greater;
+                    break;
+
                 case Operator.Greater:
-                    op = Operator.Less;
+                    op = Operator.LessOrEqual;
                     break;
 
                 case Operator.GreaterOrEqual:
-                    op = Operator.LessOrEqual;
+                    op = Operator.Less;
                     break;
             }
 


### PR DESCRIPTION
When subtracting a month, `AddMonths` [will output February 28 for non-leap years and February 29 for leap years](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.addmonths?view=net-7.0#remarks). This means that subtracting a year and then a month from a date is not equivalent to subtracting a month and then a year from a date, as this changes the leap-year-ness of the month subtraction.

~~(also fixes a war crime against mathematics, but this change is insignificant, as it only makes a difference on a microscopic scale)~~