### PR TITLE
Remove "Special" `ManiaAction`s for center columns

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaLegacyReplayTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaLegacyReplayTest.cs
@@ -12,8 +12,8 @@ namespace osu.Game.Rulesets.Mania.Tests
     {
         [TestCase(ManiaAction.Key1)]
         [TestCase(ManiaAction.Key1, ManiaAction.Key2)]
-        [TestCase(ManiaAction.Special1)]
-        [TestCase(ManiaAction.Key8)]
+        [TestCase(ManiaAction.Key5)]
+        [TestCase(ManiaAction.Key9)]
         public void TestEncodeDecodeSingleStage(params ManiaAction[] actions)
         {
             var beatmap = new ManiaBeatmap(new StageDefinition(9));
@@ -29,11 +29,11 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         [TestCase(ManiaAction.Key1)]
         [TestCase(ManiaAction.Key1, ManiaAction.Key2)]
-        [TestCase(ManiaAction.Special1)]
-        [TestCase(ManiaAction.Special2)]
-        [TestCase(ManiaAction.Special1, ManiaAction.Special2)]
-        [TestCase(ManiaAction.Special1, ManiaAction.Key5)]
+        [TestCase(ManiaAction.Key3)]
         [TestCase(ManiaAction.Key8)]
+        [TestCase(ManiaAction.Key3, ManiaAction.Key8)]
+        [TestCase(ManiaAction.Key3, ManiaAction.Key6)]
+        [TestCase(ManiaAction.Key10)]
         public void TestEncodeDecodeDualStage(params ManiaAction[] actions)
         {
             var beatmap = new ManiaBeatmap(new StageDefinition(5));

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneStage.cs
@@ -14,12 +14,11 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
         {
             SetContents(_ =>
             {
-                ManiaAction normalAction = ManiaAction.Key1;
-                ManiaAction specialAction = ManiaAction.Special1;
+                ManiaAction action = ManiaAction.Key1;
 
                 return new ManiaInputManager(new ManiaRuleset().RulesetInfo, 4)
                 {
-                    Child = new Stage(0, new StageDefinition(4), ref normalAction, ref specialAction)
+                    Child = new Stage(0, new StageDefinition(4), ref action)
                 };
             });
         }

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneAutoGeneration.cs
@@ -36,8 +36,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(1000 + ManiaAutoGenerator.RELEASE_DELAY, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Special1), "Special1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Special1), "Special1 has not been released");
+            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
         }
 
         [Test]
@@ -57,8 +57,8 @@ namespace osu.Game.Rulesets.Mania.Tests
             Assert.AreEqual(generated.Frames.Count, frame_offset + 2, "Incorrect number of frames");
             Assert.AreEqual(1000, generated.Frames[frame_offset].Time, "Incorrect hit time");
             Assert.AreEqual(3000, generated.Frames[frame_offset + 1].Time, "Incorrect release time");
-            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Special1), "Special1 has not been pressed");
-            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Special1), "Special1 has not been released");
+            Assert.IsTrue(checkContains(generated.Frames[frame_offset], ManiaAction.Key1), "Key1 has not been pressed");
+            Assert.IsFalse(checkContains(generated.Frames[frame_offset + 1], ManiaAction.Key1), "Key1 has not been released");
         }
 
         [Test]

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneStage.cs
@@ -131,9 +131,7 @@ namespace osu.Game.Rulesets.Mania.Tests
 
         private ScrollingTestContainer createStage(ScrollingDirection direction, ManiaAction action)
         {
-            var specialAction = ManiaAction.Special1;
-
-            var stage = new Stage(0, new StageDefinition(2), ref action, ref specialAction);
+            var stage = new Stage(0, new StageDefinition(2), ref action);
             stages.Add(stage);
 
             return new ScrollingTestContainer(direction)

--- a/osu.Game.Rulesets.Mania/DualStageVariantGenerator.cs
+++ b/osu.Game.Rulesets.Mania/DualStageVariantGenerator.cs
@@ -45,18 +45,15 @@ namespace osu.Game.Rulesets.Mania
                 LeftKeys = stage1LeftKeys,
                 RightKeys = stage1RightKeys,
                 SpecialKey = InputKey.V,
-                SpecialAction = ManiaAction.Special1,
-                NormalActionStart = ManiaAction.Key1
-            }.GenerateKeyBindingsFor(singleStageVariant, out var nextNormal);
+            }.GenerateKeyBindingsFor(singleStageVariant);
 
             var stage2Bindings = new VariantMappingGenerator
             {
                 LeftKeys = stage2LeftKeys,
                 RightKeys = stage2RightKeys,
                 SpecialKey = InputKey.B,
-                SpecialAction = ManiaAction.Special2,
-                NormalActionStart = nextNormal
-            }.GenerateKeyBindingsFor(singleStageVariant, out _);
+                ActionStart = (ManiaAction)singleStageVariant,
+            }.GenerateKeyBindingsFor(singleStageVariant);
 
             return stage1Bindings.Concat(stage2Bindings);
         }

