### PR TITLE
Add IndicationOnly setting for Alternate and Single Tap and tests

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
@@ -177,5 +177,37 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 }
             ).ToList()
         });
+
+        [Test]
+        public void TestInputIndicationOnly() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModAlternate{
+                IndicationOnly = { Value = true }
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
+            Autoplay = false,
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(100)),
+                new OsuReplayFrame(1000, new Vector2(200, 100), OsuAction.LeftButton),
+            }
+        });
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
@@ -181,7 +181,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         [Test]
         public void TestInputIndicationOnly() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModAlternate{
+            Mod = new OsuModAlternate
+            {
                 IndicationOnly = { Value = true }
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
@@ -175,7 +175,8 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         [Test]
         public void TestInputIndicationOnly() => CreateModTest(new ModTestData
         {
-            Mod = new OsuModSingleTap{
+            Mod = new OsuModSingleTap
+            {
                 IndicationOnly = { Value = true }
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
@@ -171,5 +171,37 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 new OsuReplayFrame(3001, new Vector2(500, 100)),
             }
         });
+
+        [Test]
+        public void TestInputIndicationOnly() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModSingleTap{
+                IndicationOnly = { Value = true }
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
+            Autoplay = false,
+            Beatmap = new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new HitCircle
+                    {
+                        StartTime = 500,
+                        Position = new Vector2(100),
+                    },
+                    new HitCircle
+                    {
+                        StartTime = 1000,
+                        Position = new Vector2(200, 100),
+                    },
+                },
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(500, new Vector2(100), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(100)),
+                new OsuReplayFrame(1000, new Vector2(200, 100), OsuAction.RightButton),
+            }
+        });
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
+++ b/osu.Game.Rulesets.Osu/Mods/InputBlockingMod.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
@@ -24,6 +26,10 @@ namespace osu.Game.Rulesets.Osu.Mods
         public override double ScoreMultiplier => 1.0;
         public override Type[] IncompatibleMods => new[] { typeof(ModAutoplay), typeof(ModRelax), typeof(OsuModCinema) };
         public override ModType Type => ModType.Conversion;
+        public override bool Ranked => IndicationOnly.Value;
+
+        [SettingSource("Indication Only", "Just indicate wrong inputs without affecting scoring")]
+        public BindableBool IndicationOnly { get; } = new BindableBool(false);
 
         private const double flash_duration = 1000;
 
@@ -94,6 +100,8 @@ namespace osu.Game.Rulesets.Osu.Mods
             }
 
             ruleset.Cursor.FlashColour(Colour4.Red, flash_duration, Easing.OutQuint);
+            if (IndicationOnly.Value)
+                return true;
             return false;
         }
 


### PR DESCRIPTION
This adds an option for Alternate and Single Tap mods to be able to be used without affecting the scoring, only doing the visual clue for rejected inputs while allowing the inputs to pass.

It should be identical to no-mod gameplay-wise, so the mods were made Ranked when IndicationOnly is active.