### PR TITLE
Always log missing official build attribute

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Humanizer;
@@ -870,6 +871,9 @@ namespace osu.Game
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            if (RuntimeInfo.EntryAssembly.GetCustomAttribute<OfficialBuildAttribute>() == null)
+                Logger.Log(NotificationsStrings.NotOfficialBuild.ToString());
 
             var languages = Enum.GetValues<Language>();
 


### PR DESCRIPTION
This is normally "logged" (via a notification) here:

https://github.com/ppy/osu/blob/3d6a9ccb6d8e2ed270ca45a97ed5a0fa18e9781f/osu.Game/Updater/UpdateManager.cs#L52-L60

... but this only happens once on a new version of the game. In particular, it makes it difficult for us developers to understand what went wrong. This should help with figuring out the appropriate response to re-occurrences of https://github.com/ppy/osu/issues/28556.

I also don't particularly care about translations here, only that the text is the same as the other case.