### PR TITLE
Add sound feedback to all tab controls with keyboard interaction

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTabControl.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -143,13 +145,6 @@ namespace osu.Game.Graphics.UserInterface
                     FadeUnhovered();
             }
 
-            [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
-            {
-                if (accentColour == default)
-                    AccentColour = colours.Blue;
-            }
-
             public OsuTabItem(T value)
                 : base(value)
             {
@@ -196,8 +191,19 @@ namespace osu.Game.Graphics.UserInterface
                         Origin = Anchor.BottomLeft,
                         Anchor = Anchor.BottomLeft,
                     },
-                    new HoverClickSounds(HoverSampleSet.TabSelect)
+                    new HoverSounds(HoverSampleSet.TabSelect)
                 };
+            }
+
+            private Sample selectSample;
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours, AudioManager audio)
+            {
+                if (accentColour == default)
+                    AccentColour = colours.Blue;
+
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             protected override void OnActivated()
@@ -211,6 +217,8 @@ namespace osu.Game.Graphics.UserInterface
                 Text.Font = Text.Font.With(weight: FontWeight.Medium);
                 FadeUnhovered();
             }
+
+            protected override void OnActivatedByUser() => selectSample.Play();
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/PageTabControl.cs
+++ b/osu.Game/Graphics/UserInterface/PageTabControl.cs
@@ -7,6 +7,8 @@ using System;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -53,6 +55,8 @@ namespace osu.Game.Graphics.UserInterface
                 }
             }
 
+            private Sample selectSample = null!;
+
             public PageTabItem(T value)
                 : base(value)
             {
@@ -78,10 +82,16 @@ namespace osu.Game.Graphics.UserInterface
                         Origin = Anchor.BottomLeft,
                         Anchor = Anchor.BottomLeft,
                     },
-                    new HoverClickSounds(HoverSampleSet.TabSelect)
+                    new HoverSounds(HoverSampleSet.TabSelect)
                 };
 
                 Active.BindValueChanged(active => Text.Font = Text.Font.With(Typeface.Torus, weight: active.NewValue ? FontWeight.Bold : FontWeight.Medium), true);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(AudioManager audio)
+            {
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             protected virtual LocalisableString CreateText() => (Value as Enum)?.GetLocalisableDescription() ?? Value.ToString();
@@ -112,6 +122,8 @@ namespace osu.Game.Graphics.UserInterface
             protected override void OnActivated() => slideActive();
 
             protected override void OnDeactivated() => slideInactive();
+
+            protected override void OnActivatedByUser() => selectSample.Play();
         }
     }
 }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingCardSizeTabControl.cs
@@ -5,6 +5,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -47,13 +49,15 @@ namespace osu.Game.Overlays.BeatmapListing
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; }
 
+            private Sample selectSample = null!;
+
             public TabItem(BeatmapCardSize value)
                 : base(value)
             {
             }
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(AudioManager audio)
             {
                 AutoSizeAxes = Axes.Both;
                 Masking = true;
@@ -79,8 +83,10 @@ namespace osu.Game.Overlays.BeatmapListing
                             Icon = getIconForCardSize(Value)
                         }
                     },
-                    new HoverClickSounds(HoverSampleSet.TabSelect)
+                    new HoverSounds(HoverSampleSet.TabSelect)
                 };
+
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             private static IconUsage getIconForCardSize(BeatmapCardSize cardSize)
@@ -110,6 +116,8 @@ namespace osu.Game.Overlays.BeatmapListing
                 if (IsLoaded)
                     updateState();
             }
+
+            protected override void OnActivatedByUser() => selectSample.Play();
 
             protected override void OnDeactivated()
             {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 base.OnClick(e);
                 Active.Toggle();
+                SelectSample.Play();
                 return true;
             }
         }

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -128,6 +128,9 @@ namespace osu.Game.Overlays.BeatmapListing
             protected override bool OnClick(ClickEvent e)
             {
                 base.OnClick(e);
+
+                // this tab item implementation is not managed by a TabControl,
+                // therefore we have to manually update Active state and play select sound when this tab item is clicked.
                 Active.Toggle();
                 SelectSample.Play();
                 return true;

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -5,6 +5,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
@@ -24,13 +26,15 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private OsuSpriteText text;
 
+        private Sample selectSample = null!;
+
         public FilterTabItem(T value)
             : base(value)
         {
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             AutoSizeAxes = Axes.Both;
             AddRangeInternal(new Drawable[]
@@ -40,10 +44,12 @@ namespace osu.Game.Overlays.BeatmapListing
                     Font = OsuFont.GetFont(size: 13, weight: FontWeight.Regular),
                     Text = LabelFor(Value)
                 },
-                new HoverClickSounds(HoverSampleSet.TabSelect)
+                new HoverSounds(HoverSampleSet.TabSelect)
             });
 
             Enabled.Value = true;
