### PR TITLE
Fix `cursormiddle` not using the same source as `cursor`

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
@@ -13,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Testing;
 using osu.Framework.Testing.Input;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Osu.Skinning.Legacy;
@@ -70,6 +72,22 @@ namespace osu.Game.Rulesets.Osu.Tests
             });
         }
 
+        [Test]
+        public void TestLegacyDisjointCursorTrailViaNoCursor()
+        {
+            createTest(() =>
+            {
+                var skinContainer = new LegacySkinContainer(renderer, false, false);
+                var legacyCursorTrail = new LegacyCursorTrail(skinContainer);
+
+                skinContainer.Child = legacyCursorTrail;
+
+                return skinContainer;
+            });
+
+            AddAssert("trail is disjoint", () => this.ChildrenOfType<LegacyCursorTrail>().Single().DisjointTrail, () => Is.True);
+        }
+
         private void createTest(Func<Drawable> createContent) => AddStep("create trail", () =>
         {
             Clear();
@@ -87,11 +105,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             private readonly IRenderer renderer;
             private readonly bool disjoint;
+            private readonly bool provideCursor;
 
-            public LegacySkinContainer(IRenderer renderer, bool disjoint)
+            public LegacySkinContainer(IRenderer renderer, bool disjoint, bool provideCursor = true)
             {
                 this.renderer = renderer;
                 this.disjoint = disjoint;
+                this.provideCursor = provideCursor;
 
                 RelativeSizeAxes = Axes.Both;
             }
@@ -102,12 +122,11 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 switch (componentName)
                 {
-                    case "cursortrail":
-                        var tex = new Texture(renderer.WhitePixel);
+                    case "cursor":
+                        return provideCursor ? new Texture(renderer.WhitePixel) : null;
 
-                        if (disjoint)
-                            tex.ScaleAdjust = 1 / 25f;
-                        return tex;
+                    case "cursortrail":
+                        return new Texture(renderer.WhitePixel);
 
                     case "cursormiddle":
                         return disjoint ? null : renderer.WhitePixel;

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             createTest(() =>
             {
-                var skinContainer = new LegacySkinContainer(renderer, false);
+                var skinContainer = new LegacySkinContainer(renderer, provideMiddle: false);
                 var legacyCursorTrail = new LegacyCursorTrail(skinContainer);
 
                 skinContainer.Child = legacyCursorTrail;
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             createTest(() =>
             {
-                var skinContainer = new LegacySkinContainer(renderer, true);
+                var skinContainer = new LegacySkinContainer(renderer, provideMiddle: true);
                 var legacyCursorTrail = new LegacyCursorTrail(skinContainer);
 
                 skinContainer.Child = legacyCursorTrail;
@@ -77,7 +77,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         {
             createTest(() =>
             {
-                var skinContainer = new LegacySkinContainer(renderer, false, false);
+                var skinContainer = new LegacySkinContainer(renderer, provideMiddle: false, provideCursor: false);
                 var legacyCursorTrail = new LegacyCursorTrail(skinContainer);
 
                 skinContainer.Child = legacyCursorTrail;
@@ -104,13 +104,13 @@ namespace osu.Game.Rulesets.Osu.Tests
         private partial class LegacySkinContainer : Container, ISkinSource
         {
             private readonly IRenderer renderer;
-            private readonly bool disjoint;
+            private readonly bool provideMiddle;
             private readonly bool provideCursor;
 
-            public LegacySkinContainer(IRenderer renderer, bool disjoint, bool provideCursor = true)
+            public LegacySkinContainer(IRenderer renderer, bool provideMiddle, bool provideCursor = true)
             {
                 this.renderer = renderer;
-                this.disjoint = disjoint;
+                this.provideMiddle = provideMiddle;
                 this.provideCursor = provideCursor;
 
                 RelativeSizeAxes = Axes.Both;
@@ -129,7 +129,7 @@ namespace osu.Game.Rulesets.Osu.Tests
                         return new Texture(renderer.WhitePixel);
 
                     case "cursormiddle":
-                        return disjoint ? null : renderer.WhitePixel;
+                        return provideMiddle ? null : renderer.WhitePixel;
                 }
 
                 return null;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly ISkin skin;
         private const double disjoint_trail_time_separation = 1000 / 60.0;
 
-        private bool disjointTrail;
+        public bool DisjointTrail { get; private set; }
         private double lastTrailTime;
 
         private IBindable<float> cursorSize = null!;
@@ -36,9 +36,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize).GetBoundCopy();
 
             Texture = skin.GetTexture("cursortrail");
-            disjointTrail = skin.GetTexture("cursormiddle") == null;
+            DisjointTrail = skin.GetTexture("cursormiddle") == null;
 
-            if (disjointTrail)
+            if (DisjointTrail)
             {
                 bool centre = skin.GetConfig<OsuSkinConfiguration, bool>(OsuSkinConfiguration.CursorCentre)?.Value ?? true;
 
@@ -57,19 +57,19 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             }
         }
 
-        protected override double FadeDuration => disjointTrail ? 150 : 500;
+        protected override double FadeDuration => DisjointTrail ? 150 : 500;
         protected override float FadeExponent => 1;
 
-        protected override bool InterpolateMovements => !disjointTrail;
+        protected override bool InterpolateMovements => !DisjointTrail;
 
         protected override float IntervalMultiplier => 1 / Math.Max(cursorSize.Value, 1);
-        protected override bool AvoidDrawingNearCursor => !disjointTrail;
+        protected override bool AvoidDrawingNearCursor => !DisjointTrail;
 
         protected override void Update()
         {
             base.Update();
 
-            if (!disjointTrail || !currentPosition.HasValue)
+            if (!DisjointTrail || !currentPosition.HasValue)
                 return;
 
             if (Time.Current - lastTrailTime >= disjoint_trail_time_separation)
@@ -81,7 +81,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            if (!disjointTrail)
+            if (!DisjointTrail)
                 return base.OnMouseMove(e);
 
             currentPosition = e.ScreenSpaceMousePosition;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
@@ -31,12 +31,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config)
+        private void load(OsuConfigManager config, ISkinSource skinSource)
         {
             cursorSize = config.GetBindable<float>(OsuSetting.GameplayCursorSize).GetBoundCopy();
 
             Texture = skin.GetTexture("cursortrail");
-            DisjointTrail = skin.GetTexture("cursormiddle") == null;
+
+            var cursorProvider = skinSource.FindProvider(s => s.GetTexture("cursor") != null);
+            DisjointTrail = cursorProvider?.GetTexture("cursormiddle") == null;
 
             if (DisjointTrail)
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyCursorTrail.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             Texture = skin.GetTexture("cursortrail");
 
+            // Cursor and cursor trail components are sourced from potentially different skin sources.
+            // Stable always chooses cursor trail disjoint behaviour based on the cursor texture lookup source, so we need to fetch where that occurred.
+            // See https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Skinning/SkinManager.cs#L269
             var cursorProvider = skinSource.FindProvider(s => s.GetTexture("cursor") != null);
             DisjointTrail = cursorProvider?.GetTexture("cursormiddle") == null;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/27952

Relevant code in osu!stable:
```
cursor2.Texture = TextureManager.Load(@"cursormiddle", t_cursor.Source);
```
`t_cursor.Source` represents the final skin where the `cursor` texture was sourced from, not where it's _allowed_ to be source from.