### PR TITLE
Add "No Release" mod

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
@@ -523,7 +523,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                                                                       .All(j => !j.Type.IsHit()));
 
             AddAssert("second hold note hit", () => judgementResults.Where(j => beatmap.HitObjects[1].NestedHitObjects.Contains(j.HitObject))
-                                                                       .All(j => j.Type.IsHit()));
+                                                                    .All(j => j.Type.IsHit()));
         }
 
         [Test]
@@ -639,6 +639,5 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             {
             }
         }
-
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModNoRelease.cs
@@ -273,10 +273,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
 
         /// <summary>
         ///     -----[ ]--------------
-        ///             xo
+        ///               xo
         /// </summary>
         [Test]
-        public void TestPressAndReleaseJustAfterTailWithCloseByHead()
+        public void TestPressAndReleaseAfterTailWithCloseByHead()
         {
             const int duration = 30;
 
@@ -301,11 +301,11 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
 
             performTest(new List<ReplayFrame>
             {
-                new ManiaReplayFrame(time_head + duration + 20, ManiaAction.Key1),
-                new ManiaReplayFrame(time_head + duration + 30),
+                new ManiaReplayFrame(time_head + duration + 60, ManiaAction.Key1),
+                new ManiaReplayFrame(time_head + duration + 70),
             }, beatmap);
 
-            assertHeadJudgement(HitResult.Good);
+            assertHeadJudgement(HitResult.Ok);
             assertTailJudgement(HitResult.Perfect);
         }
 

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneHoldNoteInput.cs
@@ -475,7 +475,7 @@ namespace osu.Game.Rulesets.Mania.Tests
                                                                       .All(j => !j.Type.IsHit()));
 
             AddAssert("second hold note hit", () => judgementResults.Where(j => beatmap.HitObjects[1].NestedHitObjects.Contains(j.HitObject))
-                                                                       .All(j => j.Type.IsHit()));
+                                                                    .All(j => j.Type.IsHit()));
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -241,6 +241,7 @@ namespace osu.Game.Rulesets.Mania
                         new ManiaModEasy(),
                         new ManiaModNoFail(),
                         new MultiMod(new ManiaModHalfTime(), new ManiaModDaycore()),
