### PR TITLE
Remove daily challenge tooltip from main menu

### DIFF
--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -9,12 +9,10 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.Drawables;
-using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
@@ -30,7 +28,7 @@ using osuTK.Input;
 
 namespace osu.Game.Screens.Menu
 {
-    public partial class DailyChallengeButton : MainMenuButton, IHasCustomTooltip<APIBeatmapSet?>
+    public partial class DailyChallengeButton : MainMenuButton
     {
         public Room? Room { get; private set; }
 
@@ -201,36 +199,6 @@ namespace osu.Game.Screens.Menu
             base.UpdateState();
         }
 
-        public ITooltip<APIBeatmapSet?> GetCustomTooltip() => new DailyChallengeTooltip();
-
         public APIBeatmapSet? TooltipContent { get; private set; }
-
-        internal partial class DailyChallengeTooltip : CompositeDrawable, ITooltip<APIBeatmapSet?>
-        {
-            [Cached]
-            private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
-
-            private APIBeatmapSet? lastContent;
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                AutoSizeAxes = Axes.Both;
-            }
-
-            public void Move(Vector2 pos) => Position = pos;
-
-            public void SetContent(APIBeatmapSet? content)
-            {
-                if (content == lastContent)
-                    return;
-
-                lastContent = content;
-
-                ClearInternal();
-                if (content != null)
-                    AddInternal(new BeatmapCardNano(content));
-            }
-        }
     }
 }


### PR DESCRIPTION
Now that we have a nice intro screen for the daily challenge, it's generally thought that we want to "spoil" the beatmap until the intro is shown.

Also I was never a huge fan of having a tooltip on a main menu button.. just feels a bit odd.