### PR TITLE
Remove unneeded `Previous` calls from `RhythmEvaluator`

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -66,10 +66,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     }
                     else
                     {
-                        if (current.Previous(i - 1).BaseObject is Slider) // bpm change is into slider, this is easy acc window
+                        if (currObj.BaseObject is Slider) // bpm change is into slider, this is easy acc window
                             effectiveRatio *= 0.125;
 
-                        if (current.Previous(i).BaseObject is Slider) // bpm change was from a slider, this is easier typically than circle -> circle
+                        if (prevObj.BaseObject is Slider) // bpm change was from a slider, this is easier typically than circle -> circle
                             effectiveRatio *= 0.25;
 
                         if (previousIslandSize == islandSize) // repeated island size (ex: triplet -> triplet)


### PR DESCRIPTION
These extra calls to `Previous` just aren't needed as they're already done earlier in the evaluator. Looks useless at first glance but can provide up to 2 less calls for the amount of objects in a beatmap so I think it's past the point of just nit picking.

This isn't intending to change difficulty calculation numbers at all, and from my few tests it doesn't but would be useful to get a smoogi sheet just in case.

Testing with [The Unforgiving](https://osu.ppy.sh/beatmapsets/29157#osu/156352), calls to `Previous` in this evaluator decrease from ~522k to ~467k:
### Before
<img width="348" alt="image" src="https://github.com/ppy/osu/assets/51536154/2dbc6e45-bd1e-4ab6-addc-a647d06a3fe6">

### After
<img width="338" alt="image" src="https://github.com/ppy/osu/assets/51536154/7b371129-fdd9-4dfb-802a-ad05cf5f59af">