### PR TITLE
Adjust chat sizing to better fit long usernames

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneDrawableChannel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays.Chat;
@@ -88,19 +89,17 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestBackgroundAlternating()
         {
-            var localUser = new APIUser
-            {
-                Id = 3,
-                Username = "LocalUser"
-            };
-
             int messageCount = 1;
 
             AddRepeatStep("add messages", () =>
             {
                 channel.AddNewMessages(new Message(messageCount)
                 {
-                    Sender = localUser,
+                    Sender = new APIUser
+                    {
+                        Id = 3,
+                        Username = "LocalUser " + RNG.Next(0, int.MaxValue - 100).ToString("N")
+                    },
                     Content = "Hi there all!",
                     Timestamp = new DateTimeOffset(2022, 11, 21, 20, messageCount, 13, TimeSpan.Zero),
                     Uuid = Guid.NewGuid().ToString(),

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Online.Chat
         {
             protected override float FontSize => 13;
             protected override float Spacing => 5;
-            protected override float UsernameWidth => 75;
+            protected override float UsernameWidth => 90;
 
             public StandAloneMessage(Message message)
                 : base(message)

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Online.Chat
 
         protected partial class StandAloneDaySeparator : DaySeparator
         {
-            protected override float TextSize => 14;
+            protected override float TextSize => 13;
             protected override float LineHeight => 1;
             protected override float Spacing => 5;
             protected override float DateAlign => 125;
@@ -198,7 +198,7 @@ namespace osu.Game.Online.Chat
 
         protected partial class StandAloneMessage : ChatLine
         {
-            protected override float FontSize => 15;
+            protected override float FontSize => 13;
             protected override float Spacing => 5;
             protected override float UsernameWidth => 75;
 

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Overlays.Chat
 
         public IReadOnlyCollection<Drawable> DrawableContentFlow => drawableContentFlow;
 
-        protected virtual float FontSize => 14;
+        protected virtual float FontSize => 12;
 
         protected virtual float Spacing => 15;
 

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Overlays.Chat
 
         private void updateTimestamp()
         {
-            drawableTimestamp.Text = message.Timestamp.LocalDateTime.ToLocalisableString(prefer24HourTime.Value ? @"HH:mm:ss" : @"hh:mm:ss tt");
+            drawableTimestamp.Text = message.Timestamp.LocalDateTime.ToLocalisableString(prefer24HourTime.Value ? @"HH:mm" : @"hh:mm tt");
         }
 
         private static readonly Color4[] default_username_colours =

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -71,6 +71,25 @@ namespace osu.Game.Overlays.Chat
         private Drawable? background;
 
         private bool alternatingBackground;
+        private bool requiresTimestamp = true;
+
+
+        public bool RequiresTimestamp
+        {
+            get => requiresTimestamp;
+            set
+            {
+                if (requiresTimestamp == value)
+                    return;
+
+                requiresTimestamp = value;
+
+                if (!IsLoaded)
+                    return;
+
+                updateMessageContent();
+            }
+        }
 
         public bool AlternatingBackground
         {
@@ -244,9 +263,17 @@ namespace osu.Game.Overlays.Chat
         private void updateMessageContent()
         {
             this.FadeTo(message is LocalEchoMessage ? 0.4f : 1.0f, 500, Easing.OutQuint);
-            drawableTimestamp.FadeTo(message is LocalEchoMessage ? 0 : 1, 500, Easing.OutQuint);
 
-            updateTimestamp();
+            if (requiresTimestamp && !(message is LocalEchoMessage))
+            {
+                drawableTimestamp.Show();
+                updateTimestamp();
+            }
+            else
+            {
+                drawableTimestamp.Hide();
+            }
+
             drawableUsername.Text = $@"{message.Sender.Username}";
 
             // remove non-existent channels from the link list

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -20,6 +20,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Chat
@@ -50,7 +51,7 @@ namespace osu.Game.Overlays.Chat
 
         protected virtual float Spacing => 15;
 
-        protected virtual float UsernameWidth => 130;
+        protected virtual float UsernameWidth => 150;
 
         [Resolved]
         private ChannelManager? chatManager { get; set; }
@@ -72,7 +73,6 @@ namespace osu.Game.Overlays.Chat
 
         private bool alternatingBackground;
         private bool requiresTimestamp = true;
-
 
         public bool RequiresTimestamp
         {
@@ -166,7 +166,7 @@ namespace osu.Game.Overlays.Chat
                     RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
                     ColumnDimensions = new[]
                     {
-                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.Absolute, 45),
                         new Dimension(GridSizeMode.Absolute, Spacing + UsernameWidth + Spacing),
                         new Dimension(),
                     },
@@ -177,9 +177,10 @@ namespace osu.Game.Overlays.Chat
                             drawableTimestamp = new OsuSpriteText
                             {
                                 Shadow = false,
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                Font = OsuFont.GetFont(size: FontSize * 0.75f, weight: FontWeight.SemiBold, fixedWidth: true),
+                                Anchor = Anchor.TopLeft,
+                                Origin = Anchor.TopLeft,
+                                Spacing = new Vector2(-1, 0),
+                                Font = OsuFont.GetFont(size: FontSize, weight: FontWeight.SemiBold, fixedWidth: true),
                                 AlwaysPresent = true,
                             },
                             drawableUsername = new DrawableChatUsername(message.Sender)

--- a/osu.Game/Overlays/Chat/DaySeparator.cs
+++ b/osu.Game/Overlays/Chat/DaySeparator.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Overlays.Chat
 {
     public partial class DaySeparator : Container
     {
-        protected virtual float TextSize => 15;
+        protected virtual float TextSize => 13;
 
         protected virtual float LineHeight => 2;
 

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -88,13 +88,13 @@ namespace osu.Game.Overlays.Chat
         {
             base.Update();
 
-            int? lastMinutes = null;
+            long? lastMinutes = null;
 
             for (int i = 0; i < ChatLineFlow.Count; i++)
             {
                 if (ChatLineFlow[i] is ChatLine chatline)
                 {
-                    int minutes = chatline.Message.Timestamp.TotalOffsetMinutes;
+                    long minutes = chatline.Message.Timestamp.ToUnixTimeSeconds() / 60;
 
                     chatline.AlternatingBackground = i % 2 == 0;
                     chatline.RequiresTimestamp = minutes != lastMinutes;

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Overlays.Chat
                     Padding = new MarginPadding { Bottom = 5 },
                     Child = ChatLineFlow = new FillFlowContainer
                     {
-                        Padding = new MarginPadding { Horizontal = 10 },
+                        Padding = new MarginPadding { Left = 3, Right = 10 },
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Vertical,

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -88,15 +88,17 @@ namespace osu.Game.Overlays.Chat
         {
             base.Update();
 
-            int? minute = null;
+            int? lastMinutes = null;
 
             for (int i = 0; i < ChatLineFlow.Count; i++)
             {
                 if (ChatLineFlow[i] is ChatLine chatline)
                 {
+                    int minutes = chatline.Message.Timestamp.TotalOffsetMinutes;
+
                     chatline.AlternatingBackground = i % 2 == 0;
-                    chatline.RequiresTimestamp = chatline.Message.Timestamp.Minute != minute;
-                    minute = chatline.Message.Timestamp.Minute;
+                    chatline.RequiresTimestamp = minutes != lastMinutes;
+                    lastMinutes = minutes;
                 }
             }
         }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -88,10 +88,16 @@ namespace osu.Game.Overlays.Chat
         {
             base.Update();
 
+            int? minute = null;
+
             for (int i = 0; i < ChatLineFlow.Count; i++)
             {
                 if (ChatLineFlow[i] is ChatLine chatline)
+                {
                     chatline.AlternatingBackground = i % 2 == 0;
+                    chatline.RequiresTimestamp = chatline.Message.Timestamp.Minute != minute;
+                    minute = chatline.Message.Timestamp.Minute;
+                }
             }
         }
 


### PR DESCRIPTION
Arguably 12 point is too small, but we use it in so many other places. It's more likely that a lot of other text is just too large 🤷 

- Reduce clutter by only showing timestamps when more than a minute has passed
- Reduce size of font and padding
- Don't show seconds

| Before | After |
| :---: | :---: |
| ![osu! 2024-07-30 at 09 00 01](https://github.com/user-attachments/assets/b41fc1ec-dc85-4841-8564-1164fd36aedd) | ![osu! 2024-07-30 at 08 59 32](https://github.com/user-attachments/assets/61f818d4-ad0a-4fca-9086-f657036c045a) |
| ![osu! 2024-07-30 at 09 00 18](https://github.com/user-attachments/assets/96310bd9-0f0c-4b38-bff2-78e7ccc44297) | ![osu! 2024-07-30 at 09 00 41](https://github.com/user-attachments/assets/9c223fdf-6354-48a9-85df-02c0c6bbff9c) |