### PR TITLE
Do not change mania column width on mobile platforms

### DIFF
--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -3,15 +3,12 @@
 
 #nullable disable
 
-using System;
-using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Skinning;
 using osu.Game.Skinning;
-using osuTK;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
@@ -62,12 +59,6 @@ namespace osu.Game.Rulesets.Mania.UI
             onSkinChanged();
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            updateMobileSizing();
-        }
-
         private void onSkinChanged()
         {
             for (int i = 0; i < stageDefinition.Columns; i++)
@@ -92,8 +83,6 @@ namespace osu.Game.Rulesets.Mania.UI
 
                 columns[i].Width = width.Value;
             }
-
-            updateMobileSizing();
         }
 
         /// <summary>
@@ -104,31 +93,6 @@ namespace osu.Game.Rulesets.Mania.UI
         public void SetContentForColumn(int column, TContent content)
         {
             Content[column] = columns[column].Child = content;
-        }
-
-        private void updateMobileSizing()
-        {
-            if (!IsLoaded || !RuntimeInfo.IsMobile)
-                return;
-
-            // GridContainer+CellContainer containing this stage (gets split up for dual stages).
-            Vector2? containingCell = this.FindClosestParent<Stage>()?.Parent?.DrawSize;
-
-            // Will be null in tests.
-            if (containingCell == null)
-                return;
-
-            float aspectRatio = containingCell.Value.X / containingCell.Value.Y;
-
-            // 2.83 is a mostly arbitrary scale-up (170 / 60, based on original implementation for argon)
-            float mobileAdjust = 2.83f * Math.Min(1, 7f / stageDefinition.Columns);
-            // 1.92 is a "reference" mobile screen aspect ratio for phones.
-            // We should scale it back for cases like tablets which aren't so extreme.
-            mobileAdjust *= aspectRatio / 1.92f;
-
-            // Best effort until we have better mobile support.
-            for (int i = 0; i < stageDefinition.Columns; i++)
-                columns[i].Width *= mobileAdjust;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Originally proposed in https://github.com/ppy/osu/pull/28173#issuecomment-2110705174 but that seems to have gotten no reaction so PRing separately.

- Closes https://github.com/ppy/osu/issues/25852
- Reverts https://github.com/ppy/osu/pull/25336 / https://github.com/ppy/osu/pull/25777

With the columns not being directly touchable anymore after https://github.com/ppy/osu/pull/28173 I see very little point to this continuing to exist.