### PR TITLE
Add setting for the volume of ruleset elements (hitsounds)

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -211,6 +211,8 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorTimelineShowTimingChanges, true);
             SetDefault(OsuSetting.EditorTimelineShowTicks, true);
+
+            SetDefault(OsuSetting.MuteHitsounds, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -444,5 +446,6 @@ namespace osu.Game.Configuration
         HideCountryFlags,
         EditorTimelineShowTimingChanges,
         EditorTimelineShowTicks,
+        MuteHitsounds,
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -102,6 +102,7 @@ namespace osu.Game.Configuration
 
             // Audio
             SetDefault(OsuSetting.VolumeInactive, 0.25, 0, 1, 0.01);
+            SetDefault(OsuSetting.GameplayVolume, 0.6, 0, 1, 0.01);
 
             SetDefault(OsuSetting.MenuVoice, true);
             SetDefault(OsuSetting.MenuMusic, true);
@@ -211,8 +212,6 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.EditorTimelineShowTimingChanges, true);
             SetDefault(OsuSetting.EditorTimelineShowTicks, true);
-
-            SetDefault(OsuSetting.MuteHitsounds, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -446,6 +445,6 @@ namespace osu.Game.Configuration
         HideCountryFlags,
         EditorTimelineShowTimingChanges,
         EditorTimelineShowTicks,
-        MuteHitsounds,
+        GameplayVolume,
     }
 }

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -55,6 +55,11 @@ namespace osu.Game.Localisation
         public static LocalisableString MusicVolume => new TranslatableString(getKey(@"music_volume"), @"Music");
 
         /// <summary>
+        /// "Mute hitsounds"
+        /// </summary>
+        public static LocalisableString MuteHitsounds => new TranslatableString(getKey(@"mute_hitsounds"), @"Mute hitsounds");
+
+        /// <summary>
         /// "Offset Adjustment"
         /// </summary>
         public static LocalisableString OffsetHeader => new TranslatableString(getKey(@"offset_header"), @"Offset Adjustment");

--- a/osu.Game/Localisation/AudioSettingsStrings.cs
+++ b/osu.Game/Localisation/AudioSettingsStrings.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Localisation
         public static LocalisableString MusicVolume => new TranslatableString(getKey(@"music_volume"), @"Music");
 
         /// <summary>
-        /// "Mute hitsounds"
+        /// "Gameplay"
         /// </summary>
-        public static LocalisableString MuteHitsounds => new TranslatableString(getKey(@"mute_hitsounds"), @"Mute hitsounds");
+        public static LocalisableString GameplayVolume => new TranslatableString(getKey(@"gameplay_volume"), @"Gameplay");
 
         /// <summary>
         /// "Offset Adjustment"

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -49,6 +49,11 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = AudioSettingsStrings.MuteHitsounds,
+                    Current = config.GetBindable<bool>(OsuSetting.MuteHitsounds)
+                },
             };
         }
 

--- a/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/VolumeSettings.cs
@@ -36,23 +36,24 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
                 },
                 new VolumeAdjustSlider
                 {
-                    LabelText = AudioSettingsStrings.EffectVolume,
-                    Current = audio.VolumeSample,
-                    KeyboardStep = 0.01f,
-                    DisplayAsPercentage = true
-                },
-
-                new VolumeAdjustSlider
-                {
                     LabelText = AudioSettingsStrings.MusicVolume,
                     Current = audio.VolumeTrack,
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true
                 },
-                new SettingsCheckbox
+                new VolumeAdjustSlider
                 {
-                    LabelText = AudioSettingsStrings.MuteHitsounds,
-                    Current = config.GetBindable<bool>(OsuSetting.MuteHitsounds)
+                    LabelText = AudioSettingsStrings.EffectVolume,
+                    Current = audio.VolumeSample,
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true
+                },
+                new SettingsSlider<double>
+                {
+                    LabelText = AudioSettingsStrings.GameplayVolume,
+                    Current = config.GetBindable<double>(OsuSetting.GameplayVolume),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true
                 },
             };
         }

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -12,6 +12,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
@@ -69,7 +70,7 @@ namespace osu.Game.Rulesets.UI
 
         public override IAdjustableAudioComponent Audio => audioContainer;
 
-        private readonly AudioContainer audioContainer = new AudioContainer { RelativeSizeAxes = Axes.Both };
+        private readonly DrawableAudioMixer audioContainer = new DrawableAudioMixer { RelativeSizeAxes = Axes.Both, Name="GameplayMixer" };
 
         /// <summary>
         /// A container which encapsulates the <see cref="Playfield"/> and provides any adjustments to
