### PR TITLE
Correct scale of `taiko-glow` element to match stable

### DIFF
--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -21,8 +21,6 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
         private Sprite sprite = null!;
 
-        private const float base_scale = 0.8f;
-
         [BackgroundDependencyLoader(true)]
         private void load(ISkinSource skin, HealthProcessor? healthProcessor)
         {
@@ -32,7 +30,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
                 Alpha = 0,
-                Scale = new Vector2(base_scale),
+                Scale = new Vector2(TaikoLegacyHitTarget.SCALE),
                 Colour = new Colour4(255, 228, 0, 255),
             };
 
@@ -60,8 +58,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             if (!result.IsHit || !isKiaiActive)
                 return;
 
-            sprite.ScaleTo(base_scale + 0.15f).Then()
-                  .ScaleTo(base_scale, 80, Easing.OutQuad);
+            sprite.ScaleTo(TaikoLegacyHitTarget.SCALE + 0.15f).Then()
+                  .ScaleTo(TaikoLegacyHitTarget.SCALE, 80, Easing.OutQuad);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/LegacyKiaiGlow.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 
         private Sprite sprite = null!;
 
+        private const float base_scale = 0.8f;
+
         [BackgroundDependencyLoader(true)]
         private void load(ISkinSource skin, HealthProcessor? healthProcessor)
         {
@@ -30,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 Origin = Anchor.Centre,
                 Anchor = Anchor.Centre,
                 Alpha = 0,
-                Scale = new Vector2(0.7f),
+                Scale = new Vector2(base_scale),
                 Colour = new Colour4(255, 228, 0, 255),
             };
 
@@ -58,8 +60,8 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
             if (!result.IsHit || !isKiaiActive)
                 return;
 
-            sprite.ScaleTo(0.85f).Then()
-                  .ScaleTo(0.7f, 80, Easing.OutQuad);
+            sprite.ScaleTo(base_scale + 0.15f).Then()
+                  .ScaleTo(base_scale, 80, Easing.OutQuad);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacyHitTarget.cs
@@ -12,6 +12,12 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
 {
     public partial class TaikoLegacyHitTarget : CompositeDrawable
     {
+        /// <summary>
+        /// In stable this is 0.7f (see https://github.com/peppy/osu-stable-reference/blob/7519cafd1823f1879c0d9c991ba0e5c7fd3bfa02/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L592)
+        /// but for whatever reason this doesn't match visually.
+        /// </summary>
+        public const float SCALE = 0.8f;
+
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)
         {
@@ -22,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 new Sprite
                 {
                     Texture = skin.GetTexture("approachcircle"),
-                    Scale = new Vector2(0.83f),
+                    Scale = new Vector2(SCALE + 0.03f),
                     Alpha = 0.47f, // eyeballed to match stable
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -30,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                 new Sprite
                 {
                     Texture = skin.GetTexture("taikobigcircle"),
-                    Scale = new Vector2(0.8f),
+                    Scale = new Vector2(SCALE),
                     Alpha = 0.22f, // eyeballed to match stable
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,


### PR DESCRIPTION
Closes #27700.

This was incorrect from from the start (see #21459). I used the values from stable in the original PR, but it turns out they don't match 1:1 (this was even brought up at the time). I did a more thorough visual check this time around to get it right.

| master        | this PR      |  stable |
| ------------- | ------------- | ---------- |
| ![glow_lazer_master](https://github.com/ppy/osu/assets/56885706/bc14332d-b00f-4c27-9c5c-1d6fb179f1fe) | ![glow_lazer_PR](https://github.com/ppy/osu/assets/56885706/5395385c-636a-49b0-a419-1812e829747e) | ![glow_stable](https://github.com/ppy/osu/assets/56885706/97f95841-d23a-4b59-8755-abde66493ea3) |
| ![hit_lazer_master](https://github.com/ppy/osu/assets/56885706/68ccc48c-791d-4273-9673-5f401dfcdbd8) | ![hit_lazer_PR](https://github.com/ppy/osu/assets/56885706/cb8dd214-83b9-4247-bf43-f8ddcb256796) | ![hit_stable](https://github.com/ppy/osu/assets/56885706/c8670293-1540-42de-8146-badac1002ee8) |