### PR TITLE
Save grid settings to beatmap via IBeatmap

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -19,6 +19,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.RadioButtons;
 using osuTK;
 using osuTK.Graphics;
+using Vortice.DXGI;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
@@ -149,9 +150,30 @@ namespace osu.Game.Rulesets.Osu.Edit
                 },
             };
 
-            Spacing.Value = editorBeatmap.BeatmapInfo.GridSize;
+            Spacing.Value = editorBeatmap.GridSize;
+            GridLinesRotation.Value = editorBeatmap.GridRotation;
+            if (editorBeatmap.GridStartPositionX != 0)
+            {
+                StartPositionX.Value = editorBeatmap.GridStartPositionX;
+            }
+            if (editorBeatmap.GridStartPositionY != 0)
+            {
+                StartPositionY.Value = editorBeatmap.GridStartPositionY;
+            }
 
-            GridLinesRotation.Value = editorBeatmap.BeatmapInfo.GridRotation;
+            switch (editorBeatmap.GridType)
+            {
+                case "Square":
+                    GridType.Value = PositionSnapGridType.Square;
+                    break;
+                case "Triangle":
+                    GridType.Value = PositionSnapGridType.Triangle;
+                    break;
+                case "Circle":
+                    GridType.Value = PositionSnapGridType.Circle;
+                    break;
+            }
+
         }
 
         protected override void LoadComplete()
@@ -165,6 +187,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 startPositionXSlider.ContractedLabelText = $"X: {x.NewValue:N0}";
                 startPositionXSlider.ExpandedLabelText = $"X Offset: {x.NewValue:N0}";
                 StartPosition.Value = new Vector2(x.NewValue, StartPosition.Value.Y);
+                editorBeatmap.GridStartPositionX = (int)x.NewValue;
             }, true);
 
             StartPositionY.BindValueChanged(y =>
@@ -172,6 +195,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 startPositionYSlider.ContractedLabelText = $"Y: {y.NewValue:N0}";
                 startPositionYSlider.ExpandedLabelText = $"Y Offset: {y.NewValue:N0}";
                 StartPosition.Value = new Vector2(StartPosition.Value.X, y.NewValue);
+                editorBeatmap.GridStartPositionY = (int)y.NewValue;
             }, true);
 
             Spacing.BindValueChanged(spacing =>
@@ -179,14 +203,14 @@ namespace osu.Game.Rulesets.Osu.Edit
                 spacingSlider.ContractedLabelText = $"S: {spacing.NewValue:N0}";
                 spacingSlider.ExpandedLabelText = $"Spacing: {spacing.NewValue:N0}";
                 SpacingVector.Value = new Vector2(spacing.NewValue);
-                editorBeatmap.BeatmapInfo.GridSize = (int)spacing.NewValue;
+                editorBeatmap.GridSize = (int)spacing.NewValue;
             }, true);
 
             GridLinesRotation.BindValueChanged(rotation =>
             {
                 gridLinesRotationSlider.ContractedLabelText = $"R: {rotation.NewValue:#,0.##}";
                 gridLinesRotationSlider.ExpandedLabelText = $"Rotation: {rotation.NewValue:#,0.##}";
-                editorBeatmap.BeatmapInfo.GridRotation = (int)rotation.NewValue;
+                editorBeatmap.GridRotation = (int)rotation.NewValue;
             }, true);
 
             expandingContainer?.Expanded.BindValueChanged(v =>
@@ -205,12 +229,18 @@ namespace osu.Game.Rulesets.Osu.Edit
                         GridLinesRotation.Value = ((GridLinesRotation.Value + 405) % 90) - 45;
                         GridLinesRotation.MinValue = -45;
                         GridLinesRotation.MaxValue = 45;
+                        editorBeatmap.GridType = "Square";
                         break;
 
                     case PositionSnapGridType.Triangle:
                         GridLinesRotation.Value = ((GridLinesRotation.Value + 390) % 60) - 30;
                         GridLinesRotation.MinValue = -30;
                         GridLinesRotation.MaxValue = 30;
+                        editorBeatmap.GridType = "Triangle";
+                        break;
+
+                    case PositionSnapGridType.Circle:
+                        editorBeatmap.GridType = "Circle";
                         break;
                 }
             }, true);

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -150,6 +150,8 @@ namespace osu.Game.Rulesets.Osu.Edit
             };
 
             Spacing.Value = editorBeatmap.BeatmapInfo.GridSize;
+
+            GridLinesRotation.Value = editorBeatmap.BeatmapInfo.GridRotation;
         }
 
         protected override void LoadComplete()
