### PR TITLE
Use span instead of string splitting in beatmap parsing

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -22,3 +22,4 @@ M:Humanizer.InflectorExtensions.Pascalize(System.String);Humanizer's .Pascalize(
 M:Humanizer.InflectorExtensions.Camelize(System.String);Humanizer's .Camelize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToCamelCase() instead.
 M:Humanizer.InflectorExtensions.Underscore(System.String);Humanizer's .Underscore() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToSnakeCase() instead.
 M:Humanizer.InflectorExtensions.Kebaberize(System.String);Humanizer's .Kebaberize() extension method changes behaviour depending on CultureInfo.CurrentCulture. Use StringDehumanizeExtensions.ToKebabCase() instead.
+M:System.ReadOnlySpan`1.op_Equality(System.ReadOnlySpan`1,System.ReadOnlySpan`1)~System.Boolean;== on spans produces reference equality. Use SequenceEqual for value equality, or "is" to match ReadOnlySpan<char> with constant string.

--- a/osu.Game.Tests/Beatmaps/Formats/LegacyDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyDecoderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Game.Beatmaps.Formats;
@@ -38,12 +39,12 @@ namespace osu.Game.Tests.Beatmaps.Formats
             {
             }
 
-            protected override bool ShouldSkipLine(string line)
+            protected override bool ShouldSkipLine(ReadOnlySpan<char> line)
             {
                 bool result = base.ShouldSkipLine(line);
 
                 if (!result)
-                    ParsedLines.Add(line);
+                    ParsedLines.Add(line.ToString());
 
                 return result;
             }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -455,14 +455,14 @@ namespace osu.Game.Beatmaps.Formats
                         // Allow the first sprite (by file order) to act as the background in such cases.
                         if (string.IsNullOrEmpty(beatmap.BeatmapInfo.Metadata.BackgroundFile))
                         {
-                            beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(line[ranges[3]].ToString());
+                            beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(line[ranges[3]]);
                             lineSupportedByEncoder = true;
                         }
 
                         break;
 
                     case LegacyEventType.Video:
-                        string filename = CleanFilename(line[ranges[2]].ToString());
+                        string filename = CleanFilename(line[ranges[2]]);
 
                         // Some very old beatmaps had incorrect type specifications for their backgrounds (ie. using 1 for VIDEO
                         // instead of 0 for BACKGROUND). To handle this gracefully, check the file extension against known supported
@@ -476,7 +476,7 @@ namespace osu.Game.Beatmaps.Formats
                         break;
 
                     case LegacyEventType.Background:
-                        beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(line[ranges[2]].ToString());
+                        beatmap.BeatmapInfo.Metadata.BackgroundFile = CleanFilename(line[ranges[2]]);
                         lineSupportedByEncoder = true;
                         break;
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -192,7 +192,7 @@ namespace osu.Game.Beatmaps.Formats
             beatmapInfo.SamplesMatchPlaybackRate = false;
         }
 
-        protected override void ParseLine(Beatmap beatmap, Section section, string line)
+        protected override void ParseLine(Beatmap beatmap, Section section, ReadOnlySpan<char> line)
         {
             switch (section)
             {
@@ -228,7 +228,7 @@ namespace osu.Game.Beatmaps.Formats
             base.ParseLine(beatmap, section, line);
         }
 
-        private void handleGeneral(string line)
+        private void handleGeneral(ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line);
 
@@ -237,7 +237,7 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"AudioFilename":
-                    metadata.AudioFile = pair.Value.ToStandardisedPath();
+                    metadata.AudioFile = pair.Value.ToString().ToStandardisedPath();
                     break;
 
                 case @"AudioLeadIn":
@@ -317,14 +317,14 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private void handleEditor(string line)
+        private void handleEditor(ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line);
 
             switch (pair.Key)
             {
                 case @"Bookmarks":
-                    beatmap.BeatmapInfo.Bookmarks = pair.Value.Split(',').Select(v =>
+                    beatmap.BeatmapInfo.Bookmarks = pair.Value.ToString().Split(',').Select(v =>
                     {
                         bool result = int.TryParse(v, out int val);
                         return new { result, val };
@@ -349,7 +349,7 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private void handleMetadata(string line)
+        private void handleMetadata(ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line);
 
@@ -358,35 +358,35 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case @"Title":
-                    metadata.Title = pair.Value;
+                    metadata.Title = pair.Value.ToString();
                     break;
 
                 case @"TitleUnicode":
-                    metadata.TitleUnicode = pair.Value;
+                    metadata.TitleUnicode = pair.Value.ToString();
                     break;
 
                 case @"Artist":
-                    metadata.Artist = pair.Value;
+                    metadata.Artist = pair.Value.ToString();
                     break;
 
                 case @"ArtistUnicode":
-                    metadata.ArtistUnicode = pair.Value;
+                    metadata.ArtistUnicode = pair.Value.ToString();
                     break;
 
                 case @"Creator":
-                    metadata.Author.Username = pair.Value;
+                    metadata.Author.Username = pair.Value.ToString();
                     break;
 
                 case @"Version":
-                    beatmap.BeatmapInfo.DifficultyName = pair.Value;
+                    beatmap.BeatmapInfo.DifficultyName = pair.Value.ToString();
                     break;
 
                 case @"Source":
-                    metadata.Source = pair.Value;
+                    metadata.Source = pair.Value.ToString();
                     break;
 
                 case @"Tags":
-                    metadata.Tags = pair.Value;
+                    metadata.Tags = pair.Value.ToString();
                     break;
 
                 case @"BeatmapID":
@@ -399,7 +399,7 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private void handleDifficulty(string line)
+        private void handleDifficulty(ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -616,7 +616,7 @@ namespace osu.Game.Beatmaps.Formats
             pendingControlPointTypes.Clear();
         }
 
-        private void handleHitObject(string line)
+        private void handleHitObject(ReadOnlySpan<char> line)
         {
             // If the ruleset wasn't specified, assume the osu!standard ruleset.
             parser ??= new Rulesets.Objects.Legacy.Osu.ConvertHitObjectParser(getOffsetTime(), FormatVersion);

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -151,11 +151,13 @@ namespace osu.Game.Beatmaps.Formats
             };
         }
 
-        protected string CleanFilename(string path) => path
-                                                       // User error which is supported by stable (https://github.com/ppy/osu/issues/21204)
-                                                       .Replace(@"\\", @"\")
-                                                       .Trim('"')
-                                                       .ToStandardisedPath();
+        protected string CleanFilename(ReadOnlySpan<char> path) =>
+            path
+            .ToString()
+            // User error which is supported by stable (https://github.com/ppy/osu/issues/21204)
+            .Replace(@"\\", @"\")
+            .Trim('"')
+            .ToStandardisedPath();
 
         public enum Section
         {

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -154,11 +154,11 @@ namespace osu.Game.Beatmaps.Formats
 
         protected string CleanFilename(ReadOnlySpan<char> path) =>
             path
-            .ToString()
-            // User error which is supported by stable (https://github.com/ppy/osu/issues/21204)
-            .Replace(@"\\", @"\")
-            .Trim('"')
-            .ToStandardisedPath();
+                .ToString()
+                // User error which is supported by stable (https://github.com/ppy/osu/issues/21204)
+                .Replace(@"\\", @"\")
+                .Trim('"')
+                .ToStandardisedPath();
 
         public enum Section
         {

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -99,19 +99,20 @@ namespace osu.Game.Beatmaps.Formats
             var pair = SplitKeyVal(line);
 
             bool isCombo = pair.Key.StartsWith(@"Combo", StringComparison.Ordinal);
+            var colourValue = pair.Value;
 
             Span<Range> ranges = stackalloc Range[5];
-            int splitCount = line.Split(ranges, ',');
+            int splitCount = colourValue.Split(ranges, ',');
 
             if (splitCount != 3 && splitCount != 4)
-                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B or R,G,B,A): {pair.Value}");
+                throw new InvalidOperationException($@"Color specified in incorrect format (should be R,G,B or R,G,B,A): {colourValue}");
 
             Color4 colour;
 
             try
             {
-                byte alpha = allowAlpha && splitCount == 4 ? byte.Parse(line[ranges[3]]) : (byte)255;
-                colour = new Color4(byte.Parse(line[ranges[0]]), byte.Parse(line[ranges[1]]), byte.Parse(line[ranges[2]]), alpha);
+                byte alpha = allowAlpha && splitCount == 4 ? byte.Parse(colourValue[ranges[3]]) : (byte)255;
+                colour = new Color4(byte.Parse(colourValue[ranges[0]]), byte.Parse(colourValue[ranges[1]]), byte.Parse(colourValue[ranges[2]]), alpha);
             }
             catch
             {

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Beatmaps.Formats
             switch (pair.Key)
             {
                 case "UseSkinSprites":
-                    storyboard.UseSkinSprites = pair.Value.SequenceEqual("1");
+                    storyboard.UseSkinSprites = pair.Value is "1";
                     break;
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps.Formats
             base.ParseStreamInto(stream, storyboard);
         }
 
-        protected override void ParseLine(Storyboard storyboard, Section section, string line)
+        protected override void ParseLine(Storyboard storyboard, Section section, ReadOnlySpan<char> line)
         {
             switch (section)
             {
@@ -63,49 +63,42 @@ namespace osu.Game.Beatmaps.Formats
             base.ParseLine(storyboard, section, line);
         }
 
-        private void handleGeneral(Storyboard storyboard, string line)
+        private void handleGeneral(Storyboard storyboard, ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line);
 
             switch (pair.Key)
             {
                 case "UseSkinSprites":
-                    storyboard.UseSkinSprites = pair.Value == "1";
+                    storyboard.UseSkinSprites = pair.Value.SequenceEqual("1");
                     break;
             }
         }
 
-        private void handleEvents(string line)
+        private void handleEvents(ReadOnlySpan<char> line)
         {
-            decodeVariables(ref line);
+            line = decodeVariables(line);
 
-            int depth = 0;
+            int depth = line.IndexOfAnyExcept(' ', '_');
 
-            foreach (char c in line)
-            {
-                if (c == ' ' || c == '_')
-                    depth++;
-                else
-                    break;
-            }
+            line = line.Slice(depth);
 
-            line = line.Substring(depth);
-
-            string[] split = line.Split(',');
+            Span<Range> ranges = stackalloc Range[11];
+            int splitCount = line.Split(ranges, ',');
 
             if (depth == 0)
             {
                 storyboardSprite = null;
 
-                if (!Enum.TryParse(split[0], out LegacyEventType type))
-                    throw new InvalidDataException($@"Unknown event type: {split[0]}");
+                if (!Enum.TryParse(line[ranges[0]], out LegacyEventType type))
+                    throw new InvalidDataException($@"Unknown event type: {line[ranges[0]]}");
 
                 switch (type)
                 {
                     case LegacyEventType.Video:
                     {
-                        int offset = Parsing.ParseInt(split[1]);
-                        string path = CleanFilename(split[2]);
+                        int offset = Parsing.ParseInt(line[ranges[1]]);
+                        string path = CleanFilename(line[ranges[2]]);
 
                         // See handling in LegacyBeatmapDecoder for the special case where a video type is used but
                         // the file extension is not a valid video.
@@ -121,11 +114,11 @@ namespace osu.Game.Beatmaps.Formats
 
                     case LegacyEventType.Sprite:
                     {
-                        string layer = parseLayer(split[1]);
-                        var origin = parseOrigin(split[2]);
-                        string path = CleanFilename(split[3]);
-                        float x = Parsing.ParseFloat(split[4], Parsing.MAX_COORDINATE_VALUE);
-                        float y = Parsing.ParseFloat(split[5], Parsing.MAX_COORDINATE_VALUE);
+                        string layer = parseLayer(line[ranges[1]]);
+                        var origin = parseOrigin(line[ranges[2]]);
+                        string path = CleanFilename(line[ranges[3]]);
+                        float x = Parsing.ParseFloat(line[ranges[4]], Parsing.MAX_COORDINATE_VALUE);
+                        float y = Parsing.ParseFloat(line[ranges[5]], Parsing.MAX_COORDINATE_VALUE);
                         storyboardSprite = new StoryboardSprite(path, origin, new Vector2(x, y));
                         storyboard.GetLayer(layer).Add(storyboardSprite);
                         break;
@@ -133,19 +126,19 @@ namespace osu.Game.Beatmaps.Formats
 
                     case LegacyEventType.Animation:
                     {
-                        string layer = parseLayer(split[1]);
-                        var origin = parseOrigin(split[2]);
-                        string path = CleanFilename(split[3]);
-                        float x = Parsing.ParseFloat(split[4], Parsing.MAX_COORDINATE_VALUE);
-                        float y = Parsing.ParseFloat(split[5], Parsing.MAX_COORDINATE_VALUE);
-                        int frameCount = Parsing.ParseInt(split[6]);
-                        double frameDelay = Parsing.ParseDouble(split[7]);
+                        string layer = parseLayer(line[ranges[1]]);
+                        var origin = parseOrigin(line[ranges[2]]);
+                        string path = CleanFilename(line[ranges[3]]);
+                        float x = Parsing.ParseFloat(line[ranges[4]], Parsing.MAX_COORDINATE_VALUE);
+                        float y = Parsing.ParseFloat(line[ranges[5]], Parsing.MAX_COORDINATE_VALUE);
+                        int frameCount = Parsing.ParseInt(line[ranges[6]]);
+                        double frameDelay = Parsing.ParseDouble(line[ranges[7]]);
 
                         if (FormatVersion < 6)
                             // this is random as hell but taken straight from osu-stable.
                             frameDelay = Math.Round(0.015 * frameDelay) * 1.186 * (1000 / 60f);
 
-                        var loopType = split.Length > 8 ? parseAnimationLoopType(split[8]) : AnimationLoopType.LoopForever;
+                        var loopType = splitCount > 8 ? parseAnimationLoopType(line[ranges[8]]) : AnimationLoopType.LoopForever;
                         storyboardSprite = new StoryboardAnimation(path, origin, new Vector2(x, y), frameCount, frameDelay, loopType);
                         storyboard.GetLayer(layer).Add(storyboardSprite);
                         break;
@@ -153,10 +146,10 @@ namespace osu.Game.Beatmaps.Formats
 
                     case LegacyEventType.Sample:
                     {
-                        double time = Parsing.ParseDouble(split[1]);
-                        string layer = parseLayer(split[2]);
-                        string path = CleanFilename(split[3]);
-                        float volume = split.Length > 4 ? Parsing.ParseFloat(split[4]) : 100;
+                        double time = Parsing.ParseDouble(line[ranges[1]]);
+                        string layer = parseLayer(line[ranges[2]]);
+                        string path = CleanFilename(line[ranges[3]]);
+                        float volume = splitCount > 4 ? Parsing.ParseFloat(line[ranges[4]]) : 100;
                         storyboard.GetLayer(layer).Add(new StoryboardSampleInfo(path, time, (int)volume));
                         break;
                     }
@@ -167,79 +160,79 @@ namespace osu.Game.Beatmaps.Formats
                 if (depth < 2)
                     currentCommandsGroup = storyboardSprite?.Commands;
 
-                string commandType = split[0];
+                ReadOnlySpan<char> commandType = line[ranges[0]];
 
                 switch (commandType)
                 {
                     case "T":
                     {
-                        string triggerName = split[1];
-                        double startTime = split.Length > 2 ? Parsing.ParseDouble(split[2]) : double.MinValue;
-                        double endTime = split.Length > 3 ? Parsing.ParseDouble(split[3]) : double.MaxValue;
-                        int groupNumber = split.Length > 4 ? Parsing.ParseInt(split[4]) : 0;
+                        string triggerName = line[ranges[1]].ToString();
+                        double startTime = splitCount > 2 ? Parsing.ParseDouble(line[ranges[2]]) : double.MinValue;
+                        double endTime = splitCount > 3 ? Parsing.ParseDouble(line[ranges[3]]) : double.MaxValue;
+                        int groupNumber = splitCount > 4 ? Parsing.ParseInt(line[ranges[4]]) : 0;
                         currentCommandsGroup = storyboardSprite?.AddTriggerGroup(triggerName, startTime, endTime, groupNumber);
                         break;
                     }
 
                     case "L":
                     {
-                        double startTime = Parsing.ParseDouble(split[1]);
-                        int repeatCount = Parsing.ParseInt(split[2]);
+                        double startTime = Parsing.ParseDouble(line[ranges[1]]);
+                        int repeatCount = Parsing.ParseInt(line[ranges[2]]);
                         currentCommandsGroup = storyboardSprite?.AddLoopingGroup(startTime, Math.Max(0, repeatCount - 1));
                         break;
                     }
 
                     default:
                     {
-                        if (string.IsNullOrEmpty(split[3]))
-                            split[3] = split[2];
+                        if (line[ranges[3]].IsEmpty)
+                            ranges[3] = ranges[2];
 
-                        var easing = (Easing)Parsing.ParseInt(split[1]);
-                        double startTime = Parsing.ParseDouble(split[2]);
-                        double endTime = Parsing.ParseDouble(split[3]);
+                        var easing = (Easing)Parsing.ParseInt(line[ranges[1]]);
+                        double startTime = Parsing.ParseDouble(line[ranges[2]]);
+                        double endTime = Parsing.ParseDouble(line[ranges[3]]);
 
                         switch (commandType)
                         {
                             case "F":
                             {
-                                float startValue = Parsing.ParseFloat(split[4]);
-                                float endValue = split.Length > 5 ? Parsing.ParseFloat(split[5]) : startValue;
+                                float startValue = Parsing.ParseFloat(line[ranges[4]]);
+                                float endValue = splitCount > 5 ? Parsing.ParseFloat(line[ranges[5]]) : startValue;
                                 currentCommandsGroup?.AddAlpha(easing, startTime, endTime, startValue, endValue);
                                 break;
                             }
 
                             case "S":
                             {
-                                float startValue = Parsing.ParseFloat(split[4]);
-                                float endValue = split.Length > 5 ? Parsing.ParseFloat(split[5]) : startValue;
+                                float startValue = Parsing.ParseFloat(line[ranges[4]]);
+                                float endValue = splitCount > 5 ? Parsing.ParseFloat(line[ranges[5]]) : startValue;
                                 currentCommandsGroup?.AddScale(easing, startTime, endTime, startValue, endValue);
                                 break;
                             }
 
                             case "V":
                             {
-                                float startX = Parsing.ParseFloat(split[4]);
-                                float startY = Parsing.ParseFloat(split[5]);
-                                float endX = split.Length > 6 ? Parsing.ParseFloat(split[6]) : startX;
-                                float endY = split.Length > 7 ? Parsing.ParseFloat(split[7]) : startY;
+                                float startX = Parsing.ParseFloat(line[ranges[4]]);
+                                float startY = Parsing.ParseFloat(line[ranges[5]]);
+                                float endX = splitCount > 6 ? Parsing.ParseFloat(line[ranges[6]]) : startX;
+                                float endY = splitCount > 7 ? Parsing.ParseFloat(line[ranges[7]]) : startY;
                                 currentCommandsGroup?.AddVectorScale(easing, startTime, endTime, new Vector2(startX, startY), new Vector2(endX, endY));
                                 break;
                             }
 
                             case "R":
                             {
-                                float startValue = Parsing.ParseFloat(split[4]);
-                                float endValue = split.Length > 5 ? Parsing.ParseFloat(split[5]) : startValue;
+                                float startValue = Parsing.ParseFloat(line[ranges[4]]);
+                                float endValue = splitCount > 5 ? Parsing.ParseFloat(line[ranges[5]]) : startValue;
                                 currentCommandsGroup?.AddRotation(easing, startTime, endTime, float.RadiansToDegrees(startValue), float.RadiansToDegrees(endValue));
                                 break;
                             }
 
                             case "M":
                             {
-                                float startX = Parsing.ParseFloat(split[4]);
-                                float startY = Parsing.ParseFloat(split[5]);
-                                float endX = split.Length > 6 ? Parsing.ParseFloat(split[6]) : startX;
-                                float endY = split.Length > 7 ? Parsing.ParseFloat(split[7]) : startY;
+                                float startX = Parsing.ParseFloat(line[ranges[4]]);
+                                float startY = Parsing.ParseFloat(line[ranges[5]]);
+                                float endX = splitCount > 6 ? Parsing.ParseFloat(line[ranges[6]]) : startX;
+                                float endY = splitCount > 7 ? Parsing.ParseFloat(line[ranges[7]]) : startY;
                                 currentCommandsGroup?.AddX(easing, startTime, endTime, startX, endX);
                                 currentCommandsGroup?.AddY(easing, startTime, endTime, startY, endY);
                                 break;
@@ -247,28 +240,28 @@ namespace osu.Game.Beatmaps.Formats
 
                             case "MX":
                             {
-                                float startValue = Parsing.ParseFloat(split[4]);
-                                float endValue = split.Length > 5 ? Parsing.ParseFloat(split[5]) : startValue;
+                                float startValue = Parsing.ParseFloat(line[ranges[4]]);
+                                float endValue = splitCount > 5 ? Parsing.ParseFloat(line[ranges[5]]) : startValue;
                                 currentCommandsGroup?.AddX(easing, startTime, endTime, startValue, endValue);
                                 break;
                             }
 
                             case "MY":
                             {
-                                float startValue = Parsing.ParseFloat(split[4]);
-                                float endValue = split.Length > 5 ? Parsing.ParseFloat(split[5]) : startValue;
+                                float startValue = Parsing.ParseFloat(line[ranges[4]]);
+                                float endValue = splitCount > 5 ? Parsing.ParseFloat(line[ranges[5]]) : startValue;
                                 currentCommandsGroup?.AddY(easing, startTime, endTime, startValue, endValue);
                                 break;
                             }
 
                             case "C":
                             {
-                                float startRed = Parsing.ParseFloat(split[4]);
-                                float startGreen = Parsing.ParseFloat(split[5]);
-                                float startBlue = Parsing.ParseFloat(split[6]);
-                                float endRed = split.Length > 7 ? Parsing.ParseFloat(split[7]) : startRed;
-                                float endGreen = split.Length > 8 ? Parsing.ParseFloat(split[8]) : startGreen;
-                                float endBlue = split.Length > 9 ? Parsing.ParseFloat(split[9]) : startBlue;
+                                float startRed = Parsing.ParseFloat(line[ranges[4]]);
+                                float startGreen = Parsing.ParseFloat(line[ranges[5]]);
+                                float startBlue = Parsing.ParseFloat(line[ranges[6]]);
+                                float endRed = splitCount > 7 ? Parsing.ParseFloat(line[ranges[7]]) : startRed;
+                                float endGreen = splitCount > 8 ? Parsing.ParseFloat(line[ranges[8]]) : startGreen;
+                                float endBlue = splitCount > 9 ? Parsing.ParseFloat(line[ranges[9]]) : startBlue;
                                 currentCommandsGroup?.AddColour(easing, startTime, endTime,
                                     new Color4(startRed / 255f, startGreen / 255f, startBlue / 255f, 1),
                                     new Color4(endRed / 255f, endGreen / 255f, endBlue / 255f, 1));
@@ -277,7 +270,7 @@ namespace osu.Game.Beatmaps.Formats
 
                             case "P":
                             {
-                                string type = split[4];
+                                ReadOnlySpan<char> type = line[ranges[4]];
 
                                 switch (type)
                                 {
@@ -308,9 +301,9 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private string parseLayer(string value) => Enum.Parse<LegacyStoryLayer>(value).ToString();
+        private string parseLayer(ReadOnlySpan<char> value) => Enum.Parse<LegacyStoryLayer>(value).ToString();
 
-        private Anchor parseOrigin(string value)
+        private Anchor parseOrigin(ReadOnlySpan<char> value)
         {
             var origin = Enum.Parse<LegacyOrigins>(value);
 
@@ -348,34 +341,36 @@ namespace osu.Game.Beatmaps.Formats
             }
         }
 
-        private AnimationLoopType parseAnimationLoopType(string value)
+        private AnimationLoopType parseAnimationLoopType(ReadOnlySpan<char> value)
         {
             var parsed = Enum.Parse<AnimationLoopType>(value);
             return Enum.IsDefined(parsed) ? parsed : AnimationLoopType.LoopForever;
         }
 
-        private void handleVariables(string line)
+        private void handleVariables(ReadOnlySpan<char> line)
         {
             var pair = SplitKeyVal(line, '=', false);
-            variables[pair.Key] = pair.Value;
+            variables[pair.Key.ToString()] = pair.Value.ToString();
         }
 
         /// <summary>
         /// Decodes any beatmap variables present in a line into their real values.
         /// </summary>
         /// <param name="line">The line which may contains variables.</param>
-        private void decodeVariables(ref string line)
+        private ReadOnlySpan<char> decodeVariables(ReadOnlySpan<char> line)
         {
             while (line.Contains('$'))
             {
-                string origLine = line;
+                ReadOnlySpan<char> origLine = line.ToString();
 
                 foreach (var v in variables)
-                    line = line.Replace(v.Key, v.Value);
+                    line = line.ToString().Replace(v.Key, v.Value);
 
-                if (line == origLine)
+                if (line.SequenceEqual(origLine))
                     break;
             }
+
+            return line;
         }
     }
 }

--- a/osu.Game/Beatmaps/Formats/Parsing.cs
+++ b/osu.Game/Beatmaps/Formats/Parsing.cs
@@ -15,9 +15,9 @@ namespace osu.Game.Beatmaps.Formats
 
         public const double MAX_PARSE_VALUE = int.MaxValue;
 
-        public static float ParseFloat(string input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
+        public static float ParseFloat(ReadOnlySpan<char> input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
         {
-            float output = float.Parse(input, CultureInfo.InvariantCulture);
+            float output = float.Parse(input, provider: CultureInfo.InvariantCulture);
 
             if (output < -parseLimit) throw new OverflowException("Value is too low");
             if (output > parseLimit) throw new OverflowException("Value is too high");
@@ -27,9 +27,9 @@ namespace osu.Game.Beatmaps.Formats
             return output;
         }
 
-        public static double ParseDouble(string input, double parseLimit = MAX_PARSE_VALUE, bool allowNaN = false)
+        public static double ParseDouble(ReadOnlySpan<char> input, double parseLimit = MAX_PARSE_VALUE, bool allowNaN = false)
         {
-            double output = double.Parse(input, CultureInfo.InvariantCulture);
+            double output = double.Parse(input, provider: CultureInfo.InvariantCulture);
 
             if (output < -parseLimit) throw new OverflowException("Value is too low");
             if (output > parseLimit) throw new OverflowException("Value is too high");
@@ -39,9 +39,9 @@ namespace osu.Game.Beatmaps.Formats
             return output;
         }
 
-        public static int ParseInt(string input, int parseLimit = (int)MAX_PARSE_VALUE)
+        public static int ParseInt(ReadOnlySpan<char> input, int parseLimit = (int)MAX_PARSE_VALUE)
         {
-            int output = int.Parse(input, CultureInfo.InvariantCulture);
+            int output = int.Parse(input, provider: CultureInfo.InvariantCulture);
 
             if (output < -parseLimit) throw new OverflowException("Value is too low");
             if (output > parseLimit) throw new OverflowException("Value is too high");

--- a/osu.Game/Rulesets/Objects/HitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectParser.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Game.Rulesets.Objects
 {
     public abstract class HitObjectParser
     {
-        public abstract HitObject? Parse(string text);
+        public abstract HitObject? Parse(ReadOnlySpan<char> text);
     }
 }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -44,15 +44,16 @@ namespace osu.Game.Rulesets.Objects.Legacy
             FormatVersion = formatVersion;
         }
 
-        public override HitObject Parse(string text)
+        public override HitObject Parse(ReadOnlySpan<char> text)
         {
-            string[] split = text.Split(',');
+            Span<Range> ranges = stackalloc Range[12];
+            int splitCount = text.Split(ranges, ',');
 
-            Vector2 pos = new Vector2((int)Parsing.ParseFloat(split[0], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseFloat(split[1], Parsing.MAX_COORDINATE_VALUE));
+            Vector2 pos = new Vector2((int)Parsing.ParseFloat(text[ranges[0]], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseFloat(text[ranges[1]], Parsing.MAX_COORDINATE_VALUE));
 
-            double startTime = Parsing.ParseDouble(split[2]) + Offset;
+            double startTime = Parsing.ParseDouble(text[ranges[2]]) + Offset;
 
-            LegacyHitObjectType type = (LegacyHitObjectType)Parsing.ParseInt(split[3]);
+            LegacyHitObjectType type = (LegacyHitObjectType)Parsing.ParseInt(text[ranges[3]]);
 
             int comboOffset = (int)(type & LegacyHitObjectType.ComboOffset) >> 4;
             type &= ~LegacyHitObjectType.ComboOffset;
@@ -60,7 +61,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             bool combo = type.HasFlag(LegacyHitObjectType.NewCombo);
             type &= ~LegacyHitObjectType.NewCombo;
 
-            var soundType = (LegacyHitSoundType)Parsing.ParseInt(split[4]);
+            var soundType = (LegacyHitSoundType)Parsing.ParseInt(text[ranges[4]]);
             var bankInfo = new SampleBankInfo();
 
             HitObject result = null;
@@ -69,14 +70,14 @@ namespace osu.Game.Rulesets.Objects.Legacy
             {
                 result = CreateHit(pos, combo, comboOffset);
 
-                if (split.Length > 5)
-                    readCustomSampleBanks(split[5], bankInfo);
+                if (splitCount > 5)
+                    readCustomSampleBanks(text[ranges[5]], bankInfo);
             }
             else if (type.HasFlag(LegacyHitObjectType.Slider))
             {
                 double? length = null;
 
-                int repeatCount = Parsing.ParseInt(split[6]);
+                int repeatCount = Parsing.ParseInt(text[ranges[6]]);
 
                 if (repeatCount > 9000)
                     throw new FormatException(@"Repeat count is way too high");
@@ -84,15 +85,15 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 // osu-stable treated the first span of the slider as a repeat, but no repeats are happening
                 repeatCount = Math.Max(0, repeatCount - 1);
 
-                if (split.Length > 7)
+                if (splitCount > 7)
                 {
-                    length = Math.Max(0, Parsing.ParseDouble(split[7], Parsing.MAX_COORDINATE_VALUE));
+                    length = Math.Max(0, Parsing.ParseDouble(text[ranges[7]], Parsing.MAX_COORDINATE_VALUE));
                     if (length == 0)
                         length = null;
                 }
 
-                if (split.Length > 10)
-                    readCustomSampleBanks(split[10], bankInfo, true);
+                if (splitCount > 10)
+                    readCustomSampleBanks(text[ranges[10]], bankInfo, true);
 
                 // One node for each repeat + the start and end nodes
                 int nodes = repeatCount + 2;
@@ -103,17 +104,19 @@ namespace osu.Game.Rulesets.Objects.Legacy
                     nodeBankInfos.Add(bankInfo.Clone());
 
                 // Read any per-node sample banks
-                if (split.Length > 9 && split[9].Length > 0)
+                if (splitCount > 9 && text[ranges[9]] is { IsEmpty: false } sets)
                 {
-                    string[] sets = split[9].Split('|');
+                    int setsCount = sets.Count('|') + 1;
+                    Span<Range> setsRanges = setsCount <= 256 ? stackalloc Range[setsCount] : new Range[setsCount];
+                    sets.Split(setsRanges, '|');
 
                     for (int i = 0; i < nodes; i++)
                     {
-                        if (i >= sets.Length)
+                        if (i >= setsRanges.Length)
                             break;
 
                         SampleBankInfo info = nodeBankInfos[i];
-                        readCustomSampleBanks(sets[i], info);
+                        readCustomSampleBanks(sets[setsRanges[i]], info);
                     }
                 }
 
@@ -123,16 +126,18 @@ namespace osu.Game.Rulesets.Objects.Legacy
                     nodeSoundTypes.Add(soundType);
 
                 // Read any per-node sound types
-                if (split.Length > 8 && split[8].Length > 0)
+                if (splitCount > 8 && text[ranges[8]] is { IsEmpty: false } adds)
                 {
-                    string[] adds = split[8].Split('|');
+                    int addsCount = adds.Count('|') + 1;
+                    Span<Range> addsRanges = addsCount <= 256 ? stackalloc Range[addsCount] : new Range[addsCount];
+                    adds.Split(addsRanges, '|');
 
                     for (int i = 0; i < nodes; i++)
                     {
-                        if (i >= adds.Length)
+                        if (i >= addsRanges.Length)
                             break;
 
-                        int.TryParse(adds[i], out int sound);
+                        int.TryParse(adds[addsRanges[i]], out int sound);
                         nodeSoundTypes[i] = (LegacyHitSoundType)sound;
                     }
                 }
@@ -142,35 +147,36 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 for (int i = 0; i < nodes; i++)
                     nodeSamples.Add(convertSoundType(nodeSoundTypes[i], nodeBankInfos[i]));
 
-                result = CreateSlider(pos, combo, comboOffset, convertPathString(split[5], pos), length, repeatCount, nodeSamples);
+                result = CreateSlider(pos, combo, comboOffset, convertPathString(text[ranges[5]], pos), length, repeatCount, nodeSamples);
             }
             else if (type.HasFlag(LegacyHitObjectType.Spinner))
             {
-                double duration = Math.Max(0, Parsing.ParseDouble(split[5]) + Offset - startTime);
+                double duration = Math.Max(0, Parsing.ParseDouble(text[ranges[5]]) + Offset - startTime);
 
                 result = CreateSpinner(new Vector2(512, 384) / 2, combo, comboOffset, duration);
 
-                if (split.Length > 6)
-                    readCustomSampleBanks(split[6], bankInfo);
+                if (splitCount > 6)
+                    readCustomSampleBanks(text[ranges[6]], bankInfo);
             }
             else if (type.HasFlag(LegacyHitObjectType.Hold))
             {
                 // Note: Hold is generated by BMS converts
 
-                double endTime = Math.Max(startTime, Parsing.ParseDouble(split[2]));
+                double endTime = Math.Max(startTime, Parsing.ParseDouble(text[ranges[2]]));
 
-                if (split.Length > 5 && !string.IsNullOrEmpty(split[5]))
+                if (splitCount > 5 && text[ranges[5]] is { IsEmpty: false } ss)
                 {
-                    string[] ss = split[5].Split(':');
-                    endTime = Math.Max(startTime, Parsing.ParseDouble(ss[0]));
-                    readCustomSampleBanks(string.Join(':', ss.Skip(1)), bankInfo);
+                    Span<Range> ssRange = stackalloc Range[2];
+                    ss.Split(ssRange, ':');
+                    endTime = Math.Max(startTime, Parsing.ParseDouble(ss[ssRange[0]]));
+                    readCustomSampleBanks(ss[ssRange[1]], bankInfo);
                 }
 
                 result = CreateHold(pos, combo, comboOffset, endTime + Offset - startTime);
             }
 
             if (result == null)
-                throw new InvalidDataException($"Unknown hit object type: {split[3]}");
+                throw new InvalidDataException($"Unknown hit object type: {text[ranges[3]]}");
 
             result.StartTime = startTime;
 
@@ -182,18 +188,19 @@ namespace osu.Game.Rulesets.Objects.Legacy
             return result;
         }
 
-        private void readCustomSampleBanks(string str, SampleBankInfo bankInfo, bool banksOnly = false)
+        private void readCustomSampleBanks(ReadOnlySpan<char> str, SampleBankInfo bankInfo, bool banksOnly = false)
         {
-            if (string.IsNullOrEmpty(str))
+            if (str.IsEmpty)
                 return;
 
-            string[] split = str.Split(':');
+            Span<Range> ranges = stackalloc Range[5];
+            int splitCount = str.Split(ranges, ':');
 
-            var bank = (LegacySampleBank)Parsing.ParseInt(split[0]);
+            var bank = (LegacySampleBank)Parsing.ParseInt(str[ranges[0]]);
             if (!Enum.IsDefined(bank))
                 bank = LegacySampleBank.Normal;
 
-            var addBank = (LegacySampleBank)Parsing.ParseInt(split[1]);
+            var addBank = (LegacySampleBank)Parsing.ParseInt(str[ranges[1]]);
             if (!Enum.IsDefined(addBank))
                 addBank = LegacySampleBank.Normal;
 
@@ -209,16 +216,16 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             if (banksOnly) return;
 
-            if (split.Length > 2)
-                bankInfo.CustomSampleBank = Parsing.ParseInt(split[2]);
+            if (splitCount > 2)
+                bankInfo.CustomSampleBank = Parsing.ParseInt(str[ranges[2]]);
 
-            if (split.Length > 3)
-                bankInfo.Volume = Math.Max(0, Parsing.ParseInt(split[3]));
+            if (splitCount > 3)
+                bankInfo.Volume = Math.Max(0, Parsing.ParseInt(str[ranges[3]]));
 
-            bankInfo.Filename = split.Length > 4 ? split[4] : null;
+            bankInfo.Filename = splitCount > 4 ? str[ranges[4]].ToString() : null;
         }
 
-        private PathType convertPathType(string input)
+        private PathType convertPathType(ReadOnlySpan<char> input)
         {
             switch (input[0])
             {
@@ -227,7 +234,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                     return PathType.CATMULL;
 
                 case 'B':
-                    if (input.Length > 1 && int.TryParse(input.Substring(1), out int degree) && degree > 0)
+                    if (input.Length > 1 && int.TryParse(input.Slice(1), out int degree) && degree > 0)
                         return PathType.BSpline(degree);
 
                     return PathType.BEZIER;
@@ -261,20 +268,24 @@ namespace osu.Game.Rulesets.Objects.Legacy
         /// <param name="pointString">The point string.</param>
         /// <param name="offset">The positional offset to apply to the control points.</param>
         /// <returns>All control points in the resultant path.</returns>
-        private PathControlPoint[] convertPathString(string pointString, Vector2 offset)
+        private PathControlPoint[] convertPathString(ReadOnlySpan<char> pointString, Vector2 offset)
         {
             // This code takes on the responsibility of handling explicit segments of the path ("X" & "Y" from above). Implicit segments are handled by calls to convertPoints().
-            string[] pointStringSplit = pointString.Split('|');
+            int splitCount = pointString.Count('|') + 1;
 
-            var pointsBuffer = ArrayPool<Vector2>.Shared.Rent(pointStringSplit.Length);
-            var segmentsBuffer = ArrayPool<(PathType Type, int StartIndex)>.Shared.Rent(pointStringSplit.Length);
+            var splitRanges = ArrayPool<Range>.Shared.Rent(splitCount);
+            var pointsBuffer = ArrayPool<Vector2>.Shared.Rent(splitCount);
+            var segmentsBuffer = ArrayPool<(PathType Type, int StartIndex)>.Shared.Rent(splitCount);
             int currentPointsIndex = 0;
             int currentSegmentsIndex = 0;
 
             try
             {
-                foreach (string s in pointStringSplit)
+                pointString.Split(splitRanges, '|');
+
+                for (int i = 0; i < splitCount; i++)
                 {
+                    ReadOnlySpan<char> s = pointString[splitRanges[i]];
                     if (char.IsLetter(s[0]))
                     {
                         // The start of a new segment(indicated by having an alpha character at position 0).
@@ -315,15 +326,17 @@ namespace osu.Game.Rulesets.Objects.Legacy
             }
             finally
             {
+                ArrayPool<Range>.Shared.Return(splitRanges);
                 ArrayPool<Vector2>.Shared.Return(pointsBuffer);
                 ArrayPool<(PathType, int)>.Shared.Return(segmentsBuffer);
             }
 
-            static Vector2 readPoint(string value, Vector2 startPos)
+            static Vector2 readPoint(ReadOnlySpan<char> value, Vector2 startPos)
             {
-                string[] vertexSplit = value.Split(':');
+                Span<Range> ranges = stackalloc Range[3];
+                value.Split(ranges, ':');
 
-                Vector2 pos = new Vector2((int)Parsing.ParseDouble(vertexSplit[0], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseDouble(vertexSplit[1], Parsing.MAX_COORDINATE_VALUE)) - startPos;
+                Vector2 pos = new Vector2((int)Parsing.ParseDouble(value[ranges[0]], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseDouble(value[ranges[1]], Parsing.MAX_COORDINATE_VALUE)) - startPos;
                 return pos;
             }
         }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.IO;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.Audio;
-using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.ControlPoints;
@@ -286,6 +285,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
                 for (int i = 0; i < splitCount; i++)
                 {
                     ReadOnlySpan<char> s = pointString[splitRanges[i]];
+
                     if (char.IsLetter(s[0]))
                     {
                         // The start of a new segment(indicated by having an alpha character at position 0).

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -99,11 +99,11 @@ namespace osu.Game.Skinning
                         break;
 
                     case "JudgementLine":
-                        currentConfig.ShowJudgementLine = pair.Value == "1";
+                        currentConfig.ShowJudgementLine = pair.Value is "1";
                         break;
 
                     case "KeysUnderNotes":
-                        currentConfig.KeysUnderNotes = pair.Value == "1";
+                        currentConfig.KeysUnderNotes = pair.Value is "1";
                         break;
 
                     case "LightingNWidth":

--- a/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
+++ b/osu.Game/Skinning/LegacyManiaSkinDecoder.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Skinning
             currentConfig = null;
         }
 
-        protected override void ParseLine(List<LegacyManiaSkinConfiguration> output, Section section, string line)
+        protected override void ParseLine(List<LegacyManiaSkinConfiguration> output, Section section, ReadOnlySpan<char> line)
         {
             switch (section)
             {
@@ -52,7 +52,7 @@ namespace osu.Game.Skinning
                             break;
 
                         default:
-                            pendingLines.Add(line);
+                            pendingLines.Add(line.ToString());
 
                             // Hold all lines until a "Keys" item is found.
                             if (currentConfig != null)
@@ -128,17 +128,17 @@ namespace osu.Game.Skinning
                         currentConfig.LightFramePerSecond = lightFramePerSecond > 0 ? lightFramePerSecond : 24;
                         break;
 
-                    case string when pair.Key.StartsWith("Colour", StringComparison.Ordinal):
+                    case { } when pair.Key.StartsWith("Colour", StringComparison.Ordinal):
                         HandleColours(currentConfig, line, true);
                         break;
 
                     // Custom sprite paths
-                    case string when pair.Key.StartsWith("NoteImage", StringComparison.Ordinal):
-                    case string when pair.Key.StartsWith("KeyImage", StringComparison.Ordinal):
-                    case string when pair.Key.StartsWith("Hit", StringComparison.Ordinal):
-                    case string when pair.Key.StartsWith("Stage", StringComparison.Ordinal):
-                    case string when pair.Key.StartsWith("Lighting", StringComparison.Ordinal):
-                        currentConfig.ImageLookups[pair.Key] = pair.Value;
+                    case { } when pair.Key.StartsWith("NoteImage", StringComparison.Ordinal):
+                    case { } when pair.Key.StartsWith("KeyImage", StringComparison.Ordinal):
+                    case { } when pair.Key.StartsWith("Hit", StringComparison.Ordinal):
+                    case { } when pair.Key.StartsWith("Stage", StringComparison.Ordinal):
+                    case { } when pair.Key.StartsWith("Lighting", StringComparison.Ordinal):
+                        currentConfig.ImageLookups[pair.Key.ToString()] = pair.Value.ToString();
                         break;
                 }
             }
@@ -146,16 +146,18 @@ namespace osu.Game.Skinning
             pendingLines.Clear();
         }
 
-        private void parseArrayValue(string value, float[] output, bool applyScaleFactor = true)
+        private void parseArrayValue(ReadOnlySpan<char> value, float[] output, bool applyScaleFactor = true)
         {
-            string[] values = value.Split(',');
+            int valuesCount = value.Count(',') + 1;
+            Span<Range> ranges = valuesCount <= 256 ? stackalloc Range[valuesCount] : new Range[valuesCount];
+            value.Split(ranges, ',');
 
-            for (int i = 0; i < values.Length; i++)
+            for (int i = 0; i < ranges.Length; i++)
             {
                 if (i >= output.Length)
                     break;
 
-                if (!float.TryParse(values[i], NumberStyles.Float, CultureInfo.InvariantCulture, out float parsedValue))
+                if (!float.TryParse(value[ranges[i]], NumberStyles.Float, CultureInfo.InvariantCulture, out float parsedValue))
                     // some skins may provide incorrect entries in array values. to match stable behaviour, read such entries as zero.
                     // see: https://github.com/ppy/osu/issues/26464, stable code: https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Skinning/Components/Section.cs#L134-L137
                     parsedValue = 0;

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Globalization;
 using osu.Game.Beatmaps.Formats;
 
@@ -13,7 +14,7 @@ namespace osu.Game.Skinning
         {
         }
 
-        protected override void ParseLine(SkinConfiguration skin, Section section, string line)
+        protected override void ParseLine(SkinConfiguration skin, Section section, ReadOnlySpan<char> line)
         {
             if (section != Section.Colours)
             {
@@ -25,15 +26,15 @@ namespace osu.Game.Skinning
                         switch (pair.Key)
                         {
                             case @"Name":
-                                skin.SkinInfo.Name = pair.Value;
+                                skin.SkinInfo.Name = pair.Value.ToString();
                                 return;
 
                             case @"Author":
-                                skin.SkinInfo.Creator = pair.Value;
+                                skin.SkinInfo.Creator = pair.Value.ToString();
                                 return;
 
                             case @"Version":
-                                if (pair.Value == "latest")
+                                if (pair.Value.SequenceEqual("latest"))
                                     skin.LegacyVersion = SkinConfiguration.LATEST_VERSION;
                                 else if (decimal.TryParse(pair.Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out decimal version))
                                     skin.LegacyVersion = version;
@@ -50,8 +51,8 @@ namespace osu.Game.Skinning
                         return;
                 }
 
-                if (!string.IsNullOrEmpty(pair.Key))
-                    skin.ConfigDictionary[pair.Key] = pair.Value;
+                if (!pair.Key.IsEmpty)
+                    skin.ConfigDictionary[pair.Key.ToString()] = pair.Value.ToString();
             }
 
             base.ParseLine(skin, section, line);

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Skinning
                                 return;
 
                             case @"Version":
-                                if (pair.Value.SequenceEqual("latest"))
+                                if (pair.Value is "latest")
                                     skin.LegacyVersion = SkinConfiguration.LATEST_VERSION;
                                 else if (decimal.TryParse(pair.Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out decimal version))
                                     skin.LegacyVersion = version;


### PR DESCRIPTION
Supersedes #23282 .

This PR now uses `MemoryExtensions.Split(ReadOnlySpan<char>)` API in .NET 8, which splits a span of chars into pre-determined sections with no object allocation.