### PR TITLE
Handle new naming inspections on certain enums

### DIFF
--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -489,7 +489,7 @@ namespace osu.Desktop
         public static uint Stride => (uint)Marshal.SizeOf(typeof(NvApplication)) | (2 << 16);
     }
 
-    // ReSharper disable InconsistentNaming
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvStatus
     {
         OK = 0, // Success. Request is completed.
@@ -612,6 +612,7 @@ namespace osu.Desktop
         FIRMWARE_REVISION_NOT_SUPPORTED = -200, // The device's firmware is not supported.
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvSystemType
     {
         UNKNOWN = 0,
@@ -619,6 +620,7 @@ namespace osu.Desktop
         DESKTOP = 2
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvGpuType
     {
         UNKNOWN = 0,
@@ -626,6 +628,7 @@ namespace osu.Desktop
         DGPU = 2, // Discrete
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvSettingID : uint
     {
         OGL_AA_LINE_GAMMA_ID = 0x2089BF6C,
@@ -718,6 +721,7 @@ namespace osu.Desktop
         INVALID_SETTING_ID = 0xFFFFFFFF
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvShimSetting : uint
     {
         SHIM_RENDERING_MODE_INTEGRATED = 0x00000000,
@@ -732,6 +736,7 @@ namespace osu.Desktop
         SHIM_RENDERING_MODE_DEFAULT = SHIM_RENDERING_MODE_AUTO_SELECT
     }
 
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     internal enum NvThreadControlSetting : uint
     {
         OGL_THREAD_CONTROL_ENABLE = 0x00000001,
@@ -739,6 +744,4 @@ namespace osu.Desktop
         OGL_THREAD_CONTROL_NUM_VALUES = 2,
         OGL_THREAD_CONTROL_DEFAULT = 0
     }
-
-    // ReSharper restore InconsistentNaming
 }

--- a/osu.Desktop/NVAPI.cs
+++ b/osu.Desktop/NVAPI.cs
@@ -489,6 +489,7 @@ namespace osu.Desktop
         public static uint Stride => (uint)Marshal.SizeOf(typeof(NvApplication)) | (2 << 16);
     }
 
+    // ReSharper disable InconsistentNaming
     internal enum NvStatus
     {
         OK = 0, // Success. Request is completed.
@@ -738,4 +739,6 @@ namespace osu.Desktop
         OGL_THREAD_CONTROL_NUM_VALUES = 2,
         OGL_THREAD_CONTROL_DEFAULT = 0
     }
+
+    // ReSharper restore InconsistentNaming
 }

--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -163,6 +163,8 @@ namespace osu.Desktop.Windows
         [DllImport("Shell32.dll")]
         private static extern void SHChangeNotify(EventId wEventId, Flags uFlags, IntPtr dwItem1, IntPtr dwItem2);
 
+        // ReSharper disable InconsistentNaming
+
         private enum EventId
         {
             /// <summary>
@@ -174,8 +176,11 @@ namespace osu.Desktop.Windows
 
         private enum Flags : uint
         {
+            // ReSharper disable once InconsistentNaming
             SHCNF_IDLIST = 0x0000
         }
+
+        // ReSharper restore InconsistentNaming
 
         #endregion
 

--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -163,8 +164,7 @@ namespace osu.Desktop.Windows
         [DllImport("Shell32.dll")]
         private static extern void SHChangeNotify(EventId wEventId, Flags uFlags, IntPtr dwItem1, IntPtr dwItem2);
 
-        // ReSharper disable InconsistentNaming
-
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
         private enum EventId
         {
             /// <summary>
@@ -174,13 +174,11 @@ namespace osu.Desktop.Windows
             SHCNE_ASSOCCHANGED = 0x08000000
         }
 
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
         private enum Flags : uint
         {
-            // ReSharper disable once InconsistentNaming
             SHCNF_IDLIST = 0x0000
         }
-
-        // ReSharper restore InconsistentNaming
 
         #endregion
 

--- a/osu.Game/IO/Legacy/SerializationReader.cs
+++ b/osu.Game/IO/Legacy/SerializationReader.cs
@@ -123,58 +123,58 @@ namespace osu.Game.IO.Legacy
 
             switch (t)
             {
-                case ObjType.boolType:
+                case ObjType.BoolType:
                     return ReadBoolean();
 
-                case ObjType.byteType:
+                case ObjType.ByteType:
                     return ReadByte();
 
-                case ObjType.uint16Type:
+                case ObjType.UInt16Type:
                     return ReadUInt16();
 
-                case ObjType.uint32Type:
+                case ObjType.UInt32Type:
                     return ReadUInt32();
 
-                case ObjType.uint64Type:
+                case ObjType.UInt64Type:
                     return ReadUInt64();
 
-                case ObjType.sbyteType:
+                case ObjType.SByteType:
                     return ReadSByte();
 
-                case ObjType.int16Type:
+                case ObjType.Int16Type:
                     return ReadInt16();
 
-                case ObjType.int32Type:
+                case ObjType.Int32Type:
                     return ReadInt32();
 
-                case ObjType.int64Type:
+                case ObjType.Int64Type:
                     return ReadInt64();
 
-                case ObjType.charType:
+                case ObjType.CharType:
                     return ReadChar();
 
-                case ObjType.stringType:
+                case ObjType.StringType:
                     return base.ReadString();
 
-                case ObjType.singleType:
+                case ObjType.SingleType:
                     return ReadSingle();
 
-                case ObjType.doubleType:
+                case ObjType.DoubleType:
                     return ReadDouble();
 
-                case ObjType.decimalType:
+                case ObjType.DecimalType:
                     return ReadDecimal();
 
-                case ObjType.dateTimeType:
+                case ObjType.DateTimeType:
                     return ReadDateTime();
 
-                case ObjType.byteArrayType:
+                case ObjType.ByteArrayType:
                     return ReadByteArray();
 
-                case ObjType.charArrayType:
+                case ObjType.CharArrayType:
                     return ReadCharArray();
 
-                case ObjType.otherType:
+                case ObjType.OtherType:
                     throw new IOException("Deserialization of arbitrary type is not supported.");
 
                 default:
@@ -185,25 +185,25 @@ namespace osu.Game.IO.Legacy
 
     public enum ObjType : byte
     {
-        nullType,
-        boolType,
-        byteType,
-        uint16Type,
-        uint32Type,
-        uint64Type,
-        sbyteType,
-        int16Type,
-        int32Type,
-        int64Type,
-        charType,
-        stringType,
-        singleType,
-        doubleType,
-        decimalType,
-        dateTimeType,
-        byteArrayType,
-        charArrayType,
-        otherType,
-        ILegacySerializableType
+        NullType,
+        BoolType,
+        ByteType,
+        UInt16Type,
+        UInt32Type,
+        UInt64Type,
+        SByteType,
+        Int16Type,
+        Int32Type,
+        Int64Type,
+        CharType,
+        StringType,
+        SingleType,
+        DoubleType,
+        DecimalType,
+        DateTimeType,
+        ByteArrayType,
+        CharArrayType,
+        OtherType,
+        LegacySerializableType
     }
 }

--- a/osu.Game/IO/Legacy/SerializationWriter.cs
+++ b/osu.Game/IO/Legacy/SerializationWriter.cs
@@ -34,11 +34,11 @@ namespace osu.Game.IO.Legacy
         {
             if (str == null)
             {
-                Write((byte)ObjType.nullType);
+                Write((byte)ObjType.NullType);
             }
             else
             {
-                Write((byte)ObjType.stringType);
+                Write((byte)ObjType.StringType);
                 base.Write(str);
             }
         }
@@ -125,94 +125,94 @@ namespace osu.Game.IO.Legacy
         {
             if (obj == null)
             {
-                Write((byte)ObjType.nullType);
+                Write((byte)ObjType.NullType);
             }
             else
             {
                 switch (obj)
                 {
                     case bool boolObj:
-                        Write((byte)ObjType.boolType);
+                        Write((byte)ObjType.BoolType);
                         Write(boolObj);
                         break;
 
                     case byte byteObj:
-                        Write((byte)ObjType.byteType);
+                        Write((byte)ObjType.ByteType);
                         Write(byteObj);
                         break;
 
                     case ushort ushortObj:
-                        Write((byte)ObjType.uint16Type);
+                        Write((byte)ObjType.UInt16Type);
                         Write(ushortObj);
                         break;
 
                     case uint uintObj:
-                        Write((byte)ObjType.uint32Type);
+                        Write((byte)ObjType.UInt32Type);
                         Write(uintObj);
                         break;
 
                     case ulong ulongObj:
-                        Write((byte)ObjType.uint64Type);
+                        Write((byte)ObjType.UInt64Type);
                         Write(ulongObj);
                         break;
 
                     case sbyte sbyteObj:
-                        Write((byte)ObjType.sbyteType);
+                        Write((byte)ObjType.SByteType);
                         Write(sbyteObj);
                         break;
 
                     case short shortObj:
-                        Write((byte)ObjType.int16Type);
+                        Write((byte)ObjType.Int16Type);
                         Write(shortObj);
                         break;
 
                     case int intObj:
-                        Write((byte)ObjType.int32Type);
+                        Write((byte)ObjType.Int32Type);
                         Write(intObj);
                         break;
 
                     case long longObj:
-                        Write((byte)ObjType.int64Type);
+                        Write((byte)ObjType.Int64Type);
                         Write(longObj);
                         break;
 
                     case char charObj:
-                        Write((byte)ObjType.charType);
+                        Write((byte)ObjType.CharType);
                         base.Write(charObj);
                         break;
 
                     case string stringObj:
-                        Write((byte)ObjType.stringType);
+                        Write((byte)ObjType.StringType);
                         base.Write(stringObj);
                         break;
 
                     case float floatObj:
-                        Write((byte)ObjType.singleType);
+                        Write((byte)ObjType.SingleType);
                         Write(floatObj);
                         break;
 
                     case double doubleObj:
-                        Write((byte)ObjType.doubleType);
+                        Write((byte)ObjType.DoubleType);
                         Write(doubleObj);
                         break;
 
                     case decimal decimalObj:
-                        Write((byte)ObjType.decimalType);
+                        Write((byte)ObjType.DecimalType);
                         Write(decimalObj);
                         break;
 
                     case DateTime dateTimeObj:
-                        Write((byte)ObjType.dateTimeType);
+                        Write((byte)ObjType.DateTimeType);
                         Write(dateTimeObj);
                         break;
 
                     case byte[] byteArray:
-                        Write((byte)ObjType.byteArrayType);
+                        Write((byte)ObjType.ByteArrayType);
                         base.Write(byteArray);
                         break;
 
                     case char[] charArray:
-                        Write((byte)ObjType.charArrayType);
+                        Write((byte)ObjType.CharArrayType);
                         base.Write(charArray);
                         break;
 

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -4,6 +4,8 @@
 using System.ComponentModel;
 using JetBrains.Annotations;
 
+// ReSharper disable InconsistentNaming
+
 namespace osu.Game.Localisation
 {
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]

--- a/osu.Game/Localisation/Language.cs
+++ b/osu.Game/Localisation/Language.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
-
-// ReSharper disable InconsistentNaming
 
 namespace osu.Game.Localisation
 {
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public enum Language
     {

--- a/osu.Game/Scoring/ScoreRank.cs
+++ b/osu.Game/Scoring/ScoreRank.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Scoring
 
         [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.RankSH))]
         [Description(@"S+")]
+        // ReSharper disable once InconsistentNaming
         SH,
 
         [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.RankX))]
@@ -43,6 +44,7 @@ namespace osu.Game.Scoring
 
         [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.RankXH))]
         [Description(@"SS+")]
+        // ReSharper disable once InconsistentNaming
         XH,
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -486,16 +486,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
             Off = 0,
 
             [Description("30 seconds")]
-            Seconds_30 = 30,
+            Seconds30 = 30,
 
             [Description("1 minute")]
-            Seconds_60 = 60,
+            Seconds60 = 60,
 
             [Description("3 minutes")]
-            Seconds_180 = 180,
+            Seconds180 = 180,
 
             [Description("5 minutes")]
-            Seconds_300 = 300
+            Seconds300 = 300
         }
     }
 }

