### PR TITLE
Fix daily challenge not showing a replay button in results screen

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Osu.Mods;
-using osu.Game.Screens.Ranking;
-using osu.Game.Screens.SelectV2.Leaderboards;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.OnlinePlay;
 
@@ -17,14 +14,10 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 {
     public partial class TestSceneDailyChallenge : OnlinePlayTestScene
     {
-        [SetUpSteps]
-        public override void SetUpSteps()
+        [Test]
+        public void TestDailyChallenge()
         {
-            base.SetUpSteps();
-
-            Room room = null!;
-
-            AddStep("add room", () => API.Perform(new CreateRoomRequest(room = new Room
+            var room = new Room
             {
                 RoomID = { Value = 1234 },
                 Name = { Value = "Daily Challenge: June 4, 2024" },
@@ -38,22 +31,10 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 },
                 EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
                 Category = { Value = RoomCategory.DailyChallenge }
-            })));
+            };
 
+            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
             AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
-        }
-
-        [Test]
-        public void TestDailyChallenge()
-        {
-        }
-
-        [Test]
-        public void TestScoreNavigation()
-        {
-            AddStep("click on score", () => this.ChildrenOfType<LeaderboardScoreV2>().First().TriggerClick());
-            AddUntilStep("wait for load", () => Stack.CurrentScreen is ResultsScreen results && results.IsLoaded);
-            AddAssert("replay download button exists", () => this.ChildrenOfType<ReplayDownloadButton>().Count(), () => Is.EqualTo(1));
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -4,9 +4,12 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Ranking;
+using osu.Game.Screens.SelectV2.Leaderboards;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.OnlinePlay;
 
@@ -14,10 +17,14 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 {
     public partial class TestSceneDailyChallenge : OnlinePlayTestScene
     {
-        [Test]
-        public void TestDailyChallenge()
+        [SetUpSteps]
+        public override void SetUpSteps()
         {
-            var room = new Room
+            base.SetUpSteps();
+
+            Room room = null!;
+
+            AddStep("add room", () => API.Perform(new CreateRoomRequest(room = new Room
             {
                 RoomID = { Value = 1234 },
                 Name = { Value = "Daily Challenge: June 4, 2024" },
@@ -31,10 +38,22 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 },
                 EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
                 Category = { Value = RoomCategory.DailyChallenge }
-            };
+            })));
 
-            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
             AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+        }
+
+        [Test]
+        public void TestDailyChallenge()
+        {
+        }
+
+        [Test]
+        public void TestScoreNavigation()
+        {
+            AddStep("click on score", () => this.ChildrenOfType<LeaderboardScoreV2>().First().TriggerClick());
+            AddUntilStep("wait for load", () => Stack.CurrentScreen is ResultsScreen results && results.IsLoaded);
+            AddAssert("replay download button exists", () => this.ChildrenOfType<ReplayDownloadButton>().Count(), () => Is.EqualTo(1));
         }
     }
 }

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayDownloadButton.cs
@@ -117,6 +117,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddAssert("state entered downloading", () => downloadStarted);
             AddUntilStep("state left downloading", () => downloadFinished);
+
+            AddStep("change score to null", () => downloadButton.Score.Value = null);
+            AddUntilStep("state changed to unknown", () => downloadButton.State.Value, () => Is.EqualTo(DownloadState.Unknown));
         }
 
         [Test]

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Ranking
 {
     public partial class ReplayDownloadButton : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
-        public readonly Bindable<ScoreInfo> Score = new Bindable<ScoreInfo>();
+        public readonly Bindable<ScoreInfo?> Score = new Bindable<ScoreInfo?>();
 
         protected readonly Bindable<DownloadState> State = new Bindable<DownloadState>();
 
@@ -44,7 +44,7 @@ namespace osu.Game.Screens.Ranking
             }
         }
 
-        public ReplayDownloadButton(ScoreInfo score)
+        public ReplayDownloadButton(ScoreInfo? score)
         {
             Score.Value = score;
             Size = new Vector2(50, 30);
@@ -67,11 +67,11 @@ namespace osu.Game.Screens.Ranking
                 switch (State.Value)
                 {
                     case DownloadState.LocallyAvailable:
-                        game?.PresentScore(Score.Value, ScorePresentType.Gameplay);
+                        game?.PresentScore(Score.Value!, ScorePresentType.Gameplay);
                         break;
 
                     case DownloadState.NotDownloaded:
-                        scoreDownloader.Download(Score.Value);
+                        scoreDownloader.Download(Score.Value!);
                         break;
 
                     case DownloadState.Importing:
@@ -147,7 +147,7 @@ namespace osu.Game.Screens.Ranking
         {
             if (state.NewValue != DownloadState.LocallyAvailable) return;
 
-            scoreManager.Export(Score.Value);
+            scoreManager.Export(Score.Value!);
 
             State.ValueChanged -= exportWhenReady;
         }

--- a/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
+++ b/osu.Game/Screens/Ranking/ReplayDownloadButton.cs
@@ -88,6 +88,8 @@ namespace osu.Game.Screens.Ranking
                 State.ValueChanged -= exportWhenReady;
 
                 downloadTracker?.RemoveAndDisposeImmediately();
+                downloadTracker = null;
+                State.SetDefault();
 
                 if (score.NewValue != null)
                 {

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -179,11 +179,11 @@ namespace osu.Game.Screens.Ranking
                 Scheduler.AddDelayed(() => OverlayActivationMode.Value = OverlayActivation.All, shouldFlair ? AccuracyCircle.TOTAL_DURATION + 1000 : 0);
             }
 
-            if (SelectedScore.Value != null && AllowWatchingReplay)
+            if (AllowWatchingReplay)
             {
                 buttons.Add(new ReplayDownloadButton(SelectedScore.Value)
                 {
-                    Score = { BindTarget = SelectedScore! },
+                    Score = { BindTarget = SelectedScore },
                     Width = 300
                 });
             }


### PR DESCRIPTION
The results screen pushed by `DailyChallenge` always load with a null selected score, so the replay download button never gets added. There's no reason not to have the replay download button visible when there's no score selected, so just...add it?

Failing test coverage was reverted due to out-of-scope issues (see [discord](https://discord.com/channels/188630481301012481/188630652340404224/1265907061376421949)).

Before:

![CleanShot 2024-07-25 at 08 55 16](https://github.com/user-attachments/assets/7a77779d-927c-447e-b091-6fc48c70de5a)

After:

![CleanShot 2024-07-25 at 08 54 29](https://github.com/user-attachments/assets/96c8d7e2-88ce-43b5-9d3d-1f0cf868d04f)
