### PR TITLE
Fix customise button on mod overlay initially showing flash layer indefinitely

### DIFF
--- a/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
@@ -54,6 +54,7 @@ namespace osu.Game.Overlays.Mods
                     RelativeSizeAxes = Axes.Both,
                     Colour = Color4.White.Opacity(0.4f),
                     Blending = BlendingParameters.Additive,
+                    Alpha = 0,
                 },
                 new OsuSpriteText
                 {


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/f709f6ca-0d4e-410e-9243-699089951529

After:

https://github.com/user-attachments/assets/ea2886a6-8635-4b03-bea3-56b32cb2177a

