### PR TITLE
Implement relax mod for taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneSwellJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneSwellJudgements.cs
@@ -86,6 +86,42 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         }
 
         [Test]
+        public void TestAlternatingIsRequired()
+        {
+            const double hit_time = 1000;
+
+            Swell swell = new Swell
+            {
+                StartTime = hit_time,
+                Duration = 1000,
+                RequiredHits = 10
+            };
+
+            List<ReplayFrame> frames = new List<ReplayFrame>
+            {
+                new TaikoReplayFrame(0),
+                new TaikoReplayFrame(2001),
+            };
+
+            for (int i = 0; i < swell.RequiredHits; i++)
+            {
+                double frameTime = 1000 + i * 50;
+                frames.Add(new TaikoReplayFrame(frameTime, TaikoAction.LeftCentre));
+                frames.Add(new TaikoReplayFrame(frameTime + 10));
+            }
+
+            PerformTest(frames, CreateBeatmap(swell));
+
+            AssertJudgementCount(11);
+
+            AssertResult<SwellTick>(0, HitResult.IgnoreHit);
+            for (int i = 1; i < swell.RequiredHits; i++)
+                AssertResult<SwellTick>(i, HitResult.IgnoreMiss);
+
+            AssertResult<Swell>(0, HitResult.IgnoreMiss);
+        }
+
+        [Test]
         public void TestHitNoneSwell()
         {
             const double hit_time = 1000;

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
@@ -1,0 +1,46 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Mods;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Replays;
+
+namespace osu.Game.Rulesets.Taiko.Tests.Mods
+{
+    public partial class TestSceneTaikoModRelax : TaikoModTestScene
+    {
+        [Test]
+        public void TestRelax()
+        {
+            var beatmap = new TaikoBeatmap
+            {
+                HitObjects =
+                {
+                    new Hit { StartTime = 0, Type = HitType.Centre, },
+                    new Hit { StartTime = 250, Type = HitType.Rim, },
+                    new DrumRoll { StartTime = 500, Duration = 500, },
+                    new Swell { StartTime = 1250, Duration = 500 },
+                }
+            };
+            foreach (var ho in beatmap.HitObjects)
+                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
+
+            var replay = new TaikoAutoGenerator(beatmap).Generate();
+
+            foreach (var frame in replay.Frames.OfType<TaikoReplayFrame>().Where(r => r.Actions.Any()))
+                frame.Actions = [TaikoAction.LeftCentre];
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new TaikoModRelax(),
+                Beatmap = beatmap,
+                ReplayFrames = replay.Frames,
+                Autoplay = false,
+                PassCondition = () => Player.ScoreProcessor.HasCompleted.Value && Player.ScoreProcessor.Accuracy.Value == 1,
+            });
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
@@ -5,13 +5,34 @@ using System;
 using System.Linq;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {
-    public class TaikoModRelax : ModRelax
+    public class TaikoModRelax : ModRelax, IApplicableToDrawableHitObject
     {
-        public override LocalisableString Description => @"No ninja-like spinners, demanding drumrolls or unexpected katus.";
+        public override LocalisableString Description => @"No need to remember which key is correct anymore!";
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModSingleTap) }).ToArray();
+
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            var allActions = Enum.GetValues<TaikoAction>();
+
+            drawable.HitObjectApplied += dho =>
+            {
+                switch (dho)
+                {
+                    case DrawableHit hit:
+                        hit.HitActions = allActions;
+                        break;
+
+                    case DrawableSwell swell:
+                        swell.MustAlternate = false;
+                        break;
+                }
+            };
+        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// <summary>
         /// A list of keys which can result in hits for this HitObject.
         /// </summary>
-        public TaikoAction[] HitActions { get; private set; }
+        public TaikoAction[] HitActions { get; internal set; }
 
         /// <summary>
         /// The action that caused this <see cref="DrawableHit"/> to be hit.

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -43,6 +43,11 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool DisplayResult => false;
 
+        /// <summary>
+        /// Whether the player must alternate centre and rim hits.
+        /// </summary>
+        public bool MustAlternate { get; internal set; } = true;
+
         public DrawableSwell()
             : this(null)
         {
@@ -292,7 +297,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             bool isCentre = e.Action == TaikoAction.LeftCentre || e.Action == TaikoAction.RightCentre;
 
             // Ensure alternating centre and rim hits
-            if (lastWasCentre == isCentre)
+            if (lastWasCentre == isCentre && MustAlternate)
                 return false;
 
             // If we've already successfully judged a tick this frame, do not judge more.


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/7914.

The lack of this in lazer has been bugging me for a while.

This is a second try at implementing this. In the first one I tried to follow [this idea](https://github.com/ppy/osu/issues/7914#issuecomment-1193489563) of mixing input blockage and re-propagation of inputs to avoid changing hitobject classes. However, it didn't work because https://github.com/ppy/osu/pull/3493 and https://github.com/ppy/osu/pull/25010 will not allow it to work due to the "has input been handled this frame already" checks. Therefore if I was going to have to modify DHOs anyway to bypass that check then I beelined for the simplest possible / most obvious implementation instead. And yes it's slightly different than stable in behaviour because it doesn't "correct" user inputs like stable but /shrug at this point.

Also stable relax does the following things:
- turns off [a drum roll anti-mashing provision](https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L369-L381) that doesn't even exist in lazer anymore
- prevents failure - but other relax mod implementations in lazer don't do this, so neither does this