### PR TITLE
Fix composer disappearing when undoing change to control points

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
@@ -1,13 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Screens.Edit.Timing;
 using osu.Game.Tests.Visual;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Mania.Tests.Editor
 {
@@ -29,6 +34,44 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         {
             var config = (ManiaRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
             config.BindWith(ManiaRulesetSetting.ScrollDirection, direction);
+        }
+
+        [Test]
+        public void TestReloadOnBPMChange()
+        {
+            HitObjectComposer oldComposer = null!;
+
+            AddStep("store composer", () => oldComposer = this.ChildrenOfType<HitObjectComposer>().Single());
+            AddUntilStep("composer stored", () => oldComposer, () => Is.Not.Null);
+            AddStep("switch to timing tab", () => InputManager.Key(Key.F3));
+            AddUntilStep("wait for loaded", () => this.ChildrenOfType<TimingAdjustButton>().ElementAtOrDefault(1), () => Is.Not.Null);
+            AddStep("change timing point BPM", () =>
+            {
+                var bpmControl = this.ChildrenOfType<TimingAdjustButton>().ElementAt(1);
+                InputManager.MoveMouseTo(bpmControl);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("switch back to composer", () => InputManager.Key(Key.F1));
+            AddUntilStep("composer reloaded", () =>
+            {
+                var composer = this.ChildrenOfType<HitObjectComposer>().SingleOrDefault();
+                return composer != null && composer != oldComposer;
+            });
+
+            AddStep("store composer", () => oldComposer = this.ChildrenOfType<HitObjectComposer>().Single());
+            AddUntilStep("composer stored", () => oldComposer, () => Is.Not.Null);
+            AddStep("undo", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Z);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddUntilStep("composer reloaded", () =>
+            {
+                var composer = this.ChildrenOfType<HitObjectComposer>().SingleOrDefault();
+                return composer != null && composer != oldComposer;
+            });
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1023,11 +1023,15 @@ namespace osu.Game.Screens.Edit
         /// <summary>
         /// Forces a reload of the compose screen after significant configuration changes.
         /// </summary>
-        /// <remarks>
-        /// This can be necessary for scrolling rulesets, as they do not easily support control points changing under them.
-        /// The reason that this works is that <see cref="onModeChanged"/> will re-instantiate the screen whenever it is requested next.
-        /// </remarks>
-        public void ReloadComposeScreen() => screenContainer.SingleOrDefault(s => s.Type == EditorScreenMode.Compose)?.RemoveAndDisposeImmediately();
+        public void ReloadComposeScreen()
+        {
+            screenContainer.SingleOrDefault(s => s.Type == EditorScreenMode.Compose)?.RemoveAndDisposeImmediately();
+
+            // If not currently on compose screen, the reload will happen on next mode change.
+            // That said, control points *can* change on compose screen (e.g. via undo), so we have to handle that case too.
+            if (Mode.Value == EditorScreenMode.Compose)
+                Mode.TriggerChange();
+        }
 
         [CanBeNull]
         private ScheduledDelegate playbackDisabledDebounce;


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/issues/28752.
Regressed in https://github.com/ppy/osu/pull/28444.