### PR TITLE
Fix daily challenge stats display suffix not displayed

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -8,11 +8,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Resources.Localisation.Web;
 using osu.Game.Scoring;
 
 namespace osu.Game.Overlays.Profile.Header.Components
@@ -106,7 +106,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
             APIUserDailyChallengeStatistics stats = User.Value.User.DailyChallengeStatistics;
 
-            dailyPlayCount.Text = UsersStrings.ShowDailyChallengeUnitDay(stats.PlayCount.ToLocalisableString("N0"));
+            // todo: ideally we want to use UsersStrings.ShowDailyChallengeUnit{Day,Week}(...), but it's broken right now.
+            // see: https://github.com/ppy/osu/issues/29355#issuecomment-2277139889
+            dailyPlayCount.Text = LocalisableString.Interpolate($"{stats.PlayCount.ToLocalisableString("N0")}d");
             dailyPlayCount.Colour = colours.ForRankingTier(tierForPlayCount(stats.PlayCount));
 
             TooltipContent = new DailyChallengeTooltipData(colourProvider, stats);

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -112,16 +112,18 @@ namespace osu.Game.Overlays.Profile.Header.Components
             background.Colour = colourProvider.Background4;
             topBackground.Colour = colourProvider.Background5;
 
-            currentDaily.Value = UsersStrings.ShowDailyChallengeUnitDay(content.Statistics.DailyStreakCurrent.ToLocalisableString(@"N0"));
+            // todo: ideally we want to use UsersStrings.ShowDailyChallengeUnit{Day,Week}(...), but it's broken right now.
+            // see: https://github.com/ppy/osu/issues/29355#issuecomment-2277139889
+            currentDaily.Value = LocalisableString.Interpolate($"{statistics.DailyStreakCurrent.ToLocalisableString("N0")}d");
             currentDaily.ValueColour = colours.ForRankingTier(TierForDaily(statistics.DailyStreakCurrent));
 
-            currentWeekly.Value = UsersStrings.ShowDailyChallengeUnitWeek(statistics.WeeklyStreakCurrent.ToLocalisableString(@"N0"));
+            currentWeekly.Value = LocalisableString.Interpolate($"{statistics.WeeklyStreakCurrent.ToLocalisableString(@"N0")}w");
             currentWeekly.ValueColour = colours.ForRankingTier(TierForWeekly(statistics.WeeklyStreakCurrent));
 
-            bestDaily.Value = UsersStrings.ShowDailyChallengeUnitDay(statistics.DailyStreakBest.ToLocalisableString(@"N0"));
+            bestDaily.Value = LocalisableString.Interpolate($"{statistics.DailyStreakBest.ToLocalisableString(@"N0")}d");
             bestDaily.ValueColour = colours.ForRankingTier(TierForDaily(statistics.DailyStreakBest));
 
-            bestWeekly.Value = UsersStrings.ShowDailyChallengeUnitWeek(statistics.WeeklyStreakBest.ToLocalisableString(@"N0"));
+            bestWeekly.Value = LocalisableString.Interpolate($"{statistics.WeeklyStreakBest.ToLocalisableString(@"N0")}w");
             bestWeekly.ValueColour = colours.ForRankingTier(TierForWeekly(statistics.WeeklyStreakBest));
 
             topTen.Value = statistics.Top10PercentPlacements.ToLocalisableString(@"N0");


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29355

Almost forgot to fix this one before release. The new code may be a little too complicated, it just tries to preserve localisation of the number itself while arbitrarily adding "d"/"w" at the end. We can remove localisation from the number itself and simplify further but I think this is fine as-is.