### PR TITLE
Flash customise button on mod overlay when it becomes available

### DIFF
--- a/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -11,14 +12,16 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
-using osuTK;
 using osu.Game.Localisation;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Mods
 {
     public partial class ModCustomisationHeader : OsuHoverContainer
     {
         private Box background = null!;
+        private Box backgroundFlash = null!;
         private SpriteIcon icon = null!;
 
         [Resolved]
@@ -45,6 +48,12 @@ namespace osu.Game.Overlays.Mods
                 background = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
+                },
+                backgroundFlash = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.White.Opacity(0.4f),
+                    Blending = BlendingParameters.Additive,
                 },
                 new OsuSpriteText
                 {
@@ -84,6 +93,12 @@ namespace osu.Game.Overlays.Mods
                 TooltipText = e.NewValue
                     ? string.Empty
                     : ModSelectOverlayStrings.CustomisationPanelDisabledReason;
+
+                if (e.NewValue)
+                {
+                    backgroundFlash.FadeInFromZero(150, Easing.OutQuad).Then()
+                                   .FadeOutFromOne(350, Easing.OutQuad);
+                }
             }, true);
 
             Expanded.BindValueChanged(v =>


### PR DESCRIPTION
I want to make it more visible when it becomes enabled, since some users (myself included) may overlook it. Just a helpful little nudge.


https://github.com/user-attachments/assets/b1f6a704-26f8-4409-8f83-5e3c278bdb8a

