### PR TITLE
Fix incorrectly encoded score IsPerfect value

### DIFF
--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -27,11 +27,6 @@ namespace osu.Game.Scoring.Legacy
 {
     public abstract class LegacyScoreDecoder
     {
-        /// <summary>
-        /// The decoded "IsPerfect" value. This isn't used by osu!lazer.
-        /// </summary>
-        public bool DecodedPerfectValue { get; private set; }
-
         private IBeatmap currentBeatmap;
         private Ruleset currentRuleset;
 
@@ -87,7 +82,7 @@ namespace osu.Game.Scoring.Legacy
                 scoreInfo.MaxCombo = sr.ReadUInt16();
 
                 /* score.Perfect = */
-                DecodedPerfectValue = sr.ReadBoolean();
+                sr.ReadBoolean();
 
                 scoreInfo.Mods = currentRuleset.ConvertFromLegacyMods((LegacyMods)sr.ReadInt32()).ToArray();
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Scoring.Legacy
 {
     public abstract class LegacyScoreDecoder
     {
+        /// <summary>
+        /// The decoded "IsPerfect" value. This isn't used by osu!lazer.
+        /// </summary>
+        public bool DecodedPerfectValue { get; private set; }
+
         private IBeatmap currentBeatmap;
         private Ruleset currentRuleset;
 
@@ -82,7 +87,7 @@ namespace osu.Game.Scoring.Legacy
                 scoreInfo.MaxCombo = sr.ReadUInt16();
 
                 /* score.Perfect = */
-                sr.ReadBoolean();
+                DecodedPerfectValue = sr.ReadBoolean();
 
                 scoreInfo.Mods = currentRuleset.ConvertFromLegacyMods((LegacyMods)sr.ReadInt32()).ToArray();
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Scoring.Legacy
                 sw.Write((ushort)(score.ScoreInfo.GetCountMiss() ?? 0));
                 sw.Write((int)(score.ScoreInfo.TotalScore));
                 sw.Write((ushort)score.ScoreInfo.MaxCombo);
-                sw.Write(score.ScoreInfo.Combo == score.ScoreInfo.MaxCombo);
+                sw.Write(score.ScoreInfo.Combo == score.ScoreInfo.GetMaximumAchievableCombo());
                 sw.Write((int)score.ScoreInfo.Ruleset.CreateInstance().ConvertToLegacyMods(score.ScoreInfo.Mods));
 
                 sw.Write(getHpGraphFormatted());

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Scoring.Legacy
                 sw.Write((ushort)(score.ScoreInfo.GetCountMiss() ?? 0));
                 sw.Write((int)(score.ScoreInfo.TotalScore));
                 sw.Write((ushort)score.ScoreInfo.MaxCombo);
-                sw.Write(score.ScoreInfo.Combo == score.ScoreInfo.GetMaximumAchievableCombo());
+                sw.Write(score.ScoreInfo.MaxCombo == score.ScoreInfo.GetMaximumAchievableCombo());
                 sw.Write((int)score.ScoreInfo.Ruleset.CreateInstance().ConvertToLegacyMods(score.ScoreInfo.Mods));
 
                 sw.Write(getHpGraphFormatted());


### PR DESCRIPTION
Fixes the score appearing as perfect, as mentioned in https://github.com/ppy/osu-stable-issues/issues/1219

<img width="537" alt="image" src="https://github.com/ppy/osu/assets/1329837/02ca329e-2d9b-4abc-9f3f-4055c311915b">

We may want to deploy a new osu-server-spectator with this, but it isn't a huge deal in my opinion (only affects stable afaik).

The test is kinda wishy-washy by manually putting the score into the correct state. I can make it a `Player`-based test if requested, but it felt like too much.