### PR TITLE
Fix path blueprint becoming desynced from slider path size

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
@@ -61,8 +61,18 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                 body.SetVertices(vertices);
             }
 
-            Size = body.Size;
             OriginPosition = body.PathOffset;
+        }
+
+        public override Vector2 Size
+        {
+            get
+            {
+                if (base.Size != body.Size)
+                    Size = body.Size;
+                return base.Size;
+            }
+            set => base.Size = value;
         }
 
         public void RecyclePath() => body.RecyclePath();

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
@@ -41,6 +42,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         private void load(OsuColour colours)
         {
             body.BorderColour = colours.Yellow;
+            AutoSizeAxes = Axes.Both;
         }
 
         private int? lastVersion;
@@ -62,17 +64,6 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
 
             OriginPosition = body.PathOffset;
-        }
-
-        public override Vector2 Size
-        {
-            get
-            {
-                if (base.Size != body.Size)
-                    Size = body.Size;
-                return base.Size;
-            }
-            set => base.Size = value;
         }
 
         public void RecyclePath() => body.RecyclePath();

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs
@@ -28,21 +28,22 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         public SliderBodyPiece()
         {
-            InternalChild = body = new ManualSliderBody
-            {
-                AccentColour = Color4.Transparent
-            };
+            AutoSizeAxes = Axes.Both;
 
             // SliderSelectionBlueprint relies on calling ReceivePositionalInputAt on this drawable to determine whether selection should occur.
             // Without AlwaysPresent, a movement in a parent container (ie. the editor composer area resizing) could cause incorrect input handling.
             AlwaysPresent = true;
+
+            InternalChild = body = new ManualSliderBody
+            {
+                AccentColour = Color4.Transparent
+            };
         }
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
             body.BorderColour = colours.Yellow;
-            AutoSizeAxes = Axes.Both;
         }
 
         private int? lastVersion;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
@@ -13,15 +15,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     {
         public new void SetVertices(IReadOnlyList<Vector2> vertices) => base.SetVertices(vertices);
 
-        public override Vector2 Size
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            get
-            {
-                if (base.Size != Path.Size)
-                    Size = Path.Size;
-                return base.Size;
-            }
-            set => base.Size = value;
+            AutoSizeAxes = Axes.Both;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osuTK;
 
@@ -13,12 +12,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     /// </summary>
     public partial class ManualSliderBody : SliderBody
     {
-        public new void SetVertices(IReadOnlyList<Vector2> vertices) => base.SetVertices(vertices);
-
-        [BackgroundDependencyLoader]
-        private void load()
+        public ManualSliderBody()
         {
             AutoSizeAxes = Axes.Both;
         }
+
+        public new void SetVertices(IReadOnlyList<Vector2> vertices) => base.SetVertices(vertices);
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
@@ -11,10 +11,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     /// </summary>
     public partial class ManualSliderBody : SliderBody
     {
-        public new void SetVertices(IReadOnlyList<Vector2> vertices)
+        public new void SetVertices(IReadOnlyList<Vector2> vertices) => base.SetVertices(vertices);
+
+        public override Vector2 Size
         {
-            base.SetVertices(vertices);
-            Size = Path.Size;
+            get
+            {
+                if (base.Size != Path.Size)
+                    Size = Path.Size;
+                return base.Size;
+            }
+            set => base.Size = value;
         }
     }
 }


### PR DESCRIPTION
Closes #21679 

The `Size` getter for `ManualSliderBody` and `SliderBodyPiece` now sets the `Size` to equal `Path.Size` and `body.Size` respectively if the values differ. 

Change is needed as `body.SetVertices(vertices);` isn't called in `SliderBodyPiece.UpdateFrom` unless the version of the HitObject has changed, which is not a guarantee when the `Path.Size` changes.
https://github.com/ppy/osu/blob/3a608aa8153541f4f610d7bea018ce67586f9907/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/SliderBodyPiece.cs#L48-L54