### PR TITLE
Interpolate parts in local space to avoid broken cursor trails

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -16,7 +16,6 @@ using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Layout;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
@@ -63,9 +62,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 // -1 signals that the part is unusable, and should not be drawn
                 parts[i].InvalidationID = -1;
             }
-
-            AddLayout(partSizeCache);
-            AddLayout(scaleRatioCache);
         }
 
         [BackgroundDependencyLoader]
@@ -95,12 +91,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 Invalidate(Invalidation.DrawNode);
             }
         }
-
-        private readonly LayoutValue<Vector2> partSizeCache = new LayoutValue<Vector2>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence);
-
-        private Vector2 partSize => partSizeCache.IsValid
-            ? partSizeCache.Value
-            : (partSizeCache.Value = new Vector2(Texture.DisplayWidth, Texture.DisplayHeight) * DrawInfo.Matrix.ExtractScale().Xy);
 
         /// <summary>
         /// The amount of time to fade the cursor trail pieces.
@@ -155,12 +145,6 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             return base.OnMouseMove(e);
         }
 
-        private readonly LayoutValue<Vector2> scaleRatioCache = new LayoutValue<Vector2>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence);
-
-        private Vector2 scaleRatio => scaleRatioCache.IsValid
-            ? scaleRatioCache.Value
-            : (scaleRatioCache.Value = DrawInfo.MatrixInverse.ExtractScale().Xy);
-
         protected void AddTrail(Vector2 position)
         {
             position = ToLocalSpace(position);
@@ -183,10 +167,10 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                     float distance = diff.Length;
                     Vector2 direction = diff / distance;
 
-                    Vector2 interval = partSize.X / 2.5f * IntervalMultiplier * scaleRatio;
-                    float stopAt = distance - (AvoidDrawingNearCursor ? interval.Length : 0);
+                    float interval = Texture.DisplayWidth / 2.5f * IntervalMultiplier;
+                    float stopAt = distance - (AvoidDrawingNearCursor ? interval : 0);
 
-                    for (Vector2 d = interval; d.Length < stopAt; d += interval)
+                    for (float d = interval; d < stopAt; d += interval)
                     {
                         lastPosition = pos1 + direction * d;
                         addPart(lastPosition.Value);


### PR DESCRIPTION
fixes #29214 
The trail parts were originally interpolated in the screen space but stored in local space. With `Barrel Roll` on, even if we are adding trails at the same position, the new parts have different angles compared to the previous parts because the whole playfield is rotating. This leads to the incorrect interpolation direction(`position - lastPosition`) because the `lastPosition` was actually rotated back a little relatively. 
![before](https://github.com/user-attachments/assets/e6ad08ae-3653-49d7-b3d6-dfc93a6cbc9d)

This PR interpolates parts in the local space, so the interpolation always follows the correct direction.

https://github.com/user-attachments/assets/adfe8dea-3db4-43c6-9b17-873cd6cc33e4
