### PR TITLE
Add a chevron to distinguish editor menus with submenus

### DIFF
--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -184,6 +185,17 @@ namespace osu.Game.Screens.Edit.Components.Menus
                 {
                 }
 
+                private bool hasSubmenu => Item.Items.Any();
+
+                protected override TextContainer CreateTextContainer() => base.CreateTextContainer().With(c =>
+                {
+                    c.Padding = new MarginPadding
+                    {
+                        // Add some padding for the chevron below.
+                        Right = hasSubmenu ? 5 : 0,
+                    };
+                });
+
                 [BackgroundDependencyLoader]
                 private void load(OverlayColourProvider colourProvider)
                 {
@@ -191,6 +203,18 @@ namespace osu.Game.Screens.Edit.Components.Menus
                     BackgroundColourHover = colourProvider.Background1;
 
                     Foreground.Padding = new MarginPadding { Vertical = 2 };
+
+                    if (hasSubmenu)
+                    {
+                        AddInternal(new SpriteIcon
+                        {
+                            Margin = new MarginPadding(6),
+                            Size = new Vector2(8),
+                            Icon = FontAwesome.Solid.ChevronRight,
+                            Anchor = Anchor.CentreRight,
+                            Origin = Anchor.CentreRight,
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/27916.

| Before | After |
| :---: | :---: |
| ![2024-04-23 21 34 46@2x](https://github.com/ppy/osu/assets/191335/708a05dc-5f58-4a3d-b0ed-d5d1f6a86fa3) | ![2024-04-23 21 36 37@2x](https://github.com/ppy/osu/assets/191335/aff00933-abdf-462d-9a39-11fc7240a759) |