### PR TITLE
Do not lookup usernames for scores without an online ID

### DIFF
--- a/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
+++ b/osu.Game.Tests/Scores/IO/ImportScoreTest.cs
@@ -15,6 +15,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.IO.Archives;
 using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Tests.Beatmaps.IO;
 using osu.Game.Tests.Resources;
+using osu.Game.Users;
 
 namespace osu.Game.Tests.Scores.IO
 {
@@ -276,6 +278,196 @@ namespace osu.Game.Tests.Scores.IO
                         BeatmapInfo = beatmap.Beatmaps.First(),
                         OnlineID = 2
                     }));
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
+        public void TestUserLookedUpForOnlineScore()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = LoadOsuIntoHost(host, true);
+
+                    var api = (DummyAPIAccess)osu.API;
+                    api.HandleRequest = req =>
+                    {
+                        switch (req)
+                        {
+                            case GetUserRequest userRequest:
+                                userRequest.TriggerSuccess(new APIUser
+                                {
+                                    Username = "Test user",
+                                    CountryCode = CountryCode.JP,
+                                    Id = 1234
+                                });
+                                return true;
+
+                            default:
+                                return false;
+                        }
+                    };
+
+                    var beatmap = BeatmapImportHelper.LoadOszIntoOsu(osu, TestResources.GetQuickTestBeatmapForImport()).GetResultSafely();
+
+                    var toImport = new ScoreInfo
+                    {
+                        Rank = ScoreRank.B,
+                        TotalScore = 987654,
+                        Accuracy = 0.8,
+                        MaxCombo = 500,
+                        Combo = 250,
+                        User = new APIUser { Username = "Test user" },
+                        Date = DateTimeOffset.Now,
+                        OnlineID = 12345,
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                        BeatmapInfo = beatmap.Beatmaps.First()
+                    };
+
+                    var imported = LoadScoreIntoOsu(osu, toImport);
+
+                    Assert.AreEqual(toImport.Rank, imported.Rank);
+                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
+                    Assert.AreEqual(toImport.Date, imported.Date);
+                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    Assert.AreEqual(1234, imported.RealmUser.OnlineID);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
+        public void TestUserLookedUpForLegacyOnlineScore()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = LoadOsuIntoHost(host, true);
+
+                    var api = (DummyAPIAccess)osu.API;
+                    api.HandleRequest = req =>
+                    {
+                        switch (req)
+                        {
+                            case GetUserRequest userRequest:
+                                userRequest.TriggerSuccess(new APIUser
+                                {
+                                    Username = "Test user",
+                                    CountryCode = CountryCode.JP,
+                                    Id = 1234
+                                });
+                                return true;
+
+                            default:
+                                return false;
+                        }
+                    };
+
+                    var beatmap = BeatmapImportHelper.LoadOszIntoOsu(osu, TestResources.GetQuickTestBeatmapForImport()).GetResultSafely();
+
+                    var toImport = new ScoreInfo
+                    {
+                        Rank = ScoreRank.B,
+                        TotalScore = 987654,
+                        Accuracy = 0.8,
+                        MaxCombo = 500,
+                        Combo = 250,
+                        User = new APIUser { Username = "Test user" },
+                        Date = DateTimeOffset.Now,
+                        LegacyOnlineID = 12345,
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                        BeatmapInfo = beatmap.Beatmaps.First()
+                    };
+
+                    var imported = LoadScoreIntoOsu(osu, toImport);
+
+                    Assert.AreEqual(toImport.Rank, imported.Rank);
+                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
+                    Assert.AreEqual(toImport.Date, imported.Date);
+                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    Assert.AreEqual(1234, imported.RealmUser.OnlineID);
+                }
+                finally
+                {
+                    host.Exit();
+                }
+            }
+        }
+
+        [Test]
+        public void TestUserNotLookedUpForOfflineScore()
+        {
+            using (HeadlessGameHost host = new CleanRunHeadlessGameHost())
+            {
+                try
+                {
+                    var osu = LoadOsuIntoHost(host, true);
+
+                    var api = (DummyAPIAccess)osu.API;
+                    api.HandleRequest = req =>
+                    {
+                        switch (req)
+                        {
+                            case GetUserRequest userRequest:
+                                userRequest.TriggerSuccess(new APIUser
+                                {
+                                    Username = "Test user",
+                                    CountryCode = CountryCode.JP,
+                                    Id = 1234
+                                });
+                                return true;
+
+                            default:
+                                return false;
+                        }
+                    };
+
+                    var beatmap = BeatmapImportHelper.LoadOszIntoOsu(osu, TestResources.GetQuickTestBeatmapForImport()).GetResultSafely();
+
+                    var toImport = new ScoreInfo
+                    {
+                        Rank = ScoreRank.B,
+                        TotalScore = 987654,
+                        Accuracy = 0.8,
+                        MaxCombo = 500,
+                        Combo = 250,
+                        User = new APIUser { Username = "Test user" },
+                        Date = DateTimeOffset.Now,
+                        OnlineID = -1,
+                        LegacyOnlineID = -1,
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                        BeatmapInfo = beatmap.Beatmaps.First()
+                    };
+
+                    var imported = LoadScoreIntoOsu(osu, toImport);
+
+                    Assert.AreEqual(toImport.Rank, imported.Rank);
+                    Assert.AreEqual(toImport.TotalScore, imported.TotalScore);
+                    Assert.AreEqual(toImport.Accuracy, imported.Accuracy);
+                    Assert.AreEqual(toImport.MaxCombo, imported.MaxCombo);
+                    Assert.AreEqual(toImport.User.Username, imported.User.Username);
+                    Assert.AreEqual(toImport.Date, imported.Date);
+                    Assert.AreEqual(toImport.OnlineID, imported.OnlineID);
+                    Assert.AreEqual(toImport.User.Username, imported.RealmUser.Username);
+                    Assert.That(imported.RealmUser.OnlineID, Is.LessThanOrEqualTo(1));
                 }
                 finally
                 {

--- a/osu.Game/Scoring/ScoreImporter.cs
+++ b/osu.Game/Scoring/ScoreImporter.cs
@@ -127,6 +127,9 @@ namespace osu.Game.Scoring
             if (model.RealmUser.OnlineID == APIUser.SYSTEM_USER_ID)
                 return;
 
+            if (model.OnlineID < 0 && model.LegacyOnlineID <= 0)
+                return;
+
             string username = model.RealmUser.Username;
 
             if (usernameLookupCache.TryGetValue(username, out var existing))


### PR DESCRIPTION
RFC. This would be the first step towards addressing https://github.com/ppy/osu/issues/24624.

I'd be fine with adding `user_id` to the replay export as proposed in https://github.com/ppy/osu/issues/24624#issuecomment-1918401500, but I'd see that a secondary measure after this, because adding anything to replay is only going to fix any replays set after we deploy that change, and if we only start using that as a source of truth, that means that no scores prior to that will get linked back to their corresponding users, both stable _and_ lazer, which feels like throwing the baby out with the bathwater.

If you're so inclined, you can use [this zip](https://github.com/ppy/osu/files/15199880/tests.zip) for some real-world testing. Note that you will need to use the production endpoints.