### PR TITLE
Add custom message in the case of a `invalid beatmap_hash`

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -152,6 +152,10 @@ namespace osu.Game.Screens.Play
                                 Logger.Log($"Please ensure that you are using the latest version of the official game releases.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
+                            case @"invalid beatmap hash":
+                                Logger.Log($"A new version of this beatmapset is available please update. \n\n{whatWillHappen}", level: LogLevel.Important);
+                                break;
+
                             case @"expired token":
                                 Logger.Log($"Your system clock is set incorrectly. Please check your system time, date and timezone.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Screens.Play
                                 break;
 
                             case @"invalid beatmap hash":
-                                Logger.Log($"A new version of this beatmapset is available please update. \n\n{whatWillHappen}", level: LogLevel.Important);
+                                Logger.Log($"This beatmap does not match the online version. Please update or redownload it.\n\n{whatWillHappen}", level: LogLevel.Important);
                                 break;
 
                             case @"expired token":


### PR DESCRIPTION
Closes #27781, very small PR just adding a case for the "invalid beatmap_hash" `exception.Message`. Now it will show
a better message: "A new version of this beatmapset is available please update. Your score will not be submitted."