### PR TITLE
Fix summary timeline not correctly updating after changes to breaks

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -25,6 +25,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             breaks.BindTo(beatmap.Breaks);
             breaks.BindCollectionChanged((_, _) =>
             {
+                Clear();
                 foreach (var breakPeriod in beatmap.Breaks)
                     Add(new BreakVisualisation(breakPeriod));
             }, true);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28678.

Oops.