### PR TITLE
Alternate background colour of chat lines to better visually distinguish wrapped lines

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
-        public void TestBackgroundAltering()
+        public void TestBackgroundAlternating()
         {
             var localUser = new APIUser
             {

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Logging;
 using osu.Framework.Testing;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
@@ -31,8 +30,6 @@ namespace osu.Game.Tests.Visual.Online
             {
                 RelativeSizeAxes = Axes.Both
             });
-            Logger.Log("v.dwadwaawddwa");
-
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -4,10 +4,15 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Testing;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Chat;
 
 namespace osu.Game.Tests.Visual.Online
@@ -30,6 +35,8 @@ namespace osu.Game.Tests.Visual.Online
             {
                 RelativeSizeAxes = Axes.Both
             });
+            Logger.Log("v.dwadwaawddwa");
+
         }
 
         [Test]
@@ -82,6 +89,44 @@ namespace osu.Game.Tests.Visual.Online
             }));
             AddUntilStep("three day separators present", () => drawableChannel.ChildrenOfType<DaySeparator>().Count() == 3);
             AddAssert("last day separator is from correct day", () => drawableChannel.ChildrenOfType<DaySeparator>().Last().Date.Date == new DateTime(2022, 11, 22));
+        }
+
+        [Test]
+        public void TestBackgroundAltering()
+        {
+            var localUser = new APIUser
+            {
+                Id = 3,
+                Username = "LocalUser"
+            };
+
+            string uuid = Guid.NewGuid().ToString();
+
+            int messageCount = 1;
+
+            AddRepeatStep($"add messages", () =>
+            {
+                channel.AddNewMessages(new Message(messageCount)
+                {
+                    Sender = localUser,
+                    Content = "Hi there all!",
+                    Timestamp = new DateTimeOffset(2022, 11, 21, 20, 11, 13, TimeSpan.Zero),
+                    Uuid = uuid,
+                });
+                messageCount++;
+            }, 10);
+
+
+            AddUntilStep("10 message present", () => drawableChannel.ChildrenOfType<ChatLine>().Count() == 10);
+
+            int checkCount = 0;
+
+            AddRepeatStep("check background", () =>
+            {
+                // +1 because the day separator take one index
+                Assert.AreEqual((checkCount + 1) % 2 == 0, drawableChannel.ChildrenOfType<ChatLine>().ToList()[checkCount].AlteringBackground);
+                checkCount++;
+            }, 10);
         }
     }
 }

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -94,8 +94,6 @@ namespace osu.Game.Tests.Visual.Online
                 Username = "LocalUser"
             };
 
-            string uuid = Guid.NewGuid().ToString();
-
             int messageCount = 1;
 
             AddRepeatStep("add messages", () =>
@@ -104,8 +102,8 @@ namespace osu.Game.Tests.Visual.Online
                 {
                     Sender = localUser,
                     Content = "Hi there all!",
-                    Timestamp = new DateTimeOffset(2022, 11, 21, 20, 11, 13, TimeSpan.Zero),
-                    Uuid = uuid,
+                    Timestamp = new DateTimeOffset(2022, 11, 21, 20, messageCount, 13, TimeSpan.Zero),
+                    Uuid = Guid.NewGuid().ToString(),
                 });
                 messageCount++;
             }, 10);

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -4,15 +4,11 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 using osu.Framework.Testing;
-using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
-using osu.Game.Overlays;
 using osu.Game.Overlays.Chat;
 
 namespace osu.Game.Tests.Visual.Online
@@ -47,6 +43,7 @@ namespace osu.Game.Tests.Visual.Online
                 Id = 3,
                 Username = "LocalUser"
             };
