### PR TITLE
Add "sr" as an alias for searching Star Rating

### DIFF
--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Select
             {
                 case "star":
                 case "stars":
+                case "sr":
                     return TryUpdateCriteriaRange(ref criteria.StarDifficulty, op, value, 0.01d / 2);
 
                 case "ar":


### PR DESCRIPTION
Add sr as an alias for star rating in the search parameters.

I have done this since i personally regularly attempt to use sr to filter by star rating and was repeatedly surprised that it did not yield results.

I expected it to yield results since other parameters are searchable via the same scheme 
Approach Rate -> ar
Circle Size -> cs
Overall Difficulty -> od