### PR TITLE
Use hash rather than online ID as primary lookup key when presenting score

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentScore.cs
@@ -145,6 +145,19 @@ namespace osu.Game.Tests.Visual.Navigation
             presentAndConfirm(secondImport, type);
         }
 
+        [Test]
+        public void TestPresentTwoImportsWithSameOnlineIDButDifferentHashes([Values] ScorePresentType type)
+        {
+            AddStep("enter song select", () => Game.ChildrenOfType<ButtonSystem>().Single().OnSolo?.Invoke());
+            AddUntilStep("song select is current", () => Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect && songSelect.BeatmapSetsLoaded);
+
+            var firstImport = importScore(1);
+            presentAndConfirm(firstImport, type);
+
+            var secondImport = importScore(1);
+            presentAndConfirm(secondImport, type);
+        }
+
         private void returnToMenu()
         {
             // if we don't pause, there's a chance the track may change at the main menu out of our control (due to reaching the end of the track).

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -88,14 +88,14 @@ namespace osu.Game.Scoring
         {
             ScoreInfo? databasedScoreInfo = null;
 
+            if (originalScoreInfo is ScoreInfo scoreInfo)
+                databasedScoreInfo = Query(s => s.Hash == scoreInfo.Hash);
+
             if (originalScoreInfo.OnlineID > 0)
-                databasedScoreInfo = Query(s => s.OnlineID == originalScoreInfo.OnlineID);
+                databasedScoreInfo ??= Query(s => s.OnlineID == originalScoreInfo.OnlineID);
 
             if (originalScoreInfo.LegacyOnlineID > 0)
                 databasedScoreInfo ??= Query(s => s.LegacyOnlineID == originalScoreInfo.LegacyOnlineID);
-
-            if (originalScoreInfo is ScoreInfo scoreInfo)
-                databasedScoreInfo ??= Query(s => s.Hash == scoreInfo.Hash);
 
             if (databasedScoreInfo == null)
             {


### PR DESCRIPTION
Something I ran into when investigating https://github.com/ppy/osu/issues/28169.

If there are two scores with the same online ID available in the database - for instance, one being recorded locally, and one recorded by spectator server, of one single play - the lookup code would use online ID first to find the score and pick any first one that matched. This could lead to the wrong replay being refetched and presented / exported.

(In the case of the aforementioned issue, I was confused as to why after restarting spectator server midway through a play and importing the replay saved by spectator server after the restart, I was seeing a complete replay with no dropped frames, even though there was nothing in the code that prevented the frame drop. It turns out that I was getting
presented the locally recorded replay instead all along.)

Instead, jiggle the fallback preference to use hash first.

---

If inclined to test this manually, here's a pair of replays that should demonstrate the issue: [example-replays.zip](https://github.com/ppy/osu/files/15306905/example-replays.zip)

One should have cursor movement start-to-end (client-side recording), one should have no movement for the first half a minute or so and then resume playback after (server-side recording after a restart)