### PR TITLE
Fix NVAPI startup exception on non-Windows platforms

### DIFF
--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -8,11 +8,13 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using osu.Framework.Logging;
 
 namespace osu.Desktop
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SupportedOSPlatform("windows")]
     internal static class NVAPI
     {
         private const string osu_filename = "osu!.exe";

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -70,7 +70,8 @@ namespace osu.Desktop
             // NVIDIA profiles are based on the executable name of a process.
             // Lazer and stable share the same executable name.
             // Stable sets this setting to "Off", which may not be what we want, so let's force it back to the default "Auto" on startup.
-            NVAPI.ThreadedOptimisations = NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
+            if (OperatingSystem.IsWindows())
+                NVAPI.ThreadedOptimisations = NvThreadControlSetting.OGL_THREAD_CONTROL_DEFAULT;
 
             // Back up the cwd before DesktopGameHost changes it
             string cwd = Environment.CurrentDirectory;


### PR DESCRIPTION
It's caught, but very annoying for debugger.