### PR TITLE
Do not show non-basic results in timing distribution graph

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneHitEventTimingDistributionGraph.cs
@@ -83,6 +83,14 @@ namespace osu.Game.Tests.Visual.Ranking
         }
 
         [Test]
+        public void TestNonBasicHitResultsAreIgnored()
+        {
+            createTest(CreateDistributedHitEvents(0, 50)
+                       .Select(h => new HitEvent(h.TimeOffset, 1.0, h.TimeOffset > 0 ? HitResult.Ok : HitResult.LargeTickHit, placeholder_object, placeholder_object, null))
+                       .ToList());
+        }
+
+        [Test]
         public void TestMultipleWindowsOfHitResult()
         {
             var wide = CreateDistributedHitEvents(0, 50).Select(h =>

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="hitEvents">The <see cref="HitEvent"/>s to display the timing distribution of.</param>
         public HitEventTimingDistributionGraph(IReadOnlyList<HitEvent> hitEvents)
         {
-            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit()).ToList();
+            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsBasic() && e.Result.IsHit()).ToList();
             bins = Enumerable.Range(0, total_timing_distribution_bins).Select(_ => new Dictionary<HitResult, int>()).ToArray<IDictionary<HitResult, int>>();
         }
 


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/24274.

Bit of an ad-hoc resolution but maybe fine? This basically proposes to bypass the problem described in the issue by just not showing tick hits (and bonus hits, I guess) at all on the distribution graph. End result being that with classic mod active, slider head hits will not be shown on the distribution graph at all.

An arguable alternative way of fixing the issue would be to just go through the hit windows every time rather than use the results as given by the hit events:

```diff
diff --git a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
index 1260ec2339..63574fc3c3 100644
--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -110,8 +110,9 @@ private void updateDisplay()
                 // may be out of range when applying an offset. for such cases we can just drop the results.
                 if (index >= 0 && index < bins.Length)
                 {
-                    bins[index].TryGetValue(e.Result, out int value);
-                    bins[index][e.Result] = ++value;
+                    var resultFromHitWindows = e.HitObject.HitWindows.ResultFor(e.TimeOffset);
+                    bins[index].TryGetValue(resultFromHitWindows, out int value);
+                    bins[index][resultFromHitWindows] = ++value;
                 }
             }
 

```

but I dunno. This is much simpler for one - the above diff would need to be checked wrt correctness for stuff like mania, wherein mods change hit windows - and also this may end up being a bit confusing as well, because technically that makes the graph no longer match the hit statistics?