### PR TITLE
Rename concept of "ranked" mods to "eligible for PP"

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
         public override double ScoreMultiplier => 1; // TODO: Implement the mania key mod score multiplier
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModCover.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Mods
             typeof(ManiaModFadeIn)
         }).ToArray();
 
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
 
         [SettingSource("Coverage", "The proportion of playfield height that notes will be hidden for.")]
         public override BindableNumber<float> Coverage { get; } = new BindableFloat(0.5f)

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModHardRock.cs
@@ -8,6 +8,6 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModHardRock : ModHardRock
     {
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey1.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "One Key";
         public override string Acronym => "1K";
         public override LocalisableString Description => @"Play with one key.";
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey10.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Ten Keys";
         public override string Acronym => "10K";
         public override LocalisableString Description => @"Play with ten keys.";
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey2.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Two Keys";
         public override string Acronym => "2K";
         public override LocalisableString Description => @"Play with two keys.";
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModKey3.cs
@@ -11,6 +11,6 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Name => "Three Keys";
         public override string Acronym => "3K";
         public override LocalisableString Description => @"Play with three keys.";
-        public override bool Ranked => false;
+        public override bool EligibleForPP => false;
     }
 }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModMirror.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
     public class ManiaModMirror : ModMirror, IApplicableToBeatmap
     {
         public override LocalisableString Description => "Notes are flipped horizontally.";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBlinds.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.12 : 1;
         public override Type[] IncompatibleMods => new[] { typeof(OsuModFlashlight) };
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
 
         private DrawableOsuBlinds blinds = null!;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSpunOut.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override LocalisableString Description => @"Spinners will be automatically completed.";
         public override double ScoreMultiplier => 0.9;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(OsuModAutopilot), typeof(OsuModTargetPractice) };
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         public void ApplyToDrawableHitObject(DrawableHitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTouchDevice.cs
@@ -10,6 +10,6 @@ namespace osu.Game.Rulesets.Osu.Mods
     public class OsuModTouchDevice : ModTouchDevice
     {
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot) }).ToArray();
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
     }
 }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -312,7 +312,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("wait for join", () => RoomJoined);
 
             ClickButtonWhenEnabled<RoomSubScreen.UserModSelectButton>();
-            AddAssert("mod select shows unranked", () => screen.UserModsSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().Ranked.Value == false);
+            AddAssert("mod select shows ineligible for pp", () => screen.UserModsSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().EligibleForPP.Value == false);
             AddAssert("score multiplier = 1.20", () => screen.UserModsSelectOverlay.ChildrenOfType<RankingInformationDisplay>().Single().ModMultiplier.Value, () => Is.EqualTo(1.2).Within(0.01));
 
             AddStep("select flashlight", () => screen.UserModsSelectOverlay.ChildrenOfType<ModPanel>().Single(m => m.Mod is ModFlashlight).TriggerClick());

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFooterButtonMods.cs
@@ -71,10 +71,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestUnrankedBadge()
         {
-            AddStep(@"Add unranked mod", () => changeMods(new[] { new OsuModDeflate() }));
-            AddAssert("Unranked badge shown", () => footerButtonMods.UnrankedBadge.Alpha == 1);
+            AddStep(@"Add mod ineligible for pp", () => changeMods(new[] { new OsuModDeflate() }));
+            AddAssert("Not eligible for pp badge shown", () => footerButtonMods.NotEligibleForPPBadge.Alpha == 1);
             AddStep(@"Clear selected mod", () => changeMods(Array.Empty<Mod>()));
-            AddAssert("Unranked badge not shown", () => footerButtonMods.UnrankedBadge.Alpha == 0);
+            AddAssert("Not eligible for pp badge not shown", () => footerButtonMods.NotEligibleForPPBadge.Alpha == 0);
         }
 
         private void changeMods(IReadOnlyList<Mod> mods)
@@ -93,7 +93,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private partial class TestFooterButtonMods : FooterButtonMods
         {
             public new OsuSpriteText MultiplierText => base.MultiplierText;
-            public new Drawable UnrankedBadge => base.UnrankedBadge;
+            public new Drawable NotEligibleForPPBadge => base.NotEligibleForPPBadge;
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRankingInformationDisplay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRankingInformationDisplay.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Origin = Anchor.Centre
             });
 
-            AddToggleStep("toggle ranked", ranked => onlinePropertiesDisplay.Ranked.Value = ranked);
+            AddToggleStep("toggle pp eligibility", ranked => onlinePropertiesDisplay.EligibleForPP.Value = ranked);
 
             AddStep("set multiplier below 1", () => onlinePropertiesDisplay.ModMultiplier.Value = 0.5);
             AddStep("set multiplier to 1", () => onlinePropertiesDisplay.ModMultiplier.Value = 1);

