### PR TITLE
Show results in results screen based on leaderboard selected in song select

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -361,6 +361,10 @@ namespace osu.Game.Tests.Visual.Background
 
             protected override BackgroundScreen CreateBackground() => new FadeAccessibleBackground(Beatmap.Value);
 
+            protected override void PopulateScorePanelList()
+            {
+            }
+
             public Vector2 ExpectedBackgroundBlur => new Vector2(BACKGROUND_BLUR);
         }
 

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -399,7 +399,7 @@ namespace osu.Game.Tests.Visual.Ranking
         private partial class TestResultsScreen : SoloResultsScreen
         {
             public HotkeyRetryOverlay RetryOverlay;
-            protected BindableList<ScoreInfo> Leaderboard = new BindableList<ScoreInfo>();
+            protected readonly BindableList<ScoreInfo> Leaderboard = new BindableList<ScoreInfo>();
 
             public TestResultsScreen(ScoreInfo score)
                 : base(score)

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -6,7 +6,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
+using osu.Game.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Ranking;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Edit.GameplayTest
@@ -80,5 +82,11 @@ namespace osu.Game.Screens.Edit.GameplayTest
             editor.RestoreState(editorState);
             return base.OnExiting(e);
         }
+
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
+        {
+            AllowRetry = true,
+            ShowUserStatistics = true,
+        };
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
@@ -3,9 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using osu.Game.Online.API;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 
@@ -24,9 +21,5 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
             Scheduler.AddDelayed(() => StatisticsPanel.ToggleVisibility(), 1000);
         }
-
-        protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
-
-        protected override APIRequest FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
     }
 }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -1224,11 +1224,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         /// <param name="score">The <see cref="ScoreInfo"/> to be displayed in the results screen.</param>
         /// <returns>The <see cref="ResultsScreen"/>.</returns>
-        protected virtual ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
-        {
-            AllowRetry = true,
-            ShowUserStatistics = true,
-        };
+        protected abstract ResultsScreen CreateResults(ScoreInfo score);
 
         private void fadeOut(bool instant = false)
         {

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -92,7 +92,10 @@ namespace osu.Game.Screens.Play
                 Scores = { BindTarget = LeaderboardScores }
             };
 
-        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score);
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
+        {
+            Scores = { BindTarget = LeaderboardScores }
+        };
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {

--- a/osu.Game/Screens/Play/SoloPlayer.cs
+++ b/osu.Game/Screens/Play/SoloPlayer.cs
@@ -14,6 +14,7 @@ using osu.Game.Online.Rooms;
 using osu.Game.Online.Solo;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Screens.Play
 {
@@ -72,5 +73,12 @@ namespace osu.Game.Screens.Play
 
             return new SubmitSoloScoreRequest(score.ScoreInfo, token, beatmap.OnlineID);
         }
+
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
+        {
+            AllowRetry = true,
+            ShowUserStatistics = true,
+            Scores = { BindTarget = LeaderboardScores }
+        };
     }
 }

--- a/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorPlayer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Screens;
 using osu.Game.Online.Spectator;
 using osu.Game.Scoring;
+using osu.Game.Screens.Ranking;
 using osu.Game.Users;
 
 namespace osu.Game.Screens.Play
@@ -52,5 +53,8 @@ namespace osu.Game.Screens.Play
             if (SpectatorClient.IsNotNull())
                 SpectatorClient.OnUserBeganPlaying -= userBeganPlaying;
         }
+
+        protected override ResultsScreen CreateResults(ScoreInfo score)
+            => new SpectatorResultsScreen(score);
     }
 }

--- a/osu.Game/Screens/Play/SpectatorPlayer.cs
+++ b/osu.Game/Screens/Play/SpectatorPlayer.cs
@@ -12,7 +12,6 @@ using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Scoring;
-using osu.Game.Screens.Ranking;
 
 namespace osu.Game.Screens.Play
 {
@@ -111,9 +110,6 @@ namespace osu.Game.Screens.Play
         }
 
         protected override Score CreateScore(IBeatmap beatmap) => score;
-
-        protected override ResultsScreen CreateResults(ScoreInfo score)
-            => new SpectatorResultsScreen(score);
 
         protected override void PrepareReplay()
         {

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -21,7 +21,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -54,9 +54,6 @@ namespace osu.Game.Screens.Ranking
         [Resolved(CanBeNull = true)]
         private Player player { get; set; }
 
-        [Resolved]
-        private IAPIProvider api { get; set; }
-
         protected StatisticsPanel StatisticsPanel { get; private set; }
 
         private Drawable bottomPanel;

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -1,49 +1,40 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using osu.Framework.Allocation;
-using osu.Game.Beatmaps;
-using osu.Game.Extensions;
-using osu.Game.Online.API;
-using osu.Game.Online.API.Requests;
-using osu.Game.Rulesets;
+using osu.Framework.Bindables;
 using osu.Game.Scoring;
 
 namespace osu.Game.Screens.Ranking
 {
     public partial class SoloResultsScreen : ResultsScreen
     {
-        private GetScoresRequest? getScoreRequest;
+        public readonly IBindableList<ScoreInfo> Scores = new BindableList<ScoreInfo>();
 
-        [Resolved]
-        private RulesetStore rulesets { get; set; } = null!;
+        private bool hasLoaded;
 
         public SoloResultsScreen(ScoreInfo score)
             : base(score)
         {
         }
 
-        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>>? scoresCallback)
+        protected override void PopulateScorePanelList()
         {
-            Debug.Assert(Score != null);
-
-            if (Score.BeatmapInfo!.OnlineID <= 0 || Score.BeatmapInfo.Status <= BeatmapOnlineStatus.Pending)
-                return null;
-
-            getScoreRequest = new GetScoresRequest(Score.BeatmapInfo, Score.Ruleset);
-            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => !s.MatchesOnlineID(Score)).Select(s => s.ToScoreInfo(rulesets, Beatmap.Value.BeatmapInfo)));
-            return getScoreRequest;
+            Scores.BindCollectionChanged((_, _) => Scheduler.AddOnce(addScores), true);
         }
 
