### PR TITLE
Added health replacement setting to AccuracyChallenge

### DIFF
--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -26,13 +26,13 @@ namespace osu.Game.Rulesets.Mods
 
         public override ModType Type => ModType.DifficultyIncrease;
 
-        public override double ScoreMultiplier => 1.0;
+        public override double ScoreMultiplier => ReplaceHealth.Value ? 0.5 : 1.0;
 
         public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModEasyWithExtraLives), typeof(ModPerfect) }).ToArray();
 
         public override bool RequiresConfiguration => false;
 
-        public override bool Ranked => true;
+        public override bool Ranked => !ReplaceHealth.Value;
 
         public override string SettingDescription => base.SettingDescription.Replace(MinimumAccuracy.ToString(), MinimumAccuracy.Value.ToString("##%", NumberFormatInfo.InvariantInfo));
 

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -59,6 +59,7 @@ namespace osu.Game.Rulesets.Mods
         {
             base.ApplyToHealthProcessor(healthProcessor);
             this.healthProcessor = healthProcessor;
+            healthProcessor.OverrideHealth = ReplaceHealth.Value;
         }
 
         public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Localisation;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Localisation.HUD;
 using osu.Game.Overlays.Settings;
@@ -81,7 +82,7 @@ namespace osu.Game.Rulesets.Mods
                 {
                     var accuracyRange = 1 - MinimumAccuracy.Value;
                     var accuracyMargin = s.NewValue - MinimumAccuracy.Value;
-                    healthProcessor.Health.Value = accuracyMargin / accuracyRange;
+                    healthProcessor.Health.Value = accuracyMargin / accuracyRange + Precision.DOUBLE_EPSILON; // Precision.AlmostEquals will be used, so need to add margin.
                 }
 
                 if (s.NewValue < MinimumAccuracy.Value)

--- a/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
+++ b/osu.Game/Rulesets/Mods/ModAccuracyChallenge.cs
@@ -80,8 +80,8 @@ namespace osu.Game.Rulesets.Mods
             {
                 if (ReplaceHealth.Value)
                 {
-                    var accuracyRange = 1 - MinimumAccuracy.Value;
-                    var accuracyMargin = s.NewValue - MinimumAccuracy.Value;
+                    double accuracyRange = 1 - MinimumAccuracy.Value;
+                    double accuracyMargin = s.NewValue - MinimumAccuracy.Value;
                     healthProcessor.Health.Value = accuracyMargin / accuracyRange + Precision.DOUBLE_EPSILON; // Precision.AlmostEquals will be used, so need to add margin.
                 }
 

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -93,7 +93,7 @@ namespace osu.Game.Rulesets.Scoring
             double lastGameplayTime = Math.Clamp(Time.Current - Time.Elapsed, DrainStartTime, gameplayEndTime);
             double currentGameplayTime = Math.Clamp(Time.Current, DrainStartTime, gameplayEndTime);
 
-            if (DrainLenience < 1)
+            if (!OverrideHealth && DrainLenience < 1)
                 Health.Value -= DrainRate * (currentGameplayTime - lastGameplayTime);
         }
 

--- a/osu.Game/Rulesets/Scoring/HealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/HealthProcessor.cs
@@ -22,6 +22,12 @@ namespace osu.Game.Rulesets.Scoring
         public event Func<HealthProcessor, JudgementResult, bool>? FailConditions;
 
         /// <summary>
+        /// Whether to rewrite Health.
+        /// The normal increase or decrease in health will no longer be performed.
+        /// </summary>
+        public bool OverrideHealth { get; set; } = false;
+
+        /// <summary>
         /// The current health.
         /// </summary>
         public readonly BindableDouble Health = new BindableDouble(1) { MinValue = 0, MaxValue = 1 };
@@ -51,7 +57,8 @@ namespace osu.Game.Rulesets.Scoring
             if (HasFailed)
                 return;
 
-            Health.Value += GetHealthIncreaseFor(result);
+            if (!OverrideHealth)
+                Health.Value += GetHealthIncreaseFor(result);
 
             if (meetsAnyFailCondition(result))
                 TriggerFailure();


### PR DESCRIPTION
Added a setting to AccuracyChallenge that prevents it from failing for reasons other than insufficient Accuracy.
When this setting is enabled, in some cases the behavior will be the same as NoFail, making the pass easier.
Therefore, with it enabled, it is set to Unranked and the score multiplier is set to 0.5x.


https://github.com/ppy/osu/assets/75152752/c00b2433-ac9e-4381-b688-1d4dbb4027bb