+
+            selectSample = audio.Samples.Get(@"UI/tabselect-select");
         }
 
         protected override void LoadComplete()
@@ -70,6 +76,8 @@ namespace osu.Game.Overlays.BeatmapListing
         protected override void OnActivated() => UpdateState();
 
         protected override void OnDeactivated() => UpdateState();
+
+        protected override void OnActivatedByUser() => selectSample.Play();
 
         /// <summary>
         /// Returns the label text to be used for the supplied <paramref name="value"/>.

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private OsuSpriteText text;
 
-        private Sample selectSample = null!;
+        protected Sample SelectSample { get; private set; } = null!;
 
         public FilterTabItem(T value)
             : base(value)
@@ -49,7 +49,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
             Enabled.Value = true;
 
-            selectSample = audio.Samples.Get(@"UI/tabselect-select");
+            SelectSample = audio.Samples.Get(@"UI/tabselect-select");
         }
 
         protected override void LoadComplete()
@@ -77,7 +77,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         protected override void OnDeactivated() => UpdateState();
 
-        protected override void OnActivatedByUser() => selectSample.Play();
+        protected override void OnActivatedByUser() => SelectSample.Play();
 
         /// <summary>
         /// Returns the label text to be used for the supplied <paramref name="value"/>.

--- a/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.BeatmapSet
                 // propagate value to tab items first to enable only available rulesets.
                 beatmapSet.Value = value;
 
-                SelectTab(TabContainer.TabItems.FirstOrDefault(t => t.Enabled.Value));
+                Current.Value = TabContainer.TabItems.FirstOrDefault(t => t.Enabled.Value)?.Value;
             }
         }
 

--- a/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
+++ b/osu.Game/Overlays/OverlayPanelDisplayStyleControl.cs
@@ -11,6 +11,8 @@ using osuTK;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
@@ -65,6 +67,8 @@ namespace osu.Game.Overlays
 
             private readonly SpriteIcon icon;
 
+            private Sample selectSample = null!;
+
             public PanelDisplayTabItem(OverlayPanelDisplayStyle value)
                 : base(value)
             {
@@ -78,13 +82,21 @@ namespace osu.Game.Overlays
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fit
                     },
-                    new HoverClickSounds()
+                    new HoverSounds(HoverSampleSet.TabSelect)
                 });
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(AudioManager audio)
+            {
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             protected override void OnActivated() => updateState();
 
             protected override void OnDeactivated() => updateState();
+
+            protected override void OnActivatedByUser() => selectSample.Play();
 
             protected override bool OnHover(HoverEvent e)
             {

--- a/osu.Game/Overlays/OverlayRulesetTabItem.cs
+++ b/osu.Game/Overlays/OverlayRulesetTabItem.cs
@@ -10,6 +10,8 @@ using osu.Game.Rulesets;
 using osuTK.Graphics;
 using osuTK;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Containers;
@@ -39,6 +41,8 @@ namespace osu.Game.Overlays
 
         public LocalisableString TooltipText => Value.Name;
 
+        private Sample selectSample = null!;
+
         public OverlayRulesetTabItem(RulesetInfo value)
             : base(value)
         {
@@ -59,10 +63,16 @@ namespace osu.Game.Overlays
                         Icon = value.CreateInstance().CreateIcon(),
                     },
                 },
-                new HoverClickSounds()
+                new HoverSounds(HoverSampleSet.TabSelect)
             });
 
             Enabled.Value = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            selectSample = audio.Samples.Get(@"UI/tabselect-select");
         }
 
         protected override void LoadComplete()
@@ -89,6 +99,8 @@ namespace osu.Game.Overlays
         protected override void OnActivated() => updateState();
 
         protected override void OnDeactivated() => updateState();
