### PR TITLE
Adjust beatmap carousel's spacing to remove dead-space

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1000,8 +1000,6 @@ namespace osu.Game.Screens.Select
             return set;
         }
 
-        private const float panel_padding = 5;
-
         /// <summary>
         /// Computes the target Y positions for every item in the carousel.
         /// </summary>
@@ -1023,10 +1021,18 @@ namespace osu.Game.Screens.Select
                 {
                     case CarouselBeatmapSet set:
                     {
+                        bool isSelected = item.State.Value == CarouselItemState.Selected;
+
+                        float padding = isSelected ? 5 : -5;
+
+                        if (isSelected)
+                            // double padding because we want to cancel the negative padding from the last item.
+                            currentY += padding * 2;
+
                         visibleItems.Add(set);
                         set.CarouselYPosition = currentY;
 
-                        if (item.State.Value == CarouselItemState.Selected)
+                        if (isSelected)
                         {
                             // scroll position at currentY makes the set panel appear at the very top of the carousel's screen space
                             // move down by half of visible height (height of the carousel's visible extent, including semi-transparent areas)
@@ -1048,7 +1054,7 @@ namespace osu.Game.Screens.Select
                             }
                         }
 
-                        currentY += set.TotalHeight + panel_padding;
+                        currentY += set.TotalHeight + padding;
                         break;
                     }
                 }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -144,9 +144,9 @@ namespace osu.Game.Screens.Select.Carousel
             }
 
             if (!Item.Visible)
-                this.FadeOut(300, Easing.OutQuint);
+                this.FadeOut(100, Easing.OutQuint);
             else
-                this.FadeIn(250);
+                this.FadeIn(400, Easing.OutQuint);
         }
 
         protected virtual void Selected()


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu/discussions/28599.

I think this feels better overall, and would like to apply the change before other design changes to the carousel.

| Before | After |
| :---: | :---: |
| ![osu! 2024-06-26 at 02 58 23](https://github.com/ppy/osu/assets/191335/18a03941-91f8-4187-9af7-4890bfc24dc5) | ![osu! 2024-06-26 at 02 53 34](https://github.com/ppy/osu/assets/191335/6792802a-cb84-4151-afc5-63f216c9f866) |

I also adjusted the fade out of panels as quickly switching between beatmap sets had a lot of visual noise from difficulty panels fading from previous selections.