### PR TITLE
Fix beatmap backgrounds loading default briefly before final display

### DIFF
--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -56,7 +56,7 @@ namespace osu.Game.Beatmaps.Drawables
                 return Empty();
 
             // prefer online cover where available.
-            if (model?.BeatmapSet is IBeatmapSetOnlineInfo online)
+            if (model.BeatmapSet is IBeatmapSetOnlineInfo online)
                 return new OnlineBeatmapSetCover(online, beatmapSetCoverType);
 
             if (model is BeatmapInfo localModel)

--- a/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
+++ b/osu.Game/Beatmaps/Drawables/UpdateableBeatmapBackgroundSprite.cs
@@ -52,6 +52,9 @@ namespace osu.Game.Beatmaps.Drawables
 
         private Drawable getDrawableForModel(IBeatmapInfo? model)
         {
+            if (model == null)
+                return Empty();
+
             // prefer online cover where available.
             if (model?.BeatmapSet is IBeatmapSetOnlineInfo online)
                 return new OnlineBeatmapSetCover(online, beatmapSetCoverType);


### PR DESCRIPTION
Due to the way `ModelBackedDrawable` works, the default starts to get loaded even though a final `Beatmap` has been set. This avoids loading the default fallback unless a beatmap has been set (and has no background itself).

| Before | After |
| :---: | :---: |
| ![2024-05-03 13 47 07](https://github.com/ppy/osu/assets/191335/e66d2390-db9c-452c-9c7f-6197c37d7559) | ![2024-05-03 13 46 04](https://github.com/ppy/osu/assets/191335/8383fde2-c855-4102-8de1-98f813db7a68) |