### PR TITLE
Update F rank badge colours to match latest designs

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneDrawableRank.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneDrawableRank.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Online.Leaderboards;
+using osu.Game.Scoring;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Ranking
+{
+    public partial class TestSceneDrawableRank : OsuTestScene
+    {
+        [Test]
+        public void TestAllRanks()
+        {
+            AddStep("create content", () => Child = new FillFlowContainer<DrawableRank>
+            {
+                AutoSizeAxes = Axes.X,
+                RelativeSizeAxes = Axes.Y,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Direction = FillDirection.Vertical,
+                Padding = new MarginPadding(20),
+                Spacing = new Vector2(10),
+                ChildrenEnumerable = Enum.GetValues<ScoreRank>().OrderBy(v => v).Select(rank => new DrawableRank(rank)
+                {
+                    RelativeSizeAxes = Axes.None,
+                    Size = new Vector2(50, 25),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                })
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/OsuColour.cs
+++ b/osu.Game/Graphics/OsuColour.cs
@@ -63,8 +63,12 @@ namespace osu.Game.Graphics
                 case ScoreRank.C:
                     return Color4Extensions.FromHex(@"ff8e5d");
 
-                default:
+                case ScoreRank.D:
                     return Color4Extensions.FromHex(@"ff5a5a");
+
+                case ScoreRank.F:
+                default:
+                    return Color4Extensions.FromHex(@"3f3f3f");
             }
         }
 

--- a/osu.Game/Online/Leaderboards/DrawableRank.cs
+++ b/osu.Game/Online/Leaderboards/DrawableRank.cs
@@ -95,8 +95,12 @@ namespace osu.Game.Online.Leaderboards
                 case ScoreRank.C:
                     return Color4Extensions.FromHex(@"473625");
 
-                default:
+                case ScoreRank.D:
                     return Color4Extensions.FromHex(@"512525");
+
+                case ScoreRank.F:
+                default:
+                    return Color4Extensions.FromHex(@"CC3333");
             }
         }
     }


### PR DESCRIPTION
During other travels I noticed that web has a proper F rank badge now since https://github.com/ppy/osu-web/commit/a93a4398c46b4715fb4c48f35bfcba3f06797100 rather than just changing text on D. So here's a diff that brings this across.

It's a bit not-quite-matching because the web asset appears to be using a different font than Venera. It's directly [pulled from figma, though](https://www.figma.com/file/VIkXMYNPMtQem2RJg9k2iQ/Master-Library?type=design&node-id=4581-7057&mode=design&t=O6c4ViUgkSuTl3Gk-4), so...

| test scene | song select leaderboard | results screen (notice no glow) |
| :-: | :-: | :-: |
| ![1709560112](https://github.com/ppy/osu/assets/20418176/f0f6a71b-d50e-44a3-a650-8b0651101476) | ![osu_2024-03-04_14-47-09](https://github.com/ppy/osu/assets/20418176/bac57547-f31d-40d7-88f4-82e24660cda6) | ![osu_2024-03-04_14-46-59](https://github.com/ppy/osu/assets/20418176/6a6b63aa-3407-4f73-99da-9e86ed5df42d) |
