### PR TITLE
Don't update SubTreeMasking in `OsuPlayfield`

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
+++ b/osu.Game.Rulesets.Osu/Edit/DrawableOsuEditorRuleset.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
@@ -25,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private partial class OsuEditorPlayfield : OsuPlayfield
         {
-            protected override GameplayCursorContainer CreateCursor() => null;
+            protected override GameplayCursorContainer? CreateCursor() => null;
 
             public OsuEditorPlayfield()
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -34,6 +34,8 @@ namespace osu.Game.Rulesets.Osu.UI
 
         private readonly JudgementPooler<DrawableOsuJudgement> judgementPooler;
 
+        // For osu! gameplay, everything is always on screen.
+        // Skipping masking calculations improves performance in intense beatmaps (ie. https://osu.ppy.sh/beatmapsets/150945#osu/372245)
         public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
 
         public SmokeContainer Smoke { get; }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -79,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.UI
             NewResult += onNewResult;
         }
 
-        private IHitPolicy hitPolicy;
+        private IHitPolicy hitPolicy = null!;
 
         public IHitPolicy HitPolicy
         {
@@ -119,12 +117,12 @@ namespace osu.Game.Rulesets.Osu.UI
             judgementAboveHitObjectLayer.Add(judgement.ProxiedAboveHitObjectsContent);
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(OsuRulesetConfigManager config, IBeatmap beatmap)
+        [BackgroundDependencyLoader]
+        private void load(OsuRulesetConfigManager? config, IBeatmap? beatmap)
         {
             config?.BindWith(OsuRulesetSetting.PlayfieldBorderStyle, playfieldBorder.PlayfieldBorderStyle);
 
-            var osuBeatmap = (OsuBeatmap)beatmap;
+            var osuBeatmap = (OsuBeatmap?)beatmap;
 
             RegisterPool<HitCircle, DrawableHitCircle>(20, 100);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public static readonly Vector2 BASE_SIZE = new Vector2(512, 384);
 
-        protected override GameplayCursorContainer CreateCursor() => new OsuCursorContainer();
+        protected override GameplayCursorContainer? CreateCursor() => new OsuCursorContainer();
 
         private readonly Container judgementAboveHitObjectLayer;
 

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -34,6 +35,8 @@ namespace osu.Game.Rulesets.Osu.UI
         private readonly JudgementContainer<DrawableOsuJudgement> judgementLayer;
 
         private readonly JudgementPooler<DrawableOsuJudgement> judgementPooler;
+
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
 
         public SmokeContainer Smoke { get; }
         public FollowPointRenderer FollowPoints { get; }

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -79,11 +80,12 @@ namespace osu.Game.Rulesets.Osu.UI
             NewResult += onNewResult;
         }
 
-        private IHitPolicy hitPolicy = null!;
+        private IHitPolicy hitPolicy;
 
         public IHitPolicy HitPolicy
         {
             get => hitPolicy;
+            [MemberNotNull(nameof(hitPolicy))]
             set
             {
                 hitPolicy = value ?? throw new ArgumentNullException(nameof(value));

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -15,7 +15,6 @@ using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Lists;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
@@ -631,8 +630,6 @@ namespace osu.Game.Rulesets.Objects.Drawables
         }
 
         #endregion
-
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
 
         protected override void UpdateAfterChildren()
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -15,6 +15,7 @@ using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Lists;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
@@ -630,6 +631,8 @@ namespace osu.Game.Rulesets.Objects.Drawables
         }
 
         #endregion
+
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
 
         protected override void UpdateAfterChildren()
         {


### PR DESCRIPTION
This pr helps in cases when there are many objects present on the screen (mostly low AR) and barely has effect in "normal" gameplay.
`UpdateSubTreeMasking` is used to compute `IsMaskedAway` property which is used to determine whether we should not draw objects outside the container with masking enabled, however this operation is quite expensive. And in this particular case it's a waste of resources because there's no scenario in which anything on the playfield will be masked away (or I can't think of any except may be some maps in which circles fully are outside the playfield, but these are super rare most likely).

Centipede with ar0 was used in this example:
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/d93f5f63-a440-4ae6-88d3-9f7d3fd93773)|![pr](https://github.com/ppy/osu/assets/22874522/eee592c4-f1bb-4300-8858-b37a43e15676)|

Normal "partial" masking isn't affected as seen here:
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/589ab689-1a6c-479b-a38c-e8bbedcd256b)|![pr](https://github.com/ppy/osu/assets/22874522/b70ccd0f-74fe-47cb-bb1d-05b4e2e4a065)|