### PR TITLE
Fix crash when adding mania notes right after changing timing point

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -9,6 +9,7 @@ using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -404,6 +405,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 // As per stable editor, when changing tools, we should forcefully commit any pending placement.
                 CommitIfPlacementActive();
             }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (Beatmap.IsNotNull())
+                Beatmap.HitObjectAdded -= hitObjectAdded;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28938.

This is related to reloading the composer on timing point changes in scrolling rulesets. The lack of unsubscription from this would cause blueprints to be created for disposed composers via the `hitObjectAdded()` flow.

The following line looks as if a sync load should be forced on a newly created placement blueprint:

https://github.com/ppy/osu/blob/da4d37c4aded5e10d0a65ff44a08a886e3897e19/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs#L364

however, it is not the case if the parent (`placementBlueprintContainer`) is disposed, which it would be in this case. Therefore, the blueprint stays `NotLoaded` rather than `Ready`, therefore it never receives its DI dependencies, therefore it dies on an `EditorBeatmap` nullref.