### PR TITLE
Add notification on daily challenge conclusion & start of new one

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         private void load()
         {
             base.Content.Add(notificationOverlay);
+            base.Content.Add(metadataClient);
         }
 
         [Test]
@@ -63,7 +64,7 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 Name = { Value = "Daily Challenge: June 4, 2024" },
                 Playlist =
                 {
-                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
+                    new PlaylistItem(TestResources.CreateTestBeatmapSetInfo().Beatmaps.First())
                     {
                         RequiredMods = [new APIMod(new OsuModTraceable())],
                         AllowedMods = [new APIMod(new OsuModDoubleTime())]

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -80,44 +80,6 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             AddStep("push screen", () => LoadScreen(screen = new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
             AddUntilStep("wait for screen", () => screen.IsCurrentScreen());
             AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
-
-            Func<APIRequest, bool>? previousHandler = null;
-
-            AddStep("install custom handler", () =>
-            {
-                previousHandler = ((DummyAPIAccess)API).HandleRequest;
-                ((DummyAPIAccess)API).HandleRequest = req =>
-                {
-                    switch (req)
-                    {
-                        case GetRoomRequest r:
-                        {
-                            r.TriggerSuccess(new Room
-                            {
-                                RoomID = { Value = 1235, },
-                                Name = { Value = "Daily Challenge: June 5, 2024" },
-                                Playlist =
-                                {
-                                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
-                                    {
-                                        RequiredMods = [new APIMod(new OsuModTraceable())],
-                                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
-                                    }
-                                },
-                                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
-                                Category = { Value = RoomCategory.DailyChallenge }
-                            });
-                            return true;
-                        }
-
-                        default:
-                            return false;
-                    }
-                };
-            });
-            AddStep("next daily challenge started", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1235 });
-
-            AddStep("restore previous handler", () => ((DummyAPIAccess)API).HandleRequest = previousHandler);
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -76,8 +76,12 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             AddStep("set daily challenge info", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1234 });
             AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
             AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
+
+            Func<APIRequest, bool>? previousHandler = null;
+
             AddStep("install custom handler", () =>
             {
+                previousHandler = ((DummyAPIAccess)API).HandleRequest;
                 ((DummyAPIAccess)API).HandleRequest = req =>
                 {
                     switch (req)
@@ -108,6 +112,8 @@ namespace osu.Game.Tests.Visual.DailyChallenge
                 };
             });
             AddStep("next daily challenge started", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1235 });
+
+            AddStep("restore previous handler", () => ((DummyAPIAccess)API).HandleRequest = previousHandler);
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Screens;
 using osu.Game.Online.API;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
@@ -74,7 +75,10 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 
             AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
             AddStep("set daily challenge info", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1234 });
-            AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+
+            Screens.OnlinePlay.DailyChallenge.DailyChallenge screen = null!;
+            AddStep("push screen", () => LoadScreen(screen = new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+            AddUntilStep("wait for screen", () => screen.IsCurrentScreen());
             AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
 
             Func<APIRequest, bool>? previousHandler = null;

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -4,16 +4,32 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Game.Online.API;
+using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Tests.Resources;
+using osu.Game.Tests.Visual.Metadata;
 using osu.Game.Tests.Visual.OnlinePlay;
 
 namespace osu.Game.Tests.Visual.DailyChallenge
 {
     public partial class TestSceneDailyChallenge : OnlinePlayTestScene
     {
+        [Cached(typeof(MetadataClient))]
+        private TestMetadataClient metadataClient = new TestMetadataClient();
+
+        [Cached(typeof(INotificationOverlay))]
+        private NotificationOverlay notificationOverlay = new NotificationOverlay();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            base.Content.Add(notificationOverlay);
+        }
+
         [Test]
         public void TestDailyChallenge()
         {
@@ -35,6 +51,63 @@ namespace osu.Game.Tests.Visual.DailyChallenge
 
             AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
             AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+        }
+
+        [Test]
+        public void TestNotifications()
+        {
+            var room = new Room
+            {
+                RoomID = { Value = 1234 },
+                Name = { Value = "Daily Challenge: June 4, 2024" },
+                Playlist =
+                {
+                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
+                    {
+                        RequiredMods = [new APIMod(new OsuModTraceable())],
+                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
+                    }
+                },
+                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
+                Category = { Value = RoomCategory.DailyChallenge }
+            };
+
+            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
+            AddStep("set daily challenge info", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1234 });
+            AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+            AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
+            AddStep("install custom handler", () =>
+            {
+                ((DummyAPIAccess)API).HandleRequest = req =>
+                {
+                    switch (req)
+                    {
+                        case GetRoomRequest r:
+                        {
+                            r.TriggerSuccess(new Room
+                            {
+                                RoomID = { Value = 1235, },
+                                Name = { Value = "Daily Challenge: June 5, 2024" },
+                                Playlist =
+                                {
+                                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
+                                    {
+                                        RequiredMods = [new APIMod(new OsuModTraceable())],
+                                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
+                                    }
+                                },
+                                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
+                                Category = { Value = RoomCategory.DailyChallenge }
+                            });
+                            return true;
+                        }
+
+                        default:
+                            return false;
+                    }
+                };
+            });
+            AddStep("next daily challenge started", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1235 });
         }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -10,6 +11,7 @@ using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
 using osu.Game.Screens.Menu;
 using osuTK.Input;
 using Color4 = osuTK.Graphics.Color4;
@@ -39,8 +41,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestDailyChallengeButton()
         {
-            AddStep("beatmap of the day not active", () => metadataClient.DailyChallengeUpdated(null));
-
             AddStep("set up API", () => dummyAPI.HandleRequest = req =>
             {
                 switch (req)
@@ -67,17 +67,45 @@ namespace osu.Game.Tests.Visual.UserInterface
                 }
             });
 
-            AddStep("add button", () => Child = new DailyChallengeButton(@"button-default-select", new Color4(102, 68, 204, 255), _ => { }, 0, Key.D)
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                ButtonSystemState = ButtonSystemState.TopLevel,
-            });
+            NotificationOverlay notificationOverlay = null!;
+            DependencyProvidingContainer buttonContainer = null!;
 
             AddStep("beatmap of the day active", () => metadataClient.DailyChallengeUpdated(new DailyChallengeInfo
             {
                 RoomID = 1234,
             }));
