### PR TITLE
Fix checkboxes looking misaligned when placed next to a slider bar

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -52,8 +52,6 @@ namespace osu.Game.Graphics.UserInterface
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
 
-            const float nub_padding = 5;
-
             Children = new Drawable[]
             {
                 LabelTextFlowContainer = new OsuTextFlowContainer(ApplyLabelParameters)
@@ -69,15 +67,13 @@ namespace osu.Game.Graphics.UserInterface
             {
                 Nub.Anchor = Anchor.CentreRight;
                 Nub.Origin = Anchor.CentreRight;
-                Nub.Margin = new MarginPadding { Right = nub_padding };
-                LabelTextFlowContainer.Padding = new MarginPadding { Right = Nub.DEFAULT_EXPANDED_SIZE + nub_padding * 2 };
+                LabelTextFlowContainer.Padding = new MarginPadding { Right = Nub.DEFAULT_EXPANDED_SIZE + 10f };
             }
             else
             {
                 Nub.Anchor = Anchor.CentreLeft;
                 Nub.Origin = Anchor.CentreLeft;
-                Nub.Margin = new MarginPadding { Left = nub_padding };
-                LabelTextFlowContainer.Padding = new MarginPadding { Left = Nub.DEFAULT_EXPANDED_SIZE + nub_padding * 2 };
+                LabelTextFlowContainer.Padding = new MarginPadding { Left = Nub.DEFAULT_EXPANDED_SIZE + 10f };
             }
 
             Nub.Current.BindTo(Current);


### PR DESCRIPTION
| Before | After |
|--------|-------|
| ![CleanShot 2024-05-18 at 11 06 08](https://github.com/ppy/osu/assets/22781491/82571c83-5e88-453b-b15b-5b5977d6f005) | ![CleanShot 2024-05-18 at 11 07 05](https://github.com/ppy/osu/assets/22781491/b5ee5f09-4bfe-48da-a356-543312097fee) | 

I just noticed this while working on [this](https://discord.com/channels/188630481301012481/188630652340404224/1240921163895672892) and it felt jarring. The padding existed for a very long time, and I couldn't find any reason for it. @peppy requesting your review because I'm not sure if this remains to be intentional.