### PR TITLE
Always inherit the volume from the previous hit object on placement

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -5,11 +5,13 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
+using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Tests.Beatmaps;
@@ -101,6 +103,57 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("change tool to circle", () => InputManager.Key(Key.Number2));
             AddAssert("slider placed", () => EditorBeatmap.HitObjects.Count, () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestAutomaticBankAssignment()
+        {
+            AddStep("add object with soft bank", () => EditorBeatmap.Add(new HitCircle
+            {
+                StartTime = 0,
+                Samples =
+                {
+                    new HitSampleInfo(name: HitSampleInfo.HIT_NORMAL, bank: HitSampleInfo.BANK_SOFT, volume: 70),
+                    new HitSampleInfo(name: HitSampleInfo.HIT_WHISTLE, bank: HitSampleInfo.BANK_SOFT, volume: 70),
+                }
+            }));
+            AddStep("seek to 500", () => EditorClock.Seek(500));
+            AddStep("enable automatic bank assignment", () =>
+            {
+                InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.Q);
+                InputManager.ReleaseKey(Key.LShift);
+            });
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddAssert("circle has soft bank", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Bank == HitSampleInfo.BANK_SOFT));
+            AddAssert("circle inherited volume", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Volume == 70));
+        }
+
+        [Test]
+        public void TestVolumeIsInheritedFromLastObject()
+        {
+            AddStep("add object with soft bank", () => EditorBeatmap.Add(new HitCircle
+            {
+                StartTime = 0,
+                Samples =
+                {
+                    new HitSampleInfo(name: HitSampleInfo.HIT_NORMAL, bank: HitSampleInfo.BANK_SOFT, volume: 70),
+                }
+            }));
+            AddStep("seek to 500", () => EditorClock.Seek(500));
+            AddStep("select drum bank", () =>
+            {
+                InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.LShift);
+            });
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddAssert("circle has drum bank", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Bank == HitSampleInfo.BANK_DRUM));
+            AddAssert("circle inherited volume", () => EditorBeatmap.HitObjects[1].Samples.All(s => s.Volume == 70));
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -156,24 +156,20 @@ namespace osu.Game.Rulesets.Edit
                     comboInformation.UpdateComboInformation(getPreviousHitObject() as IHasComboInformation);
             }
 
-            if (AutomaticBankAssignment)
-            {
-                // Take the hitnormal sample of the last hit object
-                var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
-                if (lastHitNormal != null)
-                    HitObject.Samples[0] = lastHitNormal;
-            }
-            else
-            {
-                // Only inherit the volume from the previous hit object
-                var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
+            var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
 
-                if (lastHitNormal != null)
+            if (lastHitNormal != null)
+            {
+                if (AutomaticBankAssignment)
                 {
+                    // Take the hitnormal sample of the last hit object
+                    HitObject.Samples[0] = lastHitNormal;
+                }
+                else
+                {
+                    // Only inherit the volume from the previous hit object
                     for (int i = 0; i < HitObject.Samples.Count; i++)
-                    {
                         HitObject.Samples[i] = HitObject.Samples[i].With(newVolume: lastHitNormal.Volume);
-                    }
                 }
             }
         }

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -163,6 +163,19 @@ namespace osu.Game.Rulesets.Edit
                 if (lastHitNormal != null)
                     HitObject.Samples[0] = lastHitNormal;
             }
+            else
+            {
+                // Only inherit the volume from the previous hit object
+                var lastHitNormal = getPreviousHitObject()?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
+
+                if (lastHitNormal != null)
+                {
+                    for (int i = 0; i < HitObject.Samples.Count; i++)
+                    {
+                        HitObject.Samples[i] = HitObject.Samples[i].With(newVolume: lastHitNormal.Volume);
+                    }
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Before this PR the next hit object you place would only inherit volume from the previous hit object if you have the 'Auto' bank selected. If you had any other bank selected, the volume would default to 100.
Now I made it always inherit volume from the previous hit object. I think this better matches the user's expectation and mimics stable behaviour.