### PR TITLE
Fix daily challenge background clipping when settings/notifications is opened

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -106,6 +106,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             this.room = room;
             playlistItem = room.Playlist.Single();
             roomManager = new RoomManager();
+            Padding = new MarginPadding { Horizontal = -HORIZONTAL_OVERFLOW_PADDING };
         }
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)


### PR DESCRIPTION
Same as `OnlinePlayScreen`:
https://github.com/ppy/osu/blob/788b70469d855f46d08adce40bd5ab983d381bcb/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs#L55