### PR TITLE
Allow searching enum descriptions from `SettingsEnumDropdown`s

### DIFF
--- a/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
+++ b/osu.Game/Overlays/Settings/SettingsEnumDropdown.cs
@@ -2,7 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Settings
@@ -10,6 +14,8 @@ namespace osu.Game.Overlays.Settings
     public partial class SettingsEnumDropdown<T> : SettingsDropdown<T>
         where T : struct, Enum
     {
+        public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(Control.Items.Select(i => i.GetLocalisableDescription()));
+
         protected override OsuDropdown<T> CreateDropdown() => new DropdownControl();
 
         protected new partial class DropdownControl : OsuEnumDropdown<T>


### PR DESCRIPTION
Examples:

| Before | After |
| --- | --- |
| <img width="482" alt="Screenshot 2024-08-03 at 2 51 55 PM" src="https://github.com/user-attachments/assets/7ae793fa-d1eb-40ec-b8d0-c3d73703d18c"> | <img width="506" alt="Screenshot 2024-08-03 at 2 49 06 PM" src="https://github.com/user-attachments/assets/6fc5ad3c-cf1a-404c-b212-2a6cdb1fcb74"> |
| <img width="482" alt="Screenshot 2024-08-03 at 2 52 28 PM" src="https://github.com/user-attachments/assets/b0545f34-2324-49bd-8512-66b306db3ef5"> | <img width="488" alt="Screenshot 2024-08-03 at 2 49 21 PM" src="https://github.com/user-attachments/assets/ccd27ad8-9876-4051-9c64-9e02ad8a5da3"> |
| <img width="483" alt="Screenshot 2024-08-03 at 2 52 48 PM" src="https://github.com/user-attachments/assets/6ac46b97-4f19-42b7-925b-8ec65a27260e"> | <img width="479" alt="Screenshot 2024-08-03 at 2 49 56 PM" src="https://github.com/user-attachments/assets/6718330a-d95d-4aa4-8b84-80bfbd113835"> |