### PR TITLE
Add bottom bar indicator to `OverlayRulesetSelector`

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using System.Linq;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Framework.Logging;
 
 namespace osu.Game.Overlays.BeatmapSet
 {
@@ -22,8 +23,6 @@ namespace osu.Game.Overlays.BeatmapSet
                 beatmapSet.Value = value;
 
                 Current.Value = TabContainer.TabItems.FirstOrDefault(t => t.Enabled.Value)?.Value;
-
-                UpdateBottomBarPosition();
             }
         }
 

--- a/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using System.Linq;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Framework.Logging;
 
 namespace osu.Game.Overlays.BeatmapSet
 {

--- a/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapRulesetSelector.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Overlays.BeatmapSet
                 beatmapSet.Value = value;
 
                 Current.Value = TabContainer.TabItems.FirstOrDefault(t => t.Enabled.Value)?.Value;
+
+                UpdateBottomBarPosition();
             }
         }
 

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Rulesets;
 using osuTK;
@@ -14,9 +15,50 @@ namespace osu.Game.Overlays
         // Since this component is used in online overlays and currently web-side doesn't support non-legacy rulesets, let's disable them for now.
         protected override bool LegacyOnly => true;
 
+        protected Drawable BottomBar { get; private set; }
+
+        protected int BottomBarHeight = 5;
+
         public OverlayRulesetSelector()
         {
-            AutoSizeAxes = Axes.Both;
+            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Y;
+
+            AddRangeInternal(new[]
+            {
+                BottomBar = new Container
+                {
+                    Height = BottomBarHeight,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Y = -1,
+                    Child = new Circle
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        RelativeSizeAxes = Axes.Both
+                    }
+                }
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Current.BindValueChanged(_ => UpdateBottomBarPosition(), true);
+        }
+
+        protected void UpdateBottomBarPosition(float? width = null)
+        {
+            if (SelectedTab != null)
+                BottomBar
+                    .ResizeHeightTo(BottomBarHeight, 500, Easing.OutElasticQuarter)
+                    .ResizeWidthTo(width ?? SelectedTab.DrawWidth, 500, Easing.OutElasticQuarter)
+                    .MoveTo(new Vector2(SelectedTab.DrawPosition.X, 0), 500, Easing.OutElasticQuarter);
+            else
+                BottomBar
+                   .ResizeHeightTo(0, 500, Easing.OutElasticQuarter);
         }
 
         protected override TabItem<RulesetInfo> CreateTabItem(RulesetInfo value) => new OverlayRulesetTabItem(value);
@@ -26,6 +68,8 @@ namespace osu.Game.Overlays
             AutoSizeAxes = Axes.Both,
             Direction = FillDirection.Horizontal,
             Spacing = new Vector2(20, 0),
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft,
         };
     }
 }

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays
                     {
                         Margin = new MarginPadding
                         {
-                            Top = BottomBarHeight / 2.0,
+                            Top = BottomBarHeight / 2.0f,
                         },
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -31,9 +31,12 @@ namespace osu.Game.Overlays
                     Height = BottomBarHeight,
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
-                    Y = -1,
                     Child = new Circle
                     {
+                        Margin = new MarginPadding
+                        {
+                            Top = BottomBarHeight / 2,
+                        },
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
                         RelativeSizeAxes = Axes.Both
@@ -52,13 +55,17 @@ namespace osu.Game.Overlays
         protected void UpdateBottomBarPosition()
         {
             if (SelectedTab != null)
+            {
                 BottomBar
                     .ResizeHeightTo(BottomBarHeight, 500, Easing.OutElasticQuarter)
                     .ResizeWidthTo(SelectedTab.DrawWidth, 500, Easing.OutElasticQuarter)
                     .MoveTo(new Vector2(SelectedTab.DrawPosition.X, 0), 500, Easing.OutElasticQuarter);
+            }
             else
+            {
                 BottomBar
-                   .ResizeHeightTo(0, 500, Easing.OutElasticQuarter);
+                    .ResizeHeightTo(0, 500, Easing.OutElasticQuarter);
+            }
         }
 
         protected override TabItem<RulesetInfo> CreateTabItem(RulesetInfo value) => new OverlayRulesetTabItem(value);

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -49,12 +49,12 @@ namespace osu.Game.Overlays
             Current.BindValueChanged(_ => UpdateBottomBarPosition(), true);
         }
 
-        protected void UpdateBottomBarPosition(float? width = null)
+        protected void UpdateBottomBarPosition()
         {
             if (SelectedTab != null)
                 BottomBar
                     .ResizeHeightTo(BottomBarHeight, 500, Easing.OutElasticQuarter)
-                    .ResizeWidthTo(width ?? SelectedTab.DrawWidth, 500, Easing.OutElasticQuarter)
+                    .ResizeWidthTo(SelectedTab.DrawWidth, 500, Easing.OutElasticQuarter)
                     .MoveTo(new Vector2(SelectedTab.DrawPosition.X, 0), 500, Easing.OutElasticQuarter);
             else
                 BottomBar

--- a/osu.Game/Overlays/OverlayRulesetSelector.cs
+++ b/osu.Game/Overlays/OverlayRulesetSelector.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Overlays
                     {
                         Margin = new MarginPadding
                         {
-                            Top = BottomBarHeight / 2,
+                            Top = BottomBarHeight / 2.0,
                         },
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,


### PR DESCRIPTION
To match the toolbar ruleset selector style

| Master| PR|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1f1bad42-76e8-4cfe-96fd-1df0381a28ea) | ![image](https://github.com/user-attachments/assets/fae34124-64df-4db2-bcb9-4bbea1de48c7) | 

https://github.com/user-attachments/assets/d8d3907b-1a6d-4c7b-a15d-23373ec58d00

