### PR TITLE
Fix intermittent failure in online menu banner tests

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -3,8 +3,6 @@
 
 using System.Linq;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Online.API.Requests.Responses;

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -3,6 +3,8 @@
 
 using System.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Online.API.Requests.Responses;
@@ -20,6 +22,7 @@ namespace osu.Game.Tests.Visual.Menus
         {
             base.SetUpSteps();
             AddStep("don't fetch online content", () => onlineMenuBanner.FetchOnlineContent = false);
+            AddStep("disable return to top on idle", () => Game.ChildrenOfType<ButtonSystem>().Single().ReturnToTopOnIdle = false);
         }
 
         [Test]


### PR DESCRIPTION
Noticed locally and on CI (https://github.com/ppy/osu/actions/runs/9638362199/job/26578941060?pr=28559). The image could take too long to load that the game becomes idle and the main menu screen returns to `Initial` state (as mentioned on [discord](https://discord.com/channels/188630481301012481/188630652340404224/1255394022852136962) and signified by [this line](https://github.com/ppy/osu/actions/runs/9638362199/job/26578941060?pr=28559#step:5:234)). When the main menu is in `Initial` state, the online banner is hidden and will not receive updates, therefore not adding new images after they finish loading.