### PR TITLE
Implement time remaining display for daily challenge screen

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTimeRemainingRing.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTimeRemainingRing.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.DailyChallenge;
+
+namespace osu.Game.Tests.Visual.DailyChallenge
+{
+    public partial class TestSceneDailyChallengeTimeRemainingRing : OsuTestScene
+    {
+        private readonly Bindable<Room> room = new Bindable<Room>(new Room());
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) => new CachedModelDependencyContainer<Room>(base.CreateChildDependencies(parent))
+        {
+            Model = { BindTarget = room }
+        };
+
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
+
+        [Test]
+        public void TestBasicAppearance()
+        {
+            DailyChallengeTimeRemainingRing ring = null!;
+
+            AddStep("create content", () => Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background4,
+                },
+                ring = new DailyChallengeTimeRemainingRing
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            });
+            AddSliderStep("adjust width", 0.1f, 1, 1, width =>
+            {
+                if (ring.IsNotNull())
+                    ring.Width = width;
+            });
+            AddSliderStep("adjust height", 0.1f, 1, 1, height =>
+            {
+                if (ring.IsNotNull())
+                    ring.Height = height;
+            });
+            AddStep("just started", () =>
+            {
+                room.Value.StartDate.Value = DateTimeOffset.Now.AddMinutes(-1);
+                room.Value.EndDate.Value = room.Value.StartDate.Value.Value.AddDays(1);
+            });
+            AddStep("midway through", () =>
+            {
+                room.Value.StartDate.Value = DateTimeOffset.Now.AddHours(-12);
+                room.Value.EndDate.Value = room.Value.StartDate.Value.Value.AddDays(1);
+            });
+            AddStep("nearing end", () =>
+            {
+                room.Value.StartDate.Value = DateTimeOffset.Now.AddDays(-1).AddMinutes(8);
+                room.Value.EndDate.Value = room.Value.StartDate.Value.Value.AddDays(1);
+            });
+            AddStep("already ended", () =>
+            {
+                room.Value.StartDate.Value = DateTimeOffset.Now.AddDays(-2);
+                room.Value.EndDate.Value = room.Value.StartDate.Value.Value.AddDays(1);
+            });
+            AddSliderStep("manual progress", 0f, 1f, 0f, progress =>
+            {
+                var startedTimeAgo = TimeSpan.FromHours(24) * progress;
+                room.Value.StartDate.Value = DateTimeOffset.Now - startedTimeAgo;
+                room.Value.EndDate.Value = room.Value.StartDate.Value.Value.AddDays(1);
+            });
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/SectionHeader.cs
+++ b/osu.Game/Graphics/UserInterface/SectionHeader.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public partial class SectionHeader : CompositeDrawable
+    {
+        private readonly LocalisableString text;
+
+        public SectionHeader(LocalisableString text)
+        {
+            this.text = text;
+
+            Margin = new MarginPadding { Vertical = 10, Horizontal = 5 };
+
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(2),
+                Children = new Drawable[]
+                {
+                    new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold))
+                    {
+                        Text = text,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                    },
+                    new Circle
+                    {
+                        Colour = colourProvider.Highlight1,
+                        Size = new Vector2(28, 2),
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -148,6 +148,11 @@ namespace osu.Game.Online.Rooms
 
         // Only supports retrieval for now
         [Cached]
+        [JsonProperty("starts_at")]
+        public readonly Bindable<DateTimeOffset?> StartDate = new Bindable<DateTimeOffset?>();
+
+        // Only supports retrieval for now
+        [Cached]
         [JsonProperty("ends_at")]
         public readonly Bindable<DateTimeOffset?> EndDate = new Bindable<DateTimeOffset?>();
 

--- a/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
+++ b/osu.Game/Screens/Edit/Components/EditorSidebarSection.cs
@@ -1,15 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
-using osu.Game.Overlays;
-using osuTK;
+using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Edit.Components
 {
@@ -37,47 +32,6 @@ namespace osu.Game.Screens.Edit.Components
                     },
                 }
             };
