### PR TITLE
Improve performance of automatic break regeneration

### DIFF
--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
@@ -17,6 +18,11 @@ namespace osu.Game.Screens.Edit
         IBeatmap IBeatmapProcessor.Beatmap => Beatmap;
 
         private readonly IBeatmapProcessor? rulesetBeatmapProcessor;
+
+        /// <summary>
+        /// Kept for the purposes of reducing redundant regeneration of automatic breaks.
+        /// </summary>
+        private HashSet<(double, double)> objectDurationCache = new HashSet<(double, double)>();
 
         public EditorBeatmapProcessor(EditorBeatmap beatmap, Ruleset ruleset)
         {
@@ -38,6 +44,13 @@ namespace osu.Game.Screens.Edit
 
         private void autoGenerateBreaks()
         {
+            var objectDuration = Beatmap.HitObjects.Select(ho => (ho.StartTime, ho.GetEndTime())).ToHashSet();
+
+            if (objectDuration.SetEquals(objectDurationCache))
+                return;
+
+            objectDurationCache = objectDuration;
+
             Beatmap.Breaks.RemoveAll(b => b is not ManualBreakPeriod);
 
             foreach (var manualBreak in Beatmap.Breaks.ToList())


### PR DESCRIPTION
## [Do not regenerate breaks unless meaningful change to object start/end times is detected](https://github.com/ppy/osu/commit/343090e3b140780fd708bf69107e70bd328c0172)

Tangentially found when profiling https://github.com/ppy/osu/pull/28792.

For reproduction, import https://osu.ppy.sh/beatmapsets/972#osu/9007, move any object on the playfield, and observe a half-second freeze when ending the drag.

## [Pool summary timeline break visualisations to reduce allocations](https://github.com/ppy/osu/commit/b881c25b17f7ae8615737432a63915c6dbbba1ff)

Self-explanatory.

## Profiling results (release configuration, profile with tracing)

| map | master | this PR, initial processing / processing after change to start or end time | this PR, processing after no change to start or end time |
| :-: | :-: | :-: | :-: |
| https://osu.ppy.sh/beatmapsets/972#osu/9007 | ![image](https://github.com/ppy/osu/assets/20418176/bce18b04-5a93-4993-9c41-a565bf075bb9) | ![image](https://github.com/ppy/osu/assets/20418176/557a6c8a-8214-4970-986b-8dc8d72dba0b) | ![image](https://github.com/ppy/osu/assets/20418176/7b4a8bdb-7b47-43c7-9409-9f4e9d0e4316) |
| https://osu.ppy.sh/beatmapsets/479671#osu/1024215 | ![image](https://github.com/ppy/osu/assets/20418176/7bad0b9b-dea0-4f4b-9c4a-8d3ffbee5753) | ![image](https://github.com/ppy/osu/assets/20418176/411e2d4c-337f-454c-ac94-3117dd4dec9e) | ![image](https://github.com/ppy/osu/assets/20418176/261f7ded-66a3-4227-b807-4919461d2272) |