### PR TITLE
Fix incorrect background being loaded due to async race

### DIFF
--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -56,10 +56,6 @@ namespace osu.Game.Screens.Backgrounds
             introSequence = config.GetBindable<IntroSequence>(OsuSetting.IntroSequence);
 
             AddInternal(seasonalBackgroundLoader);
-
-            // Load first background asynchronously as part of BDL load.
-            currentDisplay = RNG.Next(0, background_count);
-            Next();
         }
 
         protected override void LoadComplete()
@@ -72,6 +68,9 @@ namespace osu.Game.Screens.Backgrounds
             beatmap.ValueChanged += _ => Scheduler.AddOnce(next);
             introSequence.ValueChanged += _ => Scheduler.AddOnce(next);
             seasonalBackgroundLoader.SeasonalBackgroundChanged += () => Scheduler.AddOnce(next);
+
+            currentDisplay = RNG.Next(0, background_count);
+            Next();
 
             // helper function required for AddOnce usage.
             void next() => Next();


### PR DESCRIPTION
If the API login (and thus user set) completed between `load` and `LoadComplete`, the re-fetch on user change would not yet be hooked up, causing an incorrect default background to be used instead.

Of note, moving this out of async load doesn't really affect load performance as the bulk of the load operation is already scheduled and `LoadComponentAsync`ed anyway

Closes https://github.com/ppy/osu/issues/28038 in theory.