### PR TITLE
Change default control point sample bank to use custom hitsounds

### DIFF
--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -549,7 +549,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
             /// </summary>
             public bool BankSpecified;
 
-            public LegacyHitSampleInfo(string name, string? bank = null, int volume = 0, int customSampleBank = 0, bool isLayered = false)
+            public LegacyHitSampleInfo(string name, string? bank = null, int volume = 0, int customSampleBank = 1, bool isLayered = false)
                 : base(name, bank ?? SampleControlPoint.DEFAULT_BANK, customSampleBank >= 2 ? customSampleBank.ToString() : null, volume)
             {
                 CustomSampleBank = customSampleBank;


### PR DESCRIPTION
Addresses #29028 

# Description
Currently, control points created in Lazer are created via `LegacyHitSampleInfo` with customSampleBank 0, which is the equivalent of Sampleset Default in Stable. This causes custom hitsounds added with "Edit externally" to not persist properly (see #29028)

This PR changes the default customSampleBank to 1, which is the equivalent of Sampleset Custom 1 in Stable. 

# Potential issues
- Does not implement a way to change the custom sample bank in the editor
- This attribute may be better off as part of `SamplePointPiece`, similar to Addition Bank?

[PR-CustomSampleBank.webm](https://github.com/user-attachments/assets/2278fe9a-0cb1-4809-ad92-095e3a773c14)