--- a/osu.Game.Rulesets.Mania/ManiaInputManager.cs
+++ b/osu.Game.Rulesets.Mania/ManiaInputManager.cs
@@ -19,16 +19,8 @@ namespace osu.Game.Rulesets.Mania
 
     public enum ManiaAction
     {
-        [Description("Special 1")]
-        Special1 = 1,
-
-        [Description("Special 2")]
-        Special2,
-
-        // This offsets the start value of normal keys in-case we add more special keys
-        // above at a later time, without breaking replays/configs.
         [Description("Key 1")]
-        Key1 = 10,
+        Key1,
 
         [Description("Key 2")]
         Key2,

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -17,28 +17,9 @@ namespace osu.Game.Rulesets.Mania.Replays
 
         public new ManiaBeatmap Beatmap => (ManiaBeatmap)base.Beatmap;
 
-        private readonly ManiaAction[] columnActions;
-
         public ManiaAutoGenerator(ManiaBeatmap beatmap)
             : base(beatmap)
         {
-            columnActions = new ManiaAction[Beatmap.TotalColumns];
-
-            var normalAction = ManiaAction.Key1;
-            var specialAction = ManiaAction.Special1;
-            int totalCounter = 0;
-
-            foreach (var stage in Beatmap.Stages)
-            {
-                for (int i = 0; i < stage.Columns; i++)
-                {
-                    if (stage.IsSpecialColumn(i))
-                        columnActions[totalCounter] = specialAction++;
-                    else
-                        columnActions[totalCounter] = normalAction++;
-                    totalCounter++;
-                }
-            }
         }
 
         protected override void GenerateFrames()
@@ -57,11 +38,11 @@ namespace osu.Game.Rulesets.Mania.Replays
                     switch (point)
                     {
                         case HitPoint:
-                            actions.Add(columnActions[point.Column]);
+                            actions.Add((ManiaAction)point.Column);
                             break;
 
                         case ReleasePoint:
-                            actions.Remove(columnActions[point.Column]);
+                            actions.Remove((ManiaAction)point.Column);
                             break;
                     }
                 }

--- a/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaAutoGenerator.cs
@@ -38,11 +38,11 @@ namespace osu.Game.Rulesets.Mania.Replays
                     switch (point)
                     {
                         case HitPoint:
-                            actions.Add((ManiaAction)point.Column);
+                            actions.Add(ManiaAction.Key1 + point.Column);
                             break;
 
                         case ReleasePoint:
-                            actions.Remove((ManiaAction)point.Column);
+                            actions.Remove(ManiaAction.Key1 + point.Column);
                             break;
                     }
                 }

--- a/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
+++ b/osu.Game.Rulesets.Mania/Replays/ManiaReplayFrame.cs
@@ -1,11 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Replays.Legacy;
-using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Types;
 
