### PR TITLE
Fix break overlay arrows look ugly on bright backgrounds

### DIFF
--- a/osu.Game/Graphics/Sprites/GlowingDrawable.cs
+++ b/osu.Game/Graphics/Sprites/GlowingDrawable.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace osu.Game.Graphics.Sprites
+{
+    public abstract partial class GlowingDrawable : BufferedContainer
+    {
+        // Inflate draw quad to prevent glow from trimming at the edges.
+        // Padding won't suffice since it will affect drawable position in cases when it's not centered.
+        protected override Quad ComputeScreenSpaceDrawQuad()
+            => base.ComputeScreenSpaceDrawQuad().AABBFloat.Inflate(new Vector2(Blur.KernelSize(BlurSigma.X), Blur.KernelSize(BlurSigma.Y)));
+
+        public ColourInfo GlowColour
+        {
+            get => EffectColour;
+            set
+            {
+                EffectColour = value;
+                BackgroundColour = value.MultiplyAlpha(0f);
+            }
+        }
+
+        protected GlowingDrawable()
+            : base(cachedFrameBuffer: true)
+        {
+            AutoSizeAxes = Axes.Both;
+            RedrawOnScale = false;
+            DrawOriginal = true;
+            Child = CreateDrawable();
+        }
+
+        protected abstract Drawable CreateDrawable();
+    }
+}

--- a/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
+++ b/osu.Game/Graphics/Sprites/GlowingSpriteText.cs
@@ -4,24 +4,17 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Game.Graphics.Sprites
 {
-    public partial class GlowingSpriteText : BufferedContainer, IHasText
+    public partial class GlowingSpriteText : GlowingDrawable, IHasText
     {
         private const float blur_sigma = 3f;
 
-        // Inflate draw quad to prevent glow from trimming at the edges.
-        // Padding won't suffice since it will affect text position in cases when it's not centered.
-        protected override Quad ComputeScreenSpaceDrawQuad() => base.ComputeScreenSpaceDrawQuad().AABBFloat.Inflate(Blur.KernelSize(blur_sigma));
-
-        private readonly OsuSpriteText text;
+        private OsuSpriteText text = null!;
 
         public LocalisableString Text
         {
@@ -47,16 +40,6 @@ namespace osu.Game.Graphics.Sprites
             set => text.Colour = value;
         }
 
-        public ColourInfo GlowColour
-        {
-            get => EffectColour;
-            set
-            {
-                EffectColour = value;
-                BackgroundColour = value.MultiplyAlpha(0f);
-            }
-        }
-
         public Vector2 Spacing
         {
             get => text.Spacing;
@@ -76,20 +59,16 @@ namespace osu.Game.Graphics.Sprites
         }
 
         public GlowingSpriteText()
-            : base(cachedFrameBuffer: true)
         {
-            AutoSizeAxes = Axes.Both;
             BlurSigma = new Vector2(blur_sigma);
-            RedrawOnScale = false;
-            DrawOriginal = true;
             EffectBlending = BlendingParameters.Additive;
-            EffectPlacement = EffectPlacement.InFront;
-            Child = text = new OsuSpriteText
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                Shadow = false,
-            };
         }
+
+        protected override Drawable CreateDrawable() => text = new OsuSpriteText
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Shadow = false,
+        };
     }
 }

--- a/osu.Game/Screens/Play/Break/BlurredIcon.cs
+++ b/osu.Game/Screens/Play/Break/BlurredIcon.cs
@@ -1,52 +1,16 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
-using osu.Game.Graphics;
-using osuTK;
 
 namespace osu.Game.Screens.Play.Break
 {
-    public partial class BlurredIcon : BufferedContainer
+    public partial class BlurredIcon : GlowIcon
     {
-        private readonly SpriteIcon icon;
-
-        public IconUsage Icon
-        {
-            set => icon.Icon = value;
-            get => icon.Icon;
-        }
-
-        public override Vector2 Size
-        {
-            set
-            {
-                icon.Size = value;
-                base.Size = value + BlurSigma * 5;
-                ForceRedraw();
-            }
-            get => base.Size;
-        }
-
         public BlurredIcon()
-            : base(cachedFrameBuffer: true)
         {
-            RelativePositionAxes = Axes.X;
-            Child = icon = new SpriteIcon
-            {
-                Origin = Anchor.Centre,
-                Anchor = Anchor.Centre,
-                Shadow = false,
-            };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            Colour = colours.BlueLighter;
+            EffectBlending = BlendingParameters.Additive;
+            DrawOriginal = false;
         }
     }
 }

--- a/osu.Game/Screens/Play/Break/BreakArrows.cs
+++ b/osu.Game/Screens/Play/Break/BreakArrows.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Play.Break
 
         private const int blurred_icon_blur_sigma = 20;
         private const int blurred_icon_size = 130;
-        private const float blurred_icon_final_offset = 0.35f;
+        private const float blurred_icon_final_offset = 0.38f;
         private const float blurred_icon_offscreen_offset = 0.7f;
 
         private readonly GlowIcon leftGlowIcon;

--- a/osu.Game/Screens/Play/Break/GlowIcon.cs
+++ b/osu.Game/Screens/Play/Break/GlowIcon.cs
@@ -3,64 +3,45 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osuTK;
 
 namespace osu.Game.Screens.Play.Break
 {
-    public partial class GlowIcon : Container
+    public partial class GlowIcon : GlowingDrawable
     {
-        private readonly SpriteIcon spriteIcon;
-        private readonly BlurredIcon blurredIcon;
-
-        public override Vector2 Size
-        {
-            get => base.Size;
-            set
-            {
-                blurredIcon.Size = spriteIcon.Size = value;
-                blurredIcon.ForceRedraw();
-            }
-        }
-
-        public Vector2 BlurSigma
-        {
-            get => blurredIcon.BlurSigma;
-            set => blurredIcon.BlurSigma = value;
-        }
+        private SpriteIcon icon = null!;
 
         public IconUsage Icon
         {
-            get => spriteIcon.Icon;
-            set => spriteIcon.Icon = blurredIcon.Icon = value;
+            set => icon.Icon = value;
+            get => icon.Icon;
+        }
+
+        public new Vector2 Size
+        {
+            set => icon.Size = value;
+            get => icon.Size;
         }
 
         public GlowIcon()
         {
             RelativePositionAxes = Axes.X;
-            AutoSizeAxes = Axes.Both;
-            Children = new Drawable[]
-            {
-                blurredIcon = new BlurredIcon
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                },
-                spriteIcon = new SpriteIcon
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Shadow = false,
-                }
-            };
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
-            blurredIcon.Colour = colours.Blue;
+            GlowColour = colours.BlueLighter;
         }
+
+        protected override Drawable CreateDrawable() => icon = new SpriteIcon
+        {
+            Origin = Anchor.Centre,
+            Anchor = Anchor.Centre,
+            Shadow = false,
+        };
     }
 }


### PR DESCRIPTION
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu/assets/22874522/ec2162fd-9901-4e30-8924-3bd9a4a62fff)|![pr](https://github.com/ppy/osu/assets/22874522/b7140438-e5ed-4ed9-ab57-3e042f81a5d8)|