### PR TITLE
Fix legacy skin hold note bodies not appearing when scrolling upwards

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyBodyPiece.cs
@@ -239,7 +239,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                         // i dunno this looks about right??
                         // the guard against zero draw height is intended for zero-length hold notes. yes, such cases have been spotted in the wild.
                         if (sprite.DrawHeight > 0)
-                            bodySprite.Scale = new Vector2(1, MathF.Max(1, scaleDirection * 32800 / sprite.DrawHeight));
+                            bodySprite.Scale = new Vector2(1, scaleDirection * MathF.Max(1, 32800 / sprite.DrawHeight));
                     }
 
                     break;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28567.
- Regressed in https://github.com/ppy/osu/pull/28466.

Bit of a facepalm moment innit...