### PR TITLE
Fix total score without mods migration failing on custom ruleset scores when custom ruleset cannot be loaded

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -1134,7 +1134,17 @@ namespace osu.Game.Database
 
                 case 41:
                     foreach (var score in migration.NewRealm.All<ScoreInfo>())
-                        LegacyScoreDecoder.PopulateTotalScoreWithoutMods(score);
+                    {
+                        try
+                        {
+                            // this can fail e.g. if a user has a score set on a ruleset that can no longer be loaded.
+                            LegacyScoreDecoder.PopulateTotalScoreWithoutMods(score);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Log($@"Failed to populate total score without mods for score {score.ID}: {ex}", LoggingTarget.Database);
+                        }
+                    }
 
                     break;
             }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28209.

Yes this means that such scores will have a zero total score without mods in DB and thus might up getting their total recalculated to zero when we try a mod multiplier rebalance (unless we skip scores with zero completely I suppose). I also don't really care about that right now.