### PR TITLE
Fix drawing slider with touch inserts a random control point at beginning

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditor.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuEditor.cs
@@ -1,8 +1,19 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit.Components.RadioButtons;
+using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Tests.Visual;
+using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Rulesets.Osu.Tests.Editor
 {
@@ -10,5 +21,66 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
     public partial class TestSceneOsuEditor : EditorTestScene
     {
         protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestTouchInputAfterTouchingComposeArea()
+        {
+            AddStep("tap circle", () => tap(this.ChildrenOfType<EditorRadioButton>().Single(b => b.Button.Label == "HitCircle")));
+
+            // this input is just for interacting with compose area
+            AddStep("tap playfield", () => tap(this.ChildrenOfType<Playfield>().Single()));
+
+            AddStep("move current time", () => InputManager.Key(Key.Right));
+
+            AddStep("tap to place circle", () => tap(this.ChildrenOfType<Playfield>().Single().ToScreenSpace(new Vector2(10, 10))));
+            AddAssert("circle placed correctly", () =>
+            {
+                var circle = (HitCircle)EditorBeatmap.HitObjects.Single(h => h.StartTime == EditorClock.CurrentTimeAccurate);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(circle.Position.X, Is.EqualTo(10f).Within(0.01f));
+                    Assert.That(circle.Position.Y, Is.EqualTo(10f).Within(0.01f));
+                });
+
+                return true;
+            });
+
+            AddStep("tap slider", () => tap(this.ChildrenOfType<EditorRadioButton>().Single(b => b.Button.Label == "Slider")));
+
+            // this input is just for interacting with compose area
+            AddStep("tap playfield", () => tap(this.ChildrenOfType<Playfield>().Single()));
+
+            AddStep("move current time", () => InputManager.Key(Key.Right));
+
+            AddStep("hold to draw slider", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, this.ChildrenOfType<Playfield>().Single().ToScreenSpace(new Vector2(50, 20)))));
+            AddStep("drag to draw", () => InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, this.ChildrenOfType<Playfield>().Single().ToScreenSpace(new Vector2(200, 50)))));
+            AddAssert("selection not initiated", () => this.ChildrenOfType<DragBox>().All(d => d.State == Visibility.Hidden));
+            AddStep("end", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, InputManager.CurrentState.Touch.GetTouchPosition(TouchSource.Touch1)!.Value)));
+            AddAssert("slider placed correctly", () =>
+            {
+                var slider = (Slider)EditorBeatmap.HitObjects.Single(h => h.StartTime == EditorClock.CurrentTimeAccurate);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(slider.Position.X, Is.EqualTo(50f).Within(0.01f));
+                    Assert.That(slider.Position.Y, Is.EqualTo(20f).Within(0.01f));
+                    Assert.That(slider.Path.ControlPoints.Count, Is.EqualTo(2));
+                    Assert.That(slider.Path.ControlPoints[0].Position, Is.EqualTo(Vector2.Zero));
+
+                    // the final position may be slightly off from the mouse position when drawing, account for that.
+                    Assert.That(slider.Path.ControlPoints[1].Position.X, Is.EqualTo(150).Within(5));
+                    Assert.That(slider.Path.ControlPoints[1].Position.Y, Is.EqualTo(30).Within(5));
+                });
+
+                return true;
+            });
+        }
+
+        private void tap(Drawable drawable) => tap(drawable.ScreenSpaceDrawQuad.Centre);
+
+        private void tap(Vector2 position)
+        {
+            InputManager.BeginTouch(new Touch(TouchSource.Touch1, position));
+            InputManager.EndTouch(new Touch(TouchSource.Touch1, position));
+        }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
@@ -393,6 +394,29 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         [Test]
+        public void TestSliderDrawingViaTouch()
+        {
+            Vector2 startPoint = new Vector2(200);
+
+            AddStep("move mouse to a random point", () => InputManager.MoveMouseTo(InputManager.ToScreenSpace(Vector2.Zero)));
+            AddStep("begin touch at start point", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, InputManager.ToScreenSpace(startPoint))));
+
+            for (int i = 1; i < 20; i++)
+                addTouchMovementStep(startPoint + new Vector2(i * 40, MathF.Sin(i * MathF.PI / 5) * 50));
+
+            AddStep("release touch at end point", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, InputManager.CurrentState.Touch.GetTouchPosition(TouchSource.Touch1)!.Value)));
+
+            assertPlaced(true);
+            assertLength(808, tolerance: 10);
+            assertControlPointCount(5);
+            assertFinalControlPointType(0, PathType.BSpline(4));
+            assertFinalControlPointType(1, null);
+            assertFinalControlPointType(2, null);
+            assertFinalControlPointType(3, null);
+            assertFinalControlPointType(4, null);
+        }
+
+        [Test]
         public void TestPlacePerfectCurveSegmentAlmostLinearlyExterior()
         {
             Vector2 startPosition = new Vector2(200);
@@ -491,6 +515,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         }
 
         private void addMovementStep(Vector2 position) => AddStep($"move mouse to {position}", () => InputManager.MoveMouseTo(InputManager.ToScreenSpace(position)));
