### PR TITLE
Warn if Windows compatibility mode flags are detected on startup

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -145,6 +145,9 @@ namespace osu.Desktop
 
             LoadComponentAsync(new ElevatedPrivilegesChecker(), Add);
 
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+                LoadComponentAsync(new CompatibilityModeChecker(), Add);
+
             osuSchemeLinkIPCChannel = new OsuSchemeLinkIPCChannel(Host, this);
             archiveImportIPCChannel = new ArchiveImportIPCChannel(Host, this);
         }

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -145,7 +145,7 @@ namespace osu.Desktop
 
             LoadComponentAsync(new ElevatedPrivilegesChecker(), Add);
 
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+            if (OperatingSystem.IsWindows())
                 LoadComponentAsync(new CompatibilityModeChecker(), Add);
 
             osuSchemeLinkIPCChannel = new OsuSchemeLinkIPCChannel(Host, this);

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -52,8 +52,7 @@ namespace osu.Desktop
                 // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
-                    bool isInCompatibilityMode = new CompatibilityModeChecker()
-                        .checkCompatibilityMode();
+                    bool isInCompatibilityMode = CompatibilityModeChecker.CheckCompatibilityMode();
 
                     if (isInCompatibilityMode)
                     {

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -52,10 +52,6 @@ namespace osu.Desktop
                 // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
-                    // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider
-                    // disabling it ourselves.
-                    // We could also better detect compatibility mode if required:
-                    // https://stackoverflow.com/questions/10744651/how-i-can-detect-if-my-application-is-running-under-compatibility-mode#comment58183249_10744730
                     SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
                         "Your operating system is too old to run osu!",
                         "This version of osu! requires at least Windows 8.1 to run.\n"

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -69,6 +69,8 @@ namespace osu.Desktop
                             + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!", IntPtr.Zero);
                     }
 
+                    CompatibilityModeChecker.LogCompatibilityFlags();
+
                     return;
                 }
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -59,6 +59,8 @@ namespace osu.Desktop
                         SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
                             "osu! is running in compatibility mode",
                             "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.", IntPtr.Zero);
+
+                        CompatibilityModeChecker.LogCompatibilityFlags();
                     }
                     else
                     {
@@ -68,8 +70,6 @@ namespace osu.Desktop
                             + "Please upgrade your operating system or consider using an older version of osu!.\n\n"
                             + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!", IntPtr.Zero);
                     }
-
-                    CompatibilityModeChecker.LogCompatibilityFlags();
 
                     return;
                 }

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -52,11 +52,24 @@ namespace osu.Desktop
                 // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
