### PR TITLE
Fix catch pp calculator not matching live with respect to miss handling

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -2,22 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
 
 namespace osu.Game.Rulesets.Catch.Difficulty
 {
     public class CatchPerformanceCalculator : PerformanceCalculator
     {
-        private int fruitsHit;
-        private int ticksHit;
-        private int tinyTicksHit;
-        private int tinyTicksMissed;
-        private int misses;
+        private int num300;
+        private int num100;
+        private int num50;
+        private int numKatu;
+        private int numMiss;
 
         public CatchPerformanceCalculator()
             : base(new CatchRuleset())
@@ -28,11 +27,11 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         {
             var catchAttributes = (CatchDifficultyAttributes)attributes;
 
-            fruitsHit = score.Statistics.GetValueOrDefault(HitResult.Great);
-            ticksHit = score.Statistics.GetValueOrDefault(HitResult.LargeTickHit);
-            tinyTicksHit = score.Statistics.GetValueOrDefault(HitResult.SmallTickHit);
-            tinyTicksMissed = score.Statistics.GetValueOrDefault(HitResult.SmallTickMiss);
-            misses = score.Statistics.GetValueOrDefault(HitResult.Miss);
+            num300 = score.GetCount300() ?? 0; // HitResult.Great
+            num100 = score.GetCount100() ?? 0; // HitResult.LargeTickHit
+            num50 = score.GetCount50() ?? 0; // HitResult.SmallTickHit
+            numKatu = score.GetCountKatu() ?? 0; // HitResult.SmallTickMiss
+            numMiss = score.GetCountMiss() ?? 0; // HitResult.Miss PLUS HitResult.LargeTickMiss
 
             // We are heavily relying on aim in catch the beat
             double value = Math.Pow(5.0 * Math.Max(1.0, catchAttributes.StarRating / 0.0049) - 4.0, 2.0) / 100000.0;
@@ -45,7 +44,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
                 (numTotalHits > 2500 ? Math.Log10(numTotalHits / 2500.0) * 0.475 : 0.0);
             value *= lengthBonus;
 
-            value *= Math.Pow(0.97, misses);
+            value *= Math.Pow(0.97, numMiss);
 
             // Combo scaling
             if (catchAttributes.MaxCombo > 0)
@@ -86,8 +85,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         }
 
         private double accuracy() => totalHits() == 0 ? 0 : Math.Clamp((double)totalSuccessfulHits() / totalHits(), 0, 1);
-        private int totalHits() => tinyTicksHit + ticksHit + fruitsHit + misses + tinyTicksMissed;
-        private int totalSuccessfulHits() => tinyTicksHit + ticksHit + fruitsHit;
-        private int totalComboHits() => misses + ticksHit + fruitsHit;
+        private int totalHits() => num50 + num100 + num300 + numMiss + numKatu;
+        private int totalSuccessfulHits() => num50 + num100 + num300;
+        private int totalComboHits() => numMiss + num100 + num300;
     }
 }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -432,7 +432,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
             CultureInfo.CurrentCulture = originalCulture;
         }
 
-        private class TestLegacyScoreDecoder : LegacyScoreDecoder
+        public class TestLegacyScoreDecoder : LegacyScoreDecoder
         {
             private readonly int beatmapVersion;
 

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreEncoderTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using osu.Game.Beatmaps.Formats;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
+using osu.Game.Tests.Resources;
+
+namespace osu.Game.Tests.Beatmaps.Formats
+{
+    public class LegacyScoreEncoderTest
+    {
+        [TestCase(1, 3)]
+        [TestCase(1, 0)]
+        [TestCase(0, 3)]
+        public void CatchMergesFruitAndDropletMisses(int missCount, int largeTickMissCount)
+        {
+            var ruleset = new CatchRuleset().RulesetInfo;
+
+            var scoreInfo = TestResources.CreateTestScoreInfo(ruleset);
+            var beatmap = new TestBeatmap(ruleset);
+            scoreInfo.Statistics = new Dictionary<HitResult, int>
+            {
+                [HitResult.Great] = 50,
+                [HitResult.LargeTickHit] = 5,
+                [HitResult.Miss] = missCount,
+                [HitResult.LargeTickMiss] = largeTickMissCount
+            };
+            var score = new Score { ScoreInfo = scoreInfo };
+
+            var decodedAfterEncode = encodeThenDecode(LegacyBeatmapDecoder.LATEST_VERSION, score, beatmap);
+
+            Assert.That(decodedAfterEncode.ScoreInfo.GetCountMiss(), Is.EqualTo(missCount + largeTickMissCount));
+        }
+
+        private static Score encodeThenDecode(int beatmapVersion, Score score, TestBeatmap beatmap)
+        {
+            var encodeStream = new MemoryStream();
+
+            var encoder = new LegacyScoreEncoder(score, beatmap);
+            encoder.Encode(encodeStream);
+
+            var decodeStream = new MemoryStream(encodeStream.GetBuffer());
+
+            var decoder = new LegacyScoreDecoderTest.TestLegacyScoreDecoder(beatmapVersion);
+            var decodedAfterEncode = decoder.Parse(decodeStream);
+            return decodedAfterEncode;
+        }
+    }
+}

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -198,10 +198,25 @@ namespace osu.Game.Scoring.Legacy
             }
         }
 
