### PR TITLE
Move timeline toggle controls to "view" menu

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -208,6 +208,9 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.ComboColourNormalisationAmount, 0.2f, 0f, 1f, 0.01f);
             SetDefault<UserStatus?>(OsuSetting.UserOnlineStatus, null);
+
+            SetDefault(OsuSetting.EditorTimelineShowTimingChanges, true);
+            SetDefault(OsuSetting.EditorTimelineShowTicks, true);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -439,5 +442,7 @@ namespace osu.Game.Configuration
         UserOnlineStatus,
         MultiplayerRoomFilter,
         HideCountryFlags,
+        EditorTimelineShowTimingChanges,
+        EditorTimelineShowTicks,
     }
 }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -100,16 +100,6 @@ namespace osu.Game.Localisation
         public static LocalisableString TestBeatmap => new TranslatableString(getKey(@"test_beatmap"), @"Test!");
 
         /// <summary>
-        /// "Waveform"
-        /// </summary>
-        public static LocalisableString TimelineWaveform => new TranslatableString(getKey(@"timeline_waveform"), @"Waveform");
-
-        /// <summary>
-        /// "Ticks"
-        /// </summary>
-        public static LocalisableString TimelineTicks => new TranslatableString(getKey(@"timeline_ticks"), @"Ticks");
-
-        /// <summary>
         /// "{0:0}&#176;"
         /// </summary>
         public static LocalisableString RotationUnsnapped(float newRotation) => new TranslatableString(getKey(@"rotation_unsnapped"), @"{0:0}°", newRotation);
@@ -133,6 +123,21 @@ namespace osu.Game.Localisation
         /// "Failed to parse editor link"
         /// </summary>
         public static LocalisableString FailedToParseEditorLink => new TranslatableString(getKey(@"failed_to_parse_edtior_link"), @"Failed to parse editor link");
+
+        /// <summary>
+        /// "Timeline"
+        /// </summary>
+        public static LocalisableString Timeline => new TranslatableString(getKey(@"timeline"), @"Timeline");
+
+        /// <summary>
+        /// "Show timing changes"
+        /// </summary>
+        public static LocalisableString TimelineShowTimingChanges => new TranslatableString(getKey(@"timeline_show_timing_changes"), @"Show timing changes");
+
+        /// <summary>
+        /// "Show ticks"
+        /// </summary>
+        public static LocalisableString TimelineShowTicks => new TranslatableString(getKey(@"timeline_show_ticks"), @"Show ticks");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -30,12 +30,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private readonly Drawable userContent;
 
-        public readonly Bindable<bool> WaveformVisible = new Bindable<bool>();
-
-        public readonly Bindable<bool> ControlPointsVisible = new Bindable<bool>();
-
-        public readonly Bindable<bool> TicksVisible = new Bindable<bool>();
-
         [Resolved]
         private EditorClock editorClock { get; set; }
 
@@ -88,6 +82,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Container mainContent;
 
         private Bindable<float> waveformOpacity;
+        private Bindable<bool> controlPointsVisible;
+        private Bindable<bool> ticksVisible;
 
         private double trackLengthForZoom;
 
@@ -139,6 +135,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             });
 
             waveformOpacity = config.GetBindable<float>(OsuSetting.EditorWaveformOpacity);
+            controlPointsVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
+            ticksVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
 
             track.BindTo(editorClock.Track);
             track.BindValueChanged(_ =>
@@ -168,12 +166,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.LoadComplete();
 
-            WaveformVisible.BindValueChanged(_ => updateWaveformOpacity());
             waveformOpacity.BindValueChanged(_ => updateWaveformOpacity(), true);
 
-            TicksVisible.BindValueChanged(visible => ticks.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint), true);
+            ticksVisible.BindValueChanged(visible => ticks.FadeTo(visible.NewValue ? 1 : 0, 200, Easing.OutQuint), true);
 
