### PR TITLE
Fix mod search box not tracking external changes to focus state

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModSelectOverlay.cs
@@ -613,6 +613,23 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestSearchBoxFocusToggleRespondsToExternalChanges()
+        {
+            AddStep("text search does not start active", () => configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, false));
+            createScreen();
+
+            AddUntilStep("search text box not focused", () => !modSelectOverlay.SearchTextBox.HasFocus);
+
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+
+            AddStep("unfocus search text box externally", () => InputManager.ChangeFocus(null));
+
+            AddStep("press tab", () => InputManager.Key(Key.Tab));
+            AddAssert("search text box focused", () => modSelectOverlay.SearchTextBox.HasFocus);
+        }
+
+        [Test]
         public void TestTextSearchDoesNotBlockCustomisationPanelKeyboardInteractions()
         {
             AddStep("text search starts active", () => configManager.SetValue(OsuSetting.ModSelectTextSearchStartsActive, true));

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -420,7 +420,7 @@ namespace osu.Game.Overlays.Mods
                 yield return new ColumnDimContainer(new ModPresetColumn
                 {
                     Margin = new MarginPadding { Right = 10 }
-                });
+                }, this);
             }
 
             yield return createModColumnContent(ModType.DifficultyReduction);
@@ -438,7 +438,7 @@ namespace osu.Game.Overlays.Mods
                 column.Margin = new MarginPadding { Right = 10 };
             });
 
-            return new ColumnDimContainer(column);
+            return new ColumnDimContainer(column, this);
         }
 
         private void createLocalMods()
@@ -899,13 +899,17 @@ namespace osu.Game.Overlays.Mods
             [Resolved]
             private OsuColour colours { get; set; } = null!;
 
-            public ColumnDimContainer(ModSelectColumn column)
+            private ModSelectOverlay modSelectOverlayInstance;
+
+            public ColumnDimContainer(ModSelectColumn column, ModSelectOverlay modSelectOverlay)
             {
                 AutoSizeAxes = Axes.X;
                 RelativeSizeAxes = Axes.Y;
 
                 Child = Column = column;
                 column.Active.BindTo(Active);
+
+                this.modSelectOverlayInstance = modSelectOverlay;
             }
 
             [BackgroundDependencyLoader]
@@ -953,7 +957,7 @@ namespace osu.Game.Overlays.Mods
                     RequestScroll?.Invoke(this);
 
                 // Killing focus is done here because it's the only feasible place on ModSelectOverlay you can click on without triggering any action.
-                Scheduler.Add(() => GetContainingInputManager().ChangeFocus(null));
+                modSelectOverlayInstance.setTextBoxFocus(false);
 
                 return true;
             }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -418,7 +418,7 @@ namespace osu.Game.Overlays.Mods
                 yield return new ColumnDimContainer(new ModPresetColumn
                 {
                     Margin = new MarginPadding { Right = 10 }
-                }, this);
+                });
             }
 
             yield return createModColumnContent(ModType.DifficultyReduction);
@@ -436,7 +436,7 @@ namespace osu.Game.Overlays.Mods
                 column.Margin = new MarginPadding { Right = 10 };
             });
 
-            return new ColumnDimContainer(column, this);
+            return new ColumnDimContainer(column);
         }
 
         private void createLocalMods()
@@ -895,17 +895,13 @@ namespace osu.Game.Overlays.Mods
             [Resolved]
             private OsuColour colours { get; set; } = null!;
 
-            private ModSelectOverlay modSelectOverlayInstance;
-
-            public ColumnDimContainer(ModSelectColumn column, ModSelectOverlay modSelectOverlay)
+            public ColumnDimContainer(ModSelectColumn column)
             {
                 AutoSizeAxes = Axes.X;
                 RelativeSizeAxes = Axes.Y;
 
                 Child = Column = column;
                 column.Active.BindTo(Active);
-
-                this.modSelectOverlayInstance = modSelectOverlay;
             }
 
             [BackgroundDependencyLoader]
@@ -953,7 +949,7 @@ namespace osu.Game.Overlays.Mods
                     RequestScroll?.Invoke(this);
 
                 // Killing focus is done here because it's the only feasible place on ModSelectOverlay you can click on without triggering any action.
-                modSelectOverlayInstance.setTextBoxFocus(false);
+                Scheduler.Add(() => GetContainingInputManager().ChangeFocus(null));
 
                 return true;
             }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -143,8 +143,6 @@ namespace osu.Game.Overlays.Mods
         protected ShearedToggleButton? CustomisationButton { get; private set; }
         protected SelectAllModsButton? SelectAllModsButton { get; set; }
 
-        private bool textBoxShouldFocus;
-
         private Sample? columnAppearSample;
 
         private WorkingBeatmap? beatmap;
@@ -542,7 +540,7 @@ namespace osu.Game.Overlays.Mods
             if (customisationVisible.Value)
                 SearchTextBox.KillFocus();
             else
-                setTextBoxFocus(textBoxShouldFocus);
+                setTextBoxFocus(textSearchStartsActive.Value);
         }
 
         /// <summary>
@@ -798,15 +796,13 @@ namespace osu.Game.Overlays.Mods
                 return false;
 
             // TODO: should probably eventually support typical platform search shortcuts (`Ctrl-F`, `/`)
-            setTextBoxFocus(!textBoxShouldFocus);
+            setTextBoxFocus(!SearchTextBox.HasFocus);
             return true;
         }
 
-        private void setTextBoxFocus(bool keepFocus)
+        private void setTextBoxFocus(bool focus)
         {
-            textBoxShouldFocus = keepFocus;
-
-            if (textBoxShouldFocus)
+            if (focus)
                 SearchTextBox.TakeFocus();
             else
                 SearchTextBox.KillFocus();


### PR DESCRIPTION
In the Mod selection area, the search bar's focus could be changed by pressing TAB. However, when clicking outside of the search bar, the focus would be killed but two TABs were required to get the focus back on the search bar. This happened because the action of clicking in an empty area would trigger the search bar to change its appearence, but not its internal state. In my solution, I made the OnClick function aware of the search bar's state, so it would not only change its appearance, but also its state. Now, after clicking in an empty area, there is only needed one TAB to select the search box again, as expected.