### PR TITLE
Unblock beatmap/skin/log export on mobile

### DIFF
--- a/osu.Game/Database/LegacyExporter.cs
+++ b/osu.Game/Database/LegacyExporter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework;
 using osu.Framework.Platform;
 using osu.Game.Extensions;
 using osu.Game.Overlays.Notifications;
@@ -105,7 +106,12 @@ namespace osu.Game.Database
                 throw;
             }
 
-            notification.CompletionText = $"Exported {itemFilename}! Click to view.";
+            notification.CompletionText = $"Exported {itemFilename}!";
+
+            // mobile platforms don't support `PresentFileExternally()` yet
+            if (RuntimeInfo.IsDesktop)
+                notification.CompletionText += " Click to view.";
+
             notification.CompletionClickAction = () => exportStorage.PresentFileExternally(filename);
             notification.State = ProgressNotificationState.Completed;
         }

--- a/osu.Game/Database/LegacyExporter.cs
+++ b/osu.Game/Database/LegacyExporter.cs
@@ -112,7 +112,14 @@ namespace osu.Game.Database
             if (RuntimeInfo.IsDesktop)
                 notification.CompletionText += " Click to view.";
 
-            notification.CompletionClickAction = () => exportStorage.PresentFileExternally(filename);
+            notification.CompletionClickAction = () =>
+            {
+                exportStorage.PresentFileExternally(filename);
+
+                // always return true so that mobile platforms dismiss on click
+                return true;
+            };
+
             notification.State = ProgressNotificationState.Completed;
         }
 

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -134,7 +134,12 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 throw;
             }
 
-            notification.CompletionText = "Exported logs! Click to view.";
+            notification.CompletionText = "Exported logs!";
+
+            // mobile platforms don't support `PresentFileExternally()` yet
+            if (RuntimeInfo.IsDesktop)
+                notification.CompletionText += " Click to view.";
+
             notification.CompletionClickAction = () => storage.PresentFileExternally(archive_filename);
 
             notification.State = ProgressNotificationState.Completed;

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -140,7 +140,13 @@ namespace osu.Game.Overlays.Settings.Sections.General
             if (RuntimeInfo.IsDesktop)
                 notification.CompletionText += " Click to view.";
 
-            notification.CompletionClickAction = () => storage.PresentFileExternally(archive_filename);
+            notification.CompletionClickAction = () =>
+            {
+                storage.PresentFileExternally(archive_filename);
+
+                // always return true so that mobile platforms dismiss on click
+                return true;
+            };
 
             notification.State = ProgressNotificationState.Completed;
         }

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -78,14 +78,17 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     Keywords = new[] { @"logs", @"files", @"access", "directory" },
                     Action = () => storage.PresentExternally(),
                 });
+            }
 
-                Add(new SettingsButton
-                {
-                    Text = GeneralSettingsStrings.ExportLogs,
-                    Keywords = new[] { @"bug", "report", "logs", "files" },
-                    Action = () => Task.Run(exportLogs),
-                });
+            Add(new SettingsButton
+            {
+                Text = GeneralSettingsStrings.ExportLogs,
+                Keywords = new[] { @"bug", "report", "logs", "files" },
+                Action = () => Task.Run(exportLogs),
+            });
 
+            if (RuntimeInfo.IsDesktop)
+            {
                 Add(new SettingsButton
                 {
                     Text = GeneralSettingsStrings.ChangeFolderLocation,

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -152,7 +151,7 @@ namespace osu.Game.Overlays.SkinEditor
                                                 Items = new OsuMenuItem[]
                                                 {
                                                     new EditorMenuItem(Web.CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
-                                                    new EditorMenuItem(CommonStrings.Export, MenuItemType.Standard, () => skins.ExportCurrentSkin()) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
+                                                    new EditorMenuItem(CommonStrings.Export, MenuItemType.Standard, () => skins.ExportCurrentSkin()),
                                                     new OsuMenuItemSpacer(),
                                                     new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, () => dialogOverlay?.Push(new RevertConfirmDialog(revert))),
                                                     new OsuMenuItemSpacer(),

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
@@ -1035,8 +1034,8 @@ namespace osu.Game.Screens.Edit
         {
             var exportItems = new List<MenuItem>
             {
-                new EditorMenuItem(EditorStrings.ExportForEditing, MenuItemType.Standard, () => exportBeatmap(false)) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
-                new EditorMenuItem(EditorStrings.ExportForCompatibility, MenuItemType.Standard, () => exportBeatmap(true)) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
+                new EditorMenuItem(EditorStrings.ExportForEditing, MenuItemType.Standard, () => exportBeatmap(false)),
+                new EditorMenuItem(EditorStrings.ExportForCompatibility, MenuItemType.Standard, () => exportBeatmap(true)),
             };
 
             return new EditorMenuItem(CommonStrings.Export) { Items = exportItems };


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/27869

In https://github.com/ppy/osu/pull/7977, `PresentFileExternally()` (`OpenInNativeExplorer()` formerly) crashed the game and exports were never exposed on mobile (even if the exporting itself worked at that time).

Since https://github.com/ppy/osu-framework/pull/5075, `PresentFileExternally()` just silently fails now.