-            ControlPointsVisible.BindValueChanged(visible =>
+            controlPointsVisible.BindValueChanged(visible =>
             {
                 if (visible.NewValue)
                 {
@@ -195,7 +192,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         private void updateWaveformOpacity() =>
-            waveform.FadeTo(WaveformVisible.Value ? waveformOpacity.Value : 0, 200, Easing.OutQuint);
+            waveform.FadeTo(waveformOpacity.Value, 200, Easing.OutQuint);
 
         protected override void Update()
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -7,10 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Localisation;
 using osu.Game.Overlays;
-using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Edit;
 using osuTK;
 
@@ -33,10 +30,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuColour colours)
         {
-            OsuCheckbox waveformCheckbox;
-            OsuCheckbox controlPointsCheckbox;
-            OsuCheckbox ticksCheckbox;
-
             const float padding = 10;
 
             InternalChildren = new Drawable[]
@@ -51,7 +44,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     },
                     ColumnDimensions = new[]
                     {
-                        new Dimension(GridSizeMode.Absolute, 135),
                         new Dimension(),
                         new Dimension(GridSizeMode.Absolute, 35),
                         new Dimension(GridSizeMode.Absolute, HitObjectComposer.TOOLBOX_CONTRACTED_SIZE_RIGHT - padding * 2),
@@ -60,44 +52,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     {
                         new Drawable[]
                         {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Name = @"Toggle controls",
-                                Children = new Drawable[]
-                                {
-                                    new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = colourProvider.Background2,
-                                    },
-                                    new FillFlowContainer
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Padding = new MarginPadding(padding),
-                                        Direction = FillDirection.Vertical,
-                                        Spacing = new Vector2(0, 4),
-                                        Children = new[]
-                                        {
-                                            waveformCheckbox = new OsuCheckbox(nubSize: 30f)
-                                            {
-                                                LabelText = EditorStrings.TimelineWaveform,
-                                                Current = { Value = true },
-                                            },
-                                            ticksCheckbox = new OsuCheckbox(nubSize: 30f)
-                                            {
-                                                LabelText = EditorStrings.TimelineTicks,
-                                                Current = { Value = true },
-                                            },
-                                            controlPointsCheckbox = new OsuCheckbox(nubSize: 30f)
-                                            {
-                                                LabelText = BeatmapsetsStrings.ShowStatsBpm,
-                                                Current = { Value = true },
-                                            },
-                                        }
-                                    }
-                                }
-                            },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
@@ -167,10 +121,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     },
                 }
             };
