### PR TITLE
Fix clicking the beatmap import notification at the daily challenge screen exiting to main menu

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -642,10 +642,10 @@ namespace osu.Game
             Live<BeatmapSetInfo> databasedSet = null;
 
             if (beatmap.OnlineID > 0)
-                databasedSet = BeatmapManager.QueryBeatmapSet(s => s.OnlineID == beatmap.OnlineID);
+                databasedSet = BeatmapManager.QueryBeatmapSet(s => s.OnlineID == beatmap.OnlineID && !s.DeletePending);
 
             if (beatmap is BeatmapSetInfo localBeatmap)
-                databasedSet ??= BeatmapManager.QueryBeatmapSet(s => s.Hash == localBeatmap.Hash);
+                databasedSet ??= BeatmapManager.QueryBeatmapSet(s => s.Hash == localBeatmap.Hash && !s.DeletePending);
 
             if (databasedSet == null)
             {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -559,6 +559,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             // If the import was for a different beatmap, pass the duty off to global handling.
             if (beatmap.BeatmapSetInfo.OnlineID != playlistItem.Beatmap.BeatmapSet!.OnlineID)
             {
+                this.Exit();
                 game?.PresentBeatmap(beatmap.BeatmapSetInfo, b => b.ID == beatmap.BeatmapInfo.ID);
             }
 

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -44,7 +44,7 @@ using osuTK;
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     [Cached(typeof(IPreviewTrackOwner))]
-    public partial class DailyChallenge : OsuScreen, IPreviewTrackOwner
+    public partial class DailyChallenge : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
     {
         private readonly Room room;
         private readonly PlaylistItem playlistItem;
@@ -545,6 +545,24 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             if (metadataClient.IsNotNull())
                 metadataClient.MultiplayerRoomScoreSet -= onRoomScoreSet;
+        }
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            // We can only handle the current daily challenge beatmap.
+            // If the import was for a different beatmap, pass the duty off to global handling.
+            if (beatmap.BeatmapSetInfo.OnlineID != playlistItem.Beatmap.BeatmapSet!.OnlineID)
+            {
+                game?.PresentBeatmap(beatmap.BeatmapSetInfo, b => b.ID == beatmap.BeatmapInfo.ID);
+            }
+
+            // And if we're handling, we don't really have much to do here.
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/29303.

This also fixes an issue with presentation that I found while testing (the present would fail if you just deleted the beatmap you're testing re-import with). I attempted to write a test for this but give up after 20 minutes of trying. Getting the deletion in the same state is hard. Test diff below if anyone wants to give it further time:

```diff
diff --git a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
index c054792168..2570488425 100644
--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -37,6 +35,22 @@ public void TestFromMainMenu()
             presentSecondDifficultyAndConfirm(secondImport, 3);
         }
 
+        [Test]
+        public void TestFromMainMenuWithDelete()
+        {
+            var firstImport = importBeatmap(1);
+            var secondImport = importBeatmap(3);
+
+            presentAndConfirm(firstImport);
+            returnToMenu();
+            presentAndConfirm(secondImport);
+            returnToMenu();
+
+            AddStep("delete first", () => Game.BeatmapManager.Delete(firstImport()));
+            var firstImportAgain = importBeatmap(1);
+            presentAndConfirm(firstImportAgain);
+        }
+
         [Test]
         public void TestFromMainMenuDifferentRuleset()
         {
@@ -133,9 +147,9 @@ private void returnToMenu()
             AddUntilStep("wait for menu", () => Game.ScreenStack.CurrentScreen is MainMenu);
         }
 
-        private Func<BeatmapSetInfo> importBeatmap(int i, RulesetInfo ruleset = null)
+        private Func<BeatmapSetInfo> importBeatmap(int i, RulesetInfo? ruleset = null)
         {
-            BeatmapSetInfo imported = null;
+            BeatmapSetInfo? imported = null;
             AddStep($"import beatmap {i}", () =>
             {
                 var metadata = new BeatmapMetadata
@@ -171,7 +185,7 @@ private Func<BeatmapSetInfo> importBeatmap(int i, RulesetInfo ruleset = null)
 
             AddAssert($"import {i} succeeded", () => imported != null);
 
-            return () => imported;
+            return () => imported!;
         }
 
         private void confirmBeatmapInSongSelect(Func<BeatmapSetInfo> getImport)

```