### PR TITLE
Apply NRT to results-related components

### DIFF
--- a/osu.Game/Screens/Ranking/Contracted/ContractedPanelTopContent.cs
+++ b/osu.Game/Screens/Ranking/Contracted/ContractedPanelTopContent.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -16,7 +14,7 @@ namespace osu.Game.Screens.Ranking.Contracted
     {
         public readonly Bindable<int?> ScorePosition = new Bindable<int?>();
 
-        private OsuSpriteText text;
+        private OsuSpriteText text = null!;
 
         public ContractedPanelTopContent()
         {

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/AccuracyCircle.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -93,17 +91,17 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
 
         private readonly ScoreInfo score;
 
-        private CircularProgress accuracyCircle;
-        private GradedCircles gradedCircles;
-        private Container<RankBadge> badges;
-        private RankText rankText;
+        private CircularProgress accuracyCircle = null!;
+        private GradedCircles gradedCircles = null!;
+        private Container<RankBadge> badges = null!;
+        private RankText rankText = null!;
 
-        private PoolableSkinnableSample scoreTickSound;
-        private PoolableSkinnableSample badgeTickSound;
-        private PoolableSkinnableSample badgeMaxSound;
-        private PoolableSkinnableSample swooshUpSound;
-        private PoolableSkinnableSample rankImpactSound;
-        private PoolableSkinnableSample rankApplauseSound;
+        private PoolableSkinnableSample? scoreTickSound;
+        private PoolableSkinnableSample? badgeTickSound;
+        private PoolableSkinnableSample? badgeMaxSound;
+        private PoolableSkinnableSample? swooshUpSound;
+        private PoolableSkinnableSample? rankImpactSound;
+        private PoolableSkinnableSample? rankApplauseSound;
 
         private readonly Bindable<double> tickPlaybackRate = new Bindable<double>();
 
@@ -119,7 +117,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
         private readonly bool withFlair;
 
         private readonly bool isFailedSDueToMisses;
-        private RankText failedSRankText;
+        private RankText failedSRankText = null!;
 
         public AccuracyCircle(ScoreInfo score, bool withFlair = false)
         {
@@ -229,8 +227,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
 
                 this.Delay(swoosh_pre_delay).Schedule(() =>
                 {
-                    swooshUpSound.VolumeTo(swoosh_volume);
-                    swooshUpSound.Play();
+                    swooshUpSound!.VolumeTo(swoosh_volume);
+                    swooshUpSound!.Play();
                 });
             }
 
@@ -287,8 +285,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                         this.TransformBindableTo(tickPlaybackRate, score_tick_debounce_rate_start);
                         this.TransformBindableTo(tickPlaybackRate, score_tick_debounce_rate_end, ACCURACY_TRANSFORM_DURATION, Easing.OutSine);
 
-                        scoreTickSound.FrequencyTo(1 + targetAccuracy, ACCURACY_TRANSFORM_DURATION, Easing.OutSine);
-                        scoreTickSound.VolumeTo(score_tick_volume_start).Then().VolumeTo(score_tick_volume_end, ACCURACY_TRANSFORM_DURATION, Easing.OutSine);
+                        scoreTickSound!.FrequencyTo(1 + targetAccuracy, ACCURACY_TRANSFORM_DURATION, Easing.OutSine);
+                        scoreTickSound!.VolumeTo(score_tick_volume_start).Then().VolumeTo(score_tick_volume_end, ACCURACY_TRANSFORM_DURATION, Easing.OutSine);
 
                         isTicking = true;
                     });
@@ -314,8 +312,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                                 {
                                     var dink = badgeNum < badges.Count - 1 ? badgeTickSound : badgeMaxSound;
 
-                                    dink.FrequencyTo(1 + badgeNum++ * 0.05);
-                                    dink.Play();
+                                    dink!.FrequencyTo(1 + badgeNum++ * 0.05);
+                                    dink!.Play();
                                 });
                             }
                         }
