### PR TITLE
Enforce difficulty setting limits during decode

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -1188,5 +1188,35 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(beatmap.HitObjects[0].GetEndTime(), Is.EqualTo(3153));
             }
         }
+
+        [Test]
+        public void TestBeatmapDifficultyIsClamped()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("out-of-range-difficulties.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var decoded = decoder.Decode(stream).Difficulty;
+                Assert.That(decoded.DrainRate, Is.EqualTo(10));
+                Assert.That(decoded.CircleSize, Is.EqualTo(10));
+                Assert.That(decoded.OverallDifficulty, Is.EqualTo(10));
+                Assert.That(decoded.ApproachRate, Is.EqualTo(10));
+                Assert.That(decoded.SliderMultiplier, Is.EqualTo(3.6));
+                Assert.That(decoded.SliderTickRate, Is.EqualTo(8));
+            }
+        }
+        [Test]
+        public void TestManiaBeatmapDifficultyCircleSizeClamp()
+        {
+            var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };
+
+            using (var resStream = TestResources.OpenResource("out-of-range-difficulties-mania.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var decoded = decoder.Decode(stream).Difficulty;
+                Assert.That(decoded.CircleSize, Is.EqualTo(14));
+            }
+        }
     }
 }

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -1206,6 +1206,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                 Assert.That(decoded.SliderTickRate, Is.EqualTo(8));
             }
         }
+
         [Test]
         public void TestManiaBeatmapDifficultyCircleSizeClamp()
         {

--- a/osu.Game.Tests/Resources/out-of-range-difficulties-mania.osu
+++ b/osu.Game.Tests/Resources/out-of-range-difficulties-mania.osu
@@ -1,0 +1,5 @@
+[General]
+Mode: 3
+
+[Difficulty]
+CircleSize:14

--- a/osu.Game.Tests/Resources/out-of-range-difficulties.osu
+++ b/osu.Game.Tests/Resources/out-of-range-difficulties.osu
@@ -1,0 +1,10 @@
+[General]
+Mode: 0
+
+[Difficulty]
+HPDrainRate:25
+CircleSize:25
+OverallDifficulty:25
+ApproachRate:30
+SliderMultiplier:30
+SliderTickRate:30

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -383,21 +383,24 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"HPDrainRate":
-                    difficulty.DrainRate = Parsing.ParseFloat(pair.Value);
+                    difficulty.DrainRate = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
                     break;
 
                 case @"CircleSize":
                     difficulty.CircleSize = Parsing.ParseFloat(pair.Value);
+                    //If the mode is not Mania, clamp circle size to [0,10]
+                    if (!beatmap.BeatmapInfo.Ruleset.OnlineID.Equals(3))
+                        difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 0, 10);
                     break;
 
                 case @"OverallDifficulty":
-                    difficulty.OverallDifficulty = Parsing.ParseFloat(pair.Value);
+                    difficulty.OverallDifficulty = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
                     if (!hasApproachRate)
                         difficulty.ApproachRate = difficulty.OverallDifficulty;
                     break;
 
                 case @"ApproachRate":
-                    difficulty.ApproachRate = Parsing.ParseFloat(pair.Value);
+                    difficulty.ApproachRate = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
                     hasApproachRate = true;
                     break;
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -111,12 +111,12 @@ namespace osu.Game.Beatmaps.Formats
         {
             difficulty.DrainRate = Math.Clamp(difficulty.DrainRate, 0, 10);
             //If the mode is not Mania, clamp circle size to [0,10]
-            if (!beatmap.BeatmapInfo.Ruleset.OnlineID.Equals(3))
+            if (beatmap.BeatmapInfo.Ruleset.OnlineID != 3)
                 difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 0, 10);
-            //If it is Mania, it must be within [1,20] - dual stages with 10 keys each.
+            //If it is Mania, it must be within [1,18] - copying what stable does https://github.com/ppy/osu/pull/28200#discussion_r1609522988
             //The lower bound should be 4, but there are ranked maps that are lower than this.
             else
-                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 1, 20);
+                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 1, 18);
             difficulty.OverallDifficulty = Math.Clamp(difficulty.OverallDifficulty, 0, 10);
             difficulty.ApproachRate = Math.Clamp(difficulty.ApproachRate, 0, 10);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Beatmaps.Formats
 
             base.ParseStreamInto(stream, beatmap);
 
