### PR TITLE
Remove `Passed` flag from score classes

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneScoreProcessor.cs
@@ -138,7 +138,6 @@ namespace osu.Game.Tests.Gameplay
             scoreProcessor.FailScore(score);
 
             Assert.That(score.Rank, Is.EqualTo(ScoreRank.F));
-            Assert.That(score.Passed, Is.False);
             Assert.That(score.Statistics.Sum(kvp => kvp.Value), Is.EqualTo(4));
             Assert.That(score.MaximumStatistics.Sum(kvp => kvp.Value), Is.EqualTo(8));
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerScoreSubmission.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
-            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == true);
+            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Rank != ScoreRank.F);
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
-            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == true);
+            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Rank != ScoreRank.F);
             AddAssert("submitted score has correct ruleset ID", () => Player.SubmittedScore?.ScoreInfo.Ruleset.ShortName == new TaikoRuleset().RulesetInfo.ShortName);
         }
 
@@ -141,7 +141,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("seek to completion", () => Player.GameplayClockContainer.Seek(Player.DrawableRuleset.Objects.Last().GetEndTime()));
 
             AddUntilStep("results displayed", () => Player.GetChildScreen() is ResultsScreen);
-            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Passed == true);
+            AddAssert("ensure passing submission", () => Player.SubmittedScore?.ScoreInfo.Rank != ScoreRank.F);
             AddAssert("submitted score has correct ruleset ID", () => Player.SubmittedScore?.ScoreInfo.Ruleset.ShortName == new ManiaRuleset().RulesetInfo.ShortName);
         }
 
@@ -191,7 +191,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("wait for fail", () => Player.GameplayState.HasFailed);
 
             AddUntilStep("wait for submission", () => Player.SubmittedScore != null);
-            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Passed == false);
+            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Rank == ScoreRank.F);
         }
 
         [Test]
@@ -221,7 +221,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("exit", () => Player.Exit());
 
             AddUntilStep("wait for submission", () => Player.SubmittedScore != null);
-            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Passed == false);
+            AddAssert("ensure failing submission", () => Player.SubmittedScore.ScoreInfo.Rank == ScoreRank.F);
         }
 
         [Test]
@@ -342,7 +342,6 @@ namespace osu.Game.Tests.Visual.Gameplay
                                     MaxCombo = requestScore.MaxCombo,
                                     Mods = requestScore.Mods,
                                     Statistics = requestScore.Statistics,
-                                    Passed = requestScore.Passed,
                                     EndedAt = DateTimeOffset.Now,
                                     Position = 1
                                 });

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -694,12 +694,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddUntilStep("wait for results", () => multiplayerComponents.CurrentScreen is ResultsScreen);
 
-            AddAssert("check is fail", () =>
-            {
-                var scoreInfo = ((ResultsScreen)multiplayerComponents.CurrentScreen).Score;
-
-                return scoreInfo?.Passed == false && scoreInfo.Rank == ScoreRank.F;
-            });
+            AddAssert("check is fail", () => ((ResultsScreen)multiplayerComponents.CurrentScreen).Score?.Rank == ScoreRank.F);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -292,7 +292,6 @@ namespace osu.Game.Tests.Visual.Playlists
             {
                 ID = highestScoreId,
                 Accuracy = userScore.Accuracy,
-                Passed = userScore.Passed,
                 Rank = userScore.Rank,
                 Position = real_user_position,
                 MaxCombo = userScore.MaxCombo,
@@ -312,7 +311,6 @@ namespace osu.Game.Tests.Visual.Playlists
                 {
                     ID = getNextLowestScoreId(),
                     Accuracy = userScore.Accuracy,
-                    Passed = true,
                     Rank = userScore.Rank,
                     MaxCombo = userScore.MaxCombo,
                     User = new APIUser
@@ -327,7 +325,6 @@ namespace osu.Game.Tests.Visual.Playlists
                 {
                     ID = getNextHighestScoreId(),
                     Accuracy = userScore.Accuracy,
-                    Passed = true,
                     Rank = userScore.Rank,
                     MaxCombo = userScore.MaxCombo,
                     User = new APIUser
@@ -361,7 +358,6 @@ namespace osu.Game.Tests.Visual.Playlists
                 {
                     ID = sort == "score_asc" ? getNextHighestScoreId() : getNextLowestScoreId(),
                     Accuracy = 1,
-                    Passed = true,
                     Rank = ScoreRank.X,
                     MaxCombo = 1000,
                     User = new APIUser

--- a/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
+++ b/osu.Game/Online/API/Requests/Responses/SoloScoreInfo.cs
@@ -27,9 +27,6 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("build_id")]
         public int? BuildID { get; set; }
 
-        [JsonProperty("passed")]
-        public bool Passed { get; set; }
-
         [JsonProperty("total_score")]
         public long TotalScore { get; set; }
 
@@ -204,7 +201,6 @@ namespace osu.Game.Online.API.Requests.Responses
                 User = User ?? new APIUser { Id = UserID },
                 BeatmapInfo = new BeatmapInfo { OnlineID = BeatmapID },
                 Ruleset = new RulesetInfo { OnlineID = RulesetID },
-                Passed = Passed,
                 TotalScore = TotalScore,
                 LegacyTotalScore = LegacyTotalScore,
                 Accuracy = Accuracy,
@@ -243,7 +239,6 @@ namespace osu.Game.Online.API.Requests.Responses
             PP = score.PP,
             MaxCombo = score.MaxCombo,
             RulesetID = score.RulesetID,
-            Passed = score.Passed,
             Mods = score.APIMods,
             Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -46,9 +46,6 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics = new Dictionary<HitResult, int>();
 
-        [JsonProperty("passed")]
-        public bool Passed { get; set; }
-
         [JsonProperty("ended_at")]
         public DateTimeOffset EndedAt { get; set; }
 

--- a/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/PerformanceBreakdownCalculator.cs
@@ -59,7 +59,6 @@ namespace osu.Game.Rulesets.Difficulty
                 Ruleset ruleset = score.Ruleset.CreateInstance();
                 ScoreInfo perfectPlay = score.DeepClone();
                 perfectPlay.Accuracy = 1;
-                perfectPlay.Passed = true;
 
                 // calculate max combo
                 // todo: Get max combo from difficulty calculator instead when diffcalc properly supports lazer-first scores

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -457,9 +457,7 @@ namespace osu.Game.Rulesets.Scoring
             if (Rank.Value == ScoreRank.F)
                 return;
 
-            score.Passed = false;
             rank.Value = ScoreRank.F;
-
             PopulateScore(score);
         }
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -229,9 +229,6 @@ namespace osu.Game.Scoring
             return clone;
         }
 
-        [Ignored]
-        public bool Passed { get; set; } = true;
-
         public int Combo { get; set; }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -126,7 +126,6 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                         ID = currentScoreId++,
                         Accuracy = 1,
                         EndedAt = DateTimeOffset.Now,
-                        Passed = true,
                         Rank = ScoreRank.S,
                         MaxCombo = 1000,
                         TotalScore = 1000000,


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27864
- [ ] Check all consumers of `SoloScoreInfo`/`MultiplayerScore` no longer rely on the now-removed `passed` flag (replace with `rank != F`).

I'm not sure how to go about doing the above myself so I'm leaving it as a task for others to tick off.