### PR TITLE
Fix incorrect gradient application in `TimelineHitObjectBlueprint`

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -471,6 +471,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         /// </summary>
         public partial class ExtendableCircle : CompositeDrawable
         {
+            public new ColourInfo Colour
+            {
+                get => Content.Colour;
+                set => Content.Colour = value;
+            }
+
             protected readonly Circle Content;
 
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Content.ReceivePositionalInputAt(screenSpacePos);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27561

We were applying colour to the drawable with negative padding (which by itself is a workaround). Now applying directly to the content.

|master|pr|
|---|---|
|![master-long](https://github.com/ppy/osu/assets/22874522/09b7cfbc-017e-4ed3-b236-08405cc457d9)|![pr-long](https://github.com/ppy/osu/assets/22874522/4bf98eb0-8e17-4b3d-8555-ca3557ad4557)|
|![master-short](https://github.com/ppy/osu/assets/22874522/77766364-78a9-4b42-83c0-59746ed38f2c)|![pr-short](https://github.com/ppy/osu/assets/22874522/7eaa4c51-81c9-4b2f-b570-adeee742b61b)|