### PR TITLE
Fix allocations in `EffectPointVisualisation`

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -53,7 +52,18 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             // for changes. ControlPointInfo needs a refactor to make this flow better, but it should do for now.
             Scheduler.AddDelayed(() =>
             {
-                var next = beatmap.ControlPointInfo.EffectPoints.FirstOrDefault(c => c.Time > effect.Time);
+                EffectControlPoint? next = null;
+
+                for (int i = 0; i < beatmap.ControlPointInfo.EffectPoints.Count; i++)
+                {
+                    var point = beatmap.ControlPointInfo.EffectPoints[i];
+
+                    if (point.Time > effect.Time)
+                    {
+                        next = point;
+                        break;
+                    }
+                }
 
                 if (!ReferenceEquals(nextControlPoint, next))
                 {


### PR DESCRIPTION
Affects editor for maps with many effect points.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/8d062353-4cc1-45b5-85cb-58d4d909b354)|![pr](https://github.com/ppy/osu/assets/22874522/7530d7c0-71e1-4a17-a627-1eb2394f5316)|