--- a/osu.Game/Localisation/ModSelectOverlayStrings.cs
+++ b/osu.Game/Localisation/ModSelectOverlayStrings.cs
@@ -50,24 +50,24 @@ namespace osu.Game.Localisation
         public static LocalisableString ScoreMultiplier => new TranslatableString(getKey(@"score_multiplier"), @"Score Multiplier");
 
         /// <summary>
-        /// "Ranked"
+        /// "Eligible for pp"
         /// </summary>
-        public static LocalisableString Ranked => new TranslatableString(getKey(@"ranked"), @"Ranked");
+        public static LocalisableString EligibleForPP => new TranslatableString(getKey(@"eligible_for_pp"), @"Eligible for pp");
 
         /// <summary>
         /// "Performance points can be granted for the active mods."
         /// </summary>
-        public static LocalisableString RankedExplanation => new TranslatableString(getKey(@"ranked_explanation"), @"Performance points can be granted for the active mods.");
+        public static LocalisableString EligibleForPPExplanation => new TranslatableString(getKey(@"eligible_for_pp_explanation"), @"Performance points can be granted for the active mods.");
 
         /// <summary>
-        /// "Unranked"
+        /// "Not eligible for pp"
         /// </summary>
-        public static LocalisableString Unranked => new TranslatableString(getKey(@"unranked"), @"Unranked");
+        public static LocalisableString NotEligibleForPP => new TranslatableString(getKey(@"not_eligible_for_pp"), @"Not eligible for pp");
 
         /// <summary>
         /// "Performance points will not be granted due to active mods."
         /// </summary>
-        public static LocalisableString UnrankedExplanation => new TranslatableString(getKey(@"unranked_explanation"), @"Performance points will not be granted due to active mods.");
+        public static LocalisableString NotEligibleForPPExplanation => new TranslatableString(getKey(@"not_eligible_for_pp_explanation"), @"Performance points will not be granted due to active mods.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -484,7 +484,7 @@ namespace osu.Game.Overlays.Mods
                     multiplier *= mod.ScoreMultiplier;
 
                 rankingInformationDisplay.ModMultiplier.Value = multiplier;
-                rankingInformationDisplay.Ranked.Value = ActiveMods.Value.All(m => m.EligibleForPP);
+                rankingInformationDisplay.EligibleForPP.Value = ActiveMods.Value.All(m => m.EligibleForPP);
             }
 
             if (beatmapAttributesDisplay != null)

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -484,7 +484,7 @@ namespace osu.Game.Overlays.Mods
                     multiplier *= mod.ScoreMultiplier;
 
                 rankingInformationDisplay.ModMultiplier.Value = multiplier;
-                rankingInformationDisplay.Ranked.Value = ActiveMods.Value.All(m => m.Ranked);
+                rankingInformationDisplay.Ranked.Value = ActiveMods.Value.All(m => m.EligibleForPP);
             }
 
             if (beatmapAttributesDisplay != null)

--- a/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
+++ b/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
@@ -30,8 +30,6 @@ namespace osu.Game.Overlays.Mods
 
         public Bindable<bool> Ranked { get; } = new BindableBool(true);
 
-        private readonly BindableWithCurrent<double> current = new BindableWithCurrent<double>();
-
         private const float transition_duration = 200;
 
         private RollingCounter<double> counter = null!;

--- a/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
+++ b/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
@@ -28,14 +28,14 @@ namespace osu.Game.Overlays.Mods
 
         public Bindable<double> ModMultiplier = new BindableDouble(1);
 
-        public Bindable<bool> Ranked { get; } = new BindableBool(true);
+        public Bindable<bool> EligibleForPP { get; } = new BindableBool(true);
 
         private const float transition_duration = 200;
 
         private RollingCounter<double> counter = null!;
 
         private Box flashLayer = null!;
