### PR TITLE
Fix results screen accuracy circle not showing correctly for failed S with no flair

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -88,8 +88,21 @@ namespace osu.Game.Tests.Visual.Ranking
             AddAssert("play time not displayed", () => !this.ChildrenOfType<ExpandedPanelMiddleContent.PlayedOnText>().Any());
         }
 
-        private void showPanel(ScoreInfo score) =>
-            Child = new ExpandedPanelMiddleContentContainer(score);
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestFailedSDisplay(bool withFlair)
+        {
+            AddStep("show failed S score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(createTestBeatmap(new RealmUser()));
+                score.Rank = ScoreRank.A;
+                score.Accuracy = 0.975;
+                showPanel(score, withFlair);
+            });
+        }
+
+        private void showPanel(ScoreInfo score, bool withFlair = false) =>
+            Child = new ExpandedPanelMiddleContentContainer(score, withFlair);
 
         private BeatmapInfo createTestBeatmap([NotNull] RealmUser author)
         {
@@ -107,7 +120,7 @@ namespace osu.Game.Tests.Visual.Ranking
 
         private partial class ExpandedPanelMiddleContentContainer : Container
         {
-            public ExpandedPanelMiddleContentContainer(ScoreInfo score)
+            public ExpandedPanelMiddleContentContainer(ScoreInfo score, bool withFlair)
             {
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
@@ -119,7 +132,7 @@ namespace osu.Game.Tests.Visual.Ranking
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4Extensions.FromHex("#444"),
                     },
-                    new ExpandedPanelMiddleContent(score)
+                    new ExpandedPanelMiddleContent(score, withFlair)
                 };
             }
         }

--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -88,9 +88,8 @@ namespace osu.Game.Tests.Visual.Ranking
             AddAssert("play time not displayed", () => !this.ChildrenOfType<ExpandedPanelMiddleContent.PlayedOnText>().Any());
         }
 
-        [TestCase(false)]
-        [TestCase(true)]
-        public void TestFailedSDisplay(bool withFlair)
+        [Test]
+        public void TestFailedSDisplay([Values] bool withFlair)
         {
             AddStep("show failed S score", () =>
             {

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -194,11 +194,11 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                 rankText = new RankText(score.Rank)
             };
 
+            if (isFailedSDueToMisses)
+                AddInternal(failedSRankText = new RankText(ScoreRank.S));
+
             if (withFlair)
             {
-                if (isFailedSDueToMisses)
-                    AddInternal(failedSRankText = new RankText(ScoreRank.S));
-
                 var applauseSamples = new List<string> { applauseSampleName };
                 if (score.Rank >= ScoreRank.B)
                     // when rank is B or higher, play legacy applause sample on legacy skins.
@@ -326,24 +326,25 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                 {
                     rankText.Appear();
 
-                    if (!withFlair) return;
-
-                    Schedule(() =>
-                    {
-                        isTicking = false;
-                        rankImpactSound.Play();
-                    });
-
-                    const double applause_pre_delay = 545f;
-                    const double applause_volume = 0.8f;
-
-                    using (BeginDelayedSequence(applause_pre_delay))
+                    if (withFlair)
                     {
                         Schedule(() =>
                         {
-                            rankApplauseSound.VolumeTo(applause_volume);
-                            rankApplauseSound.Play();
+                            isTicking = false;
+                            rankImpactSound.Play();
                         });
+
+                        const double applause_pre_delay = 545f;
+                        const double applause_volume = 0.8f;
+
+                        using (BeginDelayedSequence(applause_pre_delay))
+                        {
+                            Schedule(() =>
+                            {
+                                rankApplauseSound.VolumeTo(applause_volume);
+                                rankApplauseSound.Play();
+                            });
+                        }
                     }
                 }
 


### PR DESCRIPTION
Because of an early return. Was confused with multiple `AccuracyCircle.withFlair` conditions all around the transform logic. Seems to be just for the samples and not the full flair (animation + samples). Seems to be renamed back in https://github.com/ppy/osu/commit/21a63efd7808a4c91647cc98846835f464890993 for the sake of matching the parent `ExpandedPanelMiddleContent`.

`ExpandedPanelMiddleContent` is the one handling whether the flair animation plays or not:
https://github.com/ppy/osu/blob/0881e7c8c1f003416cc37507ce6448f74e9d1a7f/osu.Game/Screens/Ranking/Expanded/ExpandedPanelMiddleContent.cs#L276-L277

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-06 at 10 56 21 PM](https://github.com/ppy/osu/assets/35318437/04af1bf2-8488-44b5-b7ba-9eef75fd40d8) | ![Screenshot 2024-03-06 at 10 58 17 PM](https://github.com/ppy/osu/assets/35318437/109c0f81-6b04-41f4-8c84-e006118ffd21) |