-
-            Timeline.WaveformVisible.BindTo(waveformCheckbox.Current);
-            Timeline.ControlPointsVisible.BindTo(controlPointsCheckbox.Current);
-            Timeline.TicksVisible.BindTo(ticksCheckbox.Current);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     {
                         new Dimension(),
                         new Dimension(GridSizeMode.Absolute, 35),
-                        new Dimension(GridSizeMode.Absolute, HitObjectComposer.TOOLBOX_CONTRACTED_SIZE_RIGHT - padding * 2),
+                        new Dimension(GridSizeMode.Absolute, HitObjectComposer.TOOLBOX_CONTRACTED_SIZE_RIGHT),
                     },
                     Content = new[]
                     {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -58,16 +58,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 AutoSizeAxes = Axes.Y,
                                 Children = new Drawable[]
                                 {
-                                    // the out-of-bounds portion of the centre marker.
-                                    new Box
-                                    {
-                                        Width = 24,
-                                        Height = EditorScreenWithTimeline.PADDING,
-                                        Depth = float.MaxValue,
-                                        Colour = colours.Red1,
-                                        Anchor = Anchor.TopCentre,
-                                        Origin = Anchor.BottomCentre,
-                                    },
                                     new Box
                                     {
                                         RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -211,6 +211,8 @@ namespace osu.Game.Screens.Edit
         private Bindable<bool> editorHitMarkers;
         private Bindable<bool> editorAutoSeekOnPlacement;
         private Bindable<bool> editorLimitedDistanceSnap;
+        private Bindable<bool> editorTimelineShowTimingChanges;
+        private Bindable<bool> editorTimelineShowTicks;
 
         public Editor(EditorLoader loader = null)
         {
@@ -305,6 +307,8 @@ namespace osu.Game.Screens.Edit
             editorHitMarkers = config.GetBindable<bool>(OsuSetting.EditorShowHitMarkers);
             editorAutoSeekOnPlacement = config.GetBindable<bool>(OsuSetting.EditorAutoSeekOnPlacement);
             editorLimitedDistanceSnap = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
+            editorTimelineShowTimingChanges = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
+            editorTimelineShowTicks = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
 
             AddInternal(new OsuContextMenuContainer
             {
@@ -357,7 +361,21 @@ namespace osu.Game.Screens.Edit
                                     {
                                         Items = new MenuItem[]
                                         {
-                                            new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
+                                            new MenuItem(EditorStrings.Timeline)
+                                            {
+                                                Items =
+                                                [
+                                                    new WaveformOpacityMenuItem(config.GetBindable<float>(OsuSetting.EditorWaveformOpacity)),
+                                                    new ToggleMenuItem(EditorStrings.TimelineShowTimingChanges)
+                                                    {
+                                                        State = { BindTarget = editorTimelineShowTimingChanges }
+                                                    },
+                                                    new ToggleMenuItem(EditorStrings.TimelineShowTicks)
+                                                    {
+                                                        State = { BindTarget = editorTimelineShowTicks }
+                                                    },
+                                                ]
+                                            },
                                             new BackgroundDimMenuItem(editorBackgroundDim),
                                             new ToggleMenuItem(EditorStrings.ShowHitMarkers)
                                             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -359,7 +359,7 @@ namespace osu.Game.Screens.Edit
                                     },
                                     new MenuItem(CommonStrings.MenuBarView)
                                     {
-                                        Items = new MenuItem[]
+                                        Items = new[]
                                         {
                                             new MenuItem(EditorStrings.Timeline)
                                             {

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Screens.Edit
                                     Name = "Timeline content",
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding { Horizontal = PADDING, Top = PADDING },
                                     Content = new[]
                                     {
                                         new Drawable[]

--- a/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
+++ b/osu.Game/Screens/Edit/WaveformOpacityMenuItem.cs
@@ -20,6 +20,7 @@ namespace osu.Game.Screens.Edit
         {
             Items = new[]
             {
+                createMenuItem(0f),
                 createMenuItem(0.25f),
                 createMenuItem(0.5f),
                 createMenuItem(0.75f),


### PR DESCRIPTION
RFC

![osu_2024-06-17_10-26-02](https://github.com/ppy/osu/assets/20418176/970cd4a2-3f7d-4b06-a845-dd0c8714d7ea)

- Waveform toggle off replaced by 0% opacity
- Rest migrated to the submenu depicted above
- As a bonus, this will now be persistent across sessions by the virtue of being stored to `OsuSetting` / ini config

Based on [this bit of reddit feedback](https://www.reddit.com/r/osugame/comments/1dga6m5/comment/l8pyanu/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button):

> I don't get why the options on the left of the timeline (waveform, ticks and bpm) are permanently there, and not in a drop-down menu in the View section? Who wants to see less of the timeline? 

that I tend to agree with.

This also changes some paddings because stuff looked kind of bad after just moving the settings. There's still some badness elsewhere on the timeline (colour clashes / alignment mostly) but I kinda don't care and want to put functionality above appearance for the time being. Can be adjusted upon feedback if this isn't rejected outright.

| master | b42752c9f06d10da5985ff4ab10e8e728a1a5be0 | 03049d45bb136826c70d632825150492ba36cbc1 |
| :-: | :-: | :-: |
| ![osu_2024-06-17_10-24-16](https://github.com/ppy/osu/assets/20418176/964388d7-8c04-4e7f-9475-975493e3a53d) | ![osu_2024-06-17_10-24-57](https://github.com/ppy/osu/assets/20418176/743316f4-8966-4264-83e3-b84a26a8529d) | ![osu_2024-06-17_10-25-54](https://github.com/ppy/osu/assets/20418176/a0e26ac4-73f1-4c5b-965d-e4d3e796e140) |

| editor playfield scale | gameplay playfield scale |
| :-: | :-: |
| ![osu_2024-06-17_10-31-38](https://github.com/ppy/osu/assets/20418176/5d38f8de-4b49-4e1d-bbc1-0b0dfdcf5f36) | ![osu_2024-06-17_10-31-34](https://github.com/ppy/osu/assets/20418176/fe17014b-0348-4c9f-9b38-4074f63897d2) |