### PR TITLE
Add "HP" to the abbreviations list

### DIFF
--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -347,6 +347,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GL/@EntryIndexedValue">GL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GLSL/@EntryIndexedValue">GLSL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HID/@EntryIndexedValue">HID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HP/@EntryIndexedValue">HP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HSL/@EntryIndexedValue">HSL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HSPA/@EntryIndexedValue">HSPA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HSV/@EntryIndexedValue">HSV</s:String>


### PR DESCRIPTION
- Lost change from https://github.com/ppy/osu/pull/28051, fixes one final inspection error.

![CleanShot 2024-05-05 at 21 39 54](https://github.com/ppy/osu/assets/22781491/53d3664c-312f-4fcf-9d89-f902b4e5e342)

There are existing fields that use the name `Hp` rather than `HP` but I care more about fixing the error than bringing up a set of unnecessary changes.