### PR TITLE
Improve editor performance for maps with many `EffectControlPoint`s

### DIFF
--- a/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
+++ b/osu.Game/Beatmaps/ControlPoints/ControlPointInfo.cs
@@ -216,7 +216,7 @@ namespace osu.Game.Beatmaps.ControlPoints
         public static T BinarySearchWithFallback<T>(IReadOnlyList<T> list, double time, T fallback)
             where T : class, IControlPoint
         {
-            return BinarySearch(list, time) ?? fallback;
+            return BinarySearch(list, time).Point ?? fallback;
         }
 
         /// <summary>
@@ -224,20 +224,20 @@ namespace osu.Game.Beatmaps.ControlPoints
         /// </summary>
         /// <param name="list">The list to search.</param>
         /// <param name="time">The time to find the control point at.</param>
-        /// <returns>The active control point at <paramref name="time"/>. Will return <c>null</c> if there are no control points, or if the time is before the first control point.</returns>
-        public static T BinarySearch<T>(IReadOnlyList<T> list, double time)
+        /// <returns>The active control point at <paramref name="time"/> and its index. Will return <c>null, -1</c> if there are no control points, or if the time is before the first control point.</returns>
+        public static (T Point, int Index) BinarySearch<T>(IReadOnlyList<T> list, double time)
             where T : class, IControlPoint
         {
             ArgumentNullException.ThrowIfNull(list);
 
             if (list.Count == 0)
-                return null;
+                return (null, -1);
 
             if (time < list[0].Time)
-                return null;
+                return (null, -1);
 
             if (time >= list[^1].Time)
-                return list[^1];
+                return (list[^1], list.Count - 1);
 
             int l = 0;
             int r = list.Count - 2;
@@ -251,11 +251,11 @@ namespace osu.Game.Beatmaps.ControlPoints
                 else if (list[pivot].Time > time)
                     r = pivot - 1;
                 else
-                    return list[pivot];
+                    return (list[pivot], pivot);
             }
 
             // l will be the first control point with Time > time, but we want the one before it
-            return list[l - 1];
+            return (list[l - 1], l - 1);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace osu.Game.Beatmaps.ControlPoints
             {
                 case TimingControlPoint:
                     // Timing points are a special case and need to be added regardless of fallback availability.
-                    existing = BinarySearch(TimingPoints, time);
+                    existing = BinarySearch(TimingPoints, time).Point;
                     break;
 
                 case EffectControlPoint:

--- a/osu.Game/Beatmaps/Legacy/LegacyControlPointInfo.cs
+++ b/osu.Game/Beatmaps/Legacy/LegacyControlPointInfo.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Beatmaps.Legacy
             {
                 case SampleControlPoint:
                     // intentionally don't use SamplePointAt (we always need to consider the first sample point).
-                    var existing = BinarySearch(SamplePoints, time);
+                    var existing = BinarySearch(SamplePoints, time).Point;
                     return newPoint.IsRedundant(existing);
 
                 case DifficultyControlPoint:

--- a/osu.Game/Rulesets/UI/Scrolling/Algorithms/OverlappingScrollAlgorithm.cs
+++ b/osu.Game/Rulesets/UI/Scrolling/Algorithms/OverlappingScrollAlgorithm.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.UI.Scrolling.Algorithms
         /// <returns>The <see cref="MultiplierControlPoint"/>.</returns>
         private MultiplierControlPoint controlPointAt(double time)
         {
-            return ControlPointInfo.BinarySearch(controlPoints, time)
+            return ControlPointInfo.BinarySearch(controlPoints, time).Point
                    // The standard binary search will fail if there's no control points, or if the time is before the first.
                    // For this method, we want to use the first control point in the latter case.
                    ?? controlPoints.FirstOrDefault()

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/EffectPointVisualisation.cs
@@ -56,16 +56,9 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
             {
                 EffectControlPoint? next = null;
 
-                for (int i = 0; i < beatmap.ControlPointInfo.EffectPoints.Count; i++)
-                {
-                    var point = beatmap.ControlPointInfo.EffectPoints[i];
-
-                    if (point.Time > effect.Time)
-                    {
-                        next = point;
-                        break;
-                    }
-                }
+                int activePointIndex = ControlPointInfo.BinarySearch(beatmap.ControlPointInfo.EffectPoints, effect.Time).Index;
+                if (activePointIndex + 1 <= beatmap.ControlPointInfo.EffectPoints.Count - 1)
+                    next = beatmap.ControlPointInfo.EffectPoints[activePointIndex + 1];
 
                 if (!ReferenceEquals(nextControlPoint, next))
                 {


### PR DESCRIPTION
|master|pr|
|---|---|
|![osu_2024-08-11_20-44-20](https://github.com/user-attachments/assets/89511b17-642c-4776-9b3d-cb73cd17eff5)|![osu_2024-08-11_20-44-59](https://github.com/user-attachments/assets/ef2753d0-4e10-4d0e-89c6-2f0c163a3fcf)|

map: https://osu.ppy.sh/beatmapsets/1248234#mania/2594305