### PR TITLE
Fix occasionally `ChatOverlay` test failures due to RNG usage

### DIFF
--- a/osu.Game.Tests/Resources/TestResources.cs
+++ b/osu.Game.Tests/Resources/TestResources.cs
@@ -73,7 +73,12 @@ namespace osu.Game.Tests.Resources
 
         private static string getTempFilename() => temp_storage.GetFullPath(Guid.NewGuid() + ".osz");
 
-        private static int importId;
+        private static int testId = 1;
+
+        /// <summary>
+        /// Get a unique int value which is incremented each call.
+        /// </summary>
+        public static int GetNextTestID() => Interlocked.Increment(ref testId);
 
         /// <summary>
         /// Create a test beatmap set model.
@@ -88,7 +93,7 @@ namespace osu.Game.Tests.Resources
 
             RulesetInfo getRuleset() => rulesets?[j++ % rulesets.Length];
 
-            int setId = Interlocked.Increment(ref importId);
+            int setId = GetNextTestID();
 
             var metadata = new BeatmapMetadata
             {

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -139,8 +139,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void addRandomPlayer()
         {
-            int randomUser = RNG.Next(200000, 500000);
-            multiplayerClient.AddUser(new APIUser { Id = randomUser, Username = $"user {randomUser}" });
+            int id = TestResources.GetNextTestID();
+            multiplayerClient.AddUser(new APIUser { Id = id, Username = $"user {id}" });
         }
 
         private void removeLastUser()

--- a/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChannelList.cs
@@ -9,13 +9,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Chat.ChannelList;
 using osu.Game.Overlays.Chat.Listing;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -160,7 +160,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createRandomPublicChannel()
         {
-            int id = RNG.Next(0, 10000);
+            int id = TestResources.GetNextTestID();
             return new Channel
             {
                 Name = $"#channel-{id}",
@@ -171,7 +171,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createRandomPrivateChannel()
         {
-            int id = RNG.Next(0, 10000);
+            int id = TestResources.GetNextTestID();
             return new Channel(new APIUser
             {
                 Id = id,
@@ -181,7 +181,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createRandomAnnounceChannel()
         {
-            int id = RNG.Next(0, 10000);
+            int id = TestResources.GetNextTestID();
             return new Channel
             {
                 Name = $"Announce {id}",

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -32,6 +32,7 @@ using osu.Game.Overlays.Chat.ChannelList;
 using osuTK;
 using osuTK.Input;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -121,7 +122,7 @@ namespace osu.Game.Tests.Visual.Online
                             return true;
 
                         case PostMessageRequest postMessage:
-                            postMessage.TriggerSuccess(new Message(getNextTestID())
+                            postMessage.TriggerSuccess(new Message(TestResources.GetNextTestID())
                             {
                                 Content = postMessage.Message.Content,
                                 ChannelId = postMessage.Message.ChannelId,
@@ -718,7 +719,7 @@ namespace osu.Game.Tests.Visual.Online
 
         private Channel createPrivateChannel()
         {
-            int id = getNextTestID();
+            int id = TestResources.GetNextTestID();
 
             return new Channel(new APIUser
             {
@@ -738,10 +739,6 @@ namespace osu.Game.Tests.Visual.Online
                 Id = announce_channel_id,
             };
         }
-
-        private static int testId = DummyAPIAccess.DUMMY_USER_ID + 1;
-
-        private static int getNextTestID() => Interlocked.Increment(ref testId);
 
         private partial class TestChatOverlay : ChatOverlay
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -19,7 +19,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Logging;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
@@ -122,7 +121,7 @@ namespace osu.Game.Tests.Visual.Online
                             return true;
 
                         case PostMessageRequest postMessage:
-                            postMessage.TriggerSuccess(new Message(RNG.Next(0, 10000000))
+                            postMessage.TriggerSuccess(new Message(getNextTestID())
                             {
                                 Content = postMessage.Message.Content,
                                 ChannelId = postMessage.Message.ChannelId,
@@ -717,11 +716,9 @@ namespace osu.Game.Tests.Visual.Online
             Type = ChannelType.Public,
         };
 
-        private static int privateChannelUser = DummyAPIAccess.DUMMY_USER_ID + 1;
-
         private Channel createPrivateChannel()
         {
-            int id = Interlocked.Increment(ref privateChannelUser);
+            int id = getNextTestID();
 
             return new Channel(new APIUser
             {
@@ -741,6 +738,10 @@ namespace osu.Game.Tests.Visual.Online
                 Id = announce_channel_id,
             };
         }
+
+        private static int testId = DummyAPIAccess.DUMMY_USER_ID + 1;
+
+        private static int getNextTestID() => Interlocked.Increment(ref testId);
 
         private partial class TestChatOverlay : ChatOverlay
         {

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -717,9 +717,12 @@ namespace osu.Game.Tests.Visual.Online
             Type = ChannelType.Public,
         };
 
+        private static int privateChannelUser = DummyAPIAccess.DUMMY_USER_ID + 1;
+
         private Channel createPrivateChannel()
         {
-            int id = RNG.Next(0, DummyAPIAccess.DUMMY_USER_ID - 1);
+            int id = Interlocked.Increment(ref privateChannelUser);
+
             return new Channel(new APIUser
             {
                 Id = id,


### PR DESCRIPTION
See https://github.com/ppy/osu/actions/runs/10302758137/job/28517150950.

Same ID gets chosen twice for PM channel.

Update: Did a full pass of RNG usage in tests and replaced any that look like they could have failed in a similar way.