### PR TITLE
Use new ToDictionary() overload without delegates

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -245,8 +245,8 @@ namespace osu.Game.Online.API.Requests.Responses
             RulesetID = score.RulesetID,
             Passed = score.Passed,
             Mods = score.APIMods,
-            Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
-            MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
+            MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
+++ b/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
@@ -42,8 +42,8 @@ namespace osu.Game.Scoring.Legacy
         {
             OnlineID = score.OnlineID,
             Mods = score.APIMods,
-            Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
-            MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
+            MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             ClientVersion = score.ClientVersion,
         };
     }


### PR DESCRIPTION
Since .NET 8 `ToDictionary()` has an overload for `IEnumerable<KeyValuePair<TKey, TValue>>` , which is cleaner and also a bit faster/reduces allocations.