### PR TITLE
Fix beatmap carousel performance regression with large databases

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -278,13 +278,27 @@ namespace osu.Game.Screens.Select
 
             if (changes == null)
             {
+                // Usually we'd handle the initial load case here, but that's already done in load() as an optimisation.
+                // So the only thing we need to handle here is the edge case where realm blocks-resumes all operations.
                 realmBeatmapSets.Clear();
                 realmBeatmapSets.AddRange(sender.Select(r => r.ID));
 
+                // Do a full two-way check on missing beatmaps.
+                // Let's assume that the worst that can happen is deletions or additions.
                 setsRequiringRemoval.Clear();
                 setsRequiringUpdate.Clear();
 
-                loadBeatmapSets(sender);
+                foreach (Guid id in realmBeatmapSets)
+                {
+                    if (!root.BeatmapSetsByID.ContainsKey(id))
+                        setsRequiringUpdate.Add(id);
+                }
+
+                foreach (Guid id in root.BeatmapSetsByID.Keys)
+                {
+                    if (!realmBeatmapSets.Contains(id))
+                        setsRequiringRemoval.Add(id);
+                }
             }
             else
             {


### PR DESCRIPTION
The main fix here is avoiding running `Detach` in the update thread.

This was incorrectly added in this call..

https://github.com/ppy/osu/blob/123d3d2ff814bb0fca56334de90c7a8ba5f1e7f9/osu.Game/Screens/Select/BeatmapCarousel.cs#L287

..in an attempt to handle realm subscription resetting better. While fixing this I have been testing blocking realm with song select open. This was causing deadlocks. 

Let me first preface **a user should never get into this state**. Game-wide realm blocking is done from the main menu in all cases, not song select. But while I was here I wanted to fix this.

The simplest fix is to *not* handle the "blocking happened, clear everything" and just wait for the operation restoration to come in. The clear operation causes an ungodly event flow which eventually hits a blocking realm operation:

![JetBrains Rider-EAP 2024-07-19 at 08 17 14](https://github.com/user-attachments/assets/ce815af7-76d0-4443-8106-181279f1f699)

Hopefully the inline comments explain this amicably.

---

Closes https://github.com/ppy/osu/issues/28929.