### PR TITLE
Always show control points in timing mode

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -195,15 +195,17 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 }
                 else
                 {
-                    this.ResizeHeightTo(timeline_height, 200, Easing.OutQuint);
-                    mainContent.MoveToY(0, 200, Easing.OutQuint);
+                    // delay the resize until the fade is complete.
+                    this.Delay(180).ResizeHeightTo(timeline_height, 200, Easing.OutQuint);
+                    mainContent.Delay(180).MoveToY(0, 200, Easing.OutQuint);
                 }
             }, true);
 
             controlPointsVisible.BindValueChanged(visible =>
             {
                 if (visible.NewValue)
-                    controlPoints.FadeIn(400, Easing.OutQuint);
+                    // delay the fade in else masking looks weird.
+                    controlPoints.Delay(180).FadeIn(400, Easing.OutQuint);
                 else
                     controlPoints.FadeOut(200, Easing.OutQuint);
             }, true);


### PR DESCRIPTION
i was trying to time a piano-only beatmap yesterday and got very frustrated since i couldn't tell what bpm i was on in the timing panel... until i realized it was disabled, which for some reason also means that it's invisible in the panel specifically meant for timing.

maybe the top menu text should also change to `Always show timing changes` to indicate that timing changes may be shown forcibly at times.

thanks in advance for review, still very unfamiliar with codebase.