-        }
-
-        public partial class SectionHeader : CompositeDrawable
-        {
-            private readonly LocalisableString text;
-
-            public SectionHeader(LocalisableString text)
-            {
-                this.text = text;
-
-                Margin = new MarginPadding { Vertical = 10, Horizontal = 5 };
-
-                RelativeSizeAxes = Axes.X;
-                AutoSizeAxes = Axes.Y;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
-            {
-                InternalChild = new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(2),
-                    Children = new Drawable[]
-                    {
-                        new OsuTextFlowContainer(cp => cp.Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold))
-                        {
-                            Text = text,
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                        },
-                        new Circle
-                        {
-                            Colour = colourProvider.Highlight1,
-                            Size = new Vector2(28, 2),
-                        }
-                    }
-                };
-            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
@@ -161,7 +162,10 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                             {
                                                 new Drawable?[]
                                                 {
-                                                    null,
+                                                    new DailyChallengeTimeRemainingRing
+                                                    {
+                                                        RelativeSizeAxes = Axes.Both,
+                                                    },
                                                     null,
                                                     // Middle column (leaderboard)
                                                     new GridContainer
@@ -171,7 +175,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                                         {
                                                             new Drawable[]
                                                             {
-                                                                new OverlinedHeader("Leaderboard")
+                                                                new SectionHeader("Leaderboard")
                                                             },
                                                             [leaderboard = new MatchLeaderboard { RelativeSizeAxes = Axes.Both }],
                                                         },
@@ -191,7 +195,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                                         {
                                                             new Drawable[]
                                                             {
-                                                                new OverlinedHeader("Chat")
+                                                                new SectionHeader("Chat")
                                                             },
                                                             [new MatchChatDisplay(room) { RelativeSizeAxes = Axes.Both }]
                                                         },

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeTimeRemainingRing.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeTimeRemainingRing.cs
@@ -1,0 +1,136 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge
+{
+    public partial class DailyChallengeTimeRemainingRing : OnlinePlayComposite
+    {
+        private CircularProgress progress = null!;
+        private OsuSpriteText timeText = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = new DrawSizePreservingFillContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                TargetDrawSize = new Vector2(200),
+                Strategy = DrawSizePreservationStrategy.Minimum,
+                Children = new Drawable[]
+                {
+                    new CircularProgress
+                    {
+                        Size = new Vector2(180),
+                        InnerRadius = 0.1f,
+                        Progress = 1,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = colourProvider.Background5,
+                    },
+                    progress = new CircularProgress
+                    {
+                        Size = new Vector2(180),
+                        InnerRadius = 0.1f,
+                        Progress = 1,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Direction = FillDirection.Vertical,
+                        Children = new[]
+                        {
+                            timeText = new OsuSpriteText
+                            {
+                                Text = "00:00:00",
+                                Font = OsuFont.TorusAlternate.With(size: 40),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            },
+                            new OsuSpriteText
+                            {
+                                Text = "remaining",
+                                Font = OsuFont.Default.With(size: 20),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            StartDate.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+            EndDate.BindValueChanged(_ => Scheduler.AddOnce(updateState));
+            updateState();
+            FinishTransforms(true);
+        }
+
+        private ScheduledDelegate? scheduledUpdate;
+
+        private void updateState()
+        {
+            scheduledUpdate?.Cancel();
+            scheduledUpdate = null;
+
+            const float transition_duration = 300;
+
+            if (StartDate.Value == null || EndDate.Value == null || EndDate.Value < DateTimeOffset.Now)
+            {
+                timeText.Text = TimeSpan.Zero.ToString(@"hh\:mm\:ss");
+                progress.Progress = 0;
+                timeText.FadeColour(colours.Red2, transition_duration, Easing.OutQuint);
+                progress.FadeColour(colours.Red2, transition_duration, Easing.OutQuint);
+                return;
+            }
+
+            var roomDuration = EndDate.Value.Value - StartDate.Value.Value;
+            var remaining = EndDate.Value.Value - DateTimeOffset.Now;
+
+            timeText.Text = remaining.ToString(@"hh\:mm\:ss");
+            progress.Progress = remaining.TotalSeconds / roomDuration.TotalSeconds;
+
+            if (remaining < TimeSpan.FromMinutes(15))
+            {
+                timeText.Colour = progress.Colour = colours.Red1;
+                timeText
+                    .FadeColour(colours.Red1)
+                    .Then().FlashColour(colours.Red0, transition_duration, Easing.OutQuint);
+                progress
+                    .FadeColour(colours.Red1)
+                    .Then().FlashColour(colours.Red0, transition_duration, Easing.OutQuint);
+            }
+            else
+            {
+                timeText.FadeColour(Colour4.White, transition_duration, Easing.OutQuint);
+                progress.FadeColour(colourProvider.Highlight1, transition_duration, Easing.OutQuint);
+            }
+
+            scheduledUpdate = Scheduler.AddDelayed(updateState, 1000);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeTimeRemainingRing.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeTimeRemainingRing.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Threading;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK;
 
@@ -28,51 +29,56 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChild = new DrawSizePreservingFillContainer
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                TargetDrawSize = new Vector2(200),
-                Strategy = DrawSizePreservationStrategy.Minimum,
-                Children = new Drawable[]
+                new SectionHeader("Time remaining"),
+                new DrawSizePreservingFillContainer
                 {
-                    new CircularProgress
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = 35 },
+                    TargetDrawSize = new Vector2(200),
+                    Strategy = DrawSizePreservationStrategy.Minimum,
+                    Children = new Drawable[]
                     {
-                        Size = new Vector2(180),
-                        InnerRadius = 0.1f,
-                        Progress = 1,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Colour = colourProvider.Background5,
-                    },
-                    progress = new CircularProgress
-                    {
-                        Size = new Vector2(180),
-                        InnerRadius = 0.1f,
-                        Progress = 1,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                    },
-                    new FillFlowContainer
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Direction = FillDirection.Vertical,
-                        Children = new[]
+                        new CircularProgress
                         {
-                            timeText = new OsuSpriteText
+                            Size = new Vector2(180),
+                            InnerRadius = 0.1f,
+                            Progress = 1,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Colour = colourProvider.Background5,
+                        },
+                        progress = new CircularProgress
+                        {
+                            Size = new Vector2(180),
+                            InnerRadius = 0.1f,
+                            Progress = 1,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Direction = FillDirection.Vertical,
+                            Children = new[]
                             {
-                                Text = "00:00:00",
-                                Font = OsuFont.TorusAlternate.With(size: 40),
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                            },
-                            new OsuSpriteText
-                            {
-                                Text = "remaining",
-                                Font = OsuFont.Default.With(size: 20),
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
+                                timeText = new OsuSpriteText
+                                {
+                                    Text = "00:00:00",
+                                    Font = OsuFont.TorusAlternate.With(size: 40),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                },
+                                new OsuSpriteText
+                                {
+                                    Text = "remaining",
+                                    Font = OsuFont.Default.With(size: 20),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                }
                             }
                         }
                     }

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayComposite.cs
@@ -69,6 +69,9 @@ namespace osu.Game.Screens.OnlinePlay
         public Bindable<PlaylistAggregateScore> UserScore { get; private set; }
 
         [Resolved(typeof(Room))]
+        protected Bindable<DateTimeOffset?> StartDate { get; private set; }
+
+        [Resolved(typeof(Room))]
         protected Bindable<DateTimeOffset?> EndDate { get; private set; }
 
         [Resolved(typeof(Room))]


### PR DESCRIPTION
Continuation of https://github.com/ppy/osu/issues/28136

https://github.com/ppy/osu/assets/20418176/71f5519e-4122-489e-a499-6b6cf7898e19

Temporarily added to daily challenge screen to fill blank space:

![1718185705](https://github.com/ppy/osu/assets/20418176/141c3a3c-1588-4b4b-bc63-594e39a2490e)

but the intention is that it won't fill all of that space in the end.