-                    SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
-                        "Your operating system is too old to run osu!",
-                        "This version of osu! requires at least Windows 8.1 to run.\n"
-                        + "Please upgrade your operating system or consider using an older version of osu!.\n\n"
-                        + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!", IntPtr.Zero);
+                    bool isInCompatibilityMode = new CompatibilityModeChecker()
+                        .checkCompatibilityMode();
+
+                    if (isInCompatibilityMode)
+                    {
+                        SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
+                            "osu! is running in compatibility mode",
+                            "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.", IntPtr.Zero);
+                    }
+                    else
+                    {
+                        SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
+                            "Your operating system is too old to run osu!",
+                            "This version of osu! requires at least Windows 8.1 to run.\n"
+                            + "Please upgrade your operating system or consider using an older version of osu!.\n\n"
+                            + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!", IntPtr.Zero);
+                    }
+
                     return;
                 }
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -58,9 +58,8 @@ namespace osu.Desktop
                     {
                         SDL.SDL_ShowSimpleMessageBox(SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
                             "osu! is running in compatibility mode",
-                            "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.", IntPtr.Zero);
-
-                        CompatibilityModeChecker.LogCompatibilityFlags();
+                            "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.\n\n"
+                            + "Debug information: " + CompatibilityModeChecker.GetCompatibilityFlags(), IntPtr.Zero);
                     }
                     else
                     {

--- a/osu.Desktop/Security/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Security/CompatibilityModeChecker.cs
@@ -16,7 +16,7 @@ namespace osu.Desktop.Security
     /// <summary>
     /// Checks if the game is running with windows compatibility optimizations which could cause issues. Displays a warning notification if so.
     /// </summary>
-    public partial class CompatibilityModeChecker : Drawable
+    public partial class CompatibilityModeChecker : Component
     {
         [Resolved]
         private INotificationOverlay notifications { get; set; } = null!;

--- a/osu.Desktop/Security/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Security/CompatibilityModeChecker.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence. // See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using Microsoft.Win32;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+
+namespace osu.Desktop.Security
+{
+    /// <summary>
+    /// Checks if the game is running with windows compatibility optimizations which could cause issues. Displays a warning notification if so.
+    /// </summary>
+    public partial class CompatibilityModeChecker : Drawable
+    {
+        [Resolved]
+        private INotificationOverlay notifications { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (checkCompatibilityMode())
+                notifications.Post(new CompatibilityModeNotification());
+        }
+
+        private bool checkCompatibilityMode()
+        {
+            if (!OperatingSystem.IsWindows())
+                return false;
+
+            using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
+
+            return layers != null && layers.GetValueNames().Any(name => name.EndsWith("osu!.exe", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private partial class CompatibilityModeNotification : SimpleNotification
+        {
+            public override bool IsImportant => true;
+
+            public CompatibilityModeNotification()
+            {
+                Text = "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.";
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                Icon = FontAwesome.Solid.ShieldAlt;
+                IconContent.Colour = colours.YellowDark;
+            }
+        }
+    }
+}

--- a/osu.Desktop/Security/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Security/CompatibilityModeChecker.cs
@@ -1,4 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence. // See the LICENCE file in the repository root for full licence text.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Linq;

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Logging;
 using osu.Game.Graphics;
+using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 
@@ -61,7 +62,7 @@ namespace osu.Desktop.Windows
 
             public CompatibilityModeNotification()
             {
-                Text = "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.";
+                Text = WindowsCompatibilityModeCheckerStrings.NotificationText;
             }
 
             [BackgroundDependencyLoader]

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
 using osu.Framework.Allocation;
@@ -34,7 +35,9 @@ namespace osu.Desktop.Windows
         {
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
-            return layers != null && layers.GetValueNames().Any(name => name.EndsWith("osu!.exe", StringComparison.OrdinalIgnoreCase));
+            var exePath = Assembly.GetExecutingAssembly().Location;
+
+            return layers != null && layers.GetValueNames().Any(name => name.Equals(exePath, StringComparison.OrdinalIgnoreCase));
         }
 
         private partial class CompatibilityModeNotification : SimpleNotification

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -11,7 +11,7 @@ using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 
-namespace osu.Desktop.Security
+namespace osu.Desktop.Windows
 {
     /// <summary>
     /// Checks if the game is running with windows compatibility optimizations which could cause issues. Displays a warning notification if so.

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -30,7 +30,7 @@ namespace osu.Desktop.Windows
                 notifications.Post(new CompatibilityModeNotification());
         }
 
-        private bool checkCompatibilityMode()
+        public bool checkCompatibilityMode()
         {
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -16,6 +17,7 @@ namespace osu.Desktop.Windows
     /// <summary>
     /// Checks if the game is running with windows compatibility optimizations which could cause issues. Displays a warning notification if so.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     public partial class CompatibilityModeChecker : Component
     {
         [Resolved]
@@ -30,9 +32,6 @@ namespace osu.Desktop.Windows
 
         private bool checkCompatibilityMode()
         {
-            if (!OperatingSystem.IsWindows())
-                return false;
-
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
             return layers != null && layers.GetValueNames().Any(name => name.EndsWith("osu!.exe", StringComparison.OrdinalIgnoreCase));

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -27,15 +27,15 @@ namespace osu.Desktop.Windows
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (checkCompatibilityMode())
+            if (CheckCompatibilityMode())
                 notifications.Post(new CompatibilityModeNotification());
         }
 
-        public bool checkCompatibilityMode()
+        public static bool CheckCompatibilityMode()
         {
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
-            var exePath = Assembly.GetExecutingAssembly().Location;
+            string exePath = Assembly.GetExecutingAssembly().Location;
 
             return layers != null && layers.GetValueNames().Any(name => name.Equals(exePath, StringComparison.OrdinalIgnoreCase));
         }

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -50,10 +50,18 @@ namespace osu.Desktop.Windows
         /// </summary>
         public static void LogCompatibilityFlags()
         {
+            Logger.Log($"Compatibility flags for {Environment.ProcessPath}: {GetCompatibilityFlags()}");
+        }
+
+        /// <summary>
+        /// Get the compatibility flags for the current process if they exist
+        /// </summary>
+        /// <returns>The compatibility flags</returns>
+        public static string GetCompatibilityFlags()
+        {
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
-            if (layers?.GetValue(Environment.ProcessPath) is string flags)
-                Logger.Log($"Compatibility flags for {Environment.ProcessPath}: {flags}");
+            return layers?.GetValue(Environment.ProcessPath) as string ?? string.Empty;
         }
 
         private partial class CompatibilityModeNotification : SimpleNotification

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -37,7 +37,7 @@ namespace osu.Desktop.Windows
         /// <summary>
         /// Check if the game is running with windows compatibility optimizations
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Whether compatibility mode flags are detected or not</returns>
         public static bool CheckCompatibilityMode()
         {
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");

--- a/osu.Desktop/Windows/CompatibilityModeChecker.cs
+++ b/osu.Desktop/Windows/CompatibilityModeChecker.cs
@@ -53,7 +53,7 @@ namespace osu.Desktop.Windows
             using var layers = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers");
 
             if (layers?.GetValue(Environment.ProcessPath) is string flags)
-                Logger.Log($"Compatibility flags for {Environment.ProcessPath}: {flags}", LoggingTarget.Information);
+                Logger.Log($"Compatibility flags for {Environment.ProcessPath}: {flags}");
         }
 
         private partial class CompatibilityModeNotification : SimpleNotification

--- a/osu.Game/Localisation/WindowsCompatibilityModeCheckerStrings.cs
+++ b/osu.Game/Localisation/WindowsCompatibilityModeCheckerStrings.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class WindowsCompatibilityModeCheckerStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.WindowsCompatibilityModeChecker";
+
+        /// <summary>
+        /// "osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode."
+        /// </summary>
+        public static LocalisableString NotificationText => new TranslatableString(getKey(@"notification_text"), @"osu! is running in compatibility mode. This may cause issues with the game. Please ensure osu! is not set to run in compatibility mode.");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}


### PR DESCRIPTION
Closes #22092

## Description
This PR adds a new component, `CompatibilityModeChecker.cs` to `osu.Desktop/Windows`, which does as the name implies.

Windows writes to `HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers` to track compatibility flags for applications. The key names in the registry folder coincide with the path to the executables. Following this logic, we can check each path in the registry folder to see if they contain `osu!.exe` which would likely mean a path to the lazer installation. If this is detected, the component gives the user a notification to warn them about using compatibility mode.

Lazer in general already refuses to run under compatibility mode (since it requires windows 8.1 or later) but the same can't be said for other values, such as fullscreen optimizations, dpi optimizations, etc. By using the registry, we can make sure that virtually every value that would be in the properties -> compatibility tab is turned off. Windows automatically deletes the keys if there are no compatibility options set, so we really only have to check that a key pointing to the lazer executable exists, and if so, warn the user.

## Concerns
I do have a bit of concerns with this implementation. I could have addressed the concerns below before making the PR, but for the sake of simplicity, I decided to leave them out pending discussion.
1. Checking for `osu!.exe` seems a bit hacky, it would probably be better to try and find matches to the runtime executable. Although I'm not sure if this would work properly since it looks like there's two executables, an entry `osu!.exe`, and another `osu!.exe` in the squirrel installation folder
	- This could also possibly trigger if there are compatibility options set for stable
	- It could be wise to wait until peppy finishes his [squirrel update](https://github.com/ppy/osu/issues/14824#issuecomment-1891532983), then come back to this
2. The notification strings should probably be made translatable, both in this component and in `ElevatedPrivilegesChecker.cs`
3. There also exists `HKLM\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers` which similarly holds compatibility flag information. In my experience, this is rarely used and is only written to if the user presses "change settings for all users" when making the compatibility mode changes. Although I personally don't think that it's worth it since a user isn't likely to do this, we could also track this to be safe (grab the array of names from `HKLM`, combine it with the array from `HKCU`, then look through the final concatenated array instead)
4. Instead of simply notifying the user, we could outright disallow using any compatibility mode flags as peppy discussed in the issue thread. I personally don't think we need to go to that extreme, but it is an option
5. We can also turn off the flags for the user by deleting the registry key, but I don't believe we should do this since it'd be best to avoid touching the registry unless we need to

If the concerns above aren't pressing, then this implementation should be capable of easily checking to see if there are any compatibility flags set for the application