### PR TITLE
Use room watching functionality to receive realtime daily challenge updates

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeCarousel.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeCarousel.cs
@@ -11,10 +11,11 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
-using osu.Game.Tests.Resources;
+using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
 
 namespace osu.Game.Tests.Visual.DailyChallenge
 {
@@ -129,19 +130,27 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             });
             AddStep("add normal score", () =>
             {
-                var testScore = TestResources.CreateTestScoreInfo();
-                testScore.TotalScore = RNG.Next(1_000_000);
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), null);
 
-                feed.AddNewScore(new DailyChallengeEventFeed.NewScoreEvent(testScore, null));
-                breakdown.AddNewScore(testScore);
+                feed.AddNewScore(ev);
+                breakdown.AddNewScore(ev);
             });
             AddStep("add new user best", () =>
             {
-                var testScore = TestResources.CreateTestScoreInfo();
-                testScore.TotalScore = RNG.Next(1_000_000);
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), RNG.Next(1, 1000));
 
-                feed.AddNewScore(new DailyChallengeEventFeed.NewScoreEvent(testScore, RNG.Next(1, 1000)));
-                breakdown.AddNewScore(testScore);
+                feed.AddNewScore(ev);
+                breakdown.AddNewScore(ev);
             });
         }
 

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeEventFeed.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeEventFeed.cs
@@ -7,8 +7,10 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
+using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
 using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.DailyChallenge
@@ -50,26 +52,41 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 
             AddStep("add normal score", () =>
             {
-                var testScore = TestResources.CreateTestScoreInfo();
-                testScore.TotalScore = RNG.Next(1_000_000);
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), null);
 
-                feed.AddNewScore(new DailyChallengeEventFeed.NewScoreEvent(testScore, null));
+                feed.AddNewScore(ev);
             });
 
             AddStep("add new user best", () =>
             {
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), RNG.Next(11, 1000));
+
                 var testScore = TestResources.CreateTestScoreInfo();
                 testScore.TotalScore = RNG.Next(1_000_000);
 
-                feed.AddNewScore(new DailyChallengeEventFeed.NewScoreEvent(testScore, RNG.Next(1, 1000)));
+                feed.AddNewScore(ev);
             });
 
             AddStep("add top 10 score", () =>
             {
-                var testScore = TestResources.CreateTestScoreInfo();
-                testScore.TotalScore = RNG.Next(1_000_000);
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), RNG.Next(1, 10));
 
-                feed.AddNewScore(new DailyChallengeEventFeed.NewScoreEvent(testScore, RNG.Next(1, 10)));
+                feed.AddNewScore(ev);
             });
         }
     }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
@@ -7,9 +7,10 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
-using osu.Game.Tests.Resources;
+using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
 
 namespace osu.Game.Tests.Visual.DailyChallenge
 {
@@ -51,10 +52,14 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             AddStep("set initial data", () => breakdown.SetInitialCounts([1, 4, 9, 16, 25, 36, 49, 36, 25, 16, 9, 4, 1]));
             AddStep("add new score", () =>
             {
-                var testScore = TestResources.CreateTestScoreInfo();
-                testScore.TotalScore = RNG.Next(1_000_000);
+                var ev = new NewScoreEvent(1, new APIUser
+                {
+                    Id = 2,
+                    Username = "peppy",
+                    CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                }, RNG.Next(1_000_000), null);
 
-                breakdown.AddNewScore(testScore);
+                breakdown.AddNewScore(ev);
             });
         }
     }

--- a/osu.Game/Online/Metadata/OnlineMetadataClient.cs
+++ b/osu.Game/Online/Metadata/OnlineMetadataClient.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Online.Metadata
                 throw new OperationCanceledException();
 
             Debug.Assert(connection != null);
-            await connection.InvokeAsync(nameof(IMetadataServer.EndWatchingMultiplayerRoom)).ConfigureAwait(false);
+            await connection.InvokeAsync(nameof(IMetadataServer.EndWatchingMultiplayerRoom), id).ConfigureAwait(false);
         }
 
         public override async Task DisconnectRequested()

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeEventFeed.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeEventFeed.cs
@@ -9,8 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
 using osu.Game.Users.Drawables;
 using osuTK;
 
@@ -70,8 +69,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             }
         }
 
