### PR TITLE
Fix hit object coordinates being truncated to `int` values

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -469,6 +469,40 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestDecodeBeatmapHitObjectCoordinatesLegacy()
+        {
+            var decoder = new LegacyBeatmapDecoder();
+
+            using (var resStream = TestResources.OpenResource("hitobject-coordinates-legacy.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var hitObjects = decoder.Decode(stream).HitObjects;
+
+                var positionData = hitObjects[0] as IHasPosition;
+
+                Assert.IsNotNull(positionData);
+                Assert.AreEqual(new Vector2(256, 256), positionData!.Position);
+            }
+        }
+
+        [Test]
+        public void TestDecodeBeatmapHitObjectCoordinatesLazer()
+        {
+            var decoder = new LegacyBeatmapDecoder(LegacyBeatmapEncoder.FIRST_LAZER_VERSION);
+
+            using (var resStream = TestResources.OpenResource("hitobject-coordinates-lazer.osu"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                var hitObjects = decoder.Decode(stream).HitObjects;
+
+                var positionData = hitObjects[0] as IHasPosition;
+
+                Assert.IsNotNull(positionData);
+                Assert.AreEqual(new Vector2(256.99853f, 256.001f), positionData!.Position);
+            }
+        }
+
+        [Test]
         public void TestDecodeBeatmapHitObjects()
         {
             var decoder = new LegacyBeatmapDecoder { ApplyOffsets = false };

--- a/osu.Game.Tests/Resources/hitobject-coordinates-lazer.osu
+++ b/osu.Game.Tests/Resources/hitobject-coordinates-lazer.osu
@@ -1,0 +1,6 @@
+osu file format v128
+
+[HitObjects]
+// Coordinates should be preserves in lazer beatmaps.
+
+256.99853,256.001,1000,49,0,0:0:0:0:

--- a/osu.Game.Tests/Resources/hitobject-coordinates-legacy.osu
+++ b/osu.Game.Tests/Resources/hitobject-coordinates-legacy.osu
@@ -1,0 +1,5 @@
+osu file format v14
+
+[HitObjects]
+// Coordinates should be truncated to int values in legacy beatmaps.
+256.99853,256.001,1000,49,0,0:0:0:0:

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -18,6 +18,12 @@ namespace osu.Game.Beatmaps.Formats
     {
         public const int LATEST_VERSION = 14;
 
+        /// <summary>
+        /// The .osu format (beatmap) version.
+        ///
+        /// osu!stable's versions end at <see cref="LATEST_VERSION"/>.
+        /// osu!lazer's versions starts at <see cref="LegacyBeatmapEncoder.FIRST_LAZER_VERSION"/>.
+        /// </summary>
         protected readonly int FormatVersion;
 
         protected LegacyDecoder(int version)

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
         protected readonly double Offset;
 
         /// <summary>
-        /// The beatmap version.
+        /// The .osu format (beatmap) version.
         /// </summary>
         protected readonly int FormatVersion;
 
@@ -48,7 +48,10 @@ namespace osu.Game.Rulesets.Objects.Legacy
         {
             string[] split = text.Split(',');
 
-            Vector2 pos = new Vector2((int)Parsing.ParseFloat(split[0], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseFloat(split[1], Parsing.MAX_COORDINATE_VALUE));
+            Vector2 pos =
+                FormatVersion >= LegacyBeatmapEncoder.FIRST_LAZER_VERSION
+                    ? new Vector2(Parsing.ParseFloat(split[0], Parsing.MAX_COORDINATE_VALUE), Parsing.ParseFloat(split[1], Parsing.MAX_COORDINATE_VALUE))
+                    : new Vector2((int)Parsing.ParseFloat(split[0], Parsing.MAX_COORDINATE_VALUE), (int)Parsing.ParseFloat(split[1], Parsing.MAX_COORDINATE_VALUE));
 
             double startTime = Parsing.ParseDouble(split[2]) + Offset;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29340.