--- a/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinConfigurationLookup.cs
@@ -67,7 +67,10 @@ namespace osu.Game.Skinning
         LeftStageImage,
         RightStageImage,
         BottomStageImage,
+
+        // ReSharper disable once InconsistentNaming
         Hit300g,
+
         Hit300,
         Hit200,
         Hit100,

--- a/osu.Game/Users/CountryCode.cs
+++ b/osu.Game/Users/CountryCode.cs
@@ -6,6 +6,8 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
+// ReSharper disable InconsistentNaming
+
 namespace osu.Game.Users
 {
     /// <summary>

--- a/osu.Game/Users/CountryCode.cs
+++ b/osu.Game/Users/CountryCode.cs
@@ -2,11 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-
-// ReSharper disable InconsistentNaming
 
 namespace osu.Game.Users
 {
@@ -14,6 +13,7 @@ namespace osu.Game.Users
     /// Matches `osu_countries` database table.
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public enum CountryCode
     {

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -340,6 +340,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ARGB/@EntryIndexedValue">ARGB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BPM/@EntryIndexedValue">BPM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DDKK/@EntryIndexedValue">DDKK</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EF/@EntryIndexedValue">EF</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FPS/@EntryIndexedValue">FPS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GC/@EntryIndexedValue">GC</s:String>
@@ -357,6 +358,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JIT/@EntryIndexedValue">JIT</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KDDK/@EntryIndexedValue">KDDK</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KKDD/@EntryIndexedValue">KKDD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LTRB/@EntryIndexedValue">LTRB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NS/@EntryIndexedValue">NS</s:String>
@@ -375,6 +378,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QAT/@EntryIndexedValue">QAT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BNG/@EntryIndexedValue">BNG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=WIP/@EntryIndexedValue">WIP</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;


### PR DESCRIPTION
All enum fields by default should follow the pascal-case naming style, unless there's a specific reason not to (e.g. p/invoke).

If an enum field is named after a specific abbreviation, said abbreviation should be added to rider configuration in this manner:

![CleanShot 2024-05-01 at 17 29 07](https://github.com/ppy/osu/assets/22781491/9c407c72-156b-491c-a96a-b9039472181a)

There are existing fields in general that can benefit from the abbreviation feature (e.g. `HpDrain`), but I've abstained from including them here.