### PR TITLE
Fix beatmap listing cards being far too large

### DIFF
--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -198,6 +198,7 @@ namespace osu.Game.Overlays
         {
             c.Anchor = Anchor.TopCentre;
             c.Origin = Anchor.TopCentre;
+            c.Scale = new Vector2(0.8f);
         })).ToArray();
 
         private static ReverseChildIDFillFlowContainer<BeatmapCard> createCardContainerFor(IEnumerable<BeatmapCard> newCards)


### PR DESCRIPTION
I'm going to start fixing these locally to the screens/elements which look out of place, one at a time.

| Before | After |
| :---: | :---: |
| ![old](https://github.com/ppy/osu/assets/191335/f6133718-4fbc-4dc6-bd62-73c299b15825) | ![new](https://github.com/ppy/osu/assets/191335/80d1048b-b225-48dd-9b6d-d45d7b6b21fc) |


