### PR TITLE
Adjust editor transparent tweens to be less "flashy"

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -269,9 +269,16 @@ namespace osu.Game.Rulesets.Edit
 
             composerFocusMode.BindValueChanged(_ =>
             {
-                float targetAlpha = composerFocusMode.Value ? 0.5f : 1;
-                leftToolboxBackground.FadeTo(targetAlpha, 400, Easing.OutQuint);
-                rightToolboxBackground.FadeTo(targetAlpha, 400, Easing.OutQuint);
+                if (!composerFocusMode.Value)
+                {
+                    leftToolboxBackground.FadeIn(750, Easing.OutQuint);
+                    rightToolboxBackground.FadeIn(750, Easing.OutQuint);
+                }
+                else
+                {
+                    leftToolboxBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
+                    rightToolboxBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
+                }
             }, true);
         }
 

--- a/osu.Game/Screens/Edit/BottomBar.cs
+++ b/osu.Game/Screens/Edit/BottomBar.cs
@@ -82,10 +82,13 @@ namespace osu.Game.Screens.Edit
             saveInProgress.BindValueChanged(_ => TestGameplayButton.Enabled.Value = !saveInProgress.Value, true);
             composerFocusMode.BindValueChanged(_ =>
             {
-                float targetAlpha = composerFocusMode.Value ? 0.5f : 1;
-
                 foreach (var c in this.ChildrenOfType<BottomBarContainer>())
-                    c.Background.FadeTo(targetAlpha, 400, Easing.OutQuint);
+                {
+                    if (!composerFocusMode.Value)
+                        c.Background.FadeIn(750, Easing.OutQuint);
+                    else
+                        c.Background.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
+                }
             }, true);
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -132,7 +132,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             base.LoadComplete();
 
-            composerFocusMode.BindValueChanged(_ => timelineBackground.FadeTo(composerFocusMode.Value ? 0.5f : 1, 400, Easing.OutQuint), true);
+            composerFocusMode.BindValueChanged(_ =>
+            {
+                if (!composerFocusMode.Value)
+                    timelineBackground.FadeIn(750, Easing.OutQuint);
+                else
+                    timelineBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
+            }, true);
         }
     }
 }


### PR DESCRIPTION
Touched on in https://github.com/ppy/osu/discussions/28581.

After a bit more usage of the editor I do agree with this and think that making the fades a bit more gentle helps a lot.

https://github.com/ppy/osu/assets/191335/5f295b20-86f2-4993-a1d4-55eac31ceea1

Was considering moving the transform logic to `Editor` and exposing just the `Alpha` to be applied locally to each component, but probably not worth it.