### PR TITLE
Allow inheriting addition bank from previous hitobject when using auto bank assignment

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -114,10 +114,11 @@ namespace osu.Game.Tests.Visual.Editing
                 Samples =
                 {
                     new HitSampleInfo(name: HitSampleInfo.HIT_NORMAL, bank: HitSampleInfo.BANK_SOFT, volume: 70),
-                    new HitSampleInfo(name: HitSampleInfo.HIT_WHISTLE, bank: HitSampleInfo.BANK_SOFT, volume: 70),
+                    new HitSampleInfo(name: HitSampleInfo.HIT_WHISTLE, bank: HitSampleInfo.BANK_DRUM, volume: 70),
                 }
             }));
-            AddStep("seek to 500", () => EditorClock.Seek(500));
+
+            AddStep("seek to 500", () => EditorClock.Seek(500)); // previous object is the one at time 0
             AddStep("enable automatic bank assignment", () =>
             {
                 InputManager.PressKey(Key.LShift);
@@ -127,8 +128,28 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
             AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));
-            AddAssert("circle has soft bank", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Bank == HitSampleInfo.BANK_SOFT));
+            AddAssert("circle has soft bank", () => EditorBeatmap.HitObjects[1].Samples.Single().Bank, () => Is.EqualTo(HitSampleInfo.BANK_SOFT));
             AddAssert("circle inherited volume", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Volume == 70));
+
+            AddStep("seek to 250", () => EditorClock.Seek(250)); // previous object is the one at time 0
+            AddStep("enable clap addition", () => InputManager.Key(Key.R));
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddAssert("circle has 2 samples", () => EditorBeatmap.HitObjects[1].Samples, () => Has.Count.EqualTo(2));
+            AddAssert("normal sample has soft bank", () => EditorBeatmap.HitObjects[1].Samples.Single(s => s.Name == HitSampleInfo.HIT_NORMAL).Bank,
+                () => Is.EqualTo(HitSampleInfo.BANK_SOFT));
+            AddAssert("clap sample has drum bank", () => EditorBeatmap.HitObjects[1].Samples.Single(s => s.Name == HitSampleInfo.HIT_CLAP).Bank,
+                () => Is.EqualTo(HitSampleInfo.BANK_DRUM));
+            AddAssert("circle inherited volume", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Volume == 70));
+
+            AddStep("seek to 1000", () => EditorClock.Seek(1000)); // previous object is the one at time 500, which has no additions
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddAssert("circle has 2 samples", () => EditorBeatmap.HitObjects[3].Samples, () => Has.Count.EqualTo(2));
+            AddAssert("all samples have soft bank", () => EditorBeatmap.HitObjects[3].Samples.All(s => s.Bank == HitSampleInfo.BANK_SOFT));
+            AddAssert("circle inherited volume", () => EditorBeatmap.HitObjects[3].Samples.All(s => s.Volume == 70));
         }
 
         [Test]

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -158,10 +158,16 @@ namespace osu.Game.Rulesets.Edit
 
             if (AutomaticBankAssignment)
             {
-                // Take the hitnormal sample of the last hit object
-                var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
-                if (lastHitNormal != null)
-                    HitObject.Samples[0] = lastHitNormal;
+                // Create samples based on the sample settings of the previous hit object
+                var lastHitObject = getPreviousHitObject();
+
+                if (lastHitObject != null)
+                {
+                    for (int i = 0; i < HitObject.Samples.Count; i++)
+                    {
+                        HitObject.Samples[i] = lastHitObject.CreateHitSampleInfo(HitObject.Samples[i].Name);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/28728

Placing hit objects with additions would always result in a normal addition bank when using the 'Auto' bank assignment mode. Now it will inherit the addition bank from the previous hit object if it has additions, or inherit from the normal bank if the previous hit object has no additions.