+
+        private void addTouchMovementStep(Vector2 position) => AddStep($"move touch1 to {position}", () => InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, InputManager.ToScreenSpace(position))));
 
         private void addClickStep(MouseButton button)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -295,8 +295,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             ensurePlacementCreated();
         }
 
-        private void updatePlacementPosition()
+        private void updatePlacementTimeAndPosition()
         {
+            if (CurrentPlacement == null)
+                return;
+
             var snapResult = Composer.FindSnappedPositionAndTime(InputManager.CurrentState.Mouse.Position, CurrentPlacement.SnapType);
 
             // if no time was found from positional snapping, we should still quantize to the beat.
@@ -329,8 +332,15 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (Composer.CursorInPlacementArea)
                 ensurePlacementCreated();
 
-            if (CurrentPlacement != null)
-                updatePlacementPosition();
+            // updates the placement with the latest editor clock time.
+            updatePlacementTimeAndPosition();
+        }
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            // updates the placement with the latest mouse position.
+            updatePlacementTimeAndPosition();
+            return base.OnMouseMove(e);
         }
 
         protected sealed override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject item)
@@ -367,7 +377,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 placementBlueprintContainer.Child = CurrentPlacement = blueprint;
 
                 // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
-                updatePlacementPosition();
+                updatePlacementTimeAndPosition();
 
                 updatePlacementSamples();
 

--- a/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
+++ b/osu.Game/Tests/Visual/PlacementBlueprintTestScene.cs
@@ -3,9 +3,11 @@
 
 #nullable disable
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
@@ -24,6 +26,10 @@ namespace osu.Game.Tests.Visual
         protected PlacementBlueprintTestScene()
         {
             base.Content.Add(HitObjectContainer = CreateHitObjectContainer().With(c => c.Clock = new FramedClock(new StopwatchClock())));
+            base.Content.Add(new MouseMovementInterceptor
+            {
+                MouseMoved = updatePlacementTimeAndPosition,
+            });
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -83,9 +89,10 @@ namespace osu.Game.Tests.Visual
         protected override void Update()
         {
             base.Update();
-
-            CurrentBlueprint.UpdateTimeAndPosition(SnapForBlueprint(CurrentBlueprint));
+            updatePlacementTimeAndPosition();
         }
+
+        private void updatePlacementTimeAndPosition() => CurrentBlueprint.UpdateTimeAndPosition(SnapForBlueprint(CurrentBlueprint));
 
         protected virtual SnapResult SnapForBlueprint(HitObjectPlacementBlueprint blueprint) =>
             new SnapResult(InputManager.CurrentState.Mouse.Position, null);
@@ -107,5 +114,22 @@ namespace osu.Game.Tests.Visual
 
         protected abstract DrawableHitObject CreateHitObject(HitObject hitObject);
         protected abstract HitObjectPlacementBlueprint CreateBlueprint();
+
+        private partial class MouseMovementInterceptor : Drawable
+        {
+            public Action MouseMoved;
+
+            public MouseMovementInterceptor()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Depth = float.MinValue;
+            }
+
+            protected override bool OnMouseMove(MouseMoveEvent e)
+            {
+                MouseMoved?.Invoke();
+                return base.OnMouseMove(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
- Resolves one part of https://github.com/ppy/osu/issues/26509

As can be seen in the video attached in https://github.com/ppy/osu/issues/26509#issue-2080421810, when drawing a slider after touching the playfield, a control point is inserted at the point where the user put their finger before drawing.

This is caused by `SliderPlacementBlueprint` reading the snap result of the last frame instead of the current frame where the touch input was triggered, therefore beginning a curve with the old mouse position. 

The solution in this PR might not sit well with everyone because it's essentially a schedule underneath a three-line comment block, but I would like to say that the flow at which the blueprint receives the snap result warrants a schedule so that the placement begins with the snap result constructed based off the current update frame.

Note that `PlacementBlueprintTestScene` required a refactor so that the solution works. While this might feel like the solution is flaky, `PlacementBlueprintTestScene` was written in a way that operates opposite to how the editor naturally works. By that I mean the test scene updates the snap result before the test input manager's update flow, so even if `beginCurve` is scheduled in the mouse event, it'll execute before the next snap result update (in other words, the snap result update flow in the test scene always reads the input state of the last frame)