### PR TITLE
Fix intermittent test failure in `TestSceneArgonHealthDisplay`

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneArgonHealthDisplay.cs
@@ -99,6 +99,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 Scheduler.AddDelayed(applyMiss, 500 + 30);
             });
+            AddUntilStep("wait for sequence", () => !Scheduler.HasPendingTasks);
         }
 
         [Test]
@@ -120,6 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     }
                 }
             });
+            AddUntilStep("wait for sequence", () => !Scheduler.HasPendingTasks);
         }
 
         [Test]


### PR DESCRIPTION
See: https://github.com/ppy/osu/runs/27575426047#r0s0

Caused by some tests adding a repeating action that affects the run of other test cases. Fixed by delaying said tests until the delegates are finished.