### PR TITLE
Fix catch banana shower judgement causing fail when at 0 HP

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/CatchHealthProcessorTest.cs
+++ b/osu.Game.Rulesets.Catch.Tests/CatchHealthProcessorTest.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             [new Droplet(), 0.01, true],
             [new TinyDroplet(), 0, false],
             [new Banana(), 0, false],
+            [new BananaShower(), 0, false]
         ];
 
         [TestCaseSource(nameof(test_cases))]

--- a/osu.Game.Rulesets.Catch/Scoring/CatchHealthProcessor.cs
+++ b/osu.Game.Rulesets.Catch/Scoring/CatchHealthProcessor.cs
@@ -32,6 +32,10 @@ namespace osu.Game.Rulesets.Catch.Scoring
             if (result.Type == HitResult.SmallTickMiss)
                 return false;
 
+            // on stable, banana showers don't exist as concrete objects themselves, so they can't cause a fail.
+            if (result.HitObject is BananaShower)
+                return false;
+
             return base.CheckDefaultFailCondition(result);
         }
 

--- a/osu.Game/Rulesets/Scoring/LegacyDrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/LegacyDrainingHealthProcessor.cs
@@ -108,6 +108,9 @@ namespace osu.Game.Rulesets.Scoring
                     increaseHp(h);
                 }
 
+                if (topLevelObjectCount == 0)
+                    return testDrop;
+
                 if (!fail && currentHp < lowestHpEnd)
                 {
                     fail = true;


### PR DESCRIPTION
Fixes the follow-up issue in https://github.com/ppy/osu/issues/27121