### PR TITLE
Change NoScope opacity for spectators and replays

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
@@ -81,11 +81,11 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 }
             });
 
-            AddUntilStep("wait for catcher to hide", () => catcherAlphaAlmostEquals(0));
+            AddUntilStep("wait for catcher to hide", () => catcherAlphaAlmostEquals(expectedSmallestAlpha()));
             AddUntilStep("wait for start of break", isBreak);
             AddUntilStep("wait for catcher to show", () => catcherAlphaAlmostEquals(1));
             AddUntilStep("wait for end of break", () => !isBreak());
-            AddUntilStep("wait for catcher to hide", () => catcherAlphaAlmostEquals(0));
+            AddUntilStep("wait for catcher to hide", () => catcherAlphaAlmostEquals(expectedSmallestAlpha()));
         }
 
         [Test]
@@ -130,6 +130,8 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
         }
 
         private bool isBreak() => Player.IsBreakTime.Value;
+
+        private float expectedSmallestAlpha() => Player.HUDOverlay.PlayerSettingsOverlay.VisualSettings.MinimumNoScopeAlpha.Value;
 
         private bool catcherAlphaAlmostEquals(float alpha)
         {

--- a/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModNoScope.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
 using osu.Game.Rulesets.Mods;
-using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.UI;
 
@@ -25,11 +23,11 @@ namespace osu.Game.Rulesets.Catch.Mods
         {
             var catchPlayfield = (CatchPlayfield)playfield;
             bool shouldAlwaysShowCatcher = IsBreakTime.Value;
-            float targetAlpha = shouldAlwaysShowCatcher ? 1 : ComboBasedAlpha;
+            float currentAlpha = ComputeNewAlpha(catchPlayfield.CatcherArea.Alpha, shouldAlwaysShowCatcher, catchPlayfield.Time.Elapsed);
 
             // AlwaysPresent required for catcher to still act on input when fully hidden.
             catchPlayfield.CatcherArea.AlwaysPresent = true;
-            catchPlayfield.CatcherArea.Alpha = (float)Interpolation.Lerp(catchPlayfield.CatcherArea.Alpha, targetAlpha, Math.Clamp(catchPlayfield.Time.Elapsed / TRANSITION_DURATION, 0, 1));
+            catchPlayfield.CatcherArea.Alpha = currentAlpha;
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -53,11 +53,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 }
             });
 
-            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(0));
+            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(expectedSmallestAlpha()));
             AddUntilStep("wait for start of break", isBreak);
             AddUntilStep("wait for cursor to show", () => cursorAlphaAlmostEquals(1));
             AddUntilStep("wait for end of break", () => !isBreak());
-            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(0));
+            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(expectedSmallestAlpha()));
         }
 
         [Test]
@@ -95,11 +95,11 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 }
             });
 
-            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(0));
+            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(expectedSmallestAlpha()));
             AddUntilStep("wait for start of spinner", isSpinning);
             AddUntilStep("wait for cursor to show", () => cursorAlphaAlmostEquals(1));
             AddUntilStep("wait for end of spinner", () => !isSpinning());
-            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(0));
+            AddUntilStep("wait for cursor to hide", () => cursorAlphaAlmostEquals(expectedSmallestAlpha()));
         }
 
         [Test]
@@ -146,6 +146,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         private bool isSpinning() => Player.ChildrenOfType<DrawableSpinner>().SingleOrDefault()?.Progress > 0;
 
         private bool isBreak() => Player.IsBreakTime.Value;
+
+        private float expectedSmallestAlpha() => Player.HUDOverlay.PlayerSettingsOverlay.VisualSettings.MinimumNoScopeAlpha.Value;
 
         private OsuPlayfield playfield => (OsuPlayfield)Player.DrawableRuleset.Playfield;
 

--- a/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModNoScope.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Objects;
@@ -39,8 +37,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             Debug.Assert(osuPlayfield.Cursor != null);
 
             bool shouldAlwaysShowCursor = IsBreakTime.Value || spinnerPeriods.IsInAny(osuPlayfield.Clock.CurrentTime);
-            float targetAlpha = shouldAlwaysShowCursor ? 1 : ComboBasedAlpha;
-            float currentAlpha = (float)Interpolation.Lerp(osuPlayfield.Cursor.Alpha, targetAlpha, Math.Clamp(osuPlayfield.Time.Elapsed / TRANSITION_DURATION, 0, 1));
+            float currentAlpha = ComputeNewAlpha(osuPlayfield.Cursor.Alpha, shouldAlwaysShowCursor, osuPlayfield.Time.Elapsed);
 
             osuPlayfield.Cursor.Alpha = currentAlpha;
             osuPlayfield.Smoke.Alpha = currentAlpha;

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -110,6 +110,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ComboColourNormalisation => new TranslatableString(getKey(@"combo_colour_normalisation"), @"Combo colour normalisation");
 
         /// <summary>