@@ -331,7 +329,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                         Schedule(() =>
                         {
                             isTicking = false;
-                            rankImpactSound.Play();
+                            rankImpactSound!.Play();
                         });
 
                         const double applause_pre_delay = 545f;
@@ -341,8 +339,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
                         {
                             Schedule(() =>
                             {
-                                rankApplauseSound.VolumeTo(applause_volume);
-                                rankApplauseSound.Play();
+                                rankApplauseSound!.VolumeTo(applause_volume);
+                                rankApplauseSound!.Play();
                             });
                         }
                     }

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/RankBadge.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/RankBadge.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
@@ -34,8 +32,8 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
 
         public readonly ScoreRank Rank;
 
-        private Drawable rankContainer;
-        private Drawable overlay;
+        private Drawable rankContainer = null!;
+        private Drawable overlay = null!;
 
         /// <summary>
         /// Creates a new <see cref="RankBadge"/>.

--- a/osu.Game/Screens/Ranking/Expanded/Accuracy/RankText.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Accuracy/RankText.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -23,9 +21,9 @@ namespace osu.Game.Screens.Ranking.Expanded.Accuracy
     {
         private readonly ScoreRank rank;
 
-        private BufferedContainer flash;
-        private BufferedContainer superFlash;
-        private GlowingSpriteText rankText;
+        private BufferedContainer flash = null!;
+        private BufferedContainer superFlash = null!;
+        private GlowingSpriteText rankText = null!;
 
         public RankText(ScoreRank rank)
         {

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/AccuracyStatistic.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -22,7 +20,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     {
         private readonly double accuracy;
 
-        private RollingCounter<double> counter;
+        private RollingCounter<double> counter = null!;
 
         /// <summary>
         /// Creates a new <see cref="AccuracyStatistic"/>.

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/ComboStatistic.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -22,7 +20,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     {
         private readonly bool isPerfect;
 
-        private Drawable perfectText;
+        private Drawable perfectText = null!;
 
         /// <summary>
         /// Creates a new <see cref="ComboStatistic"/>.

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/CounterStatistic.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
@@ -21,7 +19,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
         private readonly int count;
         private readonly int? maxCount;
 
-        private RollingCounter<int> counter;
+        private RollingCounter<int> counter = null!;
 
         /// <summary>
         /// Creates a new <see cref="CounterStatistic"/>.

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/PerformanceStatistic.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +30,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-        private RollingCounter<int> counter;
+        private RollingCounter<int> counter = null!;
 
         public PerformanceStatistic(ScoreInfo score)
             : base(BeatmapsetsStrings.ShowScoreboardHeaderspp)
@@ -107,7 +105,7 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
 
         protected override void Dispose(bool isDisposing)
         {
-            cancellationTokenSource?.Cancel();
+            cancellationTokenSource.Cancel();
             base.Dispose(isDisposing);
         }
 

--- a/osu.Game/Screens/Ranking/Expanded/Statistics/StatisticDisplay.cs
+++ b/osu.Game/Screens/Ranking/Expanded/Statistics/StatisticDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -21,10 +19,10 @@ namespace osu.Game.Screens.Ranking.Expanded.Statistics
     /// </summary>
     public abstract partial class StatisticDisplay : CompositeDrawable
     {
-        protected SpriteText HeaderText { get; private set; }
+        protected SpriteText HeaderText { get; private set; } = null!;
 
         private readonly LocalisableString header;
-        private Drawable content;
+        private Drawable content = null!;
 
         /// <summary>
         /// Creates a new <see cref="StatisticDisplay"/>.

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -329,6 +330,7 @@ namespace osu.Game.Screens.Ranking
         {
             if (state.NewValue == Visibility.Visible)
             {
+                Debug.Assert(SelectedScore.Value != null);
                 // Detach the panel in its original location, and move into the desired location in the local container.
                 var expandedPanel = ScorePanelList.GetPanelForScore(SelectedScore.Value);
                 var screenSpacePos = expandedPanel.ScreenSpaceDrawQuad.TopLeft;

--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -1,10 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
-using JetBrains.Annotations;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -83,8 +80,7 @@ namespace osu.Game.Screens.Ranking
         private static readonly Color4 contracted_top_layer_colour = Color4Extensions.FromHex("#353535");
         private static readonly Color4 contracted_middle_layer_colour = Color4Extensions.FromHex("#353535");
 
-        [CanBeNull]
-        public event Action<PanelState> StateChanged;
+        public event Action<PanelState>? StateChanged;
 
         /// <summary>
         /// The position of the score in the rankings.
@@ -94,28 +90,30 @@ namespace osu.Game.Screens.Ranking
         /// <summary>
         /// An action to be invoked if this <see cref="ScorePanel"/> is clicked while in an expanded state.
         /// </summary>
-        public Action PostExpandAction;
+        public Action? PostExpandAction;
 
         public readonly ScoreInfo Score;
 
         [Resolved]
-        private OsuGameBase game { get; set; }
+        private OsuGameBase game { get; set; } = null!;
 
-        private AudioContainer audioContent;
+        private AudioContainer audioContent = null!;
 
         private bool displayWithFlair;
 
-        private Container topLayerContainer;
-        private Drawable topLayerBackground;
-        private Container topLayerContentContainer;
-        private Drawable topLayerContent;
+        private Container topLayerContainer = null!;
+        private Drawable topLayerBackground = null!;
+        private Container topLayerContentContainer = null!;
+        private Drawable? topLayerContent;
 
-        private Container middleLayerContainer;
-        private Drawable middleLayerBackground;
-        private Container middleLayerContentContainer;
-        private Drawable middleLayerContent;
+        private Container middleLayerContainer = null!;
+        private Drawable middleLayerBackground = null!;
+        private Container middleLayerContentContainer = null!;
+        private Drawable? middleLayerContent;
 
-        private DrawableSample samplePanelFocus;
+        private ScorePanelTrackingContainer? trackingContainer;
+
+        private DrawableSample? samplePanelFocus;
 
         public ScorePanel(ScoreInfo score, bool isNewLocalScore = false)
         {
@@ -333,8 +331,6 @@ namespace osu.Game.Screens.Ranking
             => base.ReceivePositionalInputAt(screenSpacePos)
                || topLayerContainer.ReceivePositionalInputAt(screenSpacePos)
                || middleLayerContainer.ReceivePositionalInputAt(screenSpacePos);
-
-        private ScorePanelTrackingContainer trackingContainer;
 
         /// <summary>
         /// Creates a <see cref="ScorePanelTrackingContainer"/> which this <see cref="ScorePanel"/> can reside inside.

--- a/osu.Game/Screens/Ranking/ScorePanelList.cs
+++ b/osu.Game/Screens/Ranking/ScorePanelList.cs
@@ -1,14 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -64,14 +61,14 @@ namespace osu.Game.Screens.Ranking
         /// <summary>
         /// An action to be invoked if a <see cref="ScorePanel"/> is clicked while in an expanded state.
         /// </summary>
-        public Action PostExpandAction;
+        public Action? PostExpandAction;
 
-        public readonly Bindable<ScoreInfo> SelectedScore = new Bindable<ScoreInfo>();
+        public readonly Bindable<ScoreInfo?> SelectedScore = new Bindable<ScoreInfo?>();
 
         private readonly CancellationTokenSource loadCancellationSource = new CancellationTokenSource();
         private readonly Flow flow;
         private readonly Scroll scroll;
-        private ScorePanel expandedPanel;
+        private ScorePanel? expandedPanel;
 
         /// <summary>
         /// Creates a new <see cref="ScorePanelList"/>.
@@ -174,7 +171,7 @@ namespace osu.Game.Screens.Ranking
         /// Brings a <see cref="ScoreInfo"/> to the centre of the screen and expands it.
         /// </summary>
         /// <param name="score">The <see cref="ScoreInfo"/> to present.</param>
-        private void selectedScoreChanged(ValueChangedEvent<ScoreInfo> score)
+        private void selectedScoreChanged(ValueChangedEvent<ScoreInfo?> score)
         {
             // avoid contracting panels unnecessarily when TriggerChange is fired manually.
             if (score.OldValue != null && !score.OldValue.Equals(score.NewValue))
@@ -317,7 +314,7 @@ namespace osu.Game.Screens.Ranking
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            loadCancellationSource?.Cancel();
+            loadCancellationSource.Cancel();
         }
 
         private partial class Flow : FillFlowContainer<ScorePanelTrackingContainer>
@@ -326,11 +323,9 @@ namespace osu.Game.Screens.Ranking
 
             public int GetPanelIndex(ScoreInfo score) => applySorting(Children).TakeWhile(s => !s.Panel.Score.Equals(score)).Count();
 
-            [CanBeNull]
-            public ScoreInfo GetPreviousScore(ScoreInfo score) => applySorting(Children).TakeWhile(s => !s.Panel.Score.Equals(score)).LastOrDefault()?.Panel.Score;
+            public ScoreInfo? GetPreviousScore(ScoreInfo score) => applySorting(Children).TakeWhile(s => !s.Panel.Score.Equals(score)).LastOrDefault()?.Panel.Score;
 
-            [CanBeNull]
-            public ScoreInfo GetNextScore(ScoreInfo score) => applySorting(Children).SkipWhile(s => !s.Panel.Score.Equals(score)).ElementAtOrDefault(1)?.Panel.Score;
+            public ScoreInfo? GetNextScore(ScoreInfo score) => applySorting(Children).SkipWhile(s => !s.Panel.Score.Equals(score)).ElementAtOrDefault(1)?.Panel.Score;
 
             private IEnumerable<ScorePanelTrackingContainer> applySorting(IEnumerable<Drawable> drawables) => drawables.OfType<ScorePanelTrackingContainer>()
                                                                                                                        .OrderByDescending(GetLayoutPosition)

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
@@ -31,16 +28,16 @@ namespace osu.Game.Screens.Ranking.Statistics
         private readonly ScoreInfo score;
         private readonly IBeatmap playableBeatmap;
 
-        private Drawable spinner;
-        private Drawable content;
-        private GridContainer chart;
-        private OsuSpriteText achievedPerformance;
-        private OsuSpriteText maximumPerformance;
+        private Drawable spinner = null!;
+        private Drawable content = null!;
+        private GridContainer chart = null!;
+        private OsuSpriteText achievedPerformance = null!;
+        private OsuSpriteText maximumPerformance = null!;
 
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         [Resolved]
-        private BeatmapDifficultyCache difficultyCache { get; set; }
+        private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
 
         public PerformanceBreakdownChart(ScoreInfo score, IBeatmap playableBeatmap)
         {
@@ -147,7 +144,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
             new PerformanceBreakdownCalculator(playableBeatmap, difficultyCache)
                 .CalculateAsync(score, cancellationTokenSource.Token)
-                .ContinueWith(t => Schedule(() => setPerformanceValue(t.GetResultSafely())));
+                .ContinueWith(t => Schedule(() => setPerformanceValue(t.GetResultSafely()!)));
         }
 
         private void setPerformanceValue(PerformanceBreakdown breakdown)
@@ -189,8 +186,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             maximumPerformance.Text = Math.Round(perfectAttribute.Value, MidpointRounding.AwayFromZero).ToLocalisableString();
         }
 
-        [CanBeNull]
-        private Drawable[] createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute perfectAttribute)
+        private Drawable[]? createAttributeRow(PerformanceDisplayAttribute attribute, PerformanceDisplayAttribute perfectAttribute)
         {
             // Don't display the attribute if its maximum is 0
             // For example, flashlight bonus would be zero if flashlight mod isn't on
@@ -239,7 +235,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
         protected override void Dispose(bool isDisposing)
         {
-            cancellationTokenSource?.Cancel();
+            cancellationTokenSource.Cancel();
             base.Dispose(isDisposing);
         }
     }

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticItem.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
@@ -61,7 +59,7 @@ namespace osu.Game.Screens.Ranking.Statistics
     /// </summary>
     public partial class SimpleStatisticItem<TValue> : SimpleStatisticItem
     {
-        private TValue value;
+        private TValue value = default!;
 
         /// <summary>
         /// The statistic's value to be displayed.
@@ -80,7 +78,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// Used to convert <see cref="Value"/> to a text representation.
         /// Defaults to using <see cref="object.ToString"/>.
         /// </summary>
-        protected virtual string DisplayValue(TValue value) => value.ToString();
+        protected virtual string DisplayValue(TValue value) => value!.ToString() ?? string.Empty;
 
         public SimpleStatisticItem(string name)
             : base(name)

--- a/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
+++ b/osu.Game/Screens/Ranking/Statistics/SimpleStatisticTable.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -24,14 +21,14 @@ namespace osu.Game.Screens.Ranking.Statistics
         private readonly SimpleStatisticItem[] items;
         private readonly int columnCount;
 
-        private FillFlowContainer[] columns;
+        private FillFlowContainer[] columns = null!;
 
         /// <summary>
         /// Creates a statistic row for the supplied <see cref="SimpleStatisticItem"/>s.
         /// </summary>
         /// <param name="columnCount">The number of columns to layout the <paramref name="items"/> into.</param>
         /// <param name="items">The <see cref="SimpleStatisticItem"/>s to display in this row.</param>
-        public SimpleStatisticTable(int columnCount, [ItemNotNull] IEnumerable<SimpleStatisticItem> items)
+        public SimpleStatisticTable(int columnCount, IEnumerable<SimpleStatisticItem> items)
         {
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(columnCount);
 

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -28,19 +26,20 @@ namespace osu.Game.Screens.Ranking.Statistics
     {
         public const float SIDE_PADDING = 30;
 
-        public readonly Bindable<ScoreInfo> Score = new Bindable<ScoreInfo>();
+        public readonly Bindable<ScoreInfo?> Score = new Bindable<ScoreInfo?>();
 
         protected override bool StartHidden => true;
 
         [Resolved]
-        private BeatmapManager beatmapManager { get; set; }
+        private BeatmapManager beatmapManager { get; set; } = null!;
 
         private readonly Container content;
         private readonly LoadingSpinner spinner;
 
         private bool wasOpened;
-        private Sample popInSample;
-        private Sample popOutSample;
+        private Sample? popInSample;
+        private Sample? popOutSample;
+        private CancellationTokenSource? loadCancellation;
 
         public StatisticsPanel()
         {
@@ -71,9 +70,7 @@ namespace osu.Game.Screens.Ranking.Statistics
             popOutSample = audio.Samples.Get(@"Results/statistics-panel-pop-out");
         }
 
-        private CancellationTokenSource loadCancellation;
-
-        private void populateStatistics(ValueChangedEvent<ScoreInfo> score)
+        private void populateStatistics(ValueChangedEvent<ScoreInfo?> score)
         {
             loadCancellation?.Cancel();
             loadCancellation = null;
@@ -187,7 +184,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                 LoadComponentAsync(container, d =>
                 {
-                    if (!Score.Value.Equals(newScore))
+                    if (Score.Value?.Equals(newScore) != true)
                         return;
 
                     spinner.Hide();


### PR DESCRIPTION
Some more NRT stuff in preparation for attempting to get the whole `ScoreInfo` mess in results screen under control. End goal is fixing https://github.com/ppy/osu/issues/16480.

I'm not gonna claim I have this figured out start to end, this will be a severe mess to untangle over multiple changes probably, there are several areas of badness in the results screens. So I'm going to do this piece by piece whenever I have the energy to try and continue this.