### PR TITLE
Improve score breakdown on daily challenge

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
 using osu.Game.Screens.OnlinePlay.DailyChallenge.Events;
@@ -61,6 +62,8 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 
                 breakdown.AddNewScore(ev);
             });
+            AddStep("set user score", () => breakdown.UserBestScore.Value = new MultiplayerScore { TotalScore = RNG.Next(1_000_000) });
+            AddStep("unset user score", () => breakdown.UserBestScore.Value = null);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -324,6 +324,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             }
 
             metadataClient.MultiplayerRoomScoreSet += onRoomScoreSet;
+
+            ((IBindable<MultiplayerScore?>)breakdown.UserBestScore).BindTo(leaderboard.UserBestScore);
         }
 
         private void presentScore(long id)

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
     public partial class DailyChallengeLeaderboard : CompositeDrawable
     {
         public IBindable<MultiplayerScore?> UserBestScore => userBestScore;
-        private Bindable<MultiplayerScore?> userBestScore = new Bindable<MultiplayerScore?>();
+        private readonly Bindable<MultiplayerScore?> userBestScore = new Bindable<MultiplayerScore?>();
 
         public Action<long>? PresentScore { get; init; }
 

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeLeaderboard.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     public partial class DailyChallengeLeaderboard : CompositeDrawable
     {
+        public IBindable<MultiplayerScore?> UserBestScore => userBestScore;
+        private Bindable<MultiplayerScore?> userBestScore = new Bindable<MultiplayerScore?>();
+
         public Action<long>? PresentScore { get; init; }
 
         private readonly Room room;
@@ -130,7 +133,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             request.Success += req => Schedule(() =>
             {
                 var best = req.Scores.Select(s => s.CreateScoreInfo(scoreManager, rulesets, playlistItem, beatmap.Value.BeatmapInfo)).ToArray();
-                var userBest = req.UserScore?.CreateScoreInfo(scoreManager, rulesets, playlistItem, beatmap.Value.BeatmapInfo);
+
+                userBestScore.Value = req.UserScore;
+                var userBest = userBestScore.Value?.CreateScoreInfo(scoreManager, rulesets, playlistItem, beatmap.Value.BeatmapInfo);
 
                 cancellationTokenSource?.Cancel();
                 cancellationTokenSource = null;

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -131,8 +131,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             public Bar(int binStart, int binEnd)
             {
-                this.BinStart = binStart;
-                this.BinEnd = binEnd;
+                BinStart = binStart;
+                BinEnd = binEnd;
             }
 
             [Resolved]

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -44,23 +45,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             for (int i = 0; i < bin_count; ++i)
             {
-                LocalisableString? label = null;
-
-                switch (i)
-                {
-                    case 2:
-                    case 4:
-                    case 6:
-                    case 8:
-                        label = @$"{100 * i}k";
-                        break;
-
-                    case 10:
-                        label = @"1M";
-                        break;
-                }
-
-                barsContainer.Add(new Bar(label)
+                barsContainer.Add(new Bar(100_000 * i, 100_000 * (i + 1) - 1)
                 {
                     Width = 1f / bin_count,
                 });
@@ -113,18 +98,20 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 barsContainer[i].UpdateCounts(bins[i], max);
         }
 
-        private partial class Bar : CompositeDrawable
+        private partial class Bar : CompositeDrawable, IHasTooltip
         {
-            private readonly LocalisableString? label;
+            private readonly int binStart;
+            private readonly int binEnd;
 
             private long count;
             private long max;
 
             public Container CircularBar { get; private set; } = null!;
 
-            public Bar(LocalisableString? label = null)
+            public Bar(int binStart, int binEnd)
             {
-                this.label = label;
+                this.binStart = binStart;
+                this.binEnd = binEnd;
             }
 
             [BackgroundDependencyLoader]
@@ -159,13 +146,29 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     }
                 });
 
+                string? label = null;
+
+                switch (binStart)
+                {
+                    case 200_000:
+                    case 400_000:
+                    case 600_000:
+                    case 800_000:
+                        label = @$"{binStart / 1000}k";
+                        break;
+
+                    case 1_000_000:
+                        label = @"1M";
+                        break;
+                }
+
                 if (label != null)
                 {
                     AddInternal(new OsuSpriteText
                     {
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomCentre,
-                        Text = label.Value,
+                        Text = label,
                         Colour = colourProvider.Content2,
                     });
                 }
@@ -189,6 +192,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 if (isIncrement)
                     CircularBar.FlashColour(Colour4.White, 600, Easing.OutQuint);
             }
+
+            public LocalisableString TooltipText => LocalisableString.Format("{0:N0} passes in {1:N0} - {2:N0} range", count, binStart, binEnd);
         }
     }
 }


### PR DESCRIPTION
- Add tooltips showing counts and ranges for each bar
- Highlight bar which user's score belongs to

https://github.com/user-attachments/assets/464c2bdc-0069-4b0d-8a9a-bb088ac1495e

![osu_2024-07-26_14-36-06](https://github.com/user-attachments/assets/fac78034-7e1a-4514-b103-1451666684d2)

The implementation is a bit dodgy (parasites off the leaderboard) but maybe fine?