+
             string uuid = Guid.NewGuid().ToString();
             AddStep("add local echo message", () => channel.AddLocalEcho(new LocalEchoMessage
             {
@@ -104,7 +101,7 @@ namespace osu.Game.Tests.Visual.Online
 
             int messageCount = 1;
 
-            AddRepeatStep($"add messages", () =>
+            AddRepeatStep("add messages", () =>
             {
                 channel.AddNewMessages(new Message(messageCount)
                 {
@@ -115,7 +112,6 @@ namespace osu.Game.Tests.Visual.Online
                 });
                 messageCount++;
             }, 10);
-
 
             AddUntilStep("10 message present", () => drawableChannel.ChildrenOfType<ChatLine>().Count() == 10);
 

--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Visual.Online
             AddRepeatStep("check background", () =>
             {
                 // +1 because the day separator take one index
-                Assert.AreEqual((checkCount + 1) % 2 == 0, drawableChannel.ChildrenOfType<ChatLine>().ToList()[checkCount].AlteringBackground);
+                Assert.AreEqual((checkCount + 1) % 2 == 0, drawableChannel.ChildrenOfType<ChatLine>().ToList()[checkCount].AlternatingBackground);
                 checkCount++;
             }, 10);
         }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -77,6 +77,9 @@ namespace osu.Game.Overlays.Chat
             get => alternatingBackground;
             set
             {
+                if (alternatingBackground == value)
+                    return;
+
                 alternatingBackground = value;
                 updateBackground();
             }
@@ -122,6 +125,7 @@ namespace osu.Game.Overlays.Chat
                     Masking = true,
                     Blending = BlendingParameters.Additive,
                     CornerRadius = 4,
+                    Alpha = 0,
                     RelativeSizeAxes = Axes.Both,
                     Child = new Box
                     {

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -118,6 +118,8 @@ namespace osu.Game.Overlays.Chat
             configManager.BindWith(OsuSetting.Prefer24HourTime, prefer24HourTime);
             prefer24HourTime.BindValueChanged(_ => updateTimestamp());
 
+            Padding = new MarginPadding { Right = 5 };
+
             InternalChildren = new[]
             {
                 background = new Container
@@ -135,10 +137,10 @@ namespace osu.Game.Overlays.Chat
                 },
                 new GridContainer
                 {
-                    Margin = new MarginPadding
+                    Padding = new MarginPadding
                     {
-                        Horizontal = 10,
-                        Vertical = 1,
+                        Horizontal = 2,
+                        Vertical = 2,
                     },
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -70,14 +70,14 @@ namespace osu.Game.Overlays.Chat
 
         private Drawable? background;
 
-        private bool alteringBackground;
+        private bool alternatingBackground;
 
-        public bool AlteringBackground
+        public bool AlternatingBackground
         {
-            get => alteringBackground;
+            get => alternatingBackground;
             set
             {
-                alteringBackground = value;
+                alternatingBackground = value;
                 updateBackground();
             }
         }
@@ -115,53 +115,70 @@ namespace osu.Game.Overlays.Chat
             configManager.BindWith(OsuSetting.Prefer24HourTime, prefer24HourTime);
             prefer24HourTime.BindValueChanged(_ => updateTimestamp());
 
-            InternalChild = new GridContainer
+            InternalChildren = new[]
             {
-                Margin = new MarginPadding
+                background = new Container
                 {
-                    Horizontal = 10,
-                    Vertical = 1,
-                },
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.AutoSize),
-                    new Dimension(GridSizeMode.Absolute, Spacing + UsernameWidth + Spacing),
-                    new Dimension(),
-                },
-                Content = new[]
-                {
-                    new Drawable[]
+                    Masking = true,
+                    Blending = BlendingParameters.Additive,
+                    CornerRadius = 4,
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Box
                     {
-                        drawableTimestamp = new OsuSpriteText
-                        {
-                            Shadow = false,
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Font = OsuFont.GetFont(size: FontSize * 0.75f, weight: FontWeight.SemiBold, fixedWidth: true),
-                            AlwaysPresent = true,
-                        },
-                        drawableUsername = new DrawableChatUsername(message.Sender)
-                        {
-                            Width = UsernameWidth,
-                            FontSize = FontSize,
-                            AutoSizeAxes = Axes.Y,
-                            Origin = Anchor.TopRight,
-                            Anchor = Anchor.TopRight,
-                            Margin = new MarginPadding { Horizontal = Spacing },
-                            AccentColour = UsernameColour,
-                            Inverted = !string.IsNullOrEmpty(message.Sender.Colour),
-                        },
-                        drawableContentFlow = new LinkFlowContainer(styleMessageContent)
-                        {
-                            AutoSizeAxes = Axes.Y,
-                            RelativeSizeAxes = Axes.X,
-                        }
+                        Colour = Color4.White,
+                        RelativeSizeAxes = Axes.Both,
                     },
+                },
+                new GridContainer
+                {
+                    Margin = new MarginPadding
+                    {
+                        Horizontal = 10,
+                        Vertical = 1,
+                    },
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, Spacing + UsernameWidth + Spacing),
+                        new Dimension(),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            drawableTimestamp = new OsuSpriteText
+                            {
+                                Shadow = false,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Font = OsuFont.GetFont(size: FontSize * 0.75f, weight: FontWeight.SemiBold, fixedWidth: true),
+                                AlwaysPresent = true,
+                            },
+                            drawableUsername = new DrawableChatUsername(message.Sender)
+                            {
+                                Width = UsernameWidth,
+                                FontSize = FontSize,
+                                AutoSizeAxes = Axes.Y,
+                                Origin = Anchor.TopRight,
+                                Anchor = Anchor.TopRight,
+                                Margin = new MarginPadding { Horizontal = Spacing },
+                                AccentColour = UsernameColour,
+                                Inverted = !string.IsNullOrEmpty(message.Sender.Colour),
+                            },
+                            drawableContentFlow = new LinkFlowContainer(styleMessageContent)
+                            {
+                                AutoSizeAxes = Axes.Y,
+                                RelativeSizeAxes = Axes.X,
+                            }
+                        },
+                    }
                 }
             };
