### PR TITLE
Save grid rotation to beatmap

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -150,6 +150,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             };
 
             Spacing.Value = editorBeatmap.BeatmapInfo.GridSize;
+
+            GridLinesRotation.Value = editorBeatmap.BeatmapInfo.GridRotation;
         }
 
         protected override void LoadComplete()
@@ -184,6 +186,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 gridLinesRotationSlider.ContractedLabelText = $"R: {rotation.NewValue:#,0.##}";
                 gridLinesRotationSlider.ExpandedLabelText = $"Rotation: {rotation.NewValue:#,0.##}";
+                editorBeatmap.BeatmapInfo.GridRotation = (int)rotation.NewValue;
             }, true);
 
             expandingContainer?.Expanded.BindValueChanged(v =>

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -427,6 +427,7 @@ namespace osu.Game.Beatmaps
                         DistanceSpacing = decodedInfo.DistanceSpacing,
                         BeatDivisor = decodedInfo.BeatDivisor,
                         GridSize = decodedInfo.GridSize,
+                        GridRotation = decodedInfo.GridRotation,
                         TimelineZoom = decodedInfo.TimelineZoom,
                         MD5Hash = memoryStream.ComputeMD5Hash(),
                         EndTimeObjectCount = decoded.HitObjects.Count(h => h is IHasDuration),

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -173,6 +173,8 @@ namespace osu.Game.Beatmaps
 
         public int GridSize { get; set; }
 
+        public int GridRotation { get; set; }
+
         public double TimelineZoom { get; set; } = 1.0;
 
         /// <summary>

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -343,6 +343,10 @@ namespace osu.Game.Beatmaps.Formats
                     beatmap.BeatmapInfo.GridSize = Parsing.ParseInt(pair.Value);
                     break;
 
+                case @"GridRotation":
+                    beatmap.BeatmapInfo.GridRotation = Parsing.ParseInt(pair.Value);
+                    break;
+
                 case @"TimelineZoom":
                     beatmap.BeatmapInfo.TimelineZoom = Math.Max(0, Parsing.ParseDouble(pair.Value));
                     break;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -115,7 +115,9 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine(FormattableString.Invariant($"DistanceSpacing: {beatmap.BeatmapInfo.DistanceSpacing}"));
             writer.WriteLine(FormattableString.Invariant($"BeatDivisor: {beatmap.BeatmapInfo.BeatDivisor}"));
             writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.BeatmapInfo.GridSize}"));
+            writer.WriteLine(FormattableString.Invariant($"GridRotation: {beatmap.BeatmapInfo.GridRotation}"));
             writer.WriteLine(FormattableString.Invariant($"TimelineZoom: {beatmap.BeatmapInfo.TimelineZoom}"));
+
         }
 
         private void handleMetadata(TextWriter writer)


### PR DESCRIPTION
Adds the `GridLinesRotation` int from `OsuGridToolboxGroup.cs` to the [Editor] portion of the beatmap .osu file. Allows grid rotation to be saved instead of reverting to default every time the map is loaded.

I'd imagine something similar can be done for `StartPosition` and `GridType`, but I am not familiar enough with C# typing to implement.

[Osu-Save-Rotation.webm](https://github.com/user-attachments/assets/89220df1-12c3-4d47-95ef-93492aa2ad1f)
