### PR TITLE
Fix preview play button having incorrect click area

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardNormal.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected override Drawable IdleContent => idleBottomContent;
         protected override Drawable DownloadInProgressContent => downloadProgressBar;
 
-        private const float height = 100;
+        public const float HEIGHT = 100;
 
         [Cached]
         private readonly BeatmapCardContent content;
@@ -42,14 +42,14 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         public BeatmapCardNormal(APIBeatmapSet beatmapSet, bool allowExpansion = true)
             : base(beatmapSet, allowExpansion)
         {
-            content = new BeatmapCardContent(height);
+            content = new BeatmapCardContent(HEIGHT);
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
             Width = WIDTH;
-            Height = height;
+            Height = HEIGHT;
 
             FillFlowContainer leftIconArea = null!;
             FillFlowContainer titleBadgeArea = null!;
@@ -65,7 +65,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                         thumbnail = new BeatmapCardThumbnail(BeatmapSet, BeatmapSet)
                         {
                             Name = @"Left (icon) area",
-                            Size = new Vector2(height),
+                            Size = new Vector2(HEIGHT),
                             Padding = new MarginPadding { Right = CORNER_RADIUS },
                             Child = leftIconArea = new FillFlowContainer
                             {
@@ -77,8 +77,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards
                         },
                         buttonContainer = new CollapsibleButtonContainer(BeatmapSet)
                         {
-                            X = height - CORNER_RADIUS,
-                            Width = WIDTH - height + CORNER_RADIUS,
+                            X = HEIGHT - CORNER_RADIUS,
+                            Width = WIDTH - HEIGHT + CORNER_RADIUS,
                             FavouriteState = { BindTarget = FavouriteState },
                             ButtonsCollapsedWidth = CORNER_RADIUS,
                             ButtonsExpandedWidth = 30,

--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCardThumbnail.cs
@@ -90,10 +90,9 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected override void Update()
         {
             base.Update();
-            progress.Progress = playButton.Progress.Value;
 
-            playButton.Scale = new Vector2(DrawWidth / 100);
-            progress.Size = new Vector2(50 * DrawWidth / 100);
+            progress.Progress = playButton.Progress.Value;
+            progress.Size = new Vector2(50 * playButton.DrawWidth / (BeatmapCardNormal.HEIGHT - BeatmapCard.CORNER_RADIUS));
         }
 
         private void updateState()

--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/PlayButton.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
         {
             base.Update();
 
+            icon.Scale = new Vector2(DrawWidth / (BeatmapCardNormal.HEIGHT - BeatmapCard.CORNER_RADIUS));
+
             if (Playing.Value && previewTrack != null && previewTrack.TrackLoaded)
                 progress.Value = previewTrack.CurrentTime / previewTrack.Length;
             else


### PR DESCRIPTION
Scales the icon instead of the clickable `PlayButton`. Note the yellow hover/click area:

| Before | After |
| --- | --- |
| <img width="188" alt="Screenshot 2024-08-15 at 10 53 33 PM" src="https://github.com/user-attachments/assets/c899a9f0-0c97-4e1a-bc98-46cb3c0ec8c6"> | <img width="171" alt="Screenshot 2024-08-15 at 10 55 47 PM" src="https://github.com/user-attachments/assets/45788858-ec29-4c27-80a6-8946a7edc3b3"> |
| <img width="116" alt="Screenshot 2024-08-15 at 10 53 55 PM" src="https://github.com/user-attachments/assets/87108db9-b149-42cf-a9d0-525242a447a7"> | <img width="118" alt="Screenshot 2024-08-15 at 10 55 09 PM" src="https://github.com/user-attachments/assets/f39646c1-e500-464e-8514-cc010aa1bb68"> |

Uses const variables to know where 100 came from.

`BeatmapCardNormal` is visually the same, but other usages are slightly bigger because of the corner radius subtraction. It is because `PlayButton.DrawWidth` in `BeatmapCardNormal` is reduced by 10 by the parent's padding to accommodate for the corner radius on the right.