### PR TITLE
Fix file association descriptions not being written when updating from an older version

### DIFF
--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -82,6 +82,10 @@ namespace osu.Desktop.Windows
             try
             {
                 updateAssociations();
+
+                // TODO: Remove once UpdateDescriptions() is called as specified in the xmldoc.
+                updateDescriptions(null); // always write default descriptions, in case of updating from an older version in which file associations were not implemented/installed
+
                 NotifyShellUpdate();
             }
             catch (Exception e)


### PR DESCRIPTION
- Fixes an oversight from https://github.com/ppy/osu/pull/27001

When updating an older version to the one where file associations are implemented, `InstallAssociations()` is never called, instead only `UpdateAssociations()` is called. I forgot to account for this case.

This would result in the file association descriptions never being written. This is only a cosmetic issue, as the file and URI associations work as expected:

![image](https://github.com/ppy/osu/assets/16479013/c146033a-0419-4c73-b847-8b0d95feb3c9)

Can be tested by manually invoking the static method `UpdateAssociations()` without previously calling `InstallAssociations()`.