### PR TITLE
Add option to remove breaks via timeline context menu

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using NUnit.Framework;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimelineSelection.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Humanizer;
 using NUnit.Framework;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
@@ -401,6 +402,28 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddUntilStep("hitobject selected", () => EditorBeatmap.SelectedHitObjects, () => NUnit.Framework.Contains.Item(addedObjects[0]));
             AddAssert("placement committed", () => EditorBeatmap.HitObjects, () => Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void TestBreakRemoval()
+        {
+            var addedObjects = new[]
+            {
+                new HitCircle { StartTime = 0 },
+                new HitCircle { StartTime = 5000 },
+            };
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(addedObjects));
+            AddAssert("beatmap has one break", () => EditorBeatmap.Breaks, () => Has.Count.EqualTo(1));
+
+            AddStep("move mouse to break", () => InputManager.MoveMouseTo(this.ChildrenOfType<TimelineBreak>().Single()));
+            AddStep("right click", () => InputManager.Click(MouseButton.Right));
+
+            AddStep("move mouse to delete menu item", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuContextMenu>().First().ChildrenOfType<DrawableOsuMenuItem>().First()));
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("beatmap has no breaks", () => EditorBeatmap.Breaks, () => Is.Empty);
+            AddAssert("break piece went away", () => this.ChildrenOfType<TimelineBreak>().Count(), () => Is.Zero);
         }
 
         private void assertSelectionIs(IEnumerable<HitObject> hitObjects)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
@@ -9,19 +9,30 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets.Objects;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    public partial class TimelineBreak : CompositeDrawable
+    public partial class TimelineBreak : CompositeDrawable, IHasContextMenu
     {
         public Bindable<BreakPeriod> Break { get; } = new Bindable<BreakPeriod>();
+
+        public Action<BreakPeriod>? OnDeleted { get; init; }
+
+        private Box background = null!;
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
 
         public TimelineBreak(BreakPeriod b)
         {
@@ -42,7 +53,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Horizontal = 5 },
-                    Child = new Box
+                    Child = background = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = colours.Gray5,
@@ -76,6 +87,28 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 Width = (float)Break.Value.Duration;
             }, true);
         }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateState();
+            base.OnHoverLost(e);
+        }
+
+        private void updateState()
+        {
+            background.FadeColour(IsHovered ? colours.Gray6 : colours.Gray5, 400, Easing.OutQuint);
+        }
+
+        public MenuItem[]? ContextMenuItems => new MenuItem[]
+        {
+            new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => OnDeleted?.Invoke(Break.Value)),
+        };
 
         private partial class DragHandle : FillFlowContainer
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreak.cs
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             background.FadeColour(IsHovered ? colours.Gray6 : colours.Gray5, 400, Easing.OutQuint);
         }
 
-        public MenuItem[]? ContextMenuItems => new MenuItem[]
+        public MenuItem[] ContextMenuItems => new MenuItem[]
         {
             new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => OnDeleted?.Invoke(Break.Value)),
         };

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private Timeline timeline { get; set; } = null!;
 
         [Resolved]
-        private IEditorChangeHandler editorChangeHandler { get; set; } = null!;
+        private IEditorChangeHandler? editorChangeHandler { get; set; }
 
         /// <summary>
         /// The visible time/position range of the timeline.
@@ -78,9 +78,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     OnDeleted = b =>
                     {
-                        editorChangeHandler.BeginChange();
+                        editorChangeHandler?.BeginChange();
                         breaks.Remove(b);
-                        editorChangeHandler.EndChange();
+                        editorChangeHandler?.EndChange();
                     },
                 });
             }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
@@ -71,7 +71,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 if (!shouldBeVisible(breakPeriod))
                     continue;
 
-                Add(new TimelineBreak(breakPeriod));
+                Add(new TimelineBreak(breakPeriod)
+                {
+                    OnDeleted = b => breaks.Remove(b),
+                });
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private Timeline timeline { get; set; } = null!;
 
+        [Resolved]
+        private IEditorChangeHandler editorChangeHandler { get; set; } = null!;
+
         /// <summary>
         /// The visible time/position range of the timeline.
         /// </summary>
@@ -73,7 +76,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 Add(new TimelineBreak(breakPeriod)
                 {
-                    OnDeleted = b => breaks.Remove(b),
+                    OnDeleted = b =>
+                    {
+                        editorChangeHandler.BeginChange();
+                        breaks.Remove(b);
+                        editorChangeHandler.EndChange();
+                    },
                 });
             }
         }


### PR DESCRIPTION
Because people keep asking for it.

It's not very smartly implemented, meaning that you can remove it, but if you change any object and the automatic generator determines that a break _should_ be where you just removed it, it'll add another one back. I can *probably* do something about that but maybe let's just start simple and see how many people complain?