### PR TITLE
Add key to enable iOS 18's game mode

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -145,5 +145,9 @@
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music-games</string>
+	<key>CFBundleExecutable</key>
+	<string></string>
+	<key>GCSupportsGameMode</key>
+	<true/>
 </dict>
 </plist>

--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -145,8 +145,6 @@
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music-games</string>
-	<key>CFBundleExecutable</key>
-	<string></string>
 	<key>GCSupportsGameMode</key>
 	<true/>
 </dict>


### PR DESCRIPTION
In iOS 18, Apple's added a Game Mode to iOS, similar to what they added on macOS, and this plist key enables it.
Reference: [https://youtu.be/SgshkDg1QN8?si=rBlukBrAP0JEBNF5&t=498](https://youtu.be/SgshkDg1QN8?si=rBlukBrAP0JEBNF5&t=498)