### PR TITLE
Fix editor performance dropping over time when hit markers are enabled

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -325,13 +325,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle);
+            UpdateState(ArmedState.Idle, true);
             UpdateComboColour();
 
             // This method is called every frame. If we need to, the following can likely be converted
             // to code which doesn't use transforms at all.
 
             // Matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
+
             using (BeginAbsoluteSequence(StateUpdateTime - 5))
                 this.TransformBindableTo(AccentColour, Color4.White, Math.Max(0, HitStateUpdateTime - StateUpdateTime));
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -375,7 +375,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle);
+            UpdateState(ArmedState.Idle, true);
             HeadCircle.SuppressHitAnimations();
             TailCircle.SuppressHitAnimations();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle);
+            UpdateState(ArmedState.Idle, true);
             UpdateComboColour();
 
             using (BeginAbsoluteSequence(StateUpdateTime - 5))


### PR DESCRIPTION
There's probably a better solution but let's hotfix this for now.
