### PR TITLE
Fix fruit positions getting mangled when exploded from the plate

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatcher.cs
@@ -248,7 +248,8 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             AddStep("enable hit lighting", () => config.SetValue(OsuSetting.HitLighting, true));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
-            AddAssert("correct hit lighting colour", () => catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == this.ChildrenOfType<DrawableCatchHitObject>().First().AccentColour.Value);
+            AddAssert("correct hit lighting colour",
+                () => catcher.ChildrenOfType<HitExplosion>().First()?.Entry?.ObjectColour == this.ChildrenOfType<DrawableCatchHitObject>().First().AccentColour.Value);
         }
 
         [Test]
@@ -257,6 +258,16 @@ namespace osu.Game.Rulesets.Catch.Tests
             AddStep("disable hit lighting", () => config.SetValue(OsuSetting.HitLighting, false));
             AddStep("catch fruit", () => attemptCatch(new Fruit()));
             AddAssert("no hit lighting", () => !catcher.ChildrenOfType<HitExplosion>().Any());
+        }
+
+        [Test]
+        public void TestAllExplodedObjectsAtUniquePositions()
+        {
+            AddStep("catch normal fruit", () => attemptCatch(new Fruit()));
+            AddStep("catch normal fruit", () => attemptCatch(new Fruit { IndexInBeatmap = 2, LastInCombo = true }));
+            AddAssert("two fruit at distinct x coordinates",
+                () => this.ChildrenOfType<CaughtFruit>().Select(f => f.DrawPosition.X).Distinct(),
+                () => Has.Exactly(2).Items);
         }
 
         private void checkPlate(int count) => AddAssert($"{count} objects on the plate", () => catcher.CaughtObjects.Count() == count);

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/CaughtObject.cs
@@ -21,11 +21,9 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         public Bindable<Color4> AccentColour { get; } = new Bindable<Color4>();
         public Bindable<bool> HyperDash { get; } = new Bindable<bool>();
         public Bindable<int> IndexInBeatmap { get; } = new Bindable<int>();
-
+        public Vector2 DisplayPosition => DrawPosition;
         public Vector2 DisplaySize => Size * Scale;
-
         public float DisplayRotation => Rotation;
-
         public double DisplayStartTime => HitObject.StartTime;
 
         /// <summary>
@@ -44,25 +42,23 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             Size = new Vector2(CatchHitObject.OBJECT_RADIUS * 2);
         }
 
-        /// <summary>
-        /// Copies the hit object visual state from another <see cref="IHasCatchObjectState"/> object.
-        /// </summary>
-        public virtual void CopyStateFrom(IHasCatchObjectState objectState)
-        {
-            HitObject = objectState.HitObject;
-            Scale = Vector2.Divide(objectState.DisplaySize, Size);
-            Rotation = objectState.DisplayRotation;
-            AccentColour.Value = objectState.AccentColour.Value;
-            HyperDash.Value = objectState.HyperDash.Value;
-            IndexInBeatmap.Value = objectState.IndexInBeatmap.Value;
-        }
-
         protected override void FreeAfterUse()
         {
             ClearTransforms();
             Alpha = 1;
 
             base.FreeAfterUse();
+        }
+
+        public void RestoreState(CatchObjectState state)
+        {
+            HitObject = state.HitObject;
+            AccentColour.Value = state.AccentColour;
+            HyperDash.Value = state.HyperDash;
+            IndexInBeatmap.Value = state.IndexInBeatmap;
+            Position = state.DisplayPosition;
+            Scale = Vector2.Divide(state.DisplaySize, Size);
+            Rotation = state.DisplayRotation;
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawablePalpableCatchHitObject.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         /// </summary>
         protected readonly Container ScalingContainer;
 
+        public Vector2 DisplayPosition => DrawPosition;
+
         public Vector2 DisplaySize => ScalingContainer.Size * ScalingContainer.Scale;
 
         public float DisplayRotation => ScalingContainer.Rotation;
@@ -95,5 +97,7 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
             base.OnFree();
         }
+
+        public void RestoreState(CatchObjectState state) => throw new NotSupportedException("Cannot restore state into a drawable catch hitobject.");
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -31,7 +31,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             target.AccentColour.Value,
             target.HyperDash.Value,
             target.IndexInBeatmap.Value,
-            target.DisplayStartTime,
             target.DisplayPosition,
             target.DisplaySize,
             target.DisplayRotation);
@@ -42,7 +41,6 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         Color4 AccentColour,
         bool HyperDash,
         int IndexInBeatmap,
-        double DisplayStartTime,
         Vector2 DisplayPosition,
         Vector2 DisplaySize,
         float DisplayRotation);

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/IHasCatchObjectState.cs
@@ -13,17 +13,37 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
     public interface IHasCatchObjectState
     {
         PalpableCatchHitObject HitObject { get; }
-
-        double DisplayStartTime { get; }
-
         Bindable<Color4> AccentColour { get; }
-
         Bindable<bool> HyperDash { get; }
-
         Bindable<int> IndexInBeatmap { get; }
-
+        double DisplayStartTime { get; }
+        Vector2 DisplayPosition { get; }
         Vector2 DisplaySize { get; }
-
         float DisplayRotation { get; }
+
+        void RestoreState(CatchObjectState state);
     }