+                        new ManiaModNoRelease(),
                     };
 
                 case ModType.DifficultyIncrease:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -1,15 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using System.Threading;
 using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Mania.Mods
 {
-    public class ManiaModNoRelease : Mod, IApplicableToDrawableHitObject
+    public partial class ManiaModNoRelease : Mod, IApplicableAfterBeatmapConversion, IApplicableToDrawableRuleset<ManiaHitObject>
     {
         public override string Name => "No Release";
 
@@ -21,14 +27,80 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override ModType Type => ModType.DifficultyReduction;
 
-        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        public void ApplyToBeatmap(IBeatmap beatmap)
         {
-            if (drawable is DrawableHoldNote hold)
+            var maniaBeatmap = (ManiaBeatmap)beatmap;
+            var hitObjects = maniaBeatmap.HitObjects.Select(obj =>
             {
-                hold.HitObjectApplied += dho =>
+                if (obj is HoldNote hold)
+                    return new NoReleaseHoldNote(hold);
+
+                return obj;
+            }).ToList();
+
+            maniaBeatmap.HitObjects = hitObjects;
+        }
+
+        public void ApplyToDrawableRuleset(DrawableRuleset<ManiaHitObject> drawableRuleset)
+        {
+            var maniaRuleset = (DrawableManiaRuleset)drawableRuleset;
+
+            foreach (var stage in maniaRuleset.Playfield.Stages)
+            {
+                foreach (var column in stage.Columns)
                 {
-                    ((DrawableHoldNote)dho).Tail.LateReleaseResult = HitResult.Perfect;
-                };
+                    column.RegisterPool<NoReleaseTailNote, NoReleaseDrawableHoldNoteTail>(10, 50);
+                }
+            }
+        }
+
+        private partial class NoReleaseDrawableHoldNoteTail : DrawableHoldNoteTail
+        {
+            protected override void CheckForResult(bool userTriggered, double timeOffset)
+            {
+                // apply perfect once the tail is reached
+                if (HoldNote.HoldStartTime != null && timeOffset >= 0)
+                    ApplyResult(GetCappedResult(HitResult.Perfect));
+                else
+                    base.CheckForResult(userTriggered, timeOffset);
+            }
+        }
+
+        private class NoReleaseTailNote : TailNote
+        {
+        }
+
+        private class NoReleaseHoldNote : HoldNote
+        {
+            public NoReleaseHoldNote(HoldNote hold)
+            {
+                StartTime = hold.StartTime;
+                Duration = hold.Duration;
+                Column = hold.Column;
+                NodeSamples = hold.NodeSamples;
+            }
+
+            protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
+            {
+                AddNested(Head = new HeadNote
+                {
+                    StartTime = StartTime,
+                    Column = Column,
+                    Samples = GetNodeSamples(0),
+                });
+
+                AddNested(Tail = new NoReleaseTailNote
+                {
+                    StartTime = EndTime,
+                    Column = Column,
+                    Samples = GetNodeSamples((NodeSamples?.Count - 1) ?? 1),
+                });
+
+                AddNested(Body = new HoldNoteBody
+                {
+                    StartTime = StartTime,
+                    Column = Column
+                });
             }
         }
     }

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModNoRelease : Mod, IApplicableToDrawableHitObject
+    {
+        public override string Name => "No Release";
+
+        public override string Acronym => "NR";
+
+        public override LocalisableString Description => "No more timing the end of hold notes.";
+
+        public override double ScoreMultiplier => 0.9;
+
+        public override ModType Type => ModType.DifficultyReduction;
+
+        public void ApplyToDrawableHitObject(DrawableHitObject drawable)
+        {
+            if (drawable is DrawableHoldNote hold)
+            {
+                hold.HitObjectApplied += dho =>
+                {
+                    ((DrawableHoldNote)dho).Tail.LateReleaseResult = HitResult.Perfect;
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
+++ b/osu.Game.Rulesets.Mania/Objects/Drawables/DrawableHoldNoteTail.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Diagnostics;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Scoring;
@@ -19,11 +18,6 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         protected internal DrawableHoldNote HoldNote => (DrawableHoldNote)ParentHitObject;
 
-        /// <summary>
-        /// The minimum uncapped result for a late release.
-        /// </summary>
-        public HitResult LateReleaseResult { get; set; } = HitResult.Miss;
-
         public DrawableHoldNoteTail()
             : this(null)
         {
@@ -38,23 +32,9 @@ namespace osu.Game.Rulesets.Mania.Objects.Drawables
 
         public void UpdateResult() => base.UpdateResult(true);
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset)
-        {
-            Debug.Assert(HitObject.HitWindows != null);
-
+        protected override void CheckForResult(bool userTriggered, double timeOffset) =>
             // Factor in the release lenience
-            double scaledTimeOffset = timeOffset / TailNote.RELEASE_WINDOW_LENIENCE;
-
-            // Check for late release
-            if (HoldNote.HoldStartTime != null && scaledTimeOffset > HitObject.HitWindows.WindowFor(LateReleaseResult))
-            {
-                ApplyResult(GetCappedResult(LateReleaseResult));
-            }
-            else
-            {
-                base.CheckForResult(userTriggered, scaledTimeOffset);
-            }
-        }
+            base.CheckForResult(userTriggered, timeOffset / TailNote.RELEASE_WINDOW_LENIENCE);
 
         protected override HitResult GetCappedResult(HitResult result)
         {

--- a/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
+++ b/osu.Game.Rulesets.Mania/Objects/HoldNote.cs
@@ -72,18 +72,18 @@ namespace osu.Game.Rulesets.Mania.Objects
         /// <summary>
         /// The head note of the hold.
         /// </summary>
-        public HeadNote Head { get; private set; }
+        public HeadNote Head { get; protected set; }
 
         /// <summary>
         /// The tail note of the hold.
         /// </summary>
-        public TailNote Tail { get; private set; }
+        public TailNote Tail { get; protected set; }
 
         /// <summary>
         /// The body of the hold.
         /// This is an invisible and silent object that tracks the holding state of the <see cref="HoldNote"/>.
         /// </summary>
-        public HoldNoteBody Body { get; private set; }
+        public HoldNoteBody Body { get; protected set; }
 
         public override double MaximumJudgementOffset => Tail.MaximumJudgementOffset;
 


### PR DESCRIPTION
This pull request adds a new osu!mania mod, No Release, that relaxes tail judgements. The current implementation automatically awards Perfect (or Meh if the hold note is broken midway) for a hold note tail once it crosses the hit target.


Todo:

- [x] Add tests. This should probably derive from the hold note input testsuite.