### PR TITLE
Preserve score rank on lazer scores during encode/decode

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreDecoderTest.cs
@@ -352,6 +352,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 [HitResult.Great] = 200,
                 [HitResult.LargeTickHit] = 1,
             };
+            scoreInfo.Rank = ScoreRank.A;
 
             var beatmap = new TestBeatmap(ruleset);
             var score = new Score

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyScoreEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyScoreEncoderTest.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
         [TestCase(1, 3)]
         [TestCase(1, 0)]
         [TestCase(0, 3)]
-        public void CatchMergesFruitAndDropletMisses(int missCount, int largeTickMissCount)
+        public void TestCatchMergesFruitAndDropletMisses(int missCount, int largeTickMissCount)
         {
             var ruleset = new CatchRuleset().RulesetInfo;
             var scoreInfo = TestResources.CreateTestScoreInfo(ruleset);
@@ -41,7 +41,22 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
-        public void ScoreWithMissIsNotPerfect()
+        public void TestFailPreserved()
+        {
+            var ruleset = new OsuRuleset().RulesetInfo;
+            var scoreInfo = TestResources.CreateTestScoreInfo();
+            var beatmap = new TestBeatmap(ruleset);
+
+            scoreInfo.Rank = ScoreRank.F;
+
+            var score = new Score { ScoreInfo = scoreInfo };
+            var decodedAfterEncode = encodeThenDecode(LegacyBeatmapDecoder.LATEST_VERSION, score, beatmap);
+
+            Assert.That(decodedAfterEncode.ScoreInfo.Rank, Is.EqualTo(ScoreRank.F));
+        }
+
+        [Test]
+        public void TestScoreWithMissIsNotPerfect()
         {
             var ruleset = new OsuRuleset().RulesetInfo;
             var scoreInfo = TestResources.CreateTestScoreInfo(ruleset);

--- a/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
+++ b/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Scoring;
@@ -38,6 +39,10 @@ namespace osu.Game.Scoring.Legacy
         [JsonProperty("client_version")]
         public string ClientVersion = string.Empty;
 
+        [JsonProperty("rank")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ScoreRank? Rank;
+
         public static LegacyReplaySoloScoreInfo FromScore(ScoreInfo score) => new LegacyReplaySoloScoreInfo
         {
             OnlineID = score.OnlineID,
@@ -45,6 +50,7 @@ namespace osu.Game.Scoring.Legacy
             Statistics = score.Statistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             MaximumStatistics = score.MaximumStatistics.Where(kvp => kvp.Value != 0).ToDictionary(),
             ClientVersion = score.ClientVersion,
+            Rank = score.Rank,
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Scoring.Legacy
             };
 
             WorkingBeatmap workingBeatmap;
+            ScoreRank? decodedRank = null;
 
             using (SerializationReader sr = new SerializationReader(stream))
             {
@@ -129,6 +130,7 @@ namespace osu.Game.Scoring.Legacy
                         score.ScoreInfo.MaximumStatistics = readScore.MaximumStatistics;
                         score.ScoreInfo.Mods = readScore.Mods.Select(m => m.ToMod(currentRuleset)).ToArray();
                         score.ScoreInfo.ClientVersion = readScore.ClientVersion;
+                        decodedRank = readScore.Rank;
                     });
                 }
             }
@@ -139,6 +141,9 @@ namespace osu.Game.Scoring.Legacy
                 score.ScoreInfo.LegacyTotalScore = score.ScoreInfo.TotalScore;
 
             StandardisedScoreMigrationTools.UpdateFromLegacy(score.ScoreInfo, workingBeatmap);
+
+            if (decodedRank != null)
+                score.ScoreInfo.Rank = decodedRank.Value;
 
             // before returning for database import, we must restore the database-sourced BeatmapInfo.
             // if not, the clone operation in GetPlayableBeatmap will cause a dereference and subsequent database exception.


### PR DESCRIPTION
- https://github.com/ppy/osu/issues/27865

The `Rank` property is marked nullable for compatibility with previous lazer scores, to indicate to the decoder that the rank is unknown. I can achieve the same by defining a new score version and checking against it instead, but I'm not sure that's necessary.