### PR TITLE
Consider keymods in beatmap filtering + panel display

### DIFF
--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs
@@ -23,11 +23,6 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         public int TotalColumns => Stages.Sum(g => g.Columns);
 
         /// <summary>
-        /// The total number of columns that were present in this <see cref="ManiaBeatmap"/> before any user adjustments.
-        /// </summary>
-        public readonly int OriginalTotalColumns;
-
-        /// <summary>
         /// Creates a new <see cref="ManiaBeatmap"/>.
         /// </summary>
         /// <param name="defaultStage">The initial stages.</param>
@@ -35,7 +30,6 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         public ManiaBeatmap(StageDefinition defaultStage, int? originalTotalColumns = null)
         {
             Stages.Add(defaultStage);
-            OriginalTotalColumns = originalTotalColumns ?? defaultStage.Columns;
         }
 
         public override IEnumerable<BeatmapStatistic> GetStatistics()

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -27,8 +27,24 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         /// </summary>
         private const int max_notes_for_density = 7;
 
+        /// <summary>
+        /// The total number of columns.
+        /// </summary>
+        public int TotalColumns => TargetColumns * (Dual ? 2 : 1);
+
+        /// <summary>
+        /// The number of columns per-stage.
+        /// </summary>
         public int TargetColumns;
+
+        /// <summary>
+        /// Whether to double the number of stages.
+        /// </summary>
         public bool Dual;
+
+        /// <summary>
+        /// Whether the beatmap instantiated with is for the mania ruleset.
+        /// </summary>
         public readonly bool IsForCurrentRuleset;
 
         private readonly int originalTargetColumns;
