### PR TITLE
Fix `ManiaModInvert` permanently destroying the beatmap

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Tests.Visual;
 
@@ -17,5 +19,22 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModInvert(),
             PassCondition = () => Player.ScoreProcessor.JudgedHits >= 2
         });
+
+        [Test]
+        public void TestBreaksPreservedOnOriginalBeatmap()
+        {
+            var beatmap = CreateBeatmap(new ManiaRuleset().RulesetInfo);
+            beatmap.Breaks.Clear();
+            beatmap.Breaks.Add(new BreakPeriod(0, 1000));
+
+            var workingBeatmap = new FlatWorkingBeatmap(beatmap);
+
+            var playableWithInvert = workingBeatmap.GetPlayableBeatmap(new ManiaRuleset().RulesetInfo, new[] { new ManiaModInvert() });
+            Assert.That(playableWithInvert.Breaks.Count, Is.Zero);
+
+            var playableWithoutInvert = workingBeatmap.GetPlayableBeatmap(new ManiaRuleset().RulesetInfo);
+            Assert.That(playableWithoutInvert.Breaks.Count, Is.Not.Zero);
+            Assert.That(playableWithoutInvert.Breaks[0], Is.EqualTo(new BreakPeriod(0, 1000)));
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
@@ -25,10 +24,8 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         public void TestBreaksPreservedOnOriginalBeatmap()
         {
             var beatmap = CreateBeatmap(new ManiaRuleset().RulesetInfo);
-            var breaks = (List<BreakPeriod>)beatmap.Breaks;
-
-            breaks.Clear();
-            breaks.Add(new BreakPeriod(0, 1000));
+            beatmap.Breaks.Clear();
+            beatmap.Breaks.Add(new BreakPeriod(0, 1000));
 
             var workingBeatmap = new FlatWorkingBeatmap(beatmap);
 

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModInvert.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
@@ -24,8 +25,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
         public void TestBreaksPreservedOnOriginalBeatmap()
         {
             var beatmap = CreateBeatmap(new ManiaRuleset().RulesetInfo);
-            beatmap.Breaks.Clear();
-            beatmap.Breaks.Add(new BreakPeriod(0, 1000));
+            var breaks = (List<BreakPeriod>)beatmap.Breaks;
+
+            breaks.Clear();
+            breaks.Add(new BreakPeriod(0, 1000));
 
             var workingBeatmap = new FlatWorkingBeatmap(beatmap);
 

--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -21,10 +21,11 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
-            };
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -38,14 +39,15 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -59,15 +61,16 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
                     new HitCircle { StartTime = 2000 },
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -81,14 +84,15 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HoldNote { StartTime = 1000, Duration = 10000 },
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new ManiaRuleset());
             beatmapProcessor.PreProcess();
@@ -102,16 +106,17 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HoldNote { StartTime = 1000, Duration = 10000 },
                     new Note { StartTime = 2000 },
                     new Note { StartTime = 12000 },
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new ManiaRuleset());
             beatmapProcessor.PreProcess();
