### PR TITLE
Fix online status not persisting correctly

### DIFF
--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -118,12 +118,11 @@ namespace osu.Game.Online.API
                 u.OldValue?.Activity.UnbindFrom(activity);
                 u.NewValue.Activity.BindTo(activity);
 
-                if (u.OldValue != null)
-                    localUserStatus.UnbindFrom(u.OldValue.Status);
-                localUserStatus.BindTo(u.NewValue.Status);
+                u.OldValue?.Status.UnbindFrom(localUserStatus);
+                u.NewValue.Status.BindTo(localUserStatus);
             }, true);
 
-            localUserStatus.BindValueChanged(val => configStatus.Value = val.NewValue);
+            localUserStatus.BindTo(configStatus);
 
             var thread = new Thread(run)
             {

--- a/osu.Game/Online/API/APIAccess.cs
+++ b/osu.Game/Online/API/APIAccess.cs
@@ -599,6 +599,7 @@ namespace osu.Game.Online.API
             password = null;
             SecondFactorCode = null;
             authentication.Clear();
+            configStatus.Value = UserStatus.Online;
 
             // Scheduled prior to state change such that the state changed event is invoked with the correct user and their friends present
             Schedule(() =>

--- a/osu.Game/Overlays/Login/LoginPanel.cs
+++ b/osu.Game/Overlays/Login/LoginPanel.cs
@@ -157,6 +157,7 @@ namespace osu.Game.Overlays.Login
                         },
                     };
 
+                    updateDropdownCurrent(status.Value);
                     dropdown.Current.BindValueChanged(action =>
                     {
                         switch (action.NewValue)


### PR DESCRIPTION
Regressed at some point. Can't find why but oh well.

I don't see much reason not to link the bindable directly with config. It seems to work as you'd expect. Tested with logout (resets to "Online") and connection failure (persists). Not going to overthink this until we have full support for it.

Closes https://github.com/ppy/osu/issues/29173.