@@ -152,7 +168,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         /// <returns>The hit objects generated.</returns>
         private IEnumerable<ManiaHitObject> generateSpecific(HitObject original, IBeatmap originalBeatmap)
         {
-            var generator = new SpecificBeatmapPatternGenerator(Random, original, beatmap, lastPattern, originalBeatmap);
+            var generator = new SpecificBeatmapPatternGenerator(Random, original, originalBeatmap, TotalColumns, lastPattern);
 
             foreach (var newPattern in generator.Generate())
             {
@@ -171,13 +187,13 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         /// <returns>The hit objects generated.</returns>
         private IEnumerable<ManiaHitObject> generateConverted(HitObject original, IBeatmap originalBeatmap)
         {
-            Patterns.PatternGenerator conversion = null;
+            Patterns.PatternGenerator? conversion = null;
 
             switch (original)
             {
                 case IHasPath:
                 {
-                    var generator = new PathObjectPatternGenerator(Random, original, beatmap, lastPattern, originalBeatmap);
+                    var generator = new PathObjectPatternGenerator(Random, original, originalBeatmap, TotalColumns, lastPattern);
                     conversion = generator;
 
                     var positionData = original as IHasPosition;
@@ -195,7 +211,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
 
                 case IHasDuration endTimeData:
                 {
-                    conversion = new EndTimeObjectPatternGenerator(Random, original, beatmap, lastPattern, originalBeatmap);
+                    conversion = new EndTimeObjectPatternGenerator(Random, original, originalBeatmap, TotalColumns, lastPattern);
 
                     recordNote(endTimeData.EndTime, new Vector2(256, 192));
                     computeDensity(endTimeData.EndTime);
@@ -206,7 +222,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 {
                     computeDensity(original.StartTime);
 
-                    conversion = new HitObjectPatternGenerator(Random, original, beatmap, lastPattern, lastTime, lastPosition, density, lastStair, originalBeatmap);
+                    conversion = new HitObjectPatternGenerator(Random, original, originalBeatmap, TotalColumns, lastPattern, lastTime, lastPosition, density, lastStair);
 
                     recordNote(original.StartTime, positionData.Position);
                     break;
@@ -231,8 +247,8 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         /// </summary>
         private class SpecificBeatmapPatternGenerator : Patterns.Legacy.PatternGenerator
         {
-            public SpecificBeatmapPatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, IBeatmap originalBeatmap)
-                : base(random, hitObject, beatmap, previousPattern, originalBeatmap)
+            public SpecificBeatmapPatternGenerator(LegacyRandom random, HitObject hitObject, IBeatmap beatmap, int totalColumns, Pattern previousPattern)
+                : base(random, hitObject, beatmap, previousPattern, totalColumns)
             {
             }
 

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -98,9 +98,6 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
             }
         }
 
-        public static int GetColumnCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
-            => GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), mods);
-
         public static int GetColumnCount(LegacyBeatmapConversionDifficultyInfo difficulty, IReadOnlyList<Mod>? mods = null)
         {
             var converter = new ManiaBeatmapConverter(null, difficulty, new ManiaRuleset());

--- a/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs
@@ -46,8 +46,6 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
         /// </summary>
         public readonly bool IsForCurrentRuleset;
 
-        private readonly int originalTargetColumns;
-
         // Internal for testing purposes
         internal readonly LegacyRandom Random;
 
@@ -70,8 +68,6 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
                 TargetColumns /= 2;
                 Dual = true;
             }
-
-            originalTargetColumns = TargetColumns;
 
             static int getColumnCount(LegacyBeatmapConversionDifficultyInfo difficulty)
             {
@@ -122,7 +118,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps
 
         protected override Beatmap<ManiaHitObject> CreateBeatmap()
         {
-            ManiaBeatmap beatmap = new ManiaBeatmap(new StageDefinition(TargetColumns), originalTargetColumns);
+            ManiaBeatmap beatmap = new ManiaBeatmap(new StageDefinition(TargetColumns));
 
             if (Dual)
                 beatmap.Stages.Add(new StageDefinition(TargetColumns));

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/EndTimeObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/EndTimeObjectPatternGenerator.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
         private readonly int endTime;
         private readonly PatternType convertType;
 
-        public EndTimeObjectPatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, IBeatmap originalBeatmap)
-            : base(random, hitObject, beatmap, previousPattern, originalBeatmap)
+        public EndTimeObjectPatternGenerator(LegacyRandom random, HitObject hitObject, IBeatmap beatmap, int totalColumns, Pattern previousPattern)
+            : base(random, hitObject, beatmap, previousPattern, totalColumns)
         {
             endTime = (int)((HitObject as IHasDuration)?.EndTime ?? 0);
 

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/HitObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/HitObjectPatternGenerator.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
 
         private readonly PatternType convertType;
 
-        public HitObjectPatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, double previousTime, Vector2 previousPosition, double density,
-                                         PatternType lastStair, IBeatmap originalBeatmap)
-            : base(random, hitObject, beatmap, previousPattern, originalBeatmap)
+        public HitObjectPatternGenerator(LegacyRandom random, HitObject hitObject, IBeatmap beatmap, int totalColumns, Pattern previousPattern, double previousTime, Vector2 previousPosition,
+                                         double density, PatternType lastStair)
+            : base(random, hitObject, beatmap, previousPattern, totalColumns)
         {
             StairType = lastStair;
 

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PathObjectPatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PathObjectPatternGenerator.cs
@@ -31,8 +31,8 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
 
         private PatternType convertType;
 
-        public PathObjectPatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, IBeatmap originalBeatmap)
-            : base(random, hitObject, beatmap, previousPattern, originalBeatmap)
+        public PathObjectPatternGenerator(LegacyRandom random, HitObject hitObject, IBeatmap beatmap, int totalColumns, Pattern previousPattern)
+            : base(random, hitObject, beatmap, previousPattern, totalColumns)
         {
             convertType = PatternType.None;
             if (!Beatmap.ControlPointInfo.EffectPointAt(hitObject.StartTime).KiaiMode)

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/Legacy/PatternGenerator.cs
@@ -27,20 +27,12 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
         /// </summary>
         protected readonly LegacyRandom Random;
 
-        /// <summary>
-        /// The beatmap which <see cref="HitObject"/> is being converted from.
-        /// </summary>
-        protected readonly IBeatmap OriginalBeatmap;
-
-        protected PatternGenerator(LegacyRandom random, HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern, IBeatmap originalBeatmap)
-            : base(hitObject, beatmap, previousPattern)
+        protected PatternGenerator(LegacyRandom random, HitObject hitObject, IBeatmap beatmap, Pattern previousPattern, int totalColumns)
+            : base(hitObject, beatmap, totalColumns, previousPattern)
         {
             ArgumentNullException.ThrowIfNull(random);
-            ArgumentNullException.ThrowIfNull(originalBeatmap);
 
             Random = random;
-            OriginalBeatmap = originalBeatmap;
-
             RandomStart = TotalColumns == 8 ? 1 : 0;
         }
 
@@ -104,17 +96,17 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns.Legacy
                 if (conversionDifficulty != null)
                     return conversionDifficulty.Value;
 
-                HitObject lastObject = OriginalBeatmap.HitObjects.LastOrDefault();
-                HitObject firstObject = OriginalBeatmap.HitObjects.FirstOrDefault();
+                HitObject lastObject = Beatmap.HitObjects.LastOrDefault();
+                HitObject firstObject = Beatmap.HitObjects.FirstOrDefault();
 
                 // Drain time in seconds
-                int drainTime = (int)(((lastObject?.StartTime ?? 0) - (firstObject?.StartTime ?? 0) - OriginalBeatmap.TotalBreakTime) / 1000);
+                int drainTime = (int)(((lastObject?.StartTime ?? 0) - (firstObject?.StartTime ?? 0) - Beatmap.TotalBreakTime) / 1000);
 
                 if (drainTime == 0)
                     drainTime = 10000;
 
-                IBeatmapDifficultyInfo difficulty = OriginalBeatmap.Difficulty;
-                conversionDifficulty = ((difficulty.DrainRate + Math.Clamp(difficulty.ApproachRate, 4, 7)) / 1.5 + (double)OriginalBeatmap.HitObjects.Count / drainTime * 9f) / 38f * 5f / 1.15;
+                IBeatmapDifficultyInfo difficulty = Beatmap.Difficulty;
+                conversionDifficulty = ((difficulty.DrainRate + Math.Clamp(difficulty.ApproachRate, 4, 7)) / 1.5 + (double)Beatmap.HitObjects.Count / drainTime * 9f) / 38f * 5f / 1.15;
                 conversionDifficulty = Math.Min(conversionDifficulty.Value, 12);
 
                 return conversionDifficulty.Value;

--- a/osu.Game.Rulesets.Mania/Beatmaps/Patterns/PatternGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Beatmaps/Patterns/PatternGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns
@@ -25,11 +26,11 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns
         /// <summary>
         /// The beatmap which <see cref="HitObject"/> is a part of.
         /// </summary>
-        protected readonly ManiaBeatmap Beatmap;
+        protected readonly IBeatmap Beatmap;
 
         protected readonly int TotalColumns;
 
-        protected PatternGenerator(HitObject hitObject, ManiaBeatmap beatmap, Pattern previousPattern)
+        protected PatternGenerator(HitObject hitObject, IBeatmap beatmap, int totalColumns, Pattern previousPattern)
         {
             ArgumentNullException.ThrowIfNull(hitObject);
             ArgumentNullException.ThrowIfNull(beatmap);
@@ -38,8 +39,7 @@ namespace osu.Game.Rulesets.Mania.Beatmaps.Patterns
             HitObject = hitObject;
             Beatmap = beatmap;
             PreviousPattern = previousPattern;
-
-            TotalColumns = Beatmap.TotalColumns;
+            TotalColumns = totalColumns;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaLegacyScoreSimulator.cs
@@ -51,13 +51,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty
                 return multiplier;
 
             // Apply key mod multipliers.
-
             int originalColumns = ManiaBeatmapConverter.GetColumnCount(difficulty);
-            int actualColumns = originalColumns;
-
-            actualColumns = mods.OfType<ManiaKeyMod>().SingleOrDefault()?.KeyCount ?? actualColumns;
-            if (mods.Any(m => m is ManiaModDualStages))
-                actualColumns *= 2;
+            int actualColumns = ManiaBeatmapConverter.GetColumnCount(difficulty, mods);
 
             if (actualColumns > originalColumns)
                 multiplier *= 0.9;

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -4,6 +4,7 @@
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
@@ -15,7 +16,7 @@ namespace osu.Game.Rulesets.Mania
 
         public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria)
         {
-            return !keys.HasFilter || keys.IsInRange(ManiaBeatmapConverter.GetColumnCount(beatmapInfo, criteria.Mods));
+            return !keys.HasFilter || keys.IsInRange(ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), criteria.Mods));
         }
 
         public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -4,7 +4,6 @@
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mania.Beatmaps;
-using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
@@ -14,9 +13,9 @@ namespace osu.Game.Rulesets.Mania
     {
         private FilterCriteria.OptionalRange<float> keys;
 
-        public bool Matches(BeatmapInfo beatmapInfo)
+        public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria)
         {
-            return !keys.HasFilter || keys.IsInRange(ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo)));
+            return !keys.HasFilter || keys.IsInRange(ManiaBeatmapConverter.GetColumnCount(beatmapInfo, criteria.Mods));
         }
 
         public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -423,8 +423,8 @@ namespace osu.Game.Rulesets.Mania
 
         public override DifficultySection CreateEditorDifficultySection() => new ManiaDifficultySection();
 
-        public int GetKeyCount(IBeatmapInfo beatmapInfo)
-            => ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo));
+        public int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
+            => ManiaBeatmapConverter.GetColumnCount(beatmapInfo, mods);
     }
 
     public enum PlayfieldType

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -424,7 +424,7 @@ namespace osu.Game.Rulesets.Mania
         public override DifficultySection CreateEditorDifficultySection() => new ManiaDifficultySection();
 
         public int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
