### PR TITLE
Fix editor toolboxes being incorrectly chopped

### DIFF
--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Edit
             RelativeSizeAxes = Axes.Y;
 
             FillFlow.Spacing = new Vector2(5);
-            Padding = new MarginPadding { Vertical = 5 };
+            FillFlow.Padding = new MarginPadding { Vertical = 5 };
         }
 
         protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => base.ReceivePositionalInputAtSubTree(screenSpacePos) && anyToolboxHovered(screenSpacePos);


### PR DESCRIPTION
Fixes this weirdness, which was only made visible by the recent opacity changes:

![2024-07-15 21 04 25@2x](https://github.com/user-attachments/assets/75e52728-d1d2-40f0-9aac-c35ddc1fce4f)
