### PR TITLE
Fix ruleset medals not displaying due to deserialisation failure

### DIFF
--- a/osu.Game/Online/Notifications/WebSocket/Events/UserAchievementUnlock.cs
+++ b/osu.Game/Online/Notifications/WebSocket/Events/UserAchievementUnlock.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Online.Notifications.WebSocket.Events
         public uint AchievementId { get; set; }
 
         [JsonProperty("achievement_mode")]
-        public ushort? AchievementMode { get; set; }
+        public string? AchievementMode { get; set; }
 
         [JsonProperty("cover_url")]
         public string CoverUrl { get; set; } = string.Empty;


### PR DESCRIPTION
🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦🤦

probably got confused and lifted `ushort` from the database instead of the actual structure (https://github.com/ppy/osu-web/blob/b29eeff28e100bd5ed43a26f355575f19918e556/app/Models/Achievement.php#L14).

reported in https://discord.com/channels/188630481301012481/188630652340404224/1216812697589518386.

can be tested full-stack using same procedure as described in https://github.com/ppy/osu/pull/27276, just do a `UPDATE osu_achievements SET mode = 1 WHERE achievement_id = 18;` or similar on your chosen achievement before.