### PR TITLE
Fix audio in video check crashing on unexpected failures

### DIFF
--- a/osu.Game/Rulesets/Edit/Checks/CheckAudioInVideo.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckAudioInVideo.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.IO.FileAbstraction;
 using osu.Game.Rulesets.Edit.Checks.Components;
@@ -74,6 +76,11 @@ namespace osu.Game.Rulesets.Edit.Checks
                 catch (UnsupportedFormatException)
                 {
                     issue = new IssueTemplateFileError(this).Create(filename, "Unsupported format");
+                }
+                catch (Exception ex)
+                {
+                    issue = new IssueTemplateFileError(this).Create(filename, "Internal failure - see logs for more info");
+                    Logger.Log($"Failed when running {nameof(CheckAudioInVideo)}: {ex}");
                 }
 
                 yield return issue;


### PR DESCRIPTION
Fixes the last case from https://github.com/ppy/osu/issues/27588

The failure there is

```
2024-03-13 12:54:07 [verbose]: Failed when running CheckAudioInVideo: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'length')
2024-03-13 12:54:07 [verbose]: at TagLib.ByteVector.Mid(Int32 startIndex, Int32 length)
2024-03-13 12:54:07 [verbose]: at TagLib.Riff.List.Parse(ByteVector data)
2024-03-13 12:54:07 [verbose]: at TagLib.Riff.List..ctor(File file, Int64 position, Int32 length)
2024-03-13 12:54:07 [verbose]: at TagLib.Riff.AviHeaderList..ctor(File file, Int64 position, Int32 length)
2024-03-13 12:54:07 [verbose]: at TagLib.Riff.File.Read(Boolean read_tags, ReadStyle style, UInt32& riff_size, Int64& tag_start, Int64& tag_end)
2024-03-13 12:54:07 [verbose]: at TagLib.Riff.File..ctor(IFileAbstraction abstraction, ReadStyle propertiesStyle)
2024-03-13 12:54:07 [verbose]: at InvokeStub_File..ctor(Object, Span`1)
2024-03-13 12:54:07 [verbose]: at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)   at TagLib.File.Create(IFileAbstraction abstraction, String mimetype, ReadStyle propertiesStyle)
2024-03-13 12:54:07 [verbose]: at TagLib.File.Create(IFileAbstraction abstraction)
2024-03-13 12:54:07 [verbose]: at osu.Game.Rulesets.Edit.Checks.CheckAudioInVideo.Run(BeatmapVerifierContext context)+MoveNext() in /home/dachb/Documents/opensource/osu/osu.Game/Rulesets/Edit/Checks/CheckAudioInVideo.cs:line 64
```

Possibly something to report upstream, but definitely should not be resulting in crashes.