+
+            updateBackground();
         }
 
         protected override void LoadComplete()
@@ -279,23 +296,8 @@ namespace osu.Game.Overlays.Chat
 
         private void updateBackground()
         {
-            if (alteringBackground)
-            {
-                if (background?.IsAlive != true)
-                {
-                    AddInternal(background = new Circle
-                    {
-                        MaskingSmoothness = 2.5f,
-                        Depth = float.MaxValue,
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.White,
-                    });
-                }
-
-                background.Alpha = 0.04f;
-            }
-            else
-                background?.Expire();
+            if (background != null)
+                background.Alpha = alternatingBackground ? 0.03f : 0;
         }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -69,6 +69,29 @@ namespace osu.Game.Overlays.Chat
 
         private Container? highlight;
 
+        private Drawable? background;
+
+        private bool alteringBackground;
+
+        public bool AlteringBackground
+        {
+            get => alteringBackground;
+            set
+            {
+                alteringBackground = value;
+
+                if (background == null)
+                    AddInternal(background = new Box
+                    {
+                        BypassAutoSizeAxes = Axes.Both,
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White,
+                    });
+
+                background.Alpha = value ? 0.04f : 0f;
+            }
+        }
+
         /// <summary>
         /// The colour used to paint the author's username.
         /// </summary>

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -123,13 +123,13 @@ namespace osu.Game.Overlays.Chat
                 background = new Container
                 {
                     Masking = true,
-                    Blending = BlendingParameters.Additive,
                     CornerRadius = 4,
                     Alpha = 0,
                     RelativeSizeAxes = Axes.Both,
+                    Blending = BlendingParameters.Additive,
                     Child = new Box
                     {
-                        Colour = Color4.White,
+                        Colour = Colour4.FromHex("#3b3234"),
                         RelativeSizeAxes = Axes.Both,
                     },
                 },
@@ -301,7 +301,7 @@ namespace osu.Game.Overlays.Chat
         private void updateBackground()
         {
             if (background != null)
-                background.Alpha = alternatingBackground ? 0.03f : 0;
+                background.Alpha = alternatingBackground ? 0.2f : 0;
         }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -79,18 +79,7 @@ namespace osu.Game.Overlays.Chat
             set
             {
                 alteringBackground = value;
-
-                if (background == null)
-                {
-                    AddInternal(background = new Box
-                    {
-                        BypassAutoSizeAxes = Axes.Both,
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = Color4.White,
-                    });
-                }
-
-                background.Alpha = value ? 0.04f : 0f;
+                updateBackground();
             }
         }
 
@@ -283,5 +272,20 @@ namespace osu.Game.Overlays.Chat
             Color4Extensions.FromHex("812a96"),
             Color4Extensions.FromHex("992861"),
         };
+
+        private void updateBackground()
+        {
+            if (background == null)
+            {
+                AddInternal(background = new Box
+                {
+                    BypassAutoSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.White,
+                });
+            }
+
+            background.Alpha = alteringBackground ? 0.04f : 0f;
+        }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -21,7 +21,6 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osuTK.Graphics;
-using Message = osu.Game.Online.Chat.Message;
 
 namespace osu.Game.Overlays.Chat
 {
@@ -118,6 +117,11 @@ namespace osu.Game.Overlays.Chat
 
             InternalChild = new GridContainer
             {
+                Margin = new MarginPadding
+                {
+                    Horizontal = 10,
+                    Vertical = 1,
+                },
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
@@ -275,17 +279,23 @@ namespace osu.Game.Overlays.Chat
 
         private void updateBackground()
         {
-            if (background == null)
+            if (alteringBackground)
             {
-                AddInternal(background = new Box
+                if (background?.IsAlive != true)
                 {
-                    BypassAutoSizeAxes = Axes.Both,
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Color4.White,
-                });
-            }
+                    AddInternal(background = new Circle
+                    {
+                        MaskingSmoothness = 2.5f,
+                        Depth = float.MaxValue,
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White,
+                    });
+                }
 
-            background.Alpha = alteringBackground ? 0.04f : 0f;
+                background.Alpha = 0.04f;
+            }
+            else
+                background?.Expire();
         }
     }
 }

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -81,12 +81,14 @@ namespace osu.Game.Overlays.Chat
                 alteringBackground = value;
 
                 if (background == null)
