### PR TITLE
Stop using visually noisy `bg4` for default backgrounds

### DIFF
--- a/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/DummyWorkingBeatmap.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Beatmaps
 
         protected override IBeatmap GetBeatmap() => new Beatmap();
 
-        public override Texture GetBackground() => textures?.Get(@"Backgrounds/bg4");
+        public override Texture GetBackground() => textures?.Get(@"Backgrounds/bg2");
 
         protected override Track GetBeatmapTrack() => GetVirtualTrack();
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -422,7 +422,7 @@ namespace osu.Game.Overlays
             [BackgroundDependencyLoader]
             private void load(LargeTextureStore textures)
             {
-                sprite.Texture = beatmap.GetBackground() ?? textures.Get(@"Backgrounds/bg4");
+                sprite.Texture = beatmap.GetBackground() ?? textures.Get(@"Backgrounds/bg2");
             }
         }
 


### PR DESCRIPTION
This has always really annoyed me. The illustration doesn't match what the background is visualising (a fallback when nothing else is available).

| Before | After |
| :---: | :---: |
| ![2024-05-03 13 39 22@2x](https://github.com/ppy/osu/assets/191335/172e0385-8043-4cc1-a1f8-6b1bc794bf4a) | ![2024-05-03 13 39 04@2x](https://github.com/ppy/osu/assets/191335/680ef999-129b-4589-9fc7-69506ddcbfa4)  |