### PR TITLE
Add slight animation when revert to default button is displayed

### DIFF
--- a/osu.Game/Overlays/RevertToDefaultButton.cs
+++ b/osu.Game/Overlays/RevertToDefaultButton.cs
@@ -87,6 +87,7 @@ namespace osu.Game.Overlays
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
             updateState();
             FinishTransforms(true);
         }
@@ -95,33 +96,50 @@ namespace osu.Game.Overlays
 
         protected override bool OnHover(HoverEvent e)
         {
-            UpdateState();
+            updateHover();
             return false;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            UpdateState();
+            updateHover();
         }
 
         public void UpdateState() => Scheduler.AddOnce(updateState);
 
         private const double fade_duration = 200;
 
+        private bool? isDisplayed;
+
         private void updateState()
         {
             if (current == null)
                 return;
 
-            Enabled.Value = !current.Disabled;
+            // Avoid running animations if we are already in an up-to-date state.
+            if (Enabled.Value == !current.Disabled && isDisplayed == !current.IsDefault)
+                return;
 
-            if (current.IsDefault)
+            Enabled.Value = !current.Disabled;
+            isDisplayed = !current.IsDefault;
+
+            updateHover();
+
+            if (isDisplayed == false)
                 this.FadeTo(0, fade_duration, Easing.OutQuint);
             else if (current.Disabled)
                 this.FadeTo(0.2f, fade_duration, Easing.OutQuint);
             else
-                this.FadeTo(1, fade_duration, Easing.OutQuint);
+            {
+                icon.RotateTo(150).RotateTo(0, fade_duration * 2, Easing.OutQuint);
+                icon.ScaleTo(0.7f).ScaleTo(1, fade_duration * 2, Easing.OutQuint);
 
+                this.FadeTo(1, fade_duration, Easing.OutQuint);
+            }
+        }
+
+        private void updateHover()
+        {
             if (IsHovered && Enabled.Value)
             {
                 icon.RotateTo(-40, 500, Easing.OutQuint);


### PR DESCRIPTION
This also fixes the transforms running too often (could make the initial transform take longer than expected if adjusting a slider bar, for instance).


https://github.com/ppy/osu/assets/191335/ac9e0d93-baa1-4fc3-83c7-602761fa0074

