### PR TITLE
Fully refetch working beatmap when entering editor

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -425,6 +425,7 @@ namespace osu.Game.Screens.Select
             if (!AllowEditing)
                 throw new InvalidOperationException($"Attempted to edit when {nameof(AllowEditing)} is disabled");
 
+            // Forced refetch is important here to guarantee correct invalidation across all difficulties.
             Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo ?? beatmapInfoNoDebounce, true);
             this.Push(new EditorLoader());
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -425,7 +425,7 @@ namespace osu.Game.Screens.Select
             if (!AllowEditing)
                 throw new InvalidOperationException($"Attempted to edit when {nameof(AllowEditing)} is disabled");
 
-            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo ?? beatmapInfoNoDebounce);
+            Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo ?? beatmapInfoNoDebounce, true);
             this.Push(new EditorLoader());
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21794.

I'm not actually super sure as to what the exact mode of failure is here, but it's 99% to do with working beatmap cache invalidation. Likely this can be even considered as another case of https://github.com/ppy/osu/issues/21357, but because this is a one-liner "fix," I'm PRing it anyways. I spent about 1.5 hours too much on this already anyways compared to how long this _should_ have taken to debug.

The issue is confusing to understand when working with the swap scenario given in the issue, but it's a little easier to understand when performing the following:

1. Have a beatmap set with 2 difficulties. Let's call them "A" and "B".
2. From song select, **without ever exiting to main menu**, edit "A". Change the difficulty name to "AA". Save and exit back to song select; **do not exit out to main menu**.
3. From song select, edit "B". Change the difficulty name to "BB". Save and exit back to song select.
4. The difficulty names will be "A" and "BB".

Basically what I *think* is causing this, is the fact that even though editor invalidates the working beatmap by refetching it afresh on exit, song select is blissfully unaware of this, and continues working with its own `BeatmapInfo` instances which have backlinks to `BeatmapSetInfo`.

When editing the first of the two difficulties and then the second, the editing of the first one only invalidates the first one rather than the entire set, and the second difficulty continues to have a stale reference to the first one via the beatmap set with the old name, and as such ends up overwriting the changes from the first save when passed into the editor and modified again.

No tests because it's annoying to write one. I'll try on request.