### PR TITLE
Fix duplicated localisation key in `DeleteConfirmationContentStrings`

### DIFF
--- a/osu.Game/Localisation/DeleteConfirmationContentStrings.cs
+++ b/osu.Game/Localisation/DeleteConfirmationContentStrings.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Are you sure you want to delete all scores? This cannot be undone!"
         /// </summary>
-        public static LocalisableString Scores => new TranslatableString(getKey(@"collections"), @"Are you sure you want to delete all scores? This cannot be undone!");
+        public static LocalisableString Scores => new TranslatableString(getKey(@"scores"), @"Are you sure you want to delete all scores? This cannot be undone!");
 
         /// <summary>
         /// "Are you sure you want to delete all mod presets?"


### PR DESCRIPTION
Noticed via `osu-resources` build warnings.

There are also a few other warnings in `osu-resources` about the case that was already fixed in https://github.com/ppy/osu/pull/27472. Seems something in crowdin innards may still be exporting those strings even though they have been fixed. Not sure how to address that.

Probably need these to be detected via static analysis at this point since it's happened again. ~~Might look into the feasibility of making that happen.~~ See https://github.com/ppy/osu-localisation-analyser/pull/63.