### PR TITLE
Add intro screen for daily challenge

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneBackgroundScreenDefault.cs
@@ -304,11 +304,6 @@ namespace osu.Game.Tests.Visual.Background
         {
             private bool? lastLoadTriggerCausedChange;
 
-            public TestBackgroundScreenDefault()
-                : base(false)
-            {
-            }
-
             public override bool Next()
             {
                 bool didChange = base.Next();

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Online.API;
+using osu.Game.Online.Metadata;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Tests.Resources;
+using osu.Game.Tests.Visual.Metadata;
+using osu.Game.Tests.Visual.OnlinePlay;
+using CreateRoomRequest = osu.Game.Online.Rooms.CreateRoomRequest;
+
+namespace osu.Game.Tests.Visual.DailyChallenge
+{
+    public partial class TestSceneDailyChallengeIntro : OnlinePlayTestScene
+    {
+        [Cached(typeof(MetadataClient))]
+        private TestMetadataClient metadataClient = new TestMetadataClient();
+
+        [Cached(typeof(INotificationOverlay))]
+        private NotificationOverlay notificationOverlay = new NotificationOverlay();
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            base.Content.Add(notificationOverlay);
+            base.Content.Add(metadataClient);
+        }
+
+        [Test]
+        [Solo]
+        public void TestDailyChallenge()
+        {
+            var room = new Room
+            {
+                RoomID = { Value = 1234 },
+                Name = { Value = "Daily Challenge: June 4, 2024" },
+                Playlist =
+                {
+                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
+                    {
+                        RequiredMods = [new APIMod(new OsuModTraceable())],
+                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
+                    }
+                },
+                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
+                Category = { Value = RoomCategory.DailyChallenge }
+            };
+
+            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
+            AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallengeIntro(room)));
+        }
+
+        [Test]
+        public void TestNotifications()
+        {
+            var room = new Room
+            {
+                RoomID = { Value = 1234 },
+                Name = { Value = "Daily Challenge: June 4, 2024" },
+                Playlist =
+                {
+                    new PlaylistItem(TestResources.CreateTestBeatmapSetInfo().Beatmaps.First())
+                    {
+                        RequiredMods = [new APIMod(new OsuModTraceable())],
+                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
+                    }
+                },
+                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
+                Category = { Value = RoomCategory.DailyChallenge }
+            };
+
+            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
+            AddStep("set daily challenge info", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1234 });
+
+            Screens.OnlinePlay.DailyChallenge.DailyChallenge screen = null!;
+            AddStep("push screen", () => LoadScreen(screen = new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
+            AddUntilStep("wait for screen", () => screen.IsCurrentScreen());
+            AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Tests.Visual.Menus
                         getRoomRequest.TriggerSuccess(new Room
                         {
                             RoomID = { Value = 1234 },
+                            Name = { Value = "Aug 8, 2024" },
                             Playlist =
                             {
                                 new PlaylistItem(beatmap)

--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -1,11 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Metadata;
+using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Screens.Menu;
 using osuTK.Input;
@@ -21,6 +25,47 @@ namespace osu.Game.Tests.Visual.Menus
             base.SetUpSteps();
             AddStep("don't fetch online content", () => onlineMenuBanner.FetchOnlineContent = false);
             AddStep("disable return to top on idle", () => Game.ChildrenOfType<ButtonSystem>().Single().ReturnToTopOnIdle = false);
+        }
+
+        [Test]
+        public void TestDailyChallenge()
+        {
+            AddStep("set up API", () => ((DummyAPIAccess)API).HandleRequest = req =>
+            {
+                switch (req)
+                {
+                    case GetRoomRequest getRoomRequest:
+                        if (getRoomRequest.RoomId != 1234)
+                            return false;
+
+                        var beatmap = CreateAPIBeatmap();
+                        beatmap.OnlineID = 1001;
+                        getRoomRequest.TriggerSuccess(new Room
+                        {
+                            RoomID = { Value = 1234 },
+                            Playlist =
+                            {
+                                new PlaylistItem(beatmap)
+                            },
+                            EndDate = { Value = DateTimeOffset.Now.AddSeconds(60) }
+                        });
+                        return true;
+
+                    default:
+                        return false;
+                }
+            });
+
+            AddStep("beatmap of the day active", () => Game.ChildrenOfType<IMetadataClient>().Single().DailyChallengeUpdated(new DailyChallengeInfo
+            {
+                RoomID = 1234,
+            }));
+
+            AddStep("enter menu", () => InputManager.Key(Key.P));
+            AddStep("enter submenu", () => InputManager.Key(Key.P));
+            AddStep("enter daily challenge", () => InputManager.Key(Key.D));
+
+            AddUntilStep("wait for daily challenge screen", () => Game.ScreenStack.CurrentScreen, Is.TypeOf<Screens.OnlinePlay.DailyChallenge.DailyChallenge>);
         }
 
         [Test]

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -642,10 +642,10 @@ namespace osu.Game
             Live<BeatmapSetInfo> databasedSet = null;
 
             if (beatmap.OnlineID > 0)
-                databasedSet = BeatmapManager.QueryBeatmapSet(s => s.OnlineID == beatmap.OnlineID);
+                databasedSet = BeatmapManager.QueryBeatmapSet(s => s.OnlineID == beatmap.OnlineID && !s.DeletePending);
 
             if (beatmap is BeatmapSetInfo localBeatmap)
-                databasedSet ??= BeatmapManager.QueryBeatmapSet(s => s.Hash == localBeatmap.Hash);
+                databasedSet ??= BeatmapManager.QueryBeatmapSet(s => s.Hash == localBeatmap.Hash && !s.DeletePending);
 
             if (databasedSet == null)
             {

--- a/osu.Game/Screens/BackgroundScreen.cs
+++ b/osu.Game/Screens/BackgroundScreen.cs
@@ -17,13 +17,12 @@ namespace osu.Game.Screens
 
         private const float x_movement_amount = 50;
 
-        private readonly bool animateOnEnter;
-
         public override bool IsPresent => base.IsPresent || Scheduler.HasPendingTasks;
 
-        protected BackgroundScreen(bool animateOnEnter = true)
+        public bool AnimateEntry { get; set; } = true;
+
+        protected BackgroundScreen()
         {
-            this.animateOnEnter = animateOnEnter;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
         }
@@ -53,12 +52,11 @@ namespace osu.Game.Screens
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
-            if (animateOnEnter)
+            if (AnimateEntry)
             {
                 this.FadeOut();
-                this.MoveToX(x_movement_amount);
-
                 this.FadeIn(TRANSITION_LENGTH, Easing.InOutQuart);
+                this.MoveToX(x_movement_amount);
                 this.MoveToX(0, TRANSITION_LENGTH, Easing.InOutQuart);
             }
 

--- a/osu.Game/Screens/BackgroundScreenStack.cs
+++ b/osu.Game/Screens/BackgroundScreenStack.cs
@@ -27,10 +27,14 @@ namespace osu.Game.Screens
             if (screen == null)
                 return false;
 
-            if (EqualityComparer<BackgroundScreen>.Default.Equals((BackgroundScreen)CurrentScreen, screen))
+            bool isFirstScreen = CurrentScreen == null;
+            screen.AnimateEntry = !isFirstScreen;
+
+            if (EqualityComparer<BackgroundScreen>.Default.Equals((BackgroundScreen?)CurrentScreen, screen))
                 return false;
 
             base.Push(screen);
+
             return true;
         }
     }

--- a/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
+++ b/osu.Game/Screens/Backgrounds/BackgroundScreenDefault.cs
@@ -42,11 +42,6 @@ namespace osu.Game.Screens.Backgrounds
 
         protected virtual bool AllowStoryboardBackground => true;
 
-        public BackgroundScreenDefault(bool animateOnEnter = true)
-            : base(animateOnEnter)
-        {
-        }
-
         [BackgroundDependencyLoader]
         private void load(IAPIProvider api, SkinManager skinManager, OsuConfigManager config)
         {

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Screens.Menu
         /// </summary>
         protected bool UsingThemedIntro { get; private set; }
 
-        protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault(false)
+        protected override BackgroundScreen CreateBackground() => new BackgroundScreenDefault
         {
             Colour = Color4.Black
         };

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Screens.Menu
                             OnPlaylists = () => this.Push(new Playlists()),
                             OnDailyChallenge = room =>
                             {
-                                this.Push(new DailyChallenge(room));
+                                this.Push(new DailyChallengeIntro(room));
                             },
                             OnExit = () =>
                             {

--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Screens.OnlinePlay.Components
         private PlaylistItemBackground? background;
 
         protected OnlinePlayBackgroundScreen()
-            : base(false)
         {
             AddInternal(new Box
             {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -44,7 +44,7 @@ using osuTK;
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     [Cached(typeof(IPreviewTrackOwner))]
-    public partial class DailyChallenge : OsuScreen, IPreviewTrackOwner
+    public partial class DailyChallenge : OsuScreen, IPreviewTrackOwner, IHandlePresentBeatmap
     {
         private readonly Room room;
         private readonly PlaylistItem playlistItem;
@@ -545,6 +545,24 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             if (metadataClient.IsNotNull())
                 metadataClient.MultiplayerRoomScoreSet -= onRoomScoreSet;
+        }
+
+        [Resolved]
+        private OsuGame? game { get; set; }
+
+        public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)
+        {
+            if (!this.IsCurrentScreen())
+                return;
+
+            // We can only handle the current daily challenge beatmap.
+            // If the import was for a different beatmap, pass the duty off to global handling.
+            if (beatmap.BeatmapSetInfo.OnlineID != playlistItem.Beatmap.BeatmapSet!.OnlineID)
+            {
+                game?.PresentBeatmap(beatmap.BeatmapSetInfo, b => b.ID == beatmap.BeatmapInfo.ID);
+            }
+
+            // And if we're handling, we don't really have much to do here.
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
-using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
@@ -38,10 +37,11 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private FillFlowContainer beatmapContent = null!;
 
+        private Container titleContainer = null!;
+
         private bool beatmapBackgroundLoaded;
 
         private bool animationBegan;
-        private bool trackContent;
 
         private IBindable<StarDifficulty?> starDifficulty = null!;
 
@@ -78,6 +78,67 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     Shear = new Vector2(OsuGame.SHEAR, 0f),
                     Children = new Drawable[]
                     {
+                        titleContainer = new Container
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                topTitleDisplay = new Container
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.CentreRight,
+                                    AutoSizeAxes = Axes.Both,
+                                    CornerRadius = 10f,
+                                    Masking = true,
+                                    X = -10,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colourProvider.Background3,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Text = "Today's Challenge",
+                                            Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
+                                            Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                            Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
+                                        },
+                                    }
+                                },
+                                bottomDateDisplay = new Container
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.CentreLeft,
+                                    AutoSizeAxes = Axes.Both,
+                                    CornerRadius = 10f,
+                                    Masking = true,
+                                    X = 10,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = colourProvider.Background3,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new OsuSpriteText
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Text = room.Name.Value.Split(':', StringSplitOptions.TrimEntries).Last(),
+                                            Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
+                                            Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                            Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
+                                        },
+                                    }
+                                },
+                            }
+                        },
                         beatmapContent = new FillFlowContainer
                         {
                             AlwaysPresent = true, // so we can get the size ahead of time
@@ -209,56 +270,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                 }
                             }
                         },
