### PR TITLE
Add missing space in setup wizard

### DIFF
--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -128,6 +128,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             if (available)
             {
                 copyInformation.Text = FirstRunOverlayImportFromStableScreenStrings.DataMigrationNoExtraSpace;
+                copyInformation.AddText(@" "); // just to ensure correct spacing
                 copyInformation.AddLink(FirstRunOverlayImportFromStableScreenStrings.LearnAboutHardLinks, LinkAction.OpenWiki, @"Client/Release_stream/Lazer/File_storage#via-hard-links");
             }
             else if (!RuntimeInfo.IsDesktop)


### PR DESCRIPTION
Fixes #28012
Simply did the same as commit fa894bda059e58626639e4a487181f191f207837

![image](https://github.com/ppy/osu/assets/67872932/733865d6-cbd4-4060-af77-f2c760750ee4)
