### PR TITLE
Show distance in pixels to previous/next object in osu! hitobject inspector

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             updatePositionSnapGrid();
 
             RightToolbox.Clear();
-            RightToolbox.AddRange(new EditorToolboxGroup[]
+            RightToolbox.AddRange(new[]
                 {
                     new EditorToolboxGroup("inspector")
                     {

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -51,6 +51,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private readonly Bindable<TernaryState> rectangularGridSnapToggle = new Bindable<TernaryState>();
 
+        protected override Drawable CreateHitObjectInspector() => new OsuHitObjectInspector();
+
         protected override IEnumerable<TernaryButton> CreateTernaryButtons()
             => base.CreateTernaryButtons()
                    .Concat(DistanceSnapProvider.CreateTernaryButtons())
@@ -101,13 +103,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             updatePositionSnapGrid();
 
-            RightToolbox.Clear();
-            RightToolbox.AddRange(new[]
+            RightToolbox.AddRange(new Drawable[]
                 {
-                    new EditorToolboxGroup("inspector")
-                    {
-                        Child = new OsuHitObjectInspector(),
-                    },
                     OsuGridToolboxGroup,
                     new TransformToolboxGroup
                     {

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -101,8 +101,13 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             updatePositionSnapGrid();
 
+            RightToolbox.Clear();
             RightToolbox.AddRange(new EditorToolboxGroup[]
                 {
+                    new EditorToolboxGroup("inspector")
+                    {
+                        Child = new OsuHitObjectInspector(),
+                    },
                     OsuGridToolboxGroup,
                     new TransformToolboxGroup
                     {

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Linq;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class OsuHitObjectInspector : HitObjectInspector
+    {
+        protected override void AddInspectorValues()
+        {
+            base.AddInspectorValues();
+
+            if (EditorBeatmap.SelectedHitObjects.Count > 0)
+            {
+                var firstInSelection = (OsuHitObject)EditorBeatmap.SelectedHitObjects.MinBy(ho => ho.StartTime)!;
+                var lastInSelection = (OsuHitObject)EditorBeatmap.SelectedHitObjects.MaxBy(ho => ho.GetEndTime())!;
+
+                Debug.Assert(firstInSelection != null && lastInSelection != null);
+
+                var precedingObject = (OsuHitObject?)EditorBeatmap.HitObjects.LastOrDefault(ho => ho.GetEndTime() < firstInSelection.StartTime);
+                var nextObject = (OsuHitObject?)EditorBeatmap.HitObjects.FirstOrDefault(ho => ho.StartTime > lastInSelection.GetEndTime());
+
+                if (precedingObject != null && precedingObject is not Spinner)
+                {
+                    AddHeader("To previous");
+                    AddValue($"{(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px");
+                }
+
+                if (nextObject != null && nextObject is not Spinner)
+                {
+                    AddHeader("To next");
+                    AddValue($"{(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px");
+                }
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -207,7 +207,7 @@ namespace osu.Game.Rulesets.Edit
                         {
                             Child = new EditorToolboxGroup("inspector")
                             {
-                                Child = new HitObjectInspector()
+                                Child = CreateHitObjectInspector()
                             },
                         }
                     }
@@ -328,6 +328,8 @@ namespace osu.Game.Rulesets.Edit
         /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.
         /// </summary>
         protected virtual ComposeBlueprintContainer CreateBlueprintContainer() => new ComposeBlueprintContainer(this);
+
+        protected virtual Drawable CreateHitObjectInspector() => new HitObjectInspector();
 
         /// <summary>
         /// Construct a drawable ruleset for the provided ruleset.

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -10,7 +10,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    internal partial class EditorInspector : CompositeDrawable
+    public partial class EditorInspector : CompositeDrawable
     {
         protected OsuTextFlowContainer InspectorText = null!;
 

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -9,7 +9,7 @@ using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    internal partial class HitObjectInspector : EditorInspector
+    public partial class HitObjectInspector : EditorInspector
     {
         protected override void LoadComplete()
         {
@@ -29,6 +29,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
             rollingTextUpdate?.Cancel();
             rollingTextUpdate = null;
 
+            AddInspectorValues();
+
+            // I'd hope there's a better way to do this, but I don't want to bind to each and every property above to watch for changes.
+            // This is a good middle-ground for the time being.
+            if (EditorBeatmap.SelectedHitObjects.Count > 0)
+                rollingTextUpdate ??= Scheduler.AddDelayed(updateInspectorText, 250);
+        }
+
+        protected virtual void AddInspectorValues()
+        {
             switch (EditorBeatmap.SelectedHitObjects.Count)
             {
                 case 0:
@@ -90,9 +100,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         AddValue($"{duration.Duration:#,0.##}ms");
                     }
 
-                    // I'd hope there's a better way to do this, but I don't want to bind to each and every property above to watch for changes.
-                    // This is a good middle-ground for the time being.
-                    rollingTextUpdate ??= Scheduler.AddDelayed(updateInspectorText, 250);
                     break;
 
                 default:


### PR DESCRIPTION
![image](https://github.com/ppy/osu/assets/20418176/96c7d243-340f-4b17-abeb-5bc8a5635d15)

Following [this bit of reddit feedback](https://www.reddit.com/r/osugame/comments/1dnzcqr/comment/la6o60e/).

Implementation *mostly* follows stable except for the value displayed; stable would display the value [relative to current slider velocity](https://www.reddit.com/r/osugame/comments/1dnzcqr/comment/lablgqb/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) which seemed kinda unwieldy (and also annoying to implement *wink, wink*), so I'm not doing it. Can be re-added if users say they want it back.