### PR TITLE
Add support for argon hitsounds

### DIFF
--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -80,6 +80,8 @@ namespace osu.Game.Audio
                     yield return $"Gameplay/{Bank}-{Name}{Suffix}";
 
                 yield return $"Gameplay/{Bank}-{Name}";
+
+                yield return $"Gameplay/{Name}";
             }
         }
 

--- a/osu.Game/Skinning/ArgonProSkin.cs
+++ b/osu.Game/Skinning/ArgonProSkin.cs
@@ -24,9 +24,11 @@ namespace osu.Game.Skinning
         {
             foreach (string lookup in sampleInfo.LookupNames)
             {
-                string remappedLookup = lookup.Replace(@"Gameplay/", @"Gameplay/ArgonPro/");
+                var sample = Samples?.Get(lookup)
+                             ?? Resources.AudioManager?.Samples.Get(lookup.Replace(@"Gameplay/", @"Gameplay/ArgonPro/"))
+                             ?? Resources.AudioManager?.Samples.Get(lookup.Replace(@"Gameplay/", @"Gameplay/Argon/"))
+                             ?? Resources.AudioManager?.Samples.Get(lookup);
 
-                var sample = Samples?.Get(remappedLookup) ?? Resources.AudioManager?.Samples.Get(remappedLookup);
                 if (sample != null)
                     return sample;
             }

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -77,7 +77,10 @@ namespace osu.Game.Skinning
         {
             foreach (string lookup in sampleInfo.LookupNames)
             {
-                var sample = Samples?.Get(lookup) ?? Resources.AudioManager?.Samples.Get(lookup);
+                var sample = Samples?.Get(lookup)
+                             ?? Resources.AudioManager?.Samples.Get(lookup.Replace(@"Gameplay/", @"Gameplay/Argon/"))
+                             ?? Resources.AudioManager?.Samples.Get(lookup);
+
                 if (sample != null)
                     return sample;
             }


### PR DESCRIPTION
This adds `Gameplay/Argon/` to the sample lookup paths for `ArgonSkin` in preperation for the new hitsounds. Also adds aforementioned path as a fallback for `ArgonProSkin`, allowing for shared samples to be used without having to duplicate them on disk. (argon and argon pro will be sharing spinner samples, `combobreak`, `failsound`, and likely `sectionpass`/`sectionfail` eventually)

Put another way:
argon sample lookup priority: beatmap > argon > default/triangles
argon pro sample lookup priority: beatmap > argon pro > argon > default/triangles

It should be safe to merge this separately from the sample resources, as the sample lookup fallback logic ensures argon will use default/triangles hitsounds if the new resources aren't there.