### PR TITLE
Fix duration fluctuations and one-frame jitters when editing juice streams

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Editor/TestSceneJuiceStreamSelectionBlueprint.cs
@@ -82,6 +82,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
 
             AddMouseMoveStep(-100, 100);
             addVertexCheckStep(3, 1, times[0], positions[0]);
+            addDragEndStep();
         }
 
         [Test]
@@ -100,6 +101,9 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddMouseMoveStep(times[2] - 50, positions[2] - 50);
             addVertexCheckStep(4, 1, times[1] - 50, positions[1] - 50);
             addVertexCheckStep(4, 2, times[2] - 50, positions[2] - 50);
+
+            AddStep("release control", () => InputManager.ReleaseKey(Key.ControlLeft));
+            addDragEndStep();
         }
 
         [Test]
@@ -113,6 +117,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             addDragStartStep(times[1], positions[1]);
             AddMouseMoveStep(times[1], 400);
             AddAssert("slider velocity changed", () => !hitObject.SliderVelocityMultiplierBindable.IsDefault);
+            addDragEndStep();
         }
 
         [Test]
@@ -129,6 +134,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             AddStep("scroll playfield", () => manualClock.CurrentTime += 200);
             AddMouseMoveStep(times[1] + 200, positions[1] + 100);
             addVertexCheckStep(2, 1, times[1] + 200, positions[1] + 100);
+            addDragEndStep();
         }
 
         [Test]
@@ -158,21 +164,21 @@ namespace osu.Game.Rulesets.Catch.Tests.Editor
             float[] positions = { 200, 200 };
             addBlueprintStep(times, positions, 0.2);
 
-            addAddVertexSteps(500, 180);
-            addVertexCheckStep(3, 1, 500, 180);
+            addAddVertexSteps(500, 150);
+            addVertexCheckStep(3, 1, 500, 150);
 
-            addAddVertexSteps(90, 200);
-            addVertexCheckStep(4, 1, times[0], positions[0]);
+            addAddVertexSteps(160, 200);
+            addVertexCheckStep(4, 1, 160, 200);
 
-            addAddVertexSteps(750, 200);
-            addVertexCheckStep(5, 4, 750, 200);
+            addAddVertexSteps(750, 180);
+            addVertexCheckStep(5, 4, 800, 160);
             AddAssert("duration is changed", () => Precision.AlmostEquals(hitObject.Duration, 800 - times[0], 1e-3));
         }
 
         [Test]
         public void TestDeleteVertex()
         {
-            double[] times = { 100, 300, 500 };
+            double[] times = { 100, 300, 400 };
             float[] positions = { 100, 200, 150 };
             addBlueprintStep(times, positions);
 

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -107,15 +107,22 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             //
             // The value is clamped here by the bindable min and max values.
             // In case the required velocity is too large, the path is not preserved.
+            double previousVelocity = svBindable.Value;
             svBindable.Value = Math.Ceiling(requiredVelocity / svToVelocityFactor);
 
-            path.ConvertToSliderPath(hitObject.Path, hitObject.LegacyConvertedY, hitObject.Velocity);
+            // adjust velocity locally, so that once the SV change is applied by applying defaults
+            // (triggered by `EditorBeatmap.Update()` call at end of method),
+            // it results in the outcome desired by the user.
+            double relativeChange = svBindable.Value / previousVelocity;
+            double localVelocity = hitObject.Velocity * relativeChange;
+            path.ConvertToSliderPath(hitObject.Path, hitObject.LegacyConvertedY, localVelocity);
 
             if (beatSnapProvider == null) return;
 
             double endTime = hitObject.StartTime + path.Duration;
             double snappedEndTime = beatSnapProvider.SnapTime(endTime, hitObject.StartTime);
-            hitObject.Path.ExpectedDistance.Value = (snappedEndTime - hitObject.StartTime) * hitObject.Velocity;
+            hitObject.Path.ExpectedDistance.Value = (snappedEndTime - hitObject.StartTime) * localVelocity;
+
             EditorBeatmap?.Update(hitObject);
         }
 

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/EditablePath.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI.Scrolling;
+using osu.Game.Screens.Edit;
 using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
@@ -41,6 +42,9 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         [Resolved]
         private IBeatSnapProvider? beatSnapProvider { get; set; }
+
+        [Resolved]
+        protected EditorBeatmap? EditorBeatmap { get; private set; }
 
         protected EditablePath(Func<float, double> positionToTime)
         {
@@ -112,6 +116,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             double endTime = hitObject.StartTime + path.Duration;
             double snappedEndTime = beatSnapProvider.SnapTime(endTime, hitObject.StartTime);
             hitObject.Path.ExpectedDistance.Value = (snappedEndTime - hitObject.StartTime) * hitObject.Velocity;
+            EditorBeatmap?.Update(hitObject);
         }
 
         public Vector2 ToRelativePosition(Vector2 screenSpacePosition)

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/Components/SelectionEditablePath.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Catch.Objects;
-using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Input;
 
