### PR TITLE
Fix editor performance regression with hitmarkers active

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -325,19 +326,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle, true);
+            UpdateState(ArmedState.Idle);
             UpdateComboColour();
 
-            // This method is called every frame. If we need to, the following can likely be converted
-            // to code which doesn't use transforms at all.
+            // This method is called every frame in editor contexts, thus the lack of need for transforms.
 
-            // Matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
+            if (Time.Current >= HitStateUpdateTime)
+            {
+                // More or less matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
+                AccentColour.Value = Color4.White;
+                Alpha = Interpolation.ValueAt(Time.Current, 1f, 0f, HitStateUpdateTime, HitStateUpdateTime + 700);
+            }
 
-            using (BeginAbsoluteSequence(StateUpdateTime - 5))
-                this.TransformBindableTo(AccentColour, Color4.White, Math.Max(0, HitStateUpdateTime - StateUpdateTime));
-
-            using (BeginAbsoluteSequence(HitStateUpdateTime))
-                this.FadeOut(700).Expire();
+            LifetimeEnd = HitStateUpdateTime + 700;
         }
 
         internal void RestoreHitAnimations()

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -375,14 +375,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle, true);
+            UpdateState(ArmedState.Idle);
             HeadCircle.SuppressHitAnimations();
             TailCircle.SuppressHitAnimations();
         }
 
         internal void RestoreHitAnimations()
         {
-            UpdateState(ArmedState.Hit, force: true);
+            UpdateState(ArmedState.Hit);
             HeadCircle.RestoreHitAnimations();
             TailCircle.RestoreHitAnimations();
         }

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -3,12 +3,12 @@
 
 #nullable disable
 
-using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
@@ -132,14 +132,19 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         internal void SuppressHitAnimations()
         {
-            UpdateState(ArmedState.Idle, true);
+            UpdateState(ArmedState.Idle);
             UpdateComboColour();
 
-            using (BeginAbsoluteSequence(StateUpdateTime - 5))
-                this.TransformBindableTo(AccentColour, Color4.White, Math.Max(0, HitStateUpdateTime - StateUpdateTime));
+            // This method is called every frame in editor contexts, thus the lack of need for transforms.
 
-            using (BeginAbsoluteSequence(HitStateUpdateTime))
-                this.FadeOut(700).Expire();
+            if (Time.Current >= HitStateUpdateTime)
+            {
+                // More or less matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
+                AccentColour.Value = Color4.White;
+                Alpha = Interpolation.ValueAt(Time.Current, 1f, 0f, HitStateUpdateTime, HitStateUpdateTime + 700);
+            }
+
+            LifetimeEnd = HitStateUpdateTime + 700;
         }
 
         internal void RestoreHitAnimations()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28618.

As proposed in https://github.com/ppy/osu/issues/28618#issuecomment-2191765344.

Comparison video below. Left is master, right is this PR. Includes evidence that this helps.

https://github.com/ppy/osu/assets/20418176/c37d2744-8a95-4b8c-93ae-435f149bec21

