### PR TITLE
Fix incorrect skin fallback order when beatmap skin is present

### DIFF
--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -101,8 +101,16 @@ namespace osu.Game.Skinning
                 bool userSkinIsLegacy = skins.CurrentSkin.Value is LegacySkin;
                 bool beatmapProvidingResources = skin is LegacySkinTransformer legacySkin && legacySkin.IsProvidingLegacyResources;
 
-                // If the beatmap skin looks to have skinnable resources and the user's skin choice is not a legacy skin,
-                // add the default classic skin as a fallback opportunity.
+                // Some beatmaps provide a limited selection of skin elements to add some visual flair.
+                // In stable, these elements will take lookup priority over the selected skin (whether that be a user skin or default).
+                //
+                // To replicate this we need to pay special attention to the fallback order.
+                // If a user has a non-legacy skin (argon, triangles) selected, the game won't normally fall back to a legacy skin.
+                // In turn this can create an unexpected visual experience.
+                //
+                // So here, check what skin the user has selected. If it's already a legacy skin then we don't need to do anything special.
+                // If it isn't, we insert the classic default. Note that this is only done if the beatmap seems to be providing skin elements,
+                // as we only want to override the user's (non-legacy) skin choice when required for beatmap skin visuals.
                 if (!userSkinIsLegacy && beatmapProvidingResources && classicFallback != null)
                     SetSources(new[] { skin, classicFallback });
                 else

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -28,25 +28,33 @@ namespace osu.Game.Skinning
         protected readonly Ruleset Ruleset;
         protected readonly IBeatmap Beatmap;
 
+        [CanBeNull]
+        private readonly ISkin beatmapSkin;
+
         /// <remarks>
         /// This container already re-exposes all parent <see cref="ISkinSource"/> sources in a ruleset-usable form.
         /// Therefore disallow falling back to any parent <see cref="ISkinSource"/> any further.
         /// </remarks>
         protected override bool AllowFallingBackToParent => false;
 
-        protected override Container<Drawable> Content { get; }
+        protected override Container<Drawable> Content { get; } = new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+        };
 
         public RulesetSkinProvidingContainer(Ruleset ruleset, IBeatmap beatmap, [CanBeNull] ISkin beatmapSkin)
         {
             Ruleset = ruleset;
             Beatmap = beatmap;
+            this.beatmapSkin = beatmapSkin;
+        }
 
-            InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin))
+        [BackgroundDependencyLoader]
+        private void load(SkinManager skinManager)
+        {
+            InternalChild = new BeatmapSkinProvidingContainer(GetRulesetTransformedSkin(beatmapSkin), GetRulesetTransformedSkin(skinManager.DefaultClassicSkin))
             {
-                Child = Content = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                }
+                Child = Content,
             };
         }
 

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -201,7 +202,10 @@ namespace osu.Game.Skinning
                         source.SourceChanged -= TriggerSourceChanged;
                 }
 
-                skinSources = sources.Select(skin => (skin, new DisableableSkinSource(skin, this))).ToArray();
+                skinSources = sources
+                              // Shouldn't be required after NRT is applied to all calling sources.
+                              .Where(skin => skin.IsNotNull())
+                              .Select(skin => (skin, new DisableableSkinSource(skin, this))).ToArray();
 
                 foreach (var skin in skinSources)
                 {


### PR DESCRIPTION
Fixes two issues:

- The default classic skin was not wrapped by a ruleset transformer, so would not correctly answer requests like `FindProvider`.
- The default classic skin was added in between the beatmap and user skin, even when the user skin was already a legacy skin (and would handle the classic skin fallback itself). This would mean the user skin was basically never used (except it was due to the previous bullet point bug).

Tested using [this repro](https://github.com/ppy/osu/issues/24938#issuecomment-2206748553). I've been searching for a test setup I can build off but couldn't find anything. Not sure if I want to bother, test setup is going to take hours.

- Closes https://github.com/ppy/osu/issues/20867
- Closes https://github.com/ppy/osu/issues/24938