### PR TITLE
Fix `WikiPanelContainer` causing allocations and poor performance

### DIFF
--- a/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
+++ b/osu.Game/Overlays/Wiki/WikiPanelContainer.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using Markdig.Syntax;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -22,29 +21,61 @@ using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Wiki
 {
-    public partial class WikiPanelContainer : Container
+    public partial class WikiPanelContainer : CompositeDrawable
     {
-        private WikiPanelMarkdownContainer panelContainer;
+        private const float padding = 3;
 
         private readonly string text;
-
         private readonly bool isFullWidth;
 
         public WikiPanelContainer(string text, bool isFullWidth = false)
         {
             this.text = text;
             this.isFullWidth = isFullWidth;
-
-            RelativeSizeAxes = Axes.X;
-            Padding = new MarginPadding(3);
         }
 
+        private PanelBackground background;
+
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, IAPIProvider api)
+        private void load(IAPIProvider api)
         {
-            Children = new Drawable[]
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            InternalChildren = new Drawable[]
             {
+                background = new PanelBackground
+                {
+                    BypassAutoSizeAxes = Axes.Both
+                },
                 new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding(padding),
+                    Child = new WikiPanelMarkdownContainer(isFullWidth)
+                    {
+                        CurrentPath = $@"{api.WebsiteRootUrl}/wiki/",
+                        Text = text,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y
+                    }
+                }
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            background.Size = Parent!.DrawSize * new Vector2(Size.X, 1);
+        }
+
+        private partial class PanelBackground : CompositeDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                Padding = new MarginPadding(padding);
+                InternalChild = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,
@@ -60,22 +91,9 @@ namespace osu.Game.Overlays.Wiki
                     {
                         Colour = colourProvider.Background4,
                         RelativeSizeAxes = Axes.Both,
-                    },
-                },
-                panelContainer = new WikiPanelMarkdownContainer(isFullWidth)
-                {
-                    CurrentPath = $@"{api.WebsiteRootUrl}/wiki/",
-                    Text = text,
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                }
-            };
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-            Height = Math.Max(panelContainer.Height, Parent!.DrawHeight);
+                    }
+                };
+            }
         }
 
         private partial class WikiPanelMarkdownContainer : WikiMarkdownContainer


### PR DESCRIPTION
|master|pr|
|---|---|
|![wiki-master](https://github.com/ppy/osu/assets/22874522/a4488fd7-ef82-4095-b730-65f7ee323e4a)|![wiki-pr](https://github.com/ppy/osu/assets/22874522/dbe85ea8-343a-4a7d-9557-8b1b1463ec77)|

`WikiPanelContainer` was constantly updating it's height to ensure it's background always fills the parent `GridContainer`. However while doing so it was constantly invalidating itself and its parents, which caused major overhead (constant `GridContainer` and `FillFlowContainer` layout recomputation).
To prevent that I'm updating only background's size which has `BypassAutoSizeAxes` enabled, so it won't affect parent layouts.

Regarding height difference: old height was incorrect. Since `WikiPanelContainer` had padding and we were changing it's size to the size of it's child, end size was smaller than it should've been.

Example: child has height of 100 and `WikiPanelContainer` has padding of 10 - this should result in total height of 120, but in `Update()` we were changing it's size back to 100, which caused `WikiPanelContainer` always be in invalidated state and with incorrect height.