### PR TITLE
Wrap beatmap listing filters and match web spacing

### DIFF
--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Overlays.BeatmapListing
                                 RelativeSizeAxes = Axes.X,
                                 Direction = FillDirection.Vertical,
                                 Padding = new MarginPadding { Horizontal = 10 },
+                                Spacing = new Vector2(5),
                                 Children = new Drawable[]
                                 {
                                     generalFilter = new BeatmapSearchGeneralFilterRow(),

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchFilterRow.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Graphics.UserInterface;
 using osuTK;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Localisation;
@@ -49,8 +47,6 @@ namespace osu.Game.Overlays.BeatmapListing
                     {
                         new OsuSpriteText
                         {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
                             Font = OsuFont.GetFont(size: 13),
                             Text = header
                         },
@@ -69,10 +65,8 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             public BeatmapSearchFilter()
             {
-                Anchor = Anchor.BottomLeft;
-                Origin = Anchor.BottomLeft;
                 RelativeSizeAxes = Axes.X;
-                Height = 15;
+                AutoSizeAxes = Axes.Y;
 
                 TabContainer.Spacing = new Vector2(10, 0);
 
@@ -83,33 +77,16 @@ namespace osu.Game.Overlays.BeatmapListing
                 }
             }
 
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                if (Dropdown is FilterDropdown fd)
-                    fd.AccentColour = colourProvider.Light2;
-            }
-
-            protected override Dropdown<T> CreateDropdown() => new FilterDropdown();
+            protected override Dropdown<T> CreateDropdown() => null!;
 
             protected override TabItem<T> CreateTabItem(T value) => new FilterTabItem<T>(value);
 
-            private partial class FilterDropdown : OsuTabDropdown<T>
+            protected override TabFillFlowContainer CreateTabFlow() => new TabFillFlowContainer
             {
-                protected override DropdownHeader CreateHeader() => new FilterHeader
-                {
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight
-                };
-
-                private partial class FilterHeader : OsuTabDropdownHeader
-                {
-                    public FilterHeader()
-                    {
-                        Background.Height = 1;
-                    }
-                }
-            }
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                AllowMultiline = true,
+            };
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchFilterRow.cs
@@ -6,10 +6,10 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osuTK;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
 
 namespace osu.Game.Overlays.BeatmapListing
 {
@@ -45,9 +45,10 @@ namespace osu.Game.Overlays.BeatmapListing
                 {
                     new[]
                     {
-                        new OsuSpriteText
+                        new OsuTextFlowContainer(t => t.Font = OsuFont.GetFont(size: 13))
                         {
-                            Font = OsuFont.GetFont(size: 13),
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
                             Text = header
                         },
                         filter = CreateFilter()

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -52,10 +52,8 @@ namespace osu.Game.Overlays.BeatmapListing
             [BackgroundDependencyLoader]
             private void load()
             {
-                Anchor = Anchor.BottomLeft;
-                Origin = Anchor.BottomLeft;
                 RelativeSizeAxes = Axes.X;
-                Height = 15;
+                AutoSizeAxes = Axes.Y;
                 Spacing = new Vector2(10, 0);
 
                 AddRange(GetValues().Select(CreateTabItem));

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Overlays.BeatmapListing
         private void load()
         {
             AutoSizeAxes = Axes.Both;
-            Anchor = Anchor.BottomLeft;
-            Origin = Anchor.BottomLeft;
             AddRangeInternal(new Drawable[]
             {
                 text = new OsuSpriteText


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/27532

Had this change but thought it was unimportant at the time (a month ago) and the design is *[changing again](https://www.figma.com/file/bONtBvDRWNfOuiYpueD2ms/Web%2FSearch-Result-(with-Beatmap-Listing)?type=design&node-id=46-248&mode=design&t=VyKVQc74eqhNvcJf-0)*. My intention at the time was to fix the display for high ui scales but didn't account for other languages.

| Before | After | Web |
| --- | --- | --- |
| <img width="906" alt="Screenshot 2024-03-08 at 12 09 12 PM" src="https://github.com/ppy/osu/assets/35318437/cdb67f5e-6a38-4d30-aa53-544f3dacef38"> | <img width="876" alt="Screenshot 2024-03-08 at 12 07 18 PM" src="https://github.com/ppy/osu/assets/35318437/d2e39b7a-c5f7-4520-b18c-95ccce0be246"> | <img width="927" alt="Screenshot 2024-03-08 at 12 14 45 PM" src="https://github.com/ppy/osu/assets/35318437/29a850b1-8a40-481a-ac4f-b0d67a402636"> |