+
+        protected override void OnActivatedByUser() => selectSample.Play();
 
         private void updateState()
         {

--- a/osu.Game/Overlays/OverlayStreamItem.cs
+++ b/osu.Game/Overlays/OverlayStreamItem.cs
@@ -11,6 +11,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics;
 using osuTK.Graphics;
@@ -49,8 +51,10 @@ namespace osu.Game.Overlays
             Margin = new MarginPadding(PADDING);
         }
 
+        private Sample selectSample;
+
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider colourProvider, OsuColour colours, AudioManager audio)
         {
             AddRange(new Drawable[]
             {
@@ -87,8 +91,10 @@ namespace osu.Game.Overlays
                     CollapsedSize = 2,
                     Expanded = true
                 },
-                new HoverClickSounds()
+                new HoverSounds(HoverSampleSet.TabSelect)
             });
+
+            selectSample = audio.Samples.Get(@"UI/tabselect-select");
 
             SelectedItem.BindValueChanged(_ => updateState(), true);
         }
@@ -104,6 +110,8 @@ namespace osu.Game.Overlays
         protected override void OnActivated() => updateState();
 
         protected override void OnDeactivated() => updateState();
+
+        protected override void OnActivatedByUser() => selectSample.Play();
 
         protected override bool OnHover(HoverEvent e)
         {

--- a/osu.Game/Overlays/OverlayTabControl.cs
+++ b/osu.Game/Overlays/OverlayTabControl.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
@@ -80,6 +82,8 @@ namespace osu.Game.Overlays
                 }
             }
 
+            private Sample selectSample = null!;
+
             public OverlayTabItem(T value)
                 : base(value)
             {
@@ -101,8 +105,14 @@ namespace osu.Game.Overlays
                         ExpandedSize = 5f,
                         CollapsedSize = 0
                     },
-                    new HoverClickSounds(HoverSampleSet.TabSelect)
+                    new HoverSounds(HoverSampleSet.TabSelect)
                 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(AudioManager audio)
+            {
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             protected override bool OnHover(HoverEvent e)
@@ -135,6 +145,8 @@ namespace osu.Game.Overlays
                 UnhoverAction();
                 Text.Font = Text.Font.With(weight: FontWeight.Medium);
             }
+
+            protected override void OnActivatedByUser() => selectSample.Play();
 
             private void updateState()
             {

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
@@ -3,11 +3,8 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -24,8 +21,6 @@ namespace osu.Game.Overlays.Toolbar
     {
         protected Drawable ModeButtonLine { get; private set; }
 
-        private readonly Dictionary<string, Sample> selectionSamples = new Dictionary<string, Sample>();
-
         public ToolbarRulesetSelector()
         {
             RelativeSizeAxes = Axes.Y;
@@ -33,7 +28,7 @@ namespace osu.Game.Overlays.Toolbar
         }
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio)
+        private void load()
         {
             AddRangeInternal(new[]
             {
@@ -59,9 +54,6 @@ namespace osu.Game.Overlays.Toolbar
                     }
                 },
             });
-
-            foreach (var ruleset in Rulesets.AvailableRulesets)
-                selectionSamples[ruleset.ShortName] = audio.Samples.Get($"UI/ruleset-select-{ruleset.ShortName}");
         }
 
         protected override void LoadComplete()
@@ -117,7 +109,7 @@ namespace osu.Game.Overlays.Toolbar
 
                 RulesetInfo found = Rulesets.AvailableRulesets.ElementAtOrDefault(requested);
                 if (found != null)
-                    Current.Value = found;
+                    SelectItem(found);
                 return true;
             }
 

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetSelector.cs
@@ -88,10 +88,6 @@ namespace osu.Game.Overlays.Toolbar
             if (SelectedTab != null)
             {
                 ModeButtonLine.MoveToX(SelectedTab.DrawPosition.X, !hasInitialPosition ? 0 : 500, Easing.OutElasticQuarter);
-
-                if (hasInitialPosition)
-                    selectionSamples[SelectedTab.Value.ShortName]?.Play();
-
                 hasInitialPosition = true;
             }
         }

