### PR TITLE
Fix Argon accuracy counter layout when under 10% and wireframe off

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonCounterTextComponent.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Screens.Play.HUD
                 labelText = new OsuSpriteText
                 {
                     Alpha = 0,
+                    BypassAutoSizeAxes = Axes.X,
                     Text = label.GetValueOrDefault(),
                     Font = OsuFont.Torus.With(size: 12, weight: FontWeight.Bold),
                     Margin = new MarginPadding { Left = 2.5f },
@@ -65,6 +66,8 @@ namespace osu.Game.Screens.Play.HUD
                 NumberContainer = new Container
                 {
                     AutoSizeAxes = Axes.Both,
+                    Anchor = anchor,
+                    Origin = anchor,
                     Children = new[]
                     {
                         wireframesPart = new ArgonCounterSpriteText(wireframesLookup)


### PR DESCRIPTION
When under 10% accuracy, the argon accuracy counter would leave a blank space between the whole and fractional parts.
![image](https://github.com/ppy/osu/assets/16726733/40d06482-cbbc-4c35-9ec9-666c1e65e5aa)

By applying the anchor to the number container and ignoring the label for sizing. we get a consistent visual with the rest of the counters.
![image](https://github.com/ppy/osu/assets/16726733/ca8eb268-3388-49a2-8a6e-f370e31ccb4c)
Note that moving the anchor to only the container creates the opposite problem (empty spaces when wireframes are visible).

Only problem with this approach would be very long labels not applying it's size to the element in the skin editor, but with current localizations this does not happen.