### PR TITLE
Rename SkinComponentsContainer -> SkinnableContainer

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
             if (withModifiedSkin)
             {
                 AddStep("change component scale", () => Player.ChildrenOfType<LegacyScoreCounter>().First().Scale = new Vector2(2f));
-                AddStep("update target", () => Player.ChildrenOfType<SkinComponentsContainer>().ForEach(LegacySkin.UpdateDrawableTarget));
+                AddStep("update target", () => Player.ChildrenOfType<SkinnableContainer>().ForEach(LegacySkin.UpdateDrawableTarget));
                 AddStep("exit player", () => Player.Exit());
                 CreateTest();
             }

--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -28,11 +28,11 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is SkinComponentsContainerLookup containerLookup)
+            if (lookup is SkinnableContainerLookup containerLookup)
             {
                 switch (containerLookup.Target)
                 {
-                    case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
+                    case SkinnableContainerLookup.TargetArea.MainHUDComponents:
                         var components = base.GetDrawableComponent(lookup) as Container;
 
                         if (providesComboCounter && components != null)

--- a/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
+++ b/osu.Game.Tests/Skins/SkinDeserialisationTest.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Skins
                 var skin = new TestSkin(new SkinInfo(), null, storage);
 
                 Assert.That(skin.LayoutInfos, Has.Count.EqualTo(2));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(9));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(9));
             }
         }
 
@@ -114,8 +114,8 @@ namespace osu.Game.Tests.Skins
                 var skin = new TestSkin(new SkinInfo(), null, storage);
 
                 Assert.That(skin.LayoutInfos, Has.Count.EqualTo(2));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(10));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(PlayerName)));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(10));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(PlayerName)));
             }
         }
 
@@ -128,10 +128,10 @@ namespace osu.Game.Tests.Skins
                 var skin = new TestSkin(new SkinInfo(), null, storage);
 
                 Assert.That(skin.LayoutInfos, Has.Count.EqualTo(2));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(6));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.SongSelect].AllDrawables.ToArray(), Has.Length.EqualTo(1));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(6));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.SongSelect].AllDrawables.ToArray(), Has.Length.EqualTo(1));
 
-                var skinnableInfo = skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.SongSelect].AllDrawables.First();
+                var skinnableInfo = skin.LayoutInfos[SkinnableContainerLookup.TargetArea.SongSelect].AllDrawables.First();
 
                 Assert.That(skinnableInfo.Type, Is.EqualTo(typeof(SkinnableSprite)));
                 Assert.That(skinnableInfo.Settings.First().Key, Is.EqualTo("sprite_name"));
@@ -142,10 +142,10 @@ namespace osu.Game.Tests.Skins
             using (var storage = new ZipArchiveReader(stream))
             {
                 var skin = new TestSkin(new SkinInfo(), null, storage);
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(8));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(UnstableRateCounter)));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(ColourHitErrorMeter)));
-                Assert.That(skin.LayoutInfos[SkinComponentsContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(LegacySongProgress)));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.ToArray(), Has.Length.EqualTo(8));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(UnstableRateCounter)));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(ColourHitErrorMeter)));
+                Assert.That(skin.LayoutInfos[SkinnableContainerLookup.TargetArea.MainHUDComponents].AllDrawables.Select(i => i.Type), Contains.Item(typeof(LegacySongProgress)));
             }
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapSkinFallbacks.cs
@@ -37,8 +37,8 @@ namespace osu.Game.Tests.Visual.Gameplay
         public void TestEmptyLegacyBeatmapSkinFallsBack()
         {
             CreateSkinTest(TrianglesSkin.CreateInfo(), () => new LegacyBeatmapSkin(new BeatmapInfo(), null));
-            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinComponentsContainer>().All(c => c.ComponentsLoaded));
-            AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(SkinComponentsContainerLookup.TargetArea.MainHUDComponents, skinManager.CurrentSkin.Value));
+            AddUntilStep("wait for hud load", () => Player.ChildrenOfType<SkinnableContainer>().All(c => c.ComponentsLoaded));
+            AddAssert("hud from default skin", () => AssertComponentsFromExpectedSource(SkinnableContainerLookup.TargetArea.MainHUDComponents, skinManager.CurrentSkin.Value));
         }
 
         protected void CreateSkinTest(SkinInfo gameCurrentSkin, Func<ISkin> getBeatmapSkin)
