### PR TITLE
Fix `userTriggered` param not being passed to private helper

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -540,7 +540,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected void Redo() => changeHandler?.RestoreState(1);
 
-        public void Save(bool userTriggered = true) => save(currentSkin.Value);
+        public void Save(bool userTriggered = true) => save(currentSkin.Value, userTriggered);
 
         private void save(Skin skin, bool userTriggered = true)
         {


### PR DESCRIPTION
This was accidentally removed in #28030.
Not passing `userTriggered` is just a cosmetic bug, as this param just force-displays the OSD toast.