-            => ManiaBeatmapConverter.GetColumnCount(beatmapInfo, mods);
+            => ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), mods);
     }
 
     public enum PlayfieldType

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -309,7 +309,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
                 match = shouldMatch;
             }
 
-            public bool Matches(BeatmapInfo beatmapInfo) => match;
+            public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria) => match;
             public bool TryParseCustomKeywordCriteria(string key, Operator op, string value) => false;
         }
     }

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -502,7 +502,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         {
             public string? CustomValue { get; set; }
 
-            public bool Matches(BeatmapInfo beatmapInfo) => true;
+            public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria) => true;
 
             public bool TryParseCustomKeywordCriteria(string key, Operator op, string value)
             {

--- a/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
@@ -18,11 +18,12 @@ namespace osu.Game.Rulesets.Filter
         /// in addition to the ones mandated by song select.
         /// </summary>
         /// <param name="beatmapInfo">The beatmap to test the criteria against.</param>
+        /// <param name="criteria">The filter criteria.</param>
         /// <returns>
         /// <c>true</c> if the beatmap matches the ruleset-specific custom filtering criteria,
         /// <c>false</c> otherwise.
         /// </returns>
-        bool Matches(BeatmapInfo beatmapInfo);
+        bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria);
 
         /// <summary>
         /// Attempts to parse a single custom keyword criterion, given by the user via the song select search box.

