### PR TITLE
When discord is set to privacy mode, don't show beatmap being edited

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserPanel.cs
@@ -14,7 +14,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Osu;
 using osu.Game.Scoring;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Users;
@@ -142,7 +141,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("choosing", () => activity.Value = new UserActivity.ChoosingBeatmap());
             AddStep("editing beatmap", () => activity.Value = new UserActivity.EditingBeatmap(new BeatmapInfo()));
             AddStep("modding beatmap", () => activity.Value = new UserActivity.ModdingBeatmap(new BeatmapInfo()));
-            AddStep("testing beatmap", () => activity.Value = new UserActivity.TestingBeatmap(new BeatmapInfo(), new OsuRuleset().RulesetInfo));
+            AddStep("testing beatmap", () => activity.Value = new UserActivity.TestingBeatmap(new BeatmapInfo()));
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
         private readonly Editor editor;
         private readonly EditorState editorState;
 
-        protected override UserActivity InitialActivity => new UserActivity.TestingBeatmap(Beatmap.Value.BeatmapInfo, Ruleset.Value);
+        protected override UserActivity InitialActivity => new UserActivity.TestingBeatmap(Beatmap.Value.BeatmapInfo);
 
         [Resolved]
         private MusicController musicController { get; set; } = null!;

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -151,7 +151,11 @@ namespace osu.Game.Users
             public EditingBeatmap() { }
 
             public override string GetStatus(bool hideIdentifiableInformation = false) => @"Editing a beatmap";
-            public override string GetDetails(bool hideIdentifiableInformation = false) => BeatmapDisplayTitle;
+
+            public override string GetDetails(bool hideIdentifiableInformation = false) => hideIdentifiableInformation
+                // For now let's assume that showing the beatmap a user is editing could reveal unwanted information.
+                ? string.Empty
+                : BeatmapDisplayTitle;
         }
 
         [MessagePackObject]

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Users
         [MessagePackObject]
         public class TestingBeatmap : EditingBeatmap
         {
-            public TestingBeatmap(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)
+            public TestingBeatmap(IBeatmapInfo beatmapInfo)
                 : base(beatmapInfo)
             {
             }

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -119,10 +119,10 @@ namespace osu.Game.Users
         }
 
         [MessagePackObject]
-        public class TestingBeatmap : InGame
+        public class TestingBeatmap : EditingBeatmap
         {
             public TestingBeatmap(IBeatmapInfo beatmapInfo, IRulesetInfo ruleset)
-                : base(beatmapInfo, ruleset)
+                : base(beatmapInfo)
             {
             }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27438.

Scenarios include
- Editing one's own map and revealing their username in the creator field
- Editing a private beatmap by someone else (ie. an unrevealed pool beatmap for a tournament)