### PR TITLE
Fix toolbar volume bar masking

### DIFF
--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Toolbar
             StateContainer = music;
 
             Flow.Padding = new MarginPadding { Horizontal = Toolbar.HEIGHT / 4 };
-            Flow.Add(volumeDisplay = new Container
+            Flow.Add(volumeDisplay = new CircularContainer
             {
                 Anchor = Anchor.CentreLeft,
                 Origin = Anchor.CentreLeft,
@@ -45,10 +45,9 @@ namespace osu.Game.Overlays.Toolbar
                 Height = IconContainer.Height,
                 Margin = new MarginPadding { Horizontal = 2.5f },
                 Masking = true,
-                CornerRadius = 3f,
-                Children = new Drawable[]
+                Children = new[]
                 {
-                    new Circle
+                    new Box
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.White.Opacity(0.25f),

--- a/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarMusicButton.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.Toolbar
 {
     public partial class ToolbarMusicButton : ToolbarOverlayToggleButton
     {
-        private Circle volumeBar;
+        private Box volumeBar;
 
         protected override Anchor TooltipAnchor => Anchor.TopRight;
 
@@ -45,14 +45,15 @@ namespace osu.Game.Overlays.Toolbar
                 Height = IconContainer.Height,
                 Margin = new MarginPadding { Horizontal = 2.5f },
                 Masking = true,
-                Children = new[]
+                CornerRadius = 3f,
+                Children = new Drawable[]
                 {
                     new Circle
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.White.Opacity(0.25f),
                     },
-                    volumeBar = new Circle
+                    volumeBar = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
                         Height = 0f,


### PR DESCRIPTION
Hi, noticed that the volume bar in the toolbar was not being masked.

https://github.com/ppy/osu/assets/29640516/60efe721-1194-4887-bb80-64a2d3aaf0a1

https://github.com/ppy/osu/assets/29640516/e1445a5d-c98e-4243-8b8d-2864a8f40318