### PR TITLE
Fix pause input handling in osu! not working like stable

### DIFF
--- a/osu.Android.props
+++ b/osu.Android.props
@@ -10,7 +10,7 @@
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.Android" Version="2024.720.0" />
+    <PackageReference Include="ppy.osu.Framework.Android" Version="2024.802.0" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Fody does not handle Android build well, and warns when unchanged.

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -206,6 +206,15 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => HitObjectContainer.ReceivePositionalInputAt(screenSpacePos);
 
+        private OsuResumeOverlay.OsuResumeOverlayInputBlocker resumeInputBlocker;
+
+        public void AttachResumeOverlayInputBlocker(OsuResumeOverlay.OsuResumeOverlayInputBlocker resumeInputBlocker)
+        {
+            Debug.Assert(this.resumeInputBlocker == null);
+            this.resumeInputBlocker = resumeInputBlocker;
+            AddInternal(resumeInputBlocker);
+        }
+
         private partial class ProxyContainer : LifetimeManagementContainer
         {
             public void Add(Drawable proxy) => AddInternal(proxy);

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -206,7 +206,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => HitObjectContainer.ReceivePositionalInputAt(screenSpacePos);
 
-        private OsuResumeOverlay.OsuResumeOverlayInputBlocker resumeInputBlocker;
+        private OsuResumeOverlay.OsuResumeOverlayInputBlocker? resumeInputBlocker;
 
         public void AttachResumeOverlayInputBlocker(OsuResumeOverlay.OsuResumeOverlayInputBlocker resumeInputBlocker)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -174,14 +174,9 @@ namespace osu.Game.Rulesets.Osu.UI
 
             public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
             {
-                try
-                {
-                    return BlockNextPress;
-                }
-                finally
-                {
-                    BlockNextPress = false;
-                }
+                bool block = BlockNextPress;
+                BlockNextPress = false;
+                return block;
             }
 
             public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -47,6 +47,10 @@ namespace osu.Game.Rulesets.Osu.UI
                 {
                     ResumeRequested = () =>
                     {
+                        // since the user had to press a button to tap the resume cursor,
+                        // block that press event from potentially reaching a hit circle that's behind the cursor.
+                        // we cannot do this from OsuClickToResumeCursor directly since we're in a different input manager tree than the gameplay one,
+                        // so we rely on a dedicated input blocking component that's implanted in there to do that for us.
                         if (inputBlocker != null)
                             inputBlocker.BlockNextPress = true;
 

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -115,10 +115,7 @@ namespace osu.Game.Rulesets.Osu.UI
                             return false;
 
                         scaleTransitionContainer.ScaleTo(2, TRANSITION_TIME, Easing.OutQuint);
-
-                        // When resuming with a button, we do not want the osu! input manager to see this button press and include it in the score.
-                        // To ensure that this works correctly, schedule the resume operation one frame forward, since the resume operation enables the input manager to see input events.
-                        Schedule(() => ResumeRequested?.Invoke());
+                        ResumeRequested?.Invoke();
                         return true;
                 }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
@@ -19,7 +19,6 @@ using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
-
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
@@ -13,10 +14,12 @@ using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Play.HUD;
 using osu.Game.Skinning;
 using osu.Game.Storyboards;
+
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -31,6 +34,23 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Resolved]
         private AudioManager audioManager { get; set; } = null!;
+
+        protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new Beatmap
+        {
+            HitObjects =
+            {
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 0,
+                },
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 5000,
+                }
+            }
+        };
 
         protected override WorkingBeatmap CreateWorkingBeatmap(IBeatmap beatmap, Storyboard? storyboard = null) =>
             new ClockBackedTestWorkingBeatmap(beatmap, storyboard, new FramedClock(new ManualClock { Rate = 1 }), audioManager);
@@ -70,18 +90,16 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("resume", () => Player.Resume());
             AddStep("go to resume cursor", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single()));
             AddStep("press Z to resume", () => InputManager.PressKey(Key.Z));
-
-            // Z key was released before pause, resuming should not trigger it
-            checkKey(() => counter, 1, false);
-
-            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
-            checkKey(() => counter, 1, false);
-
-            AddStep("press Z", () => InputManager.PressKey(Key.Z));
             checkKey(() => counter, 2, true);
 
             AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
             checkKey(() => counter, 2, false);
+
+            AddStep("press Z", () => InputManager.PressKey(Key.Z));
+            checkKey(() => counter, 3, true);
+
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
+            checkKey(() => counter, 3, false);
         }
 
         [Test]
@@ -90,30 +108,29 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
             checkKey(() => counter, 0, false);
 
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
             checkKey(() => counter, 1, true);
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
             checkKey(() => counter, 1, false);
 
             AddStep("pause", () => Player.Pause());
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
             checkKey(() => counter, 1, false);
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
             checkKey(() => counter, 1, false);
 
             AddStep("resume", () => Player.Resume());
             AddUntilStep("wait for resume", () => Player.GameplayClockContainer.IsRunning);
-            checkKey(() => counter, 1, false);
 
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
             checkKey(() => counter, 2, true);
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
             checkKey(() => counter, 2, false);
         }
 
@@ -145,8 +162,11 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("resume", () => Player.Resume());
             AddStep("go to resume cursor", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single()));
             AddStep("press Z to resume", () => InputManager.PressKey(Key.Z));