@@ -184,6 +186,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 gridLinesRotationSlider.ContractedLabelText = $"R: {rotation.NewValue:#,0.##}";
                 gridLinesRotationSlider.ExpandedLabelText = $"Rotation: {rotation.NewValue:#,0.##}";
+                editorBeatmap.BeatmapInfo.GridRotation = (int)rotation.NewValue;
             }, true);
 
             expandingContainer?.Expanded.BindValueChanged(v =>

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -115,6 +115,12 @@ namespace osu.Game.Beatmaps
             return mostCommon.beatLength;
         }
 
+        public int GridSize { get; set; }
+        public int GridRotation { get; set; }
+        public int GridStartPositionX { get; set; }
+        public int GridStartPositionY { get; set; }
+        public string GridType { get; set; }
+
         IBeatmap IBeatmap.Clone() => Clone();
 
         public Beatmap<T> Clone() => (Beatmap<T>)MemberwiseClone();

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -73,6 +73,11 @@ namespace osu.Game.Beatmaps
             beatmap.HitObjects = convertHitObjects(original.HitObjects, original, cancellationToken).OrderBy(s => s.StartTime).ToList();
             beatmap.Breaks = original.Breaks;
             beatmap.UnhandledEventLines = original.UnhandledEventLines;
+            beatmap.GridSize = original.GridSize;
+            beatmap.GridRotation = original.GridRotation;
+            beatmap.GridStartPositionX = original.GridStartPositionX;
+            beatmap.GridStartPositionY = original.GridStartPositionY;
+            beatmap.GridType = original.GridType;
 
             return beatmap;
         }

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -426,8 +426,6 @@ namespace osu.Game.Beatmaps
                         SamplesMatchPlaybackRate = decodedInfo.SamplesMatchPlaybackRate,
                         DistanceSpacing = decodedInfo.DistanceSpacing,
                         BeatDivisor = decodedInfo.BeatDivisor,
-                        GridSize = decodedInfo.GridSize,
-                        GridRotation = decodedInfo.GridRotation,
                         TimelineZoom = decodedInfo.TimelineZoom,
                         MD5Hash = memoryStream.ComputeMD5Hash(),
                         EndTimeObjectCount = decoded.HitObjects.Count(h => h is IHasDuration),

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -427,6 +427,7 @@ namespace osu.Game.Beatmaps
                         DistanceSpacing = decodedInfo.DistanceSpacing,
                         BeatDivisor = decodedInfo.BeatDivisor,
                         GridSize = decodedInfo.GridSize,
+                        GridRotation = decodedInfo.GridRotation,
                         TimelineZoom = decodedInfo.TimelineZoom,
                         MD5Hash = memoryStream.ComputeMD5Hash(),
                         EndTimeObjectCount = decoded.HitObjects.Count(h => h is IHasDuration),

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -171,10 +171,6 @@ namespace osu.Game.Beatmaps
 
         public int BeatDivisor { get; set; } = 4;
 
-        public int GridSize { get; set; }
-
-        public int GridRotation { get; set; }
-
         public double TimelineZoom { get; set; } = 1.0;
 
         /// <summary>

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -173,6 +173,8 @@ namespace osu.Game.Beatmaps
 
         public int GridSize { get; set; }
 
+        public int GridRotation { get; set; }
+
         public double TimelineZoom { get; set; } = 1.0;
 
         /// <summary>

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -343,6 +343,10 @@ namespace osu.Game.Beatmaps.Formats
                     beatmap.BeatmapInfo.GridSize = Parsing.ParseInt(pair.Value);
                     break;
 
+                case @"GridRotation":
+                    beatmap.BeatmapInfo.GridRotation = Parsing.ParseInt(pair.Value);
+                    break;
+
                 case @"TimelineZoom":
                     beatmap.BeatmapInfo.TimelineZoom = Math.Max(0, Parsing.ParseDouble(pair.Value));
                     break;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -340,11 +340,23 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"GridSize":
-                    beatmap.BeatmapInfo.GridSize = Parsing.ParseInt(pair.Value);
+                    beatmap.GridSize = Parsing.ParseInt(pair.Value);
                     break;
 
                 case @"GridRotation":
-                    beatmap.BeatmapInfo.GridRotation = Parsing.ParseInt(pair.Value);
+                    beatmap.GridRotation = Parsing.ParseInt(pair.Value);
+                    break;
+
+                case @"GridStartPositionX":
+                    beatmap.GridStartPositionX = Parsing.ParseInt(pair.Value);
+                    break;
+
+                case @"GridStartPositionY":
+                    beatmap.GridStartPositionY = Parsing.ParseInt(pair.Value);
+                    break;
+
+                case @"GridType":
+                    beatmap.GridType = pair.Value;
                     break;
 
                 case @"TimelineZoom":

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -114,8 +114,11 @@ namespace osu.Game.Beatmaps.Formats
                 writer.WriteLine(FormattableString.Invariant($"Bookmarks: {string.Join(',', beatmap.BeatmapInfo.Bookmarks)}"));
             writer.WriteLine(FormattableString.Invariant($"DistanceSpacing: {beatmap.BeatmapInfo.DistanceSpacing}"));
             writer.WriteLine(FormattableString.Invariant($"BeatDivisor: {beatmap.BeatmapInfo.BeatDivisor}"));
