### PR TITLE
Fix low pass filter sometimes not applied in dialog overlays

### DIFF
--- a/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -71,7 +72,7 @@ namespace osu.Game.Overlays.Dialog
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                Progress.BindValueChanged(progressChanged);
+                Progress.BindValueChanged(progressChanged, true);
             }
 
             protected override void AbortConfirm()
@@ -122,11 +123,13 @@ namespace osu.Game.Overlays.Dialog
 
             private void progressChanged(ValueChangedEvent<double> progress)
             {
-                if (progress.NewValue < progress.OldValue) return;
+                lowPassFilter.Cutoff = Math.Max(1, (int)(progress.NewValue * AudioFilter.MAX_LOWPASS_CUTOFF * 0.5));
 
-                if (Clock.CurrentTime - lastTickPlaybackTime < 30) return;
+                if (progress.NewValue < progress.OldValue)
+                    return;
 
-                lowPassFilter.CutoffTo((int)(progress.NewValue * AudioFilter.MAX_LOWPASS_CUTOFF * 0.5));
+                if (Clock.CurrentTime - lastTickPlaybackTime < 30)
+                    return;
 
                 var channel = tickSample.GetChannel();
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/28457

There are three issues resolved by this PR:
- The issue (as above) where the filter sometimes doesn't get detached, is because of the two conditions in the callback.
- The cutoff has a minimum value of 1Hz, otherwise the filter doesn't get applied at all. This is documented but not enforced by ManagedBass' [`BQFEffect`](https://github.com/ManagedBass/ManagedBass/blob/5856a8baf538e7d91fa0b4ce6ba5de45d91bb016/src/AddOns/BassFx/Effects/Objects/BQFEffect.cs#L54-L66) class (which we're not using due to reasons), but I can't find the official docs. Failing to conform makes BASS not apply the filter. I've fixed this locally for now as I'm not yet sure how to do it more generally.
- The filter wouldn't be applied when the dialog is first displayed, because of the missing `BindValueChanged(..., true)`.