### PR TITLE
Remove useless DrawablePool in `ColourHitErrorMeter`

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/ColourHitErrorMeter.cs
@@ -107,8 +107,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                 JudgementSpacing.BindValueChanged(_ => updateMetrics(), true);
             }
 
-            private readonly DrawablePool<HitErrorShape> judgementLinePool = new DrawablePool<HitErrorShape>(50);
-
             public void Push(HitErrorShape shape)
             {
                 Add(shape);


### PR DESCRIPTION
pr https://github.com/ppy/osu/pull/26549/ move the drawable pool to `ColourHitErrorMeter` but `JudgementFlow` one was not deleted.

it caused a not-collected(?) drawable pool every gameplay

![image](https://github.com/ppy/osu/assets/34775378/5e97e740-d93f-4c9e-adbc-2fff52164d35)

before this pr:

https://github.com/ppy/osu/assets/34775378/5ebf72c7-363b-47a5-a66b-60433f80545c

after this pr:

https://github.com/ppy/osu/assets/34775378/28393919-8d35-44a3-9f68-a75f031693c1
