### PR TITLE
Avoid `ChatAckRequest` failures flooding console in `OsuGameTestScene`s

### DIFF
--- a/osu.Game.Tests/Chat/TestSceneChannelManager.cs
+++ b/osu.Game.Tests/Chat/TestSceneChannelManager.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Tests.Chat
                             return true;
 
                         case ChatAckRequest ack:
-                            ack.TriggerSuccess(new ChatAckResponse { Silences = silencedUserIds.Select(u => new ChatSilence { UserId = u }).ToList() });
+                            ack.TriggerSuccess(new ChatAckResponse { Silences = silencedUserIds.Select(u => new ChatSilence { UserId = u }).ToArray() });
                             silencedUserIds.Clear();
                             return true;
 

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;

--- a/osu.Game/Online/API/DummyAPIAccess.cs
+++ b/osu.Game/Online/API/DummyAPIAccess.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
@@ -84,6 +85,13 @@ namespace osu.Game.Online.API
             {
                 if (HandleRequest?.Invoke(request) != true)
                 {
+                    // Noisy so let's silently allow these to succeed.
+                    if (request is ChatAckRequest ack)
+                    {
+                        ack.TriggerSuccess(new ChatAckResponse());
+                        return;
+                    }
+
                     request.Fail(new InvalidOperationException($@"{nameof(DummyAPIAccess)} cannot process this request."));
                 }
             });

--- a/osu.Game/Online/API/IAPIProvider.cs
+++ b/osu.Game/Online/API/IAPIProvider.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Online.API
         string APIEndpointUrl { get; }
 
         /// <summary>
-        /// The root URL of of the website, excluding the trailing slash.
+        /// The root URL of the website, excluding the trailing slash.
         /// </summary>
         string WebsiteRootUrl { get; }
 

--- a/osu.Game/Online/API/Requests/Responses/ChatAckResponse.cs
+++ b/osu.Game/Online/API/Requests/Responses/ChatAckResponse.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
+using System;
 using Newtonsoft.Json;
 
 namespace osu.Game.Online.API.Requests.Responses
@@ -10,6 +10,6 @@ namespace osu.Game.Online.API.Requests.Responses
     public class ChatAckResponse
     {
         [JsonProperty("silences")]
-        public List<ChatSilence> Silences { get; set; } = null!;
+        public ChatSilence[] Silences { get; set; } = Array.Empty<ChatSilence>();
     }
 }


### PR DESCRIPTION
Stops this kinda thing:

![JetBrains Rider 2024-05-30 at 08 40 54](https://github.com/ppy/osu/assets/191335/38dc3995-d31b-4a6f-a225-d6e3e5b8c88b)
