### PR TITLE
Fix legacy mania note body animation not resetting sometimes

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -140,10 +140,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         private void onIsHittingChanged(ValueChangedEvent<bool> isHitting)
         {
             if (bodySprite is TextureAnimation bodyAnimation)
-            {
-                bodyAnimation.GotoFrame(0);
                 bodyAnimation.IsPlaying = isHitting.NewValue;
-            }
 
             if (lightContainer == null)
                 return;
@@ -218,6 +215,9 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         protected override void Update()
         {
             base.Update();
+
+            if (!isHitting.Value)
+                (bodySprite as TextureAnimation)?.GotoFrame(0);
 
             if (holdNote.Body.HasHoldBreak)
                 missFadeTime.Value = holdNote.Body.Result.TimeAbsolute;


### PR DESCRIPTION
RFC. Hopefully closes https://github.com/ppy/osu/issues/28284.

As far as I can tell this is a somewhat difficult one to reproduce because it relies on a specific set of circumstances (at least the reproduction case that I found does). The reset to frame 0 would previously be called explicitly when `isHitting` changed:

https://github.com/ppy/osu/blob/182ca145c78432f4b832c8ea407e107dfeaaa8ad/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs#L144

However, it can be the case that `bodyAnimation` is not loaded at the point of this call. This is significant because
`SkinnableTextureAnimation` contains this logic:

https://github.com/ppy/osu/blob/182ca145c78432f4b832c8ea407e107dfeaaa8ad/osu.Game/Skinning/LegacySkinExtensions.cs#L192-L211

which cannot be moved any earlier (because any earlier the `Clock` may no longer be correct), and also causes the animation to be seeked forward while it is stopped.

I can't figure out a decent way to layer this otherwise (by scheduling or whatever), so this commit is just applying the nuclear option of just seeking back to frame 0 on every update frame in which the body piece is not being hit.

No tests because I hope it's obvious why no tests based on description above. The one reliable repro scenario that I found was to start https://osu.ppy.sh/beatmapsets/971561#mania/2034200 and then seek gameplay forward immediately via right arrow key and then pause, as per attached video:

https://github.com/ppy/osu/assets/20418176/0aca3f6e-ca49-4f5c-a432-3489599bffe8