### PR TITLE
Reduce `Previous` calls in `RhythmEvaluator` by optimising loop logic

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -36,11 +36,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             while (rhythmStart < historicalNoteCount - 2 && current.StartTime - current.Previous(rhythmStart).StartTime < history_time_max)
                 rhythmStart++;
 
+            OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)current.Previous(rhythmStart);
+            OsuDifficultyHitObject lastObj = (OsuDifficultyHitObject)current.Previous(rhythmStart + 1);
+
             for (int i = rhythmStart; i > 0; i--)
             {
                 OsuDifficultyHitObject currObj = (OsuDifficultyHitObject)current.Previous(i - 1);
-                OsuDifficultyHitObject prevObj = (OsuDifficultyHitObject)current.Previous(i);
-                OsuDifficultyHitObject lastObj = (OsuDifficultyHitObject)current.Previous(i + 1);
 
                 double currHistoricalDecay = (history_time_max - (current.StartTime - currObj.StartTime)) / history_time_max; // scales note 0 to 1 from history to now
 
@@ -100,6 +101,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                     startRatio = effectiveRatio;
                     islandSize = 1;
                 }
+
+                lastObj = prevObj;
+                prevObj = currObj;
             }
 
             return Math.Sqrt(4 + rhythmComplexitySum * rhythm_multiplier) / 2; //produces multiplier that can be applied to strain. range [1, infinity) (not really though)


### PR DESCRIPTION
Idea discussed in #28230. This reduces calls as only one new object is introduced per iteration, so we can use the other 2 pre-existing objects in the loop. Overall, this is guaranteed to reduce the amount of calls to `Previous` by 2 for each hit object.

Once again not intending to change any values, but would like a sheet for safety.

Tested on [The Unforgiving](https://osu.ppy.sh/beatmapsets/29157#osu/156352), calls to `Previous` in this evaluator decrease from ~522k to ~304k:
### Before
<img width="348" alt="image" src="https://github.com/ppy/osu/assets/51536154/2dbc6e45-bd1e-4ab6-addc-a647d06a3fe6">

### After
<img width="348" alt="image" src="https://github.com/ppy/osu/assets/51536154/5295e343-e1ba-4d16-a710-12de1cbe3c53">

---

Combined with #28230, we see a total reduction down to 249k:
<img width="348" alt="image" src="https://github.com/ppy/osu/assets/51536154/4fe96d99-c702-4a71-a718-ab278d98eef0">