### PR TITLE
Fix beatmap skin always overriding ruleset HUD components

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -43,6 +43,10 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                     if (base.GetDrawableComponent(lookup) is UserConfiguredLayoutContainer d)
                         return d;
 
+                    // we don't have enough assets to display these components (this is especially the case on a "beatmap" skin).
+                    if (!IsProvidingLegacyResources)
+                        return null;
+
                     // Our own ruleset components default.
                     // todo: remove CatchSkinComponents.CatchComboCounter and refactor LegacyCatchComboCounter to be added here instead.
                     return new DefaultSkinComponentsContainer(container =>

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -53,6 +53,10 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     if (base.GetDrawableComponent(lookup) is UserConfiguredLayoutContainer d)
                         return d;
 
+                    // we don't have enough assets to display these components (this is especially the case on a "beatmap" skin).
+                    if (!IsProvidingLegacyResources)
+                        return null;
+
                     // Our own ruleset components default.
                     switch (containerLookup.Target)
                     {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29397

The beatmap skin gets a legacy transformer applied to it, and the legacy transformer makes the beatmap skin always return the ruleset-specific HUD components as legacy regardless of availability of assets.

This does not happen on the global/non-ruleset-specific target because of this line:
https://github.com/ppy/osu/blob/98c65f36c9b81b352f4d2eb575eba0cc7fdf1ed3/osu.Game/Skinning/LegacyBeatmapSkin.cs#L58-L61

So basically do the same on each transformer that attempts to return a list of components.

This adds one extra level of complexity and there are questions to ask about this direction such as "what if there are assets available for one part of the HUD component but not the other?", but this is temporary at best and the entire skinning system will be rethought after having this concept of "ruleset-specific skinning components".

This will also solve the issue mentioned in https://github.com/ppy/osu/pull/26254#issuecomment-2283561262 / https://github.com/ppy/osu/pull/26254#pullrequestreview-2231401753 (technically https://github.com/ppy/osu/pull/26254 will have to apply this change to the mania transformer, it can't be done here).