+                {
                     AddInternal(background = new Box
                     {
                         BypassAutoSizeAxes = Axes.Both,
                         RelativeSizeAxes = Axes.Both,
                         Colour = Color4.White,
                     });
+                }
 
                 background.Alpha = value ? 0.04f : 0f;
             }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -106,7 +106,7 @@ namespace osu.Game.Overlays.Chat
 
         private void processMessageBackgroundAltering()
         {
-            for (int i = 0; i < ChatLineFlow.Count(); i++)
+            for (int i = 0; i < ChatLineFlow.Count; i++)
             {
                 if (ChatLineFlow[i] is ChatLine chatline)
                 {

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -104,6 +104,13 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.Value = null;
         });
 
+        private void processMessageBackgroundAltering()
+        {
+            for (int i = 0; i < ChatLineFlow.Count(); i++)
+                if (ChatLineFlow[i] is ChatLine chatline)
+                    chatline.AlteringBackground = i % 2 == 0;
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
@@ -158,6 +165,7 @@ namespace osu.Game.Overlays.Chat
                 scroll.ScrollToEnd();
 
             processMessageHighlighting();
+            processMessageBackgroundAltering();
         });
 
         private void pendingMessageResolved(Message existing, Message updated) => Schedule(() =>

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -84,6 +84,17 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.BindValueChanged(_ => processMessageHighlighting(), true);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            for (int i = 0; i < ChatLineFlow.Count; i++)
+            {
+                if (ChatLineFlow[i] is ChatLine chatline)
+                    chatline.AlternatingBackground = i % 2 == 0;
+            }
+        }
+
         /// <summary>
         /// Processes any pending message in <see cref="highlightedMessage"/>.
         /// </summary>
@@ -103,17 +114,6 @@ namespace osu.Game.Overlays.Chat
 
             highlightedMessage.Value = null;
         });
-
-        private void updateBackgroundAlternating()
-        {
-            for (int i = 0; i < ChatLineFlow.Count; i++)
-            {
-                if (ChatLineFlow[i] is ChatLine chatline)
-                {
-                    chatline.AlternatingBackground = i % 2 == 0;
-                }
-            }
-        }
 
         protected override void Dispose(bool isDisposing)
         {
@@ -169,7 +169,6 @@ namespace osu.Game.Overlays.Chat
                 scroll.ScrollToEnd();
 
             processMessageHighlighting();
-            updateBackgroundAlternating();
         });
 
         private void pendingMessageResolved(Message existing, Message updated) => Schedule(() =>

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -107,8 +107,12 @@ namespace osu.Game.Overlays.Chat
         private void processMessageBackgroundAltering()
         {
             for (int i = 0; i < ChatLineFlow.Count(); i++)
+            {
                 if (ChatLineFlow[i] is ChatLine chatline)
+                {
                     chatline.AlteringBackground = i % 2 == 0;
+                }
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -104,7 +104,7 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.Value = null;
         });
 
-        private void processMessageBackgroundAltering()
+        private void processChatlineBackgroundAltering()
         {
             for (int i = 0; i < ChatLineFlow.Count; i++)
             {
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Chat
                 scroll.ScrollToEnd();
 
             processMessageHighlighting();
-            processMessageBackgroundAltering();
+            processChatlineBackgroundAltering();
         });
 
         private void pendingMessageResolved(Message existing, Message updated) => Schedule(() =>

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -104,13 +104,13 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.Value = null;
         });
 
-        private void processChatlineBackgroundAltering()
+        private void updateBackgroundAlternating()
         {
             for (int i = 0; i < ChatLineFlow.Count; i++)
             {
                 if (ChatLineFlow[i] is ChatLine chatline)
                 {
-                    chatline.AlteringBackground = i % 2 == 0;
+                    chatline.AlternatingBackground = i % 2 == 0;
                 }
             }
         }
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Chat
                 scroll.ScrollToEnd();
 
             processMessageHighlighting();
-            processChatlineBackgroundAltering();
+            updateBackgroundAlternating();
         });
 
         private void pendingMessageResolved(Message existing, Message updated) => Schedule(() =>


### PR DESCRIPTION
Resolved: [#29129](https://github.com/ppy/osu/discussions/29129#discussioncomment-10165872) (first bullet point)


| Master | ![image](https://github.com/user-attachments/assets/d76b4ecb-51cb-4f17-a6cd-c2c7ba10c56f) |
|---------|-|
| PR | ![image](https://github.com/user-attachments/assets/c92e8b07-65ef-4eb6-848b-c9bcf416c3e2) |

For better accessibility, altering the chat message background color with the message id, unit test were added