### PR TITLE
Fix storyboard sprites leaving gaps on edges when "beatmap skins" is enabled

### DIFF
--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -100,14 +100,15 @@ namespace osu.Game.Storyboards.Drawables
                 skinSourceChanged();
             }
             else
-                Texture = textureStore.Get(Sprite.Path);
+                Texture = textureStore.Get(Sprite.Path, WrapMode.ClampToEdge, WrapMode.ClampToEdge);
 
             Sprite.ApplyTransforms(this);
         }
 
         private void skinSourceChanged()
         {
-            Texture = skin.GetTexture(Sprite.Path) ?? textureStore.Get(Sprite.Path);
+            Texture = skin.GetTexture(Sprite.Path, WrapMode.ClampToEdge, WrapMode.ClampToEdge) ??
+                      textureStore.Get(Sprite.Path, WrapMode.ClampToEdge, WrapMode.ClampToEdge);
 
             // Setting texture will only update the size if it's zero.
             // So let's force an explicit update.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28861

The reason why this only happens when "beatmap skins" is enabled is because `skin.GetTexture` resolves a texture from an atlas, and without `ClampToEdge`, it'll leave a gap around the edges. 

When "beatmap skins" is disabled, the storyboard sprite resolves the texture from the nearest cached `TextureStore`, which is this in particular:
https://github.com/ppy/osu/blob/67ca7e4135f5c3d3578da8db5b060b263ede984a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs#L89-L92

And that store has atlas turned off, therefore the issue is not present without "beatmap skins".