### PR TITLE
Update masking usage in line with framework changes

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -37,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         // For osu! gameplay, everything is always on screen.
         // Skipping masking calculations improves performance in intense beatmaps (ie. https://osu.ppy.sh/beatmapsets/150945#osu/372245)
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
+        protected override bool UpdateChildrenMasking => false;
 
         public SmokeContainer Smoke { get; }
         public FollowPointRenderer FollowPoints { get; }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -345,12 +345,11 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             public void Add(Drawable proxy) => AddInternal(proxy);
 
-            public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
-            {
-                // DrawableHitObject disables masking.
-                // Hitobject content is proxied and unproxied based on hit status and the IsMaskedAway value could get stuck because of this.
-                return false;
-            }
+            // DrawableHitObject disables masking.
+            // Hitobject content is proxied and unproxied based on hit status and the IsMaskedAway value could get stuck because of this.
+            protected override bool UpdateChildrenMasking => false;
+
+            protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
         }
     }
 }

--- a/osu.Game.Tournament/Screens/Ladder/LadderDragContainer.cs
+++ b/osu.Game.Tournament/Screens/Ladder/LadderDragContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Tournament.Screens.Ladder
 
         protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
 
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
+        protected override bool UpdateChildrenMasking => false;
 
         protected override void OnDrag(DragEvent e)
         {

--- a/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
+++ b/osu.Game/Rulesets/Objects/Drawables/DrawableHitObject.cs
@@ -632,7 +632,9 @@ namespace osu.Game.Rulesets.Objects.Drawables
 
         #endregion
 
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
+        protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
+
+        protected override bool UpdateChildrenMasking => false;
 
         protected override void UpdateAfterChildren()
         {

--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -119,7 +119,6 @@ namespace osu.Game.Rulesets.UI
                     break;
 
                 base.UpdateSubTree();
-                UpdateSubTreeMasking(this, ScreenSpaceDrawQuad.AABBFloat);
             } while (state == PlaybackState.RequiresCatchUp && stopwatch.ElapsedMilliseconds < max_catchup_milliseconds);
 
             return true;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -19,8 +18,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
     public partial class TimelineTickDisplay : TimelinePart<PointVisualisation>
     {
-        // With current implementation every tick in the sub-tree should be visible, no need to check whether they are masked away.
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => false;
+        protected override bool UpdateChildrenMasking => false;
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;


### PR DESCRIPTION
Depends on:
- [ ] framework bump with https://github.com/ppy/osu-framework/pull/6261

(Note that screenshots from `master` already contain https://github.com/ppy/osu-framework/pull/6243)
| |master|pr|
|---|---|---|
|song-select|![master-ss](https://github.com/ppy/osu/assets/22874522/256262bf-4e77-44ba-a750-6b0b97d1240b)|![pr-ss](https://github.com/ppy/osu/assets/22874522/5f6a95b8-bea2-4b2e-b494-2dfa5c8635ce)|
|mods|![master-mods](https://github.com/ppy/osu/assets/22874522/c1455763-e3ed-4047-a660-22242616e22c)|![pr-mods](https://github.com/ppy/osu/assets/22874522/48a55173-00d7-4953-beac-641e18350a9d)|
|song-select + mods + direct + beatmap overlay|![master-complex](https://github.com/ppy/osu/assets/22874522/0e844134-66e7-4969-828b-68f82977a36d)|![pr-complex](https://github.com/ppy/osu/assets/22874522/860d6cb5-881e-4701-94ba-2fb9b529757f)|