### PR TITLE
Add back `SDL2BatteryInfo` for desktop platforms

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -22,7 +22,6 @@ using osu.Game.IPC;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Performance;
 using osu.Game.Utils;
-using SDL;
 
 namespace osu.Desktop
 {
@@ -168,25 +167,6 @@ namespace osu.Desktop
             base.Dispose(isDisposing);
             osuSchemeLinkIPCChannel?.Dispose();
             archiveImportIPCChannel?.Dispose();
-        }
-
-        private unsafe class SDL3BatteryInfo : BatteryInfo
-        {
-            public override double? ChargeLevel
-            {
-                get
-                {
-                    int percentage;
-                    SDL3.SDL_GetPowerInfo(null, &percentage);
-
-                    if (percentage == -1)
-                        return null;
-
-                    return percentage / 100.0;
-                }
-            }
-
-            public override bool OnBattery => SDL3.SDL_GetPowerInfo(null, null) == SDL_PowerState.SDL_POWERSTATE_ON_BATTERY;
         }
     }
 }

--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -160,7 +160,7 @@ namespace osu.Desktop
             host.Window.Title = Name;
         }
 
-        protected override BatteryInfo CreateBatteryInfo() => new SDL3BatteryInfo();
+        protected override BatteryInfo CreateBatteryInfo() => FrameworkEnvironment.UseSDL3 ? new SDL3BatteryInfo() : new SDL2BatteryInfo();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -28,6 +28,14 @@ namespace osu.Desktop
 
         private static LegacyTcpIpcProvider? legacyIpc;
 
+        private static unsafe void showMessageBox(string title, string message)
+        {
+            if (FrameworkEnvironment.UseSDL3)
+                SDL3.SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, null);
+            else
+                SDL2.SDL.SDL_ShowSimpleMessageBox(SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, IntPtr.Zero);
+        }
+
         [STAThread]
         public static void Main(string[] args)
         {
@@ -52,19 +60,15 @@ namespace osu.Desktop
                 // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
-                    unsafe
-                    {
-                        // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider
-                        // disabling it ourselves.
-                        // We could also better detect compatibility mode if required:
-                        // https://stackoverflow.com/questions/10744651/how-i-can-detect-if-my-application-is-running-under-compatibility-mode#comment58183249_10744730
-                        SDL3.SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
-                            "Your operating system is too old to run osu!"u8,
-                            "This version of osu! requires at least Windows 8.1 to run.\n"u8
-                            + "Please upgrade your operating system or consider using an older version of osu!.\n\n"u8
-                            + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!"u8, null);
-                        return;
-                    }
+                    // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider
+                    // disabling it ourselves.
+                    // We could also better detect compatibility mode if required:
+                    // https://stackoverflow.com/questions/10744651/how-i-can-detect-if-my-application-is-running-under-compatibility-mode#comment58183249_10744730
+                    showMessageBox("Your operating system is too old to run osu!",
+                        "This version of osu! requires at least Windows 8.1 to run.\n"
+                        + "Please upgrade your operating system or consider using an older version of osu!.\n\n"
+                        + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!");
+                    return;
                 }
 
                 setupSquirrel();

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -28,14 +28,6 @@ namespace osu.Desktop
 
         private static LegacyTcpIpcProvider? legacyIpc;
 
-        private static unsafe void showMessageBox(string title, string message)
-        {
-            if (FrameworkEnvironment.UseSDL3)
-                SDL3.SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, null);
-            else
-                SDL2.SDL.SDL_ShowSimpleMessageBox(SDL2.SDL.SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR, title, message, IntPtr.Zero);
-        }
-
         [STAThread]
         public static void Main(string[] args)
         {
@@ -60,15 +52,19 @@ namespace osu.Desktop
                 // See https://www.mongodb.com/docs/realm/sdk/dotnet/compatibility/
                 if (windowsVersion.Major < 6 || (windowsVersion.Major == 6 && windowsVersion.Minor <= 2))
                 {
-                    // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider
-                    // disabling it ourselves.
-                    // We could also better detect compatibility mode if required:
-                    // https://stackoverflow.com/questions/10744651/how-i-can-detect-if-my-application-is-running-under-compatibility-mode#comment58183249_10744730
-                    showMessageBox("Your operating system is too old to run osu!",
-                        "This version of osu! requires at least Windows 8.1 to run.\n"
-                        + "Please upgrade your operating system or consider using an older version of osu!.\n\n"
-                        + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!");
-                    return;
+                    unsafe
+                    {
+                        // If users running in compatibility mode becomes more of a common thing, we may want to provide better guidance or even consider
+                        // disabling it ourselves.
+                        // We could also better detect compatibility mode if required:
+                        // https://stackoverflow.com/questions/10744651/how-i-can-detect-if-my-application-is-running-under-compatibility-mode#comment58183249_10744730
+                        SDL3.SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags.SDL_MESSAGEBOX_ERROR,
+                            "Your operating system is too old to run osu!"u8,
+                            "This version of osu! requires at least Windows 8.1 to run.\n"u8
+                            + "Please upgrade your operating system or consider using an older version of osu!.\n\n"u8
+                            + "If you are running a newer version of windows, please check you don't have \"Compatibility mode\" turned on for osu!"u8, null);
+                        return;
+                    }
                 }
 
                 setupSquirrel();

--- a/osu.Desktop/SDL2BatteryInfo.cs
+++ b/osu.Desktop/SDL2BatteryInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Utils;
+
+namespace osu.Desktop
+{
+    internal class SDL2BatteryInfo : BatteryInfo
+    {
+        public override double? ChargeLevel
+        {
+            get
+            {
+                SDL2.SDL.SDL_GetPowerInfo(out _, out int percentage);
+
+                if (percentage == -1)
+                    return null;
+
+                return percentage / 100.0;
+            }
+        }
+
+        public override bool OnBattery => SDL2.SDL.SDL_GetPowerInfo(out _, out _) == SDL2.SDL.SDL_PowerState.SDL_POWERSTATE_ON_BATTERY;
+    }
+}

--- a/osu.Desktop/SDL3BatteryInfo.cs
+++ b/osu.Desktop/SDL3BatteryInfo.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Utils;
+using SDL;
+
+namespace osu.Desktop
+{
+    internal unsafe class SDL3BatteryInfo : BatteryInfo
+    {
+        public override double? ChargeLevel
+        {
+            get
+            {
+                int percentage;
+                SDL3.SDL_GetPowerInfo(null, &percentage);
+
+                if (percentage == -1)
+                    return null;
+
+                return percentage / 100.0;
+            }
+        }
+
+        public override bool OnBattery => SDL3.SDL_GetPowerInfo(null, null) == SDL_PowerState.SDL_POWERSTATE_ON_BATTERY;
+    }
+}


### PR DESCRIPTION
Adds back the SDL2 code where it was replaced by SDL3.