### PR TITLE
Better signify private rooms by showing a different status pill design

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneDrawableRoom.cs
@@ -69,8 +69,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         }),
                         createLoungeRoom(new Room
                         {
-                            Name = { Value = "Multiplayer room" },
-                            Status = { Value = new RoomStatusOpen() },
+                            Name = { Value = "Private room" },
+                            Status = { Value = new RoomStatusOpenPrivate() },
+                            HasPassword = { Value = true },
                             EndDate = { Value = DateTimeOffset.Now.AddDays(1) },
                             Type = { Value = MatchType.HeadToHead },
                             Playlist =

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -396,7 +396,7 @@ namespace osu.Game.Online.Multiplayer
                 switch (state)
                 {
                     case MultiplayerRoomState.Open:
-                        APIRoom.Status.Value = new RoomStatusOpen();
+                        APIRoom.Status.Value = APIRoom.HasPassword.Value ? new RoomStatusOpenPrivate() : new RoomStatusOpen();
                         break;
 
                     case MultiplayerRoomState.Playing:

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -816,6 +816,7 @@ namespace osu.Game.Online.Multiplayer
             Room.Settings = settings;
             APIRoom.Name.Value = Room.Settings.Name;
             APIRoom.Password.Value = Room.Settings.Password;
+            APIRoom.Status.Value = string.IsNullOrEmpty(Room.Settings.Password) ? new RoomStatusOpen() : new RoomStatusOpenPrivate();
             APIRoom.Type.Value = Room.Settings.MatchType;
             APIRoom.QueueMode.Value = Room.Settings.QueueMode;
             APIRoom.AutoStartDuration.Value = Room.Settings.AutoStartDuration;

--- a/osu.Game/Online/Rooms/GetRoomsRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomsRequest.cs
@@ -46,6 +46,8 @@ namespace osu.Game.Online.Rooms
                 {
                     if (room.EndDate.Value != null && DateTimeOffset.Now >= room.EndDate.Value)
                         room.Status.Value = new RoomStatusEnded();
+                    else if (room.HasPassword.Value)
+                        room.Status.Value = new RoomStatusOpenPrivate();
                     else
                         room.Status.Value = new RoomStatusOpen();
                 }

--- a/osu.Game/Online/Rooms/GetRoomsRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomsRequest.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.IO.Network;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
+using osu.Game.Online.Rooms.RoomStatuses;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 
 namespace osu.Game.Online.Rooms
@@ -31,6 +33,23 @@ namespace osu.Game.Online.Rooms
                 req.AddParameter("category", category);
 
             return req;
+        }
+
+        protected override void PostProcess()
+        {
+            base.PostProcess();
+
+            if (Response != null)
+            {
+                // API doesn't populate status so let's do it here.
+                foreach (var room in Response)
+                {
+                    if (room.EndDate.Value != null && DateTimeOffset.Now >= room.EndDate.Value)
+                        room.Status.Value = new RoomStatusEnded();
+                    else
+                        room.Status.Value = new RoomStatusOpen();
+                }
+            }
         }
 
         protected override string Target => "rooms";

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -111,7 +111,6 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("current_user_score")]
         public readonly Bindable<PlaylistAggregateScore> UserScore = new Bindable<PlaylistAggregateScore>();
 
-        [Cached]
         [JsonProperty("has_password")]
         public readonly Bindable<bool> HasPassword = new Bindable<bool>();
 

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -111,8 +111,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("current_user_score")]
         public readonly Bindable<PlaylistAggregateScore> UserScore = new Bindable<PlaylistAggregateScore>();
 
+        [Cached]
         [JsonProperty("has_password")]
-        public readonly BindableBool HasPassword = new BindableBool();
+        public readonly Bindable<bool> HasPassword = new Bindable<bool>();
 
         [Cached]
         [JsonProperty("recent_participants")]
@@ -200,9 +201,6 @@ namespace osu.Game.Online.Rooms
             PlaylistItemStats.Value = other.PlaylistItemStats.Value;
             CurrentPlaylistItem.Value = other.CurrentPlaylistItem.Value;
             AutoSkip.Value = other.AutoSkip.Value;
-
-            if (EndDate.Value != null && DateTimeOffset.Now >= EndDate.Value)
-                Status.Value = new RoomStatusEnded();
 
             other.RemoveExpiredPlaylistItems();
 

--- a/osu.Game/Online/Rooms/RoomStatuses/RoomStatusOpenPrivate.cs
+++ b/osu.Game/Online/Rooms/RoomStatuses/RoomStatusOpenPrivate.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Graphics;
+using osuTK.Graphics;
+
+namespace osu.Game.Online.Rooms.RoomStatuses
+{
+    public class RoomStatusOpenPrivate : RoomStatus
+    {
+        public override string Message => "Open (Private)";
+        public override Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDark;
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomStatusPill.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomStatusPill.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
-using osu.Game.Online.Rooms.RoomStatuses;
 
 namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 {
@@ -36,18 +34,10 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         private void updateDisplay()
         {
-            RoomStatus status = getDisplayStatus();
+            RoomStatus status = Status.Value;
 
             Pill.Background.FadeColour(status.GetAppropriateColour(colours), 100);
             TextFlow.Text = status.Message;
-        }
-
-        private RoomStatus getDisplayStatus()
-        {
-            if (EndDate.Value < DateTimeOffset.Now)
-                return new RoomStatusEnded();
-
-            return Status.Value;
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -78,6 +78,9 @@ namespace osu.Game.Screens.OnlinePlay
         public Bindable<string> Password { get; private set; }
 
         [Resolved(typeof(Room))]
+        public Bindable<bool> HasPassword { get; private set; }
+
+        [Resolved(typeof(Room))]
         protected Bindable<TimeSpan?> Duration { get; private set; }
 
         [Resolved(typeof(Room))]

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -78,9 +78,6 @@ namespace osu.Game.Screens.OnlinePlay
         public Bindable<string> Password { get; private set; }
 
         [Resolved(typeof(Room))]
-        public Bindable<bool> HasPassword { get; private set; }
-
-        [Resolved(typeof(Room))]
         protected Bindable<TimeSpan?> Duration { get; private set; }
 
         [Resolved(typeof(Room))]


### PR DESCRIPTION
Also tidies up handling of this status update code as best can be without larger refactors.

![2024-05-03 17 17 28@2x](https://github.com/ppy/osu/assets/191335/da235370-5020-46ba-91b0-b014b2acff12)
