### PR TITLE
Fix excessive `applause` audio balancing in result screen

### DIFF
--- a/osu.Game/Screens/Ranking/ScorePanel.cs
+++ b/osu.Game/Screens/Ranking/ScorePanel.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Screens.Ranking
         protected override void Update()
         {
             base.Update();
-            audioContent.Balance.Value = ((ScreenSpaceDrawQuad.Centre.X / game.ScreenSpaceDrawQuad.Width) * 2 - 1) * OsuGameBase.SFX_STEREO_STRENGTH;
+            audioContent.Balance.Value = (Math.Clamp(ScreenSpaceDrawQuad.Centre.X / game.ScreenSpaceDrawQuad.Width, -1, 1) * 2 - 1) * OsuGameBase.SFX_STEREO_STRENGTH;
         }
 
         private void playAppearSample()


### PR DESCRIPTION
Because the `ScorePanel` can be vertically scrolled off-screen both left and right when there are many scores present at the results screen, `ScorePanel.ScreenSpaceDrawQuad.Centre` can exceed `game.ScreenSpaceDrawQuad.Width` (you can verify this in the draw visualiser). This makes it possible for the balance to be set 100% left or right without a clamp, which is more than the intended 75%. 

This issue isn't too noticable on any of the default skins but can be quite unpleasant on user skins with loud/long `applause` samples while wearing headphones. I would argue even 75% is quite high because `applause` is often used in a way that could be considered music and not a sound effect, but that's not my call.

Comparison (master first, then PR):

https://github.com/ppy/osu/assets/56885706/b50be7ac-f432-406e-b248-7c7e9ecfab5c