-        private TextWithTooltip rankedText = null!;
+        private TextWithTooltip eligibleForPPText = null!;
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
@@ -68,12 +68,12 @@ namespace osu.Game.Overlays.Mods
             {
                 new Container
                 {
-                    Width = 50,
+                    Width = 90,
                     RelativeSizeAxes = Axes.Y,
                     Margin = new MarginPadding(10),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = rankedText = new TextWithTooltip
+                    Child = eligibleForPPText = new TextWithTooltip
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
@@ -132,22 +132,22 @@ namespace osu.Game.Overlays.Mods
             // due to `Current.Value` having a nonstandard default value of 1.
             counter.SetCountWithoutRolling(ModMultiplier.Value);
 
-            Ranked.BindValueChanged(e =>
+            EligibleForPP.BindValueChanged(e =>
             {
                 flash();
 
                 if (e.NewValue)
                 {
-                    rankedText.Text = ModSelectOverlayStrings.Ranked;
-                    rankedText.TooltipText = ModSelectOverlayStrings.RankedExplanation;
-                    rankedText.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
+                    eligibleForPPText.Text = ModSelectOverlayStrings.EligibleForPP;
+                    eligibleForPPText.TooltipText = ModSelectOverlayStrings.EligibleForPPExplanation;
+                    eligibleForPPText.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
                     FrontBackground.FadeColour(ColourProvider.Background3, transition_duration, Easing.OutQuint);
                 }
                 else
                 {
-                    rankedText.Text = ModSelectOverlayStrings.Unranked;
-                    rankedText.TooltipText = ModSelectOverlayStrings.UnrankedExplanation;
-                    rankedText.FadeColour(ColourProvider.Background5, transition_duration, Easing.OutQuint);
+                    eligibleForPPText.Text = ModSelectOverlayStrings.NotEligibleForPP;
+                    eligibleForPPText.TooltipText = ModSelectOverlayStrings.NotEligibleForPPExplanation;
+                    eligibleForPPText.FadeColour(ColourProvider.Background5, transition_duration, Easing.OutQuint);
                     FrontBackground.FadeColour(colours.Orange1, transition_duration, Easing.OutQuint);
                 }
             }, true);

--- a/osu.Game/Rulesets/Mods/IMod.cs
+++ b/osu.Game/Rulesets/Mods/IMod.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Mods
         /// <summary>
         /// Whether scores with this mod active can give performance points.
         /// </summary>
-        bool Ranked { get; }
+        bool EligibleForPP { get; }
 
         /// <summary>
         /// Create a fresh <see cref="Mod"/> instance based on this mod.

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Mods
         /// Whether scores with this mod active can give performance points.
         /// </summary>
         [JsonIgnore]
-        public virtual bool Ranked => false;
+        public virtual bool EligibleForPP => false;
 
         /// <summary>
         /// The mods this mod cannot be enabled with.

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override bool RequiresConfiguration => false;
 
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
 
         public override string SettingDescription => base.SettingDescription.Replace(MinimumAccuracy.ToString(), MinimumAccuracy.Value.ToString("##%", NumberFormatInfo.InvariantInfo));
 

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -29,6 +29,6 @@ namespace osu.Game.Rulesets.Mods
         ///  - Hit windows differ (https://github.com/ppy/osu/issues/11311).
         ///  - Sliders always gives combo for slider end, even on miss (https://github.com/ppy/osu/issues/11769).
         /// </summary>
-        public sealed override bool Ranked => false;
+        public sealed override bool EligibleForPP => false;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModDaycore.cs
+++ b/osu.Game/Rulesets/Mods/ModDaycore.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => null;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Whoaaaaa...";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModDoubleTime;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Zoooooooooom...";
-        public override bool Ranked => SpeedChange.IsDefault;
+        public override bool EligibleForPP => SpeedChange.IsDefault;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModEasy.cs
+++ b/osu.Game/Rulesets/Mods/ModEasy.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyReduction;
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModHardRock), typeof(ModDifficultyAdjust) };
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         public virtual void ReadFromDifficulty(BeatmapDifficulty difficulty)
         {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModFlashlight;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Restricted view area.";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         [SettingSource("Flashlight size", "Multiplier applied to the default flashlight size.")]
         public abstract BindableFloat SizeMultiplier { get; }

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModHalftime;
         public override ModType Type => ModType.DifficultyReduction;
         public override LocalisableString Description => "Less zoom...";
-        public override bool Ranked => SpeedChange.IsDefault;
+        public override bool EligibleForPP => SpeedChange.IsDefault;
 
         [SettingSource("Speed decrease", "The actual decrease to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(0.75)

--- a/osu.Game/Rulesets/Mods/ModHardRock.cs
+++ b/osu.Game/Rulesets/Mods/ModHardRock.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Everything just got a bit harder...";
         public override Type[] IncompatibleMods => new[] { typeof(ModEasy), typeof(ModDifficultyAdjust) };
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         protected const float ADJUST_RATIO = 1.4f;
 

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "HD";
         public override IconUsage? Icon => OsuIcon.ModHidden;
         public override ModType Type => ModType.DifficultyIncrease;
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
     }
 
     public abstract class ModMuted<TObject> : ModMuted, IApplicableToDrawableRuleset<TObject>, IApplicableToTrack, IApplicableToScoreProcessor

--- a/osu.Game/Rulesets/Mods/ModNightcore.cs
+++ b/osu.Game/Rulesets/Mods/ModNightcore.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModNightcore;
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Uguuuuuuuu...";
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         [SettingSource("Speed increase", "The actual increase to apply", SettingControlType = typeof(MultiplierSettingsSlider))]
         public override BindableNumber<double> SpeedChange { get; } = new BindableDouble(1.5)

--- a/osu.Game/Rulesets/Mods/ModNoFail.cs
+++ b/osu.Game/Rulesets/Mods/ModNoFail.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Mods
         public override LocalisableString Description => "You can't fail, no matter what.";
         public override double ScoreMultiplier => 0.5;
         public override Type[] IncompatibleMods => new[] { typeof(ModFailCondition), typeof(ModCinema) };
-        public override bool Ranked => UsesDefaultConfiguration;
+        public override bool EligibleForPP => UsesDefaultConfiguration;
 
         private readonly Bindable<bool> showHealthBar = new Bindable<bool>();
 

--- a/osu.Game/Rulesets/Mods/ModNoScope.cs
+++ b/osu.Game/Rulesets/Mods/ModNoScope.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.Fun;
         public override IconUsage? Icon => FontAwesome.Solid.EyeSlash;
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
 
         /// <summary>
         /// Slightly higher than the cutoff for <see cref="Drawable.IsPresent"/>.

--- a/osu.Game/Rulesets/Mods/ModPerfect.cs
+++ b/osu.Game/Rulesets/Mods/ModPerfect.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override double ScoreMultiplier => 1;
         public override LocalisableString Description => "SS or quit.";
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModSuddenDeath), typeof(ModAccuracyChallenge) }).ToArray();
 

