### PR TITLE
Reset `SongSelect` dim before applying `PlayerLoader` dim

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -98,11 +98,7 @@ namespace osu.Game.Screens.Play
 
                 backgroundBrightnessReduction = value;
 
-                ApplyToBackground(b =>
-                {
-                    b.DimWhenUserSettingsIgnored.Value = 0;
-                    b.FadeColour(OsuColour.Gray(backgroundBrightnessReduction ? 0.8f : 1), 200);
-                });
+                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(backgroundBrightnessReduction ? 0.8f : 1), 200));
             }
         }
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -98,7 +98,11 @@ namespace osu.Game.Screens.Play
 
                 backgroundBrightnessReduction = value;
 
-                ApplyToBackground(b => b.FadeColour(OsuColour.Gray(backgroundBrightnessReduction ? 0.8f : 1), 200));
+                ApplyToBackground(b =>
+                {
+                    b.DimWhenUserSettingsIgnored.Value = 0;
+                    b.FadeColour(OsuColour.Gray(backgroundBrightnessReduction ? 0.8f : 1), 200);
+                });
             }
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -754,6 +754,9 @@ namespace osu.Game.Screens.Select
 
             endLooping();
 
+            // Reset any dim SongSelect previously applied to the background
+            ApplyToBackground(b => b.DimWhenUserSettingsIgnored.Value = 0);
+
             FilterControl.MoveToY(-120, 500, Easing.OutQuint);
             FilterControl.FadeOut(200, Easing.OutQuint);
 


### PR DESCRIPTION
Fixes #25515, and as i explained there the issue is that when you disable background blur the game sets a 60% dim for the `SongSelect` background, when the user enters the `PlayerLoader` screen it adds +20% dim on top of the song select background causing it to appear darker. The fix was to simply reset the dim `Song Select` applied to 0 before applying the `PlayerLoader` dim, the dim is applied again when the user goes back to `Song Select`.

### Before the PR
PlayerLoader             |  Editor PlayerLoader
:-------------------------:|:-------------------------:
![player-pre-pr](https://github.com/ppy/osu/assets/90941580/b4bd7196-e907-4dff-970b-e148ce0f7113) |  ![editor-pre-pr](https://github.com/ppy/osu/assets/90941580/fee122ba-d718-4c32-8262-5c36a1c40e16)

### After the PR
PlayerLoader             |  Editor PlayerLoader
:-------------------------:|:-------------------------:
![player-post-pr](https://github.com/ppy/osu/assets/90941580/8f89559f-5615-47b4-a042-6f32dfc792cd) |  ![editor-post-pr](https://github.com/ppy/osu/assets/90941580/e3a01ceb-72cc-4429-b90d-f1a028f21e20)









