### PR TITLE
Improve editor performance with many timeline ticks present

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -18,6 +19,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public partial class TimelineTickDisplay : TimelinePart<PointVisualisation>
     {
+        // With current implementation every tick in the sub-tree should be visible, no need to check whether they are masked away.
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
+
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             // save a few drawables beyond the currently used for edge cases.
             while (drawableIndex < Math.Min(usedDrawables + 16, Count))
-                Children[drawableIndex++].Hide();
+                Children[drawableIndex++].Alpha = 0;
 
             // expire any excess
             while (drawableIndex < Count)
@@ -182,7 +182,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     point = Children[drawableIndex];
 
                 drawableIndex++;
-                point.Show();
+                point.Alpha = 1;
 
                 return point;
             }


### PR DESCRIPTION
This particular example looks unrealistic, but it's allowed via editor means: we can set bpm to 10000 and zoom out as far as possible.

981ee54cdca16653753c85a71192f404cb80e85c fixes transforms allocation overhead.
![tick-alloc](https://github.com/ppy/osu/assets/22874522/89d190b7-787a-4487-8f85-819f732816f1)

34a5e2d606070ba043afc501030933bd4f158412 is the same approach as in https://github.com/ppy/osu/pull/27562. While the whole timeline is moving, we can guarantee that with the current implementation almost all ticks in the tree (except 16 ones used as a buffer) will be visible. I think it's okay to allow some overdraw including the fact that we are CPU-limited in most common cases anyway. Another bunch of problems comes from the fact that these ticks are rounded, so we can't batch them properly, but this should be fixed with SSBO, I believe? Also I would love to use `DrawNode`s to draw these, but again: we can't draw rounded rectangles directly.
Potential best approach will be some sort of `BufferedContainer` usage, though this will require major changes.

||master|pr|
|---|---|---|
|paused|![master-idle](https://github.com/ppy/osu/assets/22874522/ed59aacc-b38e-43ab-8a45-b456b371f117)|![pr-idle](https://github.com/ppy/osu/assets/22874522/61db912a-6128-4f86-87dd-40cf92094a77)|
|playing|![master-running](https://github.com/ppy/osu/assets/22874522/fe45e516-2bff-4d27-8515-0c4003dee1d5)|![pr-running](https://github.com/ppy/osu/assets/22874522/0bc6af23-3625-4655-b634-42908df558d6)|