-                        topTitleDisplay = new Container
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.CentreRight,
-                            AutoSizeAxes = Axes.Both,
-                            CornerRadius = 10f,
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    Colour = colourProvider.Background3,
-                                    RelativeSizeAxes = Axes.Both,
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Text = "Today's Challenge",
-                                    Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
-                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
-                                    Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
-                                },
-                            }
-                        },
-                        bottomDateDisplay = new Container
-                        {
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.CentreLeft,
-                            AutoSizeAxes = Axes.Both,
-                            CornerRadius = 10f,
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    Colour = colourProvider.Background3,
-                                    RelativeSizeAxes = Axes.Both,
-                                },
-                                new OsuSpriteText
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Text = room.Name.Value.Split(':', StringSplitOptions.TrimEntries).Last(),
-                                    Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
-                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
-                                    Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
-                                },
-                            }
-                        },
                     }
                 }
             };
@@ -285,20 +296,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 beatmapBackgroundLoaded = true;
                 updateAnimationState();
             });
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (trackContent)
-            {
-                float yPos = (beatmapContent.DrawHeight * beatmapContent.Scale.Y) / 2 - 20 * beatmapContent.Scale.Y;
-                float xPos = getShearForY(yPos) + beatmapContent.Scale.Y * 320;
-
-                topTitleDisplay.Position = new Vector2(-xPos, yPos);
-                bottomDateDisplay.Position = new Vector2(xPos, -yPos);
-            }
         }
 
         public override void OnEntering(ScreenTransitionEvent e)