@@ -27,118 +25,27 @@ namespace osu.Game.Rulesets.Mania.Replays
 
         public void FromLegacy(LegacyReplayFrame legacyFrame, IBeatmap beatmap, ReplayFrame? lastFrame = null)
         {
-            var maniaBeatmap = (ManiaBeatmap)beatmap;
-
-            var normalAction = ManiaAction.Key1;
-            var specialAction = ManiaAction.Special1;
-
+            var action = ManiaAction.Key1;
             int activeColumns = (int)(legacyFrame.MouseX ?? 0);
-            int counter = 0;
 
             while (activeColumns > 0)
             {
-                bool isSpecial = isColumnAtIndexSpecial(maniaBeatmap, counter);
-
                 if ((activeColumns & 1) > 0)
-                    Actions.Add(isSpecial ? specialAction : normalAction);
+                    Actions.Add(action);
 
-                if (isSpecial)
-                    specialAction++;
-                else
-                    normalAction++;
-
-                counter++;
+                action++;
                 activeColumns >>= 1;
             }
         }
 
         public LegacyReplayFrame ToLegacy(IBeatmap beatmap)
         {
-            var maniaBeatmap = (ManiaBeatmap)beatmap;
-
             int keys = 0;
 
             foreach (var action in Actions)
-            {
-                switch (action)
-                {
-                    case ManiaAction.Special1:
-                        keys |= 1 << getSpecialColumnIndex(maniaBeatmap, 0);
-                        break;
-
-                    case ManiaAction.Special2:
-                        keys |= 1 << getSpecialColumnIndex(maniaBeatmap, 1);
-                        break;
-
-                    default:
-                        // the index in lazer, which doesn't include special keys.
-                        int nonSpecialKeyIndex = action - ManiaAction.Key1;
-
-                        // the index inclusive of special keys.
-                        int overallIndex = 0;
-
-                        // iterate to find the index including special keys.
-                        for (; overallIndex < maniaBeatmap.TotalColumns; overallIndex++)
-                        {
-                            // skip over special columns.
-                            if (isColumnAtIndexSpecial(maniaBeatmap, overallIndex))
-                                continue;
-                            // found a non-special column to use.
-                            if (nonSpecialKeyIndex == 0)
-                                break;
-                            // found a non-special column but not ours.
-                            nonSpecialKeyIndex--;
-                        }
-
-                        keys |= 1 << overallIndex;
-                        break;
-                }
-            }
+                keys |= 1 << (int)action;
 
             return new LegacyReplayFrame(Time, keys, null, ReplayButtonState.None);
-        }
-
-        /// <summary>
-        /// Find the overall index (across all stages) for a specified special key.
-        /// </summary>
-        /// <param name="maniaBeatmap">The beatmap.</param>
-        /// <param name="specialOffset">The special key offset (0 is S1).</param>
-        /// <returns>The overall index for the special column.</returns>
-        private int getSpecialColumnIndex(ManiaBeatmap maniaBeatmap, int specialOffset)
-        {
-            for (int i = 0; i < maniaBeatmap.TotalColumns; i++)
-            {
-                if (isColumnAtIndexSpecial(maniaBeatmap, i))
-                {
-                    if (specialOffset == 0)
-                        return i;
-
-                    specialOffset--;
-                }
-            }
-
-            throw new ArgumentException("Special key index is too high.", nameof(specialOffset));
-        }
-
-        /// <summary>
-        /// Check whether the column at an overall index (across all stages) is a special column.
-        /// </summary>
-        /// <param name="beatmap">The beatmap.</param>
-        /// <param name="index">The overall index to check.</param>
-        private bool isColumnAtIndexSpecial(ManiaBeatmap beatmap, int index)
-        {
-            foreach (var stage in beatmap.Stages)
-            {
-                if (index >= stage.Columns)
-                {
-                    index -= stage.Columns;
-                    continue;
-                }
-
-                return stage.IsSpecialColumn(index);
-            }
-
-            throw new ArgumentException("Column index is too high.", nameof(index));
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/SingleStageVariantGenerator.cs
+++ b/osu.Game.Rulesets.Mania/SingleStageVariantGenerator.cs
@@ -34,8 +34,6 @@ namespace osu.Game.Rulesets.Mania
             LeftKeys = leftKeys,
             RightKeys = rightKeys,
             SpecialKey = InputKey.Space,
-            SpecialAction = ManiaAction.Special1,
-            NormalActionStart = ManiaAction.Key1,
-        }.GenerateKeyBindingsFor(variant, out _);
+        }.GenerateKeyBindingsFor(variant);
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -66,13 +66,12 @@ namespace osu.Game.Rulesets.Mania.UI
                 Content = new[] { new Drawable[stageDefinitions.Count] }
             });
 
