### PR TITLE
Disable primary constructor related inspections

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,6 +196,9 @@ csharp_style_prefer_switch_expression = false:none
 
 csharp_style_namespace_declarations = block_scoped:warning
 
+#Style - C# 12 features
+csharp_style_prefer_primary_constructors = false
+
 [*.{yaml,yml}]
 insert_final_newline = true
 indent_style = space

--- a/osu.sln.DotSettings
+++ b/osu.sln.DotSettings
@@ -82,7 +82,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToConstant_002ELocal/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToLambdaExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToLocalFunction/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToPrimaryConstructor/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToPrimaryConstructor/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToStaticClass/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToUsingDeclaration/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertTypeCheckPatternToNullCheck/@EntryIndexedValue">DO_NOT_SHOW</s:String>


### PR DESCRIPTION
[Relevant context.](https://discord.com/channels/188630481301012481/188630652340404224/1247076666510020718)

I'm not actually sure whether the editorconfig incantation does anything but [it's the one official sources give](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0290).