### PR TITLE
disallowing Change folder location under root/administrator privileges

### DIFF
--- a/osu.Game/IO/MigratableStorage.cs
+++ b/osu.Game/IO/MigratableStorage.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using osu.Framework;
 using osu.Framework.Platform;
 using osu.Game.Utils;
 
@@ -49,6 +50,9 @@ namespace osu.Game.IO
             // using Uri is the easiest way to check equality and contains (https://stackoverflow.com/a/7710620)
             var sourceUri = new Uri(source.FullName + Path.DirectorySeparatorChar);
             var destinationUri = new Uri(destination.FullName + Path.DirectorySeparatorChar);
+
+            if (Environment.IsPrivilegedProcess)
+                throw new ArgumentException($"Changing folder location under {(RuntimeInfo.IsUnix ? "root" : "administrator")} privileges may break integrations and poses a security risk. Please run the game as a normal user.");
 
             if (sourceUri == destinationUri)
                 throw new ArgumentException("Destination provided is already the current location", destination.FullName);


### PR DESCRIPTION
## Issue
If osu is run as administrator and the "Change folder location..." action attempts to move the folder to a directory requiring administrator permissions (such as "C:\Program Files" on Windows), osu will fail to launch unless it is run as administrator due to inability to access the data directory.

## Details
Throw an exception if it is detected that the "Change folder location..." action is run with administrator privileges.

See Also:
#20976 #22530