### PR TITLE
Fix 1px flashlight gaps when gameplay scaling mode is active

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 PassCondition = () =>
                 {
                     var flashlightOverlay = Player.DrawableRuleset.Overlays
-                                                  .OfType<ModFlashlight<OsuHitObject>.Flashlight>()
+                                                  .ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>()
                                                   .First();
 
                     return Precision.AlmostEquals(mod.DefaultFlashlightSize * .5f, flashlightOverlay.GetSize());

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -88,7 +89,13 @@ namespace osu.Game.Rulesets.Mods
             flashlight.Combo.BindTo(Combo);
             flashlight.GetPlayfieldScale = () => drawableRuleset.Playfield.Scale;
 
-            drawableRuleset.Overlays.Add(flashlight);
+            drawableRuleset.Overlays.Add(new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                // workaround for 1px gaps on the edges of the playfield which would sometimes show with "gameplay" screen scaling active.
+                Padding = new MarginPadding(-1),
+                Child = flashlight,
+            });
         }
 
         protected abstract Flashlight CreateFlashlight();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27522.

Concerns mostly taiko and catch.

Not much of a proper fix rather than a workaround but it is what it is. I tried a few other things, including setting `MaskingSmoothness = 0` on the scaling container itself, to no avail.

| | master | this PR |
| :-: | :-: | :-: |
| osu![^ref] | ![osu_2024-03-08_10-43-42](https://github.com/ppy/osu/assets/20418176/8694e4aa-9214-4c5c-abf3-f080fa1c67d6) | ![osu_2024-03-08_10-52-16](https://github.com/ppy/osu/assets/20418176/0fd5c18f-be0f-467d-a6aa-cbc4633ae9de) |
| taiko[^issue] | ![osu_2024-03-08_10-44-19](https://github.com/ppy/osu/assets/20418176/c248939c-c296-4f71-8f48-4daedba384a7) | ![osu_2024-03-08_10-52-29](https://github.com/ppy/osu/assets/20418176/0264725a-929e-4d9f-9af5-081544c3fa7a) |
| catch[^issue] | ![osu_2024-03-08_10-44-57](https://github.com/ppy/osu/assets/20418176/91eb8133-9fed-47f1-b6d1-21ff8e89b1bb) | ![osu_2024-03-08_10-52-58](https://github.com/ppy/osu/assets/20418176/c8486b0e-eb8d-4014-b697-aa44e7b60c2a) |
| mania[^ref] | ![osu_2024-03-08_10-45-19](https://github.com/ppy/osu/assets/20418176/c2d1942b-d9c6-4a95-86c0-e1c4dcc57f72) | ![osu_2024-03-08_10-53-19](https://github.com/ppy/osu/assets/20418176/68e15a6e-4928-4663-81c1-93fbbaea1e69) |

Scaling settings used @ 1920x1080:

- horizontal position: 31%
- vertical position:   50%
- horizontal scale:    65%
- vertical scale:      93%

[^ref]: Just for visual reference that nothing has visually regressed.
[^issue]: There are actual 1px gaps visible here.