### PR TITLE
 Fix some maps requiring multiple intro skips that weren't there on stable

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithIntro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithIntro.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Play;
+using osu.Game.Storyboards;
+using osuTK;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneStoryboardWithIntro : PlayerTestScene
+    {
+        protected override bool HasCustomSteps => true;
+        protected override bool AllowFail => true;
+
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset)
+        {
+            var beatmap = new Beatmap();
+            beatmap.HitObjects.Add(new HitCircle { StartTime = firstObjectStartTime });
+            return beatmap;
+        }
+
+        protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null)
+        {
+            return base.CreateWorkingBeatmap(beatmap, createStoryboard(storyboardStartTime));
+        }
+
+        private Storyboard createStoryboard(double startTime)
+        {
+            var storyboard = new Storyboard();
+            var sprite = new StoryboardSprite("unknown", Anchor.TopLeft, Vector2.Zero);
+            sprite.TimelineGroup.Alpha.Add(Easing.None, startTime, 0, 0, 1);
+            storyboard.GetLayer("Background").Add(sprite);
+            return storyboard;
+        }
+
+        private double firstObjectStartTime;
+        private double storyboardStartTime;
+
+        [SetUpSteps]
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+            AddStep("enable storyboard", () => LocalConfig.SetValue(OsuSetting.ShowStoryboard, true));
+            AddStep("set dim level to 0", () => LocalConfig.SetValue<double>(OsuSetting.DimLevel, 0));
+            AddStep("reset first hitobject time", () => firstObjectStartTime = 0);
+            AddStep("reset storyboard start time", () => storyboardStartTime = 0);
+        }
+
+        [TestCase(-5000, 0)]
+        [TestCase(-5000, 30000)]
+        public void TestStoryboardSingleSkip(double storyboardStart, double firstObject)
+        {
+            AddStep($"set storyboard start time to {storyboardStart}", () => storyboardStartTime = storyboardStart);
+            AddStep($"set first object start time to {firstObject}", () => firstObjectStartTime = firstObject);
+            CreateTest();
+
+            AddStep("skip", () => InputManager.Key(osuTK.Input.Key.Space));
+            AddAssert("skip performed", () => Player.ChildrenOfType<SkipOverlay>().Any(s => s.SkipCount == 1));
+            AddUntilStep("gameplay clock advanced", () => Player.GameplayClockContainer.CurrentTime, () => Is.GreaterThanOrEqualTo(firstObject - 2000));
+        }
+
+        [Test]
+        public void TestStoryboardDoubleSkip()
+        {
+            AddStep("set storyboard start time to -11000", () => storyboardStartTime = -11000);
+            AddStep("set first object start time to 11000", () => firstObjectStartTime = 11000);
+            CreateTest();
+
+            AddStep("skip", () => InputManager.Key(osuTK.Input.Key.Space));
+            AddAssert("skip performed", () => Player.ChildrenOfType<SkipOverlay>().Any(s => s.SkipCount == 1));
+            AddUntilStep("gameplay clock advanced", () => Player.GameplayClockContainer.CurrentTime, () => Is.GreaterThanOrEqualTo(0));
+
+            AddStep("skip", () => InputManager.Key(osuTK.Input.Key.Space));
+            AddAssert("skip performed", () => Player.ChildrenOfType<SkipOverlay>().Any(s => s.SkipCount == 2));
+            AddUntilStep("gameplay clock advanced", () => Player.GameplayClockContainer.CurrentTime, () => Is.GreaterThanOrEqualTo(9000));
+        }
+    }
+}

--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Screens.Play
 
             double skipTarget = skipTargetTime - MINIMUM_SKIP_TIME;
 
-            if (GameplayClock.CurrentTime < 0 && skipTarget > 6000)
+            if (StartTime < -10000 && GameplayClock.CurrentTime < 0 && skipTarget > 6000)
                 // double skip exception for storyboards with very long intros
                 skipTarget = 0;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/25633.

The reason why that particular beatmap did not have a double skip on stable is [here](https://github.com/peppy/osu-stable-reference/blob/e53980dd76857ee899f66ce519ba1597e7874f28/osu!/GameModes/Play/Player.cs#L1761-L1770):

```csharp
        protected bool AllowDoubleSkip
        {
            get
            {
                int leadIn = leadInTime < 10000 ? -leadInTime : 0;
                return !(this is PlayerVs)
                       && AudioEngine.Time < leadIn - (InputManager.ReplayMode ? 50 : 0)
                       && SkipBoundary > 6000;
            }
        }
```

The particular place of interest is the `leadInTime < 10000` check. If `leadInTime < 10000`, then `leadIn == -leadInTime`, and it turns out that `AudioEngine.Time` will always be more than or equal to `-leadInTime`, because it's also the gameplay start time ([link](https://github.com/peppy/osu-stable-reference/blob/e53980dd76857ee899f66ce519ba1597e7874f28/osu!/GameModes/Play/Player.cs#L2765)).

This essentially means that if the `leadInTime` is less than 10000, that particular check is just dead. So a double skip can only occur if the gameplay starts at time -10000 or earlier due to the storyboard.

Here's a beatmap to test with, which reflects the test cases included in this PR one-to-one: [storyboard - test (11).zip](https://github.com/ppy/osu/files/14855154/storyboard.-.test.11.zip)