@@ -53,9 +53,9 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
         }
 
-        protected bool AssertComponentsFromExpectedSource(SkinComponentsContainerLookup.TargetArea target, ISkin expectedSource)
+        protected bool AssertComponentsFromExpectedSource(SkinnableContainerLookup.TargetArea target, ISkin expectedSource)
         {
-            var targetContainer = Player.ChildrenOfType<SkinComponentsContainer>().First(s => s.Lookup.Target == target);
+            var targetContainer = Player.ChildrenOfType<SkinnableContainer>().First(s => s.Lookup.Target == target);
             var actualComponentsContainer = targetContainer.ChildrenOfType<Container>().SingleOrDefault(c => c.Parent == targetContainer);
 
             if (actualComponentsContainer == null)
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             var actualInfo = actualComponentsContainer.CreateSerialisedInfo();
 
-            var expectedComponentsContainer = expectedSource.GetDrawableComponent(new SkinComponentsContainerLookup(target)) as Container;
+            var expectedComponentsContainer = expectedSource.GetDrawableComponent(new SkinnableContainerLookup(target)) as Container;
             if (expectedComponentsContainer == null)
                 return false;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneHUDOverlay.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private readonly IGameplayClock gameplayClock = new GameplayClockContainer(new TrackVirtual(60000), false, false);
 
         // best way to check without exposing.
-        private Drawable hideTarget => hudOverlay.ChildrenOfType<SkinComponentsContainer>().First();
+        private Drawable hideTarget => hudOverlay.ChildrenOfType<SkinnableContainer>().First();
         private Drawable keyCounterFlow => hudOverlay.ChildrenOfType<KeyCounterDisplay>().First().ChildrenOfType<FillFlowContainer<KeyCounter>>().Single();
 
         public TestSceneHUDOverlay()
@@ -241,8 +241,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             createNew();
 
-            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Alpha == 0);
-            AddUntilStep("wait for hud load", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().All(c => c.ComponentsLoaded));
+            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinnableContainer>().Single().Alpha == 0);
+            AddUntilStep("wait for hud load", () => hudOverlay.ChildrenOfType<SkinnableContainer>().All(c => c.ComponentsLoaded));
 
             AddStep("bind on update", () =>
             {
@@ -259,10 +259,10 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             createNew();
 
-            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Alpha == 0);
+            AddUntilStep("wait for components to be hidden", () => hudOverlay.ChildrenOfType<SkinnableContainer>().Single().Alpha == 0);
 
-            AddStep("reload components", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().Reload());
-            AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Single().ComponentsLoaded);
+            AddStep("reload components", () => hudOverlay.ChildrenOfType<SkinnableContainer>().Single().Reload());
+            AddUntilStep("skinnable components loaded", () => hudOverlay.ChildrenOfType<SkinnableContainer>().Single().ComponentsLoaded);
         }
 
         private void createNew(Action<HUDOverlay>? action = null)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Cached]
         public readonly EditorClipboard Clipboard = new EditorClipboard();
 
-        private SkinComponentsContainer targetContainer => Player.ChildrenOfType<SkinComponentsContainer>().First();
+        private SkinnableContainer targetContainer => Player.ChildrenOfType<SkinnableContainer>().First();
 
         [SetUpSteps]
         public override void SetUpSteps()
