### PR TITLE
Revert recent storyboard optimisations

### DIFF
--- a/osu.Game/Storyboards/CommandTimelineGroup.cs
+++ b/osu.Game/Storyboards/CommandTimelineGroup.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics;
@@ -45,10 +46,32 @@ namespace osu.Game.Storyboards
         }
 
         [JsonIgnore]
-        public double CommandsStartTime => timelines.Min(static t => t.StartTime);
+        public double CommandsStartTime
+        {
+            get
+            {
+                double min = double.MaxValue;
+
+                for (int i = 0; i < timelines.Length; i++)
+                    min = Math.Min(min, timelines[i].StartTime);
+
+                return min;
+            }
+        }
 
         [JsonIgnore]
-        public double CommandsEndTime => timelines.Max(static t => t.EndTime);
+        public double CommandsEndTime
+        {
+            get
+            {
+                double max = double.MinValue;
+
+                for (int i = 0; i < timelines.Length; i++)
+                    max = Math.Max(max, timelines[i].EndTime);
+
+                return max;
+            }
+        }
 
         [JsonIgnore]
         public double CommandsDuration => CommandsEndTime - CommandsStartTime;
@@ -60,7 +83,19 @@ namespace osu.Game.Storyboards
         public virtual double EndTime => CommandsEndTime;
 
         [JsonIgnore]
-        public bool HasCommands => timelines.Any(static t => t.HasCommands);
+        public bool HasCommands
+        {
+            get
+            {
+                for (int i = 0; i < timelines.Length; i++)
+                {
+                    if (timelines[i].HasCommands)
+                        return true;
+                }
+
+                return false;
+            }
+        }
 
         public virtual IEnumerable<CommandTimeline<T>.TypedCommand> GetCommands<T>(CommandTimelineSelector<T> timelineSelector, double offset = 0)
         {


### PR DESCRIPTION
This reverts commit 0881e7c8c1f003416cc37507ce6448f74e9d1a7f, reversing changes made to 29a37e35852649c2f88b6c917b2921950c9e2dd9.

Regressed in https://github.com/ppy/osu/pull/27454
Supersedes/closes https://github.com/ppy/osu/pull/27753 (see discussion in thread)
Closes https://github.com/ppy/osu/issues/27627

I'm leaning on the side of caution instead of merging a fix to a regression that itself is a regression just in a slightly less way.

Next time this optimisation is attempted, a test case needs to be provided for the case broken in #27627 and the further case mentioned in #27753. Neither was done this time around.

Lazer handles transforms [differently from stable](https://github.com/ppy/osu/issues/7257#issuecomment-567844226), and that will likely need to be fixed _first_ otherwise optimisations are more likely to further regress behaviour than not.