-            var normalColumnAction = ManiaAction.Key1;
-            var specialColumnAction = ManiaAction.Special1;
+            var columnAction = ManiaAction.Key1;
             int firstColumnIndex = 0;
 
             for (int i = 0; i < stageDefinitions.Count; i++)
             {
-                var newStage = new Stage(firstColumnIndex, stageDefinitions[i], ref normalColumnAction, ref specialColumnAction);
+                var newStage = new Stage(firstColumnIndex, stageDefinitions[i], ref columnAction);
 
                 playfieldGrid.Content[0][i] = newStage;
 

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
         private ISkinSource currentSkin = null!;
 
-        public Stage(int firstColumnIndex, StageDefinition definition, ref ManiaAction normalColumnStartAction, ref ManiaAction specialColumnStartAction)
+        public Stage(int firstColumnIndex, StageDefinition definition, ref ManiaAction columnStartAction)
         {
             this.firstColumnIndex = firstColumnIndex;
             Definition = definition;
@@ -138,7 +138,7 @@ namespace osu.Game.Rulesets.Mania.UI
                 {
                     RelativeSizeAxes = Axes.Both,
                     Width = 1,
-                    Action = { Value = isSpecial ? specialColumnStartAction++ : normalColumnStartAction++ }
+                    Action = { Value = columnStartAction++ }
                 };
 
                 topLevelContainer.Add(column.TopLevelContainer.CreateProxy());

--- a/osu.Game.Rulesets.Mania/VariantMappingGenerator.cs
+++ b/osu.Game.Rulesets.Mania/VariantMappingGenerator.cs
@@ -26,37 +26,30 @@ namespace osu.Game.Rulesets.Mania
         public InputKey SpecialKey;
 
         /// <summary>
-        /// The <see cref="ManiaAction"/> at which the normal columns should begin.
+        /// The <see cref="ManiaAction"/> at which the columns should begin.
         /// </summary>
-        public ManiaAction NormalActionStart;
-
-        /// <summary>
-        /// The <see cref="ManiaAction"/> for the special column.
-        /// </summary>
-        public ManiaAction SpecialAction;
+        public ManiaAction ActionStart;
 
         /// <summary>
         /// Generates a list of <see cref="KeyBinding"/>s for a specific number of columns.
         /// </summary>
         /// <param name="columns">The number of columns that need to be bound.</param>
-        /// <param name="nextNormalAction">The next <see cref="ManiaAction"/> to use for normal columns.</param>
         /// <returns>The keybindings.</returns>
-        public IEnumerable<KeyBinding> GenerateKeyBindingsFor(int columns, out ManiaAction nextNormalAction)
+        public IEnumerable<KeyBinding> GenerateKeyBindingsFor(int columns)
         {
-            ManiaAction currentNormalAction = NormalActionStart;
+            ManiaAction currentAction = ActionStart;
 
             var bindings = new List<KeyBinding>();
 
             for (int i = LeftKeys.Length - columns / 2; i < LeftKeys.Length; i++)
-                bindings.Add(new KeyBinding(LeftKeys[i], currentNormalAction++));
+                bindings.Add(new KeyBinding(LeftKeys[i], currentAction++));
 
             if (columns % 2 == 1)
-                bindings.Add(new KeyBinding(SpecialKey, SpecialAction));
+                bindings.Add(new KeyBinding(SpecialKey, currentAction++));
 
             for (int i = 0; i < columns / 2; i++)
-                bindings.Add(new KeyBinding(RightKeys[i], currentNormalAction++));
+                bindings.Add(new KeyBinding(RightKeys[i], currentAction++));
 
-            nextNormalAction = currentNormalAction;
             return bindings;
         }
     }

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key4));
             checkKey(() => counter, 0, false);
 
             AddStep("press space", () => InputManager.PressKey(Key.Space));
@@ -174,7 +174,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key4));
 
             AddStep("press space", () => InputManager.PressKey(Key.Space));
             AddStep("pause", () => Player.Pause());
@@ -237,7 +237,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             KeyCounter counter = null!;
 
             loadPlayer(() => new ManiaRuleset());
-            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Special1));
+            AddStep("get key counter", () => counter = this.ChildrenOfType<KeyCounter>().Single(k => k.Trigger is KeyCounterActionTrigger<ManiaAction> actionTrigger && actionTrigger.Action == ManiaAction.Key4));
 
             AddStep("press space", () => InputManager.PressKey(Key.Space));
             checkKey(() => counter, 1, true);

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -92,8 +92,9 @@ namespace osu.Game.Database
         /// 39   2023-12-19    Migrate any EndTimeObjectCount and TotalObjectCount values of 0 to -1 to better identify non-calculated values.
         /// 40   2023-12-21    Add ScoreInfo.Version to keep track of which build scores were set on.
         /// 41   2024-04-17    Add ScoreInfo.TotalScoreWithoutMods for future mod multiplier rebalances.
+        /// 42   2024-08-07    Update mania key bindings to reflect changes to ManiaAction
         /// </summary>
