### PR TITLE
Annotate `ControlPoint` and `Mod` for AOT trimming support

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPoint.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using osu.Game.Graphics;
 using osu.Game.Utils;
@@ -9,6 +10,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Beatmaps.ControlPoints
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public abstract class ControlPoint : IComparable<ControlPoint>, IDeepCloneable<ControlPoint>, IEquatable<ControlPoint>, IControlPoint
     {
         [JsonIgnore]

--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -17,6 +17,7 @@ using osu.Game.Utils;
 namespace osu.Game.Beatmaps.ControlPoints
 {
     [Serializable]
+    [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public class ControlPointInfo : IDeepCloneable<ControlPointInfo>
     {
         /// <summary>

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -21,6 +22,7 @@ namespace osu.Game.Rulesets.Mods
     /// <summary>
     /// The base class for gameplay modifiers.
     /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public abstract class Mod : IMod, IEquatable<Mod>, IDeepCloneable<Mod>
     {
         [JsonIgnore]


### PR DESCRIPTION
I have a native AOT compilation project here: https://github.com/smoogipoo/osu-native-diffcalc It compiles the most minimal types from osu+osu-framework+osuTK into a project that can be used to perform difficulty calculation with.

In it, I've had to add a few workarounds for these types which use `Activator.CreateInstance()` down various paths: https://github.com/smoogipoo/osu-native-diffcalc/blob/8fb300329425e52aa078b78728ba802bb8124345/Sources/osu.Game.Native.Desktop/Program.cs#L25-L71

This change should remove the need for these workarounds with very little code-wise overhead from the game itself. This is probably good practice in general though I'm not sure when we'll/if ever move towards trimming more aggressively in production.

Here's a test app:
```csharp
using System.Diagnostics.CodeAnalysis;

new X().Clone().Print();
new Y().Clone().Print();

[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
public class X
{
    public virtual void Print()
    {
        Console.WriteLine("hello from x!");
    }

    public X Clone() => (X)Activator.CreateInstance(GetType())!;
}

public class Y : X
{
    public override void Print()
    {
        Console.WriteLine("hello from y!");
    }
}
```
In .csproj:
```
<PublishAot>true</PublishAot>
<PublishTrimmed>true</PublishTrimmed>
```