### PR TITLE
Fix selection box being initially visible on top-left corner in skin editor

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -85,10 +85,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 SelectionBox = CreateSelectionBox(),
             });
 
-            SelectedItems.CollectionChanged += (_, _) =>
-            {
-                Scheduler.AddOnce(updateVisibility);
-            };
+            SelectedItems.BindCollectionChanged((_, _) => Scheduler.AddOnce(updateVisibility), true);
         }
 
         public SelectionBox CreateSelectionBox()


### PR DESCRIPTION
- Closes #28911 

This does not occur in editor because the drag handles themselves were being hidden by the bindables in `Selection{Scale,Rotation}Handler`.

The entire selection box is supposed to be hidden when there are no items selected anyway, so just fix that not being triggered on initial state and call it a day.