### PR TITLE
Truncate break times for legacy beatmap export

### DIFF
--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -8,6 +8,7 @@ using System.Text;
 using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.IO;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -59,8 +60,12 @@ namespace osu.Game.Database
 
             // Convert beatmap elements to be compatible with legacy format
             // So we truncate time and position values to integers, and convert paths with multiple segments to bezier curves
+
             foreach (var controlPoint in playableBeatmap.ControlPointInfo.AllControlPoints)
                 controlPoint.Time = Math.Floor(controlPoint.Time);
+
+            for (int i = 0; i < playableBeatmap.Breaks.Count; i++)
+                playableBeatmap.Breaks[i] = new BreakPeriod(Math.Floor(playableBeatmap.Breaks[i].StartTime), Math.Floor(playableBeatmap.Breaks[i].EndTime));
 
             foreach (var hitObject in playableBeatmap.HitObjects)
             {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/28607

Stable expects this to be an integer: https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L483-L485