### PR TITLE
Fix node samples always having default samples on placement

### DIFF
--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -163,6 +163,15 @@ namespace osu.Game.Rulesets.Edit
                 if (lastHitNormal != null)
                     HitObject.Samples[0] = lastHitNormal;
             }
+
+            if (HitObject is IHasRepeats hasRepeats)
+            {
+                // Make sure all the node samples are identical to the hit object's samples
+                for (int i = 0; i < hasRepeats.NodeSamples.Count; i++)
+                {
+                    hasRepeats.NodeSamples[i] = HitObject.Samples.Select(o => o.With()).ToList();
+                }
+            }
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -183,9 +183,7 @@ namespace osu.Game.Rulesets.Edit
             {
                 // Make sure all the node samples are identical to the hit object's samples
                 for (int i = 0; i < hasRepeats.NodeSamples.Count; i++)
-                {
                     hasRepeats.NodeSamples[i] = HitObject.Samples.Select(o => o.With()).ToList();
-                }
             }
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28715
- [x] Depends on https://github.com/ppy/osu/pull/28727

Placing a slider with a specific bank, hitsound, or volume would only affect the body samples while the node samples would be the default normal bank with 100 volume. Node samples should be identical to the hit object's samples when placing.