### PR TITLE
Derive API response version from game version

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Online.API
 
         public string WebsiteRootUrl { get; }
 
-        public int APIVersion => 20220705; // We may want to pull this from the game version eventually.
+        public int APIVersion { get; }
 
         public Exception LastLoginError { get; private set; }
 
@@ -84,12 +84,23 @@ namespace osu.Game.Online.API
             this.config = config;
             this.versionHash = versionHash;
 
+            if (game.IsDeployedBuild)
+                APIVersion = game.AssemblyVersion.Major * 10000 + game.AssemblyVersion.Minor;
+            else
+            {
+                var now = DateTimeOffset.Now;
+                APIVersion = now.Year * 10000 + now.Month * 100 + now.Day;
+            }
+
             APIEndpointUrl = endpointConfiguration.APIEndpointUrl;
             WebsiteRootUrl = endpointConfiguration.WebsiteRootUrl;
             NotificationsClient = setUpNotificationsClient();
 
             authentication = new OAuth(endpointConfiguration.APIClientID, endpointConfiguration.APIClientSecret, APIEndpointUrl);
+
             log = Logger.GetLogger(LoggingTarget.Network);
+            log.Add($@"API endpoint root: {APIEndpointUrl}");
+            log.Add($@"API request version: {APIVersion}");
 
             ProvidedUsername = config.Get<string>(OsuSetting.Username);
 

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -42,6 +42,10 @@ namespace osu.Game.Online.API
 
         public string WebsiteRootUrl { get; }
 
+        /// <summary>
+        /// The API response version.
+        /// See: https://osu.ppy.sh/docs/index.html#api-versions
+        /// </summary>
         public int APIVersion { get; }
 
         public Exception LastLoginError { get; private set; }


### PR DESCRIPTION
(Or local date, in the case of non-deployed builds).

Came up when I was looking at https://github.com/ppy/osu-web/pull/11240 and found that we were still hardcoding this.

Thankfully, this *should not* cause issues, since there don't seem to be any ([documented](https://osu.ppy.sh/docs/index.html#api-versions) or [undocumented](https://github.com/search?q=repo%3Appy%2Fosu-web%20api_version()&type=code)) API response version checks for versions newer than 20220705 in osu-web master.

For clarity and possible debugging needs, the API response version is also logged.