### PR TITLE
Fix error when saving beatmap while export is in progress

### DIFF
--- a/osu.Game/Database/LegacyExporter.cs
+++ b/osu.Game/Database/LegacyExporter.cs
@@ -95,6 +95,21 @@ namespace osu.Game.Database
                 {
                     await ExportToStreamAsync(model, stream, notification, linkedSource.Token).ConfigureAwait(false);
                 }
+
+                notification.CompletionText = $"Exported {itemFilename}! Click to view.";
+                notification.CompletionClickAction = () => exportStorage.PresentFileExternally(filename);
+                notification.State = ProgressNotificationState.Completed;
+            }
+            catch (InvalidOperationException e)
+            {
+                notification.State = ProgressNotificationState.Cancelled;
+                exportStorage.Delete(filename);
+
+                if (e.Message.StartsWith("Collection was modified"))
+                {
+                    await ExportAsync(model, cancellationToken).ConfigureAwait(false);
+                }
+                else throw;
             }
             catch
             {
@@ -104,10 +119,6 @@ namespace osu.Game.Database
                 exportStorage.Delete(filename);
                 throw;
             }
-
-            notification.CompletionText = $"Exported {itemFilename}! Click to view.";
-            notification.CompletionClickAction = () => exportStorage.PresentFileExternally(filename);
-            notification.State = ProgressNotificationState.Completed;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #25426, this adds a catch for a `InvalidOperationException` that checks if it was thrown due to a collection change and if so it tries exporting again. I created this as a draft because i need some help testing this, i cant find a way to reproduce this issue in the tests.

https://github.com/ppy/osu/assets/90941580/0d1d6029-d972-434c-be73-63b1a7cf8bb0