@@ -125,15 +130,16 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
                     new HitCircle { StartTime = 5000 },
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -152,9 +158,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -165,7 +172,7 @@ namespace osu.Game.Tests.Editing
                     new BreakPeriod(1200, 4000),
                     new BreakPeriod(5200, 8000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -184,9 +191,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -197,7 +205,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new BreakPeriod(1200, 8000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -218,9 +226,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1100 },
@@ -230,7 +239,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new BreakPeriod(1200, 8000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -249,9 +258,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -262,7 +272,7 @@ namespace osu.Game.Tests.Editing
                     new ManualBreakPeriod(1200, 4000),
                     new ManualBreakPeriod(5200, 8000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -283,9 +293,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -296,7 +307,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new ManualBreakPeriod(1200, 8000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -317,9 +328,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -329,7 +341,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new ManualBreakPeriod(1200, 8800),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -348,9 +360,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -360,7 +373,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new BreakPeriod(10000, 15000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -374,9 +387,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 1000 },
@@ -386,7 +400,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new ManualBreakPeriod(10000, 15000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -400,9 +414,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HoldNote { StartTime = 1000, EndTime = 20000 },
@@ -412,7 +427,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new ManualBreakPeriod(10000, 15000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -426,9 +441,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 10000 },
@@ -438,7 +454,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new BreakPeriod(0, 9000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();
@@ -452,9 +468,10 @@ namespace osu.Game.Tests.Editing
         {
             var controlPoints = new ControlPointInfo();
             controlPoints.Add(0, new TimingControlPoint { BeatLength = 500 });
-            var beatmap = new Beatmap
+            var beatmap = new EditorBeatmap(new Beatmap
             {
                 ControlPointInfo = controlPoints,
+                BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
                     new HitCircle { StartTime = 10000 },
@@ -464,7 +481,7 @@ namespace osu.Game.Tests.Editing
                 {
                     new ManualBreakPeriod(0, 9000),
                 }
-            };
+            });
 
             var beatmapProcessor = new EditorBeatmapProcessor(beatmap, new OsuRuleset());
             beatmapProcessor.PreProcess();

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -61,6 +61,12 @@ namespace osu.Game.Beatmaps
 
         public ControlPointInfo ControlPointInfo { get; set; } = new ControlPointInfo();
 
+        IReadOnlyList<BreakPeriod> IBeatmap.Breaks
+        {
+            get => Breaks;
+            set => Breaks = new List<BreakPeriod>(value);
+        }
+
         public List<BreakPeriod> Breaks { get; set; } = new List<BreakPeriod>();
 
         public List<string> UnhandledEventLines { get; set; } = new List<string>();

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps.ControlPoints;
 using Newtonsoft.Json;
-using osu.Framework.Bindables;
 using osu.Game.IO.Serialization.Converters;
 
 namespace osu.Game.Beatmaps
@@ -62,7 +61,7 @@ namespace osu.Game.Beatmaps
 
         public ControlPointInfo ControlPointInfo { get; set; } = new ControlPointInfo();
 
-        public BindableList<BreakPeriod> Breaks { get; set; } = new BindableList<BreakPeriod>();
+        public List<BreakPeriod> Breaks { get; set; } = new List<BreakPeriod>();
 
         public List<string> UnhandledEventLines { get; set; } = new List<string>();
 

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -61,12 +61,6 @@ namespace osu.Game.Beatmaps
 
         public ControlPointInfo ControlPointInfo { get; set; } = new ControlPointInfo();
 
-        IReadOnlyList<BreakPeriod> IBeatmap.Breaks
-        {
-            get => Breaks;
-            set => Breaks = new List<BreakPeriod>(value);
-        }
-
         public List<BreakPeriod> Breaks { get; set; } = new List<BreakPeriod>();
 
         public List<string> UnhandledEventLines { get; set; } = new List<string>();

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 
@@ -49,9 +50,6 @@ namespace osu.Game.Beatmaps
             original.BeatmapInfo = original.BeatmapInfo.Clone();
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
 
-            // Used in osu!mania conversion.
-            original.Breaks = original.Breaks.ToList();
-
             return ConvertBeatmap(original, cancellationToken);
         }
 
@@ -68,7 +66,8 @@ namespace osu.Game.Beatmaps
             beatmap.BeatmapInfo = original.BeatmapInfo;
             beatmap.ControlPointInfo = original.ControlPointInfo;
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
-            beatmap.Breaks = original.Breaks;
+            // Used in osu!mania conversion.
+            beatmap.Breaks = new List<BreakPeriod>(original.Breaks);
             beatmap.UnhandledEventLines = original.UnhandledEventLines;
 
             return beatmap;

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -49,6 +49,8 @@ namespace osu.Game.Beatmaps
             // Can potentially be removed after `Beatmap.Difficulty` doesn't save back to `Beatmap.BeatmapInfo`.
             original.BeatmapInfo = original.BeatmapInfo.Clone();
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
+            // Used in osu!mania conversion.
+            original.Breaks = new List<BreakPeriod>(original.Breaks);
 
             return ConvertBeatmap(original, cancellationToken);
         }
@@ -66,8 +68,6 @@ namespace osu.Game.Beatmaps
             beatmap.BeatmapInfo = original.BeatmapInfo;
             beatmap.ControlPointInfo = original.ControlPointInfo;
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
-            // Used in osu!mania conversion.
-            beatmap.Breaks = new List<BreakPeriod>(original.Breaks);
             beatmap.UnhandledEventLines = original.UnhandledEventLines;
 
             return beatmap;

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -7,8 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using osu.Framework.Bindables;
-using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 
@@ -52,7 +50,7 @@ namespace osu.Game.Beatmaps
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
 
             // Used in osu!mania conversion.
-            original.Breaks = new BindableList<BreakPeriod>(original.Breaks);
+            original.Breaks = original.Breaks.ToList();
 
             return ConvertBeatmap(original, cancellationToken);
         }

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 
@@ -48,6 +50,9 @@ namespace osu.Game.Beatmaps
             // Can potentially be removed after `Beatmap.Difficulty` doesn't save back to `Beatmap.BeatmapInfo`.
             original.BeatmapInfo = original.BeatmapInfo.Clone();
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
+
+            // Used in osu!mania conversion.
+            original.Breaks = new BindableList<BreakPeriod>(original.Breaks);
 
             return ConvertBeatmap(original, cancellationToken);
         }

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -49,8 +49,6 @@ namespace osu.Game.Beatmaps
             // Can potentially be removed after `Beatmap.Difficulty` doesn't save back to `Beatmap.BeatmapInfo`.
             original.BeatmapInfo = original.BeatmapInfo.Clone();
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
-            // Used in osu!mania conversion.
-            original.Breaks = new List<BreakPeriod>(original.Breaks);
 
             return ConvertBeatmap(original, cancellationToken);
         }
@@ -68,6 +66,8 @@ namespace osu.Game.Beatmaps
             beatmap.BeatmapInfo = original.BeatmapInfo;
             beatmap.ControlPointInfo = original.ControlPointInfo;
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
+            // Used in osu!mania conversion.
+            beatmap.Breaks = new List<BreakPeriod>(original.Breaks);
             beatmap.UnhandledEventLines = original.UnhandledEventLines;
 
             return beatmap;

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 
@@ -50,6 +49,9 @@ namespace osu.Game.Beatmaps
             original.BeatmapInfo = original.BeatmapInfo.Clone();
             original.ControlPointInfo = original.ControlPointInfo.DeepClone();
 
+            // Used in osu!mania conversion.
+            original.Breaks = original.Breaks.ToList();
+
             return ConvertBeatmap(original, cancellationToken);
         }
 
