### PR TITLE
Simplify realm model tracking in `BeatmapCarousel` (and fix hard delete handling)

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1212,6 +1212,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         }
 
         [Test]
+        [Solo]
+        public void TestHardDeleteHandledCorrectly()
+        {
+            createSongSelect();
+
+            addRulesetImportStep(0);
+            AddAssert("3 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "3 matches");
+
+            AddStep("hard delete beatmap", () => Realm.Write(r => r.RemoveRange(r.All<BeatmapSetInfo>().Where(s => !s.Protected))));
+
+            AddUntilStep("0 matching shown", () => songSelect.ChildrenOfType<FilterControl>().Single().InformationalText == "0 matches");
+        }
+
+        [Test]
         public void TestDeleteHotkey()
         {
             createSongSelect();

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -198,7 +198,6 @@ namespace osu.Game.Screens.Select
 
         private IDisposable? subscriptionSets;
         private IDisposable? subscriptionBeatmaps;
-        private IDisposable? subscriptionHiddenBeatmaps;
 
         private readonly DrawablePool<DrawableCarouselBeatmapSet> setPool = new DrawablePool<DrawableCarouselBeatmapSet>(100);
 
@@ -263,10 +262,6 @@ namespace osu.Game.Screens.Select
 
             subscriptionSets = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
             subscriptionBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
-
-            // Can't use main subscriptions because we can't lookup deleted indices.
-            // https://github.com/realm/realm-dotnet/discussions/2634#discussioncomment-1605595.
-            subscriptionHiddenBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => b.Hidden), beatmapsChanged);
         }
 
         private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
@@ -1279,7 +1274,6 @@ namespace osu.Game.Screens.Select
 
             subscriptionSets?.Dispose();
             subscriptionBeatmaps?.Dispose();
-            subscriptionHiddenBeatmaps?.Dispose();
         }
     }
 }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -280,6 +280,8 @@ namespace osu.Game.Screens.Select
             {
                 realmBeatmapSets.Clear();
                 realmBeatmapSets.AddRange(sender.Select(r => r.ID));
+                setsRequiringRemoval.Clear();
+                setsRequiringUpdate.Clear();
 
                 loadBeatmapSets(sender);
             }


### PR DESCRIPTION
This implements a simplification touched on in [inline todo commentary](https://github.com/ppy/osu/blob/53509453405f8256fd66b05dabf84c65c5f2b0b2/osu.Game/Screens/Select/BeatmapCarousel.cs#L291-L294) by storing a list of GUIDs so we can properly track realm deletions (without needing to double-up on subscriptions).

Why did I do this now? It turns out we have never been handling hard deletions correctly, and this change resolves that issue. We use hard deletions in the `ImportAsUpdate` flow which I'm relying on for editor beatmap filesystem mounting, and this issue was blocking the ability to reliably reload the beatmap.

Passes existing tests and some stress testing of my own. The only potential issue could be that `beatmapsChanged` is now fired more often (on any change to a beatmap in realm), but I can't seem to have this cause an issue.

f5ef3cab2f19fdc1c58bcb4eeb8d2beb4d3b629c is optional but just felt more correct.