### PR TITLE
Fix unable to drag-scroll on collections right-click menu

### DIFF
--- a/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableStatefulMenuItem.cs
@@ -26,9 +26,12 @@ namespace osu.Game.Graphics.UserInterface
             // Right mouse button is a special case where we allow actioning without dismissing the menu.
             // This is achieved by not calling `Clicked` (as done by the base implementation in OnClick).
             if (IsActionable && e.Button == MouseButton.Right)
+            {
                 Item.Action.Value?.Invoke();
+                return true;
+            }
 
-            return true;
+            return false;
         }
 
         private partial class ToggleTextContainer : TextContainer


### PR DESCRIPTION
Broke in https://github.com/ppy/osu/pull/28086

This actually affects all such menus.