+
+    public static class HasCatchObjectStateExtensions
+    {
+        public static CatchObjectState SaveState(this IHasCatchObjectState target) => new CatchObjectState(
+            target.HitObject,
+            target.AccentColour.Value,
+            target.HyperDash.Value,
+            target.IndexInBeatmap.Value,
+            target.DisplayStartTime,
+            target.DisplayPosition,
+            target.DisplaySize,
+            target.DisplayRotation);
+    }
+
+    public readonly record struct CatchObjectState(
+        PalpableCatchHitObject HitObject,
+        Color4 AccentColour,
+        bool HyperDash,
+        int IndexInBeatmap,
+        double DisplayStartTime,
+        Vector2 DisplayPosition,
+        Vector2 DisplaySize,
+        float DisplayRotation);
 }

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -362,7 +363,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             if (caughtObject == null) return;
 
-            caughtObject.CopyStateFrom(drawableObject);
+            caughtObject.RestoreState(drawableObject.SaveState());
             caughtObject.Anchor = Anchor.TopCentre;
             caughtObject.Position = position;
             caughtObject.Scale *= caught_fruit_scale_adjust;
@@ -411,41 +412,50 @@ namespace osu.Game.Rulesets.Catch.UI
             }
         }
 
-        private CaughtObject getDroppedObject(CaughtObject caughtObject)
+        private CaughtObject getDroppedObject(CatchObjectState state)
         {
-            var droppedObject = getCaughtObject(caughtObject.HitObject);
+            var droppedObject = getCaughtObject(state.HitObject);
             Debug.Assert(droppedObject != null);
 
-            droppedObject.CopyStateFrom(caughtObject);
+            droppedObject.RestoreState(state);
             droppedObject.Anchor = Anchor.TopLeft;
-            droppedObject.Position = caughtObjectContainer.ToSpaceOfOtherDrawable(caughtObject.DrawPosition, droppedObjectTarget);
+            droppedObject.Position = caughtObjectContainer.ToSpaceOfOtherDrawable(state.DisplayPosition, droppedObjectTarget);
 
             return droppedObject;
         }
 
         private void clearPlate(DroppedObjectAnimation animation)
         {
-            var caughtObjects = caughtObjectContainer.Children.ToArray();
+            int caughtCount = caughtObjectContainer.Children.Count;
+            CatchObjectState[] states = ArrayPool<CatchObjectState>.Shared.Rent(caughtCount);
 
-            caughtObjectContainer.Clear(false);
+            try
+            {
+                for (int i = 0; i < caughtCount; i++)
+                    states[i] = caughtObjectContainer.Children[i].SaveState();
 
-            // Use the already returned PoolableDrawables for new objects
-            var droppedObjects = caughtObjects.Select(getDroppedObject).ToArray();
+                caughtObjectContainer.Clear(false);
 
-            droppedObjectTarget.AddRange(droppedObjects);
-
-            foreach (var droppedObject in droppedObjects)
-                applyDropAnimation(droppedObject, animation);
+                for (int i = 0; i < caughtCount; i++)
+                {
+                    CaughtObject obj = getDroppedObject(states[i]);
+                    droppedObjectTarget.Add(obj);
+                    applyDropAnimation(obj, animation);
+                }
+            }
+            finally
+            {
+                ArrayPool<CatchObjectState>.Shared.Return(states);
+            }
         }
 
         private void removeFromPlate(CaughtObject caughtObject, DroppedObjectAnimation animation)
         {
+            CatchObjectState state = caughtObject.SaveState();
             caughtObjectContainer.Remove(caughtObject, false);
 
-            var droppedObject = getDroppedObject(caughtObject);
-
+            var droppedObject = getDroppedObject(state);
             droppedObjectTarget.Add(droppedObject);
-
             applyDropAnimation(droppedObject, animation);
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/29319

This is an incorrect use of `DrawablePool<>`.

We have two caught fruit `[ a, b ]` and they're released back to the pool. Almost immediately afterwards they're re-retrieved from the pool as now `[ b, a ]` respectively because `DrawablePool` internally is a `Stack<>`. This means the `DrawPosition` would get mangled by the time the second hitobject is supposed to "copy" its position from the original object.  
In-fact, for this particular test, the second object will always have x-position=0 if this occurs, which is why the assertion works.

The effects of this are actually larger than the issue makes it sound, as it affects _all_ objects in the plate. It's why the objects look like they're collapsing towards the centre:

https://github.com/user-attachments/assets/e8cc665a-66ae-4f5f-9652-31488cc44417

Compared to after this fix:

https://github.com/user-attachments/assets/862b54b9-459f-47c5-b087-37d85bd82139