### PR TITLE
Warn about not using an official "deployed" build

### DIFF
--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -126,6 +126,11 @@ Click to see what's new!", version);
         public static LocalisableString UpdateReadyToInstall => new TranslatableString(getKey(@"update_ready_to_install"), @"Update ready to install. Click to restart!");
 
         /// <summary>
+        /// "This is not an official build of the game and scores will not be submitted."
+        /// </summary>
+        public static LocalisableString NotOfficialBuild => new TranslatableString(getKey(@"not_official_build"), @"This is not an official build of the game and scores will not be submitted.");
+
+        /// <summary>
         /// "Downloading update..."
         /// </summary>
         public static LocalisableString DownloadingUpdate => new TranslatableString(getKey(@"downloading_update"), @"Downloading update...");

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -126,9 +126,9 @@ Click to see what's new!", version);
         public static LocalisableString UpdateReadyToInstall => new TranslatableString(getKey(@"update_ready_to_install"), @"Update ready to install. Click to restart!");
 
         /// <summary>
-        /// "This is not an official build of the game and scores will not be submitted."
+        /// "This is not an official build of the game. Scores will not be submitted and other online systems may not work as intended."
         /// </summary>
-        public static LocalisableString NotOfficialBuild => new TranslatableString(getKey(@"not_official_build"), @"This is not an official build of the game and scores will not be submitted.");
+        public static LocalisableString NotOfficialBuild => new TranslatableString(getKey(@"not_official_build"), @"This is not an official build of the game. Scores will not be submitted and other online systems may not work as intended.");
 
         /// <summary>
         /// "Downloading update..."

--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Reflection;
 using System.Threading.Tasks;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -11,6 +13,7 @@ using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Updater
@@ -51,6 +54,9 @@ namespace osu.Game.Updater
                 // only show a notification if we've previously saved a version to the config file (ie. not the first run).
                 if (!string.IsNullOrEmpty(lastVersion))
                     Notifications.Post(new UpdateCompleteNotification(version));
+
+                if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
+                    Notifications.Post(new SimpleNotification { Text = NotificationsStrings.NotOfficialBuild });
             }
 
             // debug / local compilations will reset to a non-release string.

--- a/osu.Game/Utils/OfficialBuildAttribute.cs
+++ b/osu.Game/Utils/OfficialBuildAttribute.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+
+namespace osu.Game.Utils
+{
+    [UsedImplicitly]
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public class OfficialBuildAttribute : Attribute;
+}


### PR DESCRIPTION
Some package managers (e.g. the AUR) may choose to build "deployed" game packages from tags, attaching the true game version to the built assembly (e.g. `2024.312.0`).

See https://github.com/ppy/osu/issues/27466#issuecomment-2007481638 for a case where this has come up in practice.

This PR allows an attribute to be attached that indicates whether this is an officially sanctioned build, and displays a notification if not. The attribute is purposefully not used in this PR.