@@ -25,9 +23,6 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
         // To handle when the editor is scrolled while dragging.
         private Vector2 dragStartPosition;
 
-        [Resolved]
-        private IEditorChangeHandler? changeHandler { get; set; }
-
         public SelectionEditablePath(JuiceStream juiceStream, Func<float, double> positionToTime)
             : base(positionToTime)
         {
@@ -36,12 +31,14 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         public void AddVertex(Vector2 relativePosition)
         {
-            changeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
+
             double time = Math.Max(0, PositionToTime(relativePosition.Y));
             int index = AddVertex(time, relativePosition.X);
             UpdateHitObjectFromPath(juiceStream);
             selectOnly(index);
-            changeHandler?.EndChange();
+
+            EditorBeatmap?.EndChange();
         }
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => InternalChildren.Any(d => d.ReceivePositionalInputAt(screenSpacePos));
@@ -54,10 +51,10 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
             if (e.Button == MouseButton.Right && e.ShiftPressed)
             {
-                changeHandler?.BeginChange();
+                EditorBeatmap?.BeginChange();
                 RemoveVertex(index);
                 UpdateHitObjectFromPath(juiceStream);
-                changeHandler?.EndChange();
+                EditorBeatmap?.EndChange();
 
                 return true;
             }
@@ -85,7 +82,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
             for (int i = 0; i < VertexCount; i++)
                 VertexStates[i].VertexBeforeChange = Vertices[i];
 
-            changeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
             return true;
         }
 
@@ -99,7 +96,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         protected override void OnDragEnd(DragEndEvent e)
         {
-            changeHandler?.EndChange();
+            EditorBeatmap?.EndChange();
         }
 
         private int getMouseTargetVertex(Vector2 screenSpacePosition)
@@ -129,7 +126,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
         private void deleteSelectedVertices()
         {
-            changeHandler?.BeginChange();
+            EditorBeatmap?.BeginChange();
 
             for (int i = VertexCount - 1; i >= 0; i--)
             {
@@ -139,7 +136,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints.Components
 
             UpdateHitObjectFromPath(juiceStream);
 
-            changeHandler?.EndChange();
+            EditorBeatmap?.EndChange();
         }
     }
 }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/28999 for mergeability
- Closes https://github.com/ppy/osu/issues/28915

All of this code is a bit inscrutable and difficult to work with, but these changes _appear_ to help.

## [Fix `EditablePath.UpdateHitObjectFromPath()` not automatically updating object](https://github.com/ppy/osu/commit/56af009e7759d364b6ded4d57d0f9c32c1f6dbd0)

This is important because the editable path conversions heavily depend on the value of `JuiceStream.Velocity` being correct. The value is only guaranteed to be correct after an `ApplyDefaults()` call, which is triggered by updating the object via `EditorBeatmap`.

## [Fix editing juice stream path sometimes changing its duration](https://github.com/ppy/osu/commit/f3617eadad1f997d5cd4eea45eb28c22467c25f0)

I'm not *super* sure why this works, but it appears to, and my educated guess as to why is that it counteracts the effects of a change in the SV of the juice stream by artificially increasing or decreasing the velocity when running the appropriate path conversions and expected distance calculations. The actual SV change takes effect on the next default application, which is triggered by the `Update()` call at the end of the method.

## [Fix tests](https://github.com/ppy/osu/commit/6100f5269d757177d557af714a17a8c116530dbd)

These are again, seemingly arbitrary changes to tests, but I could not salvage this otherwise.

- The added drag end steps are just for proper test cleanup (was causing crosstalk issues)
- The delete vertex test is adjusted because for _whatever_ reason the juice stream path conversions sometimes spuriously produce extra nodes _without_ affecting the juice stream shape. I'm not super sure why this is, but it's not something I changed, it just fell out when attempting to restore sanity here. I'd ask to look away.
- The add vertex test is adjusted because:
  - The test attempts to add a control point at the same position as the juice stream's starting position. I'm not sure why this was considered valid, but the long and short of it is that without the `EditorBeatmap.Update()` call that control point would be allowed to live, but after adding it, [the path goes through an extra conversion step that removes the point as it is redundant](https://github.com/ppy/osu/blob/7e5fda45396ce7823a7b5e63c7204c9ceafd184c/osu.Game.Rulesets.Catch/Objects/JuiceStreamPath.cs#L190-L191), and that seems _more_ sane to me.
  - Additionally, the test adds a control point after the juice stream's end to test that it is extended, *but* the control point would *not be correctly snapped to an end time* on master. It would be left at 750 time, rather than snapped to 800 (test uses beat length of 100). This is another weird behaviour because if you play with the catch editor on master, you should be able to reproduce the following:
    - Select a juice stream
    - Move its last anchor (that coincides with its last fruit) to an unsnapped position
    - Deselect the juice stream and re-select it again
    - The last anchor will have moved to a snapped position (without the shape of the thing changing)
  This is all weird and strange and I would once again ask to look away because none of this is *new* breakage.