### PR TITLE
Fix user profile overlay colour resetting when selecting another ruleset

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -11,6 +11,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Users;
 
 namespace osu.Game.Tests.Visual.Online
@@ -192,13 +193,26 @@ namespace osu.Game.Tests.Visual.Online
             int hue2 = 0;
 
             AddSliderStep("hue 2", 0, 360, 50, h => hue2 = h);
-            AddStep("show user", () => profile.ShowUser(new APIUser { Id = 1 }));
+            AddStep("show user", () => profile.ShowUser(new APIUser { Id = 2 }));
             AddWaitStep("wait some", 3);
 
             AddStep("complete request", () => pendingRequest.TriggerSuccess(new APIUser
             {
                 Username = $"Colorful #{hue2}",
-                Id = 1,
+                Id = 2,
+                CountryCode = CountryCode.JP,
+                CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c2.jpg",
+                ProfileHue = hue2,
+                PlayMode = "osu",
+            }));
+
+            AddStep("show user different ruleset", () => profile.ShowUser(new APIUser { Id = 2 }, new TaikoRuleset().RulesetInfo));
+            AddWaitStep("wait some", 3);
+
+            AddStep("complete request", () => pendingRequest.TriggerSuccess(new APIUser
+            {
+                Username = $"Colorful #{hue2}",
+                Id = 2,
                 CountryCode = CountryCode.JP,
                 CoverUrl = @"https://osu.ppy.sh/images/headers/profile-covers/c2.jpg",
                 ProfileHue = hue2,

--- a/osu.Game/Overlays/UserProfileOverlay.cs
+++ b/osu.Game/Overlays/UserProfileOverlay.cs
@@ -96,7 +96,8 @@ namespace osu.Game.Overlays
         {
             Debug.Assert(user != null);
 
-            if (user.OnlineID == Header.User.Value?.User.Id && ruleset?.MatchesOnlineID(Header.User.Value?.Ruleset) == true)
+            bool sameUser = user.OnlineID == Header.User.Value?.User.Id;
+            if (sameUser && ruleset?.MatchesOnlineID(Header.User.Value?.Ruleset) == true)
                 return;
 
             if (sectionsContainer != null)
@@ -118,7 +119,9 @@ namespace osu.Game.Overlays
                 }
                 : Array.Empty<ProfileSection>();
 
-            changeOverlayColours(OverlayColourScheme.Pink.GetHue());
+            if (!sameUser)
+                changeOverlayColours(OverlayColourScheme.Pink.GetHue());
+
             recreateBaseContent();
 
             if (API.State.Value != APIState.Offline)


### PR DESCRIPTION
Caught me off guard.

Before:

https://github.com/user-attachments/assets/c0a74094-455d-4a7e-8027-ad65f0675255

After:

https://github.com/user-attachments/assets/a9db8608-2fe4-450e-bd0a-01cc245e56f8

We can also just not change the colour at all and keep the profile overlay loading with the old hue until it completes.