@@ -66,8 +68,7 @@ namespace osu.Game.Beatmaps
             beatmap.BeatmapInfo = original.BeatmapInfo;
             beatmap.ControlPointInfo = original.ControlPointInfo;
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
-            // Used in osu!mania conversion.
-            beatmap.Breaks = new List<BreakPeriod>(original.Breaks);
+            beatmap.Breaks = original.Breaks;
             beatmap.UnhandledEventLines = original.UnhandledEventLines;
 
             return beatmap;

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The breaks in this beatmap.
         /// </summary>
-        List<BreakPeriod> Breaks { get; set; }
+        IReadOnlyList<BreakPeriod> Breaks { get; set; }
 
         /// <summary>
         /// All lines from the [Events] section which aren't handled in the encoding process yet.

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The breaks in this beatmap.
         /// </summary>
-        IReadOnlyList<BreakPeriod> Breaks { get; set; }
+        List<BreakPeriod> Breaks { get; set; }
 
         /// <summary>
         /// All lines from the [Events] section which aren't handled in the encoding process yet.

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Beatmaps
 
         /// <summary>
         /// All lines from the [Events] section which aren't handled in the encoding process yet.
-        /// These lines shoule be written out to the beatmap file on save or export.
+        /// These lines should be written out to the beatmap file on save or export.
         /// </summary>
         List<string> UnhandledEventLines { get; }
 

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The breaks in this beatmap.
         /// </summary>
