### PR TITLE
Allow object deletion with middle mouse

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -74,6 +74,29 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        [Solo]
+        public void TestCommitPlacementViaRightClick()
+        {
+            Playfield playfield = null!;
+
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddStep("move mouse to top left of playfield", () =>
+            {
+                playfield = this.ChildrenOfType<Playfield>().Single();
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("begin placement", () => InputManager.Click(MouseButton.Left));
+            AddStep("move mouse to bottom right of playfield", () =>
+            {
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("confirm via right click", () => InputManager.Click(MouseButton.Right));
+            AddAssert("slider placed", () => EditorBeatmap.HitObjects.Count, () => Is.EqualTo(1));
+        }
+
+        [Test]
         public void TestCommitPlacementViaGlobalAction()
         {
             Playfield playfield = null!;

--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -29,6 +29,51 @@ namespace osu.Game.Tests.Visual.Editing
         private GlobalActionContainer globalActionContainer => this.ChildrenOfType<GlobalActionContainer>().Single();
 
         [Test]
+        public void TestDeleteUsingMiddleMouse()
+        {
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("one circle added", () => EditorBeatmap.HitObjects, () => Has.One.Items);
+            AddStep("delete with middle mouse", () => InputManager.Click(MouseButton.Middle));
+            AddAssert("circle removed", () => EditorBeatmap.HitObjects, () => Is.Empty);
+        }
+
+        [Test]
+        public void TestDeleteUsingShiftRightClick()
+        {
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("one circle added", () => EditorBeatmap.HitObjects, () => Has.One.Items);
+            AddStep("delete with right mouse", () =>
+            {
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Click(MouseButton.Right);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+            });
+            AddAssert("circle removed", () => EditorBeatmap.HitObjects, () => Is.Empty);
+        }
+
+        [Test]
+        public void TestContextMenu()
+        {
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to center of playfield", () => InputManager.MoveMouseTo(this.ChildrenOfType<Playfield>().Single()));
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+
+            AddAssert("one circle added", () => EditorBeatmap.HitObjects, () => Has.One.Items);
+            AddStep("delete with right mouse", () =>
+            {
+                InputManager.Click(MouseButton.Right);
+            });
+            AddAssert("circle not removed", () => EditorBeatmap.HitObjects, () => Has.One.Items);
+            AddAssert("circle selected", () => EditorBeatmap.SelectedHitObjects, () => Has.One.Items);
+        }
+
+        [Test]
         public void TestCommitPlacementViaGlobalAction()
         {
             Playfield playfield = null!;

--- a/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/PlacementBlueprint.cs
@@ -209,9 +209,7 @@ namespace osu.Game.Rulesets.Edit
 
                 case MouseButtonEvent mouse:
                     // placement blueprints should generally block mouse from reaching underlying components (ie. performing clicks on interface buttons).
-                    // for now, the one exception we want to allow is when using a non-main mouse button when shift is pressed, which is used to trigger object deletion
-                    // while in placement mode.
-                    return mouse.Button == MouseButton.Left || !mouse.ShiftPressed;
+                    return mouse.Button == MouseButton.Left || PlacementActive == PlacementState.Active;
 
                 default:
                     return false;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -263,7 +263,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>Whether a selection was performed.</returns>
         internal virtual bool MouseDownSelectionRequested(SelectionBlueprint<T> blueprint, MouseButtonEvent e)
         {
-            if (e.ShiftPressed && e.Button == MouseButton.Right)
+            if (e.Button == MouseButton.Middle || (e.ShiftPressed && e.Button == MouseButton.Right))
             {
                 handleQuickDeletion(blueprint);
                 return true;


### PR DESCRIPTION
This is in addition to Shift + Right-click.

I think middle mouse feels more natural and is a good permanent solution to this issue.

Note that this also *allows triggering the context menu from placement mode*. Until now it's done nothing. This may be annoying to users with muscle memory but I want to make the change and harvest feedback. I think showing the context menu is more correct behaviour (although arguably it should return to placement mode on dismiss?).

Closes https://github.com/ppy/osu/issues/29277 ~~maybe~~ probably.