### PR TITLE
Fix results screen fetching scores twice when scrolled to edge

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsResultsScreen.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Tests.Visual.Playlists
                 AddAssert("right loading spinner shown", () => resultsScreen.RightSpinner.State.Value == Visibility.Visible);
                 waitForDisplay();
 
-                AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() >= beforePanelCount + scores_per_result);
+                AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() == beforePanelCount + scores_per_result);
                 AddAssert("right loading spinner hidden", () => resultsScreen.RightSpinner.State.Value == Visibility.Hidden);
             }
         }
@@ -156,7 +156,7 @@ namespace osu.Game.Tests.Visual.Playlists
             AddAssert("right loading spinner shown", () => resultsScreen.RightSpinner.State.Value == Visibility.Visible);
             waitForDisplay();
 
-            AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() >= beforePanelCount + scores_per_result);
+            AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() == beforePanelCount + scores_per_result);
             AddAssert("right loading spinner hidden", () => resultsScreen.RightSpinner.State.Value == Visibility.Hidden);
 
             AddStep("get panel count", () => beforePanelCount = this.ChildrenOfType<ScorePanel>().Count());
@@ -191,7 +191,7 @@ namespace osu.Game.Tests.Visual.Playlists
                 AddAssert("left loading spinner shown", () => resultsScreen.LeftSpinner.State.Value == Visibility.Visible);
                 waitForDisplay();
 
-                AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() >= beforePanelCount + scores_per_result);
+                AddAssert($"count increased by {scores_per_result}", () => this.ChildrenOfType<ScorePanel>().Count() == beforePanelCount + scores_per_result);
                 AddAssert("left loading spinner hidden", () => resultsScreen.LeftSpinner.State.Value == Visibility.Hidden);
             }
         }

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -267,7 +267,8 @@ namespace osu.Game.Screens.Ranking
             foreach (var s in scores)
                 addScore(s);
 
-            lastFetchCompleted = true;
+            // allow a frame for scroll container to adjust its dimensions with the added scores before fetching again.
+            Schedule(() => lastFetchCompleted = true);
 
             if (ScorePanelList.IsEmpty)
             {


### PR DESCRIPTION
- [x] Depends on #29058 to be able to test this in game

This one is not necessarily tied to daily challenge but it's something I noticed and it didn't feel well.

The fix here is, well, a schedule... Here's the order of how things happen:
 1. `ResultsScreen.Update` notices user is scrolled to beginning/end and fetches scores, blocking further fetches with `lastFetchCompleted`
 2. The scheduled logic in `fetchScoresCallback` is invoked, resetting `lastFetchCompleted`
 3. `ResultsScreen.Update` is called with `lastFetchCompleted` state reset, therefore incorrectly fetching more scores.

The fix is to schedule resetting `lastFetchCompleted` just one frame after adding the scores, so that the scroll container's state is updated before checking whether it's scrolled to beginning/end.

Before:

https://github.com/user-attachments/assets/89f7ef8e-515d-4d9d-a907-cbac1f4a9bd6

After:

https://github.com/user-attachments/assets/08ac4328-8b78-4961-aa2f-fe62df0b8f7b

