### PR TITLE
Fix bulbs on Catmull sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Slider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Slider.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         public Vector2 StackedPositionAt(double t) => StackedPosition + this.CurvePositionAt(t);
 
-        private readonly SliderPath path = new SliderPath();
+        private readonly SliderPath path = new SliderPath { OptimiseCatmull = true };
 
         public SliderPath Path
         {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/27712

For those with access, the optimisation I'm referring to is here: https://github.com/peppy/osu-stable-reference/blob/e53980dd76857ee899f66ce519ba1597e7874f28/osu!/GameplayElements/HitObjects/Osu/SliderOsu.cs#L1145-L1184

I'm not sure how I could ever add tests for this. If tests are necessary then please give a suggestion for what I could assert.