### PR TITLE
Fix high memory usage during spectator modes when background processing is running

### DIFF
--- a/osu.Desktop/Performance/HighPerformanceSessionManager.cs
+++ b/osu.Desktop/Performance/HighPerformanceSessionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Game.Performance;
@@ -11,6 +12,8 @@ namespace osu.Desktop.Performance
 {
     public class HighPerformanceSessionManager : IHighPerformanceSessionManager
     {
+        public bool IsSessionActive => activeSessions > 0;
+
         private int activeSessions;
 
         private GCLatencyMode originalGCMode;

--- a/osu.Desktop/Performance/HighPerformanceSessionManager.cs
+++ b/osu.Desktop/Performance/HighPerformanceSessionManager.cs
@@ -11,16 +11,24 @@ namespace osu.Desktop.Performance
 {
     public class HighPerformanceSessionManager : IHighPerformanceSessionManager
     {
+        private int activeSessions;
+
         private GCLatencyMode originalGCMode;
 
         public IDisposable BeginSession()
         {
-            enableHighPerformanceSession();
-            return new InvokeOnDisposal<HighPerformanceSessionManager>(this, static m => m.disableHighPerformanceSession());
+            enterSession();
+            return new InvokeOnDisposal<HighPerformanceSessionManager>(this, static m => m.exitSession());
         }
 
-        private void enableHighPerformanceSession()
+        private void enterSession()
         {
+            if (Interlocked.Increment(ref activeSessions) > 1)
+            {
+                Logger.Log($"High performance session requested ({activeSessions} others already running)");
+                return;
+            }
+
             Logger.Log("Starting high performance session");
 
             originalGCMode = GCSettings.LatencyMode;
@@ -30,8 +38,14 @@ namespace osu.Desktop.Performance
             GC.Collect(0);
         }
 
-        private void disableHighPerformanceSession()
+        private void exitSession()
         {
+            if (Interlocked.Decrement(ref activeSessions) > 0)
+            {
+                Logger.Log($"High performance session finished ({activeSessions} others remain)");
+                return;
+            }
+
             Logger.Log("Ending high performance session");
 
             if (GCSettings.LatencyMode == GCLatencyMode.LowLatency)

--- a/osu.Desktop/Performance/HighPerformanceSessionManager.cs
+++ b/osu.Desktop/Performance/HighPerformanceSessionManager.cs
@@ -28,7 +28,7 @@ namespace osu.Desktop.Performance
         {
             if (Interlocked.Increment(ref activeSessions) > 1)
             {
-                Logger.Log($"High performance session requested ({activeSessions} others already running)");
+                Logger.Log($"High performance session requested ({activeSessions} running in total)");
                 return;
             }
 

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -16,6 +16,7 @@ using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Performance;
 using osu.Game.Rulesets;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
@@ -50,6 +51,9 @@ namespace osu.Game.Database
 
         [Resolved]
         private ILocalUserPlayInfo? localUserPlayInfo { get; set; }
+
+        [Resolved]
+        private IHighPerformanceSessionManager? highPerformanceSessionManager { get; set; }
 
         [Resolved]
         private INotificationOverlay? notificationOverlay { get; set; }
@@ -493,7 +497,9 @@ namespace osu.Game.Database
 
         private void sleepIfRequired()
         {
-            while (localUserPlayInfo?.IsPlaying.Value == true)
+            // Importantly, also sleep if high performance session is active.
+            // If we don't do this, memory usage can become runaway due to GC running in a more lenient mode.
+            while (localUserPlayInfo?.IsPlaying.Value == true || highPerformanceSessionManager?.IsSessionActive == true)
             {
                 Logger.Log("Background processing sleeping due to active gameplay...");
                 Thread.Sleep(TimeToSleepDuringGameplay);

--- a/osu.Game/Performance/IHighPerformanceSessionManager.cs
+++ b/osu.Game/Performance/IHighPerformanceSessionManager.cs
@@ -15,6 +15,11 @@ namespace osu.Game.Performance
     public interface IHighPerformanceSessionManager
     {
         /// <summary>
+        /// Whether a high performance session is currently active.
+        /// </summary>
+        bool IsSessionActive { get; }
+
+        /// <summary>
         /// Start a new high performance session.
         /// </summary>
         /// <returns>An <see cref="IDisposable"/> which will end the session when disposed.</returns>


### PR DESCRIPTION
Closes #27857.

Previous checks were on `LocalUserPlaying`, which is not enough to handle the case of spectating, where local user is not playing but GC mode may be set to `LowLatency`.