### PR TITLE
Show breaks behind objects in timeline

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -69,19 +69,24 @@ namespace osu.Game.Screens.Edit.Compose
             if (ruleset == null || composer == null)
                 return base.CreateTimelineContent();
 
+            TimelineBreakDisplay breakDisplay = new TimelineBreakDisplay
+            {
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Height = 0.75f,
+            };
+
             return wrapSkinnableContent(new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                Children = new[]
                 {
+                    // We want to display this below hitobjects to better expose placement objects visually.
+                    // It needs to be above the blueprint container to handle drags on breaks though.
+                    breakDisplay.CreateProxy(),
                     new TimelineBlueprintContainer(composer),
-                    new TimelineBreakDisplay
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Height = 0.75f,
-                    },
+                    breakDisplay
                 }
             });
         }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29227.

![osu! 2024-08-01 at 10 44 56](https://github.com/user-attachments/assets/0878d44b-72f7-44a0-a2c2-9eed854a2019)