+            AddStep("add content", () =>
+            {
+                notificationOverlay = new NotificationOverlay();
+                Children = new Drawable[]
+                {
+                    notificationOverlay,
+                    buttonContainer = new DependencyProvidingContainer
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        AutoSizeAxes = Axes.Both,
+                        CachedDependencies = [(typeof(INotificationOverlay), notificationOverlay)],
+                        Child = new DailyChallengeButton(@"button-default-select", new Color4(102, 68, 204, 255), _ => { }, 0, Key.D)
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            ButtonSystemState = ButtonSystemState.TopLevel,
+                        },
+                    },
+                };
+            });
+            AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
+
+            AddStep("beatmap of the day not active", () => metadataClient.DailyChallengeUpdated(null));
+            AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
+
+            AddStep("hide button's parent", () => buttonContainer.Hide());
+            AddStep("beatmap of the day active", () => metadataClient.DailyChallengeUpdated(new DailyChallengeInfo
+            {
+                RoomID = 1234,
+            }));
+            AddAssert("notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
         }
     }
 }

--- a/osu.Game/Localisation/DailyChallengeStrings.cs
+++ b/osu.Game/Localisation/DailyChallengeStrings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+
+namespace osu.Game.Localisation
+{
+    public static class DailyChallengeStrings
+    {
+        private const string prefix = @"osu.Game.Resources.Localisation.DailyChallenge";
+
+        /// <summary>
+        /// "Today&#39;s daily challenge has concluded – thanks for playing!
+        ///
+        /// Tomorrow&#39;s challenge is now being prepared and will appear soon."
+        /// </summary>
+        public static LocalisableString ChallengeEndedNotification => new TranslatableString(getKey(@"todays_daily_challenge_has_concluded"),
+            @"Today's daily challenge has concluded – thanks for playing!
+
+Tomorrow's challenge is now being prepared and will appear soon.");
+
+        /// <summary>
+        /// "Today&#39;s daily challenge is now live! Click here to play."
+        /// </summary>
+        public static LocalisableString ChallengeLiveNotification => new TranslatableString(getKey(@"todays_daily_challenge_is_now"), @"Today's daily challenge is now live! Click here to play.");
+
+        private static string getKey(string key) => $@"{prefix}:{key}";
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -67,8 +67,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         private DailyChallengeTotalsDisplay totals = null!;
         private DailyChallengeEventFeed feed = null!;
 
-        private SimpleNotification? waitForNextChallengeNotification;
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
 
@@ -419,7 +417,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         {
             if (change.OldValue?.RoomID == room.RoomID.Value && change.NewValue == null)
             {
-                notificationOverlay?.Post(waitForNextChallengeNotification = new SimpleNotification
+                notificationOverlay?.Post(new SimpleNotification
                 {
                     Text = "Today's daily challenge has concluded. Thanks for playing! The next one should appear in a few minutes."
                 });

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -419,7 +419,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             {
                 notificationOverlay?.Post(new SimpleNotification
                 {
-                    Text = "Today's daily challenge has concluded. Thanks for playing! The next one should appear in a few minutes."
+                    Text = "Today's daily challenge has concluded – thanks for playing!\n\nTomorrow's challenge is now being prepared and will appear soon."
                 });
             }
         }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -424,18 +424,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     Text = "Today's daily challenge has concluded. Thanks for playing! The next one should appear in a few minutes."
                 });
             }
-
-            if (change.NewValue != null && change.NewValue.Value.RoomID != room.RoomID.Value)
-            {
-                var roomRequest = new GetRoomRequest(change.NewValue.Value.RoomID);
-
-                roomRequest.Success += room =>
-                {
-                    waitForNextChallengeNotification?.Close(false);
-                    notificationOverlay?.Post(new NewDailyChallengeNotification(room));
-                };
-                API.Queue(roomRequest);
-            }
         }
 
         private void forcefullyExit()

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -417,16 +417,13 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         {
             if (change.OldValue?.RoomID == room.RoomID.Value && change.NewValue == null)
             {
-                notificationOverlay?.Post(new SimpleNotification
-                {
-                    Text = "Today's daily challenge has concluded – thanks for playing!\n\nTomorrow's challenge is now being prepared and will appear soon."
-                });
+                notificationOverlay?.Post(new SimpleNotification { Text = DailyChallengeStrings.ChallengeEndedNotification });
             }
         }
 
         private void forcefullyExit()
         {
-            Logger.Log($"{this} forcefully exiting due to loss of API connection");
+            Logger.Log(@$"{this} forcefully exiting due to loss of API connection");
 
             // This is temporary since we don't currently have a way to force screens to be exited
             // See also: `OnlinePlayScreen.forcefullyExit()`

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -9,6 +9,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         [BackgroundDependencyLoader]
         private void load(OsuGame? game)
         {
-            Text = "Today's daily challenge is now live! Click here to play.";
+            Text = DailyChallengeStrings.ChallengeLiveNotification;
             Content.Add(card = new BeatmapCardNano((APIBeatmapSet)room.Playlist.Single().Beatmap.BeatmapSet!));
             Activated = () =>
             {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         [BackgroundDependencyLoader]
         private void load(OsuGame? game)
         {
-            Text = "Today's daily challenge is here! Click here to play.";
+            Text = "Today's daily challenge is now live! Click here to play.";
             Content.Add(card = new BeatmapCardNano((APIBeatmapSet)room.Playlist.Single().Beatmap.BeatmapSet!));
             Activated = () =>
             {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Screens;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge
+{
+    public partial class NewDailyChallengeNotification : SimpleNotification
+    {
+        private readonly Room room;
+
+        private BeatmapCardNano card = null!;
+
+        public NewDailyChallengeNotification(Room room)
+        {
+            this.room = room;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame? game)
+        {
+            Text = "Today's daily challenge is here! Click here to play.";
+            Content.Add(card = new BeatmapCardNano((APIBeatmapSet)room.Playlist.Single().Beatmap.BeatmapSet!));
+            Activated = () =>
+            {
+                game?.PerformFromScreen(s => s.Push(new DailyChallenge(room)), [typeof(MainMenu)]);
+                return true;
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            card.Width = Content.DrawWidth;
+        }
+    }
+}

--- a/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
+++ b/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Metadata
         public override IBindableDictionary<int, UserPresence> UserStates => userStates;
         private readonly BindableDictionary<int, UserPresence> userStates = new BindableDictionary<int, UserPresence>();
 
-        public override IBindable<DailyChallengeInfo?> DailyChallengeInfo => dailyChallengeInfo;
+        public override Bindable<DailyChallengeInfo?> DailyChallengeInfo => dailyChallengeInfo;
         private readonly Bindable<DailyChallengeInfo?> dailyChallengeInfo = new Bindable<DailyChallengeInfo?>();
 
         [Resolved]

--- a/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
+++ b/osu.Game/Tests/Visual/Metadata/TestMetadataClient.cs
@@ -88,7 +88,14 @@ namespace osu.Game.Tests.Visual.Metadata
         }
 
         public override Task<MultiplayerPlaylistItemStats[]> BeginWatchingMultiplayerRoom(long id)
-            => Task.FromResult(new MultiplayerPlaylistItemStats[MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS]);
+        {
+            var stats = new MultiplayerPlaylistItemStats[MultiplayerPlaylistItemStats.TOTAL_SCORE_DISTRIBUTION_BINS];
+
+            for (int i = 0; i < stats.Length; i++)
+                stats[i] = new MultiplayerPlaylistItemStats { PlaylistItemID = i };
+
+            return Task.FromResult(stats);
+        }
 
         public override Task EndWatchingMultiplayerRoom(long id) => Task.CompletedTask;
     }


### PR DESCRIPTION
https://github.com/user-attachments/assets/d11a6b0c-a96e-4b70-b98e-44b1fe318844

Because I wish to stop seeing "DAILY CHALLENGE WHERE" every day on #general.

The notifications are constrained to the daily challenge screen only to not spam users who may not care.