### PR TITLE
Force exit to main menu when presenting scores from within playlists / multiplayer

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -63,7 +63,6 @@ using osu.Game.Screens;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.Menu;
-using osu.Game.Screens.OnlinePlay;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
 using osu.Game.Screens.OnlinePlay.Multiplayer;
 using osu.Game.Screens.Play;
@@ -757,11 +756,13 @@ namespace osu.Game
             // As a special case, if the beatmap and ruleset already match, allow immediately displaying the score from song select.
             // This is guaranteed to not crash, and feels better from a user's perspective (ie. if they are clicking a score in the
             // song select leaderboard).
-            // Similar exemptions are made here for online flows where there are good chances that beatmap and ruleset match
-            // (playlists / multiplayer / daily challenge).
+            // Similar exemptions are made here for daily challenge where it is guaranteed that beatmap and ruleset match.
+            // `OnlinePlayScreen` is excluded because when resuming back to it,
+            // `RoomSubScreen` changes the global beatmap to the next playlist item on resume,
+            // which may not match the score, and thus crash.
             IEnumerable<Type> validScreens =
                 Beatmap.Value.BeatmapInfo.Equals(databasedBeatmap) && Ruleset.Value.Equals(databasedScore.ScoreInfo.Ruleset)
-                    ? new[] { typeof(SongSelect), typeof(OnlinePlayScreen), typeof(DailyChallenge) }
+                    ? new[] { typeof(SongSelect), typeof(DailyChallenge) }
                     : Array.Empty<Type>();
 
             PerformFromScreen(screen =>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29152
- Partially reverts https://github.com/ppy/osu/pull/29097
- Reopens https://github.com/ppy/osu/issues/26666

When testing I failed to predict that in multiplayer there can be a different beatmap in the playlist queue. If this is the case, `PresentScore()` will exit out to `Multiplayer`, whose `RoomSubScreen` will update the selected item - and thus, the global beatmap - to the next item in queue, at which point trying to play games with "not touching the global beatmap bindable if we don't need to" fail to work, because the bindable *must* be touched for correct operation, yet it cannot (because `OnlinePlayScreen`s disable it).

I'm not sure what the fix is here:

- making replay player somehow independent of the global beatmap?
- not exiting out to multiplayer, but instead doing the present from the results screen itself? if so, then how to ensure the screen stack can't overflow to infinity?

so I'm just reverting the broken part. The daily challenge part is left in because as is it should not cause issues.