### PR TITLE
Fix incorrect continuation in `ImportAsUpdate` causing UI blockage

### DIFF
--- a/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
+++ b/osu.Game.Tests/Database/BeatmapImporterUpdateTests.cs
@@ -168,11 +168,11 @@ namespace osu.Game.Tests.Database
                 Assert.That(importAfterUpdate, Is.Not.Null);
                 Debug.Assert(importAfterUpdate != null);
 
+                realm.Run(r => r.Refresh());
+
                 // should only contain the modified beatmap (others purged).
                 Assert.That(importBeforeUpdate.Value.Beatmaps, Has.Count.EqualTo(1));
                 Assert.That(importAfterUpdate.Value.Beatmaps, Has.Count.EqualTo(count_beatmaps));
-
-                realm.Run(r => r.Refresh());
 
                 checkCount<BeatmapInfo>(realm, count_beatmaps + 1);
                 checkCount<BeatmapMetadata>(realm, count_beatmaps + 1);

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -43,7 +43,9 @@ namespace osu.Game.Beatmaps
 
         public override async Task<Live<BeatmapSetInfo>?> ImportAsUpdate(ProgressNotification notification, ImportTask importTask, BeatmapSetInfo original)
         {
-            var imported = await Import(notification, new[] { importTask }).ConfigureAwait(true);
+            Guid originalId = original.ID;
+
+            var imported = await Import(notification, new[] { importTask }).ConfigureAwait(false);
 
             if (!imported.Any())
                 return null;
@@ -53,7 +55,7 @@ namespace osu.Game.Beatmaps
             var first = imported.First();
 
             // If there were no changes, ensure we don't accidentally nuke ourselves.
-            if (first.ID == original.ID)
+            if (first.ID == originalId)
             {
                 first.PerformRead(s =>
                 {
@@ -69,7 +71,8 @@ namespace osu.Game.Beatmaps
 
                 Logger.Log($"Beatmap \"{updated}\" update completed successfully", LoggingTarget.Database);
 
-                original = realm!.Find<BeatmapSetInfo>(original.ID)!;
+                // Re-fetch as we are likely on a different thread.
+                original = realm!.Find<BeatmapSetInfo>(originalId)!;
 
                 // Generally the import process will do this for us if the OnlineIDs match,
                 // but that isn't a guarantee (ie. if the .osu file doesn't have OnlineIDs populated).


### PR DESCRIPTION
Noticed in https://github.com/ppy/osu/pull/28800#discussion_r1672057367.

I have no idea why this was set this way, doesn't make much sense 🙈

https://github.com/ppy/osu/pull/21629/commits/de079e08dcbe845e4e8b944a5beabeb875033755 doesn't really give any clues about why/what was wrong, but i'm inclined to think that whatever made it "wrong" has been fixed either since that commit, or with the very simple change I made in this PR to avoid cross-thread realm access.