-        private const int schema_version = 41;
+        private const int schema_version = 42;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1142,6 +1143,51 @@ namespace osu.Game.Database
                         catch (Exception ex)
                         {
                             Logger.Log($@"Failed to populate total score without mods for score {score.ID}: {ex}", LoggingTarget.Database);
+                        }
+                    }
+
+                    break;
+
+                case 42:
+                    for (int columns = 1; columns <= 10; columns++)
+                    {
+                        remapKeyBindingsForVariant(columns, false);
+                        remapKeyBindingsForVariant(columns, true);
+                    }
+
+                    // Replace existing key bindings with new ones reflecting changes to ManiaAction:
+                    // - "Special#" actions are removed and "Key#" actions are inserted in their place.
+                    // - All actions are renumbered to remove the old offsets.
+                    void remapKeyBindingsForVariant(int columns, bool dual)
+                    {
+                        // https://github.com/ppy/osu/blob/8773c2f7ebc226942d6124eb95c07a83934272ea/osu.Game.Rulesets.Mania/ManiaRuleset.cs#L327-L336
+                        int variant = dual ? 1000 + columns * 2 : columns;
+
+                        var oldKeyBindingsQuery = migration.NewRealm
+                                                           .All<RealmKeyBinding>()
+                                                           .Where(kb => kb.RulesetName == @"mania" && kb.Variant == variant);
+                        var oldKeyBindings = oldKeyBindingsQuery.Detach();
+
+                        migration.NewRealm.RemoveRange(oldKeyBindingsQuery);
+
+                        // https://github.com/ppy/osu/blob/8773c2f7ebc226942d6124eb95c07a83934272ea/osu.Game.Rulesets.Mania/ManiaInputManager.cs#L22-L31
+                        int oldNormalAction = 10; // Old Key1 offset
+                        int oldSpecialAction = 1; // Old Special1 offset
+
+                        for (int column = 0; column < columns * (dual ? 2 : 1); column++)
+                        {
+                            if (columns % 2 == 1 && column % columns == columns / 2)
+                                remapKeyBinding(oldSpecialAction++, column);
+                            else
+                                remapKeyBinding(oldNormalAction++, column);
+                        }
+
+                        void remapKeyBinding(int oldAction, int newAction)
+                        {
+                            var oldKeyBinding = oldKeyBindings.Find(kb => kb.ActionInt == oldAction);
+
+                            if (oldKeyBinding != null)
+                                migration.NewRealm.Add(new RealmKeyBinding(newAction, oldKeyBinding.KeyCombination, @"mania", variant));
                         }
                     }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -1161,7 +1161,7 @@ namespace osu.Game.Database
                     void remapKeyBindingsForVariant(int columns, bool dual)
                     {
                         // https://github.com/ppy/osu/blob/8773c2f7ebc226942d6124eb95c07a83934272ea/osu.Game.Rulesets.Mania/ManiaRuleset.cs#L327-L336
-                        int variant = dual ? 1000 + columns * 2 : columns;
+                        int variant = dual ? 1000 + (columns * 2) : columns;
 
                         var oldKeyBindingsQuery = migration.NewRealm
                                                            .All<RealmKeyBinding>()


### PR DESCRIPTION
my actual motivation for this change is that it builds up to making https://github.com/ppy/osu/discussions/25936 possible, but I believe that it can be motivated on its own as well

currently, center columns in odd-keycount mania stages are bound to one of two "Special" `ManiaActions`, instead of normal "Keys". I suspect that this was originally done because in some ways the center columns do get distinct behavior, as in skinning and beatmap conversion. however for the purpose of keybinds there is no reason to define these as "Special", all it's doing here is convoluting the code and probably causing confusion down the line when adding support for `SpecialStyle` proper (which has nothing to do with center columns as far as keybinds go).

in this PR I remove the two Special `ManiaActions` and remove the enum offset for the other Keys there. the rest of the PR is fixing everything to work with the new enum values, including the realm migration, which is required to not break existing mania keybinds

this PR was intended to have no user-facing changes but there ended up being one: in the keybinds menu, keys are now labeled according to the new enum, so "Special 1" for example is gone and replaced by Keys with shifted numbers. I see this as a good thing because it felt weird to not actually have the amount of "Key" binds indicated by the key count (e.g. 7K used to end at Key 6)

also I wanted to add a test for the migration but I couldn't figure out how to set it up. I confirmed that it works though with odd and even keycounts and single and dual stages