### PR TITLE
Disable Discord URI registration on macOS for now

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -6,6 +6,7 @@ using System.Text;
 using DiscordRPC;
 using DiscordRPC.Message;
 using Newtonsoft.Json;
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -78,9 +79,13 @@ namespace osu.Desktop
             client.OnError += (_, e) => Logger.Log($"An error occurred with Discord RPC Client: {e.Message} ({e.Code})", LoggingTarget.Network, LogLevel.Error);
 
             // A URI scheme is required to support game invitations, as well as informing Discord of the game executable path to support launching the game when a user clicks on join/spectate.
-            client.RegisterUriScheme();
-            client.Subscribe(EventType.Join);
-            client.OnJoin += onJoin;
+            // The library doesn't properly support URI registration when ran from an app bundle on macOS.
+            if (!RuntimeInfo.IsApple)
+            {
+                client.RegisterUriScheme();
+                client.Subscribe(EventType.Join);
+                client.OnJoin += onJoin;
+            }
 
             config.BindWith(OsuSetting.DiscordRichPresence, privacyMode);
 


### PR DESCRIPTION
```
2024-04-04 00:29:57 [error]: An unhandled error has occurred.
2024-04-04 00:29:57 [error]: System.IO.IOException: Read-only file system : '/~'
2024-04-04 00:29:57 [error]: at System.IO.FileSystem.CreateParentsAndDirectory(String fullPath, UnixFileMode unixCreateMode)
2024-04-04 00:29:57 [error]: at System.IO.FileSystem.CreateDirectory(String fullPath, UnixFileMode unixCreateMode)
2024-04-04 00:29:57 [error]: at System.IO.Directory.CreateDirectory(String path)
2024-04-04 00:29:57 [error]: at DiscordRPC.Registry.MacUriSchemeCreator.RegisterUriScheme(UriSchemeRegister register)
2024-04-04 00:29:57 [error]: at DiscordRPC.Registry.UriSchemeRegister.RegisterUriScheme()
2024-04-04 00:29:57 [error]: at DiscordRPC.DiscordRpcClient.RegisterUriScheme(String steamAppID, String executable)
2024-04-04 00:29:57 [error]: at osu.Desktop.DiscordRichPresence.load(OsuConfigManager config) in /Users/smgi/Repos/osu/osu.Desktop/DiscordRichPresence.cs:line 81
```

It's trying to create the directory `~/Library/Application Support/discord/games`, but since .app bundles are run in Apple's sandbox, they can't just randomly touch the user's home directory. Disabling this for now - issue appears to be [known?](https://github.com/Lachee/discord-rpc-csharp/blob/82d16877dd7c5ec7eea6e868fe38729fc983581a/DiscordRPC/Registry/MacUriSchemeCreator.cs#L36) in the library but has been untouched for the good part of 2+ years.