### PR TITLE
Fix PathControlPointVisualiser eating inputs when no control points are selected

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderPlacementBlueprint.cs
@@ -299,6 +299,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
             assertControlPointTypeDuringPlacement(0, PathType.BSpline(4));
 
+            AddStep("press alt-2", () =>
+            {
+                InputManager.PressKey(Key.AltLeft);
+                InputManager.Key(Key.Number2);
+                InputManager.ReleaseKey(Key.AltLeft);
+            });
+            assertControlPointTypeDuringPlacement(0, PathType.BEZIER);
+
             AddStep("start new segment via S", () => InputManager.Key(Key.S));
             assertControlPointTypeDuringPlacement(2, PathType.LINEAR);
 
@@ -309,7 +317,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             addClickStep(MouseButton.Right);
 
             assertPlaced(true);
-            assertFinalControlPointType(0, PathType.BSpline(4));
+            assertFinalControlPointType(0, PathType.BEZIER);
             assertFinalControlPointType(2, PathType.PERFECT_CURVE);
         }
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -309,8 +309,13 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
                     if (!e.AltPressed)
                         return false;
 
+                    // If no pieces are selected, we can't change the path type.
+                    if (Pieces.All(p => !p.IsSelected.Value))
+                        return false;
+
                     var type = path_types[e.Key - Key.Number1];
 
+                    // The first control point can never be inherit type
                     if (Pieces[0].IsSelected.Value && type == null)
                         return false;
 


### PR DESCRIPTION
closes #29333