### PR TITLE
Allow storyboard sprites/animations to explicitly fall back to osu!classic skin

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
@@ -31,6 +32,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private TestStoryboard storyboard { get; set; } = new TestStoryboard();
 
         private IEnumerable<DrawableStoryboardSprite> sprites => this.ChildrenOfType<DrawableStoryboardSprite>();
+        private IEnumerable<DrawableStoryboardAnimation> animations => this.ChildrenOfType<DrawableStoryboardAnimation>();
 
         private const string lookup_name = "hitcircleoverlay";
 
@@ -60,9 +62,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
 
-            // Only checking for at least one sprite that succeeded, as not all skins in this test provide the hitcircleoverlay texture.
             AddAssert("sprite found texture", () =>
-                sprites.Any(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
+                sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
 
             assertStoryboardSourced();
         }
@@ -78,9 +79,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
 
-            // Only checking for at least one sprite that succeeded, as not all skins in this test provide the hitcircleoverlay texture.
-            AddAssert("sprite found texture", () =>
-                sprites.Any(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
+            AddAssert("all sprites found texture", () =>
+                sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
 
             assertSkinSourced();
         }
@@ -96,11 +96,15 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
 
-            // Only checking for at least one sprite that succeeded, as not all skins in this test provide the hitcircleoverlay texture.
-            AddAssert("sprite found texture", () =>
-                sprites.Any(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
+            AddAssert("all sprites found texture", () =>
+                sprites.All(sprite => sprite.ChildrenOfType<Sprite>().All(s => s.Texture != null)));
 
             assertSkinSourced();
+
+            AddStep("create animations", () => SetContents(_ => createAnimation(@"pippidonclear", Anchor.TopLeft, Vector2.Zero, 30)));
+
+            AddAssert("all animations found texture", () =>
+                animations.All(animation => animation.ChildrenOfType<TextureAnimation>().All(s => s.FrameCount > 0 && s.CurrentFrame != null)));
         }
 
         [Test]
@@ -179,6 +183,19 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             layer.Elements.Clear();
             layer.Add(sprite);
+
+            return storyboard.CreateDrawable().With(s => s.RelativeSizeAxes = Axes.Both);
+        }
+
+        private DrawableStoryboard createAnimation(string lookupName, Anchor origin, Vector2 initialPosition, int frameCount)
+        {
+            var layer = storyboard.GetLayer("Background");
+
+            var animation = new StoryboardAnimation(lookupName, origin, initialPosition, frameCount, 0, AnimationLoopType.LoopForever);
+            animation.AddLoop(Time.Current, 100).Alpha.Add(Easing.None, 0, 10000, 1, 1);
+
+            layer.Elements.Clear();
+            layer.Add(animation);
 
             return storyboard.CreateDrawable().With(s => s.RelativeSizeAxes = Axes.Both);
         }

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -92,6 +92,9 @@ namespace osu.Game.Storyboards.Drawables
         private ISkinSource skin { get; set; }
 
         [Resolved]
+        private SkinManager skins { get; set; }
+
+        [Resolved]
         private IBeatSyncProvider beatSyncProvider { get; set; }
 
         [Resolved]
@@ -130,6 +133,10 @@ namespace osu.Game.Storyboards.Drawables
             // When reading from a skin, we match stables weird behaviour where `FrameCount` is ignored
             // and resources are retrieved until the end of the animation.
             var skinTextures = skin.GetTextures(Path.ChangeExtension(Animation.Path, null), default, default, true, string.Empty, null, out _);
+
+            if (skinTextures.Length == 0)
+                  // osu!classic is the default skin for storyboards. explicitly fall back to the osu!classic skin in case the skin provider does not provide osu!classic as a source (i.e. user does not have legacy skin selected).
+                skinTextures = skins.DefaultClassicSkin.GetTextures(Path.ChangeExtension(Animation.Path, null), default, default, true, string.Empty, null, out _);
 
             if (skinTextures.Length > 0)
             {

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -78,6 +78,9 @@ namespace osu.Game.Storyboards.Drawables
         private ISkinSource skin { get; set; } = null!;
 
         [Resolved]
+        private SkinManager skins { get; set; } = null!;
+
+        [Resolved]
         private TextureStore textureStore { get; set; } = null!;
 
         public DrawableStoryboardSprite(StoryboardSprite sprite)
@@ -106,7 +109,10 @@ namespace osu.Game.Storyboards.Drawables
 
         private void skinSourceChanged()
         {
-            Texture = skin.GetTexture(Sprite.Path) ?? textureStore.Get(Sprite.Path);
+            Texture = skin.GetTexture(Sprite.Path)
+                      // osu!classic is the default skin for storyboards. explicitly fall back to the osu!classic skin in case the skin provider does not provide osu!classic as a source (i.e. user does not have legacy skin selected).
+                      ?? skins.DefaultClassicSkin.GetTexture(Sprite.Path)
+                      ?? textureStore.Get(Sprite.Path);
 
             // Setting texture will only update the size if it's zero.
             // So let's force an explicit update.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27569

In stable, if storyboards enable skin sprites, and the selected skin does not contain the corresponding texture for the sprite, then stable falls back to its default skin (which is known here as "osu!classic" skin).

We already have this behaviour implicitly supported when the user has a legacy skin selected. But, if the user has a non-legacy skin selected, then the osu!classic skin is not included as part of the sources that `DrawableStoryboardSprite` fetches the texture from.

To accommodate for this, storyboard sprites/animations explicitly falls back to the osu!classic skin when the texture is not found in `ISkinProvider`.

I agree this doesn't really feel good now that `ISkinProvider` isn't enough to retrieve the skin texture, but it's a special behaviour for storyboards since they generally expect an osu!classic skin to be present as a source for texture retrieval, regardless of what skin the user has selected. One could argue that lazer should enforce a legacy skin to be active when playing a storyboard that has skin sprites enabled, but I think it's best to leave that for a future discussion.