### PR TITLE
Fix osu!mania key images potentially showing gaps between columns

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Mania.UI;
@@ -49,14 +50,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                     upSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
-                        Texture = skin.GetTexture(upImage),
+                        Texture = skin.GetTexture(upImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                         RelativeSizeAxes = Axes.X,
                         Width = 1
                     },
                     downSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
-                        Texture = skin.GetTexture(downImage),
+                        Texture = skin.GetTexture(downImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                         RelativeSizeAxes = Axes.X,
                         Width = 1,
                         Alpha = 0

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
@@ -47,19 +47,18 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                 AutoSizeAxes = Axes.Y,
                 Children = new Drawable[]
                 {
+                    // Key images are placed side-to-side on the playfield, therefore ClampToEdge must be used to prevent any gaps between each key.
                     upSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
-                        // ClampToEdge is used to avoid gaps between keys, see: https://github.com/ppy/osu/issues/27431
-                        Texture = skin.GetTexture(upImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
+                        Texture = skin.GetTexture(upImage, WrapMode.ClampToEdge, default),
                         RelativeSizeAxes = Axes.X,
                         Width = 1
                     },
                     downSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
-                        // ClampToEdge is used to avoid gaps between keys, see: https://github.com/ppy/osu/issues/27431
-                        Texture = skin.GetTexture(downImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
+                        Texture = skin.GetTexture(downImage, WrapMode.ClampToEdge, default),
                         RelativeSizeAxes = Axes.X,
                         Width = 1,
                         Alpha = 0

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyKeyArea.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                     upSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
+                        // ClampToEdge is used to avoid gaps between keys, see: https://github.com/ppy/osu/issues/27431
                         Texture = skin.GetTexture(upImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                         RelativeSizeAxes = Axes.X,
                         Width = 1
@@ -57,6 +58,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                     downSprite = new Sprite
                     {
                         Origin = Anchor.BottomCentre,
+                        // ClampToEdge is used to avoid gaps between keys, see: https://github.com/ppy/osu/issues/27431
                         Texture = skin.GetTexture(downImage, WrapMode.ClampToEdge, WrapMode.ClampToEdge),
                         RelativeSizeAxes = Axes.X,
                         Width = 1,


### PR DESCRIPTION
- Workaround for https://github.com/ppy/osu/issues/27431

| Before | After |
|--------|--------|
| ![CleanShot 2024-03-01 at 22 52 59](https://github.com/ppy/osu/assets/22781491/71d021e2-844f-43f9-b1ba-6f416d133ee7) | ![CleanShot 2024-03-01 at 22 53 28](https://github.com/ppy/osu/assets/22781491/15eba055-0b13-4f89-b041-832960c05ca2) |

(notice the gaps between columns below the white/cyan keys)

If merged, I will move the linked issue thread over to ppy/osu-framework to track the underlying issue, as we probably need to look into it at some point.

Skin used: https://github.com/ppy/osu/issues/27431#issuecomment-1973419601