### PR TITLE
Fix cross-talk between pooled `DrawableSliderRepeat` usage causing incorrect rotation

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             base.OnApply();
 
             Position = HitObject.Position - DrawableSlider.Position;
+            hasRotation = false;
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset) => DrawableSlider.SliderInputManager.TryJudgeNestedObject(this, timeOffset);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27433.

Tested using the suggested beatmap in the thread (https://osu.ppy.sh/beatmapsets/40440#osu/128718) which contains many repeat sliders in succession at the end of the beatmap..

I'm investigating the [second issue](https://github.com/ppy/osu/issues/27433#issuecomment-1971794221) reported in that thread but will fix separately.