### PR TITLE
Fix editor UI transparency being incorrectly opaque when hovering slider control points

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -88,7 +88,6 @@ namespace osu.Game.Rulesets.Edit
 
         private IBindable<bool> hasTiming;
         private Bindable<bool> autoSeekOnPlacement;
-        private readonly Bindable<bool> composerFocusMode = new Bindable<bool>();
 
         protected DrawableRuleset<TObject> DrawableRuleset { get; private set; }
 
@@ -104,9 +103,6 @@ namespace osu.Game.Rulesets.Edit
         private void load(OsuConfigManager config, [CanBeNull] Editor editor)
         {
             autoSeekOnPlacement = config.GetBindable<bool>(OsuSetting.EditorAutoSeekOnPlacement);
-
-            if (editor != null)
-                composerFocusMode.BindTo(editor.ComposerFocusMode);
 
             Config = Dependencies.Get<IRulesetConfigCache>().GetConfigFor(Ruleset);
 
@@ -132,7 +128,7 @@ namespace osu.Game.Rulesets.Edit
 
             InternalChildren = new[]
             {
-                PlayfieldContentContainer = new ContentContainer
+                PlayfieldContentContainer = new Container
                 {
                     Name = "Playfield content",
                     RelativeSizeAxes = Axes.Y,
@@ -234,6 +230,9 @@ namespace osu.Game.Rulesets.Edit
             setSelectTool();
 
             EditorBeatmap.SelectedHitObjects.CollectionChanged += selectionChanged;
+
+            editor?.RegisterMainUIElement(leftToolboxBackground, new[] { leftToolboxBackground });
+            editor?.RegisterMainUIElement(rightToolboxBackground, new[] { rightToolboxBackground });
         }
 
         /// <summary>
@@ -264,20 +263,6 @@ namespace osu.Game.Rulesets.Edit
                 foreach (var item in toolboxCollection.Items)
                 {
                     item.Selected.Disabled = !hasTiming.NewValue;
-                }
-            }, true);
-
-            composerFocusMode.BindValueChanged(_ =>
-            {
-                if (!composerFocusMode.Value)
-                {
-                    leftToolboxBackground.FadeIn(750, Easing.OutQuint);
-                    rightToolboxBackground.FadeIn(750, Easing.OutQuint);
-                }
-                else
-                {
-                    leftToolboxBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
-                    rightToolboxBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
                 }
             }, true);
         }
@@ -529,31 +514,6 @@ namespace osu.Game.Rulesets.Edit
         }
 
         #endregion
-
-        private partial class ContentContainer : Container
-        {
-            public override bool HandlePositionalInput => true;
-
-            private readonly Bindable<bool> composerFocusMode = new Bindable<bool>();
-
-            [BackgroundDependencyLoader(true)]
-            private void load([CanBeNull] Editor editor)
-            {
-                if (editor != null)
-                    composerFocusMode.BindTo(editor.ComposerFocusMode);
-            }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                composerFocusMode.Value = true;
-                return false;
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                composerFocusMode.Value = false;
-            }
-        }
     }
 
     /// <summary>

--- a/osu.Game/Screens/Edit/BottomBar.cs
+++ b/osu.Game/Screens/Edit/BottomBar.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -21,7 +22,6 @@ namespace osu.Game.Screens.Edit
         public TestGameplayButton TestGameplayButton { get; private set; } = null!;
 
         private IBindable<bool> saveInProgress = null!;
-        private Bindable<bool> composerFocusMode = null!;
 
         [BackgroundDependencyLoader]
         private void load(Editor editor)
@@ -72,24 +72,14 @@ namespace osu.Game.Screens.Edit
             };
 
             saveInProgress = editor.MutationTracker.InProgress.GetBoundCopy();
-            composerFocusMode = editor.ComposerFocusMode.GetBoundCopy();
+
+            editor.RegisterMainUIElement(this, this.ChildrenOfType<BottomBarContainer>().Select(c => c.Background));
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
             saveInProgress.BindValueChanged(_ => TestGameplayButton.Enabled.Value = !saveInProgress.Value, true);
-            composerFocusMode.BindValueChanged(_ =>
-            {
-                foreach (var c in this.ChildrenOfType<BottomBarContainer>())
-                {
-                    if (!composerFocusMode.Value)
-                        c.Background.FadeIn(750, Easing.OutQuint);
-                    else
-                        c.Background.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
-                }
-            }, true);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
+++ b/osu.Game/Screens/Edit/Components/Menus/EditorMenuBar.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Edit.Components.Menus
         }
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, TextureStore textures)
+        private void load(OverlayColourProvider colourProvider, Editor editor)
         {
             BackgroundColour = colourProvider.Background3;
 
@@ -69,6 +69,8 @@ namespace osu.Game.Screens.Edit.Components.Menus
                 t.Font = OsuFont.TorusAlternate;
                 t.Colour = colourProvider.Highlight1;
             });
+
+            editor.RegisterMainUIElement(this, Enumerable.Empty<Drawable>());
         }
 
         protected override Framework.Graphics.UserInterface.Menu CreateSubMenu() => new SubMenu

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -124,21 +124,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
             };
 
-            if (editor != null)
-                composerFocusMode.BindTo(editor.ComposerFocusMode);
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            composerFocusMode.BindValueChanged(_ =>
-            {
-                if (!composerFocusMode.Value)
-                    timelineBackground.FadeIn(750, Easing.OutQuint);
-                else
-                    timelineBackground.Delay(600).FadeTo(0.5f, 4000, Easing.OutQuint);
-            }, true);
+            editor?.RegisterMainUIElement(this, new[] { timelineBackground });
         }
     }
 }


### PR DESCRIPTION
As mentioned [here](https://github.com/ppy/osu/pull/28787#issuecomment-2221150025).

Sorry for ripping up the previous method of doing this dimming, I couldn't find a better way. This also manages to centralise the transforms being applied, which I think is a win?