### PR TITLE
Respect pre-empt time when auto-generating breaks

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/CatchHitObject.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects
 {
-    public abstract class CatchHitObject : HitObject, IHasPosition, IHasComboInformation
+    public abstract class CatchHitObject : HitObject, IHasPosition, IHasComboInformation, IHasTimePreempt
     {
         public const float OBJECT_RADIUS = 64;
 

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -14,7 +14,7 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Objects
 {
-    public abstract class OsuHitObject : HitObject, IHasComboInformation, IHasPosition
+    public abstract class OsuHitObject : HitObject, IHasComboInformation, IHasPosition, IHasTimePreempt
     {
         /// <summary>
         /// The radius of hit objects (ie. the radius of a <see cref="HitCircle"/>).
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Objects
         /// </summary>
         public const double PREEMPT_MAX = 1800;
 
-        public double TimePreempt = 600;
+        public double TimePreempt { get; set; } = 600;
         public double TimeFadeIn = 400;
 
         private HitObjectProperty<Vector2> position;

--- a/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
+++ b/osu.Game.Tests/Editing/TestSceneEditorBeatmapProcessor.cs
@@ -8,7 +8,6 @@ using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
 
 namespace osu.Game.Tests.Editing
@@ -45,7 +44,7 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
+                    new Note { StartTime = 1000 },
                 }
             });
 
@@ -67,8 +66,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 2000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 2000 },
                 }
             });
 
@@ -136,8 +135,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 5000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 5000 },
                 }
             });
 
@@ -164,8 +163,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -197,9 +196,9 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 5000 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 5000 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -232,8 +231,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1100 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1100 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -264,8 +263,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -299,9 +298,9 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 5000 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 5000 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -334,8 +333,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 9000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 9000 },
                 },
                 Breaks =
                 {
@@ -366,8 +365,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 2000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 2000 },
                 },
                 Breaks =
                 {
@@ -393,8 +392,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 1000 },
-                    new HitCircle { StartTime = 2000 },
+                    new Note { StartTime = 1000 },
+                    new Note { StartTime = 2000 },
                 },
                 Breaks =
                 {
@@ -447,8 +446,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 10000 },
-                    new HitCircle { StartTime = 11000 },
+                    new Note { StartTime = 10000 },
+                    new Note { StartTime = 11000 },
                 },
                 Breaks =
                 {
@@ -474,8 +473,8 @@ namespace osu.Game.Tests.Editing
                 BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo },
                 HitObjects =
                 {
-                    new HitCircle { StartTime = 10000 },
-                    new HitCircle { StartTime = 11000 },
+                    new Note { StartTime = 10000 },
+                    new Note { StartTime = 11000 },
                 },
                 Breaks =
                 {

--- a/osu.Game/Rulesets/Objects/Types/IHasTimePreempt.cs
+++ b/osu.Game/Rulesets/Objects/Types/IHasTimePreempt.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Rulesets.Objects.Types
+{
+    /// <summary>
+    /// A <see cref="HitObject"/> that appears on screen at a fixed time interval before its <see cref="HitObject.StartTime"/>.
+    /// </summary>
+    public interface IHasTimePreempt
+    {
+        double TimePreempt { get; }
+    }
+}

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Edit
 
         private void autoGenerateBreaks()
         {
-            var objectDuration = Beatmap.HitObjects.Select(ho => (ho.StartTime, ho.GetEndTime())).ToHashSet();
+            var objectDuration = Beatmap.HitObjects.Select(ho => (ho.StartTime - ((ho as IHasTimePreempt)?.TimePreempt ?? 0), ho.GetEndTime())).ToHashSet();
 
             if (objectDuration.SetEquals(objectDurationCache))
                 return;

--- a/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmapProcessor.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Screens.Edit
 {
@@ -67,19 +68,26 @@ namespace osu.Game.Screens.Edit
 
             for (int i = 1; i < Beatmap.HitObjects.Count; ++i)
             {
+                var previousObject = Beatmap.HitObjects[i - 1];
+                var nextObject = Beatmap.HitObjects[i];
+
                 // Keep track of the maximum end time encountered thus far.
                 // This handles cases like osu!mania's hold notes, which could have concurrent other objects after their start time.
                 // Note that we're relying on the implicit assumption that objects are sorted by start time,
                 // which is why similar tracking is not done for start time.
-                currentMaxEndTime = Math.Max(currentMaxEndTime, Beatmap.HitObjects[i - 1].GetEndTime());
+                currentMaxEndTime = Math.Max(currentMaxEndTime, previousObject.GetEndTime());
 
-                double nextObjectStartTime = Beatmap.HitObjects[i].StartTime;
-
-                if (nextObjectStartTime - currentMaxEndTime < BreakPeriod.MIN_GAP_DURATION)
+                if (nextObject.StartTime - currentMaxEndTime < BreakPeriod.MIN_GAP_DURATION)
                     continue;
 
                 double breakStartTime = currentMaxEndTime + BreakPeriod.GAP_BEFORE_BREAK;
-                double breakEndTime = nextObjectStartTime - Math.Max(BreakPeriod.GAP_AFTER_BREAK, Beatmap.ControlPointInfo.TimingPointAt(nextObjectStartTime).BeatLength * 2);
+
+                double breakEndTime = nextObject.StartTime;
+
+                if (nextObject is IHasTimePreempt hasTimePreempt)
+                    breakEndTime -= hasTimePreempt.TimePreempt;
+                else
+                    breakEndTime -= Math.Max(BreakPeriod.GAP_AFTER_BREAK, Beatmap.ControlPointInfo.TimingPointAt(nextObject.StartTime).BeatLength * 2);
 
                 if (breakEndTime - breakStartTime < BreakPeriod.MIN_BREAK_DURATION)
                     continue;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28703.

Before:

https://github.com/user-attachments/assets/d319eaa7-0560-41d7-8e86-23b7e83b31af

After:

https://github.com/user-attachments/assets/65e00269-6d6f-4492-97db-ac211fecb570

Map / timestamp used for video: https://osu.ppy.sh/beatmapsets/2113786#osu/4566218, 01:08:715 (11,12,13,14,15)