### PR TITLE
Fix preview tracks playing after their owning overlay has hidden

### DIFF
--- a/osu.Game/Overlays/WaveOverlayContainer.cs
+++ b/osu.Game/Overlays/WaveOverlayContainer.cs
@@ -40,10 +40,12 @@ namespace osu.Game.Overlays
 
         protected override void PopOut()
         {
-            base.PopOut();
-
             Waves.Hide();
-            this.FadeOut(WaveContainer.DISAPPEAR_DURATION, Easing.InQuint);
+            this.FadeOut(WaveContainer.DISAPPEAR_DURATION, Easing.InQuint)
+                // base call is responsible for stopping preview tracks.
+                // delay it until the fade has concluded to ensure that nothing inside the overlay has triggered
+                // another preview track playback in the meantime, leaving an "orphaned" preview playing.
+                .OnComplete(_ => base.PopOut());
         }
     }
 }


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/27883.

The idea here is that `PopOut()` is called _when the hide is requested_, so once an overlay hide would trigger, the overlay would `StopAnyPlaying()`, but because of async load things, the actual track would start playing after that but before the overlay has fully hidden. (That last part is significant because after the overlay has fully hidden, schedules save the day.)

Due to the loose coupling between `PreviewTrackManager` and `IPreviewTrackOwner` there's really no easy way to handle this locally to the usages of the preview tracks. Heck, `PreviewTrackManager` doesn't really know which preview track owner is to be considered _present_ at any time, it just kinda works on vibes based on DI until the owner tells all of its preview tracks to stop.

This solution causes the preview tracks to stop a little bit later but maybe that's fine? Just trying to not overthink the issue is all.

No tests because this is going to suck to test automatically while it is pretty easy to test manually (got it in a few tries on master).

The issue also mentions that the track can sometimes resume playing after the overlay is pulled up again, but I don't see that as a problem necessarily, and even if it was, it's not going to be that easy to address due to the aforementioned loose coupling - to fix that, play buttons would have to know who is the current preview track owner and cancel schedules upon determining that their preview track owner has gone away.