### PR TITLE
Fix changing distance spacing multiplier hiding the distance snap grid when it's already shown

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles;
 using osu.Game.Tests.Visual;
@@ -52,6 +53,30 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+        }
+
+        [Test]
+        public void TestDistanceSnapAdjustDoesNotHideTheGrid()
+        {
+            double distanceSnap = double.PositiveInfinity;
+
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
+
+            AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("store distance snap", () => distanceSnap = this.ChildrenOfType<IDistanceSnapProvider>().First().DistanceSpacingMultiplier.Value);
+
+            AddStep("increase distance", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.ScrollVerticalBy(1);
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.AltLeft);
+            });
+
+            AddUntilStep("distance snap increased", () => this.ChildrenOfType<IDistanceSnapProvider>().First().DistanceSpacingMultiplier.Value, () => Is.GreaterThan(distanceSnap));
+            AddUntilStep("distance snap grid still visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
         }
 
         [Test]

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditorGrids.cs
@@ -53,10 +53,17 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
             AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
             AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+
+            AddStep("enable distance snap grid", () => InputManager.Key(Key.T));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("hold alt", () => InputManager.PressKey(Key.AltLeft));
+            AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("release alt", () => InputManager.ReleaseKey(Key.AltLeft));
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
         }
 
         [Test]
-        public void TestDistanceSnapAdjustDoesNotHideTheGrid()
+        public void TestDistanceSnapAdjustDoesNotHideTheGridIfStartingEnabled()
         {
             double distanceSnap = double.PositiveInfinity;
 
@@ -77,6 +84,34 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
             AddUntilStep("distance snap increased", () => this.ChildrenOfType<IDistanceSnapProvider>().First().DistanceSpacingMultiplier.Value, () => Is.GreaterThan(distanceSnap));
             AddUntilStep("distance snap grid still visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+        }
+
+        [Test]
+        public void TestDistanceSnapAdjustShowsGridMomentarilyIfStartingDisabled()
+        {
+            double distanceSnap = double.PositiveInfinity;
+
+            AddStep("select second object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects.ElementAt(1)));
+            AddUntilStep("distance snap grid hidden", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+            AddStep("store distance snap", () => distanceSnap = this.ChildrenOfType<IDistanceSnapProvider>().First().DistanceSpacingMultiplier.Value);
+
+            AddStep("start increasing distance", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.PressKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("distance snap grid visible", () => this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
+
+            AddStep("finish increasing distance", () =>
+            {
+                InputManager.ScrollVerticalBy(1);
+                InputManager.ReleaseKey(Key.ControlLeft);
+                InputManager.ReleaseKey(Key.AltLeft);
+            });
+
+            AddUntilStep("distance snap increased", () => this.ChildrenOfType<IDistanceSnapProvider>().First().DistanceSpacingMultiplier.Value, () => Is.GreaterThan(distanceSnap));
+            AddUntilStep("distance snap hidden in the end", () => !this.ChildrenOfType<OsuDistanceSnapGrid>().Any());
         }
 
         [Test]

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Rulesets.Edit
         public readonly Bindable<TernaryState> DistanceSnapToggle = new Bindable<TernaryState>();
 
         private bool distanceSnapMomentary;
+        private TernaryState? distanceSnapStateBeforeMomentaryToggle;
 
         private EditorToolboxGroup? toolboxGroup;
 
@@ -213,10 +214,19 @@ namespace osu.Game.Rulesets.Edit
         {
             bool altPressed = key.AltPressed;
 
-            if (altPressed != distanceSnapMomentary)
+            if (altPressed && !distanceSnapMomentary)
             {
-                distanceSnapMomentary = altPressed;
+                distanceSnapStateBeforeMomentaryToggle = DistanceSnapToggle.Value;
                 DistanceSnapToggle.Value = DistanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                distanceSnapMomentary = true;
+            }
+
+            if (!altPressed && distanceSnapMomentary)
+            {
+                Debug.Assert(distanceSnapStateBeforeMomentaryToggle != null);
+                DistanceSnapToggle.Value = distanceSnapStateBeforeMomentaryToggle.Value;
+                distanceSnapStateBeforeMomentaryToggle = null;
+                distanceSnapMomentary = false;
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28042.

Please see tests or video below for intended behaviour.

https://github.com/ppy/osu/assets/20418176/fd7f29cc-79dd-4db5-b2ba-f8c0e7da992a

