### PR TITLE
Fix crashes when attempting to change object duration via timeline during placement

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -397,6 +397,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     if (timeline.FindSnappedPositionAndTime(e.ScreenSpaceMousePosition).Time is double time)
                     {
+                        if (beatmap.PlacementObject.Value != null)
+                            return;
+
                         switch (hitObject)
                         {
                             case IHasRepeats repeatHitObject:


### PR DESCRIPTION
Currently, you can adjust the duration while placing a hitobject which can cause a crash due to the ordering of the blueprints being messed up. This can be done if you drag the duration to be longer than a slider placed below a spinner, for example.

Given this change to duration is not visual due to every update the duration is set to the current time minus the start time, I believe this is the proper way this should've been handled. Although it might be potentially worthwhile fixing the cause of the crash directly, if blueprints in the timeline are improperly ordered as well.


https://github.com/ppy/osu/assets/7444073/37d9bcbb-c73d-40ce-8f81-61534c92e0fe

```
Exception has occurred: CLR/System.InvalidOperationException
An exception of type 'System.InvalidOperationException' occurred in System.Private.CoreLib.dll but was not handled in user code: 'Collection was modified; enumeration operation may not execute.'
   at System.ThrowHelper.ThrowInvalidOperationException_InvalidOperation_EnumFailedVersion()
   at System.Linq.Enumerable.<ExceptIterator>d__99`1.MoveNext()
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at osu.Game.Screens.Edit.Compose.Components.Timeline.TimelineBlueprintContainer.UpdateSelectionFromDragBox() in /Users/REDACTED/Projects/osu/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs:line 179
   at osu.Game.Screens.Edit.Compose.Components.BlueprintContainer`1.Update() in /Users/REDACTED/Projects/osu/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs:line 230
   at osu.Game.Screens.Edit.Compose.Components.EditorBlueprintContainer.Update() in /Users/REDACTED/Projects/osu/osu.Game/Screens/Edit/Compose/Components/EditorBlueprintContainer.cs:line 70
   at osu.Game.Screens.Edit.Compose.Components.Timeline.TimelineBlueprintContainer.Update() in /Users/REDACTED/Projects/osu/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs:line 114
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
...
...
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.processFrame()
```