### PR TITLE
Exclude protected beatmaps from consideration in several places

### DIFF
--- a/osu.Game/Overlays/Music/PlaylistOverlay.cs
+++ b/osu.Game/Overlays/Music/PlaylistOverlay.cs
@@ -102,7 +102,7 @@ namespace osu.Game.Overlays.Music
         {
             base.LoadComplete();
 
-            beatmapSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => !s.DeletePending), beatmapsChanged);
+            beatmapSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected), beatmapsChanged);
 
             list.Items.BindTo(beatmapSets);
             beatmap.BindValueChanged(working => list.SelectedSet.Value = working.NewValue.BeatmapSetInfo.ToLive(realm), true);

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Overlays
                     return;
 
                 Logger.Log($"{nameof(MusicController)} skipping next track to {nameof(EnsurePlayingSomething)}");
-                NextTrack();
+                NextTrack(allowProtectedTracks: true);
             }
             else if (!IsPlaying)
             {
@@ -207,9 +207,10 @@ namespace osu.Game.Overlays
         /// Play the previous track or restart the current track if it's current time below <see cref="restart_cutoff_point"/>.
         /// </summary>
         /// <param name="onSuccess">Invoked when the operation has been performed successfully.</param>
-        public void PreviousTrack(Action<PreviousTrackResult>? onSuccess = null) => Schedule(() =>
+        /// <param name="allowProtectedTracks">Whether to include <see cref="BeatmapSetInfo.Protected"/> beatmap sets when navigating.</param>
+        public void PreviousTrack(Action<PreviousTrackResult>? onSuccess = null, bool allowProtectedTracks = false) => Schedule(() =>
         {
-            PreviousTrackResult res = prev();
+            PreviousTrackResult res = prev(allowProtectedTracks);
             if (res != PreviousTrackResult.None)
                 onSuccess?.Invoke(res);
         });
@@ -217,8 +218,9 @@ namespace osu.Game.Overlays
         /// <summary>
         /// Play the previous track or restart the current track if it's current time below <see cref="restart_cutoff_point"/>.
         /// </summary>
+        /// <param name="allowProtectedTracks">Whether to include <see cref="BeatmapSetInfo.Protected"/> beatmap sets when navigating.</param>
         /// <returns>The <see cref="PreviousTrackResult"/> that indicate the decided action.</returns>
-        private PreviousTrackResult prev()
+        private PreviousTrackResult prev(bool allowProtectedTracks)
         {
             if (beatmap.Disabled || !AllowTrackControl.Value)
                 return PreviousTrackResult.None;
@@ -233,8 +235,8 @@ namespace osu.Game.Overlays
 
             queuedDirection = TrackChangeDirection.Prev;
 
-            var playableSet = getBeatmapSets().AsEnumerable().TakeWhile(i => !i.Equals(current?.BeatmapSetInfo)).LastOrDefault()
-                              ?? getBeatmapSets().LastOrDefault();
+            var playableSet = getBeatmapSets().AsEnumerable().TakeWhile(i => !i.Equals(current?.BeatmapSetInfo)).LastOrDefault(s => !s.Protected || allowProtectedTracks)
+                              ?? getBeatmapSets().AsEnumerable().LastOrDefault(s => !s.Protected || allowProtectedTracks);
 
             if (playableSet != null)
             {
@@ -250,10 +252,11 @@ namespace osu.Game.Overlays
         /// Play the next random or playlist track.
         /// </summary>
         /// <param name="onSuccess">Invoked when the operation has been performed successfully.</param>
+        /// <param name="allowProtectedTracks">Whether to include <see cref="BeatmapSetInfo.Protected"/> beatmap sets when navigating.</param>
         /// <returns>A <see cref="ScheduledDelegate"/> of the operation.</returns>
-        public void NextTrack(Action? onSuccess = null) => Schedule(() =>
+        public void NextTrack(Action? onSuccess = null, bool allowProtectedTracks = false) => Schedule(() =>
         {
-            bool res = next();
+            bool res = next(allowProtectedTracks);
             if (res)
                 onSuccess?.Invoke();
         });
@@ -306,15 +309,15 @@ namespace osu.Game.Overlays
             Scheduler.AddDelayed(() => duckOperation.Dispose(), delayUntilRestore);
         }
 
-        private bool next()
+        private bool next(bool allowProtectedTracks)
         {
             if (beatmap.Disabled || !AllowTrackControl.Value)
                 return false;
 
             queuedDirection = TrackChangeDirection.Next;
 
-            var playableSet = getBeatmapSets().AsEnumerable().SkipWhile(i => !i.Equals(current?.BeatmapSetInfo)).ElementAtOrDefault(1)
-                              ?? getBeatmapSets().FirstOrDefault();
+            var playableSet = getBeatmapSets().AsEnumerable().SkipWhile(i => !i.Equals(current?.BeatmapSetInfo) && (!i.Protected || allowProtectedTracks)).ElementAtOrDefault(1)
+                              ?? getBeatmapSets().AsEnumerable().FirstOrDefault(i => !i.Protected || allowProtectedTracks);
 
             var playableBeatmap = playableSet?.Beatmaps.FirstOrDefault();
 
@@ -432,7 +435,7 @@ namespace osu.Game.Overlays
         private void onTrackCompleted()
         {
             if (!CurrentTrack.Looping && !beatmap.Disabled && AllowTrackControl.Value)
-                NextTrack();
+                NextTrack(allowProtectedTracks: true);
         }
 
         private bool applyModTrackAdjustments;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -505,6 +505,13 @@ namespace osu.Game.Screens.Select
             var beatmap = e?.NewValue ?? Beatmap.Value;
             if (beatmap is DummyWorkingBeatmap || !this.IsCurrentScreen()) return;
 
+            if (beatmap.BeatmapSetInfo.Protected && e != null)
+            {
+                Logger.Log($"Denying working beatmap switch to protected beatmap {beatmap}");
+                Beatmap.Value = e.OldValue;
+                return;
+            }
+
             Logger.Log($"Song select working beatmap updated to {beatmap}");
 
             if (!Carousel.SelectBeatmap(beatmap.BeatmapInfo, false))


### PR DESCRIPTION
RFC.

- Closes https://github.com/ppy/osu/issues/28880
- Closes https://github.com/ppy/osu/issues/23199

In particular:

- Song select will not permit `Beatmap.Value` to switch to a protected beatmap (will roll back to old value instead). This is mostly a safety rather than a proper fix.
- Protected beatmaps are not shown in now playing overlay (thus they can't be navigated to, preventing the breakage)
- Protected beatmaps are not considered by music controller when using previous/next buttons (knock-on fix of undesirable effects of the other changes)