### PR TITLE
Fix break generation not accounting for concurrent hitobjects correctly

### DIFF
--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -5,6 +5,8 @@ using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
@@ -72,6 +74,50 @@ namespace osu.Game.Tests.Editing
             beatmapProcessor.PostProcess();
 
             Assert.That(beatmap.Breaks, Is.Empty);
+        }
+
+        [Test]
+        public void TestHoldNote()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HoldNote { StartTime = 1000, Duration = 10000 },
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new ManiaRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Has.Count.EqualTo(0));
+        }
+
+        [Test]
+        public void TestHoldNoteWithOverlappingNote()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HoldNote { StartTime = 1000, Duration = 10000 },
+                    new Note { StartTime = 2000 },
+                    new Note { StartTime = 12000 },
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new ManiaRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Has.Count.EqualTo(0));
         }
 
         [Test]

--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -396,6 +396,32 @@ namespace osu.Game.Tests.Editing
         }
 
         [Test]
+        public void TestManualBreaksAtEndOfBeatmapAreRemovedCorrectlyEvenWithConcurrentObjects()
+        {
+            var controlPoints = new ControlPointInfo();
+            controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
+            var beatmap = new Beatmap
+            {
+                ControlPointInfo = controlPoints,
+                HitObjects =
+                {
+                    new HoldNote { StartTime = 1000, EndTime = 20000 },
+                    new HoldNote { StartTime = 2000, EndTime = 3000 },
+                },
+                Breaks =
+                {
+                    new ManualBreakPeriod(10000, 15000),
+                }
+            };
+
+            var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
+            beatmapProcessor.PreProcess();
+            beatmapProcessor.PostProcess();
+
+            Assert.That(beatmap.Breaks, Is.Empty);
+        }
+
+        [Test]
         public void TestBreaksAtStartOfBeatmapAreRemoved()
         {
             var controlPoints = new ControlPointInfo();

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -48,15 +48,20 @@ namespace osu.Game.Screens.Edit
                 }
             }
 
+            double currentMaxEndTime = double.MinValue;
+
             for (int i = 1; i < Beatmap.HitObjects.Count; ++i)
             {
-                double previousObjectEndTime = Beatmap.HitObjects[i - 1].GetEndTime();
+                // Keep track of the maximum end time encountered thus far.
+                // This handles cases like osu!mania's hold notes, which could have concurrent other objects after their start time.
+                currentMaxEndTime = Math.Max(currentMaxEndTime, Beatmap.HitObjects[i - 1].GetEndTime());
+
                 double nextObjectStartTime = Beatmap.HitObjects[i].StartTime;
 
-                if (nextObjectStartTime - previousObjectEndTime < BreakPeriod.MIN_GAP_DURATION)
+                if (nextObjectStartTime - currentMaxEndTime < BreakPeriod.MIN_GAP_DURATION)
                     continue;
 
-                double breakStartTime = previousObjectEndTime + BreakPeriod.GAP_BEFORE_BREAK;
+                double breakStartTime = currentMaxEndTime + BreakPeriod.GAP_BEFORE_BREAK;
                 double breakEndTime = nextObjectStartTime - Math.Max(BreakPeriod.GAP_AFTER_BREAK, Beatmap.ControlPointInfo.TimingPointAt(nextObjectStartTime).BeatLength * 2);
 
                 if (breakEndTime - breakStartTime < BreakPeriod.MIN_BREAK_DURATION)

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -54,6 +54,8 @@ namespace osu.Game.Screens.Edit
             {
                 // Keep track of the maximum end time encountered thus far.
                 // This handles cases like osu!mania's hold notes, which could have concurrent other objects after their start time.
+                // Note that we're relying on the implicit assumption that objects are sorted by start time,
+                // which is why similar tracking is not done for start time.
                 currentMaxEndTime = Math.Max(currentMaxEndTime, Beatmap.HitObjects[i - 1].GetEndTime());
 
                 double nextObjectStartTime = Beatmap.HitObjects[i].StartTime;

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Edit
             foreach (var manualBreak in Beatmap.Breaks.ToList())
             {
                 if (manualBreak.EndTime <= Beatmap.HitObjects.FirstOrDefault()?.StartTime
-                    || manualBreak.StartTime >= Beatmap.HitObjects.LastOrDefault()?.GetEndTime()
+                    || manualBreak.StartTime >= Beatmap.GetLastObjectTime()
                     || Beatmap.HitObjects.Any(ho => ho.StartTime <= manualBreak.EndTime && ho.GetEndTime() >= manualBreak.StartTime))
                 {
                     Beatmap.Breaks.Remove(manualBreak);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28622.