### PR TITLE
Rearrange rankings overlay tabs to match web

### DIFF
--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -52,9 +52,9 @@ namespace osu.Game.Overlays.Rankings
                 switch (scope)
                 {
                     case RankingsScope.Performance:
-                    case RankingsScope.Spotlights:
                     case RankingsScope.Score:
                     case RankingsScope.Country:
+                    case RankingsScope.Spotlights:
                         return true;
 
                     default:

--- a/osu.Game/Overlays/Rankings/RankingsScope.cs
+++ b/osu.Game/Overlays/Rankings/RankingsScope.cs
@@ -11,14 +11,14 @@ namespace osu.Game.Overlays.Rankings
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypePerformance))]
         Performance,
 
-        [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeCharts))]
-        Spotlights,
-
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeScore))]
         Score,
 
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeCountry))]
         Country,
+
+        [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeCharts))]
+        Spotlights,
 
         [LocalisableDescription(typeof(RankingsStrings), nameof(RankingsStrings.TypeKudosu))]
         Kudosu,


### PR DESCRIPTION
- To be in line with https://github.com/ppy/osu-web/pull/10831

Have checked the code to see that there is no `{<=|>=} RankingsScope. ...` anywhere.