### PR TITLE
Apply generic version of `LifetimeEntryManager`

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
@@ -7,7 +7,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class CatcherTrailEntry : LifetimeEntry<CatcherTrailEntry>
+    public class CatcherTrailEntry : LifetimeEntryBase<CatcherTrailEntry>
     {
         public readonly CatcherAnimationState CatcherState;
 

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Performance;
+
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailEntry.cs
@@ -6,7 +6,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class CatcherTrailEntry : LifetimeEntry
+    public class CatcherTrailEntry : LifetimeEntry<CatcherTrailEntry>
     {
         public readonly CatcherAnimationState CatcherState;
 

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
@@ -9,7 +9,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class HitExplosionEntry : LifetimeEntry<HitExplosionEntry>
+    public class HitExplosionEntry : LifetimeEntryBase<HitExplosionEntry>
     {
         /// <summary>
         /// The judgement result that triggered this explosion.

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.UI
 {
-    public class HitExplosionEntry : LifetimeEntry
+    public class HitExplosionEntry : LifetimeEntry<HitExplosionEntry>
     {
         /// <summary>
         /// The judgement result that triggered this explosion.

--- a/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
+++ b/osu.Game.Rulesets.Catch/UI/HitExplosionEntry.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Judgements;
+
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.UI

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Diagnostics;
+
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Objects;
+
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -12,7 +12,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
-    public class FollowPointLifetimeEntry : LifetimeEntry<FollowPointLifetimeEntry>
+    public class FollowPointLifetimeEntry : LifetimeEntryBase<FollowPointLifetimeEntry>
     {
         public event Action? Invalidated;
         public readonly OsuHitObject Start;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/Connections/FollowPointLifetimeEntry.cs
@@ -10,7 +10,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables.Connections
 {
-    public class FollowPointLifetimeEntry : LifetimeEntry
+    public class FollowPointLifetimeEntry : LifetimeEntry<FollowPointLifetimeEntry>
     {
         public event Action? Invalidated;
         public readonly OsuHitObject Start;

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -12,9 +12,9 @@ using osu.Game.Rulesets.Objects.Drawables;
 namespace osu.Game.Rulesets.Objects
 {
     /// <summary>
-    /// A <see cref="LifetimeEntry{T}"/> that stores the lifetime for a <see cref="HitObject"/>.
+    /// A <see cref="LifetimeEntryBase{T}"/> that stores the lifetime for a <see cref="HitObject"/>.
     /// </summary>
-    public class HitObjectLifetimeEntry : LifetimeEntry<HitObjectLifetimeEntry>
+    public class HitObjectLifetimeEntry : LifetimeEntryBase<HitObjectLifetimeEntry>
     {
         /// <summary>
         /// The <see cref="HitObject"/>.
@@ -123,12 +123,12 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         /// <remarks>
         /// This is only used as an optimisation to delay the initial application of the <see cref="HitObject"/> to a <see cref="DrawableHitObject"/>.
-        /// A more accurate <see cref="LifetimeEntry{T}.LifetimeStart"/> should be set on the hit object application, for further optimisation.
+        /// A more accurate <see cref="LifetimeEntryBase{T}.LifetimeStart"/> should be set on the hit object application, for further optimisation.
         /// </remarks>
         protected virtual double InitialLifetimeOffset => 10000;
 
         /// <summary>
-        /// Set <see cref="LifetimeEntry{T}.LifetimeStart"/> using <see cref="InitialLifetimeOffset"/>.
+        /// Set <see cref="LifetimeEntryBase{T}.LifetimeStart"/> using <see cref="InitialLifetimeOffset"/>.
         /// </summary>
         internal void SetInitialLifetime() => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
 

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Performance;
 using osu.Game.Rulesets.Judgements;
@@ -11,7 +12,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 namespace osu.Game.Rulesets.Objects
 {
     /// <summary>
-    /// A <see cref="LifetimeEntry"/> that stores the lifetime for a <see cref="HitObject"/>.
+    /// A <see cref="LifetimeEntry{T}"/> that stores the lifetime for a <see cref="HitObject"/>.
     /// </summary>
     public class HitObjectLifetimeEntry : LifetimeEntry<HitObjectLifetimeEntry>
     {

--- a/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectLifetimeEntry.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Objects
     /// <summary>
     /// A <see cref="LifetimeEntry"/> that stores the lifetime for a <see cref="HitObject"/>.
     /// </summary>
-    public class HitObjectLifetimeEntry : LifetimeEntry
+    public class HitObjectLifetimeEntry : LifetimeEntry<HitObjectLifetimeEntry>
     {
         /// <summary>
         /// The <see cref="HitObject"/>.
@@ -122,12 +122,12 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         /// <remarks>
         /// This is only used as an optimisation to delay the initial application of the <see cref="HitObject"/> to a <see cref="DrawableHitObject"/>.
-        /// A more accurate <see cref="LifetimeEntry.LifetimeStart"/> should be set on the hit object application, for further optimisation.
+        /// A more accurate <see cref="LifetimeEntry{T}.LifetimeStart"/> should be set on the hit object application, for further optimisation.
         /// </remarks>
         protected virtual double InitialLifetimeOffset => 10000;
 
         /// <summary>
-        /// Set <see cref="LifetimeEntry.LifetimeStart"/> using <see cref="InitialLifetimeOffset"/>.
+        /// Set <see cref="LifetimeEntry{T}.LifetimeStart"/> using <see cref="InitialLifetimeOffset"/>.
         /// </summary>
         internal void SetInitialLifetime() => LifetimeStart = HitObject.StartTime - InitialLifetimeOffset;
 

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
     /// A <see cref="PoolableDrawable"/> that is controlled by <see cref="Entry"/> to implement drawable pooling and replay rewinding.
     /// </summary>
     /// <typeparam name="TEntry">The <see cref="LifetimeEntry"/> type storing state and controlling this drawable.</typeparam>
-    public abstract partial class PoolableDrawableWithLifetime<TEntry> : PoolableDrawable where TEntry : LifetimeEntry
+    public abstract partial class PoolableDrawableWithLifetime<TEntry> : PoolableDrawable where TEntry : LifetimeEntry<TEntry>
     {
         private TEntry? entry;
 
@@ -150,7 +150,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
             HasEntryApplied = false;
         }
 
-        private void setLifetimeFromEntry(LifetimeEntry entry)
+        private void setLifetimeFromEntry(TEntry entry)
         {
             Debug.Assert(entry == Entry);
             base.LifetimeStart = entry.LifetimeStart;

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Pooling;
@@ -12,7 +13,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
     /// <summary>
     /// A <see cref="PoolableDrawable"/> that is controlled by <see cref="Entry"/> to implement drawable pooling and replay rewinding.
     /// </summary>
-    /// <typeparam name="TEntry">The <see cref="LifetimeEntry"/> type storing state and controlling this drawable.</typeparam>
+    /// <typeparam name="TEntry">The <see cref="LifetimeEntry{T}"/> type storing state and controlling this drawable.</typeparam>
     public abstract partial class PoolableDrawableWithLifetime<TEntry> : PoolableDrawable where TEntry : LifetimeEntry<TEntry>
     {
         private TEntry? entry;

--- a/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PoolableDrawableWithLifetime.cs
@@ -13,8 +13,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
     /// <summary>
     /// A <see cref="PoolableDrawable"/> that is controlled by <see cref="Entry"/> to implement drawable pooling and replay rewinding.
     /// </summary>
-    /// <typeparam name="TEntry">The <see cref="LifetimeEntry{T}"/> type storing state and controlling this drawable.</typeparam>
-    public abstract partial class PoolableDrawableWithLifetime<TEntry> : PoolableDrawable where TEntry : LifetimeEntry<TEntry>
+    /// <typeparam name="TEntry">The <see cref="LifetimeEntryBase{T}"/> type storing state and controlling this drawable.</typeparam>
+    public abstract partial class PoolableDrawableWithLifetime<TEntry> : PoolableDrawable where TEntry : LifetimeEntryBase<TEntry>
     {
         private TEntry? entry;
 

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
     /// <typeparam name="TEntry">The type of entries managed by this container.</typeparam>
     /// <typeparam name="TDrawable">The type of drawables corresponding to the entries.</typeparam>
     public abstract partial class PooledDrawableWithLifetimeContainer<TEntry, TDrawable> : CompositeDrawable
-        where TEntry : LifetimeEntry
+        where TEntry : LifetimeEntry<TEntry>
         where TDrawable : Drawable
     {
         /// <summary>
@@ -40,8 +40,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
         public readonly SlimReadOnlyDictionaryWrapper<TEntry, TDrawable> AliveEntries;
 
         /// <summary>
-        /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry.LifetimeStart"/>.
-        /// Used when entries are dynamically added at its <see cref="LifetimeEntry.LifetimeStart"/> to prevent duplicated entries.
+        /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry{T}.LifetimeStart"/>.
+        /// Used when entries are dynamically added at its <see cref="LifetimeEntry{T}.LifetimeStart"/> to prevent duplicated entries.
         /// </summary>
         protected virtual bool RemoveRewoundEntry => false;
 
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
         private readonly Dictionary<TEntry, TDrawable> aliveDrawableMap = new Dictionary<TEntry, TDrawable>();
         private readonly HashSet<TEntry> allEntries = new HashSet<TEntry>();
 
-        private readonly LifetimeEntryManager lifetimeManager = new LifetimeEntryManager();
+        private readonly LifetimeEntryManager<TEntry> lifetimeManager = new();
 
         protected PooledDrawableWithLifetimeContainer()
         {
@@ -102,9 +102,9 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// <returns>The <typeparamref name="TDrawable"/> corresponding to the entry.</returns>
         protected abstract TDrawable GetDrawable(TEntry entry);
 
-        private void entryBecameAlive(LifetimeEntry lifetimeEntry)
+        private void entryBecameAlive(TEntry lifetimeEntry)
         {
-            var entry = (TEntry)lifetimeEntry;
+            var entry = lifetimeEntry;
             Debug.Assert(!aliveDrawableMap.ContainsKey(entry));
 
             TDrawable drawable = GetDrawable(entry);
@@ -120,9 +120,9 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </remarks>
         protected virtual void AddDrawable(TEntry entry, TDrawable drawable) => AddInternal(drawable);
 
-        private void entryBecameDead(LifetimeEntry lifetimeEntry)
+        private void entryBecameDead(TEntry lifetimeEntry)
         {
-            var entry = (TEntry)lifetimeEntry;
+            var entry = lifetimeEntry;
             Debug.Assert(aliveDrawableMap.ContainsKey(entry));
 
             TDrawable drawable = aliveDrawableMap[entry];
@@ -138,10 +138,10 @@ namespace osu.Game.Rulesets.Objects.Pooling
         /// </remarks>
         protected virtual void RemoveDrawable(TEntry entry, TDrawable drawable) => RemoveInternal(drawable, false);
 
-        private void entryCrossedBoundary(LifetimeEntry lifetimeEntry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
+        private void entryCrossedBoundary(TEntry lifetimeEntry, LifetimeBoundaryKind kind, LifetimeBoundaryCrossingDirection direction)
         {
             if (RemoveRewoundEntry && kind == LifetimeBoundaryKind.Start && direction == LifetimeBoundaryCrossingDirection.Backward)
-                Remove((TEntry)lifetimeEntry);
+                Remove(lifetimeEntry);
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+
 using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
+++ b/osu.Game/Rulesets/Objects/Pooling/PooledDrawableWithLifetimeContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Objects.Pooling
     /// <typeparam name="TEntry">The type of entries managed by this container.</typeparam>
     /// <typeparam name="TDrawable">The type of drawables corresponding to the entries.</typeparam>
     public abstract partial class PooledDrawableWithLifetimeContainer<TEntry, TDrawable> : CompositeDrawable
-        where TEntry : LifetimeEntry<TEntry>
+        where TEntry : LifetimeEntryBase<TEntry>
         where TDrawable : Drawable
     {
         /// <summary>
@@ -41,8 +41,8 @@ namespace osu.Game.Rulesets.Objects.Pooling
         public readonly SlimReadOnlyDictionaryWrapper<TEntry, TDrawable> AliveEntries;
 
         /// <summary>
-        /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntry{T}.LifetimeStart"/>.
-        /// Used when entries are dynamically added at its <see cref="LifetimeEntry{T}.LifetimeStart"/> to prevent duplicated entries.
+        /// Whether to remove an entry when clock goes backward and crossed its <see cref="LifetimeEntryBase{T}.LifetimeStart"/>.
+        /// Used when entries are dynamically added at its <see cref="LifetimeEntryBase{T}.LifetimeStart"/> to prevent duplicated entries.
         /// </summary>
         protected virtual bool RemoveRewoundEntry => false;
 


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu-framework/pull/6212
- [ ] Depends on framework bump

Change `LifetimeEntryManager` in `PooledDrawableWithLifetimeContainer` to generic version. Based on [this PR](https://github.com/ppy/osu-framework/pull/6212). Needs to be applied after that has been merged.