### PR TITLE
Fix xmldoc mismatches in localisation files

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "ppy.localisationanalyser.tools": {
-      "version": "2023.1117.0",
+      "version": "2024.517.0",
       "commands": [
         "localisation"
       ]

--- a/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
+++ b/osu.Game/Localisation/FirstRunOverlayImportFromStableScreenStrings.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Localisation
         public static LocalisableString Calculating => new TranslatableString(getKey(@"calculating"), @"calculating...");
 
         /// <summary>
-        /// "{0} items"
+        /// "{0} item(s)"
         /// </summary>
         public static LocalisableString Items(int arg0) => new TranslatableString(getKey(@"items"), @"{0} item(s)", arg0);
 

--- a/osu.Game/Localisation/NotificationsStrings.cs
+++ b/osu.Game/Localisation/NotificationsStrings.cs
@@ -114,7 +114,7 @@ Please try changing your audio device to a working setting.");
         public static LocalisableString MismatchingBeatmapForReplay => new TranslatableString(getKey(@"mismatching_beatmap_for_replay"), @"Your local copy of the beatmap for this replay appears to be different than expected. You may need to update or re-download it.");
 
         /// <summary>
-        /// "You are now running osu! {version}.
+        /// "You are now running osu! {0}.
         /// Click to see what's new!"
         /// </summary>
         public static LocalisableString GameVersionAfterUpdate(string version) => new TranslatableString(getKey(@"game_version_after_update"), @"You are now running osu! {0}.

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="ppy.LocalisationAnalyser" Version="2024.318.0">
+    <PackageReference Include="ppy.LocalisationAnalyser" Version="2024.517.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="ppy.LocalisationAnalyser" Version="2023.1117.0">
+    <PackageReference Include="ppy.LocalisationAnalyser" Version="2024.318.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Found these during testing of https://github.com/ppy/osu-localisation-analyser/pull/63.

Going forward the matching is enforced by the localisation analyser after https://github.com/ppy/osu-localisation-analyser/pull/62, but it appears the analyser was never actually bumped game-side after that change and I'm not super sure why, as there does not appear to be a reason to _not_ do that. So this PR does it.