### PR TITLE
Change song select footer mod multiplier text colour to match mod icon background

### DIFF
--- a/osu.Game/Screens/Select/FooterButtonMods.cs
+++ b/osu.Game/Screens/Select/FooterButtonMods.cs
@@ -59,8 +59,8 @@ namespace osu.Game.Screens.Select
         {
             SelectedColour = colours.Yellow;
             DeselectedColour = SelectedColour.Opacity(0.5f);
-            lowMultiplierColour = colours.Red;
-            highMultiplierColour = colours.Green;
+            lowMultiplierColour = colours.Green;
+            highMultiplierColour = colours.Red;
             Text = @"mods";
             Hotkey = GlobalAction.ToggleModSelection;
 


### PR DESCRIPTION
The current version of the mod select button is displayed as follows:
| High multiplier | Low multiplier |
| ------------- | ------------- |
| ![ScreenShot_2024-06-26_21-35-39](https://github.com/ppy/osu/assets/52519933/31be2791-34c8-4b45-a161-598467c79560) | ![ScreenShot_2024-06-26_21-37-25](https://github.com/ppy/osu/assets/52519933/6ad8ce7d-9096-4299-bc1e-5bff2769002a) |

However, within the mod select menu, featuring red for higher multipliers and green for lower multipliers.
| High multiplier | Low multiplier |
| ------------- | ------------- |
| ![image](https://github.com/ppy/osu/assets/52519933/c87491c0-5f78-4f8f-b4b0-d4156d265ebc) | ![image](https://github.com/ppy/osu/assets/52519933/ecf8f327-c492-4b27-8a3a-153adcfc7d8d) |

Considering that the mod stat also adheres to the high red and low green color scheme, could it be plausible that the text color of the mod button multiplier abides by the same principle as the menu?

Therefore, I modified the text color of the mod button to align with the same principles observed by the others.
| Before | After |
| ------------- | ------------- |
| ![ScreenShot_2024-06-26_21-37-25](https://github.com/ppy/osu/assets/52519933/06827e68-74d9-410e-9e86-1eeda2bf1bb7) | ![ScreenShot_2024-06-26_21-37-06](https://github.com/ppy/osu/assets/52519933/9653b983-60db-4891-8ded-6245e37355fb) |
| ![ScreenShot_2024-06-26_21-35-39](https://github.com/ppy/osu/assets/52519933/336d889b-5aac-4b72-9e84-4339be06a3e5) | ![ScreenShot_2024-06-26_21-36-43](https://github.com/ppy/osu/assets/52519933/d6b119ad-bcc9-424a-a89a-934e86218162) |
