### PR TITLE
Update hit error metre to use new icons

### DIFF
--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -175,6 +175,8 @@ namespace osu.Game.Graphics
         public static IconUsage EditorSelect => get(OsuIconMapping.EditorSelect);
         public static IconUsage EditorSound => get(OsuIconMapping.EditorSound);
         public static IconUsage EditorWhistle => get(OsuIconMapping.EditorWhistle);
+        public static IconUsage Tortoise => get(OsuIconMapping.Tortoise);
+        public static IconUsage Hare => get(OsuIconMapping.Hare);
 
         private static IconUsage get(OsuIconMapping glyph) => new IconUsage((char)glyph, FONT_NAME);
 
@@ -380,6 +382,12 @@ namespace osu.Game.Graphics
 
             [Description(@"Editor/whistle")]
             EditorWhistle,
+
+            [Description(@"tortoise")]
+            Tortoise,
+
+            [Description(@"hare")]
+            Hare,
         }
 
         public class OsuIconStore : ITextureStore, ITexturedGlyphLookupStore

--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/BarHitErrorMeter.cs
@@ -303,13 +303,13 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
                     labelEarly.Child = new SpriteIcon
                     {
                         Size = new Vector2(icon_size),
-                        Icon = FontAwesome.Solid.ShippingFast,
+                        Icon = OsuIcon.Hare
                     };
 
                     labelLate.Child = new SpriteIcon
                     {
                         Size = new Vector2(icon_size),
-                        Icon = FontAwesome.Solid.Bicycle,
+                        Icon = OsuIcon.Tortoise
                     };
 
                     break;

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2024.306.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2024.321.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2024.404.0" />
     <PackageReference Include="Sentry" Version="3.41.3" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.36.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-resources/pull/317.

Closes https://github.com/ppy/osu/issues/11915.