### PR TITLE
Check realm file can be written to before attempting further initialisation

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -311,9 +311,12 @@ namespace osu.Game.Database
             {
                 // If this fails we allow it to block game startup.
                 // It's better than any alternative we can offer.
-                using (var _ = storage.GetStream(Filename, FileAccess.ReadWrite))
+                FileUtils.AttemptOperation(() =>
                 {
-                }
+                    using (var _ = storage.GetStream(Filename, FileAccess.ReadWrite))
+                    {
+                    }
+                });
             }
 
             string newerVersionFilename = $"{Filename.Replace(realm_extension, string.Empty)}_newer_version{realm_extension}";

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -307,17 +307,17 @@ namespace osu.Game.Database
             // Realms.Exceptions.RealmException: SetEndOfFile() failed: unknown error (1224)
             //
             // which can occur due to file handles still being open by a previous instance.
-            if (storage.Exists(Filename))
+            //
+            // If this fails we allow it to block game startup. It's better than any alternative we can offer.
+            FileUtils.AttemptOperation(() =>
             {
-                // If this fails we allow it to block game startup.
-                // It's better than any alternative we can offer.
-                FileUtils.AttemptOperation(() =>
+                if (storage.Exists(Filename))
                 {
                     using (var _ = storage.GetStream(Filename, FileAccess.ReadWrite))
                     {
                     }
-                });
-            }
+                }
+            });
 
             string newerVersionFilename = $"{Filename.Replace(realm_extension, string.Empty)}_newer_version{realm_extension}";
 


### PR DESCRIPTION
Rather than creating a "corrupt" realm file in such cases, the game will now refuse to start. This behaviour is usually what we want. In most cases a second click on the game will start it successfully (the previous instance's file handles are still doing stuff, or windows defender is being silly).

Closes https://github.com/ppy/osu/issues/28018.