### PR TITLE
Use system clipboard for hitobjects in the editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -34,6 +34,14 @@ namespace osu.Game.Tests.Visual.Editing
         [Resolved]
         private Clipboard hostClipboard { get; set; } = null!;
 
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            // writing arbitrary value to the clipboard to make sure the clipboard contains no hitobects before each test
+            AddStep("clear clipboard", () => hostClipboard.SetText("dummy text"));
+        }
+
         [Test]
         public void TestCutRemovesObjects()
         {

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -173,10 +173,33 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestCopyCreatesClipboardEntry()
+        {
+            var addedObject = new HitCircle { StartTime = 1000 };
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+            AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+            AddStep("copy hitobject", () => Editor.Copy());
+
+            AddAssert("clipboard contains entry for hitobjects", () => hostClipboard.GetCustom(ClipboardContent.CLIPBOARD_FORMAT) != null);
+        }
+
+        [Test]
+        public void TestCutCreatesClipboardEntry()
+        {
+            var addedObject = new HitCircle { StartTime = 1000 };
+            AddStep("add hitobject", () => EditorBeatmap.Add(addedObject));
+            AddStep("select added object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+            AddStep("cut hitobject", () => Editor.Cut());
+
+            AddAssert("clipboard contains entry for hitobjects", () => hostClipboard.GetCustom(ClipboardContent.CLIPBOARD_FORMAT) != null);
+        }
+
+        [Test]
         public void TestCutNothing()
         {
             AddStep("cut hitobject", () => Editor.Cut());
             AddAssert("are no objects", () => EditorBeatmap.HitObjects.Count == 0);
+            AddAssert("clipboard contains no objects", () => hostClipboard.GetCustom(ClipboardContent.CLIPBOARD_FORMAT) == null);
         }
 
         [Test]
@@ -184,6 +207,7 @@ namespace osu.Game.Tests.Visual.Editing
         {
             AddStep("copy hitobject", () => Editor.Copy());
             AddAssert("are no objects", () => EditorBeatmap.HitObjects.Count == 0);
+            AddAssert("clipboard contains no objects", () => hostClipboard.GetCustom(ClipboardContent.CLIPBOARD_FORMAT) == null);
         }
 
         [Test]
@@ -211,7 +235,7 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestPasteJsonContent()
+        public void TestPasteRawClipboardCootent()
         {
             var hitObjects = new List<HitObject>
             {
@@ -226,7 +250,7 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestPasteUnparseableContent()
+        public void TestPasteUnparseableClipboardContent()
         {
             AddStep("store invalid content in clipboard", () => hostClipboard.SetCustom(ClipboardContent.CLIPBOARD_FORMAT, "invalid json content"));
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClipboard.cs
@@ -4,15 +4,20 @@
 #nullable disable
 
 using System.Linq;
+using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Testing;
+using osu.Framework.Platform;
 using osu.Game.Beatmaps;
+using osu.Game.IO.Serialization;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Tests.Beatmaps;
@@ -25,6 +30,9 @@ namespace osu.Game.Tests.Visual.Editing
         protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Resolved]
+        private Clipboard hostClipboard { get; set; } = null!;
 
         [Test]
         public void TestCutRemovesObjects()
@@ -200,6 +208,31 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("is one object", () => EditorBeatmap.HitObjects.Count == 1);
             AddStep("clone", () => Editor.Clone());
             AddAssert("still one object", () => EditorBeatmap.HitObjects.Count == 1);
+        }
+
+        [Test]
+        public void TestPasteJsonContent()
+        {
+            var hitObjects = new List<HitObject>
+            {
+                new HitCircle { StartTime = 1000 }
+            };
+
+            AddStep("store json content in clipboard", () => hostClipboard.SetCustom(ClipboardContent.CLIPBOARD_FORMAT, new ClipboardContent(hitObjects).Serialize()));
+
+            AddStep("paste hitobject", () => Editor.Paste());
+
+            AddAssert("one object", () => EditorBeatmap.HitObjects.Count == 1);
+        }
+
+        [Test]
+        public void TestPasteUnparseableContent()
+        {
+            AddStep("store invalid content in clipboard", () => hostClipboard.SetCustom(ClipboardContent.CLIPBOARD_FORMAT, "invalid json content"));
+
+            AddStep("paste hitobject", () => Editor.Paste());
+
+            AddAssert("zero objects", () => EditorBeatmap.HitObjects.Count == 0);
         }
     }
 }

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -140,6 +140,11 @@ Click to see what's new!", version);
         /// </summary>
         public static LocalisableString InstallingUpdate => new TranslatableString(getKey(@"installing_update"), @"Installing update...");
 
+        /// <summary>
+        /// "Failed to paste objects: Invalid clipboard content."
+        /// </summary>
+        public static LocalisableString InvalidHitObjectClipboardContent => new TranslatableString(getKey(@"invalid_hitobject_clipboard_content"), @"Failed to paste objects: Invalid clipboard content.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Edit/ClipboardContent.cs
+++ b/osu.Game/Screens/Edit/ClipboardContent.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit
         [JsonConverter(typeof(TypedListConverter<HitObject>))]
         public IList<HitObject> HitObjects;
 
-        public const string CLIPBOARD_FORMAT = "osu/hitobjects";
+        public const string CLIPBOARD_FORMAT = "application/x-osu-hitobjects";
 
         public ClipboardContent()
         {

--- a/osu.Game/Screens/Edit/ClipboardContent.cs
+++ b/osu.Game/Screens/Edit/ClipboardContent.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Screens.Edit
         [JsonConverter(typeof(TypedListConverter<HitObject>))]
         public IList<HitObject> HitObjects;
 
+        public const string CLIPBOARD_FORMAT = "osu/hitobjects";
+
         public ClipboardContent()
         {
         }

--- a/osu.Game/Screens/Edit/ClipboardContent.cs
+++ b/osu.Game/Screens/Edit/ClipboardContent.cs
@@ -26,5 +26,10 @@ namespace osu.Game.Screens.Edit
         {
             HitObjects = editorBeatmap.SelectedHitObjects.ToList();
         }
+
+        public ClipboardContent(IList<HitObject> hitObjects)
+        {
+            HitObjects = hitObjects;
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -133,10 +133,8 @@ namespace osu.Game.Screens.Edit.Compose
 
             var objects = clipboardContent?.Deserialize<ClipboardContent>().HitObjects;
 
-            if (objects == null)
+            if (objects == null || objects.Count == 0)
                 return;
-
-            Debug.Assert(objects.Any());
 
             double timeOffset = clock.CurrentTime - objects.Min(o => o.StartTime);
 

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -107,17 +107,20 @@ namespace osu.Game.Screens.Edit.Compose
             // regardless of whether anything was even selected at all.
             // UX-wise this is generally strange and unexpected, but make it work anyways to preserve muscle memory.
             // note that this means that `getTimestamp()` must handle no-selection case, too.
+            var clipboardData = new ClipboardData
+            {
+                Text = getTimestamp()
+            };
+
             if (CanCopy.Value)
             {
-                hostClipboard.SetData(
-                    new ClipboardTextEntry(getTimestamp()),
-                    new ClipboardCustomEntry(ClipboardContent.CLIPBOARD_FORMAT, new ClipboardContent(EditorBeatmap).Serialize())
+                clipboardData.AddCustom(
+                    ClipboardContent.CLIPBOARD_FORMAT,
+                    new ClipboardContent(EditorBeatmap).Serialize()
                 );
             }
-            else
-            {
-                hostClipboard.SetText(getTimestamp());
-            }
+
+            hostClipboard.SetData(clipboardData);
 
             updateClipboardActionAvailability();
         }

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -114,10 +114,7 @@ namespace osu.Game.Screens.Edit.Compose
 
             if (CanCopy.Value)
             {
-                clipboardData.AddCustom(
-                    ClipboardContent.CLIPBOARD_FORMAT,
-                    new ClipboardContent(EditorBeatmap).Serialize()
-                );
+                clipboardData.CustomFormatValues[ClipboardContent.CLIPBOARD_FORMAT] = new ClipboardContent(EditorBeatmap).Serialize();
             }
 
             hostClipboard.SetData(clipboardData);

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -77,11 +77,6 @@ namespace osu.Game.Screens.Edit.Compose
             return new EditorSkinProvidingContainer(EditorBeatmap).WithChild(content);
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -116,9 +116,7 @@ namespace osu.Game.Screens.Edit.Compose
             {
                 hostClipboard.SetData(
                     new ClipboardTextEntry(getTimestamp()),
-                    new ClipboardCustomEntry("osu/hitobjects",
-                        new ClipboardContent(EditorBeatmap).Serialize()
-                    )
+                    new ClipboardCustomEntry(ClipboardContent.CLIPBOARD_FORMAT, new ClipboardContent(EditorBeatmap).Serialize())
                 );
             }
             else
@@ -131,7 +129,7 @@ namespace osu.Game.Screens.Edit.Compose
 
         public override void Paste()
         {
-            string clipboardContent = hostClipboard.GetCustom("osu/hitobjects");
+            string clipboardContent = hostClipboard.GetCustom(ClipboardContent.CLIPBOARD_FORMAT);
 
             var objects = clipboardContent?.Deserialize<ClipboardContent>().HitObjects;
 


### PR DESCRIPTION
- [ ] Depends on ppy/osu-framework#6223

Uses the system clipboard when copy-pasting hitobjects in the editor. When copying hitobjects, 2 clipboard entries will be created:
- `text/plain`: contains the timestamp
- `osu/hitobjects`: contains the json-serialized version of the copied hitobjects

This allows copy-pasting objects between osu and external tools.

https://github.com/ppy/osu/assets/8039761/f5662223-3216-4a8b-8eb9-be23f583de98

