### PR TITLE
Add tooltips to summary timeline display

### DIFF
--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BookmarkPart.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
 
@@ -19,16 +22,17 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                 Add(new BookmarkVisualisation(bookmark));
         }
 
-        private partial class BookmarkVisualisation : PointVisualisation
+        private partial class BookmarkVisualisation : PointVisualisation, IHasTooltip
         {
             public BookmarkVisualisation(double startTime)
                 : base(startTime)
             {
-                Width = 2;
             }
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours) => Colour = colours.Blue;
+
+            public LocalisableString TooltipText => $"{StartTime.ToEditorFormattedString()} bookmark";
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
         private partial class BreakVisualisation : PoolableDrawable, IHasTooltip
         {
-            private BreakPeriod breakPeriod;
+            private BreakPeriod breakPeriod = null!;
 
             public BreakPeriod BreakPeriod
             {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -4,9 +4,12 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
@@ -46,12 +49,15 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             }, true);
         }
 
-        private partial class BreakVisualisation : PoolableDrawable
+        private partial class BreakVisualisation : PoolableDrawable, IHasTooltip
         {
+            private BreakPeriod breakPeriod;
+
             public BreakPeriod BreakPeriod
             {
                 set
                 {
+                    breakPeriod = value;
                     X = (float)value.StartTime;
                     Width = (float)value.Duration;
                 }
@@ -66,6 +72,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                 InternalChild = new Circle { RelativeSizeAxes = Axes.Both };
                 Colour = colours.Gray6;
             }
+
+            public LocalisableString TooltipText => $"{breakPeriod.StartTime.ToEditorFormattedString()} - {breakPeriod.EndTime.ToEditorFormattedString()} break time";
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/ControlPointVisualisation.cs
@@ -2,18 +2,23 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 {
-    public partial class ControlPointVisualisation : PointVisualisation, IControlPointVisualisation
+    public partial class ControlPointVisualisation : PointVisualisation, IControlPointVisualisation, IHasTooltip
     {
         protected readonly ControlPoint Point;
 
         public ControlPointVisualisation(ControlPoint point)
+            : base(point.Time)
         {
             Point = point;
             Alpha = 0.3f;
@@ -27,5 +32,22 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
         }
 
         public bool IsVisuallyRedundant(ControlPoint other) => other.GetType() == Point.GetType();
+
+        public LocalisableString TooltipText
+        {
+            get
+            {
+                switch (Point)
+                {
+                    case EffectControlPoint effect:
+                        return $"{StartTime.ToEditorFormattedString()} effect [{effect.ScrollSpeed:N2}x scroll{(effect.KiaiMode ? " kiai" : "")}]";
+
+                    case TimingControlPoint timing:
+                        return $"{StartTime.ToEditorFormattedString()} timing [{timing.BPM:N2} bpm {timing.TimeSignature.GetDescription()}]";
+                }
+
+                return string.Empty;
+            }
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
@@ -5,8 +5,11 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 
 namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
@@ -90,7 +93,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
                 Width = (float)(nextControlPoint.Time - effect.Time);
 
-                AddInternal(new Circle
+                AddInternal(new KiaiVisualisation(effect.Time, nextControlPoint.Time)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.BottomLeft,
@@ -100,6 +103,20 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                     Colour = effect.GetRepresentingColour(colours),
                 });
             }
+        }
+
+        private partial class KiaiVisualisation : Circle, IHasTooltip
+        {
+            private readonly double startTime;
+            private readonly double endTime;
+
+            public KiaiVisualisation(double startTime, double endTime)
+            {
+                this.startTime = startTime;
+                this.endTime = endTime;
+            }
+
+            public LocalisableString TooltipText => $"{startTime.ToEditorFormattedString()} - {endTime.ToEditorFormattedString()} kiai time";
         }
 
         // kiai sections display duration, so are required to be visualised.

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/PreviewTimePart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/PreviewTimePart.cs
@@ -3,6 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations;
 
@@ -27,7 +30,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             }, true);
         }
 
-        private partial class PreviewTimeVisualisation : PointVisualisation
+        private partial class PreviewTimeVisualisation : PointVisualisation, IHasTooltip
         {
             public PreviewTimeVisualisation(double time)
                 : base(time)
@@ -37,6 +40,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
 
             [BackgroundDependencyLoader]
             private void load(OsuColour colours) => Colour = colours.Green1;
+
+            public LocalisableString TooltipText => $"{StartTime.ToEditorFormattedString()} preview time";
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/SummaryTimeline.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/SummaryTimeline.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary
                     Anchor = Anchor.Centre,
                     Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.Both,
-                    Height = 0.35f
+                    Height = 0.4f
                 },
                 new BreakPart
                 {

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Visualisations/PointVisualisation.cs
@@ -16,13 +16,6 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
         public const float MAX_WIDTH = 4;
 
         public PointVisualisation(double startTime)
-            : this()
-        {
-            X = (float)startTime;
-            StartTime = startTime;
-        }
-
-        public PointVisualisation()
         {
             RelativePositionAxes = Axes.Both;
             RelativeSizeAxes = Axes.Y;
@@ -32,6 +25,9 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Visualisations
 
             Width = MAX_WIDTH;
             Height = 0.4f;
+
+            X = (float)startTime;
+            StartTime = startTime;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/CentreMarker.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineTickDisplay.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 PointVisualisation point;
                 if (drawableIndex >= Count)
-                    Add(point = new PointVisualisation());
+                    Add(point = new PointVisualisation(0));
                 else
                     point = Children[drawableIndex];
 


### PR DESCRIPTION
Knowing what anything means on this timeline as a new user is quite some trial-and-error effort. This should improve things a bit.

- [x] Depends on https://github.com/ppy/osu/pull/28788 for ease-of-merging

https://github.com/user-attachments/assets/caec77d6-9794-4ef8-9c9a-a7232d82d128

