### PR TITLE
Fix crash when toggling extended statistics visibility during results load

### DIFF
--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -398,7 +398,8 @@ namespace osu.Game.Screens.Ranking
                     break;
 
                 case GlobalAction.Select:
-                    StatisticsPanel.ToggleVisibility();
+                    if (SelectedScore.Value != null)
+                        StatisticsPanel.ToggleVisibility();
                     return true;
             }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29066.

Initially I fixed this at where the assert is right now:

https://github.com/ppy/osu/blob/9790c5a574b782c41c8c6da99ad8c42dfadc9de8/osu.Game/Screens/Ranking/ResultsScreen.cs#L333

but because of the weird way that visible state management is done in this screen that made it possible for the extended statistics to be visible *behind* the score panels, without the score panels making way for it. So this is in a way safer, because it prevents the visibility state of the extended statistics from changing in the first place if there is no score selected (yet).

This can be also seen in playlists, at least.