### PR TITLE
Fix CurrentTimeAccurate being inaccurate

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorClock.cs
@@ -102,6 +102,17 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("time is clamped to track length", () => EditorClock.CurrentTime, () => Is.EqualTo(EditorClock.TrackLength));
         }
 
+        [Test]
+        public void TestCurrentTimeDoubleTransform()
+        {
+            AddAssert("seek smoothly twice and current time is accurate", () =>
+            {
+                EditorClock.SeekSmoothlyTo(1000);
+                EditorClock.SeekSmoothlyTo(2000);
+                return 2000 == EditorClock.CurrentTimeAccurate;
+            });
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             Beatmap.Disabled = false;

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -154,7 +154,7 @@ namespace osu.Game.Screens.Edit
         /// The current time of this clock, include any active transform seeks performed via <see cref="SeekSmoothlyTo"/>.
         /// </summary>
         public double CurrentTimeAccurate =>
-            Transforms.OfType<TransformSeek>().FirstOrDefault()?.EndValue ?? CurrentTime;
+            Transforms.OfType<TransformSeek>().LastOrDefault()?.EndValue ?? CurrentTime;
 
         public double CurrentTime => underlyingClock.CurrentTime;
 


### PR DESCRIPTION
Fixes `CurrentTimeAccurate` being inaccurate if seeking smoothly in the same frame and a previous smooth seek is still in progress.

Link to further discussion and quirks about this on discord: https://discord.com/channels/188630481301012481/188630652340404224/1259815772189097995