### PR TITLE
Downgrade realm to work around crashes on latest release

### DIFF
--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Realm" Version="11.7.0" />
+    <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2024.306.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2024.309.0" />
     <PackageReference Include="Sentry" Version="3.41.3" />


### PR DESCRIPTION
See https://github.com/ppy/osu/issues/27577.