### PR TITLE
Fix reverse selection not updating new combo location

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchReverseSelection.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchReverseSelection.cs
@@ -1,0 +1,313 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Catch.Tests.Editor
+{
+    [TestFixture]
+    public partial class TestSceneCatchReverseSelection : TestSceneEditor
+    {
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Test]
+        public void TestReverseSelectionTwoFruits()
+        {
+            float fruit1OldX = default;
+            float fruit2OldX = default;
+
+            addObjects([
+                new Fruit
+                {
+                    StartTime = 200,
+                    X = fruit1OldX = 0,
+                },
+                new Fruit
+                {
+                    StartTime = 400,
+                    X = fruit2OldX = 20,
+                }
+            ]);
+
+            selectEverything();
+            reverseSelection();
+
+            AddAssert("fruit1 is at fruit2's X",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
+                () => Is.EqualTo(fruit2OldX)
+            );
+
+            AddAssert("fruit2 is at fruit1's X",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
+                () => Is.EqualTo(fruit1OldX)
+            );
+
+            AddAssert("fruit2 is not a new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionThreeFruits()
+        {
+            float fruit1OldX = default;
+            float fruit2OldX = default;
+            float fruit3OldX = default;
+
+            addObjects([
+                new Fruit
+                {
+                    StartTime = 200,
+                    X = fruit1OldX = 0,
+                },
+                new Fruit
+                {
+                    StartTime = 400,
+                    X = fruit2OldX = 20,
+                },
+                new Fruit
+                {
+                    StartTime = 600,
+                    X = fruit3OldX = 40,
+                }
+            ]);
+
+            selectEverything();
+            reverseSelection();
+
+            AddAssert("fruit1 is at fruit3's X",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
+                () => Is.EqualTo(fruit3OldX)
+            );
+
+            AddAssert("fruit2's X is unchanged",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
+                () => Is.EqualTo(fruit2OldX)
+            );
+
+            AddAssert("fruit3's is at fruit1's X",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).EffectiveX,
+                () => Is.EqualTo(fruit1OldX)
+            );
+
+            AddAssert("fruit3 is not a new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionFruitAndJuiceStream()
+        {
+            addObjects([
+                new Fruit
+                {
+                    StartTime = 200,
+                    X = 0,
+                },
+                new JuiceStream
+                {
+                    StartTime = 400,
+                    X = 20,
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(),
+                            new PathControlPoint(new Vector2(50))
+                        }
+                    }
+                }
+            ]);
+
+            selectEverything();
+            reverseSelection();
+
+            AddAssert("First element is juice stream",
+                () => EditorBeatmap.HitObjects.First().GetType(),
+                () => Is.EqualTo(typeof(JuiceStream))
+            );
+
+            AddAssert("Last element is fruit",
+                () => EditorBeatmap.HitObjects.Last().GetType(),
+                () => Is.EqualTo(typeof(Fruit))
+            );
+
+            AddAssert("Fruit is not new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionTwoFruitsAndJuiceStream()
+        {
+            addObjects([
+                new Fruit
+                {
+                    StartTime = 200,
+                    X = 0,
+                },
+                new Fruit
+                {
+                    StartTime = 400,
+                    X = 20,
+                },
+                new JuiceStream
+                {
+                    StartTime = 600,
+                    X = 40,
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(),
+                            new PathControlPoint(new Vector2(50))
+                        }
+                    }
+                }
+            ]);
+
+            selectEverything();
+            reverseSelection();
+
+            AddAssert("First element is juice stream",
+                () => EditorBeatmap.HitObjects.First().GetType(),
+                () => Is.EqualTo(typeof(JuiceStream))
+            );
+
+            AddAssert("Middle element is Fruit",
+                () => EditorBeatmap.HitObjects.ElementAt(1).GetType(),
+                () => Is.EqualTo(typeof(Fruit))
+            );
+
+            AddAssert("Last element is Fruit",
+                () => EditorBeatmap.HitObjects.Last().GetType(),
+                () => Is.EqualTo(typeof(Fruit))
+            );
+
+            AddAssert("Last fruit is not new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().Last().NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionTwoCombos()
+        {
+            float fruit1OldX = default;
+            float fruit2OldX = default;
+            float fruit3OldX = default;
+
+            float fruit4OldX = default;
+            float fruit5OldX = default;
+            float fruit6OldX = default;
+
+            addObjects([
+                new Fruit
+                {
+                    StartTime = 200,
+                    X = fruit1OldX = 0,
+                },
+                new Fruit
+                {
+                    StartTime = 400,
+                    X = fruit2OldX = 20,
+                },
+                new Fruit
+                {
+                    StartTime = 600,
+                    X = fruit3OldX = 40,
+                },
+
+                new Fruit
+                {
+                    StartTime = 800,
+                    NewCombo = true,
+                    X = fruit4OldX = 60,
+                },
+                new Fruit
+                {
+                    StartTime = 1000,
+                    X = fruit5OldX = 80,
+                },
+                new Fruit
+                {
+                    StartTime = 1200,
+                    X = fruit6OldX = 100,
+                }
+            ]);
+
+            selectEverything();
+            reverseSelection();
+
+            AddAssert("fruit1 is at fruit6 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
+                () => Is.EqualTo(fruit6OldX)
+            );
+
+            AddAssert("fruit2 is at fruit5 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
+                () => Is.EqualTo(fruit5OldX)
+            );
+
+            AddAssert("fruit3 is at fruit4 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).EffectiveX,
+                () => Is.EqualTo(fruit4OldX)
+            );
+
+            AddAssert("fruit4 is at fruit3 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(3).EffectiveX,
+                () => Is.EqualTo(fruit3OldX)
+            );
+
+            AddAssert("fruit5 is at fruit2 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(4).EffectiveX,
+                () => Is.EqualTo(fruit2OldX)
+            );
+
+            AddAssert("fruit6 is at fruit1 position",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(5).EffectiveX,
+                () => Is.EqualTo(fruit1OldX)
+            );
+
+            AddAssert("fruit1 is new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).NewCombo,
+                () => Is.EqualTo(true)
+            );
+
+            AddAssert("fruit4 is new combo",
+                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(3).NewCombo,
+                () => Is.EqualTo(true)
+            );
+        }
+
+        private void addObjects(CatchHitObject[] hitObjects) => AddStep("Add objects", () => EditorBeatmap.AddRange(hitObjects));
+
+        private void selectEverything()
+        {
+            AddStep("Select everything", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+        }
+
+        private void reverseSelection()
+        {
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchReverseSelection.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneCatchReverseSelection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
@@ -20,93 +21,78 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
         [Test]
         public void TestReverseSelectionTwoFruits()
         {
-            float fruit1OldX = default;
-            float fruit2OldX = default;
+            CatchHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             addObjects([
                 new Fruit
                 {
                     StartTime = 200,
-                    X = fruit1OldX = 0,
+                    X = 0,
                 },
                 new Fruit
                 {
                     StartTime = 400,
-                    X = fruit2OldX = 20,
+                    X = 20,
                 }
             ]);
+
+            AddStep("store objects & new combo data", () =>
+            {
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
+            });
 
             selectEverything();
             reverseSelection();
 
-            AddAssert("fruit1 is at fruit2's X",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
-                () => Is.EqualTo(fruit2OldX)
-            );
-
-            AddAssert("fruit2 is at fruit1's X",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
-                () => Is.EqualTo(fruit1OldX)
-            );
-
-            AddAssert("fruit2 is not a new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionThreeFruits()
         {
-            float fruit1OldX = default;
-            float fruit2OldX = default;
-            float fruit3OldX = default;
+            CatchHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             addObjects([
                 new Fruit
                 {
                     StartTime = 200,
-                    X = fruit1OldX = 0,
+                    X = 0,
                 },
                 new Fruit
                 {
                     StartTime = 400,
-                    X = fruit2OldX = 20,
+                    X = 20,
                 },
                 new Fruit
                 {
                     StartTime = 600,
-                    X = fruit3OldX = 40,
+                    X = 40,
                 }
             ]);
+
+            AddStep("store objects & new combo data", () =>
+            {
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
+            });
 
             selectEverything();
             reverseSelection();
 
-            AddAssert("fruit1 is at fruit3's X",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
-                () => Is.EqualTo(fruit3OldX)
-            );
-
-            AddAssert("fruit2's X is unchanged",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
-                () => Is.EqualTo(fruit2OldX)
-            );
-
-            AddAssert("fruit3's is at fruit1's X",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).EffectiveX,
-                () => Is.EqualTo(fruit1OldX)
-            );
-
-            AddAssert("fruit3 is not a new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionFruitAndJuiceStream()
         {
+            CatchHitObject[] objects = null!;
+            bool[] newCombos = null!;
+
             addObjects([
                 new Fruit
                 {
@@ -128,28 +114,25 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
                 }
             ]);
 
+            AddStep("store objects & new combo data", () =>
+            {
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
+            });
+
             selectEverything();
             reverseSelection();
 
-            AddAssert("First element is juice stream",
-                () => EditorBeatmap.HitObjects.First().GetType(),
-                () => Is.EqualTo(typeof(JuiceStream))
-            );
-
-            AddAssert("Last element is fruit",
-                () => EditorBeatmap.HitObjects.Last().GetType(),
-                () => Is.EqualTo(typeof(Fruit))
-            );
-
-            AddAssert("Fruit is not new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionTwoFruitsAndJuiceStream()
         {
+            CatchHitObject[] objects = null!;
+            bool[] newCombos = null!;
+
             addObjects([
                 new Fruit
                 {
@@ -176,121 +159,78 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
                 }
             ]);
 
+            AddStep("store objects & new combo data", () =>
+            {
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
+            });
+
             selectEverything();
             reverseSelection();
 
-            AddAssert("First element is juice stream",
-                () => EditorBeatmap.HitObjects.First().GetType(),
-                () => Is.EqualTo(typeof(JuiceStream))
-            );
-
-            AddAssert("Middle element is Fruit",
-                () => EditorBeatmap.HitObjects.ElementAt(1).GetType(),
-                () => Is.EqualTo(typeof(Fruit))
-            );
-
-            AddAssert("Last element is Fruit",
-                () => EditorBeatmap.HitObjects.Last().GetType(),
-                () => Is.EqualTo(typeof(Fruit))
-            );
-
-            AddAssert("Last fruit is not new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().Last().NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionTwoCombos()
         {
-            float fruit1OldX = default;
-            float fruit2OldX = default;
-            float fruit3OldX = default;
-
-            float fruit4OldX = default;
-            float fruit5OldX = default;
-            float fruit6OldX = default;
+            CatchHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             addObjects([
                 new Fruit
                 {
                     StartTime = 200,
-                    X = fruit1OldX = 0,
+                    X = 0,
                 },
                 new Fruit
                 {
                     StartTime = 400,
-                    X = fruit2OldX = 20,
+                    X = 20,
                 },
                 new Fruit
                 {
                     StartTime = 600,
-                    X = fruit3OldX = 40,
+                    X = 40,
                 },
 
                 new Fruit
                 {
                     StartTime = 800,
                     NewCombo = true,
-                    X = fruit4OldX = 60,
+                    X = 60,
                 },
                 new Fruit
                 {
                     StartTime = 1000,
-                    X = fruit5OldX = 80,
+                    X = 80,
                 },
                 new Fruit
                 {
                     StartTime = 1200,
-                    X = fruit6OldX = 100,
+                    X = 100,
                 }
             ]);
+
+            AddStep("store objects & new combo data", () =>
+            {
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
+            });
 
             selectEverything();
             reverseSelection();
 
-            AddAssert("fruit1 is at fruit6 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).EffectiveX,
-                () => Is.EqualTo(fruit6OldX)
-            );
-
-            AddAssert("fruit2 is at fruit5 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(1).EffectiveX,
-                () => Is.EqualTo(fruit5OldX)
-            );
-
-            AddAssert("fruit3 is at fruit4 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(2).EffectiveX,
-                () => Is.EqualTo(fruit4OldX)
-            );
-
-            AddAssert("fruit4 is at fruit3 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(3).EffectiveX,
-                () => Is.EqualTo(fruit3OldX)
-            );
-
-            AddAssert("fruit5 is at fruit2 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(4).EffectiveX,
-                () => Is.EqualTo(fruit2OldX)
-            );
-
-            AddAssert("fruit6 is at fruit1 position",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(5).EffectiveX,
-                () => Is.EqualTo(fruit1OldX)
-            );
-
-            AddAssert("fruit1 is new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(0).NewCombo,
-                () => Is.EqualTo(true)
-            );
-
-            AddAssert("fruit4 is new combo",
-                () => EditorBeatmap.HitObjects.OfType<Fruit>().ElementAt(3).NewCombo,
-                () => Is.EqualTo(true)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         private void addObjects(CatchHitObject[] hitObjects) => AddStep("Add objects", () => EditorBeatmap.AddRange(hitObjects));
+
+        private IEnumerable<CatchHitObject> getObjects() => EditorBeatmap.HitObjects.OfType<CatchHitObject>();
+
+        private IEnumerable<bool> getObjectNewCombos() => getObjects().Select(ho => ho.NewCombo);
 
         private void selectEverything()
         {

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -76,17 +76,15 @@ namespace osu.Game.Rulesets.Catch.Edit
 
         public override bool HandleReverse()
         {
-            var hitObjects = EditorBeatmap.SelectedHitObjects;
+            var hitObjects = EditorBeatmap.SelectedHitObjects
+                .OfType<CatchHitObject>()
+                .OrderBy(obj => obj.StartTime)
+                .ToList();
 
             double selectionStartTime = SelectedItems.Min(h => h.StartTime);
             double selectionEndTime = SelectedItems.Max(h => h.GetEndTime());
 
-            var newComboOrder = hitObjects
-                .OfType<CatchHitObject>()
-                .Select(obj => obj.NewCombo)
-                .ToList();
-
-            newComboOrder.Reverse();
+            var newComboOrder = hitObjects.Select(obj => obj.NewCombo).ToList();
 
             foreach (var h in hitObjects)
             {
@@ -101,10 +99,13 @@ namespace osu.Game.Rulesets.Catch.Edit
                 }
             }
 
+            // re-order objects again after flipping their times
+            hitObjects = [.. hitObjects.OrderBy(obj => obj.StartTime)];
+
             int i = 0;
             foreach (bool newCombo in newComboOrder)
             {
-                hitObjects.OfType<CatchHitObject>().ToList()[i].NewCombo = newCombo;
+                hitObjects[i].NewCombo = newCombo;
                 i++;
             }
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -81,11 +81,12 @@ namespace osu.Game.Rulesets.Catch.Edit
             double selectionStartTime = SelectedItems.Min(h => h.StartTime);
             double selectionEndTime = SelectedItems.Max(h => h.GetEndTime());
 
-            var newComboPlaces = hitObjects
+            var newComboOrder = hitObjects
                 .OfType<CatchHitObject>()
-                .Where(h => h.NewCombo)
-                .Select(obj => obj.StartTime)
+                .Select(obj => obj.NewCombo)
                 .ToList();
+
+            newComboOrder.Reverse();
 
             foreach (var h in hitObjects)
             {
@@ -100,18 +101,11 @@ namespace osu.Game.Rulesets.Catch.Edit
                 }
             }
 
-            foreach (var h in hitObjects)
+            int i = 0;
+            foreach (bool newCombo in newComboOrder)
             {
-                if (h is CatchHitObject obj) obj.NewCombo = false;
-            }
-
-            foreach (double place in newComboPlaces)
-            {
-                hitObjects
-                    .OfType<CatchHitObject>()
-                    .Where(obj => obj.StartTime == place)
-                    .ToList()
-                    .ForEach(obj => obj.NewCombo = true);
+                hitObjects.OfType<CatchHitObject>().ToList()[i].NewCombo = newCombo;
+                i++;
             }
 
             return true;

--- a/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchSelectionHandler.cs
@@ -77,13 +77,16 @@ namespace osu.Game.Rulesets.Catch.Edit
         public override bool HandleReverse()
         {
             var hitObjects = EditorBeatmap.SelectedHitObjects
-                .OfType<CatchHitObject>()
-                .OrderBy(obj => obj.StartTime)
-                .ToList();
+                                          .OfType<CatchHitObject>()
+                                          .OrderBy(obj => obj.StartTime)
+                                          .ToList();
 
             double selectionStartTime = SelectedItems.Min(h => h.StartTime);
             double selectionEndTime = SelectedItems.Max(h => h.GetEndTime());
 
+            // the expectation is that even if the objects themselves are reversed temporally,
+            // the position of new combos in the selection should remain the same.
+            // preserve it for later before doing the reversal.
             var newComboOrder = hitObjects.Select(obj => obj.NewCombo).ToList();
 
             foreach (var h in hitObjects)
@@ -99,15 +102,11 @@ namespace osu.Game.Rulesets.Catch.Edit
                 }
             }
 
-            // re-order objects again after flipping their times
-            hitObjects = [.. hitObjects.OrderBy(obj => obj.StartTime)];
+            // re-order objects by start time again after reversing, and restore new combo flag positioning
+            hitObjects = hitObjects.OrderBy(obj => obj.StartTime).ToList();
 
-            int i = 0;
-            foreach (bool newCombo in newComboOrder)
-            {
-                hitObjects[i].NewCombo = newCombo;
-                i++;
-            }
+            for (int i = 0; i < hitObjects.Count; ++i)
+                hitObjects[i].NewCombo = newComboOrder[i];
 
             return true;
         }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuReverseSelection.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuReverseSelection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
@@ -20,29 +21,32 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestReverseSelectionTwoCircles()
         {
-            Vector2 circle1OldPosition = default;
-            Vector2 circle2OldPosition = default;
+            OsuHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             AddStep("Add circles", () =>
             {
                 var circle1 = new HitCircle
                 {
                     StartTime = 0,
-                    Position = circle1OldPosition = new Vector2(208, 240)
+                    Position = new Vector2(208, 240)
                 };
                 var circle2 = new HitCircle
                 {
                     StartTime = 200,
-                    Position = circle2OldPosition = new Vector2(256, 144)
+                    Position = new Vector2(256, 144)
                 };
 
                 EditorBeatmap.AddRange([circle1, circle2]);
             });
 
-            AddStep("Select circles", () =>
+            AddStep("store objects & new combo data", () =>
             {
-                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
             });
+
+            AddStep("Select circles", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
 
             AddStep("Reverse selection", () =>
             {
@@ -51,54 +55,44 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.ReleaseKey(Key.LControl);
             });
 
-            AddAssert("circle1 is at circle2 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
-                () => Is.EqualTo(circle2OldPosition)
-            );
-
-            AddAssert("circle2 is at circle1 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
-                () => Is.EqualTo(circle1OldPosition)
-            );
-
-            AddAssert("circle2 is not a new combo",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionThreeCircles()
         {
-            Vector2 circle1OldPosition = default;
-            Vector2 circle2OldPosition = default;
-            Vector2 circle3OldPosition = default;
+            OsuHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             AddStep("Add circles", () =>
             {
                 var circle1 = new HitCircle
                 {
                     StartTime = 0,
-                    Position = circle1OldPosition = new Vector2(208, 240)
+                    Position = new Vector2(208, 240)
                 };
                 var circle2 = new HitCircle
                 {
                     StartTime = 200,
-                    Position = circle2OldPosition = new Vector2(256, 144)
+                    Position = new Vector2(256, 144)
                 };
                 var circle3 = new HitCircle
                 {
                     StartTime = 400,
-                    Position = circle3OldPosition = new Vector2(304, 240)
+                    Position = new Vector2(304, 240)
                 };
 
                 EditorBeatmap.AddRange([circle1, circle2, circle3]);
             });
 
-            AddStep("Select circles", () =>
+            AddStep("store objects & new combo data", () =>
             {
-                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
             });
+
+            AddStep("Select circles", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
 
             AddStep("Reverse selection", () =>
             {
@@ -107,26 +101,16 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.ReleaseKey(Key.LControl);
             });
 
-            AddAssert("circle1 is at circle3 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
-                () => Is.EqualTo(circle3OldPosition)
-            );
-
-            AddAssert("circle3 is at circle1 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).Position,
-                () => Is.EqualTo(circle1OldPosition)
-            );
-
-            AddAssert("circle3 is not a new combo",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).NewCombo,
-                () => Is.EqualTo(false)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
 
         [Test]
         public void TestReverseSelectionCircleAndSlider()
         {
-            Vector2 circleOldPosition = default;
+            OsuHitObject[] objects = null!;
+            bool[] newCombos = null!;
+
             Vector2 sliderHeadOldPosition = default;
             Vector2 sliderTailOldPosition = default;
 
@@ -135,7 +119,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 var circle = new HitCircle
                 {
                     StartTime = 0,
-                    Position = circleOldPosition = new Vector2(208, 240)
+                    Position = new Vector2(208, 240)
                 };
                 var slider = new Slider
                 {
@@ -156,13 +140,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 EditorBeatmap.AddRange([circle, slider]);
             });
 
-            AddStep("Select objects", () =>
+            AddStep("store objects & new combo data", () =>
             {
-                var circle = (HitCircle)EditorBeatmap.HitObjects[0];
-                var slider = (Slider)EditorBeatmap.HitObjects[1];
-
-                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
             });
+
+            AddStep("Select objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
 
             AddStep("Reverse selection", () =>
             {
@@ -171,10 +155,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.ReleaseKey(Key.LControl);
             });
 
-            AddAssert("circle is at the same position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
-                () => Is.EqualTo(circleOldPosition)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
 
             AddAssert("Slider head is at slider tail", () =>
                 Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).Position, sliderTailOldPosition) < 1);
@@ -186,8 +168,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestReverseSelectionTwoCirclesAndSlider()
         {
-            Vector2 circle1OldPosition = default;
-            Vector2 circle2OldPosition = default;
+            OsuHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             Vector2 sliderHeadOldPosition = default;
             Vector2 sliderTailOldPosition = default;
@@ -197,12 +179,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 var circle1 = new HitCircle
                 {
                     StartTime = 0,
-                    Position = circle1OldPosition = new Vector2(208, 240)
+                    Position = new Vector2(208, 240)
                 };
                 var circle2 = new HitCircle
                 {
                     StartTime = 200,
-                    Position = circle2OldPosition = new Vector2(256, 144)
+                    Position = new Vector2(256, 144)
                 };
                 var slider = new Slider
                 {
@@ -223,10 +205,13 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 EditorBeatmap.AddRange([circle1, circle2, slider]);
             });
 
-            AddStep("Select objects", () =>
+            AddStep("store objects & new combo data", () =>
             {
-                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
             });
+
+            AddStep("Select objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
 
             AddStep("Reverse selection", () =>
             {
@@ -235,15 +220,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.ReleaseKey(Key.LControl);
             });
 
-            AddAssert("circle1 is at circle2 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
-                () => Is.EqualTo(circle2OldPosition)
-            );
-
-            AddAssert("circle2 is at circle1 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
-                () => Is.EqualTo(circle1OldPosition)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
 
             AddAssert("Slider head is at slider tail", () =>
                 Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).Position, sliderTailOldPosition) < 1);
@@ -255,56 +233,54 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestReverseSelectionTwoCombos()
         {
-            Vector2 circle1OldPosition = default;
-            Vector2 circle2OldPosition = default;
-            Vector2 circle3OldPosition = default;
-
-            Vector2 circle4OldPosition = default;
-            Vector2 circle5OldPosition = default;
-            Vector2 circle6OldPosition = default;
+            OsuHitObject[] objects = null!;
+            bool[] newCombos = null!;
 
             AddStep("Add circles", () =>
             {
                 var circle1 = new HitCircle
                 {
                     StartTime = 0,
-                    Position = circle1OldPosition = new Vector2(216, 240)
+                    Position = new Vector2(216, 240)
                 };
                 var circle2 = new HitCircle
                 {
                     StartTime = 200,
-                    Position = circle2OldPosition = new Vector2(120, 192)
+                    Position = new Vector2(120, 192)
                 };
                 var circle3 = new HitCircle
                 {
                     StartTime = 400,
-                    Position = circle3OldPosition = new Vector2(216, 144)
+                    Position = new Vector2(216, 144)
                 };
 
                 var circle4 = new HitCircle
                 {
                     StartTime = 646,
                     NewCombo = true,
-                    Position = circle4OldPosition = new Vector2(296, 240)
+                    Position = new Vector2(296, 240)
                 };
                 var circle5 = new HitCircle
                 {
                     StartTime = 846,
-                    Position = circle5OldPosition = new Vector2(392, 162)
+                    Position = new Vector2(392, 162)
                 };
                 var circle6 = new HitCircle
                 {
                     StartTime = 1046,
-                    Position = circle6OldPosition = new Vector2(296, 144)
+                    Position = new Vector2(296, 144)
                 };
 
                 EditorBeatmap.AddRange([circle1, circle2, circle3, circle4, circle5, circle6]);
             });
 
-            AddStep("Select circles", () =>
+            AddStep("store objects & new combo data", () =>
             {
-                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+                objects = getObjects().ToArray();
+                newCombos = getObjectNewCombos().ToArray();
             });
+
+            AddStep("Select circles", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
 
             AddStep("Reverse selection", () =>
             {
@@ -313,35 +289,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 InputManager.ReleaseKey(Key.LControl);
             });
 
-            AddAssert("circle1 is at circle6 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
-                () => Is.EqualTo(circle6OldPosition)
-            );
-
-            AddAssert("circle2 is at circle5 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
-                () => Is.EqualTo(circle5OldPosition)
-            );
-
-            AddAssert("circle3 is at circle4 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).Position,
-                () => Is.EqualTo(circle4OldPosition)
-            );
-
-            AddAssert("circle4 is at circle3 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(3).Position,
-                () => Is.EqualTo(circle3OldPosition)
-            );
-
-            AddAssert("circle5 is at circle2 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(4).Position,
-                () => Is.EqualTo(circle2OldPosition)
-            );
-
-            AddAssert("circle6 is at circle1 position",
-                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(5).Position,
-                () => Is.EqualTo(circle1OldPosition)
-            );
+            AddAssert("objects reversed", getObjects, () => Is.EqualTo(objects.Reverse()));
+            AddAssert("new combo positions preserved", getObjectNewCombos, () => Is.EqualTo(newCombos));
         }
+
+        private IEnumerable<OsuHitObject> getObjects() => EditorBeatmap.HitObjects.OfType<OsuHitObject>();
+
+        private IEnumerable<bool> getObjectNewCombos() => getObjects().Select(ho => ho.NewCombo);
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuReverseSelection.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuReverseSelection.cs
@@ -1,0 +1,347 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Tests.Beatmaps;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    [TestFixture]
+    public partial class TestSceneOsuReverseSelection : TestSceneOsuEditor
+    {
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
+
+        [Test]
+        public void TestReverseSelectionTwoCircles()
+        {
+            Vector2 circle1OldPosition = default;
+            Vector2 circle2OldPosition = default;
+
+            AddStep("Add circles", () =>
+            {
+                var circle1 = new HitCircle
+                {
+                    StartTime = 0,
+                    Position = circle1OldPosition = new Vector2(208, 240)
+                };
+                var circle2 = new HitCircle
+                {
+                    StartTime = 200,
+                    Position = circle2OldPosition = new Vector2(256, 144)
+                };
+
+                EditorBeatmap.AddRange([circle1, circle2]);
+            });
+
+            AddStep("Select circles", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+
+            AddAssert("circle1 is at circle2 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(circle2OldPosition)
+            );
+
+            AddAssert("circle2 is at circle1 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
+                () => Is.EqualTo(circle1OldPosition)
+            );
+
+            AddAssert("circle2 is not a new combo",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionThreeCircles()
+        {
+            Vector2 circle1OldPosition = default;
+            Vector2 circle2OldPosition = default;
+            Vector2 circle3OldPosition = default;
+
+            AddStep("Add circles", () =>
+            {
+                var circle1 = new HitCircle
+                {
+                    StartTime = 0,
+                    Position = circle1OldPosition = new Vector2(208, 240)
+                };
+                var circle2 = new HitCircle
+                {
+                    StartTime = 200,
+                    Position = circle2OldPosition = new Vector2(256, 144)
+                };
+                var circle3 = new HitCircle
+                {
+                    StartTime = 400,
+                    Position = circle3OldPosition = new Vector2(304, 240)
+                };
+
+                EditorBeatmap.AddRange([circle1, circle2, circle3]);
+            });
+
+            AddStep("Select circles", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+
+            AddAssert("circle1 is at circle3 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(circle3OldPosition)
+            );
+
+            AddAssert("circle3 is at circle1 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).Position,
+                () => Is.EqualTo(circle1OldPosition)
+            );
+
+            AddAssert("circle3 is not a new combo",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).NewCombo,
+                () => Is.EqualTo(false)
+            );
+        }
+
+        [Test]
+        public void TestReverseSelectionCircleAndSlider()
+        {
+            Vector2 circleOldPosition = default;
+            Vector2 sliderHeadOldPosition = default;
+            Vector2 sliderTailOldPosition = default;
+
+            AddStep("Add objects", () =>
+            {
+                var circle = new HitCircle
+                {
+                    StartTime = 0,
+                    Position = circleOldPosition = new Vector2(208, 240)
+                };
+                var slider = new Slider
+                {
+                    StartTime = 200,
+                    Position = sliderHeadOldPosition = new Vector2(257, 144),
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(),
+                            new PathControlPoint(new Vector2(100))
+                        }
+                    }
+                };
+
+                sliderTailOldPosition = slider.EndPosition;
+
+                EditorBeatmap.AddRange([circle, slider]);
+            });
+
+            AddStep("Select objects", () =>
+            {
+                var circle = (HitCircle)EditorBeatmap.HitObjects[0];
+                var slider = (Slider)EditorBeatmap.HitObjects[1];
+
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+
+            AddAssert("circle is at the same position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(circleOldPosition)
+            );
+
+            AddAssert("Slider head is at slider tail", () =>
+                Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).Position, sliderTailOldPosition) < 1);
+
+            AddAssert("Slider tail is at slider head", () =>
+                Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).EndPosition, sliderHeadOldPosition) < 1);
+        }
+
+        [Test]
+        public void TestReverseSelectionTwoCirclesAndSlider()
+        {
+            Vector2 circle1OldPosition = default;
+            Vector2 circle2OldPosition = default;
+
+            Vector2 sliderHeadOldPosition = default;
+            Vector2 sliderTailOldPosition = default;
+
+            AddStep("Add objects", () =>
+            {
+                var circle1 = new HitCircle
+                {
+                    StartTime = 0,
+                    Position = circle1OldPosition = new Vector2(208, 240)
+                };
+                var circle2 = new HitCircle
+                {
+                    StartTime = 200,
+                    Position = circle2OldPosition = new Vector2(256, 144)
+                };
+                var slider = new Slider
+                {
+                    StartTime = 200,
+                    Position = sliderHeadOldPosition = new Vector2(304, 240),
+                    Path = new SliderPath
+                    {
+                        ControlPoints =
+                        {
+                            new PathControlPoint(),
+                            new PathControlPoint(new Vector2(100))
+                        }
+                    }
+                };
+
+                sliderTailOldPosition = slider.EndPosition;
+
+                EditorBeatmap.AddRange([circle1, circle2, slider]);
+            });
+
+            AddStep("Select objects", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+
+            AddAssert("circle1 is at circle2 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(circle2OldPosition)
+            );
+
+            AddAssert("circle2 is at circle1 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
+                () => Is.EqualTo(circle1OldPosition)
+            );
+
+            AddAssert("Slider head is at slider tail", () =>
+                Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).Position, sliderTailOldPosition) < 1);
+
+            AddAssert("Slider tail is at slider head", () =>
+                Vector2.Distance(EditorBeatmap.HitObjects.OfType<Slider>().ElementAt(0).EndPosition, sliderHeadOldPosition) < 1);
+        }
+
+        [Test]
+        public void TestReverseSelectionTwoCombos()
+        {
+            Vector2 circle1OldPosition = default;
+            Vector2 circle2OldPosition = default;
+            Vector2 circle3OldPosition = default;
+
+            Vector2 circle4OldPosition = default;
+            Vector2 circle5OldPosition = default;
+            Vector2 circle6OldPosition = default;
+
+            AddStep("Add circles", () =>
+            {
+                var circle1 = new HitCircle
+                {
+                    StartTime = 0,
+                    Position = circle1OldPosition = new Vector2(216, 240)
+                };
+                var circle2 = new HitCircle
+                {
+                    StartTime = 200,
+                    Position = circle2OldPosition = new Vector2(120, 192)
+                };
+                var circle3 = new HitCircle
+                {
+                    StartTime = 400,
+                    Position = circle3OldPosition = new Vector2(216, 144)
+                };
+
+                var circle4 = new HitCircle
+                {
+                    StartTime = 646,
+                    NewCombo = true,
+                    Position = circle4OldPosition = new Vector2(296, 240)
+                };
+                var circle5 = new HitCircle
+                {
+                    StartTime = 846,
+                    Position = circle5OldPosition = new Vector2(392, 162)
+                };
+                var circle6 = new HitCircle
+                {
+                    StartTime = 1046,
+                    Position = circle6OldPosition = new Vector2(296, 144)
+                };
+
+                EditorBeatmap.AddRange([circle1, circle2, circle3, circle4, circle5, circle6]);
+            });
+
+            AddStep("Select circles", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects);
+            });
+
+            AddStep("Reverse selection", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.G);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+
+            AddAssert("circle1 is at circle6 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(0).Position,
+                () => Is.EqualTo(circle6OldPosition)
+            );
+
+            AddAssert("circle2 is at circle5 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(1).Position,
+                () => Is.EqualTo(circle5OldPosition)
+            );
+
+            AddAssert("circle3 is at circle4 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(2).Position,
+                () => Is.EqualTo(circle4OldPosition)
+            );
+
+            AddAssert("circle4 is at circle3 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(3).Position,
+                () => Is.EqualTo(circle3OldPosition)
+            );
+
+            AddAssert("circle5 is at circle2 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(4).Position,
+                () => Is.EqualTo(circle2OldPosition)
+            );
+
+            AddAssert("circle6 is at circle1 position",
+                () => EditorBeatmap.HitObjects.OfType<HitCircle>().ElementAt(5).Position,
+                () => Is.EqualTo(circle1OldPosition)
+            );
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -85,11 +85,12 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             bool moreThanOneObject = hitObjects.Count > 1;
 
-            var newComboPlaces = hitObjects
+            var newComboOrder = hitObjects
                 .OfType<OsuHitObject>()
-                .Where(h => h.NewCombo)
-                .Select(obj => obj.StartTime)
+                .Select(obj => obj.NewCombo)
                 .ToList();
+
+            newComboOrder.Reverse();
 
             foreach (var h in hitObjects)
             {
@@ -103,18 +104,11 @@ namespace osu.Game.Rulesets.Osu.Edit
                 }
             }
 
-            foreach (var h in hitObjects)
+            int i = 0;
+            foreach (bool newCombo in newComboOrder)
             {
-                if (h is OsuHitObject obj) obj.NewCombo = false;
-            }
-
-            foreach (double place in newComboPlaces)
-            {
-                hitObjects
-                    .OfType<OsuHitObject>()
-                    .Where(obj => obj.StartTime == place)
-                    .ToList()
-                    .ForEach(obj => obj.NewCombo = true);
+                hitObjects.OfType<OsuHitObject>().ToList()[i].NewCombo = newCombo;
+                i++;
             }
 
             return true;

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -85,6 +85,12 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             bool moreThanOneObject = hitObjects.Count > 1;
 
+            var newComboPlaces = hitObjects
+                .OfType<OsuHitObject>()
+                .Where(h => h.NewCombo)
+                .Select(obj => obj.StartTime)
+                .ToList();
+
             foreach (var h in hitObjects)
             {
                 if (moreThanOneObject)
@@ -95,6 +101,20 @@ namespace osu.Game.Rulesets.Osu.Edit
                     slider.Path.Reverse(out Vector2 offset);
                     slider.Position += offset;
                 }
+            }
+
+            foreach (var h in hitObjects)
+            {
+                if (h is OsuHitObject obj) obj.NewCombo = false;
+            }
+
+            foreach (double place in newComboPlaces)
+            {
+                hitObjects
+                    .OfType<OsuHitObject>()
+                    .Where(obj => obj.StartTime == place)
+                    .ToList()
+                    .ForEach(obj => obj.NewCombo = true);
             }
 
             return true;

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -79,15 +79,18 @@ namespace osu.Game.Rulesets.Osu.Edit
         public override bool HandleReverse()
         {
             var hitObjects = EditorBeatmap.SelectedHitObjects
-                .OfType<OsuHitObject>()
-                .OrderBy(obj => obj.StartTime)
-                .ToList();
+                                          .OfType<OsuHitObject>()
+                                          .OrderBy(obj => obj.StartTime)
+                                          .ToList();
 
             double endTime = hitObjects.Max(h => h.GetEndTime());
             double startTime = hitObjects.Min(h => h.StartTime);
 
             bool moreThanOneObject = hitObjects.Count > 1;
 
+            // the expectation is that even if the objects themselves are reversed temporally,
+            // the position of new combos in the selection should remain the same.
+            // preserve it for later before doing the reversal.
             var newComboOrder = hitObjects.Select(obj => obj.NewCombo).ToList();
 
             foreach (var h in hitObjects)
@@ -102,15 +105,11 @@ namespace osu.Game.Rulesets.Osu.Edit
                 }
             }
 
-            // re-order objects again after flipping their times
-            hitObjects = [.. hitObjects.OrderBy(obj => obj.StartTime)];
+            // re-order objects by start time again after reversing, and restore new combo flag positioning
+            hitObjects = hitObjects.OrderBy(obj => obj.StartTime).ToList();
 
-            int i = 0;
-            foreach (bool newCombo in newComboOrder)
-            {
-                hitObjects[i].NewCombo = newCombo;
-                i++;
-            }
+            for (int i = 0; i < hitObjects.Count; ++i)
+                hitObjects[i].NewCombo = newComboOrder[i];
 
             return true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionHandler.cs
@@ -78,19 +78,17 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override bool HandleReverse()
         {
-            var hitObjects = EditorBeatmap.SelectedHitObjects;
+            var hitObjects = EditorBeatmap.SelectedHitObjects
+                .OfType<OsuHitObject>()
+                .OrderBy(obj => obj.StartTime)
+                .ToList();
 
             double endTime = hitObjects.Max(h => h.GetEndTime());
             double startTime = hitObjects.Min(h => h.StartTime);
 
             bool moreThanOneObject = hitObjects.Count > 1;
 
-            var newComboOrder = hitObjects
-                .OfType<OsuHitObject>()
-                .Select(obj => obj.NewCombo)
-                .ToList();
-
-            newComboOrder.Reverse();
+            var newComboOrder = hitObjects.Select(obj => obj.NewCombo).ToList();
 
             foreach (var h in hitObjects)
             {
@@ -104,10 +102,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 }
             }
 
+            // re-order objects again after flipping their times
+            hitObjects = [.. hitObjects.OrderBy(obj => obj.StartTime)];
+
             int i = 0;
             foreach (bool newCombo in newComboOrder)
             {
-                hitObjects.OfType<OsuHitObject>().ToList()[i].NewCombo = newCombo;
+                hitObjects[i].NewCombo = newCombo;
                 i++;
             }
 


### PR DESCRIPTION
This PR fixes #27319  (both catch and standard).

https://github.com/ppy/osu/assets/90941580/5974e7f6-549e-445f-9279-0e35f1efa963

https://github.com/ppy/osu/assets/90941580/bf91283f-b766-4bee-91e6-24dbb3379169

