### PR TITLE
Fix daily challenge notification spam

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneMainMenu.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Tests.Visual.Menus
                             {
                                 new PlaylistItem(beatmap)
                             },
+                            StartDate = { Value = DateTimeOffset.Now.AddMinutes(-30) },
                             EndDate = { Value = DateTimeOffset.Now.AddSeconds(60) }
                         });
                         return true;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
@@ -58,6 +58,7 @@ namespace osu.Game.Tests.Visual.UserInterface
                             {
                                 new PlaylistItem(beatmap)
                             },
+                            StartDate = { Value = DateTimeOffset.Now.AddMinutes(-5) },
                             EndDate = { Value = DateTimeOffset.Now.AddSeconds(30) }
                         });
                         return true;
@@ -95,8 +96,13 @@ namespace osu.Game.Tests.Visual.UserInterface
                     },
                 };
             });
-            AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
+            AddAssert("notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
 
+            AddStep("clear notifications", () =>
+            {
+                foreach (var notification in notificationOverlay.AllNotifications)
+                    notification.Close(runFlingAnimation: false);
+            });
             AddStep("beatmap of the day not active", () => metadataClient.DailyChallengeUpdated(null));
             AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
 
@@ -105,7 +111,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             {
                 RoomID = 1234,
             }));
-            AddAssert("notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
+            AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
         }
     }
 }

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Menu
 
                     // We only want to notify the user if a new challenge recently went live.
                     if (room.StartDate.Value != null
-                        && Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 600
+                        && Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 1800
                         && room.RoomID.Value != lastNotifiedDailyChallengeRoomId)
                     {
                         lastNotifiedDailyChallengeRoomId = room.RoomID.Value;

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -132,21 +132,21 @@ namespace osu.Game.Screens.Menu
 
         private long? lastNotifiedDailyChallengeRoomId;
 
-        private void dailyChallengeChanged(ValueChangedEvent<DailyChallengeInfo?> info)
+        private void dailyChallengeChanged(ValueChangedEvent<DailyChallengeInfo?> _)
         {
             UpdateState();
 
             scheduledCountdownUpdate?.Cancel();
             scheduledCountdownUpdate = null;
 
-            if (this.info.Value == null)
+            if (info.Value == null)
             {
                 Room = null;
                 cover.OnlineInfo = TooltipContent = null;
             }
             else
             {
-                var roomRequest = new GetRoomRequest(this.info.Value.Value.RoomID);
+                var roomRequest = new GetRoomRequest(info.Value.Value.RoomID);
 
                 roomRequest.Success += room =>
                 {

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -130,6 +130,8 @@ namespace osu.Game.Screens.Menu
             }
         }
 
+        private long? lastNotifiedDailyChallengeRoomId;
+
         private void dailyChallengeChanged(ValueChangedEvent<DailyChallengeInfo?> info)
         {
             UpdateState();
@@ -152,8 +154,11 @@ namespace osu.Game.Screens.Menu
                     cover.OnlineInfo = TooltipContent = room.Playlist.FirstOrDefault()?.Beatmap.BeatmapSet as APIBeatmapSet;
 
                     // We only want to notify the user if a new challenge recently went live.
-                    if (Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 600)
+                    if (Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 600 && room.RoomID.Value != lastNotifiedDailyChallengeRoomId)
+                    {
+                        lastNotifiedDailyChallengeRoomId = room.RoomID.Value;
                         notificationOverlay?.Post(new NewDailyChallengeNotification(room));
+                    }
 
                     updateCountdown();
                     Scheduler.AddDelayed(updateCountdown, 1000, true);

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -154,7 +154,9 @@ namespace osu.Game.Screens.Menu
                     cover.OnlineInfo = TooltipContent = room.Playlist.FirstOrDefault()?.Beatmap.BeatmapSet as APIBeatmapSet;
 
                     // We only want to notify the user if a new challenge recently went live.
-                    if (Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 600 && room.RoomID.Value != lastNotifiedDailyChallengeRoomId)
+                    if (room.StartDate.Value != null
+                        && Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 600
+                        && room.RoomID.Value != lastNotifiedDailyChallengeRoomId)
                     {
                         lastNotifiedDailyChallengeRoomId = room.RoomID.Value;
                         notificationOverlay?.Post(new NewDailyChallengeNotification(room));


### PR DESCRIPTION
Notification will now only show:

- Once per room.
- Only if game was opened or user logged in within 30 minutes of the room going live.

Note that the second point here changes (simplifies) the behaviour by always showing, even in the game-started case. Previously it would only show if logging in. I think this aligns better.

Closes https://github.com/ppy/osu/issues/29295.

- [x] **Untested because staging is currently not allowing login. Should be tested before merged.**