### PR TITLE
Fix several missing properties on `MultiplayerScore`

### DIFF
--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("statistics")]
         public Dictionary<HitResult, int> Statistics = new Dictionary<HitResult, int>();
 
+        [JsonProperty("maximum_statistics")]
+        public Dictionary<HitResult, int> MaximumStatistics = new Dictionary<HitResult, int>();
+
         [JsonProperty("passed")]
         public bool Passed { get; set; }
 
@@ -58,8 +61,14 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("position")]
         public int? Position { get; set; }
 
+        [JsonProperty("pp")]
+        public double? PP { get; set; }
+
         [JsonProperty("has_replay")]
         public bool HasReplay { get; set; }
+
+        [JsonProperty("ranked")]
+        public bool Ranked { get; set; }
 
         /// <summary>
         /// Any scores in the room around this score.
@@ -83,13 +92,17 @@ namespace osu.Game.Online.Rooms
                 MaxCombo = MaxCombo,
                 BeatmapInfo = beatmap,
                 Ruleset = rulesets.GetRuleset(playlistItem.RulesetID) ?? throw new InvalidOperationException($"Ruleset with ID of {playlistItem.RulesetID} not found locally"),
+                Passed = Passed,
                 Statistics = Statistics,
+                MaximumStatistics = MaximumStatistics,
                 User = User,
                 Accuracy = Accuracy,
                 Date = EndedAt,
                 HasOnlineReplay = HasReplay,
                 Rank = Rank,
                 Mods = Mods?.Select(m => m.ToMod(rulesetInstance)).ToArray() ?? Array.Empty<Mod>(),
+                PP = PP,
+                Ranked = Ranked,
                 Position = Position,
             };
 


### PR DESCRIPTION
You wouldn't think this would be an actual thing that can happen to us, but it is. The most important one by far is `MaximumStatistics`; that is the root cause behind why stuff like spinner ticks or slider tails wasn't showing on daily challenge results screens. The rest I added is not significant but good to have nonetheless.

On a better day we should probably do cleanup to unify these models better, but today is not that day.

This'll also affect playlists (positively).

| before | after |
| :-: | :-: |
| ![osu_2024-07-25_13-11-00](https://github.com/user-attachments/assets/baa679df-583d-46ee-8e83-96316c33f45a) | ![osu_2024-07-25_13-14-26](https://github.com/user-attachments/assets/d8063691-f438-4a0a-8893-615fcd47da51) |