### PR TITLE
Update Slider path control points and connections after stacking application

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
@@ -199,8 +199,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             createVisualiser(true);
 
-            Vector2 connectionPosition = default!;
-
+            Vector2 connectionPosition;
             addControlPointStep(connectionPosition = new Vector2(300));
             addControlPointStep(new Vector2(600));
 

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
@@ -172,6 +172,54 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             assertControlPointPathType(4, null);
         }
 
+        [Test]
+        public void TestStackingUpdatesPointsPosition()
+        {
+            createVisualiser(true);
+
+            Vector2[] points = [
+                new Vector2(200),
+                new Vector2(300),
+                new Vector2(500, 300),
+                new Vector2(700, 200),
+                new Vector2(500, 100)
+            ];
+
+            foreach (var point in points) addControlPointStep(point);
+
+            AddStep("apply stacking", () => slider.StackHeightBindable.Value += 1);
+
+            for (int i = 0; i < points.Length; i++)
+                addAssertPointPositionChanged(points, i);
+        }
+
+        [Test]
+        public void TestStackingUpdatesConnectionPosition()
+        {
+            createVisualiser(true);
+
+            Vector2 connectionPosition = default!;
+
+            addControlPointStep(connectionPosition = new Vector2(300));
+            addControlPointStep(new Vector2(600));
+
+            // Apply a big number in stacking so the person running the test can clearly see if it fails
+            AddStep("apply stacking", () => slider.StackHeightBindable.Value += 10);
+
+            AddAssert($"Connection at {connectionPosition} changed",
+                () => visualiser.Connections[0].Position,
+                () => !Is.EqualTo(connectionPosition)
+            );
+        }
+
+        private void addAssertPointPositionChanged(Vector2[] points, int index)
+        {
+            AddAssert($"Point at {points.ElementAt(index)} changed",
+                () => visualiser.Pieces[index].Position,
+                () => !Is.EqualTo(points.ElementAt(index))
+            );
+        }
+
         private void createVisualiser(bool allowSelection) => AddStep("create visualiser", () => Child = visualiser = new PathControlPointVisualiser<Slider>(slider, allowSelection)
         {
             Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestScenePathControlPointVisualiser.cs
@@ -177,7 +177,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         {
             createVisualiser(true);
 
-            Vector2[] points = [
+            Vector2[] points =
+            [
                 new Vector2(200),
                 new Vector2(300),
                 new Vector2(500, 300),

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -28,6 +28,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private IBindable<Vector2> hitObjectPosition;
         private IBindable<int> pathVersion;
+        private IBindable<int> stackHeight;
 
         public PathControlPointConnectionPiece(T hitObject, int controlPointIndex)
         {
@@ -56,7 +57,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             pathVersion = hitObject.Path.Version.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Scheduler.AddOnce(updateConnectingPath));
 
-            hitObject.StackHeightBindable.BindValueChanged(_ => updateConnectingPath());
+            stackHeight = hitObject.StackHeightBindable.GetBoundCopy();
+            stackHeight.BindValueChanged(_ => updateConnectingPath());
 
             updateConnectingPath();
         }

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointConnectionPiece.cs
@@ -56,6 +56,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             pathVersion = hitObject.Path.Version.GetBoundCopy();
             pathVersion.BindValueChanged(_ => Scheduler.AddOnce(updateConnectingPath));
 
+            hitObject.StackHeightBindable.BindValueChanged(_ => updateConnectingPath());
+
             updateConnectingPath();
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private IBindable<Vector2> hitObjectPosition;
         private IBindable<float> hitObjectScale;
+        private IBindable<int> stackHeight;
 
         public PathControlPointPiece(T hitObject, PathControlPoint controlPoint)
         {
@@ -105,7 +106,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             hitObjectScale = hitObject.ScaleBindable.GetBoundCopy();
             hitObjectScale.BindValueChanged(_ => updateMarkerDisplay());
 
-            hitObject.StackHeightBindable.BindValueChanged(_ => updateMarkerDisplay());
+            stackHeight = hitObject.StackHeightBindable.GetBoundCopy();
+            stackHeight.BindValueChanged(_ => updateMarkerDisplay());
 
             IsSelected.BindValueChanged(_ => updateMarkerDisplay());
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointPiece.cs
@@ -105,6 +105,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             hitObjectScale = hitObject.ScaleBindable.GetBoundCopy();
             hitObjectScale.BindValueChanged(_ => updateMarkerDisplay());
 
+            hitObject.StackHeightBindable.BindValueChanged(_ => updateMarkerDisplay());
+
             IsSelected.BindValueChanged(_ => updateMarkerDisplay());
 
             updateMarkerDisplay();


### PR DESCRIPTION
Fixes #26460, while fixing this i found out that the connection paths were not updating too so i fixed it as well. The fix was to simply call the respective "update visuals" methods for control points and connections when `StackHeight` was changed.

https://github.com/ppy/osu/assets/90941580/5b09a47e-350b-4cdb-a5b9-9de49716f6b7

