### PR TITLE
Fix first word bold not applying correctly after first language change

### DIFF
--- a/osu.Game/Overlays/Mods/ModSelectColumn.cs
+++ b/osu.Game/Overlays/Mods/ModSelectColumn.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -8,9 +9,11 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
+using System.Linq;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
 using osuTK;
 using osuTK.Graphics;
 
@@ -181,17 +184,15 @@ namespace osu.Game.Overlays.Mods
         {
             headerText.Clear();
 
-            int wordIndex = 0;
+            ITextPart part = headerText.AddText(text);
+            part.DrawablePartsRecreated += applySemiBoldToFirstWord;
+            applySemiBoldToFirstWord(part.Drawables);
 
-            ITextPart part = headerText.AddText(text, t =>
+            void applySemiBoldToFirstWord(IEnumerable<Drawable> d)
             {
-                if (wordIndex == 0)
-                    t.Font = t.Font.With(weight: FontWeight.SemiBold);
-                wordIndex += 1;
-            });
-
-            // Reset the index so that if the parts are refreshed (e.g. through changes in localisation) the correct word is re-emboldened.
-            part.DrawablePartsRecreated += _ => wordIndex = 0;
+                if (d.FirstOrDefault() is OsuSpriteText firstWord)
+                    firstWord.Font = firstWord.Font.With(weight: FontWeight.SemiBold);
+            }
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27549.

I'm not entirely sure why the old solution failed exactly, but also think it's unimportant because I think past me was an idiot and was playing stupid games with the juggling of indices between two callbacks (with invalidation mixed in) with no ordering guarantees and expecting not to win stupid prizes. I did investigate whether [re-application was happening](https://github.com/ppy/osu/issues/27549#issuecomment-1990350549) and as far as I can tell it was, it was just very haphazard and basically presumed callback ordering that is not necessarily always correct.

I'm not sure this requires any follow-up reconsiderations of that entire text flow API because to me this is firmly in the realm of programmer error, but if opinions differ, I'll re-examine.