### PR TITLE
Change non-legacy control points to have CustomSampleBank 1

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -323,7 +323,7 @@ namespace osu.Game.Beatmaps.Formats
                     int volume = samples.Max(o => o.Volume);
                     int customIndex = samples.Any(o => o is ConvertHitObjectParser.LegacyHitSampleInfo)
                         ? samples.OfType<ConvertHitObjectParser.LegacyHitSampleInfo>().Max(o => o.CustomSampleBank)
-                        : -1;
+                        : 1;
 
                     return new LegacyBeatmapDecoder.LegacySampleControlPoint { Time = time, SampleVolume = volume, CustomSampleBank = customIndex };
                 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Beatmaps.Formats
                 // if samplePoint isn't already legacy,create LegacyHitSampleInfo with customSampleBank 1
                 HitSampleInfo tempHitSample;
 
-                if (samplePoint?.GetType() == typeof(SampleControlPoint))
+                if (samplePoint.GetType() == typeof(SampleControlPoint))
                 {
                     tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty, customSampleBank: 1));
                 }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -220,18 +220,13 @@ namespace osu.Game.Beatmaps.Formats
                 var samplePoint = legacyControlPoints.SamplePointAt(group.Time);
                 var effectPoint = legacyControlPoints.EffectPointAt(group.Time);
 
-                // if samplePoint isn't already legacy,create LegacyHitSampleInfo with customSampleBank 1
-                HitSampleInfo tempHitSample;
-
-                if (samplePoint.GetType() == typeof(SampleControlPoint))
-                {
-                    tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty, customSampleBank: 1));
-                }
+                // if samplePoint isn't already legacy, create LegacyHitSampleInfo with customSampleBank 1
                 // else create LegacyHitSampleInfo with existing customSampleBank
-                else
-                {
-                    tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty));
-                }
+                HitSampleInfo tempHitSample = samplePoint.ApplyTo(
+                    samplePoint.GetType() == typeof(SampleControlPoint)
+                    ? new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty, customSampleBank: 1)
+                    : new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty)
+                    );
 
                 // Apply the control point to a hit sample to uncover legacy properties (e.g. suffix)
                 int customSampleBank = toLegacyCustomSampleBank(tempHitSample);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -220,19 +220,19 @@ namespace osu.Game.Beatmaps.Formats
                 var samplePoint = legacyControlPoints.SamplePointAt(group.Time);
                 var effectPoint = legacyControlPoints.EffectPointAt(group.Time);
 
-                // if samplePoint isn't already legacy, create legacy with customSampleBank 1
+                // if samplePoint isn't already legacy,create LegacyHitSampleInfo with customSampleBank 1
                 HitSampleInfo tempHitSample;
-                if (samplePoint.GetType() == typeof(SampleControlPoint))
+
+                if (samplePoint?.GetType() == typeof(SampleControlPoint))
                 {
                     tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty, customSampleBank: 1));
-
                 }
                 // else create LegacyHitSampleInfo with existing customSampleBank
                 else
                 {
                     tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty));
-
                 }
+
                 // Apply the control point to a hit sample to uncover legacy properties (e.g. suffix)
                 int customSampleBank = toLegacyCustomSampleBank(tempHitSample);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -220,8 +220,20 @@ namespace osu.Game.Beatmaps.Formats
                 var samplePoint = legacyControlPoints.SamplePointAt(group.Time);
                 var effectPoint = legacyControlPoints.EffectPointAt(group.Time);
 
+                // if samplePoint isn't already legacy, create legacy with customSampleBank 1
+                HitSampleInfo tempHitSample;
+                if (samplePoint.GetType() == typeof(SampleControlPoint))
+                {
+                    tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty, customSampleBank: 1));
+
+                }
+                // else create LegacyHitSampleInfo with existing customSampleBank
+                else
+                {
+                    tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty));
+
+                }
                 // Apply the control point to a hit sample to uncover legacy properties (e.g. suffix)
-                HitSampleInfo tempHitSample = samplePoint.ApplyTo(new ConvertHitObjectParser.LegacyHitSampleInfo(string.Empty));
                 int customSampleBank = toLegacyCustomSampleBank(tempHitSample);
 
                 // Convert effect flags to the legacy format
@@ -617,7 +629,7 @@ namespace osu.Game.Beatmaps.Formats
             if (hitSampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy)
                 return legacy.CustomSampleBank;
 
-            return 1;
+            return 0;
         }
 
         private struct LegacyControlPointProperties

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -617,7 +617,7 @@ namespace osu.Game.Beatmaps.Formats
             if (hitSampleInfo is ConvertHitObjectParser.LegacyHitSampleInfo legacy)
                 return legacy.CustomSampleBank;
 
-            return 0;
+            return 1;
         }
 
         private struct LegacyControlPointProperties


### PR DESCRIPTION
- Closes #29028

Passes test `osu.Game.Tests.Beatmaps.Formats.LegacyBeatmapEncoderTest`, which previous implementation #29084 failed (thanks @smoogipoo!)

See also #29280 regarding long-term implementation of custom samplesets - this PR implements the third option proposed.