--- a/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
+++ b/osu.Game/Overlays/Toolbar/ToolbarRulesetTabButton.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
@@ -16,6 +18,8 @@ namespace osu.Game.Overlays.Toolbar
     public partial class ToolbarRulesetTabButton : TabItem<RulesetInfo>
     {
         private readonly RulesetButton ruleset;
+
+        private Sample? selectSample;
 
         public ToolbarRulesetTabButton(RulesetInfo value)
             : base(value)
@@ -34,9 +38,17 @@ namespace osu.Game.Overlays.Toolbar
             ruleset.SetIcon(rInstance.CreateIcon());
         }
 
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            selectSample = audio.Samples.Get($@"UI/ruleset-select-{Value.ShortName}");
+        }
+
         protected override void OnActivated() => ruleset.Active = true;
 
         protected override void OnDeactivated() => ruleset.Active = false;
+
+        protected override void OnActivatedByUser() => selectSample?.Play();
 
         private partial class RulesetButton : ToolbarButton
         {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -372,7 +372,7 @@ namespace osu.Game.Screens.Edit
                                     }
                                 }
                             },
-                            new EditorScreenSwitcherControl
+                            screenSwitcher = new EditorScreenSwitcherControl
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,
@@ -662,23 +662,23 @@ namespace osu.Game.Screens.Edit
                     return true;
 
                 case GlobalAction.EditorComposeMode:
-                    Mode.Value = EditorScreenMode.Compose;
+                    screenSwitcher.SelectItem(EditorScreenMode.Compose);
                     return true;
 
                 case GlobalAction.EditorDesignMode:
-                    Mode.Value = EditorScreenMode.Design;
+                    screenSwitcher.SelectItem(EditorScreenMode.Design);
                     return true;
 
                 case GlobalAction.EditorTimingMode:
-                    Mode.Value = EditorScreenMode.Timing;
+                    screenSwitcher.SelectItem(EditorScreenMode.Timing);
                     return true;
 
                 case GlobalAction.EditorSetupMode:
-                    Mode.Value = EditorScreenMode.SongSetup;
+                    screenSwitcher.SelectItem(EditorScreenMode.SongSetup);
                     return true;
 
                 case GlobalAction.EditorVerifyMode:
-                    Mode.Value = EditorScreenMode.Verify;
+                    screenSwitcher.SelectItem(EditorScreenMode.Verify);
                     return true;
 
                 case GlobalAction.EditorTestGameplay:
@@ -958,6 +958,8 @@ namespace osu.Game.Screens.Edit
 
         [CanBeNull]
         private ScheduledDelegate playbackDisabledDebounce;
+
+        private EditorScreenSwitcherControl screenSwitcher;
 
         private void updateSampleDisabledState()
         {

--- a/osu.Game/Screens/OnlinePlay/Match/Components/MatchTypePicker.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/Components/MatchTypePicker.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -78,14 +80,17 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
                             },
                         },
                     },
-                    new HoverClickSounds(),
+                    new HoverSounds(HoverSampleSet.TabSelect),
                 };
             }
 
+            private Sample selectSample;
+
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OsuColour colours, AudioManager audio)
             {
                 selection.Colour = colours.Yellow;
+                selectSample = audio.Samples.Get(@"UI/tabselect-select");
             }
 
             protected override bool OnHover(HoverEvent e)
@@ -109,6 +114,8 @@ namespace osu.Game.Screens.OnlinePlay.Match.Components
             {
                 selection.FadeOut(transition_duration, Easing.OutQuint);
             }
+
+            protected override void OnActivatedByUser() => selectSample.Play();
         }
     }
 }


### PR DESCRIPTION
- Closes #18551 
- Closes #27400
- Supersedes #27448 
- Supersedes https://github.com/ppy/osu/pull/27657
- [x] Depends on https://github.com/ppy/osu-framework/pull/6251
- [x] Depends on framework package

See https://github.com/ppy/osu/pull/27657#issuecomment-2060100727. 

Moving forward, all `TabItem` implementations must use `HoverSounds`, and manually load the select sample and play it on `OnActivatedByUser`. This extends support of sound feedback to trigger via <kbd>Ctrl-Tab</kbd> or by calling `SelectTab` (usually by handling key bindings).

The only behavioural changes by this PR are the following:
 1. Clicking on tabs while they are selected no longer plays a sound as concluded in https://github.com/ppy/osu/pull/27657#issuecomment-2016426398
 2. Ctrl-tab now plays sound when there is another tab to switch to, can be noticed in song select's beatmap details/leaderboard tabs on the left side.
 3. F2/F3/F4/F5/Ctrl-Shift-A to switch screens on editor now plays sound.

