### PR TITLE
Reset mod multiplier to 1 for classic mod in rulesets other than osu!

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModClassic.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 {
     public class OsuModClassic : ModClassic, IApplicableToHitObject, IApplicableToDrawableHitObject, IApplicableToDrawableRuleset<OsuHitObject>, IApplicableHealthProcessor
     {
+        public override double ScoreMultiplier => 0.96;
+
         public override Type[] IncompatibleMods => base.IncompatibleMods.Append(typeof(OsuModStrictTracking)).ToArray();
 
         [SettingSource("No slider head accuracy requirement", "Scores sliders proportionally to the number of ticks hit.")]

--- a/osu.Game/Rulesets/Mods/ModClassic.cs
+++ b/osu.Game/Rulesets/Mods/ModClassic.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Mods
 
         public override string Acronym => "CL";
 
-        public override double ScoreMultiplier => 0.96;
+        public override double ScoreMultiplier => 1;
 
         public override IconUsage? Icon => FontAwesome.Solid.History;
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -47,9 +47,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000014: Fix edge cases in conversion for osu! scores on selected beatmaps. Reconvert all scores.</description></item>
         /// <item><description>30000015: Fix osu! standardised score estimation algorithm violating basic invariants. Reconvert all scores.</description></item>
         /// <item><description>30000016: Fix taiko standardised score estimation algorithm not including swell tick score gain into bonus portion. Reconvert all scores.</description></item>
+        /// <item><description>30000017: Change multiplier of classic mod from 0.96x to 1.00x on all rulesets except osu!. Reconvert all relevant scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000016;
+        public const int LATEST_VERSION = 30000017;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- Partially addresses https://github.com/ppy/osu/issues/27685

Note that this PR doesn't mean that the osu! classic multiplier isn't changing. It means that I'm not generally convinced by any alternatives (and I don't believe I'm alone in that either).

Reprocessing job included, written in the simplest way possible (without persisting pre-modifier score anywhere, mirroring the server-side approach in https://github.com/ppy/osu-queue-score-statistics/pull/246). Please scrutinise the logic therein closely as it's not obvious. It is sorta designed for easy reusability in the future but I dunno.