### PR TITLE
Fix game running out of memory when approximating almost-straight perfect slider curves

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -71,12 +71,12 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         [Timeout(4000)] //Catches crashes in other threads, but not ideal. Hopefully there is a improvement to this.
         public void TestScalingSliderFlat(
-            [Values(0, 1, 2, 3)] int type_int
+            [Values(0, 1, 2, 3)] int typeInt
         )
         {
-            Slider slider = null;
+            Slider slider = null!;
 
-            switch (type_int)
+            switch (typeInt)
             {
                 case 0:
                     AddStep("Add linear slider", () =>
@@ -93,6 +93,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                         EditorBeatmap.Add(slider);
                     });
                     break;
+
                 case 1:
                     AddStep("Add perfect curve slider", () =>
                     {
@@ -109,14 +110,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                         EditorBeatmap.Add(slider);
                     });
                     break;
-                case 2:
-                    AddStep("Add bezier slider", () =>
+
+                case 3:
+                    AddStep("Add catmull slider", () =>
                     {
                         slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
 
                         PathControlPoint[] points =
                         {
-                            new PathControlPoint(new Vector2(0), PathType.BEZIER),
+                            new PathControlPoint(new Vector2(0), PathType.CATMULL),
                             new PathControlPoint(new Vector2(50, 25)),
                             new PathControlPoint(new Vector2(25, 80)),
                             new PathControlPoint(new Vector2(40, 100)),
@@ -126,14 +128,15 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                         EditorBeatmap.Add(slider);
                     });
                     break;
-                case 3:
-                    AddStep("Add catmull slider", () =>
+
+                default:
+                    AddStep("Add bezier slider", () =>
                     {
                         slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
 
                         PathControlPoint[] points =
                         {
-                            new PathControlPoint(new Vector2(0), PathType.CATMULL),
+                            new PathControlPoint(new Vector2(0), PathType.BEZIER),
                             new PathControlPoint(new Vector2(50, 25)),
                             new PathControlPoint(new Vector2(25, 80)),
                             new PathControlPoint(new Vector2(40, 100)),

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -126,21 +126,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                         EditorBeatmap.Add(slider);
                     });
                     break;
-                    AddStep("Add perfect curve slider", () =>
-                    {
-                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
-
-                        PathControlPoint[] points =
-                        {
-                            new PathControlPoint(new Vector2(0), PathType.PERFECT_CURVE),
-                            new PathControlPoint(new Vector2(50, 25)),
-                            new PathControlPoint(new Vector2(25, 100)),
-                        };
-
-                        slider.Path = new SliderPath(points);
-                        EditorBeatmap.Add(slider);
-                    });
-                    break;
                 case 3:
                     AddStep("Add catmull slider", () =>
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             if (boundingBox.Width >= 640 || boundingBox.Height >= 480)
                 return;
 
-            int subpoints = (2f * circularArcProperties.Radius <= 0.1f) ? 2 : Math.Max(2, (int)Math.Ceiling(circularArcProperties.ThetaRange / (2.0 * Math.Acos(1f - 0.1f / circularArcProperties.Radius))));
+            int subpoints = (2f * circularArcProperties.Radius <= 0.1f) ? 2 : Math.Max(2, (int)Math.Ceiling(circularArcProperties.ThetaRange / (2.0 * Math.Acos(1f - (0.1f / circularArcProperties.Radius)))));
 
             //ignore cases where subpoints is int.MaxValue, result will be garbage
             //as well, having this many subpoints will cause an out of memory error, so can't happen during normal useage
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
                 if (progress == 0.0f || progress >= (subpoints - 2) / (float)(subpoints - 1))
                     continue;
 
-                double theta = circularArcProperties.ThetaStart + circularArcProperties.Direction * progress * circularArcProperties.ThetaRange;
+                double theta = circularArcProperties.ThetaStart + (circularArcProperties.Direction * progress * circularArcProperties.ThetaRange);
                 Vector2 vector = new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta)) * circularArcProperties.Radius;
 
                 Assert.True(Precision.AlmostEquals(circularArcProperties.Centre + vector, path.PositionAt(progress), 0.01f),

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -68,6 +68,119 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddAssert("slider length shrunk", () => slider.Path.Distance < distanceBefore);
         }
 
+        [Test]
+        [Timeout(4000)] //Catches crashes in other threads, but not ideal. Hopefully there is a improvement to this.
+        public void TestScalingSliderFlat(
+            [Values(0, 1, 2, 3)] int type_int
+        )
+        {
+            Slider slider = null;
+
+            switch (type_int)
+            {
+                case 0:
+                    AddStep("Add linear slider", () =>
+                    {
+                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
+
+                        PathControlPoint[] points =
+                        {
+                            new PathControlPoint(new Vector2(0), PathType.LINEAR),
+                            new PathControlPoint(new Vector2(50, 100)),
+                        };
+
+                        slider.Path = new SliderPath(points);
+                        EditorBeatmap.Add(slider);
+                    });
+                    break;
+                case 1:
+                    AddStep("Add perfect curve slider", () =>
+                    {
+                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
+
+                        PathControlPoint[] points =
+                        {
+                            new PathControlPoint(new Vector2(0), PathType.PERFECT_CURVE),
+                            new PathControlPoint(new Vector2(50, 25)),
+                            new PathControlPoint(new Vector2(25, 100)),
+                        };
+
+                        slider.Path = new SliderPath(points);
+                        EditorBeatmap.Add(slider);
+                    });
+                    break;
+                case 2:
+                    AddStep("Add bezier slider", () =>
+                    {
+                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
+
+                        PathControlPoint[] points =
+                        {
+                            new PathControlPoint(new Vector2(0), PathType.BEZIER),
+                            new PathControlPoint(new Vector2(50, 25)),
+                            new PathControlPoint(new Vector2(25, 80)),
+                            new PathControlPoint(new Vector2(40, 100)),
+                        };
+
+                        slider.Path = new SliderPath(points);
+                        EditorBeatmap.Add(slider);
+                    });
+                    break;
+                    AddStep("Add perfect curve slider", () =>
+                    {
+                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
+
+                        PathControlPoint[] points =
+                        {
+                            new PathControlPoint(new Vector2(0), PathType.PERFECT_CURVE),
+                            new PathControlPoint(new Vector2(50, 25)),
+                            new PathControlPoint(new Vector2(25, 100)),
+                        };
+
+                        slider.Path = new SliderPath(points);
+                        EditorBeatmap.Add(slider);
+                    });
+                    break;
+                case 3:
+                    AddStep("Add catmull slider", () =>
+                    {
+                        slider = new Slider { StartTime = EditorClock.CurrentTime, Position = new Vector2(300) };
+
+                        PathControlPoint[] points =
+                        {
+                            new PathControlPoint(new Vector2(0), PathType.CATMULL),
+                            new PathControlPoint(new Vector2(50, 25)),
+                            new PathControlPoint(new Vector2(25, 80)),
+                            new PathControlPoint(new Vector2(40, 100)),
+                        };
+
+                        slider.Path = new SliderPath(points);
+                        EditorBeatmap.Add(slider);
+                    });
+                    break;
+            }
+
+            AddAssert("ensure object placed", () => EditorBeatmap.HitObjects.Count == 1);
+
+            moveMouse(new Vector2(300));
+            AddStep("select slider", () => InputManager.Click(MouseButton.Left));
+            AddStep("slider is valid", () => slider.Path.GetSegmentEnds()); //To run ensureValid();
+
+            SelectionBoxDragHandle dragHandle = null!;
+            AddStep("store drag handle", () => dragHandle = Editor.ChildrenOfType<SelectionBoxDragHandle>().Skip(1).First());
+            AddAssert("is dragHandle not null", () => dragHandle != null);
+
+            AddStep("move mouse to handle", () => InputManager.MoveMouseTo(dragHandle));
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+            moveMouse(new Vector2(0, 300));
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("move mouse to handle", () => InputManager.MoveMouseTo(dragHandle));
+            AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
+            moveMouse(new Vector2(0, 300)); //Should crash here if broken, although doesn't count as failed...
+            AddStep("end drag", () => InputManager.ReleaseButton(MouseButton.Left));
+        }
+
         private void moveMouse(Vector2 pos) =>
             AddStep($"move mouse to {pos}", () => InputManager.MoveMouseTo(playfield.ToScreenSpace(pos)));
     }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSliderScaling.cs
@@ -3,8 +3,10 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
@@ -72,48 +74,119 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         private void moveMouse(Vector2 pos) =>
             AddStep($"move mouse to {pos}", () => InputManager.MoveMouseTo(playfield.ToScreenSpace(pos)));
     }
+
     [TestFixture]
     public class TestSliderNearLinearScaling
     {
+        private readonly Random rng = new Random(1337);
+
         [Test]
         public void TestScalingSliderFlat()
         {
-            Slider sliderPerfect = new Slider
-            {
-                Position = new Vector2(300),
-                Path = new SliderPath(
-                    [
-                        new PathControlPoint(new Vector2(0), PathType.PERFECT_CURVE),
-                        new PathControlPoint(new Vector2(50, 25)),
-                        new PathControlPoint(new Vector2(25, 100)),
-                    ])
-            };
+            SliderPath sliderPathPerfect = new SliderPath(
+            [
+                new PathControlPoint(new Vector2(0), PathType.PERFECT_CURVE),
+                new PathControlPoint(new Vector2(50, 25)),
+                new PathControlPoint(new Vector2(25, 100)),
+            ]);
 
-            Slider sliderBezier = new Slider
-            {
-                Position = new Vector2(300),
-                Path = new SliderPath(
-                    [
-                        new PathControlPoint(new Vector2(0), PathType.BEZIER),
-                        new PathControlPoint(new Vector2(50, 25)),
-                        new PathControlPoint(new Vector2(25, 100)),
-                    ])
-            };
+            SliderPath sliderPathBezier = new SliderPath(
+            [
+                new PathControlPoint(new Vector2(0), PathType.BEZIER),
+                new PathControlPoint(new Vector2(50, 25)),
+                new PathControlPoint(new Vector2(25, 100)),
+            ]);
 
-            scaleSlider(sliderPerfect, new Vector2(0.000001f, 1));
-            scaleSlider(sliderBezier, new Vector2(0.000001f, 1));
+            scaleSlider(sliderPathPerfect, new Vector2(0.000001f, 1));
+            scaleSlider(sliderPathBezier, new Vector2(0.000001f, 1));
 
             for (int i = 0; i < 100; i++)
             {
-                Assert.True(Precision.AlmostEquals(sliderPerfect.Path.PositionAt(i / 100.0f), sliderBezier.Path.PositionAt(i / 100.0f)));
+                Assert.True(Precision.AlmostEquals(sliderPathPerfect.PositionAt(i / 100.0f), sliderPathBezier.PositionAt(i / 100.0f)));
             }
         }
 
-        private void scaleSlider(Slider slider, Vector2 scale)
+        [Test]
+        public void TestPerfectCurveMatchesTheoretical()
         {
-            for (int i = 0; i < slider.Path.ControlPoints.Count; i++)
+            for (int i = 0; i < 20000; i++)
             {
-                slider.Path.ControlPoints[i].Position *= scale;
+                //Only test points that are in the screen's bounds
+                float p1X = 640.0f * (float)rng.NextDouble();
+                float p2X = 640.0f * (float)rng.NextDouble();
+
+                float p1Y = 480.0f * (float)rng.NextDouble();
+                float p2Y = 480.0f * (float)rng.NextDouble();
+                SliderPath sliderPathPerfect = new SliderPath(
+                [
+                    new PathControlPoint(new Vector2(0, 0), PathType.PERFECT_CURVE),
+                    new PathControlPoint(new Vector2(p1X, p1Y)),
+                    new PathControlPoint(new Vector2(p2X, p2Y)),
+                ]);
+
+                assertMatchesPerfectCircle(sliderPathPerfect);
+
+                scaleSlider(sliderPathPerfect, new Vector2(0.00001f, 1));
+
+                assertMatchesPerfectCircle(sliderPathPerfect);
+            }
+        }
+
+        private void assertMatchesPerfectCircle(SliderPath path)
+        {
+            if (path.ControlPoints.Count != 3)
+                return;
+
+            //Replication of PathApproximator.CircularArcToPiecewiseLinear
+            CircularArcProperties circularArcProperties = new CircularArcProperties(path.ControlPoints.Select(x => x.Position).ToArray());
+
+            if (!circularArcProperties.IsValid)
+                return;
+
+            //Addresses cases where circularArcProperties.ThetaRange>0.5
+            //Occurs in code in PathControlPointVisualiser.ensureValidPathType
+            RectangleF boundingBox = PathApproximator.CircularArcBoundingBox(path.ControlPoints.Select(x => x.Position).ToArray());
+            if (boundingBox.Width >= 640 || boundingBox.Height >= 480)
+                return;
+
+            int subpoints = (2f * circularArcProperties.Radius <= 0.1f) ? 2 : Math.Max(2, (int)Math.Ceiling(circularArcProperties.ThetaRange / (2.0 * Math.Acos(1f - 0.1f / circularArcProperties.Radius))));
+
+            //ignore cases where subpoints is int.MaxValue, result will be garbage
+            //as well, having this many subpoints will cause an out of memory error, so can't happen during normal useage
+            if (subpoints == int.MaxValue)
+                return;
+
+            for (int i = 0; i < Math.Min(subpoints, 100); i++)
+            {
+                float progress = (float)rng.NextDouble();
+
+                //To avoid errors from interpolating points, ensure we check only positions that would be subpoints.
+                progress = (float)Math.Ceiling(progress * (subpoints - 1)) / (subpoints - 1);
+
+                //Special case - if few subpoints, ensure checking every single one rather than randomly
+                if (subpoints < 100)
+                    progress = i / (float)(subpoints - 1);
+
+                //edge points cause issue with interpolation, so ignore the last two points and first
+                if (progress == 0.0f || progress >= (subpoints - 2) / (float)(subpoints - 1))
+                    continue;
+
+                double theta = circularArcProperties.ThetaStart + circularArcProperties.Direction * progress * circularArcProperties.ThetaRange;
+                Vector2 vector = new Vector2((float)Math.Cos(theta), (float)Math.Sin(theta)) * circularArcProperties.Radius;
+
+                Assert.True(Precision.AlmostEquals(circularArcProperties.Centre + vector, path.PositionAt(progress), 0.01f),
+                    "A perfect circle with points " + string.Join(", ", path.ControlPoints.Select(x => x.Position)) + " and radius" + circularArcProperties.Radius + "from SliderPath does not almost equal a theoretical perfect circle with " + subpoints + " subpoints"
+                    + ": " + (circularArcProperties.Centre + vector) + " - " + path.PositionAt(progress)
+                    + " = " + (circularArcProperties.Centre + vector - path.PositionAt(progress))
+                );
+            }
+        }
+
+        private void scaleSlider(SliderPath path, Vector2 scale)
+        {
+            for (int i = 0; i < path.ControlPoints.Count; i++)
+            {
+                path.ControlPoints[i].Position *= scale;
             }
         }
     }

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -332,16 +332,15 @@ namespace osu.Game.Rulesets.Objects
 
                     CircularArcProperties circularArcProperties = new CircularArcProperties(subControlPoints);
 
-                    //if false, we'll end up breaking anyways when calculating subPath
+                    // `PathApproximator` will already internally revert to B-spline if the arc isn't valid.
                     if (!circularArcProperties.IsValid)
                         break;
 
-                    //Coppied from PathApproximator.CircularArcToPiecewiseLinear
+                    // taken from https://github.com/ppy/osu-framework/blob/1201e641699a1d50d2f6f9295192dad6263d5820/osu.Framework/Utils/PathApproximator.cs#L181-L186
                     int subPoints = (2f * circularArcProperties.Radius <= 0.1f) ? 2 : Math.Max(2, (int)Math.Ceiling(circularArcProperties.ThetaRange / (2.0 * Math.Acos(1f - (0.1f / circularArcProperties.Radius)))));
 
-                    //theoretically can be int.MaxValue, but lets set this to a lower value anyways
-                    //1000 requires an arc length of over 20 thousand to surpass this limit, which should be safe.
-                    //See here for calculations https://www.desmos.com/calculator/210bwswkbb
+                    // 1000 subpoints requires an arc length of at least ~120 thousand to occur
+                    // See here for calculations https://www.desmos.com/calculator/umj6jvmcz7
                     if (subPoints >= 1000)
                         break;
 

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -339,9 +339,10 @@ namespace osu.Game.Rulesets.Objects
                     //Coppied from PathApproximator.CircularArcToPiecewiseLinear
                     int subPoints = (2f * circularArcProperties.Radius <= 0.1f) ? 2 : Math.Max(2, (int)Math.Ceiling(circularArcProperties.ThetaRange / (2.0 * Math.Acos(1f - (0.1f / circularArcProperties.Radius)))));
 
-                    //if the amount of subpoints is int.MaxValue, causes an out of memory issue, so we default to bezier
-                    //this only occurs for very large radii, so the result should be essentially a straight line anyways
-                    if (subPoints == int.MaxValue)
+                    //theoretically can be int.MaxValue, but lets set this to a lower value anyways
+                    //1000 requires an arc length of over 20 thousand to surpass this limit, which should be safe.
+                    //See here for calculations https://www.desmos.com/calculator/210bwswkbb
+                    if (subPoints >= 1000)
                         break;
 
                     List<Vector2> subPath = PathApproximator.CircularArcToPiecewiseLinear(subControlPoints);

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -274,9 +274,9 @@ namespace osu.Game.Rulesets.Objects
         /// </summary>
         /// <para>
         /// The angle is first obtained based on the farthest vector from the first,
-        /// then we find the angle of each vector from the first, 
+        /// then we find the angle of each vector from the first,
         /// and calculate the distance between the two angle vectors.
-        /// We than scale this distance to the distance from the first vector 
+        /// We than scale this distance to the distance from the first vector
         /// (or by 10 if the distance is smaller),
         /// and if it is greater than acceptableDifference, we return false.
         /// </para>
@@ -288,6 +288,7 @@ namespace osu.Game.Rulesets.Objects
             Vector2 farthest = vectors.MaxBy(x => Vector2.Distance(first, x));
 
             Vector2 angle = Vector2.Normalize(farthest - first);
+
             foreach (Vector2 vector in vectors)
             {
                 if (vector == first)

--- a/osu.Game/Rulesets/Objects/SliderPath.cs
+++ b/osu.Game/Rulesets/Objects/SliderPath.cs
@@ -269,6 +269,37 @@ namespace osu.Game.Rulesets.Objects
             pathCache.Validate();
         }
 
+        /// <summary>
+        /// Checks if the array of vectors is almost straight.
+        /// </summary>
+        /// <para>
+        /// The angle is first obtained based on the farthest vector from the first,
+        /// then we find the angle of each vector from the first, 
+        /// and calculate the distance between the two angle vectors.
+        /// We than scale this distance to the distance from the first vector 
+        /// (or by 10 if the distance is smaller),
+        /// and if it is greater than acceptableDifference, we return false.
+        /// </para>
+        private static bool isAlmostStraight(Vector2[] vectors, float acceptableDifference = 0.1f)
+        {
+            if (vectors.Length <= 2 || vectors.All(x => x == vectors.First())) return true;
+
+            Vector2 first = vectors.First();
+            Vector2 farthest = vectors.MaxBy(x => Vector2.Distance(first, x));
+
+            Vector2 angle = Vector2.Normalize(farthest - first);
+            foreach (Vector2 vector in vectors)
+            {
+                if (vector == first)
+                    continue;
+
+                if (Math.Max(10.0f, Vector2.Distance(vector, first)) * Vector2.Distance(Vector2.Normalize(vector - first), angle) > acceptableDifference)
+                    return false;
+            }
+
+            return true;
+        }
+
         private void calculatePath()
         {
             calculatedPath.Clear();
@@ -292,6 +323,10 @@ namespace osu.Game.Rulesets.Objects
                 // The current vertex ends the segment
                 var segmentVertices = vertices.AsSpan().Slice(start, i - start + 1);
                 var segmentType = ControlPoints[start].Type ?? PathType.LINEAR;
+
+                //If a segment is almost straight, treat it as linear.
+                if (segmentType != PathType.LINEAR && isAlmostStraight(segmentVertices.ToArray()))
+                    segmentType = PathType.LINEAR;
 
                 // No need to calculate path when there is only 1 vertex
                 if (segmentVertices.Length == 1)


### PR DESCRIPTION
A crash to desktop would occur in `SliderPath.calculatePath` caused by when the control points are all approximately aligned in one of the axis, and as the type is not linear, it tries to generate a path that is nigh on infinite (or so I suspect) in `SliderPath.calculateSubPath`.

Can be demonstrated in the editor when scaling a slider that previously had a curve, that has become flat via the handles.

A test has been added to demonstrate this. (Although maybe it can be optimized? I'm not happy using the Timeout attribute, but am unsure of any other way to check for the exception occurring)

The solution I've chosen is to treat nearly straight segments as linear, rather than their previous path type. 

This check is based on (roughly) the distance each vector in the segment is away from the line formed by the first point with the farthest point. (Is technically slightly larger than this as it is based more so on the chord of a circle, but difference should be negligible)


Some odd behaviour (after it becomes flat, you can use the handles twice before scaling is locked in that axis; when flat, the slider can behave somewhat erratically when scaling vertically) does seem to occur with using the handles after, but I don't believe this is to do with the changes I made, rather just weirdness elsewhere.