### PR TITLE
Avoid reporting an import as successful when all beatmaps failed to import

### DIFF
--- a/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyBeatmapImporterTest.cs
@@ -12,6 +12,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO;
+using osu.Game.Rulesets;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Database
@@ -77,6 +78,7 @@ namespace osu.Game.Tests.Database
             {
                 using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
                 using (var tmpStorage = new TemporaryNativeStorage("stable-songs-folder"))
+                using (new RealmRulesetStore(realm, storage))
                 {
                     var stableStorage = new StableStorage(tmpStorage.GetFullPath(""), host);
                     var songsStorage = stableStorage.GetStorageForDirectory(StableStorage.STABLE_DEFAULT_SONGS_PATH);

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -435,7 +435,7 @@ namespace osu.Game.Beatmaps
             }
 
             if (!beatmaps.Any())
-                throw new ArgumentException($"No valid beatmap files found in the beatmap archive.");
+                throw new ArgumentException("No valid beatmap files found in the beatmap archive.");
 
             return beatmaps;
         }

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -434,6 +434,9 @@ namespace osu.Game.Beatmaps
                 }
             }
 
+            if (!beatmaps.Any())
+                throw new ArgumentException($"No valid beatmap files found in the beatmap archive.");
+
             return beatmaps;
         }
     }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27736

Test manually with horribly broken beatmap (https://github.com/ppy/osu/files/14796077/18.Scatman.John.-.Scatman.zip). Not worth adding test coverage for IMO because it's broken in a very specific way that will likely never come up again (and was fixed on official mirrors in the past).

A bit unfortunate that at the point of `Populate` we can't do a `return null` and have to rely on exceptions, but is what it is.