### PR TITLE
Apply partial fade on pp display on results screen when score will not give pp

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneExpandedPanelMiddleContent.cs
@@ -14,13 +14,16 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation;
 using osu.Game.Models;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Ranking;
 using osu.Game.Screens.Ranking.Expanded;
+using osu.Game.Screens.Ranking.Expanded.Statistics;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
 using osuTK;
@@ -65,6 +68,40 @@ namespace osu.Game.Tests.Visual.Ranking
                 this.ChildrenOfType<OsuSpriteText>().All(spriteText => !containsAny(spriteText.Text.ToString(), "mapped", "by")));
 
             AddAssert("play time displayed", () => this.ChildrenOfType<ExpandedPanelMiddleContent.PlayedOnText>().Any());
+        }
+
+        [Test]
+        public void TestPPShownAsProvisionalWhenBeatmapHasNoLeaderboard()
+        {
+            AddStep("show example score", () =>
+            {
+                var beatmap = createTestBeatmap(new RealmUser());
+                beatmap.Status = BeatmapOnlineStatus.Graveyard;
+                showPanel(TestResources.CreateTestScoreInfo(beatmap));
+            });
+
+            AddAssert("pp display faded out", () =>
+            {
+                var ppDisplay = this.ChildrenOfType<PerformanceStatistic>().Single();
+                return ppDisplay.Alpha == 0.5 && ppDisplay.TooltipText == ResultsScreenStrings.NoPPForUnrankedBeatmaps;
+            });
+        }
+
+        [Test]
+        public void TestPPShownAsProvisionalWhenUnrankedModsArePresent()
+        {
+            AddStep("show example score", () =>
+            {
+                var score = TestResources.CreateTestScoreInfo(createTestBeatmap(new RealmUser()));
+                score.Mods = score.Mods.Append(new OsuModDifficultyAdjust()).ToArray();
+                showPanel(score);
+            });
+
+            AddAssert("pp display faded out", () =>
+            {
+                var ppDisplay = this.ChildrenOfType<PerformanceStatistic>().Single();
+                return ppDisplay.Alpha == 0.5 && ppDisplay.TooltipText == ResultsScreenStrings.NoPPForUnrankedMods;
+            });
         }
 
         [Test]

--- a/osu.Game/Localisation/ResultsScreenStrings.cs
+++ b/osu.Game/Localisation/ResultsScreenStrings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class ResultsScreenStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.ResultsScreen";
+
+        /// <summary>
+        /// "Performance points are not granted for this score because the beatmap is not ranked."
+        /// </summary>
+        public static LocalisableString NoPPForUnrankedBeatmaps => new TranslatableString(getKey(@"no_pp_for_unranked_beatmaps"), @"Performance points are not granted for this score because the beatmap is not ranked.");
+
+        /// <summary>
+        /// "Performance points are not granted for this score because of unranked mods."
+        /// </summary>
+        public static LocalisableString NoPPForUnrankedMods => new TranslatableString(getKey(@"no_pp_for_unranked_mods"), @"Performance points are not granted for this score because of unranked mods.");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -4,20 +4,26 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Ranking.Expanded.Statistics
 {
-    public partial class PerformanceStatistic : StatisticDisplay
+    public partial class PerformanceStatistic : StatisticDisplay, IHasTooltip
     {
+        public LocalisableString TooltipText { get; private set; }
+
         private readonly ScoreInfo score;
 
         private readonly Bindable<int> performance = new Bindable<int>();
@@ -37,7 +43,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         {
             if (score.PP.HasValue)
             {
-                setPerformanceValue(score.PP.Value);
+                setPerformanceValue(score, score.PP.Value);
             }
             else
             {
@@ -52,15 +58,33 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
                     var result = await performanceCalculator.CalculateAsync(score, attributes.Value.Attributes, cancellationToken ?? default).ConfigureAwait(false);
 
-                    Schedule(() => setPerformanceValue(result.Total));
+                    Schedule(() => setPerformanceValue(score, result.Total));
                 }, cancellationToken ?? default);
             }
         }
 
-        private void setPerformanceValue(double? pp)
+        private void setPerformanceValue(ScoreInfo scoreInfo, double? pp)
         {
             if (pp.HasValue)
+            {
                 performance.Value = (int)Math.Round(pp.Value, MidpointRounding.AwayFromZero);
+
+                if (!scoreInfo.BeatmapInfo!.Status.GrantsPerformancePoints())
+                {
+                    Alpha = 0.5f;
+                    TooltipText = ResultsScreenStrings.NoPPForUnrankedBeatmaps;
+                }
+                else if (scoreInfo.Mods.Any(m => !m.Ranked))
+                {
+                    Alpha = 0.5f;
+                    TooltipText = ResultsScreenStrings.NoPPForUnrankedMods;
+                }
+                else
+                {
+                    Alpha = 1f;
+                    TooltipText = default;
+                }
+            }
         }
 
         public override void Appear()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27752

![osu_2024-03-29_11-14-44](https://github.com/ppy/osu/assets/20418176/0e4ad05a-c5ba-4b75-b845-4ffd2990bb35)
![osu_2024-03-29_11-13-02](https://github.com/ppy/osu/assets/20418176/cb8badc7-35fb-4a3e-8dfd-6b9e853059d0)

I decided not to hide the values completely because I believe people will still be interested in those (see reddit scoreposts and that "if ranked" stuff they include in titles).