### PR TITLE
Submit vertices in local space to avoid cross-thread access

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -220,7 +220,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             private float fadeExponent;
 
             private readonly TrailPart[] parts = new TrailPart[max_sprites];
-            private Vector2 size;
             private Vector2 originPosition;
 
             private IVertexBatch<TexturedTrailVertex> vertexBatch;
@@ -236,7 +235,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                 shader = Source.shader;
                 texture = Source.texture;
-                size = Source.partSize;
                 time = Source.time;
                 fadeExponent = Source.FadeExponent;
 
@@ -277,6 +275,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                 RectangleF textureRect = texture.GetTextureRect();
 
+                renderer.PushLocalMatrix(DrawInfo.Matrix);
+
                 foreach (var part in parts)
                 {
                     if (part.InvalidationID == -1)
@@ -285,11 +285,9 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     if (time - part.Time >= 1)
                         continue;
 
-                    Vector2 screenSpacePos = Source.ToScreenSpace(part.Position);
-
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(screenSpacePos.X - size.X * originPosition.X, screenSpacePos.Y + size.Y * (1 - originPosition.Y)),
+                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y)),
                         TexturePosition = textureRect.BottomLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.BottomLeft.Linear,
@@ -298,7 +296,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(screenSpacePos.X + size.X * (1 - originPosition.X), screenSpacePos.Y + size.Y * (1 - originPosition.Y)),
+                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X), part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y)),
                         TexturePosition = textureRect.BottomRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.BottomRight.Linear,
@@ -307,7 +305,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(screenSpacePos.X + size.X * (1 - originPosition.X), screenSpacePos.Y - size.Y * originPosition.Y),
+                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X), part.Position.Y - texture.DisplayHeight * originPosition.Y),
                         TexturePosition = textureRect.TopRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.TopRight.Linear,
@@ -316,13 +314,15 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(screenSpacePos.X - size.X * originPosition.X, screenSpacePos.Y - size.Y * originPosition.Y),
+                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X, part.Position.Y - texture.DisplayHeight * originPosition.Y),
                         TexturePosition = textureRect.TopLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.TopLeft.Linear,
                         Time = part.Time
                     });
                 }
+
+                renderer.PopLocalMatrix();
 
                 vertexBatch.Draw();
                 shader.Unbind();


### PR DESCRIPTION
See discussion in https://github.com/ppy/osu/pull/29070#discussion_r1696668520

Also saves doing many `ToScreenSpace()` calls in draw.