### PR TITLE
Fix now playing overlay text scroll breaking when toggling metadata language setting

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneNowPlayingOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneNowPlayingOverlay.cs
@@ -5,6 +5,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -21,8 +22,10 @@ namespace osu.Game.Tests.Visual.UserInterface
         private NowPlayingOverlay nowPlayingOverlay;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(FrameworkConfigManager frameworkConfig)
         {
+            AddToggleStep("toggle unicode", v => frameworkConfig.SetValue(FrameworkSetting.ShowUnicode, v));
+
             nowPlayingOverlay = new NowPlayingOverlay
             {
                 Origin = Anchor.Centre,
@@ -50,9 +53,9 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Metadata =
                 {
                     Artist = "very very very very very very very very very very verry long artist",
-                    ArtistUnicode = "very very very very very very very very very very verry long artist",
+                    ArtistUnicode = "very very very very very very very very very very verry long artist unicode",
                     Title = "very very very very very verry long title",
-                    TitleUnicode = "very very very very very verry long title",
+                    TitleUnicode = "very very very very very verry long title unicode",
                 }
             }));
 
@@ -61,9 +64,9 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Metadata =
                 {
                     Artist = "very very very very very very very very very very verrry long artist",
-                    ArtistUnicode = "very very very very very very very very very very verrry long artist",
+                    ArtistUnicode = "not very long artist unicode",
                     Title = "very very very very very verrry long title",
-                    TitleUnicode = "very very very very very verrry long title",
+                    TitleUnicode = "not very long title unicode",
                 }
             }));
 

--- a/osu.Game/Overlays/NowPlayingOverlay.cs
+++ b/osu.Game/Overlays/NowPlayingOverlay.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -479,6 +480,11 @@ namespace osu.Game.Overlays
             private OsuSpriteText mainSpriteText = null!;
             private OsuSpriteText fillerSpriteText = null!;
 
+            private Bindable<bool> showUnicode = null!;
+
+            [Resolved]
+            private FrameworkConfigManager frameworkConfig { get; set; } = null!;
+
             private LocalisableString text;
 
             public LocalisableString Text
@@ -530,6 +536,9 @@ namespace osu.Game.Overlays
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
+                showUnicode = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowUnicode);
+                showUnicode.BindValueChanged(_ => updateText());
 
                 updateFontAndText();
             }


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![Kapture 2024-05-05 at 15 38 08](https://github.com/ppy/osu/assets/35318437/2b2b9b61-1e07-4671-a89c-7df3dbaf95e6) | ![Kapture 2024-05-05 at 15 39 33](https://github.com/ppy/osu/assets/35318437/9bfa4cc9-d158-4c76-919a-dbfe6b551ce2) |