### PR TITLE
Automatically choose origin (along with anchor) to make skin editor placement easier for users

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinBlueprint.cs
@@ -40,7 +40,9 @@ namespace osu.Game.Overlays.SkinEditor
 
         public override bool Contains(Vector2 screenSpacePos) => drawableQuad.Contains(screenSpacePos);
 
-        public override Vector2 ScreenSpaceSelectionPoint => drawable.ToScreenSpace(drawable.OriginPosition);
+        public override Vector2 ScreenSpaceSelectionPoint =>
+            // Important to use a stable position (not based on origin) as origin may be automatically updated during drag operations.
+            drawable.ScreenSpaceDrawQuad.Centre;
 
         protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) =>
             drawableQuad.Contains(screenSpacePos);

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -457,7 +457,7 @@ namespace osu.Game.Overlays.SkinEditor
             }
 
             SelectedComponents.Add(component);
-            SkinSelectionHandler.ApplyClosestAnchor(drawableComponent);
+            SkinSelectionHandler.ApplyClosestAnchorOrigin(drawableComponent);
             return true;
         }
 

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -139,7 +139,7 @@ namespace osu.Game.Overlays.SkinEditor
                 var drawableItem = (Drawable)b.Item;
 
                 // each drawable's relative position should be maintained in the scaled quad.
-                var screenPosition = b.ScreenSpaceSelectionPoint;
+                var screenPosition = drawableItem.ToScreenSpace(drawableItem.OriginPosition);
 
                 var relativePositionInOriginal =
                     new Vector2(

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -202,10 +202,10 @@ namespace osu.Game.Overlays.SkinEditor
                 var item = c.Item;
                 Drawable drawable = (Drawable)item;
 
-                drawable.Position += drawable.ScreenSpaceDeltaToParentSpace(moveEvent.ScreenSpaceDelta);
-
                 if (!item.UsesFixedAnchor)
                     ApplyClosestAnchorOrigin(drawable);
+
+                drawable.Position += drawable.ScreenSpaceDeltaToParentSpace(moveEvent.ScreenSpaceDelta);
             }
 
             return true;
@@ -332,7 +332,7 @@ namespace osu.Game.Overlays.SkinEditor
 
                 applyOrigin(drawable, origin);
 
-                if (item.UsesFixedAnchor)
+                if (!item.UsesFixedAnchor)
                     ApplyClosestAnchorOrigin(drawable);
             }
 

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -204,15 +204,20 @@ namespace osu.Game.Overlays.SkinEditor
 
                 drawable.Position += drawable.ScreenSpaceDeltaToParentSpace(moveEvent.ScreenSpaceDelta);
 
-                if (item.UsesFixedAnchor) continue;
-
-                ApplyClosestAnchor(drawable);
+                if (!item.UsesFixedAnchor)
+                    ApplyClosestAnchorOrigin(drawable);
             }
 
             return true;
         }
 
-        public static void ApplyClosestAnchor(Drawable drawable) => applyAnchor(drawable, getClosestAnchor(drawable));
+        public static void ApplyClosestAnchorOrigin(Drawable drawable)
+        {
+            var closest = getClosestAnchor(drawable);
+
+            applyAnchor(drawable, closest);
+            applyOrigin(drawable, closest);
+        }
 
         protected override void OnSelectionChanged()
         {
@@ -325,15 +330,10 @@ namespace osu.Game.Overlays.SkinEditor
             {
                 var drawable = (Drawable)item;
 
-                if (origin == drawable.Origin) continue;
+                applyOrigin(drawable, origin);
 
-                var previousOrigin = drawable.OriginPosition;
-                drawable.Origin = origin;
-                drawable.Position += drawable.OriginPosition - previousOrigin;
-
-                if (item.UsesFixedAnchor) continue;
-
-                ApplyClosestAnchor(drawable);
+                if (item.UsesFixedAnchor)
+                    ApplyClosestAnchorOrigin(drawable);
             }
 
             OnOperationEnded();
@@ -368,7 +368,7 @@ namespace osu.Game.Overlays.SkinEditor
             foreach (var item in SelectedItems)
             {
                 item.UsesFixedAnchor = false;
-                ApplyClosestAnchor((Drawable)item);
+                ApplyClosestAnchorOrigin((Drawable)item);
             }
 
             OnOperationEnded();
@@ -412,6 +412,15 @@ namespace osu.Game.Overlays.SkinEditor
             var previousAnchor = drawable.AnchorPosition;
             drawable.Anchor = anchor;
             drawable.Position -= drawable.AnchorPosition - previousAnchor;
+        }
+
+        private static void applyOrigin(Drawable drawable, Anchor origin)
+        {
+            if (origin == drawable.Origin) return;
+
+            var previousOrigin = drawable.OriginPosition;
+            drawable.Origin = origin;
+            drawable.Position += drawable.OriginPosition - previousOrigin;
         }
 
         private static void adjustScaleFromAnchor(ref Vector2 scale, Anchor reference)

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -23,6 +23,8 @@ namespace osu.Game.Overlays.SkinEditor
 {
     public partial class SkinSelectionHandler : SelectionHandler<ISerialisableDrawable>
     {
+        private OsuMenuItem originMenu = null!;
+
         [Resolved]
         private SkinEditor skinEditor { get; set; } = null!;
 
@@ -248,10 +250,15 @@ namespace osu.Game.Overlays.SkinEditor
                         .ToArray()
             };
 
-            yield return new OsuMenuItem("Origin")
+            yield return originMenu = new OsuMenuItem("Origin");
+
+            closestItem.State.BindValueChanged(s =>
             {
-                Items = createAnchorItems((d, o) => ((Drawable)d).Origin == o, applyOrigins).ToArray()
-            };
+                // For UX simplicity, origin should only be user-editable when "closest" anchor mode is disabled.
+                originMenu.Items = s.NewValue == TernaryState.True
+                    ? Array.Empty<MenuItem>()
+                    : createAnchorItems((d, o) => ((Drawable)d).Origin == o, applyOrigins).ToArray();
+            }, true);
 
             yield return new OsuMenuItemSpacer();
 


### PR DESCRIPTION
Users still don't really understand anchors and origins (and I kinda don't blame them – as a concept it takes a bit of brain power to get right), so let's choose for them in most cases and take the guesswork out of it.


https://github.com/ppy/osu/assets/191335/88ff78ec-0dd3-4ccc-ae65-cd2c6545a0a8

