### PR TITLE
Fix daily challenge abruptly discarding score selection when opening results screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistItemScoreResultsScreen.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         {
             var scoreInfos = base.PerformSuccessCallback(callback, scores, pivot);
 
-            Schedule(() => SelectedScore.Value = scoreInfos.SingleOrDefault(score => score.OnlineID == scoreId));
+            Schedule(() => SelectedScore.Value ??= scoreInfos.SingleOrDefault(score => score.OnlineID == scoreId));
 
             return scoreInfos;
         }


### PR DESCRIPTION

`PerformSuccessCallback` is called multiple times, the first time is where the target score gets selected, but it gets called another time to add more scores to the listing, at which point `SelectedScore` incorrectly gets overwritten.

This also resolves another bug where if you scroll to the beginning, the screen will just keep fetching scores until you get to the beginning. This is caused by the fact that there's no score selected.


Before:

https://github.com/user-attachments/assets/25dc7087-dcab-4a0a-84c1-bda028ec9c88

After:

https://github.com/user-attachments/assets/26cfbaa0-a81d-461a-b354-20548326231c

