### PR TITLE
Disable the automatic offset adjustment button if the offset of the previous play was 0

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -137,5 +137,30 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
             AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
         }
+
+        [Test]
+        public void TestCalibrationNoChange()
+        {
+            const double average_error = 0;
+
+            AddAssert("Offset is neutral", () => offsetControl.Current.Value == 0);
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
+            AddStep("Set reference score", () =>
+            {
+                offsetControl.ReferenceScore.Value = new ScoreInfo
+                {
+                    HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(average_error),
+                    BeatmapInfo = Beatmap.Value.BeatmapInfo,
+                };
+            });
+
+            AddUntilStep("Has calibration button", () => offsetControl.ChildrenOfType<SettingsButton>().Any());
+            AddStep("Press button", () => offsetControl.ChildrenOfType<SettingsButton>().Single().TriggerClick());
+            AddAssert("Offset is adjusted", () => offsetControl.Current.Value == -average_error);
+
+            AddUntilStep("Button is disabled", () => !offsetControl.ChildrenOfType<SettingsButton>().Single().Enabled.Value);
+            AddStep("Remove reference score", () => offsetControl.ReferenceScore.Value = null);
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
+        }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -19,7 +17,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 {
     public partial class TestSceneBeatmapOffsetControl : OsuTestScene
     {
-        private BeatmapOffsetControl offsetControl;
+        private BeatmapOffsetControl offsetControl = null!;
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -228,7 +228,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 useAverageButton = new SettingsButton
                 {
                     Text = BeatmapOffsetControlStrings.CalibrateUsingLastPlay,
-                    Action = () => Current.Value = lastPlayBeatmapOffset - lastPlayAverage
+                    Action = () => Current.Value = lastPlayBeatmapOffset - lastPlayAverage,
+                    Enabled = { Value = !Precision.AlmostEquals(lastPlayAverage, 0, Current.Precision / 2) }
                 },
                 globalOffsetText = new LinkFlowContainer
                 {
@@ -236,8 +237,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     AutoSizeAxes = Axes.Y,
                 }
             });
-
-            useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, 0, Current.Precision / 2);
 
             if (settings != null)
             {

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -237,6 +237,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 }
             });
 
+            useAverageButton.Enabled.Value = !Precision.AlmostEquals(lastPlayAverage, 0, Current.Precision / 2);
+
             if (settings != null)
             {
                 globalOffsetText.AddText("You can also ");


### PR DESCRIPTION
I luckily found this bug when I retried with an offset of 0. It is almost impossible to reproduce outside of a test scene, but I guarantee it was there once.
I have disabled the button in the event, but if there is no change after adjusting it, it does not work.
It is strange when the button is enabled when no offset adjustment is needed in the first place, so we made sure to check it first.

| master | this PR |
| --- | --- |
|[recording.webm](https://github.com/ppy/osu/assets/75152752/11abdbfd-9745-444b-8b99-0ff662120699) | [recording (1).webm](https://github.com/ppy/osu/assets/75152752/6950b13a-d793-43b9-b089-9befa7c8c5a4) |