### PR TITLE
Fix storyboard videos not accepting transforms

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -83,8 +83,6 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 var sprite = new StoryboardVideo("Videos/test-video.mp4", Time.Current);
 
-                sprite.AddLoop(Time.Current, 100).Alpha.Add(Easing.None, 0, 10000, 1, 1);
-
                 if (scaleTransformProvided)
                 {
                     sprite.TimelineGroup.Scale.Add(Easing.None, Time.Current, Time.Current + 1000, 1, 2);

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
@@ -40,7 +41,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("disallow all lookups", () =>
             {
                 storyboard.UseSkinSprites = false;
-                storyboard.AlwaysProvideTexture = false;
+                storyboard.ProvideResources = false;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -55,7 +56,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow storyboard lookup", () =>
             {
                 storyboard.UseSkinSprites = false;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -67,13 +68,47 @@ namespace osu.Game.Tests.Visual.Gameplay
             assertStoryboardSourced();
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestVideo(bool scaleTransformProvided)
+        {
+            AddStep("allow storyboard lookup", () =>
+            {
+                storyboard.ProvideResources = true;
+            });
+
+            AddStep("create video", () => SetContents(_ =>
+            {
+                var layer = storyboard.GetLayer("Video");
+
+                var sprite = new StoryboardVideo("Videos/test-video.mp4", Time.Current);
+
+                sprite.AddLoop(Time.Current, 100).Alpha.Add(Easing.None, 0, 10000, 1, 1);
+
+                if (scaleTransformProvided)
+                    sprite.TimelineGroup.Scale.Add(Easing.None, Time.Current, Time.Current, 1, 1);
+
+                layer.Elements.Clear();
+                layer.Add(sprite);
+
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        storyboard.CreateDrawable()
+                    }
+                };
+            }));
+        }
+
         [Test]
         public void TestSkinLookupPreferredOverStoryboard()
         {
             AddStep("allow all lookups", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -91,7 +126,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow skin lookup", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = false;
+                storyboard.ProvideResources = false;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -109,7 +144,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow all lookups", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -127,7 +162,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow all lookups", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -142,7 +177,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow all lookups", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -156,7 +191,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("allow all lookups", () =>
             {
                 storyboard.UseSkinSprites = true;
-                storyboard.AlwaysProvideTexture = true;
+                storyboard.ProvideResources = true;
             });
 
             AddStep("create sprites", () => SetContents(_ => createSprite(lookup_name, Anchor.TopLeft, Vector2.Zero)));
@@ -170,7 +205,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddAssert("origin back", () => sprites.All(s => s.Origin == Anchor.TopLeft));
         }
 
-        private DrawableStoryboard createSprite(string lookupName, Anchor origin, Vector2 initialPosition)
+        private Drawable createSprite(string lookupName, Anchor origin, Vector2 initialPosition)
         {
             var layer = storyboard.GetLayer("Background");
 
@@ -180,7 +215,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             layer.Elements.Clear();
             layer.Add(sprite);
 
-            return storyboard.CreateDrawable().With(s => s.RelativeSizeAxes = Axes.Both);
+            return new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    storyboard.CreateDrawable()
+                }
+            };
         }
 
         private void assertStoryboardSourced()
@@ -202,42 +244,52 @@ namespace osu.Game.Tests.Visual.Gameplay
                 return new TestDrawableStoryboard(this, mods);
             }
 
-            public bool AlwaysProvideTexture { get; set; }
+            public bool ProvideResources { get; set; }
 
-            public override string GetStoragePathFromStoryboardPath(string path) => AlwaysProvideTexture ? path : string.Empty;
+            public override string GetStoragePathFromStoryboardPath(string path) => ProvideResources ? path : string.Empty;
 
             private partial class TestDrawableStoryboard : DrawableStoryboard
             {
-                private readonly bool alwaysProvideTexture;
+                private readonly bool provideResources;
 
                 public TestDrawableStoryboard(TestStoryboard storyboard, IReadOnlyList<Mod>? mods)
                     : base(storyboard, mods)
                 {
-                    alwaysProvideTexture = storyboard.AlwaysProvideTexture;
+                    provideResources = storyboard.ProvideResources;
                 }
 
-                protected override IResourceStore<byte[]> CreateResourceLookupStore() => alwaysProvideTexture
-                    ? new AlwaysReturnsTextureStore()
+                protected override IResourceStore<byte[]> CreateResourceLookupStore() => provideResources
+                    ? new ResourcesTextureStore()
                     : new ResourceStore<byte[]>();
 
-                internal class AlwaysReturnsTextureStore : IResourceStore<byte[]>
+                internal class ResourcesTextureStore : IResourceStore<byte[]>
                 {
-                    private const string test_image = "Resources/Textures/test-image.png";
-
                     private readonly DllResourceStore store;
 
-                    public AlwaysReturnsTextureStore()
+                    public ResourcesTextureStore()
                     {
                         store = TestResources.GetStore();
                     }
 
                     public void Dispose() => store.Dispose();
 
-                    public byte[] Get(string name) => store.Get(test_image);
+                    public byte[] Get(string name) => store.Get(map(name));
 
-                    public Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken()) => store.GetAsync(test_image, cancellationToken);
+                    public Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = new CancellationToken()) => store.GetAsync(map(name), cancellationToken);
 
