### PR TITLE
Never set `waitingOnFrames` if a replay is not attached

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -189,7 +189,7 @@ namespace osu.Game.Rulesets.UI
             double timeBehind = Math.Abs(proposedTime - referenceClock.CurrentTime);
 
             isCatchingUp.Value = timeBehind > 200;
-            waitingOnFrames.Value = state == PlaybackState.NotValid;
+            waitingOnFrames.Value = hasReplayAttached && state == PlaybackState.NotValid;
 
             manualClock.CurrentTime = proposedTime;
             manualClock.Rate = Math.Abs(referenceClock.Rate) * direction;

--- a/osu.Game/Screens/Play/GameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/GameplayClockContainer.cs
@@ -122,8 +122,17 @@ namespace osu.Game.Screens.Play
             StopGameplayClock();
         }
 
-        protected virtual void StartGameplayClock() => GameplayClock.Start();
-        protected virtual void StopGameplayClock() => GameplayClock.Stop();
+        protected virtual void StartGameplayClock()
+        {
+            Logger.Log($"{nameof(GameplayClockContainer)} started via call to {nameof(StartGameplayClock)}");
+            GameplayClock.Start();
+        }
+
+        protected virtual void StopGameplayClock()
+        {
+            Logger.Log($"{nameof(GameplayClockContainer)} stopped via call to {nameof(StopGameplayClock)}");
+            GameplayClock.Stop();
+        }
 
         /// <summary>
         /// Resets this <see cref="GameplayClockContainer"/> and the source to an initial state ready for gameplay.


### PR DESCRIPTION
For next release to see if it helps with the seeking backwards issue. Or gives us more clues.