### PR TITLE
Add option to hide song progress time/text

### DIFF
--- a/osu.Game/Localisation/HUD/SongProgressStrings.cs
+++ b/osu.Game/Localisation/HUD/SongProgressStrings.cs
@@ -19,6 +19,16 @@ namespace osu.Game.Localisation.HUD
         /// </summary>
         public static LocalisableString ShowGraphDescription => new TranslatableString(getKey(@"show_graph_description"), "Whether a graph displaying difficulty throughout the beatmap should be shown");
 
+        /// <summary>
+        /// "Show time"
+        /// </summary>
+        public static LocalisableString ShowTime => new TranslatableString(getKey(@"show_time"), "Show time");
+
+        /// <summary>
+        /// "Whether the passed and remaining time should be shown"
+        /// </summary>
+        public static LocalisableString ShowTimeDescription => new TranslatableString(getKey(@"show_time_description"), "Whether the passed and remaining time should be shown");
+
         private static string getKey(string key) => $"{prefix}:{key}";
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowGraph), nameof(SongProgressStrings.ShowGraphDescription))]
         public Bindable<bool> ShowGraph { get; } = new BindableBool(true);
 
+        [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
+        public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+
         [Resolved]
         private Player? player { get; set; }
 
@@ -90,6 +93,7 @@ namespace osu.Game.Screens.Play.HUD
 
             Interactive.BindValueChanged(_ => bar.Interactive = Interactive.Value, true);
             ShowGraph.BindValueChanged(_ => updateGraphVisibility(), true);
+            ShowTime.BindValueChanged(_ => info.FadeTo(ShowTime.Value ? 1 : 0, 200, Easing.In), true);
         }
 
         protected override void UpdateObjects(IEnumerable<HitObject> objects)

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -89,7 +89,6 @@ namespace osu.Game.Screens.Play.HUD
 
             base.LoadComplete();
         }
-        
 
         protected override void UpdateObjects(IEnumerable<HitObject> objects)
         {

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -33,6 +33,9 @@ namespace osu.Game.Screens.Play.HUD
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowGraph), nameof(SongProgressStrings.ShowGraphDescription))]
         public Bindable<bool> ShowGraph { get; } = new BindableBool(true);
 
+        [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
+        public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+
         [Resolved]
         private Player? player { get; set; }
 
@@ -82,9 +85,11 @@ namespace osu.Game.Screens.Play.HUD
         {
             Interactive.BindValueChanged(_ => updateBarVisibility(), true);
             ShowGraph.BindValueChanged(_ => updateGraphVisibility(), true);
+            ShowTime.BindValueChanged(_ => updateTimeVisibility(), true);
 
             base.LoadComplete();
         }
+        
 
         protected override void UpdateObjects(IEnumerable<HitObject> objects)
         {
@@ -128,6 +133,14 @@ namespace osu.Game.Screens.Play.HUD
 
             updateInfoMargin();
         }
+
+        private void updateTimeVisibility()
+        {
+            info.FadeTo(ShowTime.Value ? 1 : 0, transition_duration, Easing.In);
+
+            updateInfoMargin();
+        }
+
 
         private void updateInfoMargin()
         {

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -140,7 +140,6 @@ namespace osu.Game.Screens.Play.HUD
             updateInfoMargin();
         }
 
-
         private void updateInfoMargin()
         {
             float finalMargin = bottom_bar_height + (Interactive.Value ? handle_size.Y : 0) + (ShowGraph.Value ? graph_height : 0);


### PR DESCRIPTION
Adds a "Show time" checkbox to the default and argon song progress elements that shows/hides the passed and remaining song time (`info` internally).

If there are any better names (i.e. "Show text") or description ideas, feel free to share :)

![image](https://github.com/user-attachments/assets/cd31d276-24dc-40d1-abfa-371b97e3f27a)
![image](https://github.com/user-attachments/assets/ce009793-6666-4786-800b-e57b145fdc08)
