### PR TITLE
Update Sentry to fix iOS build

### DIFF
--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -39,12 +39,13 @@ namespace osu.Game.Utils
         public SentryLogger(OsuGame game)
         {
             this.game = game;
+
+            if (!game.IsDeployedBuild || !game.CreateEndpoints().WebsiteRootUrl.EndsWith(@".ppy.sh", StringComparison.Ordinal))
+                return;
+
             sentrySession = SentrySdk.Init(options =>
             {
-                // Not setting the dsn will completely disable sentry.
-                if (game.IsDeployedBuild && game.CreateEndpoints().WebsiteRootUrl.EndsWith(@".ppy.sh", StringComparison.Ordinal))
-                    options.Dsn = "https://ad9f78529cef40ac874afb95a9aca04e@sentry.ppy.sh/2";
-
+                options.Dsn = "https://ad9f78529cef40ac874afb95a9aca04e@sentry.ppy.sh/2";
                 options.AutoSessionTracking = true;
                 options.IsEnvironmentUser = false;
                 options.IsGlobalModeEnabled = true;
@@ -59,6 +60,9 @@ namespace osu.Game.Utils
 
         public void AttachUser(IBindable<APIUser> user)
         {
+            if (sentrySession == null)
+                return;
+
             Debug.Assert(localUser == null);
 
             localUser = user.GetBoundCopy();

--- a/osu.Game/Utils/SentryLogger.cs
+++ b/osu.Game/Utils/SentryLogger.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Utils
             localUser = user.GetBoundCopy();
             localUser.BindValueChanged(u =>
             {
-                SentrySdk.ConfigureScope(scope => scope.User = new User
+                SentrySdk.ConfigureScope(scope => scope.User = new SentryUser
                 {
                     Username = u.NewValue.Username,
                     Id = u.NewValue.Id.ToString(),

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2024.329.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2024.410.0" />
-    <PackageReference Include="Sentry" Version="3.41.3" />
+    <PackageReference Include="Sentry" Version="4.3.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.36.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
Looks to fix it ¯\\_(ツ)_/¯

Broke due to upgrade to SDK 8.0.204 (prev 8.0.203).