### PR TITLE
Fix osu! standardised score estimation algorithm violating basic invariants

### DIFF
--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -415,7 +415,7 @@ namespace osu.Game.Database
 
                     // Calculate how many times the longest combo the user has achieved in the play can repeat
                     // without exceeding the combo portion in score V1 as achieved by the player.
-                    // This it intentionally does not operate on object count and uses only score instead.
+                    // This intentionally does not operate on object count and uses only score instead.
                     double maximumOccurrencesOfLongestCombo = Math.Floor(comboPortionInScoreV1 / comboPortionFromLongestComboInScoreV1);
                     double comboPortionFromRepeatedLongestCombosInScoreV1 = maximumOccurrencesOfLongestCombo * comboPortionFromLongestComboInScoreV1;
 

--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -415,7 +415,7 @@ namespace osu.Game.Database
 
                     // Calculate how many times the longest combo the user has achieved in the play can repeat
                     // without exceeding the combo portion in score V1 as achieved by the player.
-                    // This is a pessimistic estimate; it intentionally does not operate on object count and uses only score instead.
+                    // This it intentionally does not operate on object count and uses only score instead.
                     double maximumOccurrencesOfLongestCombo = Math.Floor(comboPortionInScoreV1 / comboPortionFromLongestComboInScoreV1);
                     double comboPortionFromRepeatedLongestCombosInScoreV1 = maximumOccurrencesOfLongestCombo * comboPortionFromLongestComboInScoreV1;
 
@@ -426,13 +426,12 @@ namespace osu.Game.Database
                     // ...and then based on that raw combo length, we calculate how much this last combo is worth in standardised score.
                     double remainingComboPortionInStandardisedScore = Math.Pow(remainingCombo, 1 + ScoreProcessor.COMBO_EXPONENT);
 
-                    double lowerEstimateOfComboPortionInStandardisedScore
+                    double scoreBasedEstimateOfComboPortionInStandardisedScore
                         = maximumOccurrencesOfLongestCombo * comboPortionFromLongestComboInStandardisedScore
                           + remainingComboPortionInStandardisedScore;
 
                     // Compute approximate upper estimate new score for that play.
                     // This time, divide the remaining combo among remaining objects equally to achieve longest possible combo lengths.
-                    // There is no rigorous proof that doing this will yield a correct upper bound, but it seems to work out in practice.
                     remainingComboPortionInScoreV1 = comboPortionInScoreV1 - comboPortionFromLongestComboInScoreV1;
                     double remainingCountOfObjectsGivingCombo = maximumLegacyCombo - score.MaxCombo - score.Statistics.GetValueOrDefault(HitResult.Miss);
                     // Because we assumed all combos were equal, `remainingComboPortionInScoreV1`
@@ -449,7 +448,17 @@ namespace osu.Game.Database
                     // we can skip adding the 1 and just multiply by x ^ 0.5.
                     remainingComboPortionInStandardisedScore = remainingCountOfObjectsGivingCombo * Math.Pow(lengthOfRemainingCombos, ScoreProcessor.COMBO_EXPONENT);
 
-                    double upperEstimateOfComboPortionInStandardisedScore = comboPortionFromLongestComboInStandardisedScore + remainingComboPortionInStandardisedScore;
+                    double objectCountBasedEstimateOfComboPortionInStandardisedScore = comboPortionFromLongestComboInStandardisedScore + remainingComboPortionInStandardisedScore;
+
+                    // Enforce some invariants on both of the estimates.
+                    // In rare cases they can produce invalid results.
+                    scoreBasedEstimateOfComboPortionInStandardisedScore =
+                        Math.Clamp(scoreBasedEstimateOfComboPortionInStandardisedScore, 0, maximumAchievableComboPortionInStandardisedScore);
+                    objectCountBasedEstimateOfComboPortionInStandardisedScore =
+                        Math.Clamp(objectCountBasedEstimateOfComboPortionInStandardisedScore, 0, maximumAchievableComboPortionInStandardisedScore);
+
+                    double lowerEstimateOfComboPortionInStandardisedScore = Math.Min(scoreBasedEstimateOfComboPortionInStandardisedScore, objectCountBasedEstimateOfComboPortionInStandardisedScore);
+                    double upperEstimateOfComboPortionInStandardisedScore = Math.Max(scoreBasedEstimateOfComboPortionInStandardisedScore, objectCountBasedEstimateOfComboPortionInStandardisedScore);
 
                     // Approximate by combining lower and upper estimates.
                     // As the lower-estimate is very pessimistic, we use a 30/70 ratio

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -45,9 +45,10 @@ namespace osu.Game.Scoring.Legacy
         /// </description></item>
         /// <item><description>30000013: All local scores will use lazer definitions of ranks for consistency. Recalculates the rank of all scores.</description></item>
         /// <item><description>30000014: Fix edge cases in conversion for osu! scores on selected beatmaps. Reconvert all scores.</description></item>