--- a/osu.Game/Rulesets/ILegacyRuleset.cs
+++ b/osu.Game/Rulesets/ILegacyRuleset.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 
 namespace osu.Game.Rulesets
@@ -18,8 +20,7 @@ namespace osu.Game.Rulesets
         /// <summary>
         /// Retrieves the number of mania keys required to play the beatmap.
         /// </summary>
-        /// <returns></returns>
-        int GetKeyCount(IBeatmapInfo beatmapInfo) => 0;
+        int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null) => 0;
 
         ILegacyScoreSimulator CreateLegacyScoreSimulator();
     }

--- a/osu.Game/Rulesets/Scoring/Legacy/LegacyBeatmapConversionDifficultyInfo.cs
+++ b/osu.Game/Rulesets/Scoring/Legacy/LegacyBeatmapConversionDifficultyInfo.cs
@@ -19,6 +19,16 @@ namespace osu.Game.Rulesets.Scoring.Legacy
         public IRulesetInfo SourceRuleset { get; set; } = new RulesetInfo();
 
         /// <summary>
+        /// The beatmap drain rate.
+        /// </summary>
+        public float DrainRate { get; set; }
+
+        /// <summary>
+        /// The beatmap approach rate.
+        /// </summary>
+        public float ApproachRate { get; set; }
+
+        /// <summary>
         /// The beatmap circle size.
         /// </summary>
         public float CircleSize { get; set; }
