### PR TITLE
Fix various shortcomings in juice stream selection blueprint

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -158,14 +158,14 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             float[] positions = { 200, 200 };
             addBlueprintStep(times, positions, 0.2);
 
-            addAddVertexSteps(500, 150);
-            addVertexCheckStep(3, 1, 500, 150);
+            addAddVertexSteps(500, 180);
+            addVertexCheckStep(3, 1, 500, 180);
 
             addAddVertexSteps(90, 200);
             addVertexCheckStep(4, 1, times[0], positions[0]);
 
-            addAddVertexSteps(750, 180);
-            addVertexCheckStep(5, 4, 750, 180);
+            addAddVertexSteps(750, 200);
+            addVertexCheckStep(5, 4, 750, 200);
             AddAssert("duration is changed", () => Precision.AlmostEquals(hitObject.Duration, 800 - times[0], 1e-3));
         }
 
@@ -265,7 +265,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddStep("delete vertex", () =>
             {
                 InputManager.PressKey(Key.ShiftLeft);
-                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Right);
                 InputManager.ReleaseKey(Key.ShiftLeft);
             });
         }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Input;
@@ -19,22 +20,28 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
     {
         public MenuItem[] ContextMenuItems => getContextMenuItems().ToArray();
 
+        private readonly JuiceStream juiceStream;
+
         // To handle when the editor is scrolled while dragging.
         private Vector2 dragStartPosition;
 
         [Resolved]
         private IEditorChangeHandler? changeHandler { get; set; }
 
-        public SelectionEditablePath(Func<float, double> positionToTime)
+        public SelectionEditablePath(JuiceStream juiceStream, Func<float, double> positionToTime)
             : base(positionToTime)
         {
+            this.juiceStream = juiceStream;
         }
 
         public void AddVertex(Vector2 relativePosition)
         {
+            changeHandler?.BeginChange();
             double time = Math.Max(0, PositionToTime(relativePosition.Y));
             int index = AddVertex(time, relativePosition.X);
+            UpdateHitObjectFromPath(juiceStream);
             selectOnly(index);
+            changeHandler?.EndChange();
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => InternalChildren.Any(d => d.ReceivePositionalInputAt(screenSpacePos));

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -54,7 +54,11 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
             if (e.Button == MouseButton.Left && e.ShiftPressed)
             {
+                changeHandler?.BeginChange();
                 RemoveVertex(index);
+                UpdateHitObjectFromPath(juiceStream);
+                changeHandler?.EndChange();
+
                 return true;
             }
 
@@ -125,11 +129,17 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         private void deleteSelectedVertices()
         {
+            changeHandler?.BeginChange();
+
             for (int i = VertexCount - 1; i >= 0; i--)
             {
                 if (VertexStates[i].IsSelected)
                     RemoveVertex(i);
             }
+
+            UpdateHitObjectFromPath(juiceStream);
+
+            changeHandler?.EndChange();
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             if (index == -1 || VertexStates[index].IsFixed)
                 return false;
 
-            if (e.Button == MouseButton.Left && e.ShiftPressed)
+            if (e.Button == MouseButton.Right && e.ShiftPressed)
             {
                 changeHandler?.BeginChange();
                 RemoveVertex(index);

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/VertexPiece.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/VertexPiece.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osuTK;
 
@@ -12,6 +13,8 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 {
     public partial class VertexPiece : Circle
     {
+        private VertexState state = new VertexState();
+
         [Resolved]
         private OsuColour osuColour { get; set; } = null!;
 
@@ -24,7 +27,32 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         public void UpdateFrom(VertexState state)
         {
-            Colour = state.IsSelected ? osuColour.Yellow.Lighten(1) : osuColour.Yellow;
+            this.state = state;
+            updateMarkerDisplay();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateMarkerDisplay();
+            return false;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            updateMarkerDisplay();
+        }
+
+        /// <summary>
+        /// Updates the state of the circular control point marker.
+        /// </summary>
+        private void updateMarkerDisplay()
+        {
+            var colour = osuColour.Yellow;
+
+            if (IsHovered || state.IsSelected)
+                colour = colour.Lighten(1);
+
+            Colour = colour;
             Alpha = state.IsFixed ? 0.5f : 1;
         }
     }

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamSelectionBlueprint.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
             {
                 scrollingPath = new ScrollingPath(),
                 nestedOutlineContainer = new NestedOutlineContainer(),
-                editablePath = new SelectionEditablePath(positionToTime)
+                editablePath = new SelectionEditablePath(hitObject, positionToTime)
             };
         }
 


### PR DESCRIPTION
I was looking at https://github.com/ppy/osu/issues/28915 and attempting to see what was going on but the current UX of juice stream selection was tripping me up so I decided to fix first.

- Makes undo work for adding / deleting path points
- Unifies appearance with osu! slider control point pieces
  - Use same hover state
  - Use shift-right click for quick delete rather than shift-left click