### PR TITLE
Improve `EditorTable` performance

### DIFF
--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.Edit
 
         // We can avoid potentially thousands of objects being added to the input sub-tree since item selection is being handled by the BackgroundFlow
         // and no items in the underlying table are clickable.
-        protected override bool ShouldBeConsideredForInput(Drawable child) => base.ShouldBeConsideredForInput(child) && child == BackgroundFlow;
+        protected override bool ShouldBeConsideredForInput(Drawable child) => child == BackgroundFlow && base.ShouldBeConsideredForInput(child);
 
         protected EditorTable()
         {

--- a/osu.Game/Screens/Edit/EditorTable.cs
+++ b/osu.Game/Screens/Edit/EditorTable.cs
@@ -30,6 +30,10 @@ namespace osu.Game.Screens.Edit
 
         protected readonly FillFlowContainer<RowBackground> BackgroundFlow;
 
+        // We can avoid potentially thousands of objects being added to the input sub-tree since item selection is being handled by the BackgroundFlow
+        // and no items in the underlying table are clickable.
+        protected override bool ShouldBeConsideredForInput(Drawable child) => base.ShouldBeConsideredForInput(child) && child == BackgroundFlow;
+
         protected EditorTable()
         {
             RelativeSizeAxes = Axes.X;


### PR DESCRIPTION
The issue occurs while we are hovering the mouse over the table, generating input sub-tree with thousands of items that will be never used for input handling (with all the overhead that comes with it).

Map for testing: https://osu.ppy.sh/beatmapsets/1238185#mania/2574372

|master|pr|
|---|---|
|![osu_2024-04-21_17-42-22](https://github.com/ppy/osu/assets/22874522/dfe17d0c-165a-4035-b107-75d2dc5e96b8)|![osu_2024-04-21_17-43-25](https://github.com/ppy/osu/assets/22874522/8d52fd76-184a-4df5-b3af-a197e4f7b739)|