--- a/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
+++ b/osu.Game/Rulesets/Mods/ModSuddenDeath.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override LocalisableString Description => "Miss and fail.";
         public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
+        public override bool EligibleForPP => true;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(ModPerfect)).ToArray();
 

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Screens.Select
                             Colour = colours.Gray2,
                             Padding = new MarginPadding(5),
                             UseFullGlyphHeight = false,
-                            Text = ModSelectOverlayStrings.Unranked.ToLower()
+                            Text = ModSelectOverlayStrings.NotEligibleForPP.ToLower()
                         }
                     }
                 },

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Screens.Select
         }
 
         protected OsuSpriteText MultiplierText { get; private set; } = null!;
-        protected Container UnrankedBadge { get; private set; } = null!;
+        protected Container NotEligibleForPPBadge { get; private set; } = null!;
 
         private readonly ModDisplay modDisplay;
 
@@ -73,7 +73,7 @@ namespace osu.Game.Screens.Select
                     Origin = Anchor.Centre,
                     Font = OsuFont.GetFont(weight: FontWeight.Bold),
                 },
-                UnrankedBadge = new Container
+                NotEligibleForPPBadge = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -136,8 +136,8 @@ namespace osu.Game.Screens.Select
             else
                 modDisplay.FadeOut();
 
-            bool anyUnrankedMods = Current.Value?.Any(m => !m.EligibleForPP) == true;
-            UnrankedBadge.FadeTo(anyUnrankedMods ? 1 : 0);
+            bool notEligibleForPP = Current.Value?.Any(m => !m.EligibleForPP) == true;
+            NotEligibleForPPBadge.FadeTo(notEligibleForPP ? 1 : 0);
         });
     }
 }

--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Screens.Select
             else
                 modDisplay.FadeOut();
 
-            bool anyUnrankedMods = Current.Value?.Any(m => !m.Ranked) == true;
+            bool anyUnrankedMods = Current.Value?.Any(m => !m.EligibleForPP) == true;
             UnrankedBadge.FadeTo(anyUnrankedMods ? 1 : 0);
         });
     }


### PR DESCRIPTION
Because that's what it is now, and pretending otherwise has been [confusing users](https://github.com/ppy/osu/discussions/27719), and at this point, us too. The flag has nothing to do with whether scores are on the leaderboard or not.

https://github.com/ppy/osu/assets/20418176/ec1279a7-dac1-4767-96e3-a6fe441eb90d

![osu_2024-03-25_11-08-36](https://github.com/ppy/osu/assets/20418176/1938d619-6073-402d-84ae-f31449bddf2a)