### PR TITLE
Fix main menu button backgrounds not covering their entire width sometimes

### DIFF
--- a/osu.Game/Screens/Menu/MainMenuButton.cs
+++ b/osu.Game/Screens/Menu/MainMenuButton.cs
@@ -115,7 +115,6 @@ namespace osu.Game.Screens.Menu
                         backgroundContent = CreateBackground(colour).With(bg =>
                         {
                             bg.RelativeSizeAxes = Axes.Y;
-                            bg.X = -ButtonSystem.WEDGE_WIDTH;
                             bg.Anchor = Anchor.Centre;
                             bg.Origin = Anchor.Centre;
                         }),


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/28195

I thought I had fixed this already once but it still looks broken. Basically when hovering over main menu buttons every now and then it will look like their backgrounds are not covering their entire width when they expand.

See video below for what I'm seeing. This isn't visible when using the test browser's rate feature, I basically had to record this in realtime and then re-record VLC slowly playing _that_ recording back to illustrate this clearly.

https://github.com/ppy/osu/assets/20418176/45226058-550b-48b8-9f07-d28841f71585

The removed X position set looks wrong to me when inspecting the draw visualiser with the element because the element looks to be off centre horizontally, and removing it fixes that.

| master | this PR |
| :-: | :-: |
| ![1717058510](https://github.com/ppy/osu/assets/20418176/c85e05e2-85a6-4ac3-adaf-e7c1cbf17ccf) | ![1717058043](https://github.com/ppy/osu/assets/20418176/6be6bc47-71f2-4d22-845e-f0c7bd15e7aa) |
