### PR TITLE
Use `MustDisposeResource` annotation to appease new ReSharper inspection

### DIFF
--- a/osu.Game/Database/EmptyRealmSet.cs
+++ b/osu.Game/Database/EmptyRealmSet.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using JetBrains.Annotations;
 using Realms;
 using Realms.Schema;
 
@@ -15,8 +16,12 @@ namespace osu.Game.Database
     {
         private IList<T> emptySet => Array.Empty<T>();
 
+        [MustDisposeResource]
         public IEnumerator<T> GetEnumerator() => emptySet.GetEnumerator();
+
+        [MustDisposeResource]
         IEnumerator IEnumerable.GetEnumerator() => emptySet.GetEnumerator();
+
         public int Count => emptySet.Count;
         public T this[int index] => emptySet[index];
         public int IndexOf(object? item) => item == null ? -1 : emptySet.IndexOf((T)item);


### PR DESCRIPTION
Popped up out of the blue in Rider 2024.1.2:

![CleanShot 2024-05-11 at 22 32 18](https://github.com/ppy/osu/assets/22781491/1826f3fe-b6e3-44ae-b88c-b0dd792105b3)