@@ -41,8 +51,6 @@ namespace osu.Game.Rulesets.Scoring.Legacy
         /// </summary>
         public int TotalObjectCount { get; set; }
 
-        float IBeatmapDifficultyInfo.DrainRate => 0;
-        float IBeatmapDifficultyInfo.ApproachRate => 0;
         double IBeatmapDifficultyInfo.SliderMultiplier => 0;
         double IBeatmapDifficultyInfo.SliderTickRate => 0;
 
@@ -51,6 +59,8 @@ namespace osu.Game.Rulesets.Scoring.Legacy
         public static LegacyBeatmapConversionDifficultyInfo FromBeatmap(IBeatmap beatmap) => new LegacyBeatmapConversionDifficultyInfo
         {
             SourceRuleset = beatmap.BeatmapInfo.Ruleset,
+            DrainRate = beatmap.Difficulty.DrainRate,
+            ApproachRate = beatmap.Difficulty.ApproachRate,
             CircleSize = beatmap.Difficulty.CircleSize,
             OverallDifficulty = beatmap.Difficulty.OverallDifficulty,
             EndTimeObjectCount = beatmap.HitObjects.Count(h => h is IHasDuration),
@@ -60,6 +70,8 @@ namespace osu.Game.Rulesets.Scoring.Legacy
         public static LegacyBeatmapConversionDifficultyInfo FromBeatmapInfo(IBeatmapInfo beatmapInfo) => new LegacyBeatmapConversionDifficultyInfo
         {
             SourceRuleset = beatmapInfo.Ruleset,
+            DrainRate = beatmapInfo.Difficulty.DrainRate,
+            ApproachRate = beatmapInfo.Difficulty.ApproachRate,
             CircleSize = beatmapInfo.Difficulty.CircleSize,
             OverallDifficulty = beatmapInfo.Difficulty.OverallDifficulty,
             EndTimeObjectCount = beatmapInfo.EndTimeObjectCount,

--- a/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselBeatmap.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Select.Carousel
 
             match &= criteria.CollectionBeatmapMD5Hashes?.Contains(BeatmapInfo.MD5Hash) ?? true;
             if (match && criteria.RulesetCriteria != null)
-                match &= criteria.RulesetCriteria.Matches(BeatmapInfo);
+                match &= criteria.RulesetCriteria.Matches(BeatmapInfo, criteria);
 
             return match;
         }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Screens.Select.Carousel
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
 
         [Resolved]
-        private IBindable<IReadOnlyList<Mod>>? mods { get; set; } = null!;
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         private IBindable<StarDifficulty?> starDifficultyBindable = null!;
         private CancellationTokenSource? starDifficultyCancellationSource;
@@ -189,7 +189,7 @@ namespace osu.Game.Screens.Select.Carousel
             base.LoadComplete();
 
             ruleset.BindValueChanged(_ => updateKeyCount());
-            mods?.BindValueChanged(_ => updateKeyCount());
+            mods.BindValueChanged(_ => updateKeyCount());
         }
 
         protected override void Selected()