-                    public Stream GetStream(string name) => store.GetStream(test_image);
+                    public Stream GetStream(string name) => store.GetStream(map(name));
+
+                    private string map(string name)
+                    {
+                        switch (name)
+                        {
+                            case lookup_name:
+                                return "Resources/Textures/test-image.png";
+
+                            default:
+                                return $"Resources/{name}";
+                        }
+                    }
 
                     public IEnumerable<string> GetAvailableResources() => store.GetAvailableResources();
                 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -86,7 +86,10 @@ namespace osu.Game.Tests.Visual.Gameplay
                 sprite.AddLoop(Time.Current, 100).Alpha.Add(Easing.None, 0, 10000, 1, 1);
 
                 if (scaleTransformProvided)
-                    sprite.TimelineGroup.Scale.Add(Easing.None, Time.Current, Time.Current, 1, 1);
+                {
+                    sprite.TimelineGroup.Scale.Add(Easing.None, Time.Current, Time.Current + 1000, 1, 2);
+                    sprite.TimelineGroup.Scale.Add(Easing.None, Time.Current + 1000, Time.Current + 2000, 2, 1);
+                }
 
                 layer.Elements.Clear();
                 layer.Add(sprite);

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Beatmaps.Formats
                         if (!OsuGameBase.VIDEO_EXTENSIONS.Contains(Path.GetExtension(path).ToLowerInvariant()))
                             break;
 
-                        storyboard.GetLayer("Video").Add(new StoryboardVideo(path, offset));
+                        storyboard.GetLayer("Video").Add(storyboardSprite = new StoryboardVideo(path, offset));
                         break;
                     }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Storyboards.Drawables
                 Origin = Anchor.Centre,
                 Alpha = 0,
             };
+
+            Video.ApplyTransforms(drawableVideo);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -23,7 +23,17 @@ namespace osu.Game.Storyboards.Drawables
         {
             Video = video;
 
-            RelativeSizeAxes = Axes.Both;
+            // In osu-stable, a mapper can add a scale command for a storyboard.
+            // This allows scaling based on the video's absolute size.
+            //
+            // If not specified we take up the full available space.
+            bool useRelative = !video.TimelineGroup.Scale.HasCommands;
+
+            RelativeSizeAxes = useRelative ? Axes.Both : Axes.None;
+            AutoSizeAxes = useRelative ? Axes.None : Axes.Both;
+
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
         }
 
         [BackgroundDependencyLoader(true)]
@@ -36,7 +46,7 @@ namespace osu.Game.Storyboards.Drawables
 
             InternalChild = drawableVideo = new Video(stream, false)
             {
-                RelativeSizeAxes = Axes.Both,
+                RelativeSizeAxes = RelativeSizeAxes,
                 FillMode = FillMode.Fill,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Storyboards.Drawables
         {
             Video = video;
 
-            // In osu-stable, a mapper can add a scale command for a storyboard.
+            // In osu-stable, a mapper can add a scale command for a storyboard video.
             // This allows scaling based on the video's absolute size.
             //
             // If not specified we take up the full available space.

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -2,12 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Video;
-using osu.Game.Beatmaps;
 
 namespace osu.Game.Storyboards.Drawables
 {
@@ -37,7 +35,7 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(IBindable<WorkingBeatmap> beatmap, TextureStore textureStore)
+        private void load(TextureStore textureStore)
         {
             var stream = textureStore.GetStream(Video.Path);
 

--- a/osu.Game/Storyboards/StoryboardVideo.cs
+++ b/osu.Game/Storyboards/StoryboardVideo.cs
@@ -3,23 +3,18 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Storyboards.Drawables;
+using osuTK;
 
 namespace osu.Game.Storyboards
 {
-    public class StoryboardVideo : IStoryboardElement
+    public class StoryboardVideo : StoryboardSprite
     {
-        public string Path { get; }
-
-        public bool IsDrawable => true;
-
-        public double StartTime { get; }
-
         public StoryboardVideo(string path, double offset)
+            : base(path, Anchor.Centre, Vector2.Zero)
         {
-            Path = path;
-            StartTime = offset;
+            TimelineGroup.Alpha.Add(Easing.None, offset, offset, 0, 1);
         }
 
-        public Drawable CreateDrawable() => new DrawableStoryboardVideo(this);
+        public override Drawable CreateDrawable() => new DrawableStoryboardVideo(this);
     }
 }

--- a/osu.Game/Storyboards/StoryboardVideo.cs
+++ b/osu.Game/Storyboards/StoryboardVideo.cs
@@ -12,7 +12,9 @@ namespace osu.Game.Storyboards
         public StoryboardVideo(string path, double offset)
             : base(path, Anchor.Centre, Vector2.Zero)
         {
-            TimelineGroup.Alpha.Add(Easing.None, offset, offset, 0, 1);
+            // This is just required to get a valid StartTime based on the incoming offset.
+            // Actual fades are handled inside DrawableStoryboardVideo for now.
+            TimelineGroup.Alpha.Add(Easing.None, offset, offset, 0, 0);
         }
 
         public override Drawable CreateDrawable() => new DrawableStoryboardVideo(this);


### PR DESCRIPTION
In stable, storyboard videos can actually accept all kinds of transforms.

Handling of scale is a bit special here as we need to undo relative sizing. In stable, the relevant sizing code is performed in [`pSprite.ScaleToScreen()`](https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameplayElements/Events/EventManager.cs#L1058), which is undone when a transform is run.

Closes https://github.com/ppy/osu/issues/27634.