### PR TITLE
Fix noticeable masking artifact of beatmap cards when already downloaded

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                 downloadTracker,
                 background = new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.Y,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
                     Child = new Box
@@ -165,9 +165,11 @@ namespace osu.Game.Beatmaps.Drawables.Cards
 
         private void updateState()
         {
-            float targetWidth = Width - (ShowDetails.Value ? ButtonsExpandedWidth : ButtonsCollapsedWidth);
+            float buttonAreaWidth = ShowDetails.Value ? ButtonsExpandedWidth : ButtonsCollapsedWidth;
+            float mainAreaWidth = Width - buttonAreaWidth;
 
-            mainArea.ResizeWidthTo(targetWidth, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            mainArea.ResizeWidthTo(mainAreaWidth, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+            background.ResizeWidthTo(buttonAreaWidth + BeatmapCard.CORNER_RADIUS, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             background.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
             buttons.FadeTo(ShowDetails.Value ? 1 : 0, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);

--- a/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/CollapsibleButtonContainer.cs
@@ -169,6 +169,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
             float mainAreaWidth = Width - buttonAreaWidth;
 
             mainArea.ResizeWidthTo(mainAreaWidth, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
+
+            // By limiting the width we avoid this box showing up as an outline around the drawables that are on top of it.
             background.ResizeWidthTo(buttonAreaWidth + BeatmapCard.CORNER_RADIUS, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);
 
             background.FadeColour(downloadTracker.State.Value == DownloadState.LocallyAvailable ? colours.Lime0 : colourProvider.Background3, BeatmapCard.TRANSITION_DURATION, Easing.OutQuint);


### PR DESCRIPTION
Had a similar fix before seeing https://github.com/ppy/osu/pull/20743#discussion_r994955470, but using that diff instead so co-authoring.

Not sure why it was visually left broken since. Photos are on a 1920x1080 monitor.

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-13 at 11 23 00 PM](https://github.com/ppy/osu/assets/35318437/2fca359e-1ac5-448b-88fb-1875898ecd7a) | ![Screenshot 2024-03-13 at 11 21 16 PM](https://github.com/ppy/osu/assets/35318437/3e58001b-464b-45af-b88b-5854b9065ab8) |