### PR TITLE
Fix missing event unbinds

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHidden.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Rulesets.Mods;
@@ -100,6 +101,14 @@ namespace osu.Game.Rulesets.Mania.Mods
                     return base.GetHeight(coverage);
 
                 return base.GetHeight(coverage) * reference_playfield_height / availablePlayfieldHeight;
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                if (skin.IsNotNull())
+                    skin.SourceChanged -= onSkinChanged;
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
@@ -263,6 +264,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 rect = RectangleF.Union(rect, difficultyPointPiece.ScreenSpaceDrawQuad.AABBFloat);
 
             return !Precision.AlmostIntersects(maskingBounds, rect);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (skin.IsNotNull())
+                skin.SourceChanged -= updateColour;
         }
 
         private partial class Tick : Circle


### PR DESCRIPTION
Thankfully these don't seem to be affecting much right now because gameplay/editor is relatively isolated via `RulesetSkinProvidingContainer`. 

But, from within the context of either, this could cause problems. For example, delete all hitobjects -> trigger skin change -> delegate still invoked on now-disposed `TimelineHitObjectBlueprint`s.

The same could happen for gameplay with, for example, [mod toggling](https://github.com/ppy/osu/pull/19925).