+        /// "Minimum NoScope opacity"
+        /// </summary>
+        public static LocalisableString MinimumNoScopeOpacity => new TranslatableString(getKey(@"minimum_noscope_opacity"), @"Minimum NoScope opacity");
+
+        /// <summary>
         /// "Hit lighting"
         /// </summary>
         public static LocalisableString HitLighting => new TranslatableString(getKey(@"hit_lighting"), @"Hit lighting");

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -85,6 +85,8 @@ namespace osu.Game.Screens.Play
 
         private readonly BindableBool replayLoaded = new BindableBool();
 
+        public IBindable<bool> ReplayLoaded => replayLoaded;
+
         private static bool hasShownNotificationOnce;
 
         private readonly FillFlowContainer bottomRightElements;

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
@@ -16,6 +17,15 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly PlayerCheckbox showStoryboardToggle;
         private readonly PlayerCheckbox beatmapSkinsToggle;
         private readonly PlayerCheckbox beatmapColorsToggle;
+        private readonly PlayerSliderBar<float> minimumNoScopeAlphaSliderBar;
+
+        public BindableBool ShowNoScopeSettings { get; } = new BindableBool();
+
+        public BindableFloat MinimumNoScopeAlpha { get; } = new BindableFloat()
+        {
+            MinValue = 0.0f,
+            MaxValue = 1.0f
+        };
 
         public VisualSettings()
             : base("Visual Settings")
@@ -40,7 +50,20 @@ namespace osu.Game.Screens.Play.PlayerSettings
                     LabelText = GraphicsSettingsStrings.ComboColourNormalisation,
                     DisplayAsPercentage = true,
                 },
+                minimumNoScopeAlphaSliderBar = new PlayerSliderBar<float>
+                {
+                    LabelText = GraphicsSettingsStrings.MinimumNoScopeOpacity,
+                    DisplayAsPercentage = true,
+                    Current = MinimumNoScopeAlpha
+                },
             };
+
+            ShowNoScopeSettings.BindValueChanged(e =>
+            {
+                minimumNoScopeAlphaSliderBar.Alpha = e.NewValue ? 1 : 0;
+                MinimumNoScopeAlpha.Default = minimumNoScopeAlphaSliderBar.Alpha / 2;
+                MinimumNoScopeAlpha.Value = MinimumNoScopeAlpha.Default;
+            }, true);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/VisualSettings.cs
@@ -17,11 +17,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private readonly PlayerCheckbox showStoryboardToggle;
         private readonly PlayerCheckbox beatmapSkinsToggle;
         private readonly PlayerCheckbox beatmapColorsToggle;
-        private readonly PlayerSliderBar<float> minimumNoScopeAlphaSliderBar;
 
         public BindableBool ShowNoScopeSettings { get; } = new BindableBool();
 
-        public BindableFloat MinimumNoScopeAlpha { get; } = new BindableFloat()
+        public BindableFloat MinimumNoScopeAlpha { get; } = new BindableFloat
         {
             MinValue = 0.0f,
             MaxValue = 1.0f
@@ -30,6 +29,8 @@ namespace osu.Game.Screens.Play.PlayerSettings
         public VisualSettings()
             : base("Visual Settings")
         {
+            PlayerSliderBar<float> minimumNoScopeAlphaSliderBar;
+
             Children = new Drawable[]
             {
                 dimSliderBar = new PlayerSliderBar<double>


### PR DESCRIPTION
## Issue
NoScope mod was previously unwatchable in replays/spectator because cursor can be hidden for extended period of time which makes gameplay uninteresting. 

## Solution
This was addressed by making the smallest possible opacity in replays 50% by default. Additionally a SliderBar was added to Visual Settings in replays which can be used to control this value. SliderBar is visible only when watching a replay with NoScope mod.

![image](https://github.com/ppy/osu/assets/32331609/6ddb2a1e-a5a1-429b-9499-4d420770193c)


## Details
- In gameplay there is no difference
- In replays cursor opacity is now interpolated in interval [SliderBar chosen value, 1] instead of [0, 1] as was done previously
-  While spectating a player cursor will be 50% transparent as minimum with no option to configure because Visual Settings are not shown.