### PR TITLE
Add chevron to distinguish all menus with submenus

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -77,21 +77,21 @@ namespace osu.Game.Tests.Visual.UserInterface
                 new OsuMenuItem(@"Some option"),
                 new OsuMenuItem(@"Highlighted option", MenuItemType.Highlighted),
                 new OsuMenuItem(@"Another option"),
-                new OsuMenuItem(@"Nested option >")
+                new OsuMenuItem(@"Nested option")
                 {
                     Items = new MenuItem[]
                     {
                         new OsuMenuItem(@"Sub-One"),
                         new OsuMenuItem(@"Sub-Two"),
                         new OsuMenuItem(@"Sub-Three"),
-                        new OsuMenuItem(@"Sub-Nested option >")
+                        new OsuMenuItem(@"Sub-Nested option")
                         {
                             Items = new MenuItem[]
                             {
                                 new OsuMenuItem(@"Double Sub-One"),
                                 new OsuMenuItem(@"Double Sub-Two"),
                                 new OsuMenuItem(@"Double Sub-Three"),
-                                new OsuMenuItem(@"Sub-Sub-Nested option >")
+                                new OsuMenuItem(@"Sub-Sub-Nested option")
                                 {
                                     Items = new MenuItem[]
                                     {

--- a/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Graphics.UserInterface
@@ -40,6 +42,27 @@ namespace osu.Game.Graphics.UserInterface
             AddInternal(hoverClickSounds = new HoverClickSounds());
 
             updateTextColour();
+
+            bool hasSubmenu = Item.Items.Any();
+
+            // Only add right chevron if direction of menu items is vertical (i.e. width is relative size, see `DrawableMenuItem.SetFlowDirection()`).
+            if (hasSubmenu && RelativeSizeAxes == Axes.X)
+            {
+                AddInternal(new SpriteIcon
+                {
+                    Margin = new MarginPadding(6),
+                    Size = new Vector2(8),
+                    Icon = FontAwesome.Solid.ChevronRight,
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                });
+
+                text.Padding = new MarginPadding
+                {
+                    // Add some padding for the chevron above.
+                    Right = 5,
+                };
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -185,17 +185,6 @@ namespace osu.Game.Screens.Edit.Components.Menus
                 {
                 }
 
-                private bool hasSubmenu => Item.Items.Any();
-
-                protected override TextContainer CreateTextContainer() => base.CreateTextContainer().With(c =>
-                {
-                    c.Padding = new MarginPadding
-                    {
-                        // Add some padding for the chevron below.
-                        Right = hasSubmenu ? 5 : 0,
-                    };
-                });
-
                 [BackgroundDependencyLoader]
                 private void load(OverlayColourProvider colourProvider)
                 {
@@ -203,18 +192,6 @@ namespace osu.Game.Screens.Edit.Components.Menus
                     BackgroundColourHover = colourProvider.Background1;
 
                     Foreground.Padding = new MarginPadding { Vertical = 2 };
-
-                    if (hasSubmenu)
-                    {
-                        AddInternal(new SpriteIcon
-                        {
-                            Margin = new MarginPadding(6),
-                            Size = new Vector2(8),
-                            Icon = FontAwesome.Solid.ChevronRight,
-                            Anchor = Anchor.CentreRight,
-                            Origin = Anchor.CentreRight,
-                        });
-                    }
                 }
             }
         }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/pull/27974#issuecomment-2073349478

Unsure what "in other cases" mean in https://github.com/ppy/osu/pull/27974#issuecomment-2073734924. I'd assume it's the menu bar, which is horizontal direction. So I've applied it to only vertical direction menus.

Menu items don't know the flow direction of menus so checked the relative width instead w/ a comment attached.

![Screenshot 2024-04-24 at 12 22 43 AM](https://github.com/ppy/osu/assets/35318437/c480ec52-5169-406a-9a63-412c54337333)

The scroll bar overlap in the test looks kinda wrong, but I don't see a menu with submenu ingame with a lot of items yet.
Setting `ScrollbarOverlapsContent` to false doesn't work that well if the scroll bar initially disappears when menus are not long enough:

https://github.com/ppy/osu/assets/35318437/fef247e1-4162-4b58-af70-52ed9efb0987

