### PR TITLE
Fix resume overlay not appearing after pausing when mouse cursor is inside window but outside of actual playfield area

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneResume.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneResume.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public partial class TestSceneResume : PlayerTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+
+        protected override TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(true, false, AllowBackwardsSeeks);
+
+        [Test]
+        public void TestPauseViaKeyboard()
+        {
+            AddStep("move mouse to center", () => InputManager.MoveMouseTo(Player.ScreenSpaceDrawQuad.Centre));
+            AddUntilStep("wait for gameplay start", () => Player.LocalUserPlaying.Value);
+            AddStep("press escape", () => InputManager.PressKey(Key.Escape));
+            AddUntilStep("wait for pause overlay", () => Player.ChildrenOfType<PauseOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddStep("release escape", () => InputManager.ReleaseKey(Key.Escape));
+            AddStep("resume", () =>
+            {
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Space);
+            });
+            AddUntilStep("pause overlay present", () => Player.DrawableRuleset.ResumeOverlay.State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
+        [Test]
+        public void TestPauseViaKeyboardWhenMouseOutsidePlayfield()
+        {
+            AddStep("move mouse outside playfield", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield.ScreenSpaceDrawQuad.BottomRight + new Vector2(1)));
+            AddUntilStep("wait for gameplay start", () => Player.LocalUserPlaying.Value);
+            AddStep("press escape", () => InputManager.PressKey(Key.Escape));
+            AddUntilStep("wait for pause overlay", () => Player.ChildrenOfType<PauseOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddStep("release escape", () => InputManager.ReleaseKey(Key.Escape));
+            AddStep("resume", () =>
+            {
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Space);
+            });
+            AddUntilStep("pause overlay present", () => Player.DrawableRuleset.ResumeOverlay.State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
+        [Test]
+        public void TestPauseViaKeyboardWhenMouseOutsideScreen()
+        {
+            AddStep("move mouse outside playfield", () => InputManager.MoveMouseTo(new Vector2(-20)));
+            AddUntilStep("wait for gameplay start", () => Player.LocalUserPlaying.Value);
+            AddStep("press escape", () => InputManager.PressKey(Key.Escape));
+            AddUntilStep("wait for pause overlay", () => Player.ChildrenOfType<PauseOverlay>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddStep("release escape", () => InputManager.ReleaseKey(Key.Escape));
+            AddStep("resume", () =>
+            {
+                InputManager.Key(Key.Down);
+                InputManager.Key(Key.Space);
+            });
+            AddUntilStep("pause overlay not present", () => Player.DrawableRuleset.ResumeOverlay.State.Value, () => Is.EqualTo(Visibility.Hidden));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Osu.UI.Cursor;
+using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using osuTK.Graphics;
 
@@ -26,6 +27,9 @@ namespace osu.Game.Rulesets.Osu.UI
 
         protected override LocalisableString Message => "Click the orange cursor to resume";
 
+        [Resolved]
+        private DrawableRuleset? drawableRuleset { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -38,7 +42,7 @@ namespace osu.Game.Rulesets.Osu.UI
         protected override void PopIn()
         {
             // Can't display if the cursor is outside the window.
-            if (GameplayCursor.LastFrameState == Visibility.Hidden || !Contains(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre))
+            if (GameplayCursor.LastFrameState == Visibility.Hidden || drawableRuleset?.Contains(GameplayCursor.ActiveCursor.ScreenSpaceDrawQuad.Centre) == false)
             {
                 Resume();
                 return;

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -19,12 +17,12 @@ namespace osu.Game.Rulesets.Osu.UI
 {
     public partial class OsuResumeOverlay : ResumeOverlay
     {
-        private Container cursorScaleContainer;
-        private OsuClickToResumeCursor clickToResumeCursor;
+        private Container cursorScaleContainer = null!;
+        private OsuClickToResumeCursor clickToResumeCursor = null!;
 
-        private OsuCursorContainer localCursorContainer;
+        private OsuCursorContainer? localCursorContainer;
 
-        public override CursorContainer LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
+        public override CursorContainer? LocalCursor => State.Value == Visibility.Visible ? localCursorContainer : null;
 
         protected override LocalisableString Message => "Click the orange cursor to resume";
 
@@ -71,8 +69,8 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             public override bool HandlePositionalInput => true;
 
-            public Action ResumeRequested;
-            private Container scaleTransitionContainer;
+            public Action? ResumeRequested;
+            private Container scaleTransitionContainer = null!;
 
             public OsuClickToResumeCursor()
             {


### PR DESCRIPTION
Loosely related to https://github.com/ppy/osu/discussions/27871#discussioncomment-9123784 (although does not actually fix the issue with the pause button, _if_ it is to be considered an issue - the problem there is that the gameplay cursor gets hidden, so the other condition in the modified check takes over).

Regressed in https://github.com/ppy/osu/commit/bce3bd55e5a863e52f41598c306a248a79638843. Reasoning for breakage is silent change in `this` when moving the `Contains()` check (`DrawableRuleset` will encompass screen bounds, while `OsuResumeOverlay` is only as big as the actual playfield).

Not 100% sure this will be accepted given [the discussion that happened on discord](https://discord.com/channels/188630481301012481/188630652340404224/1229747238750781520) but because [the change wasn't intentional](https://discord.com/channels/188630481301012481/188630652340404224/1229752941833879612) I guess might as well put this through the review paces...?