@@ -260,7 +260,7 @@ namespace osu.Game.Screens.Select.Carousel
                 ILegacyRuleset legacyRuleset = (ILegacyRuleset)ruleset.Value.CreateInstance();
 
                 keyCountText.Alpha = 1;
-                keyCountText.Text = $"[{legacyRuleset.GetKeyCount(beatmapInfo, mods?.Value)}K]";
+                keyCountText.Text = $"[{legacyRuleset.GetKeyCount(beatmapInfo, mods.Value)}K]";
             }
             else
                 keyCountText.Alpha = 0;

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -28,6 +28,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osuTK;
 using osuTK.Graphics;
 
@@ -74,6 +75,9 @@ namespace osu.Game.Screens.Select.Carousel
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>>? mods { get; set; } = null!;
 
         private IBindable<StarDifficulty?> starDifficultyBindable = null!;
         private CancellationTokenSource? starDifficultyCancellationSource;
@@ -185,6 +189,7 @@ namespace osu.Game.Screens.Select.Carousel
             base.LoadComplete();
 
             ruleset.BindValueChanged(_ => updateKeyCount());
+            mods?.BindValueChanged(_ => updateKeyCount());
         }
 
         protected override void Selected()
@@ -255,7 +260,7 @@ namespace osu.Game.Screens.Select.Carousel
                 ILegacyRuleset legacyRuleset = (ILegacyRuleset)ruleset.Value.CreateInstance();
 
                 keyCountText.Alpha = 1;
-                keyCountText.Text = $"[{legacyRuleset.GetKeyCount(beatmapInfo)}K]";
+                keyCountText.Text = $"[{legacyRuleset.GetKeyCount(beatmapInfo, mods?.Value)}K]";
             }
             else
                 keyCountText.Alpha = 0;

--- a/osu.Game/Screens/Select/Details/AdvancedStats.cs
+++ b/osu.Game/Screens/Select/Details/AdvancedStats.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Screens.Select.Details
                     // For the time being, the key count is static no matter what, because:
                     // a) The method doesn't have knowledge of the active keymods. Doing so may require considerations for filtering.
                     // b) Using the difficulty adjustment mod to adjust OD doesn't have an effect on conversion.
-                    int keyCount = baseDifficulty == null ? 0 : legacyRuleset.GetKeyCount(BeatmapInfo);
+                    int keyCount = baseDifficulty == null ? 0 : legacyRuleset.GetKeyCount(BeatmapInfo, mods.Value);
 
                     FirstValue.Title = BeatmapsetsStrings.ShowStatsCsMania;
                     FirstValue.Value = (keyCount, keyCount);

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -218,12 +219,16 @@ namespace osu.Game.Screens.Select
             maximumStars.ValueChanged += _ => updateCriteria();
 
             ruleset.BindValueChanged(_ => updateCriteria());
-            mods.BindValueChanged(_ =>
+            mods.BindValueChanged(m =>
             {
-                // Mods are updated once by the mod select overlay when song select is entered, regardless of if there are any mods.
+                // Mods are updated once by the mod select overlay when song select is entered,
+                // regardless of if there are any mods or any changes have taken place.
                 // Updating the criteria here so early triggers a re-ordering of panels on song select, via... some mechanism.
-                // Todo: Investigate/fix the above and remove this schedule.
-                Scheduler.AddOnce(updateCriteria);
+                // Todo: Investigate/fix and potentially remove this.
+                if (m.NewValue.SequenceEqual(m.OldValue))
+                    return;
+
+                updateCriteria();
             });
 
             groupMode.BindValueChanged(_ => updateCriteria());

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -22,6 +23,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
 using osuTK.Graphics;
@@ -65,6 +67,7 @@ namespace osu.Game.Screens.Select
                 Sort = sortMode.Value,
                 AllowConvertedBeatmaps = showConverted.Value,
                 Ruleset = ruleset.Value,
+                Mods = mods.Value,
                 CollectionBeatmapMD5Hashes = collectionDropdown.Current.Value?.Collection?.PerformRead(c => c.BeatmapMD5Hashes).ToImmutableHashSet()
             };
 
