### PR TITLE
Fix occasional test failures in `TestSceneBetmapRecommendations`

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -31,8 +31,6 @@ namespace osu.Game.Tests.Visual.SongSelect
         [SetUpSteps]
         public override void SetUpSteps()
         {
-            base.SetUpSteps();
-
             AddStep("populate ruleset statistics", () =>
             {
                 Dictionary<string, UserStatistics> rulesetStatistics = new Dictionary<string, UserStatistics>();
@@ -68,6 +66,8 @@ namespace osu.Game.Tests.Visual.SongSelect
                         return 0;
                 }
             }
+
+            base.SetUpSteps();
         }
 
         [Test]


### PR DESCRIPTION
The game was being constructed befor the API was setup, which could mean depending on test execution ordering and speed, the recommendations array would not be filled.

Easy to reproduce by `[Solo]`ing `TestCorrectStarRatingIsUsed`.

See https://github.com/ppy/osu/runs/28689915929#r0s0.