+        /// <item><description>30000015: Fix osu! standardised score estimation algorithm violating basic invariants. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000014;
+        public const int LATEST_VERSION = 30000015;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27496

> [!WARNING]
> If this PR is merged, **all imported osu! scores will need to be re-verified**.

## Rationale

As it turns out, the "lower" and "upper" estimates of the combo portion of the score being converted were misnomers. In selected cases (scores with high accuracy but combo being lower than max by more than a few objects) the janky score-based math could overestimate the count of remaining objects in a map. For instance, in the case cited in the issue the numbers worked out something like this:

- Accuracy: practically 100%, which makes it basically irrelevant in the context of the score-based estimate
- Max combo on beatmap: 571x
- Max combo for score: 551x

The score-based estimation attempts to extract a "remaining object count" from score, by doing something along the lines of $\sqrt{571^2 - 551^2}$. That comes out to _almost 150_. Which leads to the estimation overshooting the total max combo count on the beatmap _by some hundred objects_.

To curtail this nonsense, enforce some basic invariants:

- Neither estimate is allowed to exceed maximum achievable
- Ensure that lower estimate is really lower and upper is really upper by just looking at the values and making sure that is so rather than just saying that it is.

## Testing

Spreadsheet: https://docs.google.com/spreadsheets/d/1DPtxdRZINENF2G1ymeZ6uF9EvFKy9KDHJx4rKXmn5FY/edit#gid=855782594

### Selected 5 biggest gains by relative %

| score | estimation on `master` | estimation with this PR | actual replay playback | comments |
| :- | -: | -: | -: | :- |
| https://osu.ppy.sh/scores/osu/4438670234 | 38,611 | 74,982 | 7,196 | Gimmick loved map. Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/2984235726 | 15,756 | 24,454 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/2232745438 | 18,188 | 27,705 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/3258433877 | 56,739 | 86,189 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/4282282416 | 17,335 | 25,794 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |

### Selected 5 biggest gains by absolute score

| score | estimation on `master` | estimation with this PR | actual replay playback | comments |
| :- | -: | -: | -: | :- |
| https://osu.ppy.sh/scores/osu/2295332227 | 283,504 | 338,700 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/2763122416 | 347,012 | 402,169 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/2314621963 | 884,463 | 934,894 | no replay | Short map. Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/4177483953 | 673,377 | 722,816 | no replay | Somewhat short map. Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |
| https://osu.ppy.sh/scores/osu/2467617229 | 239,540 | 285,508 | no replay | Change caused by the "lower" estimate being actually higher than the "higher" estimate on master. |

### Selected 5 biggest losses by relative %

| score | estimation on `master` | estimation with this PR | actual replay playback | comments |
| :- | -: | -: | -: | :- |
| https://osu.ppy.sh/scores/osu/3225520392 | 44,033 | 345 | no replay | Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2078834161 | 33,930 | 704 | no replay | Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2965554200 | 126,744 | 3,233 | no replay | Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/3159965190 | 31,803 | 882 | no replay | Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2966247419 | 136,437 | 3,967 | no replay | Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |

### Selected 5 biggest losses by absolute score

| score | estimation on `master` | estimation with this PR | actual replay playback | comments |
| :- | -: | -: | -: | :- |
| https://osu.ppy.sh/scores/osu/4442938195 | 3,358,923 | 1,150,845 | 1,140,191 | Estimated total score on master exceeds maximum possible. Estimated combo portion on master exceeded 1 which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/3002196141 | 861,713 | 32,834 | no replay | The "lower" estimate was actually higher than the "higher" estimate on master. Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2401254574 | 810,024 | 186,450 | no replay | The "lower" estimate was actually higher than the "higher" estimate on master. Estimated combo portion on master exceeded 1 which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2453690866 | 429,987 | 14,585 | no replay | The "lower" estimate was actually higher than the "higher" estimate on master. Estimated combo portion on master exceeded 1 by at least an order of magnitude which should be impossible. Was clearly broken. |
| https://osu.ppy.sh/scores/osu/2300168213 | 328,873 | 102,388 | no replay | The "lower" estimate was actually higher than the "higher" estimate on master. Estimated combo portion on master exceeded 1 which should be impossible. Was clearly broken. |

---

cc @zyfarok