### PR TITLE
Fix SpectatorClient holding references to Player

### DIFF
--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -248,6 +248,9 @@ namespace osu.Game.Online.Spectator
 
                 isPlaying = false;
                 currentBeatmap = null;
+                currentScore = null;
+                currentScoreProcessor = null;
+                currentScoreToken = null;
 
                 if (state.HasPassed)
                     currentState.State = SpectatedUserState.Passed;


### PR DESCRIPTION
Very minor because this would get cleared every play.

<img width="1106" alt="image" src="https://github.com/ppy/osu/assets/1329837/82f21f59-d03b-4ea0-918e-25ca8f93e5ea">