-        public record NewScoreEvent(IScoreInfo Score, int? NewRank);
-
         private partial class DailyChallengeEventFeedFlow : FillFlowContainer
         {
             public override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
@@ -98,8 +95,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
                 InternalChildren = new Drawable[]
                 {
-                    // TODO: cast is temporary, will be removed later
-                    new ClickableAvatar((APIUser)newScore.Score.User)
+                    new ClickableAvatar(newScore.User)
                     {
                         Size = new Vector2(16),
                         Masking = true,
@@ -117,9 +113,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     }
                 };
 
-                text.AddUserLink(newScore.Score.User);
+                text.AddUserLink(newScore.User);
                 text.AddText(" got ");
-                text.AddLink($"{newScore.Score.TotalScore:N0} points", () => { }); // TODO: present the score here
+                text.AddLink($"{newScore.TotalScore:N0} points", () => { }); // TODO: present the score here
 
                 if (newScore.NewRank != null)
                     text.AddText($" and achieved rank #{newScore.NewRank.Value:N0}");

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -13,7 +13,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Metadata;
 using osu.Game.Overlays;
-using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
@@ -67,15 +67,15 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             }
         }
 
-        public void AddNewScore(IScoreInfo scoreInfo)
+        public void AddNewScore(NewScoreEvent newScoreEvent)
         {
-            int targetBin = (int)Math.Clamp(Math.Floor((float)scoreInfo.TotalScore / 100000), 0, bin_count - 1);
+            int targetBin = (int)Math.Clamp(Math.Floor((float)newScoreEvent.TotalScore / 100000), 0, bin_count - 1);
             bins[targetBin] += 1;
             updateCounts();
 
             var text = new OsuSpriteText
             {
-                Text = scoreInfo.TotalScore.ToString(@"N0"),
+                Text = newScoreEvent.TotalScore.ToString(@"N0"),
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.BottomCentre,
                 Font = OsuFont.Default.With(size: 30),
@@ -108,7 +108,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private void updateCounts()
         {
-            long max = bins.Max();
+            long max = Math.Max(bins.Max(), 1);
             for (int i = 0; i < bin_count; ++i)
                 barsContainer[i].UpdateCounts(bins[i], max);
         }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/Events/NewScoreEvent.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/Events/NewScoreEvent.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge.Events
+{
+    public class NewScoreEvent
+    {
+        public NewScoreEvent(long scoreID, APIUser user, long totalScore, int? newRank)
+        {
+            ScoreID = scoreID;
+            User = user;
+            TotalScore = totalScore;
+            NewRank = newRank;
+        }
+
+        public long ScoreID { get; }
+        public APIUser User { get; }
+        public long TotalScore { get; }
+        public int? NewRank { get; }
+    }
+}


### PR DESCRIPTION
- Continuation of https://github.com/ppy/osu/issues/28136
- [x] Depends on deploy of https://github.com/ppy/osu-server-spectator/pull/237

https://github.com/ppy/osu/assets/20418176/0e36a8a1-4e58-4422-b47a-59efead60ed8

Also contains some drive-by fixes to issues I didn't spot before (music not playing, crash in breakdown on all initial zero counts, etc.)

Known deficiencies:
- Showing score in the feed doesn't work - I need to do some results screen restructurings for this, will come in a separate pull
- Leaderboard doesn't update. This is *fixable* using the following crude diff:

```diff
commit 535c8583f212bb750f043c11facc009107995ea7
Author: Bartłomiej Dach <dach.bartlomiej@gmail.com>
Date:   Thu Jun 6 11:06:22 2024 +0200

    leaderboard refetch (sponsored by "it's stupid but it works")

diff --git a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
index 933ab95ff5..65531aa174 100644
--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -345,6 +345,10 @@ private void onRoomScoreSet(MultiplayerRoomScoreSetEvent e)
                 {
                     breakdown.AddNewScore(ev);
                     feed.AddNewScore(ev);
+
+                    // TODO: this may not be the best idea.
+                    if (e.NewRank <= 50)
+                        Schedule(() => leaderboard.RefetchScores());
                 });
             });
         }
```

but (a) it probably needs a stagger lest we DDoS osu-web by doing this the naive way as above, and (b) I kinda do want to see if I can figure out a way to do this better in general because the leaderboard is by far the worst part of this screen (visually even) after these changes, so maybe I'll give it some time next week to see if I can steal a leaderboard design from somewhere else that could perhaps also enable dynamic updates _without_ refetching the entire leaderboard.

If wanting to test locally, you must have osu-web, osu-server-spectator, _and_ osu-queue-score-statistics (on `queue watch`) running in tandem.