### PR TITLE
Fix editor not updating ruleset when switching difficulty

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -12,7 +12,9 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Storyboards;
@@ -163,6 +165,24 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             confirmEditingBeatmap(() => targetDifficulty);
+
+            AddStep("exit editor forcefully", () => Stack.Exit());
+            // ensure editor loader didn't resume.
+            AddAssert("stack empty", () => Stack.CurrentScreen == null);
+        }
+
+        [Test]
+        public void TestSwitchToDifficultyOfAnotherRuleset()
+        {
+            BeatmapInfo targetDifficulty = null;
+
+            AddAssert("ruleset is catch", () => Ruleset.Value.CreateInstance() is CatchRuleset);
+
+            AddStep("set taiko difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.First(b => b.Ruleset.OnlineID == 1));
+            switchToDifficulty(() => targetDifficulty);
+            confirmEditingBeatmap(() => targetDifficulty);
+
+            AddAssert("ruleset switched to taiko", () => Ruleset.Value.CreateInstance() is TaikoRuleset);
 
             AddStep("exit editor forcefully", () => Stack.Exit());
             // ensure editor loader didn't resume.

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -121,7 +121,11 @@ namespace osu.Game.Screens.Edit
 
             scheduledDifficultySwitch = Schedule(() =>
             {
-                Beatmap.Value = nextBeatmap.Invoke();
+                var workingBeatmap = nextBeatmap.Invoke();
+
+                Ruleset.Value = workingBeatmap.BeatmapInfo.Ruleset;
+                Beatmap.Value = workingBeatmap;
+
                 state = editorState;
 
                 // This screen is a weird exception to the rule that nothing after song select changes the global beatmap.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28723

I have no idea how gameplay testing still worked in some rulesets regardless of this but it all works correctly now anyway.