### PR TITLE
Fix click sounds playing twice on `OsuRearrangeableListItem`

### DIFF
--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -43,6 +43,9 @@ namespace osu.Game.Collections
             //
             // if we want to support user sorting (but changes will need to be made to realm to persist).
             ShowDragHandle.Value = false;
+
+            Masking = true;
+            CornerRadius = item_height / 2;
         }
 
         protected override Drawable CreateContent() => new ItemContent(Model);
@@ -50,7 +53,7 @@ namespace osu.Game.Collections
         /// <summary>
         /// The main content of the <see cref="DrawableCollectionListItem"/>.
         /// </summary>
-        private partial class ItemContent : CircularContainer
+        private partial class ItemContent : CompositeDrawable
         {
             private readonly Live<BeatmapCollection> collection;
 
@@ -65,13 +68,12 @@ namespace osu.Game.Collections
 
                 RelativeSizeAxes = Axes.X;
                 Height = item_height;
-                Masking = true;
             }
 
             [BackgroundDependencyLoader]
             private void load()
             {
-                Children = new[]
+                InternalChildren = new[]
                 {
                     collection.IsManaged
                         ? new DeleteButton(collection)

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Collections
             }
         }
 
-        public partial class DeleteButton : CompositeDrawable
+        public partial class DeleteButton : OsuClickableContainer
         {
             public Func<Vector2, bool> IsTextBoxHovered = null!;
 
@@ -155,7 +155,7 @@ namespace osu.Game.Collections
             [BackgroundDependencyLoader]
             private void load(OsuColour colours)
             {
-                InternalChild = fadeContainer = new Container
+                Child = fadeContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
                     Alpha = 0.1f,
@@ -176,6 +176,14 @@ namespace osu.Game.Collections
                         }
                     }
                 };
+
+                Action = () =>
+                {
+                    if (collection.PerformRead(c => c.BeatmapMD5Hashes.Count) == 0)
+                        deleteCollection();
+                    else
+                        dialogOverlay?.Push(new DeleteCollectionDialog(collection, deleteCollection));
+                };
             }
 
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => base.ReceivePositionalInputAt(screenSpacePos) && !IsTextBoxHovered(screenSpacePos);
@@ -195,12 +203,7 @@ namespace osu.Game.Collections
             {
                 background.FlashColour(Color4.White, 150);
 
-                if (collection.PerformRead(c => c.BeatmapMD5Hashes.Count) == 0)
-                    deleteCollection();
-                else
-                    dialogOverlay?.Push(new DeleteCollectionDialog(collection, deleteCollection));
-
-                return true;
+                return base.OnClick(e);
             }
 
             private void deleteCollection() => collection.PerformWrite(c => c.Realm!.Remove(c));

--- a/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
+++ b/osu.Game/Graphics/Containers/OsuRearrangeableListItem.cs
@@ -64,6 +64,7 @@ namespace osu.Game.Graphics.Containers
         {
             InternalChildren = new Drawable[]
             {
+                new HoverClickSounds(),
                 new GridContainer
                 {
                     RelativeSizeAxes = Axes.X,
@@ -92,7 +93,6 @@ namespace osu.Game.Graphics.Containers
                     ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
                     RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
                 },
-                new HoverClickSounds()
             };
         }
 


### PR DESCRIPTION
- Same as https://github.com/ppy/osu/pull/22633

Have checked all inherited classes.

Before:

https://github.com/user-attachments/assets/214976d9-00ea-49d9-9c12-70f014c6c0d9


After:

https://github.com/user-attachments/assets/1c1822e6-baac-4a57-bd27-640be0d3c3fb

Side effect:
- Collection text boxes don't have click sounds anymore (only hover sounds as hover isn't handled)
	- seems right as other textboxes (i.e. on login overlay, editor setup) don't have click (and hover) sounds, so the clicking is consistent