### PR TITLE
Use title as tiebreaker when sorting beatmap carousel by artist

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -666,6 +666,56 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert($"Check {zzz_lowercase} is second last", () => carousel.BeatmapSets.SkipLast(1).Last().Metadata.Artist == zzz_lowercase);
         }
 
+        [Test]
+        public void TestSortByArtistUsesTitleAsTiebreaker()
+        {
+            var sets = new List<BeatmapSetInfo>();
+
+            AddStep("Populuate beatmap sets", () =>
+            {
+                sets.Clear();
+
+                for (int i = 0; i < 20; i++)
+                {
+                    var set = TestResources.CreateTestBeatmapSetInfo();
+
+                    if (i == 4)
+                    {
+                        set.Beatmaps.ForEach(b =>
+                        {
+                            b.Metadata.Artist = "ZZZ";
+                            b.Metadata.Title = "AAA";
+                        });
+                    }
+
+                    if (i == 8)
+                    {
+                        set.Beatmaps.ForEach(b =>
+                        {
+                            b.Metadata.Artist = "ZZZ";
+                            b.Metadata.Title = "ZZZ";
+                        });
+                    }
+
+                    sets.Add(set);
+                }
+            });
+
+            loadBeatmaps(sets);
+
+            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddAssert("Check last item", () =>
+            {
+                var lastItem = carousel.BeatmapSets.Last();
+                return lastItem.Metadata.Artist == "ZZZ" && lastItem.Metadata.Title == "ZZZ";
+            });
+            AddAssert("Check second last item", () =>
+            {
+                var secondLastItem = carousel.BeatmapSets.SkipLast(1).Last();
+                return secondLastItem.Metadata.Artist == "ZZZ" && secondLastItem.Metadata.Title == "AAA";
+            });
+        }
+
         /// <summary>
         /// Ensures stability is maintained on different sort modes for items with equal properties.
         /// </summary>

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmapSet.cs
@@ -69,6 +69,8 @@ namespace osu.Game.Screens.Select.Carousel
                 default:
                 case SortMode.Artist:
                     comparison = OrdinalSortByCaseStringComparer.DEFAULT.Compare(BeatmapSet.Metadata.Artist, otherSet.BeatmapSet.Metadata.Artist);
+                    if (comparison == 0)
+                        goto case SortMode.Title;
                     break;
 
                 case SortMode.Title:


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27548.

Reference: https://github.com/peppy/osu-stable-reference/blob/e53980dd76857ee899f66ce519ba1597e7874f28/osu!/GameplayElements/Beatmaps/BeatmapTreeManager.cs#L341-L347

Curious of thoughts on the `goto case` usage. It's the first one across game and framework, but I think it works well for what it is and alternatives are worse off?