### PR TITLE
Tweak resume overlay to allow better visibility of hit objects underneath

### DIFF
--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -529,7 +529,7 @@ namespace osu.Game.Rulesets.UI
         public ResumeOverlay ResumeOverlay { get; protected set; }
 
         /// <summary>
-        /// Whether the <see cref="ResumeOverlay"/> should be used to return the user's cursor position to its previous location after a pause.
+        /// Whether a <see cref="ResumeOverlay"/> should be displayed on resuming after a pause.
         /// </summary>
         /// <remarks>
         /// Defaults to <c>true</c>.

--- a/osu.Game/Screens/Play/DelayedResumeOverlay.cs
+++ b/osu.Game/Screens/Play/DelayedResumeOverlay.cs
@@ -170,6 +170,8 @@ namespace osu.Game.Screens.Play
             countdownProgress.Progress = amountTimePassed;
             countdownProgress.InnerRadius = progress_stroke_width / progress_size / countdownProgress.Scale.X;
 
+            Alpha = 0.2f + 0.8f * newCount / 3f;
+
             if (countdownCount != newCount)
             {
                 if (newCount > 0)

--- a/osu.Game/Screens/Play/DelayedResumeOverlay.cs
+++ b/osu.Game/Screens/Play/DelayedResumeOverlay.cs
@@ -24,8 +24,9 @@ namespace osu.Game.Screens.Play
     /// </summary>
     public partial class DelayedResumeOverlay : ResumeOverlay
     {
-        // todo: this shouldn't define its own colour provider, but nothing in Player screen does, so let's do that for now.
-        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+        // todo: this shouldn't define its own colour provider, but nothing in DrawableRuleset guarantees this, so let's do it locally for now.
+        // (of note, Player does cache one but any test which uses a DrawableRuleset without Player will fail without this).
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         private const float outer_size = 200;
         private const float inner_size = 150;

--- a/osu.Game/Screens/Play/DelayedResumeOverlay.cs
+++ b/osu.Game/Screens/Play/DelayedResumeOverlay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
-using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -35,9 +34,10 @@ namespace osu.Game.Screens.Play
 
         private const double countdown_time = 2000;
 
+        private const int total_count = 3;
+
         protected override LocalisableString Message => string.Empty;
 
-        private ScheduledDelegate? scheduledResume;
         private int? countdownCount;
         private double countdownStartTime;
         private bool countdownComplete;
@@ -121,21 +121,17 @@ namespace osu.Game.Screens.Play
             innerContent.FadeIn().ScaleTo(Vector2.Zero).Then().ScaleTo(Vector2.One, 400, Easing.OutElasticHalf);
             countdownComponents.FadeOut().Delay(50).FadeTo(1, 100);
 
+            countdownProgress.Progress = 0;
+
             // Reset states for various components.
             countdownBackground.FadeIn();
             countdownText.FadeIn();
+            countdownText.Text = string.Empty;
             countdownProgress.FadeIn().ScaleTo(1);
 
             countdownComplete = false;
             countdownCount = null;
-            countdownStartTime = Time.Current;
-
-            scheduledResume?.Cancel();
-            scheduledResume = Scheduler.AddDelayed(() =>
-            {
-                countdownComplete = true;
-                Resume();
-            }, countdown_time);
+            countdownStartTime = Time.Current + 200;
         }
 
         protected override void PopOut()
@@ -153,8 +149,6 @@ namespace osu.Game.Screens.Play
             }
             else
                 countdownProgress.FadeOut();
-
-            scheduledResume?.Cancel();
         }
 
         protected override void Update()
@@ -165,13 +159,16 @@ namespace osu.Game.Screens.Play
 
         private void updateCountdown()
         {
-            double amountTimePassed = Math.Min(countdown_time, Time.Current - countdownStartTime) / countdown_time;
-            int newCount = 3 - (int)Math.Floor(amountTimePassed * 3);
+            if (State.Value == Visibility.Hidden || countdownComplete || Time.Current < countdownStartTime)
+                return;
+
+            double amountTimePassed = Math.Clamp((Time.Current - countdownStartTime) / countdown_time, 0, countdown_time);
+            int newCount = Math.Clamp(total_count - (int)Math.Floor(amountTimePassed * total_count), 0, total_count);
 
             countdownProgress.Progress = amountTimePassed;
             countdownProgress.InnerRadius = progress_stroke_width / progress_size / countdownProgress.Scale.X;
 
-            Alpha = 0.2f + 0.8f * newCount / 3f;
+            Alpha = 0.2f + 0.8f * newCount / total_count;
 
             if (countdownCount != newCount)
             {
@@ -194,6 +191,12 @@ namespace osu.Game.Screens.Play
             }
 
             countdownCount = newCount;
+
+            if (countdownCount == 0)
+            {
+                countdownComplete = true;
+                Resume();
+            }
         }
     }
 }


### PR DESCRIPTION
This change decreases alpha as the count proceeds. It also adds an initial delay before the countdown starts, to make things feel a bit less jank when resuming gameplay. Had to restructure slightly to make that part work.

https://github.com/ppy/osu/assets/191335/d78cfd92-9787-4449-a300-f13205f80eb9


https://github.com/ppy/osu/assets/191335/dbfa652c-547c-4bf3-af16-f9545c7e4e0e

