### PR TITLE
Fix taiko legacy score simulator not including swell tick score gain into bonus portion

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -95,6 +95,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 case SwellTick:
                     scoreIncrease = 300;
                     increaseCombo = false;
+                    isBonus = true;
+                    bonusResult = HitResult.IgnoreHit;
                     break;
 
                 case DrumRollTick:

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -46,9 +46,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000013: All local scores will use lazer definitions of ranks for consistency. Recalculates the rank of all scores.</description></item>
         /// <item><description>30000014: Fix edge cases in conversion for osu! scores on selected beatmaps. Reconvert all scores.</description></item>
         /// <item><description>30000015: Fix osu! standardised score estimation algorithm violating basic invariants. Reconvert all scores.</description></item>
+        /// <item><description>30000016: Fix taiko standardised score estimation algorithm not including swell tick score gain into bonus portion. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000015;
+        public const int LATEST_VERSION = 30000016;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- Reported in [discord](https://discord.com/channels/188630481301012481/1097318920991559880/1221836384038551613).
- [Example score showcasing issue.](https://osu.ppy.sh/scores/1855965185)
- [Spreadsheet](https://docs.google.com/spreadsheets/d/1LvLwsYX1v-ppfRoWxPiJ967n9PulCa7nQ5Vyw2M7G18/edit#gid=244415604).

> [!WARNING]
> The deployment of this fix, if accepted, will consist of:
>
> - recomputation of legacy scoring attributes for **all** taiko beatmaps,
> - reverification of **all** taiko legacy scores.
>
> The fix is projected to affect short maps with swells the most, although in theory **all** maps with at least one swell will see total score changes.

## What is the problem?

The cause of the overestimation was an error in taiko's score simulator. In lazer taiko, swell ticks don't give any score anymore, while they did in stable.

For all intents and purposes, swell ticks can be considered "bonus" objects that "don't give any actual bonus score". Which is to say, during simulation of a legacy score swell ticks hit should be treated as bonus, because if they aren't, then otherwise they will be treated essentially as *normal hits*, meaning that they will be included in the *accuracy* portion of score, which breaks all sorts of follow-up assumptions:

- The accuracy portion of the best possible total score becomes overinflated in comparison to reality, while the combo portion of that maximum score becomes underestimated.
- Because the affected score has low accuracy, the estimated accuracy portion of the score (as given by maximmum accuracy portion of score times the actual numerical accuracy of the score) is also low.
- However, the next step is estimating the combo portion, which is done by taking legacy total score, subtracting the aforementioned estimation for accuracy total score from that, and then dividing the result by the maximum achievable combo score on the map. Because most of actual "combo" score from swell ticks was "moved" into the accuracy portion due to the aforementioned error, the maximum achievable combo score becomes so small that the estimated combo portion exceeds 1.

Instead, this change makes it so that gains from swell ticks are treated as "bonus", which means that they are excluded from the accuracy portion of score and instead count into the bonus portion of score, bringing the scores concerned more in line with expectations - although due to pessimistic assumptions in the simulation of the swell itself, the conversion will still overestimate total score for affected scores, just not by *that* much.

## Effects of the change

I didn't spend too much time looking at the [spreadsheet](https://docs.google.com/spreadsheets/d/1LvLwsYX1v-ppfRoWxPiJ967n9PulCa7nQ5Vyw2M7G18/edit#gid=244415604) linked above because a more-or-less random sampling of scores that moved the most looks glaringly obvious.

- Most of biggest gains by % and by total score are SS scores on short maps that were not close to the 1M (plus mods) threshold but should have been.
- Most of biggest losses by% and by total score are D scores on short maps, with accuracy and number of actual hit notes near zero, whose total scores should never have been that high.

Due to that I'm skipping rigorous analysis this time.