+            applyDifficultyRestrictions(beatmap.Difficulty);
+
             flushPendingPoints();
 
             // Objects may be out of order *only* if a user has manually edited an .osu file.
@@ -100,6 +102,26 @@ namespace osu.Game.Beatmaps.Formats
                 applyDefaults(hitObject);
                 applySamples(hitObject);
             }
+        }
+
+        /// <summary>
+        /// Clamp Difficulty settings to be within the normal range.
+        /// </summary>
+        private void applyDifficultyRestrictions(BeatmapDifficulty difficulty)
+        {
+            difficulty.DrainRate = Math.Clamp(difficulty.DrainRate, 0, 10);
+            //If the mode is not Mania, clamp circle size to [0,10]
+            if (!beatmap.BeatmapInfo.Ruleset.OnlineID.Equals(3))
+                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 0, 10);
+            //If it is Mania, it must be within [1,20] - dual stages with 10 keys each.
+            //The lower bound should be 4, but there are ranked maps that are lower than this.
+            else
+                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 1, 20);
+            difficulty.OverallDifficulty = Math.Clamp(difficulty.OverallDifficulty, 0, 10);
+            difficulty.ApproachRate = Math.Clamp(difficulty.ApproachRate, 0, 10);
+
+            difficulty.SliderMultiplier = Math.Clamp(difficulty.SliderMultiplier, 0.4, 3.6);
+            difficulty.SliderTickRate = Math.Clamp(difficulty.SliderTickRate, 0.5, 8);
         }
 
         /// <summary>
@@ -383,33 +405,30 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"HPDrainRate":
-                    difficulty.DrainRate = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
+                    difficulty.DrainRate = Parsing.ParseFloat(pair.Value);
                     break;
 
                 case @"CircleSize":
                     difficulty.CircleSize = Parsing.ParseFloat(pair.Value);
-                    //If the mode is not Mania, clamp circle size to [0,10]
-                    if (!beatmap.BeatmapInfo.Ruleset.OnlineID.Equals(3))
-                        difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 0, 10);
                     break;
 
                 case @"OverallDifficulty":
-                    difficulty.OverallDifficulty = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
+                    difficulty.OverallDifficulty = Parsing.ParseFloat(pair.Value);
                     if (!hasApproachRate)
                         difficulty.ApproachRate = difficulty.OverallDifficulty;
                     break;
 
                 case @"ApproachRate":
-                    difficulty.ApproachRate = Math.Clamp(Parsing.ParseFloat(pair.Value), 0, 10);
+                    difficulty.ApproachRate = Parsing.ParseFloat(pair.Value);
                     hasApproachRate = true;
                     break;
 
                 case @"SliderMultiplier":
-                    difficulty.SliderMultiplier = Math.Clamp(Parsing.ParseDouble(pair.Value), 0.4, 3.6);
+                    difficulty.SliderMultiplier = Parsing.ParseDouble(pair.Value);
                     break;
 
                 case @"SliderTickRate":
-                    difficulty.SliderTickRate = Math.Clamp(Parsing.ParseDouble(pair.Value), 0.5, 8);
+                    difficulty.SliderTickRate = Parsing.ParseDouble(pair.Value);
                     break;
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Beatmaps.Formats
 
             base.ParseStreamInto(stream, beatmap);
 
-            applyDifficultyRestrictions(beatmap.Difficulty);
+            applyDifficultyRestrictions(beatmap.Difficulty, beatmap);
 
             flushPendingPoints();
 
@@ -108,7 +108,7 @@ namespace osu.Game.Beatmaps.Formats
         /// Ensures that all <see cref="BeatmapDifficulty"/> settings are within the allowed ranges.
         /// See also: https://github.com/peppy/osu-stable-reference/blob/0e425c0d525ef21353c8293c235cc0621d28338b/osu!/GameplayElements/Beatmaps/Beatmap.cs#L567-L614
         /// </summary>
