### PR TITLE
Fix osu! dropdown no longer handling `Enter` key to select items

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Settings
         {
             AddStep("create", () =>
             {
-                Cell(0, 0).Children = new Drawable[]
+                ContentContainer.Children = new Drawable[]
                 {
                     new Box
                     {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuDropdown.cs
@@ -6,23 +6,51 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
-using osu.Framework.Input.States;
 using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Input.Bindings;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneOsuDropdown : ThemeComparisonTestScene
     {
-        protected override Drawable CreateContent() =>
-            new OsuEnumDropdown<TestEnum>
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.TopCentre,
-                Width = 150
-            };
+        protected override Drawable CreateContent() => new OsuEnumDropdown<TestEnum>
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.TopCentre,
+            Width = 150
+        };
+
+        [Test]
+        public void TestBackAction()
+        {
+            AddStep("open", () => dropdownMenu.Open());
+            AddStep("press back", () => InputManager.Key(Key.Escape));
+            AddAssert("closed", () => dropdownMenu.State == MenuState.Closed);
+
+            AddStep("open", () => dropdownMenu.Open());
+            AddStep("type something", () => dropdownSearchBar.SearchTerm.Value = "something");
+            AddAssert("search bar visible", () => dropdownSearchBar.State.Value == Visibility.Visible);
+            AddStep("press back", () => InputManager.Key(Key.Escape));
+            AddAssert("text clear", () => dropdownSearchBar.SearchTerm.Value == string.Empty);
+            AddAssert("search bar hidden", () => dropdownSearchBar.State.Value == Visibility.Hidden);
+            AddAssert("still open", () => dropdownMenu.State == MenuState.Open);
+            AddStep("press back", () => InputManager.Key(Key.Escape));
+            AddAssert("closed", () => dropdownMenu.State == MenuState.Closed);
+        }
+
+        [Test]
+        public void TestSelectAction()
+        {
+            AddStep("open", () => dropdownMenu.Open());
+            AddStep("press down", () => InputManager.Key(Key.Down));
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+            AddAssert("second selected", () => dropdown.Current.Value == TestEnum.ReallyLongOption);
+        }
+
+        private OsuEnumDropdown<TestEnum> dropdown => this.ChildrenOfType<OsuEnumDropdown<TestEnum>>().Last();
+        private Menu dropdownMenu => dropdown.ChildrenOfType<Menu>().Single();
+        private DropdownSearchBar dropdownSearchBar => dropdown.ChildrenOfType<DropdownSearchBar>().Single();
 
         private enum TestEnum
         {
@@ -31,27 +59,6 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             [System.ComponentModel.Description("Really lonnnnnnng option")]
             ReallyLongOption,
-        }
-
-        [Test]
-        // todo: this can be written much better if ThemeComparisonTestScene has a manual input manager
-        public void TestBackAction()
-        {
-            AddStep("open", () => dropdown().ChildrenOfType<Menu>().Single().Open());
-            AddStep("press back", () => dropdown().OnPressed(new KeyBindingPressEvent<GlobalAction>(new InputState(), GlobalAction.Back)));
-            AddAssert("closed", () => dropdown().ChildrenOfType<Menu>().Single().State == MenuState.Closed);
-
-            AddStep("open", () => dropdown().ChildrenOfType<Menu>().Single().Open());
-            AddStep("type something", () => dropdown().ChildrenOfType<DropdownSearchBar>().Single().SearchTerm.Value = "something");
-            AddAssert("search bar visible", () => dropdown().ChildrenOfType<DropdownSearchBar>().Single().State.Value == Visibility.Visible);
-            AddStep("press back", () => dropdown().OnPressed(new KeyBindingPressEvent<GlobalAction>(new InputState(), GlobalAction.Back)));
-            AddAssert("text clear", () => dropdown().ChildrenOfType<DropdownSearchBar>().Single().SearchTerm.Value == string.Empty);
-            AddAssert("search bar hidden", () => dropdown().ChildrenOfType<DropdownSearchBar>().Single().State.Value == Visibility.Hidden);
-            AddAssert("still open", () => dropdown().ChildrenOfType<Menu>().Single().State == MenuState.Open);
-            AddStep("press back", () => dropdown().OnPressed(new KeyBindingPressEvent<GlobalAction>(new InputState(), GlobalAction.Back)));
-            AddAssert("closed", () => dropdown().ChildrenOfType<Menu>().Single().State == MenuState.Closed);
-
-            OsuEnumDropdown<TestEnum> dropdown() => this.ChildrenOfType<OsuEnumDropdown<TestEnum>>().First();
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneRoundedButton.cs
@@ -53,8 +53,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void TestBackgroundColour()
         {
             AddStep("set red scheme", () => CreateThemedContent(OverlayColourScheme.Red));
-            AddAssert("rounded button has correct colour", () => Cell(0, 1).ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Colour3);
-            AddAssert("settings button has correct colour", () => Cell(0, 1).ChildrenOfType<SettingsButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Colour3);
+            AddAssert("rounded button has correct colour", () => ContentContainer.ChildrenOfType<RoundedButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Colour3);
+            AddAssert("settings button has correct colour", () => ContentContainer.ChildrenOfType<SettingsButton>().First().BackgroundColour == new OverlayColourProvider(OverlayColourScheme.Red).Colour3);
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
+++ b/osu.Game.Tests/Visual/UserInterface/ThemeComparisonTestScene.cs
@@ -6,18 +6,21 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Overlays;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public abstract partial class ThemeComparisonTestScene : OsuGridTestScene
+    public abstract partial class ThemeComparisonTestScene : OsuManualInputManagerTestScene
     {
         private readonly bool showWithoutColourProvider;
 
+        public Container ContentContainer { get; private set; } = null!;
+
         protected ThemeComparisonTestScene(bool showWithoutColourProvider = true)
-            : base(1, showWithoutColourProvider ? 2 : 1)
         {
             this.showWithoutColourProvider = showWithoutColourProvider;
         }
@@ -25,16 +28,32 @@ namespace osu.Game.Tests.Visual.UserInterface
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
+            Child = ContentContainer = new Container
+            {
+                Anchor = Anchor.TopRight,
+                Origin = Anchor.TopRight,
+                RelativeSizeAxes = Axes.Both,
+            };
+
             if (showWithoutColourProvider)
             {
-                Cell(0, 0).AddRange(new[]
+                ContentContainer.Size = new Vector2(0.5f, 1f);
+
+                Add(new Container
                 {
-                    new Box
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.5f, 1f),
+                    Children = new[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeaFoam
-                    },
-                    CreateContent()
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colours.GreySeaFoam
+                        },
+                        CreateContent()
+                    }
                 });
             }
         }
@@ -43,10 +62,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             var colourProvider = new OverlayColourProvider(colourScheme);
 
-            int col = showWithoutColourProvider ? 1 : 0;
-
-            Cell(0, col).Clear();
-            Cell(0, col).Add(new DependencyProvidingContainer
+            ContentContainer.Clear();
+            ContentContainer.Add(new DependencyProvidingContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 CachedDependencies = new (Type, object)[]

--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -418,16 +418,19 @@ namespace osu.Game.Graphics.UserInterface
                     FontSize = OsuFont.Default.Size,
                 };
 
-                private partial class DropdownSearchTextBox : SearchTextBox
+                private partial class DropdownSearchTextBox : OsuTextBox
                 {
-                    public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+                    [BackgroundDependencyLoader]
+                    private void load(OverlayColourProvider? colourProvider)
                     {
-                        if (e.Action == GlobalAction.Back)
-                            // this method is blocking Dropdown from receiving the back action, despite this text box residing in a separate input manager.
-                            // to fix this properly, a local global action container needs to be added as well, but for simplicity, just don't handle the back action here.
-                            return false;
+                        BackgroundUnfocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
+                        BackgroundFocused = colourProvider?.Background5 ?? new Color4(10, 10, 10, 255);
+                    }
 
-                        return base.OnPressed(e);
+                    protected override void OnFocus(FocusEvent e)
+                    {
+                        base.OnFocus(e);
+                        BorderThickness = 0;
                     }
                 }
             }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28627

The functionality of selecting a dropdown item by <kbd>Enter</kbd> has been changed to be triggered by a commit event from the dropdown search bar's text box, since the text box is in a focused state when the dropdown is open and therefore is the first to receive any input by the user (see https://github.com/ppy/osu-framework/commit/b12e4b11fbb0ea7118829bd762bdbf50c2ab5307).

The osu!-side implementation of the search bar was relying on `SearchTextBox`, which has commits disabled, therefore <kbd>Enter</kbd> has no longer been working.

This PR not only enables commits on the search bar, but also uses `OsuTextBox` directly to avoid any potential nuances from the focus logic in `SearchTextBox`/`FocusedTextBox`.