### PR TITLE
Favour updating daily challenge statistics when they come on screen

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
@@ -50,6 +50,8 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                     breakdown.Height = height;
             });
 
+            AddToggleStep("toggle visible", v => breakdown.Alpha = v ? 1 : 0);
+
             AddStep("set initial data", () => breakdown.SetInitialCounts([1, 4, 9, 16, 25, 36, 49, 36, 25, 16, 9, 4, 1]));
             AddStep("add new score", () =>
             {

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeScoreBreakdown.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
@@ -20,11 +21,11 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
 
-        [Test]
-        public void TestBasicAppearance()
-        {
-            DailyChallengeScoreBreakdown breakdown = null!;
+        private DailyChallengeScoreBreakdown breakdown = null!;
 
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
             AddStep("create content", () => Children = new Drawable[]
             {
                 new Box
@@ -53,6 +54,11 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             AddToggleStep("toggle visible", v => breakdown.Alpha = v ? 1 : 0);
 
             AddStep("set initial data", () => breakdown.SetInitialCounts([1, 4, 9, 16, 25, 36, 49, 36, 25, 16, 9, 4, 1]));
+        }
+
+        [Test]
+        public void TestBasicAppearance()
+        {
             AddStep("add new score", () =>
             {
                 var ev = new NewScoreEvent(1, new APIUser
@@ -66,6 +72,25 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             });
             AddStep("set user score", () => breakdown.UserBestScore.Value = new MultiplayerScore { TotalScore = RNG.Next(1_000_000) });
             AddStep("unset user score", () => breakdown.UserBestScore.Value = null);
+        }
+
+        [Test]
+        public void TestMassAdd()
+        {
+            AddStep("add 1000 scores at once", () =>
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    var ev = new NewScoreEvent(1, new APIUser
+                    {
+                        Id = 2,
+                        Username = "peppy",
+                        CoverUrl = "https://osu.ppy.sh/images/headers/profile-covers/c3.jpg",
+                    }, RNG.Next(1_000_000), null);
+
+                    breakdown.AddNewScore(ev);
+                }
+            });
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTimeRemainingRing.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTimeRemainingRing.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 if (ring.IsNotNull())
                     ring.Height = height;
             });
+            AddToggleStep("toggle visible", v => ring.Alpha = v ? 1 : 0);
+
             AddStep("just started", () =>
             {
                 room.Value.StartDate.Value = DateTimeOffset.Now.AddMinutes(-1);

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTotalsDisplay.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeTotalsDisplay.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 if (totals.IsNotNull())
                     totals.Height = height;
             });
+            AddToggleStep("toggle visible", v => totals.Alpha = v ? 1 : 0);
 
             AddStep("set counts", () => totals.SetInitialCounts(totalPassCount: 9650, cumulativeTotalScore: 10_000_000_000));
 

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeCarousel.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeCarousel.cs
@@ -50,7 +50,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         {
             drawable.RelativeSizeAxes = Axes.Both;
             drawable.Size = Vector2.One;
-            drawable.AlwaysPresent = true;
             drawable.Alpha = 0;
 
             base.Add(drawable);

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -27,9 +27,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private FillFlowContainer<Bar> barsContainer = null!;
 
-        // we're always present so that we can update while hidden, but we don't want tooltips to be displayed, therefore directly use alpha comparison here.
-        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && Alpha > 0;
-
         private const int bin_count = MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS;
         private long[] bins = new long[bin_count];
 

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -74,30 +74,34 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         {
             int targetBin = (int)Math.Clamp(Math.Floor((float)newScoreEvent.TotalScore / 100000), 0, bin_count - 1);
             bins[targetBin] += 1;
-            updateCounts();
 
-            var text = new OsuSpriteText
-            {
-                Text = newScoreEvent.TotalScore.ToString(@"N0"),
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.BottomCentre,
-                Font = OsuFont.Default.With(size: 30),
-                RelativePositionAxes = Axes.X,
-                X = (targetBin + 0.5f) / bin_count - 0.5f,
-                Alpha = 0,
-            };
-            AddInternal(text);
+            Scheduler.AddOnce(updateCounts);
 
-            Scheduler.AddDelayed(() =>
+            if (Alpha > 0)
             {
-                float startY = ToLocalSpace(barsContainer[targetBin].CircularBar.ScreenSpaceDrawQuad.TopLeft).Y;
-                text.FadeInFromZero()
-                    .ScaleTo(new Vector2(0.8f), 500, Easing.OutElasticHalf)
-                    .MoveToY(startY)
-                    .MoveToOffset(new Vector2(0, -50), 2500, Easing.OutQuint)
-                    .FadeOut(2500, Easing.OutQuint)
-                    .Expire();
-            }, 150);
+                var text = new OsuSpriteText
+                {
+                    Text = newScoreEvent.TotalScore.ToString(@"N0"),
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.BottomCentre,
+                    Font = OsuFont.Default.With(size: 30),
+                    RelativePositionAxes = Axes.X,
+                    X = (targetBin + 0.5f) / bin_count - 0.5f,
+                    Alpha = 0,
+                };
+                AddInternal(text);
+
+                Scheduler.AddDelayed(() =>
+                {
+                    float startY = ToLocalSpace(barsContainer[targetBin].CircularBar.ScreenSpaceDrawQuad.TopLeft).Y;
+                    text.FadeInFromZero()
+                        .ScaleTo(new Vector2(0.8f), 500, Easing.OutElasticHalf)
+                        .MoveToY(startY)
+                        .MoveToOffset(new Vector2(0, -50), 2500, Easing.OutQuint)
+                        .FadeOut(2500, Easing.OutQuint)
+                        .Expire();
+                }, 150);
+            }
         }
 
         public void SetInitialCounts(long[] counts)

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -67,18 +68,39 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             });
         }
 