-        BindableList<BreakPeriod> Breaks { get; }
+        BindableList<BreakPeriod> Breaks { get; set; }
 
         /// <summary>
         /// All lines from the [Events] section which aren't handled in the encoding process yet.

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Objects;
@@ -41,7 +40,7 @@ namespace osu.Game.Beatmaps
         /// <summary>
         /// The breaks in this beatmap.
         /// </summary>
-        BindableList<BreakPeriod> Breaks { get; set; }
+        List<BreakPeriod> Breaks { get; set; }
 
         /// <summary>
         /// All lines from the [Events] section which aren't handled in the encoding process yet.

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -65,11 +64,8 @@ namespace osu.Game.Database
             foreach (var controlPoint in playableBeatmap.ControlPointInfo.AllControlPoints)
                 controlPoint.Time = Math.Floor(controlPoint.Time);
 
-            var breaks = new List<BreakPeriod>(playableBeatmap.Breaks.Count);
             for (int i = 0; i < playableBeatmap.Breaks.Count; i++)
-                breaks.Add(new BreakPeriod(Math.Floor(playableBeatmap.Breaks[i].StartTime), Math.Floor(playableBeatmap.Breaks[i].EndTime)));
-
-            playableBeatmap.Breaks = breaks;
+                playableBeatmap.Breaks[i] = new BreakPeriod(Math.Floor(playableBeatmap.Breaks[i].StartTime), Math.Floor(playableBeatmap.Breaks[i].EndTime));
 
             foreach (var hitObject in playableBeatmap.HitObjects)
             {

--- a/osu.Game/Database/LegacyBeatmapExporter.cs
+++ b/osu.Game/Database/LegacyBeatmapExporter.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -64,8 +65,11 @@ namespace osu.Game.Database
             foreach (var controlPoint in playableBeatmap.ControlPointInfo.AllControlPoints)
                 controlPoint.Time = Math.Floor(controlPoint.Time);
 
+            var breaks = new List<BreakPeriod>(playableBeatmap.Breaks.Count);
             for (int i = 0; i < playableBeatmap.Breaks.Count; i++)
-                playableBeatmap.Breaks[i] = new BreakPeriod(Math.Floor(playableBeatmap.Breaks[i].StartTime), Math.Floor(playableBeatmap.Breaks[i].EndTime));
+                breaks.Add(new BreakPeriod(Math.Floor(playableBeatmap.Breaks[i].StartTime), Math.Floor(playableBeatmap.Breaks[i].EndTime)));
+
+            playableBeatmap.Breaks = breaks;
 
             foreach (var hitObject in playableBeatmap.HitObjects)
             {

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -328,7 +328,12 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Difficulty = value;
             }
 
-            public BindableList<BreakPeriod> Breaks => baseBeatmap.Breaks;
+            public BindableList<BreakPeriod> Breaks
+            {
+                get => baseBeatmap.Breaks;
+                set => baseBeatmap.Breaks = value;
+            }
+
             public List<string> UnhandledEventLines => baseBeatmap.UnhandledEventLines;
 
             public double TotalBreakTime => baseBeatmap.TotalBreakTime;

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -327,7 +327,7 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Difficulty = value;
             }
 
-            public List<BreakPeriod> Breaks
+            public IReadOnlyList<BreakPeriod> Breaks
             {
                 get => baseBeatmap.Breaks;
                 set => baseBeatmap.Breaks = value;

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -327,7 +327,7 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Difficulty = value;
             }
 
-            public IReadOnlyList<BreakPeriod> Breaks
+            public List<BreakPeriod> Breaks
             {
                 get => baseBeatmap.Breaks;
                 set => baseBeatmap.Breaks = value;

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Audio.Track;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -328,7 +327,7 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Difficulty = value;
             }
 