@@ -328,32 +325,43 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private void beginAnimation()
         {
-            const float v_spacing = 5;
-            const float initial_h_shift = 300;
-
-            introContent.ScaleTo(1.2f, 8000);
-
             using (BeginDelayedSequence(200))
             {
                 introContent.Show();
 
-                topTitleDisplay.MoveToX(getShearForY(topTitleDisplay.Y) - initial_h_shift)
-                               .MoveToX(getShearForY(topTitleDisplay.Y) - v_spacing, 300, Easing.OutQuint)
-                               .FadeInFromZero(400, Easing.OutQuint);
+                const float y_offset_start = 260;
+                const float y_offset_end = 20;
 
-                bottomDateDisplay.MoveToX(getShearForY(bottomDateDisplay.Y) + initial_h_shift)
-                                 .MoveToX(getShearForY(bottomDateDisplay.Y) + v_spacing, 300, Easing.OutQuint)
-                                 .FadeInFromZero(400, Easing.OutQuint);
+                topTitleDisplay
+                    .FadeInFromZero(400, Easing.OutQuint);
+
+                topTitleDisplay.MoveToY(-y_offset_start)
+                               .MoveToY(-y_offset_end, 300, Easing.OutQuint)
+                               .Then()
+                               .MoveToY(0, 4000);
+
+                bottomDateDisplay.MoveToY(y_offset_start)
+                                 .MoveToY(y_offset_end, 300, Easing.OutQuint)
+                                 .Then()
+                                 .MoveToY(0, 4000);
 
                 using (BeginDelayedSequence(500))
                 {
                     beatmapContent
-                        .ScaleTo(1f, 500, Easing.InQuint);
+                        .ScaleTo(3)
+                        .ScaleTo(1f, 500, Easing.In)
+                        .Then()
+                        .ScaleTo(1.1f, 4000);
+
+                    using (BeginDelayedSequence(100))
+                    {
+                        titleContainer
+                            .ScaleTo(0.4f, 400, Easing.In)
+                            .FadeOut(500, Easing.OutQuint);
+                    }
 
                     using (BeginDelayedSequence(240))
                     {
-                        Schedule(() => trackContent = true);
-
                         beatmapContent.FadeInFromZero(280, Easing.InQuad);
 
                         using (BeginDelayedSequence(300))
@@ -374,8 +382,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 }
             }
         }
-
-        private static float getShearForY(float yPos) => yPos * -OsuGame.SHEAR * 2;
 
         private partial class DailyChallengeIntroBackgroundScreen : RoomBackgroundScreen
         {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -45,8 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private IBindable<StarDifficulty?> starDifficulty = null!;
 
-        private const float final_v_shift = 340;
-
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
 
@@ -295,13 +293,11 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             if (trackContent)
             {
-                float vShift = (beatmapContent.DrawHeight * beatmapContent.Scale.Y) / 2;
+                float yPos = (beatmapContent.DrawHeight * beatmapContent.Scale.Y) / 2 - 20 * beatmapContent.Scale.Y;
+                float xPos = getShearForY(yPos) + beatmapContent.Scale.Y * 320;
 
-                float yPos = (float)Interpolation.DampContinuously(bottomDateDisplay.Y, vShift, 16, Clock.ElapsedFrameTime);
-                float xPos = (float)Interpolation.DampContinuously(bottomDateDisplay.X, getShearForY(vShift) + beatmapContent.Scale.Y * final_v_shift, 16, Clock.ElapsedFrameTime);
-
-                topTitleDisplay.Position = new Vector2(-xPos, -yPos);
-                bottomDateDisplay.Position = new Vector2(xPos, yPos);
+                topTitleDisplay.Position = new Vector2(-xPos, yPos);
+                bottomDateDisplay.Position = new Vector2(xPos, -yPos);
             }
         }
 
@@ -335,6 +331,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             const float v_spacing = 5;
             const float initial_h_shift = 300;
 
+            introContent.ScaleTo(1.2f, 8000);
+
             using (BeginDelayedSequence(200))
             {
                 introContent.Show();
@@ -350,9 +348,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                 using (BeginDelayedSequence(500))
                 {
                     beatmapContent
-                        .ScaleTo(1f, 500, Easing.InQuint)
-                        .Then()
-                        .ScaleTo(1.1f, 3000);
+                        .ScaleTo(1f, 500, Easing.InQuint);
 
                     using (BeginDelayedSequence(240))
                     {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -1,42 +1,277 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.Rooms;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Match;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     public partial class DailyChallengeIntro : OsuScreen
     {
         private readonly Room room;
+        private readonly PlaylistItem item;
+
+        private FillFlowContainer introContent = null!;
+        private Container topPart = null!;
+        private Container bottomPart = null!;
+        private Container beatmapBackground = null!;
+        private Container beatmapTitle = null!;
+
+        private bool beatmapBackgroundLoaded;
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Plum);
 
         public DailyChallengeIntro(Room room)
         {
             this.room = room;
+            item = room.Playlist.Single();
 
             ValidForResume = false;
         }
 
-        public override void OnEntering(ScreenTransitionEvent e)
-        {
-            base.OnEntering(e);
+        protected override BackgroundScreen CreateBackground() => new DailyChallengeIntroBackgroundScreen(colourProvider);
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             InternalChildren = new Drawable[]
             {
-                new OsuSpriteText
+                introContent = new FillFlowContainer
                 {
+                    Alpha = 0f,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Text = "wangs"
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0f, 10f),
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Child = topPart = new Container
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Margin = new MarginPadding { Right = 200f },
+                                CornerRadius = 10f,
+                                Masking = true,
+                                Shear = new Vector2(OsuGame.SHEAR, 0f),
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        Colour = colourProvider.Background3,
+                                        RelativeSizeAxes = Axes.Both,
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Text = "Today's Challenge",
+                                        Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
+                                        Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                        // Colour = Color4.Black,
+                                        Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
+                                    },
+                                }
+                            },
+                        },
+                        beatmapBackground = new Container
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(500f, 150f),
+                            CornerRadius = 20f,
+                            BorderColour = colourProvider.Content2,
+                            BorderThickness = 3f,
+                            Masking = true,
+                            Shear = new Vector2(OsuGame.SHEAR, 0f),
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    Colour = colourProvider.Background3,
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                            }
+                        },
+                        beatmapTitle = new Container
+                        {
+                            Width = 500f,
+                            Margin = new MarginPadding { Right = 160f * OsuGame.SHEAR },
+                            AutoSizeAxes = Axes.Y,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            CornerRadius = 10f,
+                            Masking = true,
+                            Shear = new Vector2(OsuGame.SHEAR, 0f),
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    Colour = colourProvider.Background3,
+                                    RelativeSizeAxes = Axes.Both,
+                                },
+                                new OsuSpriteText
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Text = item.Beatmap.GetDisplayString(),
+                                    Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
+                                    Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                    Font = OsuFont.GetFont(size: 24),
+                                },
+                            }
+                        },
+                        new Container
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Child = bottomPart = new Container
+                            {
+                                Alpha = 0f,
+                                AlwaysPresent = true,
+                                AutoSizeAxes = Axes.Both,
+                                Margin = new MarginPadding { Left = 210f },
+                                CornerRadius = 10f,
+                                Masking = true,
+                                Shear = new Vector2(OsuGame.SHEAR, 0f),
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        Colour = colourProvider.Background3,
+                                        RelativeSizeAxes = Axes.Both,
+                                    },
+                                    new OsuSpriteText
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Text = "Sunday, July 28th",
+                                        Margin = new MarginPadding { Horizontal = 10f, Vertical = 5f },
+                                        Shear = new Vector2(-OsuGame.SHEAR, 0f),
+                                        Font = OsuFont.GetFont(size: 32, weight: FontWeight.Light, typeface: Typeface.TorusAlternate),
+                                    },
+                                }
+                            },
+                        }
+                    }
                 }
             };
 
