### PR TITLE
Don't hide playfield layer with HUD

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -171,7 +171,7 @@ namespace osu.Game.Screens.Play
                 },
             };
 
-            hideTargets = new List<Drawable> { mainComponents, playfieldComponents, topRightElements };
+            hideTargets = new List<Drawable> { mainComponents, topRightElements };
 
             if (rulesetComponents != null)
                 hideTargets.Add(rulesetComponents);


### PR DESCRIPTION
Touched on in https://github.com/ppy/osu/issues/12039. I think this makes sense - things which are attached to the playfield are expected to always be attached and not disappear. Something like an osu!mania health bar.

This gives users a way to make elements always display (regardless of the HUD hide setting) which is also cool.
