### PR TITLE
Fix crash on changing skins when classic mod is enabled and game is rewound

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneDrawableJudgement.cs
@@ -28,14 +28,20 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
                     AddStep("Show " + result.GetDescription(), () =>
                     {
                         SetContents(_ =>
-                            new DrawableManiaJudgement(new JudgementResult(new HitObject { StartTime = Time.Current }, new Judgement())
-                            {
-                                Type = result
-                            }, null)
+                        {
+                            var drawableManiaJudgement = new DrawableManiaJudgement
                             {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                            });
+                            };
+
+                            drawableManiaJudgement.Apply(new JudgementResult(new HitObject { StartTime = Time.Current }, new Judgement())
+                            {
+                                Type = result
+                            }, null);
+
+                            return drawableManiaJudgement;
+                        });
 
                         // for test purposes, undo the Y adjustment related to the `ScorePosition` legacy positioning config value
                         // (see `LegacyManiaJudgementPiece.load()`).

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaJudgement.cs
@@ -5,22 +5,12 @@
 
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Rulesets.Mania.UI
 {
     public partial class DrawableManiaJudgement : DrawableJudgement
     {
-        public DrawableManiaJudgement(JudgementResult result, DrawableHitObject judgedObject)
-            : base(result, judgedObject)
-        {
-        }
-
-        public DrawableManiaJudgement()
-        {
-        }
-
         protected override Drawable CreateDefaultJudgement(HitResult result) => new DefaultManiaJudgementPiece(result);
 
         private partial class DefaultManiaJudgementPiece : DefaultJudgementPiece

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -36,17 +36,6 @@ namespace osu.Game.Rulesets.Judgements
         private readonly Lazy<Drawable> proxiedAboveHitObjectsContent;
         public Drawable ProxiedAboveHitObjectsContent => proxiedAboveHitObjectsContent.Value;
 
-        /// <summary>
-        /// Creates a drawable which visualises a <see cref="Judgements.Judgement"/>.
-        /// </summary>
-        /// <param name="result">The judgement to visualise.</param>
-        /// <param name="judgedObject">The object which was judged.</param>
-        public DrawableJudgement(JudgementResult result, DrawableHitObject judgedObject)
-            : this()
-        {
-            Apply(result, judgedObject);
-        }
-
         public DrawableJudgement()
         {
             Size = new Vector2(judgement_size);

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
+using osu.Framework.Logging;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
@@ -111,6 +112,9 @@ namespace osu.Game.Rulesets.Judgements
         protected override void PrepareForUse()
         {
             base.PrepareForUse();
+
+            if (!IsInPool)
+                Logger.Log($"{nameof(DrawableJudgement)} for judgement type {Result} was not retrieved from a pool. Consider adding to a JudgementPooler.");
 
             Debug.Assert(Result != null);
 

--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -119,9 +119,6 @@ namespace osu.Game.Rulesets.Judgements
 
         private void runAnimation()
         {
-            // is a no-op if the drawables are already in a correct state.
-            prepareDrawables();
-
             // undo any transforms applies in ApplyMissAnimations/ApplyHitAnimations to get a sane initial state.
             ApplyTransformsAt(double.MinValue, true);
             ClearTransforms(true);


### PR DESCRIPTION
I can't mentally figure out *what* is leading to the issue here, but in the case where `prepareDrawables` is called from `JudgementBody.OnSkinChanged`, things go very wrong. It's a weird recursive-like call that really shouldn't have existed in the first place. I think a smell test is enough for anyone to agree that the flow was very bad.

Removing this call doesn't seem to cause any issues. `runAnimation` should always be called in `PrepareForUse` (both pooled and non-pooled scenarios) so things should still always be in a correct state.

Closes #29398.

---

If anyone wishes to try and track down the actual underlying cause of this:

```diff
diff --git a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
index bdeadfd201..b37f855b41 100644
--- a/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
+++ b/osu.Game/Rulesets/Judgements/DrawableJudgement.cs
@@ -120,7 +120,10 @@ protected override void PrepareForUse()
         private void runAnimation()
         {
             // is a no-op if the drawables are already in a correct state.
-            prepareDrawables();
+            if (prepareDrawables())
+            {
+                Console.WriteLine($"WARNING bad thing happened for {Result.Type} ({Result.HitObject})"); // breakpoint
+            }
 
             // undo any transforms applies in ApplyMissAnimations/ApplyHitAnimations to get a sane initial state.
             ApplyTransformsAt(double.MinValue, true);
@@ -161,13 +164,13 @@ private void runAnimation()
 
         private HitResult? currentDrawableType;
 
-        private void prepareDrawables()
+        private bool prepareDrawables()
         {
             var type = Result?.Type ?? HitResult.Perfect; //TODO: better default type from ruleset
 
             // todo: this should be removed once judgements are always pooled.
             if (type == currentDrawableType)
-                return;
+                return false;
 
             // sub-classes might have added their own children that would be removed here if .InternalChild was used.
             if (JudgementBody != null)
@@ -199,6 +202,8 @@ void proxyContent()
                         aboveHitObjectsContent.Add(proxiedContent);
                 }
             }
+
+            return true;
         }
 
         protected virtual Drawable CreateDefaultJudgement(HitResult result) => new DefaultJudgementPiece(result);

```

- Apply classic mod
- Start with autoplay.
- Seek forward until after a slider
- Seek backward until before slider
- Change skin

Doesn't matter what skin before/after. It's clearly something to do with the classic skin slider logic, and probably something to do with different lifetimes making this only happen for said scenario.  Alternatively test that this is fixed and not worry about why it happened (probably irrelevant).