-        public static int? GetCountMiss(this ScoreInfo scoreInfo) =>
-            getCount(scoreInfo, HitResult.Miss);
+        public static int? GetCountMiss(this ScoreInfo scoreInfo)
+        {
+            switch (scoreInfo.Ruleset.OnlineID)
+            {
+                case 0:
+                case 1:
+                case 3:
+                    return getCount(scoreInfo, HitResult.Miss);
+
+                case 2:
+                    return (getCount(scoreInfo, HitResult.Miss) ?? 0) + (getCount(scoreInfo, HitResult.LargeTickMiss) ?? 0);
+            }
+
+            return null;
+        }
 
         public static void SetCountMiss(this ScoreInfo scoreInfo, int value) =>
+            // this does not match the implementation of `GetCountMiss()` for catch,
+            // but we physically cannot recover that data anymore at this point.
             scoreInfo.Statistics[HitResult.Miss] = value;
 
         private static int? getCount(ScoreInfo scoreInfo, HitResult result)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27473
- [x] Needs sheet (I will run locally overnight or something, actions workflow is broken)

Field renames in `CatchPerformanceCalculator` are purposefully obfuscatory to match [the actual live implementation](https://github.com/ppy/osu-performance/blob/8d10ac62a16cab663f79025e099d23fc529e65e3/src/performance/catch/CatchScore.cpp) closer.

For reference:

| | stable `IncreaseScoreType` | stable replay field | lazer `HitResult` |
| :- | :- | :- | :- |
| fruit hit | `Hit300` [^fruit-stable] | `Count300` [^hit300] | `Great` |
| fruit missed | `Miss` [^fruit-stable] | `CountMiss` [^miss] | `Miss` |
| droplet hit | `FruitTick` [^droplet-stable] | `Count100` [^fruit-tick] | `LargeTickHit` |
| droplet missed | `Miss` [^droplet-stable] | `CountMiss` [^miss] | `LargeTickMiss` |
| tiny droplet hit | `FruitTickTiny` [^tiny-droplet-stable] | `Count50` [^fruit-tick-tiny] | `SmallTickHit` |
| tiny droplet missed | `FruitTickTinyMiss` [^tiny-droplet-stable] | `CountKatu` [^fruit-tick-tiny-miss] | `SmallTickMiss` |
| banana hit | `SpinnerBonus` [^banana-stable] | - [^spinner-bonus] | `LargeBonus` |
| banana missed | `Ignore` [^banana-stable] | - [^ignore] | `IgnoreMiss` |

[^fruit-stable]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameplayElements/HitObjects/Fruits/HitCircleFruits.cs#L123-L131
[^droplet-stable]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameplayElements/HitObjects/Fruits/HitCircleFruitsTick.cs#L41-L49
[^tiny-droplet-stable]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameplayElements/HitObjects/Fruits/HitCircleFruitsTickTiny.cs#L34-L43
[^banana-stable]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameplayElements/HitObjects/Fruits/HitCircleFruitsSpin.cs#L66-L83
[^hit300]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L858-L869
[^miss]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L770-L776
[^fruit-tick]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L951-L956
[^fruit-tick-tiny]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L957-L963
[^fruit-tick-tiny-miss]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L964-L967
[^spinner-bonus]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L946-L950
[^ignore]: https://github.com/peppy/osu-stable-reference/blob/46cd3a10af7cc6cc96f4eba92ef1812dc8c3a27e/osu!/GameModes/Play/Rulesets/Ruleset.cs#L740