-            checkKey(() => counterZ, 1, false);
+            checkKey(() => counterZ, 2, true);
             checkKey(() => counterX, 1, false);
+
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
+            checkKey(() => counterZ, 2, false);
         }
 
         [Test]
@@ -155,12 +175,12 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
 
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
             AddStep("pause", () => Player.Pause());
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
             checkKey(() => counter, 1, true);
 
             AddStep("resume", () => Player.Resume());
@@ -202,12 +222,14 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddStep("resume", () => Player.Resume());
             AddStep("go to resume cursor", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single()));
             AddStep("press Z to resume", () => InputManager.PressKey(Key.Z));
-            checkKey(() => counterZ, 1, false);
+            checkKey(() => counterZ, 2, true);
             checkKey(() => counterX, 1, true);
 
             AddStep("release X", () => InputManager.ReleaseKey(Key.X));
-            checkKey(() => counterZ, 1, false);
             checkKey(() => counterX, 1, false);
+
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
+            checkKey(() => counterZ, 2, false);
         }
 
         [Test]
@@ -216,22 +238,48 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
 
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
             checkKey(() => counter, 1, true);
 
             AddStep("pause", () => Player.Pause());
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
-            AddStep("press D", () => InputManager.PressKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
+            AddStep("press space", () => InputManager.PressKey(Key.Space));
 
             AddStep("resume", () => Player.Resume());
             AddUntilStep("wait for resume", () => Player.GameplayClockContainer.IsRunning);
             checkKey(() => counter, 1, true);
 
-            AddStep("release D", () => InputManager.ReleaseKey(Key.D));
+            AddStep("release space", () => InputManager.ReleaseKey(Key.Space));
             checkKey(() => counter, 1, false);
+        }
+
+        [Test]
+        public void TestOsuRegisterInputFromPressingOrangeCursorButPressIsBlocked()
+        {
+            KeyCounter counter = null!;
+
+            loadPlayer(() => new OsuRuleset());
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<OsuAction> actionTrigger && actionTrigger.Action == OsuAction.LeftButton));
+
+            AddStep("pause", () => Player.Pause());
+            AddStep("resume", () => Player.Resume());
+            AddStep("go to resume cursor", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single()));
+            AddStep("press Z to resume", () => InputManager.PressKey(Key.Z));
+
+            // ensure the input manager receives the Z button press...
+            checkKey(() => counter, 1, true);
+            AddAssert("button is pressed in kbc", () => Player.DrawableRuleset.Playfield.FindClosestParent<OsuInputManager>()!.PressedActions.Single() == OsuAction.LeftButton);
+
+            // ...but also ensure the hit circle in front of the cursor isn't hit by checking max combo.
+            AddAssert("circle not hit", () => Player.ScoreProcessor.HighestCombo.Value, () => Is.EqualTo(0));
+
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
+
+            checkKey(() => counter, 1, false);
+            AddAssert("button is released in kbc", () => !Player.DrawableRuleset.Playfield.FindClosestParent<OsuInputManager>()!.PressedActions.Any());
         }
 
         private void loadPlayer(Func<Ruleset> createRuleset)
@@ -241,9 +289,10 @@ namespace osu.Game.Tests.Visual.Gameplay
             AddUntilStep("player loaded", () => Player.IsLoaded && Player.Alpha == 1);
             AddUntilStep("wait for hud", () => Player.HUDOverlay.ChildrenOfType<SkinComponentsContainer>().All(s => s.ComponentsLoaded));
 
-            AddStep("seek to gameplay", () => Player.GameplayClockContainer.Seek(20000));
-            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(20000).Within(500));
+            AddStep("seek to gameplay", () => Player.GameplayClockContainer.Seek(0));
+            AddUntilStep("wait for seek to finish", () => Player.DrawableRuleset.FrameStableClock.CurrentTime, () => Is.EqualTo(0).Within(500));
             AddAssert("not in break", () => !Player.IsBreakTime.Value);
+            AddStep("move cursor to center", () => InputManager.MoveMouseTo(Player.DrawableRuleset.Playfield));
         }
 
         private void checkKey(Func<KeyCounter> counter, int count, bool active)

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2024.720.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2024.802.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2024.713.0" />
     <PackageReference Include="Sentry" Version="4.3.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->

--- a/osu.iOS.props
+++ b/osu.iOS.props
@@ -23,6 +23,6 @@
     <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Framework.iOS" Version="2024.720.0" />
+    <PackageReference Include="ppy.osu.Framework.iOS" Version="2024.802.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6347 because `TestManiaHeldInputRemainHeldAfterResume` suffers from that
- Closes https://github.com/ppy/osu/issues/29174

In stable, when you press the resume cursor, if there's a spinner then it's aware that you're currently pressing a key, but if there's a hit circle it does not respond to the press of that key.

This is mimicked here by removing the schedule that was implanted in https://github.com/ppy/osu/pull/28954/commits/4f6c7fe7c3c6941db20abc28cf321c03fa58646c in order to allow gameplay components to see the key press when pressing the resume cursor, but also add a local component somewhere in the osu! playfield to suppress the key press event from reaching any hit circle.

Existing tests were adjusted to acknowledge that pressing on the resume cursor triggers a gameplay press.