### PR TITLE
Fix score breakdown tooltips appearing in other feeds

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private FillFlowContainer<Bar> barsContainer = null!;
 
+        // we're always present so that we can update while hidden, but we don't want tooltips to be displayed, therefore directly use alpha comparison here.
+        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && Alpha > 0;
+
         private const int bin_count = MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS;
         private long[] bins = new long[bin_count];
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29122

All feeds are set to be always present so that they can remain updated while in the background.