### PR TITLE
Remove `TreatWarningsAsErrors` flags from local builds for developer convenience

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <PropertyGroup Label="C#">
     <LangVersion>12.0</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Has been discussed in [here](https://discord.com/channels/188630481301012481/188630652340404224/1241065856272830466) and [here](https://discord.com/channels/188630481301012481/188630652340404224/1241206268681654374). This flag has been causing unnecessary hurdles with development, such as builds failing when [using obsolete methods while temporarily testing changes](https://discord.com/channels/188630481301012481/188630652340404224/1241203484330819604), or when commenting code that cuts off all usages to a field/property/constant (this is especially frusturating with hot reload, because removing members is not fully supported, and the developer loses the point of having hot reload).

Our workflows already append the `-warnaserror` flag during builds, so all warnings are still treated as errors and fail CI (tested in [here](https://github.com/frenzibyte/osu/actions/runs/9137060390/job/25126585824)).

In addition, Rider does a pretty good job of warning developers if there are warnings in build, so that should not be a concern when removing this flag (missing warnings during a PR):

![image](https://github.com/ppy/osu/assets/22781491/92208ee0-8fa1-4a1e-b780-3789231de0cb)
