### PR TITLE
Fix editor UI transparency being incorrectly opaque when hovering slider control points

### DIFF
--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Rulesets.Edit
 
             InternalChildren = new[]
             {
-                PlayfieldContentContainer = new ContentContainer
+                PlayfieldContentContainer = new Container
                 {
                     Name = "Playfield content",
                     RelativeSizeAxes = Axes.Y,
@@ -269,6 +269,7 @@ namespace osu.Game.Rulesets.Edit
 
             composerFocusMode.BindValueChanged(_ =>
             {
+                // Transforms should be kept in sync with other usages of composer focus mode.
                 if (!composerFocusMode.Value)
                 {
                     leftToolboxBackground.FadeIn(750, Easing.OutQuint);
@@ -303,6 +304,8 @@ namespace osu.Game.Rulesets.Edit
                 PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - (TOOLBOX_CONTRACTED_SIZE_LEFT + TOOLBOX_CONTRACTED_SIZE_RIGHT);
                 PlayfieldContentContainer.X = TOOLBOX_CONTRACTED_SIZE_LEFT;
             }
+
+            composerFocusMode.Value = PlayfieldContentContainer.Contains(InputManager.CurrentState.Mouse.Position);
         }
 
         public override Playfield Playfield => drawableRulesetWrapper.Playfield;
@@ -529,31 +532,6 @@ namespace osu.Game.Rulesets.Edit
         }
 
         #endregion
-
-        private partial class ContentContainer : Container
-        {
-            public override bool HandlePositionalInput => true;
-
-            private readonly Bindable<bool> composerFocusMode = new Bindable<bool>();
-
-            [BackgroundDependencyLoader(true)]
-            private void load([CanBeNull] Editor editor)
-            {
-                if (editor != null)
-                    composerFocusMode.BindTo(editor.ComposerFocusMode);
-            }
-
-            protected override bool OnHover(HoverEvent e)
-            {
-                composerFocusMode.Value = true;
-                return false;
-            }
-
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                composerFocusMode.Value = false;
-            }
-        }
     }
 
     /// <summary>

--- a/osu.Game/Screens/Edit/BottomBar.cs
+++ b/osu.Game/Screens/Edit/BottomBar.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Screens.Edit
             saveInProgress.BindValueChanged(_ => TestGameplayButton.Enabled.Value = !saveInProgress.Value, true);
             composerFocusMode.BindValueChanged(_ =>
             {
+                // Transforms should be kept in sync with other usages of composer focus mode.
                 foreach (var c in this.ChildrenOfType<BottomBarContainer>())
                 {
                     if (!composerFocusMode.Value)

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineArea.cs
@@ -134,6 +134,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             composerFocusMode.BindValueChanged(_ =>
             {
+                // Transforms should be kept in sync with other usages of composer focus mode.
                 if (!composerFocusMode.Value)
                     timelineBackground.FadeIn(750, Easing.OutQuint);
                 else

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Edit
         /// In "composer focus" mode the opacity of the aforementioned components is reduced so that the user can focus on the composer better.
         /// </summary>
         /// <remarks>
-        /// The state of this bindable is controlled by <see cref="HitObjectComposer"/>.
+        /// The state of this bindable is controlled by <see cref="HitObjectComposer"/> when in <see cref="EditorScreenMode.Compose"/> mode.
         /// </remarks>
         public Bindable<bool> ComposerFocusMode { get; } = new Bindable<bool>();
 
@@ -1018,6 +1018,9 @@ namespace osu.Game.Screens.Edit
             }
             finally
             {
+                if (Mode.Value != EditorScreenMode.Compose)
+                    ComposerFocusMode.Value = false;
+
                 updateSampleDisabledState();
                 rebindClipboardBindables();
             }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -218,6 +218,9 @@ namespace osu.Game.Screens.Edit
         /// This controls the opacity of components like the timelines, sidebars, etc.
         /// In "composer focus" mode the opacity of the aforementioned components is reduced so that the user can focus on the composer better.
         /// </summary>
+        /// <remarks>
+        /// The state of this bindable is controlled by <see cref="HitObjectComposer"/>.
+        /// </remarks>
         public Bindable<bool> ComposerFocusMode { get; } = new Bindable<bool>();
 
         public Editor(EditorLoader loader = null)


### PR DESCRIPTION
As mentioned at https://github.com/ppy/osu/pull/28787#issuecomment-2221150025.
