### PR TITLE
Fix some characters ('.', ',') being misaligned in legacy counters

### DIFF
--- a/osu.Game/Skinning/LegacySpriteText.cs
+++ b/osu.Game/Skinning/LegacySpriteText.cs
@@ -96,7 +96,7 @@ namespace osu.Game.Skinning
                     if (maxSize != null)
                         texture = texture.WithMaximumSize(maxSize.Value);
 
-                    glyph = new TexturedCharacterGlyph(new CharacterGlyph(character, 0, 0, texture.Width, texture.Height, null), texture, 1f / texture.ScaleAdjust);
+                    glyph = new TexturedCharacterGlyph(new CharacterGlyph(character, 0, 0, texture.Width, 0, null), texture, 1f / texture.ScaleAdjust);
                 }
 
                 cache[character] = glyph;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29421.

If you look closely, this causes a bit more (sub-pixel) vertical movement when numbers change, but it matches stable so I think it's fine.