### PR TITLE
Disable key navigation in volume overlay during gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -1098,6 +1098,33 @@ namespace osu.Game.Tests.Visual.Navigation
             AddAssert("still nothing selected", () => Game.Beatmap.IsDefault);
         }
 
+        [Test]
+        public void TestVolumeOverlayIgnoredDuringGameplay()
+        {
+            Screens.Select.SongSelect songSelect = null;
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadOszIntoOsu(Game, virtualTrack: true).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+            AddUntilStep("wait for player", () => Game.ScreenStack.CurrentScreen is Player);
+
+            AddStep("show volume overlay", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.PressKey(Key.Left);
+                InputManager.ReleaseKey(Key.AltLeft);
+                InputManager.ReleaseKey(Key.Left);
+            });
+            AddStep("hover volume overlay", () => InputManager.MoveMouseTo(Game.ChildrenOfType<VolumeOverlay>().Single()));
+            AddStep("hold left", () => InputManager.PressKey(Key.Left));
+
+            AddUntilStep("volume overlay still hides eventually", () => Game.ChildrenOfType<VolumeOverlay>().Single().State.Value == Visibility.Hidden);
+            AddStep("release left", () => InputManager.ReleaseKey(Key.Left));
+        }
+
         private Func<Player> playToResults()
         {
             var player = playToCompletion();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1049,7 +1049,10 @@ namespace osu.Game
                 },
             }, topMostOverlayContent.Add);
 
-            loadComponentSingleFile(volume = new VolumeOverlay(), leftFloatingOverlayContent.Add, true);
+            loadComponentSingleFile(volume = new VolumeOverlay
+            {
+                LocalUserPlaying = { BindTarget = LocalUserPlaying },
+            }, leftFloatingOverlayContent.Add, true);
 
             var onScreenDisplay = new OnScreenDisplay();
 


### PR DESCRIPTION
- Closes #19362 

Decided to look into this one as it feels really bad despite the low number of reports (assumed low by activity in the thread above).

Making gameplay key bindings take precedence over volume key bindings is not as simple as it sounds, especially since gameplay key binding handling is covered by a pass-through input manager (`RulesetInputManager`). 

Even if we bring the handling of arrow keys in volume overlay all the way to the end of the input queue, the ruleset pieces (i.e. `CactherArea` in osu!catch case) will remain unable to block the arrow key press, since they're covered by a pass-through input manager (`RulesetInputManager`) which does not block any input it receives from going to the drawables behind it.

It might be possible to solve this differently by arbitrarily blocking arrow keys in `RulesetInputManager`/`CatchInputManager`, but I feel this solution is more elegant to my eyes. Open for feedback.