### PR TITLE
Make break periods in bottom timeline transparent

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSummaryTimeline.cs
@@ -24,7 +24,10 @@ namespace osu.Game.Tests.Visual.Editing
 
             beatmap.ControlPointInfo.Add(100000, new TimingControlPoint { BeatLength = 100 });
             beatmap.ControlPointInfo.Add(50000, new DifficultyControlPoint { SliderVelocity = 2 });
+            beatmap.ControlPointInfo.Add(80000, new EffectControlPoint { KiaiMode = true });
+            beatmap.ControlPointInfo.Add(110000, new EffectControlPoint { KiaiMode = false });
             beatmap.BeatmapInfo.Bookmarks = new[] { 75000, 125000 };
+            beatmap.Breaks.Add(new ManualBreakPeriod(90000, 120000));
 
             editorBeatmap = new EditorBeatmap(beatmap);
         }

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -69,9 +69,9 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                 RelativePositionAxes = Axes.X;
                 RelativeSizeAxes = Axes.Both;
 
-                InternalChild = new Circle { RelativeSizeAxes = Axes.Both };
-                Colour = colours.Gray7;
-                Alpha = 0.8f;
+                InternalChild = new Box { RelativeSizeAxes = Axes.Both };
+                Colour = colours.Gray5;
+                Alpha = 0.4f;
             }
 
             public LocalisableString TooltipText => $"{breakPeriod.StartTime.ToEditorFormattedString()} - {breakPeriod.EndTime.ToEditorFormattedString()} break time";

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/Parts/BreakPart.cs
@@ -70,7 +70,8 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary.Parts
                 RelativeSizeAxes = Axes.Both;
 
                 InternalChild = new Circle { RelativeSizeAxes = Axes.Both };
-                Colour = colours.Gray6;
+                Colour = colours.Gray7;
+                Alpha = 0.8f;
             }
 
             public LocalisableString TooltipText => $"{breakPeriod.StartTime.ToEditorFormattedString()} - {breakPeriod.EndTime.ToEditorFormattedString()} break time";

--- a/osu.Game/Screens/Edit/Components/Timelines/Summary/SummaryTimeline.cs
+++ b/osu.Game/Screens/Edit/Components/Timelines/Summary/SummaryTimeline.cs
@@ -59,6 +59,12 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary
                     RelativeSizeAxes = Axes.Both,
                     Height = 0.4f,
                 },
+                new BreakPart
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                },
                 new ControlPointPart
                 {
                     Anchor = Anchor.Centre,
@@ -72,13 +78,6 @@ namespace osu.Game.Screens.Edit.Components.Timelines.Summary
                     Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.Both,
                     Height = 0.4f
-                },
-                new BreakPart
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                    Height = 0.15f
                 },
                 new MarkerPart { RelativeSizeAxes = Axes.Both },
             };


### PR DESCRIPTION
closes #29339

Break periods in the bottom timeline are also transparent in stable. I chose the color and alpha on what looked right to me.

![rider64_XnX1cVE8o8](https://github.com/user-attachments/assets/89d82803-bc6f-4615-ae3e-1a84ffcd8781)
