### PR TITLE
Fix crash when attempting to adjust duration of break that has no preceding/succeeding objects

### DIFF
--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -296,5 +296,109 @@ namespace osu.Game.Tests.Editing
                 Assert.That(beatmap.Breaks[0].EndTime, Is.EqualTo(8800));
             });
         }
+
+        [Test]
+        public void TestBreaksAtEndOfBeatmapAreRemoved()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 },
+                },
+                Breaks =
+                {
+                    new BreakPeriod(10000, 15000),
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Is.Empty);
+        }
+
+        [Test]
+        public void TestManualBreaksAtEndOfBeatmapAreRemoved()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 1000 },
+                    new HitCircle { StartTime = 2000 },
+                },
+                Breaks =
+                {
+                    new ManualBreakPeriod(10000, 15000),
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Is.Empty);
+        }
+
+        [Test]
+        public void TestBreaksAtStartOfBeatmapAreRemoved()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 10000 },
+                    new HitCircle { StartTime = 11000 },
+                },
+                Breaks =
+                {
+                    new BreakPeriod(0, 9000),
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Is.Empty);
+        }
+
+        [Test]
+        public void TestManualBreaksAtStartOfBeatmapAreRemoved()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HitCircle { StartTime = 10000 },
+                    new HitCircle { StartTime = 11000 },
+                },
+                Breaks =
+                {
+                    new ManualBreakPeriod(0, 9000),
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Is.Empty);
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
@@ -170,8 +170,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 changeHandler?.BeginChange();
                 updateState();
 
-                double min = beatmap.HitObjects.Last(ho => ho.GetEndTime() <= Break.Value.StartTime).GetEndTime();
-                double max = beatmap.HitObjects.First(ho => ho.StartTime >= Break.Value.EndTime).StartTime;
+                double min = beatmap.HitObjects.LastOrDefault(ho => ho.GetEndTime() <= Break.Value.StartTime)?.GetEndTime() ?? double.NegativeInfinity;
+                double max = beatmap.HitObjects.FirstOrDefault(ho => ho.StartTime >= Break.Value.EndTime)?.StartTime ?? double.PositiveInfinity;
 
                 if (isStartHandle)
                     max = Math.Min(max, Break.Value.EndTime - BreakPeriod.MIN_BREAK_DURATION);

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -40,8 +40,12 @@ namespace osu.Game.Screens.Edit
 
             foreach (var manualBreak in Beatmap.Breaks.ToList())
             {
-                if (Beatmap.HitObjects.Any(ho => ho.StartTime <= manualBreak.EndTime && ho.GetEndTime() >= manualBreak.StartTime))
+                if (manualBreak.EndTime <= Beatmap.HitObjects.FirstOrDefault()?.StartTime
+                    || manualBreak.StartTime >= Beatmap.HitObjects.LastOrDefault()?.GetEndTime()
+                    || Beatmap.HitObjects.Any(ho => ho.StartTime <= manualBreak.EndTime && ho.GetEndTime() >= manualBreak.StartTime))
+                {
                     Beatmap.Breaks.Remove(manualBreak);
+                }
             }
 
             for (int i = 1; i < Beatmap.HitObjects.Count; ++i)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28577

Additionally contains a fix to the break autogeneration logic which makes it so that manually-adjusted breaks which are placed before/after all objects are removed (they would previously persist which is undesirable). This was the secondary cause of the issue, because you could do the following:

- Have a break autogenerate itself
- Adjust either end of it to make it mark itself as manually-adjusted
- Remove all objects before or after said break

to get a break that would cause a crash when attempting to drag either end of it.