### PR TITLE
Show mod preset description text in tooltip popup

### DIFF
--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingModPanel.cs
@@ -17,6 +17,9 @@ namespace osu.Game.Overlays.Mods
         private readonly BindableBool incompatible = new BindableBool();
 
         [Resolved]
+        private OverlayColourProvider overlayColourProvider { get; set; } = null!;
+
+        [Resolved]
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
 
         public IncompatibilityDisplayingModPanel(ModState modState)
@@ -55,7 +58,7 @@ namespace osu.Game.Overlays.Mods
 
         #region IHasCustomTooltip
 
-        public ITooltip<Mod> GetCustomTooltip() => new IncompatibilityDisplayingTooltip();
+        public ITooltip<Mod> GetCustomTooltip() => new IncompatibilityDisplayingTooltip(overlayColourProvider);
 
         public Mod TooltipContent => Mod;
 

--- a/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
+++ b/osu.Game/Overlays/Mods/IncompatibilityDisplayingTooltip.cs
@@ -24,13 +24,15 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private Bindable<RulesetInfo> ruleset { get; set; } = null!;
 
-        public IncompatibilityDisplayingTooltip()
+        public IncompatibilityDisplayingTooltip(OverlayColourProvider colourProvider)
+            : base(colourProvider)
         {
             AddRange(new Drawable[]
             {
                 incompatibleText = new OsuSpriteText
                 {
                     Margin = new MarginPadding { Top = 5 },
+                    Colour = colourProvider.Content2,
                     Font = OsuFont.GetFont(weight: FontWeight.Regular),
                     Text = "Incompatible with:"
                 },
@@ -41,12 +43,6 @@ namespace osu.Game.Overlays.Mods
                     Scale = new Vector2(0.7f)
                 }
             });
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            incompatibleText.Colour = colours.BlueLight;
         }
 
         protected override void UpdateDisplay(Mod mod)

--- a/osu.Game/Overlays/Mods/ModButtonTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModButtonTooltip.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -18,11 +15,10 @@ namespace osu.Game.Overlays.Mods
     public partial class ModButtonTooltip : VisibilityContainer, ITooltip<Mod>
     {
         private readonly OsuSpriteText descriptionText;
-        private readonly Box background;
 
         protected override Container<Drawable> Content { get; }
 
-        public ModButtonTooltip()
+        public ModButtonTooltip(OverlayColourProvider colourProvider)
         {
             AutoSizeAxes = Axes.Both;
             Masking = true;
@@ -30,9 +26,10 @@ namespace osu.Game.Overlays.Mods
 
             InternalChildren = new Drawable[]
             {
-                background = new Box
+                new Box
                 {
-                    RelativeSizeAxes = Axes.Both
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background6,
                 },
                 Content = new FillFlowContainer
                 {
@@ -43,6 +40,7 @@ namespace osu.Game.Overlays.Mods
                     {
                         descriptionText = new OsuSpriteText
                         {
+                            Colour = colourProvider.Content1,
                             Font = OsuFont.GetFont(weight: FontWeight.Regular),
                         },
                     }
@@ -50,17 +48,10 @@ namespace osu.Game.Overlays.Mods
             };
         }
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            background.Colour = colours.Gray3;
-            descriptionText.Colour = colours.BlueLighter;
-        }
-
         protected override void PopIn() => this.FadeIn(200, Easing.OutQuint);
         protected override void PopOut() => this.FadeOut(200, Easing.OutQuint);
 
-        private Mod lastMod;
+        private Mod? lastMod;
 
         public void SetContent(Mod mod)
         {

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -6,6 +6,8 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 
@@ -16,6 +18,8 @@ namespace osu.Game.Overlays.Mods
         protected override Container<Drawable> Content { get; }
 
         private const double transition_duration = 200;
+
+        private readonly OsuSpriteText descriptionText;
 
         public ModPresetTooltip(OverlayColourProvider colourProvider)
         {
@@ -37,7 +41,15 @@ namespace osu.Game.Overlays.Mods
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding(7),
-                    Spacing = new Vector2(7)
+                    Spacing = new Vector2(7),
+                    Children = new[]
+                    {
+                        descriptionText = new OsuSpriteText
+                        {
+                            Font = OsuFont.GetFont(weight: FontWeight.Regular),
+                            Colour = colourProvider.Content2,
+                        },
+                    }
                 }
             };
         }
@@ -49,8 +61,12 @@ namespace osu.Game.Overlays.Mods
             if (ReferenceEquals(preset, lastPreset))
                 return;
 
+            descriptionText.Text = preset.Description;
+
             lastPreset = preset;
-            Content.ChildrenEnumerable = preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod));
+
+            Content.RemoveAll(d => d is ModPresetRow, true);
+            Content.AddRange(preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod)));
         }
 
         protected override void PopIn() => this.FadeIn(transition_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -40,14 +40,14 @@ namespace osu.Game.Overlays.Mods
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding(7),
+                    Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
                     Spacing = new Vector2(7),
                     Children = new[]
                     {
                         descriptionText = new OsuSpriteText
                         {
                             Font = OsuFont.GetFont(weight: FontWeight.Regular),
-                            Colour = colourProvider.Content2,
+                            Colour = colourProvider.Content1,
                         },
                     }
                 }


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/discussions/28610.

| Before | After |
| :---: | :---: |
| ![osu! 2024-06-28 at 04 28 18](https://github.com/ppy/osu/assets/191335/df293599-91e0-4bca-9e61-3e09f4a83c85) | ![osu! 2024-06-28 at 04 27 09](https://github.com/ppy/osu/assets/191335/3ba5bd3f-59b0-4ec2-bccb-da930f21bda1) |

This also synchronises the colours (and padding) of the mod and mod preset tooltips.