### PR TITLE
Match mania editor playfield time range with timeline zoom

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
+++ b/osu.Game.Rulesets.Mania/Edit/DrawableManiaEditorRuleset.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Mania.Configuration;
 using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
@@ -17,6 +18,8 @@ namespace osu.Game.Rulesets.Mania.Edit
     public partial class DrawableManiaEditorRuleset : DrawableManiaRuleset, ISupportConstantAlgorithmToggle
     {
         public BindableBool ShowSpeedChanges { get; } = new BindableBool();
+
+        public double? TimelineTimeRange { get; set; }
 
         public new IScrollingInfo ScrollingInfo => base.ScrollingInfo;
 
@@ -38,5 +41,11 @@ namespace osu.Game.Rulesets.Mania.Edit
             Origin = Anchor.Centre,
             Size = Vector2.One
         };
+
+        protected override void Update()
+        {
+            TargetTimeRange = TimelineTimeRange == null || ShowSpeedChanges.Value ? ComputeScrollTime(Config.Get<int>(ManiaRulesetSetting.ScrollSpeed)) : TimelineTimeRange.Value;
+            base.Update();
+        }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -21,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Edit
 {
     public partial class ManiaHitObjectComposer : ScrollingHitObjectComposer<ManiaHitObject>
     {
-        private DrawableManiaEditorRuleset drawableRuleset;
+        private DrawableManiaEditorRuleset drawableRuleset = null!;
 
         public ManiaHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -72,7 +70,7 @@ namespace osu.Game.Rulesets.Mania.Edit
                 if (!double.TryParse(split[0], out double time) || !int.TryParse(split[1], out int column))
                     continue;
 
-                ManiaHitObject current = remainingHitObjects.FirstOrDefault(h => h.StartTime == time && h.Column == column);
+                ManiaHitObject? current = remainingHitObjects.FirstOrDefault(h => h.StartTime == time && h.Column == column);
 
                 if (current == null)
                     continue;

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
@@ -12,6 +13,7 @@ using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -20,6 +22,9 @@ namespace osu.Game.Rulesets.Mania.Edit
     public partial class ManiaHitObjectComposer : ScrollingHitObjectComposer<ManiaHitObject>
     {
         private DrawableManiaEditorRuleset drawableRuleset = null!;
+
+        [Resolved]
+        private EditorScreenWithTimeline? screenWithTimeline { get; set; }
 
         public ManiaHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -80,6 +85,14 @@ namespace osu.Game.Rulesets.Mania.Edit
                 if (i < objectDescriptions.Length - 1)
                     remainingHitObjects = remainingHitObjects.Where(h => h != current && h.StartTime >= current.StartTime).ToList();
             }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (screenWithTimeline?.TimelineArea.Timeline != null)
+                drawableRuleset.TimelineTimeRange = EditorClock.TrackLength / screenWithTimeline.TimelineArea.Timeline.CurrentZoom / 2;
         }
     }
 }

--- a/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
+++ b/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs
@@ -13,13 +13,12 @@ namespace osu.Game.Screens.Edit
     [Cached]
     public abstract partial class EditorScreenWithTimeline : EditorScreen
     {
-        public const float PADDING = 10;
-
-        public Container TimelineContent { get; private set; } = null!;
+        public TimelineArea TimelineArea { get; private set; } = null!;
 
         public Container MainContent { get; private set; } = null!;
 
         private LoadingSpinner spinner = null!;
+        private Container timelineContent = null!;
 
         protected EditorScreenWithTimeline(EditorScreenMode type)
             : base(type)
@@ -60,7 +59,7 @@ namespace osu.Game.Screens.Edit
                                     {
                                         new Drawable[]
                                         {
-                                            TimelineContent = new Container
+                                            timelineContent = new Container
                                             {
                                                 RelativeSizeAxes = Axes.X,
                                                 AutoSizeAxes = Axes.Y,
@@ -108,7 +107,7 @@ namespace osu.Game.Screens.Edit
                 MainContent.Add(content);
                 content.FadeInFromZero(300, Easing.OutQuint);
 
-                LoadComponentAsync(new TimelineArea(CreateTimelineContent()), TimelineContent.Add);
+                LoadComponentAsync(TimelineArea = new TimelineArea(CreateTimelineContent()), timelineContent.Add);
             });
         }
 


### PR DESCRIPTION
RFC.

https://github.com/ppy/osu/assets/20418176/5bfbf154-657f-4925-a7f7-667836c5bb38

Honestly not super sure about this, but it _was_ mentioned as a point in https://github.com/ppy/osu/issues/24545, so gave this a go. Intentionally does not match stable which appears to apply a mostly arbitrary zoom (there appears to be zero apparent correlation between the timeline and the playfield there, so I didn't bother matching or even looking at source what stable did).

Method of application is a _bit_ ad hoc but mania's baseline scroll speed managing code was already a bit more involved than I would have liked, and it's _relatively_ isolated so maybe fine?

This only takes effect when "show scroll speed changes" is _off_. This is so that enabling that toggle provides an accurate representation of actual gameplay.

Applied locally to mania for now because the other scrolling rulesets didn't have a stable editor and I'm unsure if they would want this. I could see applying this for taiko, using the same behaviour of turning it off when showing scroll speed changes, but probably not for catch, as it would distort SVs there.

This is overlooking the fact that the timeline is generally (as per user feedback) a bit useless for mania right now which is something I'd be looking to address a bit later, *probably* by having per-ruleset implementations of timeline?