### PR TITLE
Change editor speed adjustment back to adjusting tempo

### DIFF
--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -10,9 +10,11 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -25,14 +27,16 @@ namespace osu.Game.Screens.Edit.Components
     public partial class PlaybackControl : BottomBarContainer
     {
         private IconButton playButton = null!;
+        private PlaybackSpeedControl playbackSpeedControl = null!;
 
         [Resolved]
         private EditorClock editorClock { get; set; } = null!;
 
-        private readonly BindableNumber<double> freqAdjust = new BindableDouble(1);
+        private readonly Bindable<EditorScreenMode> currentScreenMode = new Bindable<EditorScreenMode>();
+        private readonly BindableNumber<double> tempoAdjustment = new BindableDouble(1);
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider)
+        private void load(OverlayColourProvider colourProvider, Editor? editor)
         {
             Background.Colour = colourProvider.Background4;
 
@@ -47,31 +51,61 @@ namespace osu.Game.Screens.Edit.Components
                     Icon = FontAwesome.Regular.PlayCircle,
                     Action = togglePause,
                 },
-                new OsuSpriteText
+                playbackSpeedControl = new PlaybackSpeedControl
                 {
-                    Origin = Anchor.BottomLeft,
-                    Text = EditorStrings.PlaybackSpeed,
-                    RelativePositionAxes = Axes.Y,
-                    Y = 0.5f,
-                    Padding = new MarginPadding { Left = 45 }
-                },
-                new Container
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Origin = Anchor.BottomLeft,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.5f,
-                    Padding = new MarginPadding { Left = 45 },
-                    Child = new PlaybackTabControl { Current = freqAdjust },
+                    AutoSizeAxes = Axes.Y,
+                    RelativeSizeAxes = Axes.X,
+                    Padding = new MarginPadding { Left = 45, },
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = EditorStrings.PlaybackSpeed,
+                        },
+                        new PlaybackTabControl
+                        {
+                            Current = tempoAdjustment,
+                            RelativeSizeAxes = Axes.X,
+                            Height = 16,
+                        },
+                    }
                 }
             };
 
-            Track.BindValueChanged(tr => tr.NewValue?.AddAdjustment(AdjustableProperty.Frequency, freqAdjust), true);
+            Track.BindValueChanged(tr => tr.NewValue?.AddAdjustment(AdjustableProperty.Tempo, tempoAdjustment), true);
+
+            if (editor != null)
+                currentScreenMode.BindTo(editor.Mode);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            currentScreenMode.BindValueChanged(_ =>
+            {
+                if (currentScreenMode.Value == EditorScreenMode.Timing)
+                {
+                    tempoAdjustment.Value = 1;
+                    tempoAdjustment.Disabled = true;
+                    playbackSpeedControl.FadeTo(0.5f, 400, Easing.OutQuint);
+                    playbackSpeedControl.TooltipText = "Speed adjustment is unavailable in timing mode. Timing at slower speeds is inaccurate due to resampling artifacts.";
+                }
+                else
+                {
+                    tempoAdjustment.Disabled = false;
+                    playbackSpeedControl.FadeTo(1, 400, Easing.OutQuint);
+                    playbackSpeedControl.TooltipText = default;
+                }
+            });
         }
 
         protected override void Dispose(bool isDisposing)
         {
-            Track.Value?.RemoveAdjustment(AdjustableProperty.Frequency, freqAdjust);
+            Track.Value?.RemoveAdjustment(AdjustableProperty.Frequency, tempoAdjustment);
 
             base.Dispose(isDisposing);
         }
@@ -107,6 +141,11 @@ namespace osu.Game.Screens.Edit.Components
             base.Update();
 
             playButton.Icon = editorClock.IsRunning ? pause_icon : play_icon;
+        }
+
+        private partial class PlaybackSpeedControl : FillFlowContainer, IHasTooltip
+        {
+            public LocalisableString TooltipText { get; set; }
         }
 
         private partial class PlaybackTabControl : OsuTabControl<double>
@@ -174,7 +213,7 @@ namespace osu.Game.Screens.Edit.Components
                 protected override bool OnHover(HoverEvent e)
                 {
                     updateState();
-                    return true;
+                    return false;
                 }
 
                 protected override void OnHoverLost(HoverLostEvent e) => updateState();


### PR DESCRIPTION
- Partially reverts https://github.com/ppy/osu/pull/12080
- Addresses https://github.com/ppy/osu/discussions/27830, https://github.com/ppy/osu/discussions/23789, https://github.com/ppy/osu/discussions/15368, et al.

The important distinction here is that to prevent misuse when timing, the control will revert to 1.0x speed and disable when moving to timing screen, with a tooltip explaining why.

https://github.com/ppy/osu/assets/20418176/1aa8c616-8e73-4dee-a293-1820716a665e