### PR TITLE
Activate stateful menu items with right-click without closing the menu

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneStatefulMenuItem.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneStatefulMenuItem.cs
@@ -115,6 +115,51 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestItemRespondsToRightClick()
+        {
+            OsuMenu menu = null;
+
+            Bindable<TernaryState> state = new Bindable<TernaryState>(TernaryState.Indeterminate);
+
+            AddStep("create menu", () =>
+            {
+                state.Value = TernaryState.Indeterminate;
+
+                Child = menu = new OsuMenu(Direction.Vertical, true)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Items = new[]
+                    {
+                        new TernaryStateToggleMenuItem("First"),
+                        new TernaryStateToggleMenuItem("Second") { State = { BindTarget = state } },
+                        new TernaryStateToggleMenuItem("Third") { State = { Value = TernaryState.True } },
+                    }
+                };
+            });
+
+            checkState(TernaryState.Indeterminate);
+
+            click();
+            checkState(TernaryState.True);
+
+            click();
+            checkState(TernaryState.False);
+
+            AddStep("change state via bindable", () => state.Value = TernaryState.True);
+
+            void click() =>
+                AddStep("click", () =>
+                {
+                    InputManager.MoveMouseTo(menu.ScreenSpaceDrawQuad.Centre);
+                    InputManager.Click(MouseButton.Right);
+                });
+
+            void checkState(TernaryState expected)
+                => AddAssert($"state is {expected}", () => state.Value == expected);
+        }
+
+        [Test]
         public void TestCustomState()
         {
             AddStep("create menu", () =>

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -4,6 +4,8 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osuTK.Input;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
@@ -19,8 +21,16 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override TextContainer CreateTextContainer() => new ToggleTextContainer(Item);
 
+        protected override bool OnMouseDown(MouseDownEvent e)
         {
+            if (!IsActionable)
+                return true;
 
+            if (e.Button != MouseButton.Right)
+                return true;
+
+            Item.Action.Value?.Invoke();
+            return true;
         }
 
         private partial class ToggleTextContainer : TextContainer

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -2,11 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osuTK.Input;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Graphics.UserInterface
 {

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -2,9 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Input;
+using osu.Framework.Graphics;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
@@ -20,15 +19,8 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override TextContainer CreateTextContainer() => new ToggleTextContainer(Item);
 
-        private InputManager inputManager = null!;
-
-        public override bool CloseMenuOnClick => !inputManager.CurrentState.Keyboard.ControlPressed;
-
-        protected override void LoadComplete()
         {
-            base.LoadComplete();
 
-            inputManager = GetContainingInputManager();
         }
 
         private partial class ToggleTextContainer : TextContainer

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -23,13 +23,11 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (!IsActionable)
-                return true;
+            // Right mouse button is a special case where we allow actioning without dismissing the menu.
+            // This is achieved by not calling `Clicked` (as done by the base implementation in OnClick).
+            if (IsActionable && e.Button == MouseButton.Right)
+                Item.Action.Value?.Invoke();
 
-            if (e.Button != MouseButton.Right)
-                return true;
-
-            Item.Action.Value?.Invoke();
             return true;
         }
 

--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterface
@@ -18,6 +19,17 @@ namespace osu.Game.Graphics.UserInterface
         }
 
         protected override TextContainer CreateTextContainer() => new ToggleTextContainer(Item);
+
+        private InputManager inputManager = null!;
+
+        public override bool CloseMenuOnClick => !inputManager.CurrentState.Keyboard.ControlPressed;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inputManager = GetContainingInputManager();
+        }
 
         private partial class ToggleTextContainer : TextContainer
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/10255

This is a feature I first saw implemented in [SerenityOS](https://github.com/SerenityOS/serenity). It is for example usefull, when the user wants to add a beatmap to multiple collections in a multiplayer lobby.
[menu.webm](https://github.com/ppy/osu/assets/37748408/2b3001e5-9f7b-4a13-b952-b5991b5e7bef)

