### PR TITLE
Show mouse and joystick settings on mobile

### DIFF
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -578,17 +578,17 @@ namespace osu.Game
                 {
                     case ITabletHandler th:
                         return new TabletSettings(th);
-
-                    case MouseHandler mh:
-                        return new MouseSettings(mh);
-
-                    case JoystickHandler jh:
-                        return new JoystickSettings(jh);
                 }
             }
 
             switch (handler)
             {
+                case MouseHandler mh:
+                    return new MouseSettings(mh);
+
+                case JoystickHandler jh:
+                    return new JoystickSettings(jh);
+
                 case TouchHandler th:
                     return new TouchSettings(th);
 

--- a/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/MouseSettings.cs
@@ -105,12 +105,17 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             highPrecisionMouse.Current.BindValueChanged(highPrecision =>
             {
-                if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+                switch (RuntimeInfo.OS)
                 {
-                    if (highPrecision.NewValue)
-                        highPrecisionMouse.SetNoticeText(MouseSettingsStrings.HighPrecisionPlatformWarning, true);
-                    else
-                        highPrecisionMouse.ClearNoticeText();
+                    case RuntimeInfo.Platform.Linux:
+                    case RuntimeInfo.Platform.macOS:
+                    case RuntimeInfo.Platform.iOS:
+                        if (highPrecision.NewValue)
+                            highPrecisionMouse.SetNoticeText(MouseSettingsStrings.HighPrecisionPlatformWarning, true);
+                        else
+                            highPrecisionMouse.ClearNoticeText();
+
+                        break;
                 }
             }, true);
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28226

Since Android and iOS use SDL3, they the same mouse and joystick support as desktop. I've updated the [warning text](https://github.com/ppy/osu/blob/fa1d1df594d3f5307e01207952c4eb6be7ee3494/osu.Game/Localisation/MouseSettingsStrings.cs#L63) to not show on Android, as high precision mouse works fine there.

- [x] test high precision and sensitivity on iOS and remove the warning if it works fine