### PR TITLE
Reduce allocations while hovering `DrawableFlag`

### DIFF
--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -15,11 +15,14 @@ namespace osu.Game.Users.Drawables
     {
         private readonly CountryCode countryCode;
 
-        public LocalisableString TooltipText => countryCode == CountryCode.Unknown ? string.Empty : countryCode.GetDescription();
+        public LocalisableString TooltipText => countryCode == CountryCode.Unknown ? string.Empty : description;
+
+        private readonly string description;
 
         public DrawableFlag(CountryCode countryCode)
         {
             this.countryCode = countryCode;
+            description = countryCode.GetDescription();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -15,14 +15,14 @@ namespace osu.Game.Users.Drawables
     {
         private readonly CountryCode countryCode;
 
-        public LocalisableString TooltipText => countryCode == CountryCode.Unknown ? string.Empty : description;
+        public LocalisableString TooltipText => tooltipText;
 
-        private readonly string description;
+        private readonly string tooltipText;
 
         public DrawableFlag(CountryCode countryCode)
         {
             this.countryCode = countryCode;
-            description = countryCode.GetDescription();
+            tooltipText = countryCode == CountryCode.Unknown ? string.Empty : countryCode.GetDescription();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Users/Drawables/DrawableFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableFlag.cs
@@ -15,14 +15,12 @@ namespace osu.Game.Users.Drawables
     {
         private readonly CountryCode countryCode;
 
-        public LocalisableString TooltipText => tooltipText;
-
-        private readonly string tooltipText;
+        public LocalisableString TooltipText { get; }
 
         public DrawableFlag(CountryCode countryCode)
         {
             this.countryCode = countryCode;
-            tooltipText = countryCode == CountryCode.Unknown ? string.Empty : countryCode.GetDescription();
+            TooltipText = countryCode == CountryCode.Unknown ? string.Empty : countryCode.GetDescription();
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
`get_TooltipText` is being called each frame and so was `GetDescription()`.
There's also some work can be done in framework to reduce overall tooltip allocations.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/d105c785-c68d-46b7-a39f-89d4eab7eeb6)|![pr](https://github.com/ppy/osu/assets/22874522/aa136729-6d9a-4a58-82f6-bf2294713a57)|