### PR TITLE
Fix mod preset tooltip's description text being cut off

### DIFF
--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -24,7 +24,8 @@ namespace osu.Game.Overlays.Mods
             {
                 new FillFlowContainer
                 {
-                    AutoSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(7),
                     Children = new Drawable[]

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -24,8 +24,7 @@ namespace osu.Game.Overlays.Mods
             {
                 new FillFlowContainer
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Horizontal,
                     Spacing = new Vector2(7),
                     Children = new Drawable[]

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -44,10 +44,12 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(7),
                     Children = new[]
                     {
-                        descriptionText = new OsuSpriteText
+                        descriptionText = new TruncatingSpriteText
                         {
+                            RelativeSizeAxes = Axes.X,
                             Font = OsuFont.GetFont(weight: FontWeight.Regular),
                             Colour = colourProvider.Content1,
+                            AllowMultiline = true,
                         },
                     }
                 }

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -23,8 +23,7 @@ namespace osu.Game.Overlays.Mods
 
         public ModPresetTooltip(OverlayColourProvider colourProvider)
         {
-            Width = 250;
-            AutoSizeAxes = Axes.Y;
+            AutoSizeAxes = Axes.Both;
 
             Masking = true;
             CornerRadius = 7;
@@ -38,18 +37,16 @@ namespace osu.Game.Overlays.Mods
                 },
                 Content = new FillFlowContainer
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
                     Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
                     Spacing = new Vector2(7),
                     Children = new[]
                     {
-                        descriptionText = new TruncatingSpriteText
+                        descriptionText = new OsuSpriteText
                         {
-                            RelativeSizeAxes = Axes.X,
                             Font = OsuFont.GetFont(weight: FontWeight.Regular),
                             Colour = colourProvider.Content1,
-                            AllowMultiline = true,
                         },
                     }
                 }
@@ -68,7 +65,11 @@ namespace osu.Game.Overlays.Mods
             lastPreset = preset;
 
             Content.RemoveAll(d => d is ModPresetRow, true);
-            Content.AddRange(preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod)));
+            Content.AddRange(preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod)
+            {
+                RelativeSizeAxes = Axes.None,
+                AutoSizeAxes = Axes.Both,
+            }));
         }
 
         protected override void PopIn() => this.FadeIn(transition_duration, Easing.OutQuint);

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -48,6 +48,10 @@ namespace osu.Game.Overlays.Mods
                             f.Font = OsuFont.GetFont(weight: FontWeight.Regular);
                             f.Colour = colourProvider.Content1;
                         })
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                        }
                     }
                 }
             };

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osuTK;
 
@@ -19,7 +18,7 @@ namespace osu.Game.Overlays.Mods
 
         private const double transition_duration = 200;
 
-        private readonly OsuSpriteText descriptionText;
+        private readonly TextFlowContainer descriptionText;
 
         public ModPresetTooltip(OverlayColourProvider colourProvider)
         {
@@ -44,11 +43,11 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(7),
                     Children = new[]
                     {
-                        descriptionText = new OsuSpriteText
+                        descriptionText = new TextFlowContainer(f =>
                         {
-                            Font = OsuFont.GetFont(weight: FontWeight.Regular),
-                            Colour = colourProvider.Content1,
-                        },
+                            f.Font = OsuFont.GetFont(weight: FontWeight.Regular);
+                            f.Colour = colourProvider.Content1;
+                        })
                     }
                 }
             };

--- a/osu.Game/Overlays/Mods/ModPresetTooltip.cs
+++ b/osu.Game/Overlays/Mods/ModPresetTooltip.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Overlays.Mods
 
         public ModPresetTooltip(OverlayColourProvider colourProvider)
         {
-            AutoSizeAxes = Axes.Both;
+            Width = 250;
+            AutoSizeAxes = Axes.Y;
 
             Masking = true;
             CornerRadius = 7;
@@ -37,8 +38,8 @@ namespace osu.Game.Overlays.Mods
                 },
                 Content = new FillFlowContainer
                 {
-                    AutoSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Left = 10, Right = 10, Top = 5, Bottom = 5 },
                     Spacing = new Vector2(7),
                     Children = new[]
@@ -65,11 +66,7 @@ namespace osu.Game.Overlays.Mods
             lastPreset = preset;
 
             Content.RemoveAll(d => d is ModPresetRow, true);
-            Content.AddRange(preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod)
-            {
-                RelativeSizeAxes = Axes.None,
-                AutoSizeAxes = Axes.Both,
-            }));
+            Content.AddRange(preset.Mods.AsOrdered().Select(mod => new ModPresetRow(mod)));
         }
 
         protected override void PopIn() => this.FadeIn(transition_duration, Easing.OutQuint);


### PR DESCRIPTION
Fix the visual bug of the mod preset tooltip's description text being cut off

##### The tooltip was first introduced in (#28650)

|Master|![image](https://github.com/user-attachments/assets/fb95cf12-1f2b-4286-8a95-b79a72e62841)|
|---------|-|
|PR|![image](https://github.com/user-attachments/assets/d993db72-8fc9-41a3-8bbe-cd8013551bc1)|