### PR TITLE
Select all text when focusing sample bank/volume textboxes in editor (and number boxes in general)

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneOsuTextBox.cs
@@ -11,6 +11,7 @@ using osu.Framework.Testing;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -59,6 +60,22 @@ namespace osu.Game.Tests.Visual.UserInterface
             expectedValue(numberBoxes, "123");
 
             clearTextboxes(numberBoxes);
+        }
+
+        [Test]
+        public void TestSelectAllOnFocus()
+        {
+            AddStep("create themed content", () => CreateThemedContent(OverlayColourScheme.Red));
+
+            AddStep("enter numbers", () => numberBoxes.ForEach(numberBox => numberBox.Text = "987654321"));
+
+            AddAssert("nothing selected", () => string.IsNullOrEmpty(numberBoxes.First().SelectedText));
+            AddStep("click on a number box", () =>
+            {
+                InputManager.MoveMouseTo(numberBoxes.First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("text selected", () => numberBoxes.First().SelectedText == "987654321");
         }
 
         private void clearTextboxes(IEnumerable<OsuTextBox> textBoxes) => AddStep("clear textbox", () => textBoxes.ForEach(textBox => textBox.Text = null));

--- a/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
@@ -7,6 +7,11 @@ namespace osu.Game.Graphics.UserInterface
     {
         protected override bool AllowIme => false;
 
+        public OsuNumberBox()
+        {
+            SelectAllOnFocus = true;
+        }
+
         protected override bool CanAddCharacter(char character) => char.IsAsciiDigit(character);
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -63,6 +63,11 @@ namespace osu.Game.Graphics.UserInterface
 
         private Dictionary<FeedbackSampleType, Sample?[]> sampleMap = new Dictionary<FeedbackSampleType, Sample?[]>();
 
+        /// <summary>
+        /// Whether all text should be selected when the <see cref="OsuTextBox"/> gains focus.
+        /// </summary>
+        public bool SelectAllOnFocus { get; set; }
+
         public OsuTextBox()
         {
             Height = 40;
@@ -255,6 +260,9 @@ namespace osu.Game.Graphics.UserInterface
                 BorderThickness = 3;
 
             base.OnFocus(e);
+
+            if (SelectAllOnFocus)
+                SelectAll();
         }
 
         protected override void OnFocusLost(FocusLostEvent e)

--- a/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/LabelledTextBox.cs
@@ -28,6 +28,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
             set => Component.ReadOnly = value;
         }
 
+        public bool SelectAllOnFocus
+        {
+            get => Component.SelectAllOnFocus;
+            set => Component.SelectAllOnFocus = value;
+        }
+
         public LocalisableString PlaceholderText
         {
             set => Component.PlaceholderText = value;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -148,10 +148,12 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             bank = new LabelledTextBox
                             {
                                 Label = "Bank Name",
+                                SelectAllOnFocus = true,
                             },
                             additionBank = new LabelledTextBox
                             {
                                 Label = "Addition Bank",
+                                SelectAllOnFocus = true,
                             },
                             volume = new IndeterminateSliderWithTextBoxInput<int>("Volume", new BindableInt(100)
                             {

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -51,7 +51,8 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         textBox = new LabelledTextBox
                         {
-                            Label = "Time"
+                            Label = "Time",
+                            SelectAllOnFocus = true,
                         },
                         button = new RoundedButton
                         {

--- a/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
+++ b/osu.Game/Screens/Edit/Timing/IndeterminateSliderWithTextBoxInput.cs
@@ -75,6 +75,7 @@ namespace osu.Game.Screens.Edit.Timing
                         textBox = new LabelledTextBox
                         {
                             Label = labelText,
+                            SelectAllOnFocus = true,
                         },
                         slider = new SettingsSlider<T>
                         {

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -79,6 +79,7 @@ namespace osu.Game.Screens.Edit.Timing
             public BPMTextBox()
             {
                 Label = "BPM";
+                SelectAllOnFocus = true;
 
                 OnCommit += (_, isNew) =>
                 {


### PR DESCRIPTION
Coming from https://github.com/ppy/osu/issues/28713 (see second part of https://github.com/ppy/osu/issues/28713#issuecomment-2208794428 & https://github.com/ppy/osu/issues/28713#issuecomment-2209919975). This improves the experience of modifying sample bank/volume of each object on the go.


https://github.com/ppy/osu/assets/22781491/8d20f9f4-a208-42a0-92c5-5e36f2a0df46

