### PR TITLE
Attempt full editor reload on key count change

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaEditorSaving.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaEditorSaving.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Setup;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Mania.Tests.Editor
+{
+    public partial class TestSceneManiaEditorSaving : EditorSavingTestScene
+    {
+        protected override Ruleset CreateRuleset() => new ManiaRuleset();
+
+        [Test]
+        public void TestKeyCountChange()
+        {
+            LabelledSliderBar<float> keyCount = null!;
+
+            AddStep("go to setup screen", () => InputManager.Key(Key.F4));
+            AddUntilStep("retrieve key count slider", () => keyCount = Editor.ChildrenOfType<SetupScreen>().Single().ChildrenOfType<LabelledSliderBar<float>>().First(), () => Is.Not.Null);
+            AddAssert("key count is 5", () => keyCount.Current.Value, () => Is.EqualTo(5));
+            AddStep("change key count to 8", () =>
+            {
+                keyCount.Current.Value = 8;
+            });
+            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().SingleOrDefault()?.CurrentDialog, Is.InstanceOf<ReloadEditorDialog>);
+            AddStep("refuse", () => InputManager.Key(Key.Number2));
+            AddAssert("key count is 5", () => keyCount.Current.Value, () => Is.EqualTo(5));
+
+            AddStep("change key count to 8 again", () =>
+            {
+                keyCount.Current.Value = 8;
+            });
+            AddUntilStep("dialog visible", () => Game.ChildrenOfType<IDialogOverlay>().Single().CurrentDialog, Is.InstanceOf<ReloadEditorDialog>);
+            AddStep("acquiesce", () => InputManager.Key(Key.Number1));
+            AddUntilStep("beatmap became 8K", () => Game.Beatmap.Value.BeatmapInfo.Difficulty.CircleSize, () => Is.EqualTo(8));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
@@ -26,10 +26,10 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
         private LabelledSliderBar<double> tickRateSlider { get; set; } = null!;
 
         [Resolved]
-        private Editor editor { get; set; } = null!;
+        private Editor? editor { get; set; }
 
         [Resolved]
-        private IEditorChangeHandler changeHandler { get; set; } = null!;
+        private IEditorChangeHandler? changeHandler { get; set; }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -116,16 +116,19 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
         {
             if (updatingKeyCount) return;
 
+            updateValues();
+
+            if (editor == null) return;
+
             updatingKeyCount = true;
 
-            updateValues();
             editor.Reload().ContinueWith(t =>
             {
                 if (!t.GetResultSafely())
                 {
                     Schedule(() =>
                     {
-                        changeHandler.RestoreState(-1);
+                        changeHandler!.RestoreState(-1);
                         Beatmap.Difficulty.CircleSize = keyCountSlider.Current.Value = keyCount.OldValue;
                         updatingKeyCount = false;
                     });

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
@@ -3,20 +3,130 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Setup;
 
 namespace osu.Game.Rulesets.Mania.Edit.Setup
 {
-    public partial class ManiaDifficultySection : DifficultySection
+    public partial class ManiaDifficultySection : SetupSection
     {
+        public override LocalisableString Title => EditorSetupStrings.DifficultyHeader;
+
+        private LabelledSliderBar<float> keyCountSlider { get; set; } = null!;
+        private LabelledSliderBar<float> healthDrainSlider { get; set; } = null!;
+        private LabelledSliderBar<float> overallDifficultySlider { get; set; } = null!;
+        private LabelledSliderBar<double> baseVelocitySlider { get; set; } = null!;
+        private LabelledSliderBar<double> tickRateSlider { get; set; } = null!;
+
+        [Resolved]
+        private Editor editor { get; set; } = null!;
+
+        [Resolved]
+        private IEditorChangeHandler changeHandler { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
-            CircleSizeSlider.Label = BeatmapsetsStrings.ShowStatsCsMania;
-            CircleSizeSlider.Description = "The number of columns in the beatmap";
-            if (CircleSizeSlider.Current is BindableNumber<float> circleSizeFloat)
-                circleSizeFloat.Precision = 1;
+            Children = new Drawable[]
+            {
+                keyCountSlider = new LabelledSliderBar<float>
+                {
+                    Label = BeatmapsetsStrings.ShowStatsCsMania,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = "The number of columns in the beatmap",
+                    Current = new BindableFloat(Beatmap.Difficulty.CircleSize)
+                    {
+                        Default = BeatmapDifficulty.DEFAULT_DIFFICULTY,
+                        MinValue = 0,
+                        MaxValue = 10,
+                        Precision = 1,
+                    }
+                },
+                healthDrainSlider = new LabelledSliderBar<float>
+                {
+                    Label = BeatmapsetsStrings.ShowStatsDrain,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = EditorSetupStrings.DrainRateDescription,
+                    Current = new BindableFloat(Beatmap.Difficulty.DrainRate)
+                    {
+                        Default = BeatmapDifficulty.DEFAULT_DIFFICULTY,
+                        MinValue = 0,
+                        MaxValue = 10,
+                        Precision = 0.1f,
+                    }
+                },
+                overallDifficultySlider = new LabelledSliderBar<float>
+                {
+                    Label = BeatmapsetsStrings.ShowStatsAccuracy,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = EditorSetupStrings.OverallDifficultyDescription,
+                    Current = new BindableFloat(Beatmap.Difficulty.OverallDifficulty)
+                    {
+                        Default = BeatmapDifficulty.DEFAULT_DIFFICULTY,
+                        MinValue = 0,
+                        MaxValue = 10,
+                        Precision = 0.1f,
+                    }
+                },
+                baseVelocitySlider = new LabelledSliderBar<double>
+                {
+                    Label = EditorSetupStrings.BaseVelocity,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = EditorSetupStrings.BaseVelocityDescription,
+                    Current = new BindableDouble(Beatmap.Difficulty.SliderMultiplier)
+                    {
+                        Default = 1.4,
+                        MinValue = 0.4,
+                        MaxValue = 3.6,
+                        Precision = 0.01f,
+                    }
+                },
+                tickRateSlider = new LabelledSliderBar<double>
+                {
+                    Label = EditorSetupStrings.TickRate,
+                    FixedLabelWidth = LABEL_WIDTH,
+                    Description = EditorSetupStrings.TickRateDescription,
+                    Current = new BindableDouble(Beatmap.Difficulty.SliderTickRate)
+                    {
+                        Default = 1,
+                        MinValue = 1,
+                        MaxValue = 4,
+                        Precision = 1,
+                    }
+                },
+            };
+
+            keyCountSlider.Current.BindValueChanged(updateKeyCount);
+            healthDrainSlider.Current.BindValueChanged(_ => updateValues());
+            overallDifficultySlider.Current.BindValueChanged(_ => updateValues());
+            baseVelocitySlider.Current.BindValueChanged(_ => updateValues());
+            tickRateSlider.Current.BindValueChanged(_ => updateValues());
+        }
+
+        private void updateKeyCount(ValueChangedEvent<float> keyCount)
+        {
+            updateValues();
+        }
+
+        private void updateValues()
+        {
+            // for now, update these on commit rather than making BeatmapMetadata bindables.
+            // after switching database engines we can reconsider if switching to bindables is a good direction.
+            Beatmap.Difficulty.CircleSize = keyCountSlider.Current.Value;
+            Beatmap.Difficulty.DrainRate = healthDrainSlider.Current.Value;
+            Beatmap.Difficulty.OverallDifficulty = overallDifficultySlider.Current.Value;
+            Beatmap.Difficulty.SliderMultiplier = baseVelocitySlider.Current.Value;
+            Beatmap.Difficulty.SliderTickRate = tickRateSlider.Current.Value;
+
+            Beatmap.UpdateAllHitObjects();
+            Beatmap.SaveState();
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Setup/ManiaDifficultySection.cs
@@ -110,9 +110,31 @@ namespace osu.Game.Rulesets.Mania.Edit.Setup
             tickRateSlider.Current.BindValueChanged(_ => updateValues());
         }
 
+        private bool updatingKeyCount;
+
         private void updateKeyCount(ValueChangedEvent<float> keyCount)
         {
+            if (updatingKeyCount) return;
+
+            updatingKeyCount = true;
+
             updateValues();
+            editor.Reload().ContinueWith(t =>
+            {
+                if (!t.GetResultSafely())
+                {
+                    Schedule(() =>
+                    {
+                        changeHandler.RestoreState(-1);
+                        Beatmap.Difficulty.CircleSize = keyCountSlider.Current.Value = keyCount.OldValue;
+                        updatingKeyCount = false;
+                    });
+                }
+                else
+                {
+                    updatingKeyCount = false;
+                }
+            });
         }
 
         private void updateValues()

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -421,7 +421,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override RulesetSetupSection CreateEditorSetupSection() => new ManiaSetupSection();
 
-        public override DifficultySection CreateEditorDifficultySection() => new ManiaDifficultySection();
+        public override SetupSection CreateEditorDifficultySection() => new ManiaDifficultySection();
 
         public int GetKeyCount(IBeatmapInfo beatmapInfo, IReadOnlyList<Mod>? mods = null)
             => ManiaBeatmapConverter.GetColumnCount(LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmapInfo), mods);

--- a/osu.Game/Localisation/EditorDialogsStrings.cs
+++ b/osu.Game/Localisation/EditorDialogsStrings.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ContinueEditing => new TranslatableString(getKey(@"continue_editing"), @"Oops, continue editing");
 
+        /// <summary>
+        /// "The editor must be reloaded to apply this change. The beatmap will be saved."
+        /// </summary>
+        public static LocalisableString EditorReloadDialogHeader => new TranslatableString(getKey(@"editor_reload_dialog_header"), @"The editor must be reloaded to apply this change. The beatmap will be saved.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -540,6 +540,8 @@ namespace osu.Game.Overlays.SkinEditor
 
         protected void Redo() => changeHandler?.RestoreState(1);
 
+        void IEditorChangeHandler.RestoreState(int direction) => changeHandler?.RestoreState(direction);
+
         public void Save(bool userTriggered = true) => save(currentSkin.Value, userTriggered);
 
         private void save(Skin skin, bool userTriggered = true)

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -401,6 +401,6 @@ namespace osu.Game.Rulesets
         /// <summary>
         /// Can be overridden to alter the difficulty section to the editor beatmap setup screen.
         /// </summary>
-        public virtual DifficultySection? CreateEditorDifficultySection() => null;
+        public virtual SetupSection? CreateEditorDifficultySection() => null;
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1231,6 +1231,27 @@ namespace osu.Game.Screens.Edit
             loader?.CancelPendingDifficultySwitch();
         }
 
+        public Task<bool> Reload()
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            dialogOverlay.Push(new ReloadEditorDialog(
+                reload: () =>
+                {
+                    bool reloadedSuccessfully = attemptMutationOperation(() =>
+                    {
+                        if (!Save())
+                            return false;
+
+                        SwitchToDifficulty(editorBeatmap.BeatmapInfo);
+                        return true;
+                    });
+                    tcs.SetResult(reloadedSuccessfully);
+                },
+                cancel: () => tcs.SetResult(false)));
+            return tcs.Task;
+        }
+
         public void HandleTimestamp(string timestamp)
         {
             if (!EditorTimestampParser.TryParse(timestamp, out var timeSpan, out string selection))

--- a/osu.Game/Screens/Edit/EditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/EditorChangeHandler.cs
@@ -83,10 +83,6 @@ namespace osu.Game.Screens.Edit
             }
         }
 
-        /// <summary>
-        /// Restores an older or newer state.
-        /// </summary>
-        /// <param name="direction">The direction to restore in. If less than 0, an older state will be used. If greater than 0, a newer state will be used.</param>
         public void RestoreState(int direction)
         {
             if (TransactionActive)

--- a/osu.Game/Screens/Edit/IEditorChangeHandler.cs
+++ b/osu.Game/Screens/Edit/IEditorChangeHandler.cs
@@ -43,5 +43,11 @@ namespace osu.Game.Screens.Edit
         /// Note that this will be a no-op if there is a change in progress via <see cref="BeginChange"/>.
         /// </summary>
         void SaveState();
+
+        /// <summary>
+        /// Restores an older or newer state.
+        /// </summary>
+        /// <param name="direction">The direction to restore in. If less than 0, an older state will be used. If greater than 0, a newer state will be used.</param>
+        void RestoreState(int direction);
     }
 }

--- a/osu.Game/Screens/Edit/ReloadEditorDialog.cs
+++ b/osu.Game/Screens/Edit/ReloadEditorDialog.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Overlays.Dialog;
+using osu.Game.Localisation;
+
+namespace osu.Game.Screens.Edit
+{
+    public partial class ReloadEditorDialog : PopupDialog
+    {
+        public ReloadEditorDialog(Action reload, Action cancel)
+        {
+            HeaderText = EditorDialogsStrings.EditorReloadDialogHeader;
+
+            Icon = FontAwesome.Solid.Sync;
+
+            Buttons = new PopupDialogButton[]
+            {
+                new PopupDialogOkButton
+                {
+                    Text = DialogStrings.Confirm,
+                    Action = reload
+                },
+                new PopupDialogCancelButton
+                {
+                    Text = DialogStrings.Cancel,
+                    Action = cancel
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Addresses the rest of https://github.com/ppy/osu/issues/17127.

https://github.com/ppy/osu/assets/20418176/c9afe6c3-7eda-4a71-80e8-aa6bc4af4c6e

This is a workaround at best because the underlying issues are seemingly not addressable without major rewrites.

- Issue number 1 is the fact that [`EditorBeatmap` uses a different `BeatmapInfo` instance than the underlying `PlayableBeatmap`](https://github.com/ppy/osu/blob/cd3b455341dd1fe420f62235dab5598a4a15c3e0/osu.Game/Screens/Edit/EditorBeatmap.cs#L155-L159). (See also: https://github.com/ppy/osu/pull/28441.) This could possibly be addressed, but for...
- Issue number 2 is that [`Stages` is a property of `ManiaBeatmap`](https://github.com/ppy/osu/blob/cd3b455341dd1fe420f62235dab5598a4a15c3e0/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmap.cs#L15-L18) that gets populated on conversion. The editor [performs conversion once ever over its entire lifetime](https://github.com/ppy/osu/blob/cd3b455341dd1fe420f62235dab5598a4a15c3e0/osu.Game/Screens/Edit/Editor.cs#L248), so fixing this in a way that does not require reloading would entail making editor support the playable beatmap changing under it so it can be reconverted, which does not seem feasible given the degree of reliance on DI.

While I was messing with the places I was I also removed the approach rate slider from mania's difficulty section in beatmap setup because it does nothing.