### PR TITLE
Attempt to disable custom rulesets that can be linked to an unhandled crash

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -678,11 +678,13 @@ namespace osu.Game
         /// <summary>
         /// Allows a maximum of one unhandled exception, per second of execution.
         /// </summary>
-        private bool onExceptionThrown(Exception _)
+        private bool onExceptionThrown(Exception ex)
         {
             bool continueExecution = Interlocked.Decrement(ref allowableExceptions) >= 0;
 
             Logger.Log($"Unhandled exception has been {(continueExecution ? $"allowed with {allowableExceptions} more allowable exceptions" : "denied")} .");
+
+            RulesetStore.TryDisableCustomRulesetsCausing(ex);
 
             // restore the stock of allowable exceptions after a short delay.
             Task.Delay(1000).ContinueWith(_ => Interlocked.Increment(ref allowableExceptions));

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -678,18 +678,21 @@ namespace osu.Game
         /// <summary>
         /// Allows a maximum of one unhandled exception, per second of execution.
         /// </summary>
+        /// <returns>Whether to ignore the exception and continue running.</returns>
         private bool onExceptionThrown(Exception ex)
         {
-            bool continueExecution = Interlocked.Decrement(ref allowableExceptions) >= 0;
+            if (Interlocked.Decrement(ref allowableExceptions) < 0)
+            {
+                Logger.Log("Too many unhandled exceptions, crashing out.");
+                RulesetStore.TryDisableCustomRulesetsCausing(ex);
+                return false;
+            }
 
-            Logger.Log($"Unhandled exception has been {(continueExecution ? $"allowed with {allowableExceptions} more allowable exceptions" : "denied")} .");
-
-            RulesetStore.TryDisableCustomRulesetsCausing(ex);
-
+            Logger.Log($"Unhandled exception has been allowed with {allowableExceptions} more allowable exceptions.");
             // restore the stock of allowable exceptions after a short delay.
             Task.Delay(1000).ContinueWith(_ => Interlocked.Increment(ref allowableExceptions));
 
-            return continueExecution;
+            return true;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Rulesets/RealmRulesetStore.cs
+++ b/osu.Game/Rulesets/RealmRulesetStore.cs
@@ -164,25 +164,32 @@ namespace osu.Game.Rulesets
 
         internal void TryDisableCustomRulesetsCausing(Exception exception)
         {
-            var stackTrace = new StackTrace(exception);
-
-            foreach (var frame in stackTrace.GetFrames())
+            try
             {
-                var declaringAssembly = frame.GetMethod()?.DeclaringType?.Assembly;
-                if (declaringAssembly == null)
-                    continue;
+                var stackTrace = new StackTrace(exception);
 
-                if (UserRulesetAssemblies.Contains(declaringAssembly))
+                foreach (var frame in stackTrace.GetFrames())
                 {
-                    string sourceLocation = declaringAssembly.Location;
-                    string destinationLocation = Path.ChangeExtension(sourceLocation, @".dll.broken");
+                    var declaringAssembly = frame.GetMethod()?.DeclaringType?.Assembly;
+                    if (declaringAssembly == null)
+                        continue;
 
-                    if (File.Exists(sourceLocation))
+                    if (UserRulesetAssemblies.Contains(declaringAssembly))
                     {
-                        Logger.Log($"Unhandled exception traced back to custom ruleset {Path.GetFileNameWithoutExtension(sourceLocation)}. Marking as broken.");
-                        File.Move(sourceLocation, destinationLocation);
+                        string sourceLocation = declaringAssembly.Location;
+                        string destinationLocation = Path.ChangeExtension(sourceLocation, @".dll.broken");
+
+                        if (File.Exists(sourceLocation))
+                        {
+                            Logger.Log($"Unhandled exception traced back to custom ruleset {Path.GetFileNameWithoutExtension(sourceLocation)}. Marking as broken.");
+                            File.Move(sourceLocation, destinationLocation);
+                        }
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Attempt to trace back crash to custom ruleset failed: {ex}");
             }
         }
     }


### PR DESCRIPTION
RFC.

After seeing yet another report of [this](https://github.com/ppy/osu/issues/27596) something in me broke and I decided I have had enough of it.

https://github.com/ppy/osu/assets/20418176/d87ebbed-76e4-4862-a281-d4672f750a0e

What this does is that when the game is dying, it will hand off the exception to `RulesetStore` for a last-ditch inspection. `RulesetStore` will walk the call stack, and check if any ruleset has been involved in the trash fire. If it finds one, it [banishes it to the blagole](https://www.youtube.com/watch?v=AfA_2Ku1aJY) by renaming the dll to something that won't match the dll pattern (namely by attaching a `.broken` faux-extension suffix to the filename).

On launch, the game checks for `.dll.broken` ruleset files in the rulesets directory, and raises a notification for every single one that it finds to let the users know. And yes it will do that on every startup. I don't much care at this point (partially because I don't even know if reviewers will accept the starting premise of this - if they will I am willing to put some more work into this).

Is this a knee-jerk response? Yes. Am I tired of dealing with these every now and again? Also yes. Am I tired of dealing with developers who do not understand the meaning of "API boundaries" and use stupid reflection crap to do things that should never have been attempted because apparently they know better? Even more so yes.