@@ -67,7 +67,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("Add big black boxes", () =>
             {
-                var target = Player.ChildrenOfType<SkinComponentsContainer>().First();
+                var target = Player.ChildrenOfType<SkinnableContainer>().First();
                 target.Add(box1 = new BigBlackBox
                 {
                     Position = new Vector2(-90),
@@ -192,14 +192,14 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestUndoEditHistory()
         {
-            SkinComponentsContainer firstTarget = null!;
+            SkinnableContainer firstTarget = null!;
             TestSkinEditorChangeHandler changeHandler = null!;
             byte[] defaultState = null!;
             IEnumerable<ISerialisableDrawable> testComponents = null!;
 
             AddStep("Load necessary things", () =>
             {
-                firstTarget = Player.ChildrenOfType<SkinComponentsContainer>().First();
+                firstTarget = Player.ChildrenOfType<SkinnableContainer>().First();
                 changeHandler = new TestSkinEditorChangeHandler(firstTarget);
 
                 changeHandler.SaveState();

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorComponentsList.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditorComponentsList.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         [Test]
         public void TestToggleEditor()
         {
-            var skinComponentsContainer = new SkinComponentsContainer(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.SongSelect));
+            var skinComponentsContainer = new SkinnableContainer(new SkinnableContainerLookup(SkinnableContainerLookup.TargetArea.SongSelect));
 
             AddStep("show available components", () => SetContents(_ => new SkinComponentToolbox(skinComponentsContainer, null)
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinnableHUDOverlay.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         private IEnumerable<HUDOverlay> hudOverlays => CreatedDrawables.OfType<HUDOverlay>();
 
         // best way to check without exposing.
-        private Drawable hideTarget => hudOverlay.ChildrenOfType<SkinComponentsContainer>().First();
+        private Drawable hideTarget => hudOverlay.ChildrenOfType<SkinnableContainer>().First();
         private Drawable keyCounterFlow => hudOverlay.ChildrenOfType<KeyCounterDisplay>().First().ChildrenOfType<FillFlowContainer<KeyCounter>>().Single();
 
         public TestSceneSkinnableHUDOverlay()
@@ -103,7 +103,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             });
             AddUntilStep("HUD overlay loaded", () => hudOverlay.IsAlive);
             AddUntilStep("components container loaded",
-                () => hudOverlay.ChildrenOfType<SkinComponentsContainer>().Any(scc => scc.ComponentsLoaded));
+                () => hudOverlay.ChildrenOfType<SkinnableContainer>().Any(scc => scc.ComponentsLoaded));
         }
 
         protected override Ruleset CreateRulesetForSkinProvider() => new OsuRuleset();

--- a/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinComponentToolbox.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.SkinEditor
     {
         public Action<Type>? RequestPlacement;
 
-        private readonly SkinComponentsContainer target;
+        private readonly SkinnableContainer target;
 
         private readonly RulesetInfo? ruleset;
 
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays.SkinEditor
         /// </summary>
         /// <param name="target">The target. This is mainly used as a dependency source to find candidate components.</param>
         /// <param name="ruleset">A ruleset to filter components by. If null, only components which are not ruleset-specific will be included.</param>
-        public SkinComponentToolbox(SkinComponentsContainer target, RulesetInfo? ruleset)
+        public SkinComponentToolbox(SkinnableContainer target, RulesetInfo? ruleset)
             : base(ruleset == null ? SkinEditorStrings.Components : LocalisableString.Interpolate($"{SkinEditorStrings.Components} ({ruleset.Name})"))
         {
             this.target = target;

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Overlays.SkinEditor
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
-        private readonly Bindable<SkinComponentsContainerLookup?> selectedTarget = new Bindable<SkinComponentsContainerLookup?>();
+        private readonly Bindable<SkinnableContainerLookup?> selectedTarget = new Bindable<SkinnableContainerLookup?>();
 
         private bool hasBegunMutating;
 
@@ -327,7 +327,7 @@ namespace osu.Game.Overlays.SkinEditor
             }
         }
 
-        private void targetChanged(ValueChangedEvent<SkinComponentsContainerLookup?> target)
+        private void targetChanged(ValueChangedEvent<SkinnableContainerLookup?> target)
         {
             foreach (var toolbox in componentsSidebar.OfType<SkinComponentToolbox>())
                 toolbox.Expire();
@@ -357,7 +357,7 @@ namespace osu.Game.Overlays.SkinEditor
                 {
                     Children = new Drawable[]
                     {
-                        new SettingsDropdown<SkinComponentsContainerLookup?>
+                        new SettingsDropdown<SkinnableContainerLookup?>
                         {
                             Items = availableTargets.Select(t => t.Lookup).Distinct(),
                             Current = selectedTarget,
@@ -466,18 +466,18 @@ namespace osu.Game.Overlays.SkinEditor
                 settingsSidebar.Add(new SkinSettingsToolbox(component));
         }
 
-        private IEnumerable<SkinComponentsContainer> availableTargets => targetScreen.ChildrenOfType<SkinComponentsContainer>();
+        private IEnumerable<SkinnableContainer> availableTargets => targetScreen.ChildrenOfType<SkinnableContainer>();
 
-        private SkinComponentsContainer? getFirstTarget() => availableTargets.FirstOrDefault();
+        private SkinnableContainer? getFirstTarget() => availableTargets.FirstOrDefault();
 
-        private SkinComponentsContainer? getTarget(SkinComponentsContainerLookup? target)
+        private SkinnableContainer? getTarget(SkinnableContainerLookup? target)
         {
             return availableTargets.FirstOrDefault(c => c.Lookup.Equals(target));
         }
 
         private void revert()
         {
-            SkinComponentsContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableContainer[] targetContainers = availableTargets.ToArray();
 
             foreach (var t in targetContainers)
             {
@@ -545,7 +545,7 @@ namespace osu.Game.Overlays.SkinEditor
             if (targetScreen?.IsLoaded != true)
                 return;
 
-            SkinComponentsContainer[] targetContainers = availableTargets.ToArray();
+            SkinnableContainer[] targetContainers = availableTargets.ToArray();
 
             if (!targetContainers.All(c => c.ComponentsLoaded))
                 return;
@@ -590,7 +590,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         public void BringSelectionToFront()
         {
-            if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
+            if (getTarget(selectedTarget.Value) is not SkinnableContainer target)
                 return;
 
             changeHandler?.BeginChange();
@@ -614,7 +614,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         public void SendSelectionToBack()
         {
-            if (getTarget(selectedTarget.Value) is not SkinComponentsContainer target)
+            if (getTarget(selectedTarget.Value) is not SkinnableContainer target)
                 return;
 
             changeHandler?.BeginChange();

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -96,10 +96,10 @@ namespace osu.Game.Screens.Play
 
         private readonly BindableBool holdingForHUD = new BindableBool();
 
-        private readonly SkinComponentsContainer mainComponents;
+        private readonly SkinnableContainer mainComponents;
 
         [CanBeNull]
-        private readonly SkinComponentsContainer rulesetComponents;
+        private readonly SkinnableContainer rulesetComponents;
 
         /// <summary>
         /// A flow which sits at the left side of the screen to house leaderboard (and related) components.
@@ -130,7 +130,7 @@ namespace osu.Game.Screens.Play
                     ? (rulesetComponents = new HUDComponentsContainer(drawableRuleset.Ruleset.RulesetInfo) { AlwaysPresent = true, })
                     : Empty(),
                 playfieldComponents = drawableRuleset != null
-                    ? new SkinComponentsContainer(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.Playfield, drawableRuleset.Ruleset.RulesetInfo)) { AlwaysPresent = true, }
+                    ? new SkinnableContainer(new SkinnableContainerLookup(SkinnableContainerLookup.TargetArea.Playfield, drawableRuleset.Ruleset.RulesetInfo)) { AlwaysPresent = true, }
                     : Empty(),
                 topRightElements = new FillFlowContainer
                 {
@@ -278,7 +278,7 @@ namespace osu.Game.Screens.Play
             else
                 bottomRightElements.Y = 0;
 
-            void processDrawables(SkinComponentsContainer components)
+            void processDrawables(SkinnableContainer components)
             {
                 // Avoid using foreach due to missing GetEnumerator implementation.
                 // See https://github.com/ppy/osu-framework/blob/e10051e6643731e393b09de40a3a3d209a545031/osu.Framework/Bindables/IBindableList.cs#L41-L44.
@@ -438,7 +438,7 @@ namespace osu.Game.Screens.Play
             }
         }
 
-        private partial class HUDComponentsContainer : SkinComponentsContainer
+        private partial class HUDComponentsContainer : SkinnableContainer
         {
             private Bindable<ScoringMode> scoringMode;
 
@@ -446,7 +446,7 @@ namespace osu.Game.Screens.Play
             private OsuConfigManager config { get; set; }
 
             public HUDComponentsContainer([CanBeNull] RulesetInfo ruleset = null)
-                : base(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.MainHUDComponents, ruleset))
+                : base(new SkinnableContainerLookup(SkinnableContainerLookup.TargetArea.MainHUDComponents, ruleset))
             {
                 RelativeSizeAxes = Axes.Both;
             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -315,7 +315,7 @@ namespace osu.Game.Screens.Select
                         }
                     }
                 },
-                new SkinComponentsContainer(new SkinComponentsContainerLookup(SkinComponentsContainerLookup.TargetArea.SongSelect))
+                new SkinnableContainer(new SkinnableContainerLookup(SkinnableContainerLookup.TargetArea.SongSelect))
                 {
                     RelativeSizeAxes = Axes.Both,
                 },

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -98,23 +98,23 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup containerLookup:
+                case SkinnableContainerLookup containerLookup:
                     // Only handle global level defaults for now.
                     if (containerLookup.Ruleset != null)
                         return null;
 
                     switch (containerLookup.Target)
                     {
-                        case SkinComponentsContainerLookup.TargetArea.SongSelect:
-                            var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
+                        case SkinnableContainerLookup.TargetArea.SongSelect:
+                            var songSelectComponents = new SkinnableContainerWithDefaults(_ =>
                             {
                                 // do stuff when we need to.
                             });
 
                             return songSelectComponents;
 
-                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
-                            var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
+                        case SkinnableContainerLookup.TargetArea.MainHUDComponents:
+                            var skinnableTargetWrapper = new SkinnableContainerWithDefaults(container =>
                             {
                                 var health = container.OfType<ArgonHealthDisplay>().FirstOrDefault();
                                 var healthLine = container.OfType<BoxElement>().FirstOrDefault();

--- a/osu.Game/Skinning/LegacyBeatmapSkin.cs
+++ b/osu.Game/Skinning/LegacyBeatmapSkin.cs
@@ -50,11 +50,11 @@ namespace osu.Game.Skinning
 
         public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
         {
-            if (lookup is SkinComponentsContainerLookup containerLookup)
+            if (lookup is SkinnableContainerLookup containerLookup)
             {
                 switch (containerLookup.Target)
                 {
-                    case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
+                    case SkinnableContainerLookup.TargetArea.MainHUDComponents:
                         // this should exist in LegacySkin instead, but there isn't a fallback skin for LegacySkins yet.
                         // therefore keep the check here until fallback default legacy skin is supported.
                         if (!this.HasFont(LegacyFont.Score))

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -352,15 +352,15 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup containerLookup:
+                case SkinnableContainerLookup containerLookup:
                     // Only handle global level defaults for now.
                     if (containerLookup.Ruleset != null)
                         return null;
 
                     switch (containerLookup.Target)
                     {
-                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
-                            return new DefaultSkinComponentsContainer(container =>
+                        case SkinnableContainerLookup.TargetArea.MainHUDComponents:
+                            return new SkinnableContainerWithDefaults(container =>
                             {
                                 var score = container.OfType<LegacyScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<GameplayAccuracyCounter>().FirstOrDefault();

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -40,10 +40,10 @@ namespace osu.Game.Skinning
 
         public SkinConfiguration Configuration { get; set; }
 
-        public IDictionary<SkinComponentsContainerLookup.TargetArea, SkinLayoutInfo> LayoutInfos => layoutInfos;
+        public IDictionary<SkinnableContainerLookup.TargetArea, SkinLayoutInfo> LayoutInfos => layoutInfos;
 
-        private readonly Dictionary<SkinComponentsContainerLookup.TargetArea, SkinLayoutInfo> layoutInfos =
-            new Dictionary<SkinComponentsContainerLookup.TargetArea, SkinLayoutInfo>();
+        private readonly Dictionary<SkinnableContainerLookup.TargetArea, SkinLayoutInfo> layoutInfos =
+            new Dictionary<SkinnableContainerLookup.TargetArea, SkinLayoutInfo>();
 
         public abstract ISample? GetSample(ISampleInfo sampleInfo);
 
@@ -118,7 +118,7 @@ namespace osu.Game.Skinning
             }
 
             // skininfo files may be null for default skin.
-            foreach (SkinComponentsContainerLookup.TargetArea skinnableTarget in Enum.GetValues<SkinComponentsContainerLookup.TargetArea>())
+            foreach (SkinnableContainerLookup.TargetArea skinnableTarget in Enum.GetValues<SkinnableContainerLookup.TargetArea>())
             {
                 string filename = $"{skinnableTarget}.json";
 
@@ -188,7 +188,7 @@ namespace osu.Game.Skinning
         /// Remove all stored customisations for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to reset.</param>
-        public void ResetDrawableTarget(SkinComponentsContainer targetContainer)
+        public void ResetDrawableTarget(SkinnableContainer targetContainer)
         {
             LayoutInfos.Remove(targetContainer.Lookup.Target);
         }
@@ -197,7 +197,7 @@ namespace osu.Game.Skinning
         /// Update serialised information for the provided target.
         /// </summary>
         /// <param name="targetContainer">The target container to serialise to this skin.</param>
-        public void UpdateDrawableTarget(SkinComponentsContainer targetContainer)
+        public void UpdateDrawableTarget(SkinnableContainer targetContainer)
         {
             if (!LayoutInfos.TryGetValue(targetContainer.Lookup.Target, out var layoutInfo))
                 layoutInfos[targetContainer.Lookup.Target] = layoutInfo = new SkinLayoutInfo();
@@ -213,7 +213,7 @@ namespace osu.Game.Skinning
                 case SkinnableSprite.SpriteComponentLookup sprite:
                     return this.GetAnimation(sprite.LookupName, false, false, maxSize: sprite.MaxSize);
 
-                case SkinComponentsContainerLookup containerLookup:
+                case SkinnableContainerLookup containerLookup:
 
                     // It is important to return null if the user has not configured this yet.
                     // This allows skin transformers the opportunity to provide default components.

--- a/osu.Game/Skinning/SkinLayoutInfo.cs
+++ b/osu.Game/Skinning/SkinLayoutInfo.cs
@@ -11,8 +11,8 @@ using osu.Game.Rulesets;
 namespace osu.Game.Skinning
 {
     /// <summary>
-    /// A serialisable model describing layout of a <see cref="SkinComponentsContainer"/>.
-    /// May contain multiple configurations for different rulesets, each of which should manifest their own <see cref="SkinComponentsContainer"/> as required.
+    /// A serialisable model describing layout of a <see cref="SkinnableContainer"/>.
+    /// May contain multiple configurations for different rulesets, each of which should manifest their own <see cref="SkinnableContainer"/> as required.
     /// </summary>
     [Serializable]
     public class SkinLayoutInfo

--- a/osu.Game/Skinning/SkinnableContainer.cs
+++ b/osu.Game/Skinning/SkinnableContainer.cs
@@ -17,17 +17,17 @@ namespace osu.Game.Skinning
     /// </summary>
     /// <remarks>
     /// This is currently used as a means of serialising skin layouts to files.
-    /// Currently, one json file in a skin will represent one <see cref="SkinComponentsContainer"/>, containing
+    /// Currently, one json file in a skin will represent one <see cref="SkinnableContainer"/>, containing
     /// the output of <see cref="ISerialisableDrawableContainer.CreateSerialisedInfo"/>.
     /// </remarks>
-    public partial class SkinComponentsContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
+    public partial class SkinnableContainer : SkinReloadableDrawable, ISerialisableDrawableContainer
     {
         private Container? content;
 
         /// <summary>
         /// The lookup criteria which will be used to retrieve components from the active skin.
         /// </summary>
-        public SkinComponentsContainerLookup Lookup { get; }
+        public SkinnableContainerLookup Lookup { get; }
 
         public IBindableList<ISerialisableDrawable> Components => components;
 
@@ -39,7 +39,7 @@ namespace osu.Game.Skinning
 
         private CancellationTokenSource? cancellationSource;
 
-        public SkinComponentsContainer(SkinComponentsContainerLookup lookup)
+        public SkinnableContainer(SkinnableContainerLookup lookup)
         {
             Lookup = lookup;
         }

--- a/osu.Game/Skinning/SkinnableContainerLookup.cs
+++ b/osu.Game/Skinning/SkinnableContainerLookup.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Skinning
     /// <summary>
     /// Represents a lookup of a collection of elements that make up a particular skinnable <see cref="TargetArea"/> of the game.
     /// </summary>
-    public class SkinComponentsContainerLookup : ISkinComponentLookup, IEquatable<SkinComponentsContainerLookup>
+    public class SkinnableContainerLookup : ISkinComponentLookup, IEquatable<SkinnableContainerLookup>
     {
         /// <summary>
         /// The target area / layer of the game for which skin components will be returned.
@@ -24,7 +24,7 @@ namespace osu.Game.Skinning
         /// </summary>
         public readonly RulesetInfo? Ruleset;
 
-        public SkinComponentsContainerLookup(TargetArea target, RulesetInfo? ruleset = null)
+        public SkinnableContainerLookup(TargetArea target, RulesetInfo? ruleset = null)
         {
             Target = target;
             Ruleset = ruleset;
@@ -37,7 +37,7 @@ namespace osu.Game.Skinning
             return $"{Target.GetDescription()} (\"{Ruleset.Name}\" only)";
         }
 
-        public bool Equals(SkinComponentsContainerLookup? other)
+        public bool Equals(SkinnableContainerLookup? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -51,7 +51,7 @@ namespace osu.Game.Skinning
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
 
-            return Equals((SkinComponentsContainerLookup)obj);
+            return Equals((SkinnableContainerLookup)obj);
         }
 
         public override int GetHashCode()

--- a/osu.Game/Skinning/SkinnableContainerWithDefaults.cs
+++ b/osu.Game/Skinning/SkinnableContainerWithDefaults.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Skinning
     /// A container which can be used to specify default skin components layouts.
     /// Handles applying a default layout to the components.
     /// </summary>
-    public partial class DefaultSkinComponentsContainer : Container
+    public partial class SkinnableContainerWithDefaults : Container
     {
         private readonly Action<Container>? applyDefaults;
 
@@ -19,7 +19,7 @@ namespace osu.Game.Skinning
         /// Construct a wrapper with defaults that should be applied once.
         /// </summary>
         /// <param name="applyDefaults">A function to apply the default layout.</param>
-        public DefaultSkinComponentsContainer(Action<Container> applyDefaults)
+        public SkinnableContainerWithDefaults(Action<Container> applyDefaults)
         {
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -69,23 +69,23 @@ namespace osu.Game.Skinning
 
             switch (lookup)
             {
-                case SkinComponentsContainerLookup containerLookup:
+                case SkinnableContainerLookup containerLookup:
                     // Only handle global level defaults for now.
                     if (containerLookup.Ruleset != null)
                         return null;
 
                     switch (containerLookup.Target)
                     {
-                        case SkinComponentsContainerLookup.TargetArea.SongSelect:
-                            var songSelectComponents = new DefaultSkinComponentsContainer(_ =>
+                        case SkinnableContainerLookup.TargetArea.SongSelect:
+                            var songSelectComponents = new SkinnableContainerWithDefaults(_ =>
                             {
                                 // do stuff when we need to.
                             });
 
                             return songSelectComponents;
 
-                        case SkinComponentsContainerLookup.TargetArea.MainHUDComponents:
-                            var skinnableTargetWrapper = new DefaultSkinComponentsContainer(container =>
+                        case SkinnableContainerLookup.TargetArea.MainHUDComponents:
+                            var skinnableTargetWrapper = new SkinnableContainerWithDefaults(container =>
                             {
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();

--- a/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/LegacySkinPlayerTestScene.cs
@@ -45,13 +45,13 @@ namespace osu.Game.Tests.Visual
 
         private void addResetTargetsStep()
         {
-            AddStep("reset targets", () => this.ChildrenOfType<SkinComponentsContainer>().ForEach(t =>
+            AddStep("reset targets", () => this.ChildrenOfType<SkinnableContainer>().ForEach(t =>
             {
                 LegacySkin.ResetDrawableTarget(t);
                 t.Reload();
             }));
 
-            AddUntilStep("wait for components to load", () => this.ChildrenOfType<SkinComponentsContainer>().All(t => t.ComponentsLoaded));
+            AddUntilStep("wait for components to load", () => this.ChildrenOfType<SkinnableContainer>().All(t => t.ComponentsLoaded));
         }
 
         public partial class SkinProvidingPlayer : TestPlayer


### PR DESCRIPTION
I will not accept this type existing with its current name any longer. We currently have the following types:

```
SkinnableDrawable
ISkinComponentLookup
SkinComponentsContainer
SkinComponentsContainerLookup
ISerialisableDrawableContainer
ISerialisableDrawable
```

The naming of `SkinComponentsContainer` is confusing because it implies that it and `SkinnableDrawable` are totally different from one another, whereas they act pretty much the same way - both via `Skin.GetDrawableComponent()`. One just returns a `Container` and one a `Drawable`.  
Of course, `SkinnableDrawable` has some extra cruft that _it really should not have_, but I won't address that for now.

The structure I eventually want to end up with is:

```
--- Common interface ---
ISerialisableDrawableContainer

--- Targets ---
ISkinComponentLookup
GlobalSkinComponentLookup
ManiaSkinComponentLookup

--- Entrypoints (what you use) ---
SkinnableDrawable
SkinnableContainer

--- Endpoints (what you see) ---
ISerialisableDrawable
```