### PR TITLE
Fix crash on calculating playlist duration when rate-changing mods are present

### DIFF
--- a/osu.Game/Online/Rooms/PlaylistExtensions.cs
+++ b/osu.Game/Online/Rooms/PlaylistExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Humanizer;
 using Humanizer.Localisation;
 using osu.Framework.Bindables;
+using osu.Game.Rulesets;
 using osu.Game.Utils;
 
 namespace osu.Game.Online.Rooms
@@ -42,14 +43,14 @@ namespace osu.Game.Online.Rooms
         /// <summary>
         /// Returns the total duration from the <see cref="PlaylistItem"/> in playlist order from the supplied <paramref name="playlist"/>,
         /// </summary>
-        public static string GetTotalDuration(this BindableList<PlaylistItem> playlist) =>
+        public static string GetTotalDuration(this BindableList<PlaylistItem> playlist, RulesetStore rulesetStore) =>
             playlist.Select(p =>
             {
                 double rate = 1;
 
                 if (p.RequiredMods.Length > 0)
                 {
-                    var ruleset = p.Beatmap.Ruleset.CreateInstance();
+                    var ruleset = rulesetStore.GetRuleset(p.RulesetID)!.CreateInstance();
                     rate = ModUtils.CalculateRateWithMods(p.RequiredMods.Select(mod => mod.ToMod(ruleset)));
                 }
 

--- a/osu.Game/Screens/OnlinePlay/Components/OverlinedPlaylistHeader.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OverlinedPlaylistHeader.cs
@@ -1,12 +1,17 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
 
 namespace osu.Game.Screens.OnlinePlay.Components
 {
     public partial class OverlinedPlaylistHeader : OverlinedHeader
     {
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
         public OverlinedPlaylistHeader()
             : base("Playlist")
         {
@@ -16,7 +21,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             base.LoadComplete();
 
-            Playlist.BindCollectionChanged((_, _) => Details.Value = Playlist.GetTotalDuration(), true);
+            Playlist.BindCollectionChanged((_, _) => Details.Value = Playlist.GetTotalDuration(rulesets), true);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSettingsOverlay.cs
@@ -24,6 +24,7 @@ using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.Match.Components;
 using osuTK;
 using osu.Game.Localisation;
+using osu.Game.Rulesets;
 
 namespace osu.Game.Screens.OnlinePlay.Playlists
 {
@@ -77,6 +78,9 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
             [Resolved]
             private IAPIProvider api { get; set; } = null!;
+
+            [Resolved]
+            private RulesetStore rulesets { get; set; } = null!;
 
             private IBindable<APIUser> localUser = null!;
 
@@ -366,7 +370,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             public void SelectBeatmap() => editPlaylistButton.TriggerClick();
 
             private void onPlaylistChanged(object? sender, NotifyCollectionChangedEventArgs e) =>
-                playlistLength.Text = $"Length: {Playlist.GetTotalDuration()}";
+                playlistLength.Text = $"Length: {Playlist.GetTotalDuration(rulesets)}";
 
             private bool hasValidSettings => RoomID.Value == null && NameField.Text.Length > 0 && Playlist.Count > 0
                                              && hasValidDuration;


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu/pull/28399.

To reproduce, enter a playlist that has an item with a rate-changing mod (rather than create it yourself).

This is happening because `APIRuleset` has `CreateInstance()` unimplemented:

https://github.com/ppy/osu/blob/b4cefe0cc2fda0ab4b5af6138ee158bd32262f9a/osu.Game/Online/API/Requests/Responses/APIBeatmap.cs#L159

and only triggers when the playlist items in question originate from web.

This is why it is bad to have interface implementations throw outside of maybe mock implementations for tests. `CreateInstance()` is a scourge elsewhere in general, we need way less of it in the codebase (because while convenient, it's also problematic to implement in online contexts, and also expensive because reflection).