### PR TITLE
Fix incorrect slider judgement positions when classic mod is active

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableOsuJudgement.cs
@@ -48,10 +48,20 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             if (!positionTransferred && JudgedObject is DrawableOsuHitObject osuObject && JudgedObject.IsInUse)
             {
-                Position = osuObject.ToSpaceOfOtherDrawable(osuObject.OriginPosition, Parent!);
-                Scale = new Vector2(osuObject.HitObject.Scale);
+                switch (osuObject)
+                {
+                    case DrawableSlider slider:
+                        Position = slider.TailCircle.ToSpaceOfOtherDrawable(slider.TailCircle.OriginPosition, Parent!);
+                        break;
+
+                    default:
+                        Position = osuObject.ToSpaceOfOtherDrawable(osuObject.OriginPosition, Parent!);
+                        break;
+                }
 
                 positionTransferred = true;
+
+                Scale = new Vector2(osuObject.HitObject.Scale);
             }
         }
 


### PR DESCRIPTION
[As reported on discord.](https://discord.com/channels/188630481301012481/1097318920991559880/1255066205065314436)

Regressed in https://github.com/ppy/osu/pull/27977.

Bit ad-hoc but don't see how to fix without just reverting the change. Can add tests I guess but not sure if it's productive?