### PR TITLE
Extend maximum values in Difficulty Adjust to 12.5 for HP, AR, OD

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModDifficultyAdjust.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             MinValue = 0,
             MaxValue = 10,
             ExtendedMinValue = -10,
-            ExtendedMaxValue = 11,
+            ExtendedMaxValue = 12.5f,
             ReadCurrentFromDifficulty = diff => diff.ApproachRate,
         };
 

--- a/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
+++ b/osu.Game/Rulesets/Mods/ModDifficultyAdjust.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
-            ExtendedMaxValue = 11,
+            ExtendedMaxValue = 12.5f,
             ReadCurrentFromDifficulty = diff => diff.DrainRate,
         };
 
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Mods
             Precision = 0.1f,
             MinValue = 0,
             MaxValue = 10,
-            ExtendedMaxValue = 11,
+            ExtendedMaxValue = 12.5f,
             ReadCurrentFromDifficulty = diff => diff.OverallDifficulty,
         };
 


### PR DESCRIPTION
Changes the max extended value of HP, AR, and OD from 11 to 12.5 to match the maximum values of [McOsu](https://github.com/McKay42/McOsu).