@@ -84,7 +87,7 @@ namespace osu.Game.Screens.Select
             base.ReceivePositionalInputAt(screenSpacePos) || sortTabs.ReceivePositionalInputAt(screenSpacePos);
 
         [BackgroundDependencyLoader(permitNulls: true)]
-        private void load(OsuColour colours, IBindable<RulesetInfo> parentRuleset, OsuConfigManager config)
+        private void load(OsuColour colours, OsuConfigManager config)
         {
             sortMode = config.GetBindable<SortMode>(OsuSetting.SongSelectSortingMode);
             groupMode = config.GetBindable<GroupMode>(OsuSetting.SongSelectGroupingMode);
@@ -214,8 +217,8 @@ namespace osu.Game.Screens.Select
             config.BindWith(OsuSetting.DisplayStarsMaximum, maximumStars);
             maximumStars.ValueChanged += _ => updateCriteria();
 
-            ruleset.BindTo(parentRuleset);
             ruleset.BindValueChanged(_ => updateCriteria());
+            mods.BindValueChanged(_ => updateCriteria());
 
             groupMode.BindValueChanged(_ => updateCriteria());
             sortMode.BindValueChanged(_ => updateCriteria());
@@ -239,7 +242,11 @@ namespace osu.Game.Screens.Select
             searchTextBox.HoldFocus = true;
         }
 
-        private readonly IBindable<RulesetInfo> ruleset = new Bindable<RulesetInfo>();
+        [Resolved]
+        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        [Resolved]
+        private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         private readonly Bindable<bool> showConverted = new Bindable<bool>();
         private readonly Bindable<double> minimumStars = new BindableDouble();

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -218,7 +218,13 @@ namespace osu.Game.Screens.Select
             maximumStars.ValueChanged += _ => updateCriteria();
 
             ruleset.BindValueChanged(_ => updateCriteria());
-            mods.BindValueChanged(_ => updateCriteria());
+            mods.BindValueChanged(_ =>
+            {
+                // Mods are updated once by the mod select overlay when song select is entered, regardless of if there are any mods.
+                // Updating the criteria here so early triggers a re-ordering of panels on song select, via... some mechanism.
+                // Todo: Investigate/fix the above and remove this schedule.
+                Scheduler.AddOnce(updateCriteria);
+            });
 
             groupMode.BindValueChanged(_ => updateCriteria());
             sortMode.BindValueChanged(_ => updateCriteria());

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Collections;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select.Filter;
 
 namespace osu.Game.Screens.Select
@@ -50,6 +51,7 @@ namespace osu.Game.Screens.Select
         public OptionalTextFilter[] SearchTerms = Array.Empty<OptionalTextFilter>();
 
         public RulesetInfo? Ruleset;
+        public IReadOnlyList<Mod>? Mods;
         public bool AllowConvertedBeatmaps;
 
         private string searchText = string.Empty;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/27086

https://github.com/ppy/osu/assets/1329837/da199a4e-1485-42d4-abf0-8c1ce5f3e376

Still using `GetColumnCount()` for now because I'm not yet sure what the ruleset API for this is going to be. As mentioned when it was originally added, `GetColumnCount()` exists for this very reason, so I'm happy to expand its scope now rather than later when it could cause a breaking change.

The change to `IRulesetFilterCriteria` is technically a ruleset breaking change, however the two rulesets I've checked (sentakki and tau) don't use this.