### PR TITLE
Do not show integration settings on mobile

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -25,8 +26,10 @@ namespace osu.Game.Overlays.Settings.Sections
             {
                 new WebSettings(),
                 new AlertsAndPrivacySettings(),
-                new IntegrationSettings()
             };
+
+            if (RuntimeInfo.IsDesktop)
+                Add(new IntegrationSettings());
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28097.

The settings weren't actually doing anything at all there anyway.