### PR TITLE
Fix newly placed items in skin editor not getting correct anchor placement

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -454,6 +454,7 @@ namespace osu.Game.Overlays.SkinEditor
             }
 
             SelectedComponents.Add(component);
+            SkinSelectionHandler.ApplyClosestAnchor(drawableComponent);
             return true;
         }
 
@@ -666,8 +667,6 @@ namespace osu.Game.Overlays.SkinEditor
 
                 SelectedComponents.Clear();
                 placeComponent(sprite, false);
-
-                SkinSelectionHandler.ApplyClosestAnchor(sprite);
             });
 
             return Task.CompletedTask;


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| ![2024-04-12 17 09 41@2x](https://github.com/ppy/osu/assets/191335/87450691-42ca-426d-b194-c9c329aeae6c) | ![2024-04-12 17 09 27@2x](https://github.com/ppy/osu/assets/191335/84d842a9-90b9-41b1-a642-bec1edba7f12) |