### PR TITLE
Don't re-filter unless mods may change the filter

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -1,9 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Mods;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
@@ -26,6 +31,21 @@ namespace osu.Game.Rulesets.Mania
                 case "key":
                 case "keys":
                     return FilterQueryParser.TryUpdateCriteriaRange(ref keys, op, value);
+            }
+
+            return false;
+        }
+
+        public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        {
+            if (keys.HasFilter)
+            {
+                // Interpreting as the Mod type is required for equality comparison.
+                HashSet<Mod> oldSet = mods.OldValue.OfType<ManiaKeyMod>().AsEnumerable<Mod>().ToHashSet();
+                HashSet<Mod> newSet = mods.NewValue.OfType<ManiaKeyMod>().AsEnumerable<Mod>().ToHashSet();
+
+                if (!oldSet.SetEquals(newSet))
+                    return true;
             }
 
             return false;

--- a/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterMatchingTest.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
@@ -311,6 +314,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
 
             public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria) => match;
             public bool TryParseCustomKeywordCriteria(string key, Operator op, string value) => false;
+
+            public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Filter;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
@@ -514,6 +517,8 @@ namespace osu.Game.Tests.NonVisual.Filtering
 
                 return false;
             }
+
+            public bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods) => false;
         }
 
         private static readonly object[] correct_date_query_examples =

--- a/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
+++ b/osu.Game/Rulesets/Filter/IRulesetFilterCriteria.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 
@@ -52,5 +55,12 @@ namespace osu.Game.Rulesets.Filter
         /// while ignored criteria are included in <see cref="FilterCriteria.SearchText"/>.
         /// </returns>
         bool TryParseCustomKeywordCriteria(string key, Operator op, string value);
+
+        /// <summary>
+        /// Whether to reapply the filter as a result of the given change in applied mods.
+        /// </summary>
+        /// <param name="mods">The change in mods.</param>
+        /// <returns>Whether the filter should be re-applied.</returns>
+        bool FilterMayChangeFromMods(ValueChangedEvent<IReadOnlyList<Mod>> mods);
     }
 }

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -49,14 +50,13 @@ namespace osu.Game.Screens.Select
         }
 
         private OsuTabControl<SortMode> sortTabs;
-
         private Bindable<SortMode> sortMode;
-
         private Bindable<GroupMode> groupMode;
-
         private FilterControlTextBox searchTextBox;
-
         private CollectionDropdown collectionDropdown;
+
+        [CanBeNull]
+        private FilterCriteria currentCriteria;
 
         public FilterCriteria CreateCriteria()
         {
@@ -228,7 +228,8 @@ namespace osu.Game.Screens.Select
                 if (m.NewValue.SequenceEqual(m.OldValue))
                     return;
 
-                updateCriteria();
+                if (currentCriteria?.RulesetCriteria?.FilterMayChangeFromMods(m) == true)
+                    updateCriteria();
             });
 
             groupMode.BindValueChanged(_ => updateCriteria());
@@ -263,7 +264,7 @@ namespace osu.Game.Screens.Select
         private readonly Bindable<double> minimumStars = new BindableDouble();
         private readonly Bindable<double> maximumStars = new BindableDouble();
 
-        private void updateCriteria() => FilterChanged?.Invoke(CreateCriteria());
+        private void updateCriteria() => FilterChanged?.Invoke(currentCriteria = CreateCriteria());
 
         protected override bool OnClick(ClickEvent e) => true;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/27840

A bit of an RFC on the interfacing. I went with this (as opposed to doing something in, say, `Mod` itself) because the criteria has all the knowledge required to understand whether it may change from the new mod selection.