-            public BindableList<BreakPeriod> Breaks
+            public List<BreakPeriod> Breaks
             {
                 get => baseBeatmap.Breaks;
                 set => baseBeatmap.Breaks = value;

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -196,7 +196,6 @@ namespace osu.Game.Screens.Edit
         public IBeatmap Clone() => (EditorBeatmap)MemberwiseClone();
 
         private IList mutableHitObjects => (IList)PlayableBeatmap.HitObjects;
-        private IList mutableBreaks => (IList)PlayableBeatmap.Breaks;
 
         private readonly List<HitObject> batchPendingInserts = new List<HitObject>();
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.Edit
 
         public readonly BindableList<BreakPeriod> Breaks;
 
-        List<BreakPeriod> IBeatmap.Breaks
+        IReadOnlyList<BreakPeriod> IBeatmap.Breaks
         {
             get => PlayableBeatmap.Breaks;
             set => PlayableBeatmap.Breaks = value;

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Screens.Edit
 
         public readonly BindableList<BreakPeriod> Breaks;
 
-        IReadOnlyList<BreakPeriod> IBeatmap.Breaks
+        List<BreakPeriod> IBeatmap.Breaks
         {
             get => PlayableBeatmap.Breaks;
             set => PlayableBeatmap.Breaks = value;

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -110,6 +110,9 @@ namespace osu.Game.Screens.Edit
             foreach (var obj in HitObjects)
                 trackStartTime(obj);
 
+            Breaks = new BindableList<BreakPeriod>(playableBeatmap.Breaks);
+            Breaks.BindCollectionChanged((_, _) => playableBeatmap.Breaks = Breaks.ToList());
+
             PreviewTime = new BindableInt(BeatmapInfo.Metadata.PreviewTime);
             PreviewTime.BindValueChanged(s =>
             {
@@ -172,7 +175,9 @@ namespace osu.Game.Screens.Edit
             set => PlayableBeatmap.ControlPointInfo = value;
         }
 
-        public BindableList<BreakPeriod> Breaks
+        public readonly BindableList<BreakPeriod> Breaks;
+
+        List<BreakPeriod> IBeatmap.Breaks
         {
             get => PlayableBeatmap.Breaks;
             set => PlayableBeatmap.Breaks = value;
@@ -191,6 +196,7 @@ namespace osu.Game.Screens.Edit
         public IBeatmap Clone() => (EditorBeatmap)MemberwiseClone();
 
         private IList mutableHitObjects => (IList)PlayableBeatmap.HitObjects;
+        private IList mutableBreaks => (IList)PlayableBeatmap.Breaks;
 
         private readonly List<HitObject> batchPendingInserts = new List<HitObject>();
 

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -172,7 +172,11 @@ namespace osu.Game.Screens.Edit
             set => PlayableBeatmap.ControlPointInfo = value;
         }
 
-        public BindableList<BreakPeriod> Breaks => PlayableBeatmap.Breaks;
+        public BindableList<BreakPeriod> Breaks
+        {
+            get => PlayableBeatmap.Breaks;
+            set => PlayableBeatmap.Breaks = value;
+        }
 
         public List<string> UnhandledEventLines => PlayableBeatmap.UnhandledEventLines;
 

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -12,11 +12,13 @@ namespace osu.Game.Screens.Edit
 {
     public class EditorBeatmapProcessor : IBeatmapProcessor
     {
-        public IBeatmap Beatmap { get; }
+        public EditorBeatmap Beatmap { get; }
+
+        IBeatmap IBeatmapProcessor.Beatmap => Beatmap;
 
         private readonly IBeatmapProcessor? rulesetBeatmapProcessor;
 
-        public EditorBeatmapProcessor(IBeatmap beatmap, Ruleset ruleset)
+        public EditorBeatmapProcessor(EditorBeatmap beatmap, Ruleset ruleset)
         {
             Beatmap = beatmap;
             rulesetBeatmapProcessor = ruleset.CreateBeatmapProcessor(beatmap);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/28687

Steps to reproduce:
- Select a converted beatmap (osu! -> osu!mania).
- Select the invert mod
- Deselect the invert mod
- Select the constant speed mod.

Expected: Star rating should be equal to that of NM.
Actual: Star rating differs.

@peppy We may want a hotfix release for this (though I believe it's been broken since the mod's been introduced...).