### PR TITLE
Fix crashes when opening scale/rotation popovers during selection box operations

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionRotationHandler.cs
@@ -53,8 +53,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Begin()
         {
-            if (objectsInRotation != null)
+            if (OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Begin)} a rotate operation while another is in progress!");
+
+            base.Begin();
 
             changeHandler?.BeginChange();
 
@@ -68,10 +70,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Update(float rotation, Vector2? origin = null)
         {
-            if (objectsInRotation == null)
+            if (!OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Update)} a rotate operation without calling {nameof(Begin)} first!");
 
-            Debug.Assert(originalPositions != null && originalPathControlPointPositions != null && defaultOrigin != null);
+            Debug.Assert(objectsInRotation != null && originalPositions != null && originalPathControlPointPositions != null && defaultOrigin != null);
 
             Vector2 actualOrigin = origin ?? defaultOrigin.Value;
 
@@ -91,10 +93,12 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Commit()
         {
-            if (objectsInRotation == null)
+            if (!OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Commit)} a rotate operation without calling {nameof(Begin)} first!");
 
             changeHandler?.EndChange();
+
+            base.Commit();
 
             objectsInRotation = null;
             originalPositions = null;

--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
@@ -72,8 +72,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Begin()
         {
-            if (objectsInScale != null)
+            if (OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Begin)} a scale operation while another is in progress!");
+
+            base.Begin();
 
             changeHandler?.BeginChange();
 
@@ -86,10 +88,10 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Update(Vector2 scale, Vector2? origin = null, Axes adjustAxis = Axes.Both)
         {
-            if (objectsInScale == null)
+            if (!OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Update)} a scale operation without calling {nameof(Begin)} first!");
 
-            Debug.Assert(defaultOrigin != null && OriginalSurroundingQuad != null);
+            Debug.Assert(objectsInScale != null && defaultOrigin != null && OriginalSurroundingQuad != null);
 
             Vector2 actualOrigin = origin ?? defaultOrigin.Value;
 
@@ -117,10 +119,12 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         public override void Commit()
         {
-            if (objectsInScale == null)
+            if (!OperationInProgress.Value)
                 throw new InvalidOperationException($"Cannot {nameof(Commit)} a rotate operation without calling {nameof(Begin)} first!");
 
             changeHandler?.EndChange();
+
+            base.Commit();
 
             objectsInScale = null;
             OriginalSurroundingQuad = null;

--- a/osu.Game.Rulesets.Osu/Edit/TransformToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/TransformToolboxGroup.cs
@@ -77,13 +77,15 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 case GlobalAction.EditorToggleRotateControl:
                 {
-                    rotateButton.TriggerClick();
+                    if (!RotationHandler.OperationInProgress.Value || rotateButton.Selected.Value)
+                        rotateButton.TriggerClick();
                     return true;
                 }
 
                 case GlobalAction.EditorToggleScaleControl:
                 {
-                    scaleButton.TriggerClick();
+                    if (!ScaleHandler.OperationInProgress.Value || scaleButton.Selected.Value)
+                        scaleButton.TriggerClick();
                     return true;
                 }
             }

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposeSelectBox.cs
@@ -84,6 +84,8 @@ namespace osu.Game.Tests.Visual.Editing
 
                 targetContainer = getTargetContainer();
                 initialRotation = targetContainer!.Rotation;
+
+                base.Begin();
             }
 
             public override void Update(float rotation, Vector2? origin = null)
@@ -102,6 +104,8 @@ namespace osu.Game.Tests.Visual.Editing
 
                 targetContainer = null;
                 initialRotation = null;
+
+                base.Commit();
             }
         }
 

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionRotationHandler.cs
@@ -61,6 +61,8 @@ namespace osu.Game.Overlays.SkinEditor
             originalRotations = objectsInRotation.ToDictionary(d => d, d => d.Rotation);
             originalPositions = objectsInRotation.ToDictionary(d => d, d => d.ToScreenSpace(d.OriginPosition));
             defaultOrigin = GeometryUtils.GetSurroundingQuad(objectsInRotation.SelectMany(d => d.ScreenSpaceDrawQuad.GetVertices().ToArray())).Centre;
+
+            base.Begin();
         }
 
         public override void Update(float rotation, Vector2? origin = null)
@@ -99,6 +101,8 @@ namespace osu.Game.Overlays.SkinEditor
             originalPositions = null;
             originalRotations = null;
             defaultOrigin = null;
+
+            base.Commit();
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxRotationHandle.cs
@@ -67,6 +67,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (rotationHandler == null) return false;
 
+            if (rotationHandler.OperationInProgress.Value)
+                return false;
+
             rotationHandler.Begin();
             return true;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
@@ -32,6 +32,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (scaleHandler == null) return false;
 
+            if (scaleHandler.OperationInProgress.Value)
+                return false;
+
             originalAnchor = Anchor;
 
             scaleHandler.Begin();

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionRotationHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionRotationHandler.cs
@@ -13,6 +13,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
     public partial class SelectionRotationHandler : Component
     {
         /// <summary>
+        /// Whether there is any ongoing scale operation right now.
+        /// </summary>
+        public Bindable<bool> OperationInProgress { get; private set; } = new BindableBool();
+
+        /// <summary>
         /// Whether rotation anchored by the selection origin can currently be performed.
         /// </summary>
         public Bindable<bool> CanRotateAroundSelectionOrigin { get; private set; } = new BindableBool();
@@ -50,6 +55,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </remarks>
         public virtual void Begin()
         {
+            OperationInProgress.Value = true;
         }
 
         /// <summary>
@@ -85,6 +91,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </remarks>
         public virtual void Commit()
         {
+            OperationInProgress.Value = false;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionScaleHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionScaleHandler.cs
@@ -14,6 +14,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
     public partial class SelectionScaleHandler : Component
     {
         /// <summary>
+        /// Whether there is any ongoing scale operation right now.
+        /// </summary>
+        public Bindable<bool> OperationInProgress { get; private set; } = new BindableBool();
+
+        /// <summary>
         /// Whether horizontal scaling (from the left or right edge) support should be enabled.
         /// </summary>
         public Bindable<bool> CanScaleX { get; private set; } = new BindableBool();
@@ -63,6 +68,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </remarks>
         public virtual void Begin()
         {
+            OperationInProgress.Value = true;
         }
 
         /// <summary>
@@ -99,6 +105,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </remarks>
         public virtual void Commit()
         {
+            OperationInProgress.Value = false;
         }
     }
 }


### PR DESCRIPTION
The rotation and scale handlers sort of assumed that they would not be interfered with by another operation, but they actually can be - e.g. try rotating a selection via the rotate handle and then pressing <kbd>Ctrl</kbd>-<kbd>R</kbd>. It'll die on an exception. This PR changes it so that doing the same doesn't open the rotate popover.

You could argue that the other thing that could be done is to commit the previous operation, but I kinda don't wanna go there because that will be messy to handle.