-        protected override void Dispose(bool isDisposing)
+        private void addScores()
         {
-            base.Dispose(isDisposing);
+            if (!Scores.Any() || hasLoaded)
+                return;
 
-            getScoreRequest?.Cancel();
+            foreach (var s in Scores)
+            {
+                if (s.ID != Score.ID)
+                    AddScore(s);
+            }
+
+            hasLoaded = true;
         }
     }
 }

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.Ranking
 
             foreach (var s in Scores)
             {
-                if (s.ID != Score.ID)
+                if (Score == null || s.ID != Score.ID)
                     AddScore(s);
             }
 

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -53,8 +54,14 @@ namespace osu.Game.Screens.Select
             AddInternal(new SongSelectTouchInputDetector());
         }
 
+        protected IBindableList<ScoreInfo> Scores => playBeatmapDetailArea.Leaderboard.Scores;
+
         protected void PresentScore(ScoreInfo score) =>
-            FinaliseSelection(score.BeatmapInfo, score.Ruleset, () => this.Push(new SoloResultsScreen(score)));
+            FinaliseSelection(score.BeatmapInfo, score.Ruleset, () => this.Push(new SoloResultsScreen(score)
+            {
+                Scores = { BindTarget = Scores }
+            })
+            );
 
         protected override BeatmapDetailArea CreateBeatmapDetailArea()
         {
@@ -131,14 +138,14 @@ namespace osu.Game.Screens.Select
                 {
                     player = new ReplayPlayer((beatmap, mods) => replayGeneratingMod.CreateScoreFromReplayData(beatmap, mods))
                     {
-                        LeaderboardScores = { BindTarget = playBeatmapDetailArea.Leaderboard.Scores }
+                        LeaderboardScores = { BindTarget = Scores }
                     };
                 }
                 else
                 {
                     player = new SoloPlayer
                     {
-                        LeaderboardScores = { BindTarget = playBeatmapDetailArea.Leaderboard.Scores }
+                        LeaderboardScores = { BindTarget = Scores }
                     };
                 }
 

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -20,7 +20,6 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
-using osu.Game.Screens.Play.Break;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
 using osu.Game.Utils;

--- a/osu.Game/Screens/Select/PlaySongSelect.cs
+++ b/osu.Game/Screens/Select/PlaySongSelect.cs
@@ -20,6 +20,7 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Break;
 using osu.Game.Screens.Ranking;
 using osu.Game.Users;
 using osu.Game.Utils;
@@ -56,12 +57,17 @@ namespace osu.Game.Screens.Select
 
         protected IBindableList<ScoreInfo> Scores => playBeatmapDetailArea.Leaderboard.Scores;
 
-        protected void PresentScore(ScoreInfo score) =>
-            FinaliseSelection(score.BeatmapInfo, score.Ruleset, () => this.Push(new SoloResultsScreen(score)
+        protected void PresentScore(ScoreInfo score) => FinaliseSelection(score.BeatmapInfo, score.Ruleset, () => pushResultsScreen(score));
+
+        private void pushResultsScreen(ScoreInfo score)
+        {
+            var resultsScreen = new SoloResultsScreen(score)
             {
                 Scores = { BindTarget = Scores }
-            })
-            );
+            };
+
+            this.Push(resultsScreen);
+        }
 
         protected override BeatmapDetailArea CreateBeatmapDetailArea()
         {


### PR DESCRIPTION
Resolves ppy/osu#26331, resolves ppy/osu#9201.

Now `SoloResultsScreen` gets scores from `LeaderboardScores` in `Player`, similarly to `SoloGameplayLeaderboard`.

I'm not so sure about how I implemented `PopulateScorePanelList` in `SoloResultsScreen`. The idea was that, if the scores are already loaded, then `hasLoaded` prevents eventual changes that might happen later but still allow delayed fetching of scores (if they somehow didn't have time to load during gameplay and in song select?). 
Maybe that can be improved/changed though.

Other thing that changed because of that is the `SpectatorResultsScreen`, similarly to the `GameplayLeaderboard`, doesn't show any other scores, because of lack of `LeaderboardScores` in `SoloSpectatorPlayer`

edit: 
Tests seem to fail due to changing of `testResults`, even though on my local machine dotnet test gives 0 fails.
Are the tests performed parallelly and in normal situation it wouldn't occur, or just logic in `SoloResultsScreen` is not thread safe?