### PR TITLE
Remove 0.96x multiplier of Classic mod from osu!mania

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModClassic.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModClassic.cs
@@ -7,5 +7,6 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModClassic : ModClassic
     {
+        public override double ScoreMultiplier => 1.0;
     }
 }


### PR DESCRIPTION
The difference between ScoreV1 and lazer scoring is pretty small for mania, so the 0.96x multiplier does not make sense.