### PR TITLE
Apply nullability annotations to `ResultsScreen` & inheritors

### DIFF
--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -424,7 +424,7 @@ namespace osu.Game.Tests.Visual.Ranking
                     scores.Add(score);
                 }
 
-                scoresCallback?.Invoke(scores);
+                scoresCallback.Invoke(scores);
 
                 return null;
             }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerTeamResultsScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,8 +26,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
     {
         private readonly SortedDictionary<int, BindableLong> teamScores;
 
-        private Container winnerBackground;
-        private Drawable winnerText;
+        private Container winnerBackground = null!;
+        private Drawable winnerText = null!;
 
         public MultiplayerTeamResultsScreen(ScoreInfo score, long roomId, PlaylistItem playlistItem, SortedDictionary<int, BindableLong> teamScores)
             : base(score, roomId, playlistItem)
@@ -41,7 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         }
 
         [Resolved]
-        private OsuColour colours { get; set; }
+        private OsuColour colours { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/MultiSpectatorResultsScreen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using osu.Game.Online.API;
@@ -25,8 +23,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             Scheduler.AddDelayed(() => StatisticsPanel.ToggleVisibility(), 1000);
         }
 
-        protected override APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
 
-        protected override APIRequest FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected override APIRequest? FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
     }
 }

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -45,25 +42,24 @@ namespace osu.Game.Screens.Ranking
 
         protected override OverlayActivation InitialOverlayActivationMode => OverlayActivation.UserTriggered;
 
-        public readonly Bindable<ScoreInfo> SelectedScore = new Bindable<ScoreInfo>();
+        public readonly Bindable<ScoreInfo?> SelectedScore = new Bindable<ScoreInfo?>();
 
-        [CanBeNull]
-        public readonly ScoreInfo Score;
+        public readonly ScoreInfo? Score;
 
-        protected ScorePanelList ScorePanelList { get; private set; }
+        protected ScorePanelList ScorePanelList { get; private set; } = null!;
 
-        protected VerticalScrollContainer VerticalScrollContent { get; private set; }
-
-        [Resolved(CanBeNull = true)]
-        private Player player { get; set; }
+        protected VerticalScrollContainer VerticalScrollContent { get; private set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private Player? player { get; set; }
 
-        protected StatisticsPanel StatisticsPanel { get; private set; }
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
 
-        private Drawable bottomPanel;
-        private Container<ScorePanel> detachedPanelContainer;
+        protected StatisticsPanel StatisticsPanel { get; private set; } = null!;
+
+        private Drawable bottomPanel = null!;
+        private Container<ScorePanel> detachedPanelContainer = null!;
 
         private bool lastFetchCompleted;
 
@@ -84,9 +80,9 @@ namespace osu.Game.Screens.Ranking
         /// </summary>
         public bool ShowUserStatistics { get; init; }
 
-        private Sample popInSample;
+        private Sample? popInSample;
 
-        protected ResultsScreen([CanBeNull] ScoreInfo score)
+        protected ResultsScreen(ScoreInfo? score)
         {
             Score = score;
 
@@ -182,11 +178,11 @@ namespace osu.Game.Screens.Ranking
                 Scheduler.AddDelayed(() => OverlayActivationMode.Value = OverlayActivation.All, shouldFlair ? AccuracyCircle.TOTAL_DURATION + 1000 : 0);
             }
 
-            if (AllowWatchingReplay)
+            if (SelectedScore.Value != null && AllowWatchingReplay)
             {
                 buttons.Add(new ReplayDownloadButton(SelectedScore.Value)
                 {
-                    Score = { BindTarget = SelectedScore },
+                    Score = { BindTarget = SelectedScore! },
                     Width = 300
                 });
             }
@@ -225,7 +221,7 @@ namespace osu.Game.Screens.Ranking
 
             if (lastFetchCompleted)
             {
-                APIRequest nextPageRequest = null;
+                APIRequest? nextPageRequest = null;
 
                 if (ScorePanelList.IsScrolledToStart)
                     nextPageRequest = FetchNextPage(-1, fetchScoresCallback);
@@ -245,7 +241,7 @@ namespace osu.Game.Screens.Ranking
         /// </summary>
         /// <param name="scoresCallback">A callback which should be called when fetching is completed. Scheduling is not required.</param>
         /// <returns>An <see cref="APIRequest"/> responsible for the fetch operation. This will be queued and performed automatically.</returns>
-        protected virtual APIRequest FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected virtual APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
 
         /// <summary>
         /// Performs a fetch of the next page of scores. This is invoked every frame until a non-null <see cref="APIRequest"/> is returned.
@@ -253,7 +249,7 @@ namespace osu.Game.Screens.Ranking
         /// <param name="direction">The fetch direction. -1 to fetch scores greater than the current start of the list, and 1 to fetch scores lower than the current end of the list.</param>
         /// <param name="scoresCallback">A callback which should be called when fetching is completed. Scheduling is not required.</param>
         /// <returns>An <see cref="APIRequest"/> responsible for the fetch operation. This will be queued and performed automatically.</returns>
-        protected virtual APIRequest FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
+        protected virtual APIRequest? FetchNextPage(int direction, Action<IEnumerable<ScoreInfo>> scoresCallback) => null;
 
         /// <summary>
         /// Creates the <see cref="Statistics.StatisticsPanel"/> to be used to display extended information about scores.
@@ -327,7 +323,7 @@ namespace osu.Game.Screens.Ranking
                 panel.Alpha = 0;
         }
 
-        private ScorePanel detachedPanel;
+        private ScorePanel? detachedPanel;
 
         private void onStatisticsStateChanged(ValueChangedEvent<Visibility> state)
         {

--- a/osu.Game/Screens/Ranking/SoloResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/SoloResultsScreen.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Screens.Ranking
         {
         }
 
-        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>>? scoresCallback)
+        protected override APIRequest? FetchScores(Action<IEnumerable<ScoreInfo>> scoresCallback)
         {
             Debug.Assert(Score != null);
 
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Ranking
                 return null;
 
             getScoreRequest = new GetScoresRequest(Score.BeatmapInfo, Score.Ruleset);
-            getScoreRequest.Success += r => scoresCallback?.Invoke(r.Scores.Where(s => !s.MatchesOnlineID(Score)).Select(s => s.ToScoreInfo(rulesets, Beatmap.Value.BeatmapInfo)));
+            getScoreRequest.Success += r => scoresCallback.Invoke(r.Scores.Where(s => !s.MatchesOnlineID(Score)).Select(s => s.ToScoreInfo(rulesets, Beatmap.Value.BeatmapInfo)));
             return getScoreRequest;
         }
 


### PR DESCRIPTION
Did this while looking towards https://github.com/ppy/osu/issues/26725. PRing separately to get this out of the way before I attempt anything further.