### PR TITLE
Fix missing texture on extremely long hold notes

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -245,7 +245,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                         // i dunno this looks about right??
                         // the guard against zero draw height is intended for zero-length hold notes. yes, such cases have been spotted in the wild.
                         if (sprite.DrawHeight > 0)
-                            bodySprite.Scale = new Vector2(1, scaleDirection * 32800 / sprite.DrawHeight);
+                            bodySprite.Scale = new Vector2(1, MathF.Max(1, scaleDirection * 32800 / sprite.DrawHeight));
                     }
 
                     break;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/28459

This code is _shocking_, to the degree that I don't want to touch it with a 10-foot pole. With the default skin, it makes the `Sprite` drawable some 78000 pixels high, and relies on both anchor/origins and masking at a _proxied level opaque to this entire object_ to cut it off correctly. So I'm doing the simplest change possible to fix the issue without rewriting the whole thing.

The issue is clear - if the `Sprite`, after being stretched to fill the size of the body, ends up being larger than 32k pixels (i.e. the body itself is larger than 32k px), it would get scaled down. Normally, the opposite is true.