### PR TITLE
Disable macOS test runs for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
        matrix:
           os:
             - { prettyname: Windows, fullname: windows-latest }
-            - { prettyname: macOS, fullname: macos-latest }
+            # macOS runner performance has gotten unbearably slow so let's turn them off temporarily.
+            # - { prettyname: macOS, fullname: macos-latest }
             - { prettyname: Linux, fullname: ubuntu-latest }
           threadingMode: ['SingleThread', 'MultiThreaded']
     timeout-minutes: 120


### PR DESCRIPTION
We are seeing update frames run as little as [once per second](https://github.com/ppy/osu/blob/aa4d16bdb873d7296b899cee7b7491ffdf5cd6ab/osu.Game/Overlays/BeatmapListingOverlay.cs#L141). Until we can ascertain why this is happening, let's reduce developer stress by not running macOS tests for now.
