### PR TITLE
Implement toggling visibility of pass and fail storyboard layers

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboard.cs
@@ -14,8 +14,11 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play;
 using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Resources;
 using osuTK.Graphics;
 
@@ -28,14 +31,14 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         private DrawableStoryboard? storyboard;
 
+        [Cached]
+        private GameplayState testGameplayState = TestGameplayState.Create(new OsuRuleset());
+
         [Test]
         public void TestStoryboard()
         {
             AddStep("Restart", restart);
-            AddToggleStep("Passing", passing =>
-            {
-                if (storyboard != null) storyboard.Passing = passing;
-            });
+            AddToggleStep("Toggle passing state", passing => testGameplayState.HealthProcessor.Health.Value = passing ? 1 : 0);
         }
 
         [Test]
@@ -109,7 +112,6 @@ namespace osu.Game.Tests.Visual.Gameplay
             storyboardContainer.Clock = new FramedClock(Beatmap.Value.Track);
 
             storyboard = toLoad.CreateDrawable(SelectedMods.Value);
-            storyboard.Passing = false;
 
             storyboardContainer.Add(storyboard);
         }

--- a/osu.Game/Screens/Play/GameplayState.cs
+++ b/osu.Game/Screens/Play/GameplayState.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Play
         public readonly Score Score;
 
         public readonly ScoreProcessor ScoreProcessor;
+        public readonly HealthProcessor HealthProcessor;
 
         /// <summary>
         /// The storyboard associated with the beatmap.
@@ -68,7 +69,14 @@ namespace osu.Game.Screens.Play
 
         private readonly Bindable<JudgementResult> lastJudgementResult = new Bindable<JudgementResult>();
 
-        public GameplayState(IBeatmap beatmap, Ruleset ruleset, IReadOnlyList<Mod>? mods = null, Score? score = null, ScoreProcessor? scoreProcessor = null, Storyboard? storyboard = null)
+        public GameplayState(
+            IBeatmap beatmap,
+            Ruleset ruleset,
+            IReadOnlyList<Mod>? mods = null,
+            Score? score = null,
+            ScoreProcessor? scoreProcessor = null,
+            HealthProcessor? healthProcessor = null,
+            Storyboard? storyboard = null)
         {
             Beatmap = beatmap;
             Ruleset = ruleset;
@@ -82,6 +90,7 @@ namespace osu.Game.Screens.Play
             };
             Mods = mods ?? Array.Empty<Mod>();
             ScoreProcessor = scoreProcessor ?? ruleset.CreateScoreProcessor();
+            HealthProcessor = healthProcessor ?? ruleset.CreateHealthProcessor(beatmap.HitObjects[0].StartTime);
             Storyboard = storyboard ?? new Storyboard();
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -260,7 +260,7 @@ namespace osu.Game.Screens.Play
             Score.ScoreInfo.Ruleset = ruleset.RulesetInfo;
             Score.ScoreInfo.Mods = gameplayMods;
 
-            dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor, Beatmap.Value.Storyboard));
+            dependencies.CacheAs(GameplayState = new GameplayState(playableBeatmap, ruleset, gameplayMods, Score, ScoreProcessor, HealthProcessor, Beatmap.Value.Storyboard));
 
             var rulesetSkinProvider = new RulesetSkinProvidingContainer(ruleset, playableBeatmap, Beatmap.Value.Skin);
 

--- a/osu.Game/Tests/Gameplay/TestGameplayState.cs
+++ b/osu.Game/Tests/Gameplay/TestGameplayState.cs
@@ -27,7 +27,9 @@ namespace osu.Game.Tests.Gameplay
             var scoreProcessor = ruleset.CreateScoreProcessor();
             scoreProcessor.ApplyBeatmap(playableBeatmap);
 
-            return new GameplayState(playableBeatmap, ruleset, mods, score, scoreProcessor);
+            var healthProcessor = ruleset.CreateHealthProcessor(beatmap.HitObjects[0].StartTime);
+
+            return new GameplayState(playableBeatmap, ruleset, mods, score, scoreProcessor, healthProcessor);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/6842.

https://github.com/ppy/osu/assets/20418176/4ac1b403-d054-4047-98b7-6d2d48a14ded

This is a rather barebones implementation, just to get this in place somehow at least. The logic is simple - 50% health or above shows pass layer, anything below shows fail layer.

This does not match stable logic all across the board because I have no idea how to package that. Stable defines "passing" in like fifty ways:

- in mania it's >80% HP (https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameModes/Play/Rulesets/Mania/RulesetMania.cs#L333-L336)
- in taiko it's >80% *accuracy* (https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L486-L492)
- there's also the part where "geki additions" will unconditionally set passing state (https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameModes/Play/Player.cs#L3561-L3564)
- and also the part where at the end of the map, the final passing state is determined by checking whether the user passed more sections than failed (https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameModes/Play/Player.cs#L3320)

The biggest issues of these are probably the first two, and they can *probably* be fixed, but would require a new member on `Ruleset` and I'm not sure how to make one look, so I'm not doing that at this time pending collection of ideas on how to do that.