### PR TITLE
Change "playfield" skin layer to respect shifting playfield border in osu! ruleset

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
@@ -46,6 +47,8 @@ namespace osu.Game.Rulesets.Osu.UI
         public static readonly Vector2 BASE_SIZE = new Vector2(512, 384);
 
         protected override GameplayCursorContainer? CreateCursor() => new OsuCursorContainer();
+
+        public override Quad SkinnableComponentScreenSpaceDrawQuad => playfieldBorder.ScreenSpaceDrawQuad;
 
         private readonly Container judgementAboveHitObjectLayer;
 


### PR DESCRIPTION
As touched on in https://github.com/ppy/osu/discussions/28579. I personally think this makes sense.

| Before | After |
| :---: | :---: |
| ![osu! 2024-06-28 at 09 12 50](https://github.com/ppy/osu/assets/191335/cdbdd058-b6c9-4925-95ca-f0df76d20187) | ![osu! 2024-06-28 at 09 11 50](https://github.com/ppy/osu/assets/191335/22625373-a508-42aa-bbed-4b189b72f90b) |