### PR TITLE
Use Environment.IsPrivilegedProcess and remove Mono.Posix.NETStandard

### DIFF
--- a/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
+++ b/osu.Desktop/Security/ElevatedPrivilegesChecker.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Security.Principal;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -21,46 +20,12 @@ namespace osu.Desktop.Security
         [Resolved]
         private INotificationOverlay notifications { get; set; } = null!;
 
-        private bool elevated;
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            elevated = checkElevated();
-        }
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            if (elevated)
+            if (Environment.IsPrivilegedProcess)
                 notifications.Post(new ElevatedPrivilegesNotification());
-        }
-
-        private bool checkElevated()
-        {
-            try
-            {
-                switch (RuntimeInfo.OS)
-                {
-                    case RuntimeInfo.Platform.Windows:
-                        if (!OperatingSystem.IsWindows()) return false;
-
-                        var windowsIdentity = WindowsIdentity.GetCurrent();
-                        var windowsPrincipal = new WindowsPrincipal(windowsIdentity);
-
-                        return windowsPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
-
-                    case RuntimeInfo.Platform.macOS:
-                    case RuntimeInfo.Platform.Linux:
-                        return Mono.Unix.Native.Syscall.geteuid() == 0;
-                }
-            }
-            catch
-            {
-            }
-
-            return false;
         }
 
         private partial class ElevatedPrivilegesNotification : SimpleNotification

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Clowd.Squirrel" Version="2.11.1" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="8.0.0" />
     <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
   </ItemGroup>


### PR DESCRIPTION
`Environment.IsPrivilegedProcess` is now a built-in API from .NET 8. This allows us to remove a legacy dependency Mono.Posix.NETStandard.