-            Scheduler.AddDelayed(() =>
+            LoadComponentAsync(new OnlineBeatmapSetCover(item.Beatmap.BeatmapSet as IBeatmapSetOnlineInfo)
             {
-                this.Push(new DailyChallenge(room));
-            }, 2000);
+                RelativeSizeAxes = Axes.Both,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                FillMode = FillMode.Fit,
+                Scale = new Vector2(1.2f),
+                Shear = new Vector2(-OsuGame.SHEAR, 0f),
+            }, c =>
+            {
+                beatmapBackground.Add(c);
+                beatmapBackgroundLoaded = true;
+                updateAnimationState();
+            });
+        }
+
+        private bool animationBegan;
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+            this.FadeInFromZero(400, Easing.OutQuint);
+            updateAnimationState();
+        }
+
+        public override void OnSuspending(ScreenTransitionEvent e)
+        {
+            this.FadeOut(200, Easing.OutQuint);
+            base.OnSuspending(e);
+        }
+
+        private void updateAnimationState()
+        {
+            if (!beatmapBackgroundLoaded || !this.IsCurrentScreen())
+                return;
+
+            if (animationBegan)
+                return;
+
+            beginAnimation();
+            animationBegan = true;
+        }
+
+        private void beginAnimation()
+        {
+            introContent.Show();
+
+            topPart.MoveToX(-500).MoveToX(0, 300, Easing.OutQuint)
+                   .FadeInFromZero(400, Easing.OutQuint);
+
+            bottomPart.MoveToX(500).MoveToX(0, 300, Easing.OutQuint)
+                      .FadeInFromZero(400, Easing.OutQuint);
+
+            this.Delay(400).Schedule(() =>
+            {
+                introContent.AutoSizeDuration = 200;
+                introContent.AutoSizeEasing = Easing.OutQuint;
+            });
+
+            this.Delay(500).Schedule(() => ApplyToBackground(bs => ((RoomBackgroundScreen)bs).SelectedItem.Value = item));
+
+            beatmapBackground.FadeOut().Delay(500)
+                             .FadeIn(200, Easing.InQuart);
+
+            beatmapTitle.FadeOut().Delay(500)
+                        .FadeIn(200, Easing.InQuart);
+
+            introContent.Delay(1800).FadeOut(200, Easing.OutQuint)
+                        .OnComplete(_ =>
+                        {
+                            if (this.IsCurrentScreen())
+                                this.Push(new DailyChallenge(room));
+                        });
+        }
+
+        private partial class DailyChallengeIntroBackgroundScreen : RoomBackgroundScreen
+        {
+            private readonly OverlayColourProvider colourProvider;
+
+            public DailyChallengeIntroBackgroundScreen(OverlayColourProvider colourProvider)
+                : base(null)
+            {
+                this.colourProvider = colourProvider;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AddInternal(new Box
+                {
+                    Depth = float.MinValue,
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background5.Opacity(0.6f),
+                });
+            }
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -45,7 +45,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private IBindable<StarDifficulty?> starDifficulty = null!;
 
-        private const float initial_v_shift = 32;
         private const float final_v_shift = 340;
 
         [Cached]
@@ -296,10 +295,10 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             if (trackContent)
             {
-                float vShift = initial_v_shift + (beatmapContent.DrawHeight * beatmapContent.Scale.Y) / 2;
+                float vShift = (beatmapContent.DrawHeight * beatmapContent.Scale.Y) / 2;
 
                 float yPos = (float)Interpolation.DampContinuously(bottomDateDisplay.Y, vShift, 16, Clock.ElapsedFrameTime);
-                float xPos = (float)Interpolation.DampContinuously(bottomDateDisplay.X, getShearForY(vShift) + final_v_shift, 16, Clock.ElapsedFrameTime);
+                float xPos = (float)Interpolation.DampContinuously(bottomDateDisplay.X, getShearForY(vShift) + beatmapContent.Scale.Y * final_v_shift, 16, Clock.ElapsedFrameTime);
 
                 topTitleDisplay.Position = new Vector2(-xPos, -yPos);
                 bottomDateDisplay.Position = new Vector2(xPos, yPos);
@@ -333,34 +332,32 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private void beginAnimation()
         {
-            const float v_spacing = 0;
+            const float v_spacing = 5;
+            const float initial_h_shift = 300;
 
             using (BeginDelayedSequence(200))
             {
                 introContent.Show();
 
-                topTitleDisplay.MoveToOffset(new Vector2(getShearForY(-initial_v_shift), -initial_v_shift));
-                bottomDateDisplay.MoveToOffset(new Vector2(getShearForY(initial_v_shift), initial_v_shift));
-
-                topTitleDisplay.MoveToX(getShearForY(topTitleDisplay.Y) - 500)
+                topTitleDisplay.MoveToX(getShearForY(topTitleDisplay.Y) - initial_h_shift)
                                .MoveToX(getShearForY(topTitleDisplay.Y) - v_spacing, 300, Easing.OutQuint)
                                .FadeInFromZero(400, Easing.OutQuint);
 
-                bottomDateDisplay.MoveToX(getShearForY(bottomDateDisplay.Y) + 500)
+                bottomDateDisplay.MoveToX(getShearForY(bottomDateDisplay.Y) + initial_h_shift)
                                  .MoveToX(getShearForY(bottomDateDisplay.Y) + v_spacing, 300, Easing.OutQuint)
                                  .FadeInFromZero(400, Easing.OutQuint);
 
                 using (BeginDelayedSequence(500))
                 {
-                    Schedule(() => trackContent = true);
-
                     beatmapContent
                         .ScaleTo(1f, 500, Easing.InQuint)
                         .Then()
-                        .ScaleTo(1.02f, 3000);
+                        .ScaleTo(1.1f, 3000);
 
                     using (BeginDelayedSequence(240))
                     {
+                        Schedule(() => trackContent = true);
+
                         beatmapContent.FadeInFromZero(280, Easing.InQuad);
 
                         using (BeginDelayedSequence(300))

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -345,7 +345,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                                  .Then()
                                  .MoveToY(0, 4000);
 
-                using (BeginDelayedSequence(500))
+                using (BeginDelayedSequence(1000))
                 {
                     beatmapContent
                         .ScaleTo(3)

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Screens;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Online.Rooms;
+
+namespace osu.Game.Screens.OnlinePlay.DailyChallenge
+{
+    public partial class DailyChallengeIntro : OsuScreen
+    {
+        private readonly Room room;
+
+        public DailyChallengeIntro(Room room)
+        {
+            this.room = room;
+
+            ValidForResume = false;
+        }
+
+        public override void OnEntering(ScreenTransitionEvent e)
+        {
+            base.OnEntering(e);
+
+            InternalChildren = new Drawable[]
+            {
+                new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "wangs"
+                }
+            };
+
+            Scheduler.AddDelayed(() =>
+            {
+                this.Push(new DailyChallenge(room));
+            }, 2000);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreenWaveContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreenWaveContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Graphics.Containers;
 


### PR DESCRIPTION
Culmination of a community suggestion on discord, with some code from frenzi and final touches applied by me.

There's still a lot I'd like to improve about this but spent long enough on it so want to go with what I have for now.

Hopefully the quite terse code is fine because it's a very isolated implementation.


https://github.com/user-attachments/assets/5407d6d4-5a76-4169-b571-4dd2e210fbf9


Would probably be good to get the audio to start playing in the intro, and have some kind of sound design around this (@nekodex might be able to jump in here?).

Also planning to start the download of the beatmap on this intro screen in a subsequent PR.