### PR TITLE
UI SFX Tweaks/Updates

### DIFF
--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -16,14 +16,8 @@ namespace osu.Game.Graphics.UserInterface
         [Description("button-sidebar")]
         ButtonSidebar,
 
-        [Description("toolbar")]
-        Toolbar,
-
         [Description("tabselect")]
         TabSelect,
-
-        [Description("scrolltotop")]
-        ScrollToTop,
 
         [Description("dialog-cancel")]
         DialogCancel,

--- a/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialogDangerousButton.cs
@@ -67,7 +67,7 @@ namespace osu.Game.Overlays.Dialog
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                Progress.BindValueChanged(progressChanged, true);
+                Progress.BindValueChanged(progressChanged);
             }
 
             protected override void Confirm()
@@ -114,13 +114,13 @@ namespace osu.Game.Overlays.Dialog
                 if (progress.NewValue < progress.OldValue)
                     return;
 
-                if (Clock.CurrentTime - lastTickPlaybackTime < 30)
+                if (Clock.CurrentTime - lastTickPlaybackTime < 40)
                     return;
 
                 var channel = tickSample.GetChannel();
 
-                channel.Frequency.Value = 1 + progress.NewValue * 0.5f;
-                channel.Volume.Value = 0.5f + progress.NewValue / 2f;
+                channel.Frequency.Value = 1 + progress.NewValue;
+                channel.Volume.Value = 0.1f + progress.NewValue / 2f;
 
                 channel.Play();
 

--- a/osu.Game/Overlays/OverlayScrollContainer.cs
+++ b/osu.Game/Overlays/OverlayScrollContainer.cs
@@ -5,6 +5,8 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -112,8 +114,12 @@ namespace osu.Game.Overlays
 
             public Bindable<float?> LastScrollTarget = new Bindable<float?>();
 
+            protected override HoverSounds CreateHoverSounds(HoverSampleSet sampleSet) => new HoverSounds();
+
+            private Sample scrollToTopSample;
+            private Sample scrollToPreviousSample;
+
             public ScrollBackButton()
-                : base(HoverSampleSet.ScrollToTop)
             {
                 Size = new Vector2(50);
                 Alpha = 0;
@@ -150,11 +156,14 @@ namespace osu.Game.Overlays
             }
 
             [BackgroundDependencyLoader]
-            private void load(OverlayColourProvider colourProvider)
+            private void load(OverlayColourProvider colourProvider, AudioManager audio)
             {
                 IdleColour = colourProvider.Background6;
                 HoverColour = colourProvider.Background5;
                 flashColour = colourProvider.Light1;
+
+                scrollToTopSample = audio.Samples.Get(@"UI/scroll-to-top");
+                scrollToPreviousSample = audio.Samples.Get(@"UI/scroll-to-previous");
             }
 
             protected override void LoadComplete()
@@ -171,6 +180,12 @@ namespace osu.Game.Overlays
             protected override bool OnClick(ClickEvent e)
             {
                 background.FlashColour(flashColour, 800, Easing.OutQuint);
+
+                if (LastScrollTarget.Value == null)
+                    scrollToTopSample?.Play();
+                else
+                    scrollToPreviousSample?.Play();
+
                 return base.OnClick(e);
             }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -36,7 +36,7 @@
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
     <PackageReference Include="ppy.osu.Framework" Version="2024.702.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2024.705.0" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2024.713.0" />
     <PackageReference Include="Sentry" Version="4.3.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.36.0" />


### PR DESCRIPTION
- [x] depends on ppy/osu-resources#329

- Tweaked 'tick' sample looping behaviour of `PopupDialogDangerousButton` to better suit new sample
- Fixes 'tick' sample playing when dialog first appears (regression from #28652)
- Play different samples for scroll-to-top vs scroll-to-previous