-        private void applyDifficultyRestrictions(BeatmapDifficulty difficulty)
+        private static void applyDifficultyRestrictions(BeatmapDifficulty difficulty, Beatmap beatmap)
         {
             difficulty.DrainRate = Math.Clamp(difficulty.DrainRate, 0, 10);
 
@@ -127,7 +127,7 @@ namespace osu.Game.Beatmaps.Formats
         /// <summary>
         /// Processes the beatmap such that a new combo is started the first hitobject following each break.
         /// </summary>
-        private void postProcessBreaks(Beatmap beatmap)
+        private static void postProcessBreaks(Beatmap beatmap)
         {
             int currentBreak = 0;
             bool forceNewCombo = false;
@@ -183,7 +183,7 @@ namespace osu.Game.Beatmaps.Formats
         /// This method's intention is to restore those legacy defaults.
         /// See also: https://osu.ppy.sh/wiki/en/Client/File_formats/Osu_%28file_format%29
         /// </summary>
-        private void applyLegacyDefaults(BeatmapInfo beatmapInfo)
+        private static void applyLegacyDefaults(BeatmapInfo beatmapInfo)
         {
             beatmapInfo.WidescreenStoryboard = false;
             beatmapInfo.SamplesMatchPlaybackRate = false;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -105,18 +105,18 @@ namespace osu.Game.Beatmaps.Formats
         }
 
         /// <summary>
-        /// Clamp Difficulty settings to be within the normal range.
+        /// Ensures that all <see cref="BeatmapDifficulty"/> settings are within the allowed ranges.
+        /// See also: https://github.com/peppy/osu-stable-reference/blob/0e425c0d525ef21353c8293c235cc0621d28338b/osu!/GameplayElements/Beatmaps/Beatmap.cs#L567-L614
         /// </summary>
         private void applyDifficultyRestrictions(BeatmapDifficulty difficulty)
         {
             difficulty.DrainRate = Math.Clamp(difficulty.DrainRate, 0, 10);
-            //If the mode is not Mania, clamp circle size to [0,10]
-            if (beatmap.BeatmapInfo.Ruleset.OnlineID != 3)
-                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 0, 10);
-            //If it is Mania, it must be within [1,18] - copying what stable does https://github.com/ppy/osu/pull/28200#discussion_r1609522988
-            //The lower bound should be 4, but there are ranked maps that are lower than this.
-            else
-                difficulty.CircleSize = Math.Clamp(difficulty.CircleSize, 1, 18);
+
+            // mania uses "circle size" for key count, thus different allowable range
+            difficulty.CircleSize = beatmap.BeatmapInfo.Ruleset.OnlineID != 3
+                ? Math.Clamp(difficulty.CircleSize, 0, 10)
+                : Math.Clamp(difficulty.CircleSize, 1, 18);
+
             difficulty.OverallDifficulty = Math.Clamp(difficulty.OverallDifficulty, 0, 10);
             difficulty.ApproachRate = Math.Clamp(difficulty.ApproachRate, 0, 10);
 

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
             const float broken_gamefield_rounding_allowance = 1.00041f;
 
-            return (float)Math.Max(0.02, (1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1));
+            return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1);
         }
 
         public static int CalculateDifficultyPeppyStars(BeatmapDifficulty difficulty, int objectCount, int drainLength)

--- a/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/LegacyRulesetExtensions.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             // It works out to under 1 game pixel and is generally not meaningful to gameplay, but is to replay playback accuracy.
             const float broken_gamefield_rounding_allowance = 1.00041f;
 
-            return (float)(1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1);
+            return (float)Math.Max(0.02, (1.0f - 0.7f * IBeatmapDifficultyInfo.DifficultyRange(circleSize)) / 2 * (applyFudge ? broken_gamefield_rounding_allowance : 1));
         }
 
         public static int CalculateDifficultyPeppyStars(BeatmapDifficulty difficulty, int objectCount, int drainLength)


### PR DESCRIPTION
Closes #27172

To address #27172, adding a minimum value of 0.02 for the multiplier for circle size. 0.02 was chosen as it appears to be the smallest value (or well, somewhere between 0.01 and 0.02) that one can have without a crash.

Alternatively, could be capped to 0.15, that is a CS of 10, which should be the highest normally occurring, however feel is better to cap it at the smallest value possible before it's effect becomes meaningless to allow for as much freedom in design of beatmaps as possible.