### PR TITLE
Fix SkinEditor binding event to external bindable

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -67,9 +67,6 @@ namespace osu.Game.Overlays.SkinEditor
         private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
-        private EditorClipboard clipboard { get; set; } = null!;
-
-        [Resolved]
         private SkinEditorOverlay? skinEditorOverlay { get; set; }
 
         [Cached]
@@ -114,7 +111,7 @@ namespace osu.Game.Overlays.SkinEditor
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(EditorClipboard clipboard)
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -225,6 +222,8 @@ namespace osu.Game.Overlays.SkinEditor
                     }
                 }
             };
+
+            clipboardContent = clipboard.Content.GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -244,7 +243,6 @@ namespace osu.Game.Overlays.SkinEditor
                 canCopy.Value = canCut.Value = SelectedComponents.Any();
             }, true);
 
-            clipboardContent = clipboard.Content.GetBoundCopy();
             clipboardContent.BindValueChanged(content => canPaste.Value = !string.IsNullOrEmpty(content.NewValue), true);
 
             Show();
@@ -497,7 +495,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected void Copy()
         {
-            clipboard.Content.Value = JsonConvert.SerializeObject(SelectedComponents.Cast<Drawable>().Select(s => s.CreateSerialisedInfo()).ToArray());
+            clipboardContent.Value = JsonConvert.SerializeObject(SelectedComponents.Cast<Drawable>().Select(s => s.CreateSerialisedInfo()).ToArray());
         }
 
         protected void Clone()
@@ -517,7 +515,7 @@ namespace osu.Game.Overlays.SkinEditor
 
             changeHandler?.BeginChange();
 
-            var drawableInfo = JsonConvert.DeserializeObject<SerialisedDrawableInfo[]>(clipboard.Content.Value);
+            var drawableInfo = JsonConvert.DeserializeObject<SerialisedDrawableInfo[]>(clipboardContent.Value);
 
             if (drawableInfo == null)
                 return;

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -52,6 +52,7 @@ namespace osu.Game.Overlays.SkinEditor
         private OsuTextFlowContainer headerText = null!;
 
         private Bindable<Skin> currentSkin = null!;
+        private Bindable<string> clipboardContent = null!;
 
         [Resolved]
         private OsuGame? game { get; set; }
@@ -243,7 +244,8 @@ namespace osu.Game.Overlays.SkinEditor
                 canCopy.Value = canCut.Value = SelectedComponents.Any();
             }, true);
 
-            clipboard.Content.BindValueChanged(content => canPaste.Value = !string.IsNullOrEmpty(content.NewValue), true);
+            clipboardContent = clipboard.Content.GetBoundCopy();
+            clipboardContent.BindValueChanged(content => canPaste.Value = !string.IsNullOrEmpty(content.NewValue), true);
 
             Show();
 


### PR DESCRIPTION
... And in turn holding references:

<img width="1104" alt="image" src="https://github.com/ppy/osu/assets/1329837/8d92ca13-e8b5-4724-ac39-744b0518c3a2">
