### PR TITLE
Fix `BeatmapAttributeText` breaking due to enum serialisation woes

### DIFF
--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -125,6 +125,8 @@ namespace osu.Game.Skinning.Components
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
     }
 
+    // WARNING: DO NOT ADD ANY VALUES TO THIS ENUM ANYWHERE ELSE THAN AT THE END.
+    // Doing so will break existing user skins.
     public enum BeatmapAttribute
     {
         CircleSize,
@@ -134,11 +136,11 @@ namespace osu.Game.Skinning.Components
         StarRating,
         Title,
         Artist,
-        Source,
         DifficultyName,
         Creator,
         Length,
         RankedStatus,
         BPM,
+        Source,
     }
 }


### PR DESCRIPTION
See https://github.com/ppy/osu/pull/27978#issuecomment-2092896536.

Minimal viable fix. I considered putting `StringEnumConverter` on the thing but I dunno. It would prevent this issue from happening going forward but then we probably would have to maintain the warning about not putting things in the middle for the next 6 months minimum _and_ add another one to avoid renaming the enum members too. Explicit mapping maybe?