### PR TITLE
Add sound feedback when changing editor screen via key bindings

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -1,34 +1,41 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel;
+using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Testing;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    [Description("SongSelect filter control")]
-    public partial class TestSceneTabControl : OsuTestScene
+    public partial class TestSceneTabControl : OsuManualInputManagerTestScene
     {
-        public TestSceneTabControl()
+        private OsuSpriteText text = null!;
+        private OsuTabControl<GroupMode> filter = null!;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
         {
-            OsuSpriteText text;
-            OsuTabControl<GroupMode> filter;
-            Add(filter = new OsuTabControl<GroupMode>
+            Children = new Drawable[]
             {
-                Margin = new MarginPadding(4),
-                Size = new Vector2(229, 24),
-                AutoSort = true
-            });
-            Add(text = new OsuSpriteText
-            {
-                Text = "None",
-                Margin = new MarginPadding(4),
-                Position = new Vector2(275, 5)
-            });
+                filter = new OsuTabControl<GroupMode>
+                {
+                    Margin = new MarginPadding(4),
+                    Size = new Vector2(229, 24),
+                    AutoSort = true
+                },
+                text = new OsuSpriteText
+                {
+                    Text = "None",
+                    Margin = new MarginPadding(4),
+                    Position = new Vector2(275, 5)
+                }
+            };
 
             filter.PinItem(GroupMode.All);
             filter.PinItem(GroupMode.RecentlyPlayed);
@@ -37,6 +44,29 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 text.Text = "Currently Selected: " + grouping.NewValue.ToString();
             };
+        });
+
+        [Test]
+        public void TestSelection()
+        {
+            AddStep("select by user click", () =>
+            {
+                filter.Current.SetDefault();
+                InputManager.MoveMouseTo(filter.ChildrenOfType<OsuTabControl<GroupMode>.OsuTabItem>().Single(t => t.Value == GroupMode.RecentlyPlayed));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("select programmatically with feedback", () =>
+            {
+                filter.Current.SetDefault();
+                filter.SelectTabWithSound(GroupMode.RecentlyPlayed);
+            });
+
+            AddStep("select programmatically by bindable", () =>
+            {
+                filter.Current.SetDefault();
+                filter.Current.Value = GroupMode.RecentlyPlayed;
+            });
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -45,15 +45,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (buttons.Contains(e.Button))
-            {
-                var channel = Enabled.Value ? sampleClick?.GetChannel() : sampleClickDisabled?.GetChannel();
-
-                if (channel != null)
-                {
-                    channel.Frequency.Value = 0.99 + RNG.NextDouble(0.02);
-                    channel.Play();
-                }
-            }
+                PlayClickSample();
 
             return base.OnClick(e);
         }
@@ -64,6 +56,17 @@ namespace osu.Game.Graphics.UserInterface
                 return;
 
             base.PlayHoverSample();
+        }
+
+        public void PlayClickSample()
+        {
+            var channel = Enabled.Value ? sampleClick?.GetChannel() : sampleClickDisabled?.GetChannel();
+
+            if (channel != null)
+            {
+                channel.Frequency.Value = 0.99 + RNG.NextDouble(0.02);
+                channel.Play();
+            }
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -98,6 +98,14 @@ namespace osu.Game.Graphics.UserInterface
                 strip.Width = Interpolation.ValueAt(Math.Clamp(Clock.ElapsedFrameTime, 0, 1000), strip.Width, StripWidth, 0, 500, Easing.OutQuint);
         }
 
+        public void SelectTabWithSound(T item)
+        {
+            Current.Value = item;
+
+            if (SelectedTab is OsuTabItem selectedTab)
+                selectedTab.TabSelectSounds.PlayClickSample();
+        }
+
         public partial class OsuTabItem : TabItem<T>, IHasAccentColour
         {
             protected readonly SpriteText Text;
@@ -150,6 +158,8 @@ namespace osu.Game.Graphics.UserInterface
                     AccentColour = colours.Blue;
             }
 
+            public HoverClickSounds TabSelectSounds { get; }
+
             public OsuTabItem(T value)
                 : base(value)
             {
@@ -196,7 +206,7 @@ namespace osu.Game.Graphics.UserInterface
                         Origin = Anchor.BottomLeft,
                         Anchor = Anchor.BottomLeft,
                     },
-                    new HoverClickSounds(HoverSampleSet.TabSelect)
+                    TabSelectSounds = new HoverClickSounds(HoverSampleSet.TabSelect)
                 };
             }
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -197,6 +197,8 @@ namespace osu.Game.Screens.Edit
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
 
+        private EditorScreenSwitcherControl switcherControl;
+
         private Bindable<float> editorBackgroundDim;
         private Bindable<bool> editorHitMarkers;
         private Bindable<bool> editorAutoSeekOnPlacement;
@@ -372,7 +374,7 @@ namespace osu.Game.Screens.Edit
                                     }
                                 }
                             },
-                            new EditorScreenSwitcherControl
+                            switcherControl = new EditorScreenSwitcherControl
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,
@@ -662,23 +664,23 @@ namespace osu.Game.Screens.Edit
                     return true;
 
                 case GlobalAction.EditorComposeMode:
-                    Mode.Value = EditorScreenMode.Compose;
+                    switcherControl.SelectTabWithSound(EditorScreenMode.Compose);
                     return true;
 
                 case GlobalAction.EditorDesignMode:
-                    Mode.Value = EditorScreenMode.Design;
+                    switcherControl.SelectTabWithSound(EditorScreenMode.Design);
                     return true;
 
                 case GlobalAction.EditorTimingMode:
-                    Mode.Value = EditorScreenMode.Timing;
+                    switcherControl.SelectTabWithSound(EditorScreenMode.Timing);
                     return true;
 
                 case GlobalAction.EditorSetupMode:
-                    Mode.Value = EditorScreenMode.SongSetup;
+                    switcherControl.SelectTabWithSound(EditorScreenMode.SongSetup);
                     return true;
 
                 case GlobalAction.EditorVerifyMode:
-                    Mode.Value = EditorScreenMode.Verify;
+                    switcherControl.SelectTabWithSound(EditorScreenMode.Verify);
                     return true;
 
                 case GlobalAction.EditorTestGameplay:


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27400

I've took an explicit approach towards this. Playing sounds for every change to tab selection in every `OsuTabControl` gets too crowded when it's a secondary operation, e.g. the video attached in https://github.com/ppy/osu/issues/27400#issuecomment-1973216307. Instead, I believe it is rather better to add sound feedback on a case-by-case manner.