### PR TITLE
Use new footer for daily challenge

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectV2.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectV2.cs
@@ -186,12 +186,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             if (newScreen is IOsuScreen osuScreen && osuScreen.ShowFooter)
             {
                 screenScreenFooter.Show();
-                screenScreenFooter.SetButtons(osuScreen.CreateFooterButtons());
+                screenScreenFooter.SetLeftButtons(osuScreen.CreateFooterButtons());
             }
             else
             {
                 screenScreenFooter.Hide();
-                screenScreenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
+                screenScreenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>());
             }
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneScreenFooter.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                 },
             };
 
-            screenFooter.SetButtons(new ScreenFooterButton[]
+            screenFooter.SetLeftButtons(new ScreenFooterButton[]
             {
                 new ScreenFooterButtonMods(modOverlay) { Current = SelectedMods },
                 new ScreenFooterButtonRandom(),
@@ -77,7 +77,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestButtonsOut()
         {
-            AddStep("clear buttons", () => screenFooter.SetButtons(Array.Empty<ScreenFooterButton>()));
+            AddStep("clear buttons", () => screenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>()));
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestReplaceButtons()
         {
-            AddStep("replace buttons", () => screenFooter.SetButtons(new[]
+            AddStep("replace buttons", () => screenFooter.SetLeftButtons(new[]
             {
                 new ScreenFooterButton { Text = "One", Action = () => { } },
                 new ScreenFooterButton { Text = "Two", Action = () => { } },
@@ -100,7 +100,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             TestShearedOverlayContainer externalOverlay = null!;
 
             AddStep("add overlay", () => contentContainer.Add(externalOverlay = new TestShearedOverlayContainer()));
-            AddStep("set buttons", () => screenFooter.SetButtons(new[]
+            AddStep("set buttons", () => screenFooter.SetLeftButtons(new[]
             {
                 new ScreenFooterButton(externalOverlay)
                 {
@@ -128,7 +128,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             TestShearedOverlayContainer externalOverlay = null!;
 
             AddStep("hide footer", () => screenFooter.Hide());
-            AddStep("remove buttons", () => screenFooter.SetButtons(Array.Empty<ScreenFooterButton>()));
+            AddStep("remove buttons", () => screenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>()));
 
             AddStep("add external overlay", () => contentContainer.Add(externalOverlay = new TestShearedOverlayContainer()));
             AddStep("show external overlay", () => externalOverlay.Show());
@@ -158,7 +158,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             TestShearedOverlayContainer externalOverlay = null!;
 
             AddStep("hide footer", () => screenFooter.Hide());
-            AddStep("remove buttons", () => screenFooter.SetButtons(Array.Empty<ScreenFooterButton>()));
+            AddStep("remove buttons", () => screenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>()));
 
             AddStep("add external overlay", () => contentContainer.Add(externalOverlay = new TestShearedOverlayContainer()));
             AddStep("show external overlay", () => externalOverlay.Show());

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneShearedButtons.cs
@@ -13,6 +13,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
+using osu.Game.Screens.Footer;
 using osuTK;
 using osuTK.Input;
 
@@ -37,15 +38,8 @@ namespace osu.Game.Tests.Visual.UserInterface
 
                 if (bigButton)
                 {
-                    Child = button = new ShearedButton(400, 80)
+                    Child = button = new LetsGoButton
                     {
-                        LighterColour = Colour4.FromHex("#FFFFFF"),
-                        DarkerColour = Colour4.FromHex("#FFCC22"),
-                        TextColour = Colour4.Black,
-                        TextSize = 36,
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Text = "Let's GO!",
                         Action = () => actionFired = true,
                     };
                 }

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -221,5 +221,44 @@ namespace osu.Game.Graphics.UserInterface
 
             ButtonContent.FadeColour(colourContent, 150, Easing.OutQuint);
         }
+
+        public void AppearFromLeft(double delay)
+        {
+            Content.FinishTransforms();
+            Content.MoveToX(-300f)
+                   .FadeOut()
+                   .Delay(delay)
+                   .MoveToX(0f, 240, Easing.OutCubic)
+                   .FadeIn(240, Easing.OutCubic);
+        }
+
+        public void AppearFromBottom()
+        {
+            Content.FinishTransforms();
+            Content.MoveToY(100f)
+                   .FadeOut()
+                   .MoveToY(0f, 240, Easing.OutCubic)
+                   .FadeIn(240, Easing.OutCubic);
+        }
+
+        public void DisappearToRight(bool expire)
+        {
+            Content.FinishTransforms();
+            Content.FadeOut(240, Easing.InOutCubic)
+                   .MoveToX(300f, 360, Easing.InOutCubic);
+
+            if (expire)
+                this.Delay(Content.LatestTransformEndTime - Time.Current).Expire();
+        }
+
+        public void DisappearToBottom(bool expire)
+        {
+            Content.FinishTransforms();
+            Content.FadeOut(240, Easing.InOutCubic)
+                   .MoveToY(100f, 240, Easing.InOutCubic);
+
+            if (expire)
+                this.Delay(Content.LatestTransformEndTime - Time.Current).Expire();
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ShearedButton.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedButton.cs
@@ -30,7 +30,12 @@ namespace osu.Game.Graphics.UserInterface
         public float TextSize
         {
             get => text.Font.Size;
-            set => text.Font = OsuFont.TorusAlternate.With(size: value);
+            set => text.Font = text.Font.With(size: value);
+        }
+
+        public FontWeight TextWeight
+        {
+            set => text.Font = text.Font.With(weight: value);
         }
 
         public Colour4 DarkerColour

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1588,11 +1588,13 @@ namespace osu.Game
                 {
                     BackButton.Hide();
                     ScreenFooter.SetLeftButtons(newOsuScreen.CreateFooterButtons());
+                    ScreenFooter.SetRightButton(newOsuScreen.CreateRightFooterButton());
                     ScreenFooter.Show();
                 }
                 else
                 {
                     ScreenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>());
+                    ScreenFooter.SetRightButton(null);
                     ScreenFooter.Hide();
                 }
             }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1587,12 +1587,12 @@ namespace osu.Game
                 if (newOsuScreen.ShowFooter)
                 {
                     BackButton.Hide();
-                    ScreenFooter.SetButtons(newOsuScreen.CreateFooterButtons());
+                    ScreenFooter.SetLeftButtons(newOsuScreen.CreateFooterButtons());
                     ScreenFooter.Show();
                 }
                 else
                 {
-                    ScreenFooter.SetButtons(Array.Empty<ScreenFooterButton>());
+                    ScreenFooter.SetLeftButtons(Array.Empty<ScreenFooterButton>());
                     ScreenFooter.Hide();
                 }
             }

--- a/osu.Game/Screens/Footer/LetsGoButton.cs
+++ b/osu.Game/Screens/Footer/LetsGoButton.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Screens.Footer
+{
+    public partial class LetsGoButton : ShearedButton
+    {
+        public LetsGoButton()
+            : base(400)
+        {
+            LighterColour = Colour4.FromHex("#FFFFFF");
+            DarkerColour = Colour4.FromHex("#FFCC22");
+            TextColour = Colour4.Black;
+            TextSize = 30;
+            TextWeight = FontWeight.Light;
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+            Text = "Let's GO!";
+        }
+    }
+}

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -32,8 +32,8 @@ namespace osu.Game.Screens.Footer
         private readonly List<OverlayContainer> overlays = new List<OverlayContainer>();
 
         private Box background = null!;
-        private FillFlowContainer<ScreenFooterButton> buttonsFlow = null!;
-        private Container<ScreenFooterButton> removedButtonsContainer = null!;
+        private FillFlowContainer<ScreenFooterButton> leftButtonsFlow = null!;
+        private Container<ScreenFooterButton> removedLeftButtonsContainer = null!;
         private LogoTrackingContainer logoTrackingContainer = null!;
 
         [Cached]
@@ -71,7 +71,7 @@ namespace osu.Game.Screens.Footer
                     RelativeSizeAxes = Axes.Both,
                     Colour = colourProvider.Background5
                 },
-                buttonsFlow = new FillFlowContainer<ScreenFooterButton>
+                leftButtonsFlow = new FillFlowContainer<ScreenFooterButton>
                 {
                     Margin = new MarginPadding { Left = 12f + ScreenBackButton.BUTTON_WIDTH + padding },
                     Y = 10f,
@@ -88,7 +88,7 @@ namespace osu.Game.Screens.Footer
                     Origin = Anchor.BottomLeft,
                     Action = onBackPressed,
                 },
-                removedButtonsContainer = new Container<ScreenFooterButton>
+                removedLeftButtonsContainer = new Container<ScreenFooterButton>
                 {
                     Margin = new MarginPadding { Left = 12f + ScreenBackButton.BUTTON_WIDTH + padding },
                     Y = 10f,
@@ -139,26 +139,26 @@ namespace osu.Game.Screens.Footer
                 .FadeOut(transition_duration, Easing.OutQuint);
         }
 
-        public void SetButtons(IReadOnlyList<ScreenFooterButton> buttons)
+        public void SetLeftButtons(IReadOnlyList<ScreenFooterButton> buttons)
         {
-            temporarilyHiddenButtons.Clear();
+            temporarilyHiddenLeftButtons.Clear();
             overlays.Clear();
 
             clearActiveOverlayContainer();
 
-            var oldButtons = buttonsFlow.ToArray();
+            var oldButtons = leftButtonsFlow.ToArray();
 
             for (int i = 0; i < oldButtons.Length; i++)
             {
                 var oldButton = oldButtons[i];
 
-                buttonsFlow.Remove(oldButton, false);
-                removedButtonsContainer.Add(oldButton);
+                leftButtonsFlow.Remove(oldButton, false);
+                removedLeftButtonsContainer.Add(oldButton);
 
                 if (buttons.Count > 0)
-                    makeButtonDisappearToRight(oldButton, i, oldButtons.Length, true);
+                    makeLeftButtonDisappearToRight(oldButton, i, oldButtons.Length, true);
                 else
-                    makeButtonDisappearToBottom(oldButton, i, oldButtons.Length, true);
+                    makeLeftButtonDisappearToBottom(oldButton, i, oldButtons.Length, true);
             }
 
             for (int i = 0; i < buttons.Count; i++)
@@ -172,7 +172,7 @@ namespace osu.Game.Screens.Footer
                 }
 
                 Debug.Assert(!newButton.IsLoaded);
-                buttonsFlow.Add(newButton);
+                leftButtonsFlow.Add(newButton);
 
                 int index = i;
 
@@ -180,9 +180,9 @@ namespace osu.Game.Screens.Footer
                 newButton.OnLoadComplete += _ =>
                 {
                     if (oldButtons.Length > 0)
-                        makeButtonAppearFromLeft(newButton, index, buttons.Count, 240);
+                        makeLeftButtonAppearFromLeft(newButton, index, buttons.Count, 240);
                     else
-                        makeButtonAppearFromBottom(newButton, index);
+                        makeLeftButtonAppearFromBottom(newButton, index);
                 };
             }
         }
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.Footer
         private ShearedOverlayContainer? activeOverlay;
         private Container? contentContainer;
 
-        private readonly List<ScreenFooterButton> temporarilyHiddenButtons = new List<ScreenFooterButton>();
+        private readonly List<ScreenFooterButton> temporarilyHiddenLeftButtons = new List<ScreenFooterButton>();
 
         public IDisposable RegisterActiveOverlayContainer(ShearedOverlayContainer overlay, out VisibilityContainer? footerContent)
         {
@@ -202,19 +202,19 @@ namespace osu.Game.Screens.Footer
 
             activeOverlay = overlay;
 
-            Debug.Assert(temporarilyHiddenButtons.Count == 0);
+            Debug.Assert(temporarilyHiddenLeftButtons.Count == 0);
 
-            var targetButton = buttonsFlow.SingleOrDefault(b => b.Overlay == overlay);
+            var targetButton = leftButtonsFlow.SingleOrDefault(b => b.Overlay == overlay);
 
-            temporarilyHiddenButtons.AddRange(targetButton != null
-                ? buttonsFlow.SkipWhile(b => b != targetButton).Skip(1)
-                : buttonsFlow);
+            temporarilyHiddenLeftButtons.AddRange(targetButton != null
+                ? leftButtonsFlow.SkipWhile(b => b != targetButton).Skip(1)
+                : leftButtonsFlow);
 
-            for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
-                makeButtonDisappearToBottom(temporarilyHiddenButtons[i], 0, 0, false);
+            for (int i = 0; i < temporarilyHiddenLeftButtons.Count; i++)
+                makeLeftButtonDisappearToBottom(temporarilyHiddenLeftButtons[i], 0, 0, false);
 
-            var fallbackPosition = buttonsFlow.Any()
-                ? buttonsFlow.ToSpaceOfOtherDrawable(Vector2.Zero, this)
+            var fallbackPosition = leftButtonsFlow.Any()
+                ? leftButtonsFlow.ToSpaceOfOtherDrawable(Vector2.Zero, this)
                 : BackButton.ToSpaceOfOtherDrawable(BackButton.LayoutRectangle.TopRight + new Vector2(5f, 0f), this);
 
             var targetPosition = targetButton?.ToSpaceOfOtherDrawable(targetButton.LayoutRectangle.TopRight, this) ?? fallbackPosition;
@@ -233,7 +233,7 @@ namespace osu.Game.Screens.Footer
                 Child = content,
             });
 
-            if (temporarilyHiddenButtons.Count > 0)
+            if (temporarilyHiddenLeftButtons.Count > 0)
                 this.Delay(60).Schedule(() => content.Show());
             else
                 content.Show();
@@ -251,10 +251,10 @@ namespace osu.Game.Screens.Footer
 
             double timeUntilRun = contentContainer.Child.LatestTransformEndTime - Time.Current;
 
-            for (int i = 0; i < temporarilyHiddenButtons.Count; i++)
-                makeButtonAppearFromBottom(temporarilyHiddenButtons[i], 0);
+            for (int i = 0; i < temporarilyHiddenLeftButtons.Count; i++)
+                makeLeftButtonAppearFromBottom(temporarilyHiddenLeftButtons[i], 0);
 
-            temporarilyHiddenButtons.Clear();
+            temporarilyHiddenLeftButtons.Clear();
 
             updateColourScheme(OverlayColourScheme.Aquamarine.GetHue());
 
@@ -269,20 +269,20 @@ namespace osu.Game.Screens.Footer
 
             background.FadeColour(colourProvider.Background5, 150, Easing.OutQuint);
 
-            foreach (var button in buttonsFlow)
+            foreach (var button in leftButtonsFlow)
                 button.UpdateDisplay();
         }
 
-        private void makeButtonAppearFromLeft(ScreenFooterButton button, int index, int count, float startDelay)
+        private void makeLeftButtonAppearFromLeft(ScreenFooterButton button, int index, int count, float startDelay)
             => button.AppearFromLeft(startDelay + (count - index) * delay_per_button);
 
-        private void makeButtonAppearFromBottom(ScreenFooterButton button, int index)
+        private void makeLeftButtonAppearFromBottom(ScreenFooterButton button, int index)
             => button.AppearFromBottom(index * delay_per_button);
 
-        private void makeButtonDisappearToRight(ScreenFooterButton button, int index, int count, bool expire)
+        private void makeLeftButtonDisappearToRight(ScreenFooterButton button, int index, int count, bool expire)
             => button.DisappearToRight((count - index) * delay_per_button, expire);
 
-        private void makeButtonDisappearToBottom(ScreenFooterButton button, int index, int count, bool expire)
+        private void makeLeftButtonDisappearToBottom(ScreenFooterButton button, int index, int count, bool expire)
             => button.DisappearToBottom((count - index) * delay_per_button, expire);
 
         private void showOverlay(OverlayContainer overlay)

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -36,8 +36,9 @@ namespace osu.Game.Screens.Footer
         private Container<ScreenFooterButton> removedLeftButtonsContainer = null!;
         private LogoTrackingContainer logoTrackingContainer = null!;
 
+        // TODO: this should take the screen's colourProvider instead. hardcode plum for now as daily challenge is the only usage shown to users
         [Cached]
-        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
 
         [Resolved]
         private OsuGame? game { get; set; }
@@ -256,7 +257,7 @@ namespace osu.Game.Screens.Footer
 
             temporarilyHiddenLeftButtons.Clear();
 
-            updateColourScheme(OverlayColourScheme.Aquamarine.GetHue());
+            updateColourScheme(OverlayColourScheme.Plum.GetHue());
 
             contentContainer.Delay(timeUntilRun).Expire();
             contentContainer = null;

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Footer;
@@ -77,6 +78,8 @@ namespace osu.Game.Screens
         /// A list of footer buttons to be added to the game footer, or empty to display no buttons.
         /// </summary>
         IReadOnlyList<ScreenFooterButton> CreateFooterButtons();
+
+        ShearedButton? CreateRightFooterButton();
 
         /// <summary>
         /// Whether mod track adjustments should be applied on entering this screen.

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                 new Dimension(GridSizeMode.Absolute, 10),
                                 new Dimension(),
                                 new Dimension(GridSizeMode.Absolute, 30),
-                                new Dimension(GridSizeMode.Absolute, 50)
+                                new Dimension(GridSizeMode.Absolute, 60)
                             ],
                             Content = new[]
                             {

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -13,6 +13,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -306,6 +307,7 @@ namespace osu.Game.Screens
         protected virtual BackgroundScreen CreateBackground() => null;
 
         public virtual IReadOnlyList<ScreenFooterButton> CreateFooterButtons() => Array.Empty<ScreenFooterButton>();
+        public virtual ShearedButton CreateRightFooterButton() => null;
 
         public virtual bool OnBackButton() => false;
     }

--- a/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonFreeMods.cs
+++ b/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonFreeMods.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Overlays.Mods;
+
+namespace osu.Game.Screens.SelectV2.Footer
+{
+    public partial class ScreenFooterButtonFreeMods : ScreenFooterButtonMods
+    {
+        public ScreenFooterButtonFreeMods(ModSelectOverlay overlay)
+            : base(overlay)
+        {
+            Text = "Free Mods";
+
+            // TODO: this should look a bit different than the regular mods button
+        }
+    }
+}

--- a/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonMods.cs
+++ b/osu.Game/Screens/SelectV2/Footer/ScreenFooterButtonMods.cs
@@ -18,6 +18,7 @@ using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
@@ -61,13 +62,14 @@ namespace osu.Game.Screens.SelectV2.Footer
         public ScreenFooterButtonMods(ModSelectOverlay overlay)
             : base(overlay)
         {
+            Text = "Mods";
+            Icon = FontAwesome.Solid.ExchangeAlt;
+            Hotkey = GlobalAction.ToggleModSelection;
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Text = "Mods";
-            Icon = FontAwesome.Solid.ExchangeAlt;
             AccentColour = colours.Lime1;
 
             AddRange(new[]


### PR DESCRIPTION
Loosely needed for https://github.com/ppy/osu/pull/29163, so there's feedback that the mods are applied.

The mod display overlap is not the best, but neither is having more dead space on the bottom. Added enough padding so that the actual content is still readable.

Restricted to one right button for the footer as it's already wide in the designs, and I believe we only need one. For multiplayer, we can probably use the left buttons for spectate/timer or somewhere else.

https://github.com/user-attachments/assets/ede4e127-c42c-4dd0-9209-590a7315c33f

Known issues:
- Deselect button position not updating (existed before PR and believed someone reported on Discord too)
	<img width="446" alt="Screenshot 2024-07-28 at 12 29 34 AM" src="https://github.com/user-attachments/assets/a80cc9fa-edde-4c5e-a7a7-07d0627c1366">