+        private readonly Queue<NewScoreEvent> newScores = new Queue<NewScoreEvent>();
+
         public void AddNewScore(NewScoreEvent newScoreEvent)
         {
-            int targetBin = (int)Math.Clamp(Math.Floor((float)newScoreEvent.TotalScore / 100000), 0, bin_count - 1);
-            bins[targetBin] += 1;
+            newScores.Enqueue(newScoreEvent);
 
-            Scheduler.AddOnce(updateCounts);
-
-            if (Alpha > 0)
+            // ensure things don't get too out-of-hand.
+            if (newScores.Count > 25)
             {
+                bins[getTargetBin(newScores.Dequeue())] += 1;
+                Scheduler.AddOnce(updateCounts);
+            }
+        }
+
+        private double lastScoreDisplay;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Time.Current - lastScoreDisplay > 150 && newScores.TryDequeue(out var newScore))
+            {
+                if (lastScoreDisplay < Time.Current)
+                    lastScoreDisplay = Time.Current;
+
+                int targetBin = getTargetBin(newScore);
+                bins[targetBin] += 1;
+
+                updateCounts();
+
                 var text = new OsuSpriteText
                 {
-                    Text = newScoreEvent.TotalScore.ToString(@"N0"),
+                    Text = newScore.TotalScore.ToString(@"N0"),
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.BottomCentre,
                     Font = OsuFont.Default.With(size: 30),
@@ -98,6 +120,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                         .FadeOut(2500, Easing.OutQuint)
                         .Expire();
                 }, 150);
+
+                lastScoreDisplay = Time.Current;
             }
         }
 
@@ -109,6 +133,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             bins = counts;
             updateCounts();
         }
+
+        private static int getTargetBin(NewScoreEvent score) =>
+            (int)Math.Clamp(Math.Floor((float)score.TotalScore / 100000), 0, bin_count - 1);
 
         private void updateCounts()
         {


### PR DESCRIPTION
This also fixes an edge case we may have missed – score breakdown would have been creating text for each score set while in gameplay (something we fixed in the event feed locally).