@@ -211,11 +212,7 @@ namespace osu.Game.Rulesets.UI
                         .WithChild(ResumeOverlay)));
             }
 
-            var muteHitsounds = config.GetBindable<bool>(OsuSetting.MuteHitsounds);
-
-            BindableNumber<double> hitsoundMultiplier = new BindableDouble(muteHitsounds.Value ? 0.0 : 1.0);
-            muteHitsounds.ValueChanged += _ => { hitsoundMultiplier.Value = muteHitsounds.Value ? 0.0 : 1.0; };
-            audioContainer.AddAdjustment(AdjustableProperty.Volume, hitsoundMultiplier);
+            audioContainer.Volume.BindTo(config.GetBindable<double>(OsuSetting.GameplayVolume));
 
             applyRulesetMods(Mods, config);
 

--- a/osu.Game/Rulesets/UI/DrawableRuleset.cs
+++ b/osu.Game/Rulesets/UI/DrawableRuleset.cs
@@ -211,6 +211,12 @@ namespace osu.Game.Rulesets.UI
                         .WithChild(ResumeOverlay)));
             }
 
+            var muteHitsounds = config.GetBindable<bool>(OsuSetting.MuteHitsounds);
+
+            BindableNumber<double> hitsoundMultiplier = new BindableDouble(muteHitsounds.Value ? 0.0 : 1.0);
+            muteHitsounds.ValueChanged += _ => { hitsoundMultiplier.Value = muteHitsounds.Value ? 0.0 : 1.0; };
+            audioContainer.AddAdjustment(AdjustableProperty.Volume, hitsoundMultiplier);
+
             applyRulesetMods(Mods, config);
 
             loadObjects(cancellationToken ?? default);

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private Bindable<ScoreInfo> referenceScore { get; } = new Bindable<ScoreInfo>();
 
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
-        private readonly PlayerCheckbox muteHitSoundsToggle;
 
         public AudioSettings()
             : base("Audio Settings")
@@ -25,7 +24,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Children = new Drawable[]
             {
                 beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapHitsounds },
-                muteHitSoundsToggle = new PlayerCheckbox { LabelText = AudioSettingsStrings.MuteHitsounds },
                 new BeatmapOffsetControl
                 {
                     ReferenceScore = { BindTarget = referenceScore },
@@ -37,7 +35,6 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private void load(OsuConfigManager config, SessionStatics statics)
         {
             beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
-            muteHitSoundsToggle.Current = config.GetBindable<bool>(OsuSetting.MuteHitsounds);
             statics.BindWith(Static.LastLocalUserScore, referenceScore);
         }
     }

--- a/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/AudioSettings.cs
@@ -17,6 +17,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private Bindable<ScoreInfo> referenceScore { get; } = new Bindable<ScoreInfo>();
 
         private readonly PlayerCheckbox beatmapHitsoundsToggle;
+        private readonly PlayerCheckbox muteHitSoundsToggle;
 
         public AudioSettings()
             : base("Audio Settings")
@@ -24,6 +25,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
             Children = new Drawable[]
             {
                 beatmapHitsoundsToggle = new PlayerCheckbox { LabelText = SkinSettingsStrings.BeatmapHitsounds },
+                muteHitSoundsToggle = new PlayerCheckbox { LabelText = AudioSettingsStrings.MuteHitsounds },
                 new BeatmapOffsetControl
                 {
                     ReferenceScore = { BindTarget = referenceScore },
@@ -35,6 +37,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
         private void load(OsuConfigManager config, SessionStatics statics)
         {
             beatmapHitsoundsToggle.Current = config.GetBindable<bool>(OsuSetting.BeatmapHitsounds);
+            muteHitSoundsToggle.Current = config.GetBindable<bool>(OsuSetting.MuteHitsounds);
             statics.BindWith(Static.LastLocalUserScore, referenceScore);
         }
     }


### PR DESCRIPTION
Hi! First time contributing here!

This PR adds the option to mute only hitsounds.

The setting is available on the main menu and on the play "quick" menu

I followed what was already in place for the mute mod and, while this aims to only mute hitsounds, AFAIK my implementation will mute any sounds coming from the ruleset drawable, I don't know if this impacts other desired sounds, if this is acceptable or if the name should be changed from "hitsounds" to something else to better reflect this "ruleset mute".