-            writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.BeatmapInfo.GridSize}"));
-            writer.WriteLine(FormattableString.Invariant($"GridRotation: {beatmap.BeatmapInfo.GridRotation}"));
+            writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.GridSize}"));
+            writer.WriteLine(FormattableString.Invariant($"GridRotation: {beatmap.GridRotation}"));
+            writer.WriteLine(FormattableString.Invariant($"GridStartPositionX: {beatmap.GridStartPositionX}"));
+            writer.WriteLine(FormattableString.Invariant($"GridStartPositionY: {beatmap.GridStartPositionY}"));
+            writer.WriteLine(FormattableString.Invariant($"GridType: {beatmap.GridType}"));
             writer.WriteLine(FormattableString.Invariant($"TimelineZoom: {beatmap.BeatmapInfo.TimelineZoom}"));
 
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -115,7 +115,9 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine(FormattableString.Invariant($"DistanceSpacing: {beatmap.BeatmapInfo.DistanceSpacing}"));
             writer.WriteLine(FormattableString.Invariant($"BeatDivisor: {beatmap.BeatmapInfo.BeatDivisor}"));
             writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.BeatmapInfo.GridSize}"));
+            writer.WriteLine(FormattableString.Invariant($"GridRotation: {beatmap.BeatmapInfo.GridRotation}"));
             writer.WriteLine(FormattableString.Invariant($"TimelineZoom: {beatmap.BeatmapInfo.TimelineZoom}"));
+
         }
 
         private void handleMetadata(TextWriter writer)

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -74,6 +74,15 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <returns>The shallow-cloned beatmap.</returns>
         IBeatmap Clone();
+
+        /// <summary>
+        /// Grid settings for the beatmap
+        /// </summary>
+        public int GridSize { get; set; }
+        public int GridRotation { get; set; }
+        public int GridStartPositionX { get; set; }
+        public int GridStartPositionY { get; set; }
+        public string GridType { get; set; }
     }
 
     /// <summary>

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -341,6 +341,12 @@ namespace osu.Game.Rulesets.Difficulty
             public double GetMostCommonBeatLength() => baseBeatmap.GetMostCommonBeatLength();
             public IBeatmap Clone() => new ProgressiveCalculationBeatmap(baseBeatmap.Clone());
 
+            public int GridSize { get; set; }
+            public int GridRotation { get; set; }
+            public int GridStartPositionX { get; set; }
+            public int GridStartPositionY { get; set; }
+            public string GridType { get; set; }
+
             #endregion
         }
     }

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -89,6 +89,32 @@ namespace osu.Game.Screens.Edit
 
         public BindableInt PreviewTime { get; }
 
+        public int GridSize
+        {
+            get => PlayableBeatmap.GridSize;
+            set => PlayableBeatmap.GridSize = value;
+        }
+        public int GridRotation
+        {
+            get => PlayableBeatmap.GridRotation;
+            set => PlayableBeatmap.GridRotation = value;
+        }
+        public int GridStartPositionX
+        {
+            get => PlayableBeatmap.GridStartPositionX;
+            set => PlayableBeatmap.GridStartPositionX = value;
+        }
+        public int GridStartPositionY
+        {
+            get => PlayableBeatmap.GridStartPositionY;
+            set => PlayableBeatmap.GridStartPositionY = value;
+        }
+        public string GridType
+        {
+            get => PlayableBeatmap.GridType;
+            set => PlayableBeatmap.GridType = value;
+        }
+
         private readonly IBeatmapProcessor beatmapProcessor;
 
         private readonly Dictionary<HitObject, Bindable<double>> startTimeBindables = new Dictionary<HitObject, Bindable<double>>();


### PR DESCRIPTION
Re-implementation of #28973 without using `BeatmapInfo` (see #28473)

Moves GridSize from `BeatmapInfo` to `IBeatmap`, and adds GridRotation, GridStartPositionX, GridStartPositionY, and GridType

GridType does save to the `.osu` file, but does not load properly when opening the map in the editor. I was unable to determine why this happens.

[save-grid-ibeatmap.webm](https://github.com/user-attachments/assets/b2422749-de6a-49f3-a168-6dc691f866a9)
