### PR TITLE
Allow closing the Mod customize header by click only when it was opened by click.

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModCustomisationPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModCustomisationPanel.cs
@@ -130,19 +130,21 @@ namespace osu.Game.Tests.Visual.UserInterface
             checkExpanded(true);
 
             AddStep("click", () => InputManager.Click(MouseButton.Left));
-            checkExpanded(false);
-            AddStep("click", () => InputManager.Click(MouseButton.Left));
             checkExpanded(true);
 
             AddStep("move away", () => InputManager.MoveMouseTo(Vector2.One));
             checkExpanded(true);
 
+            AddStep("hover header", () => InputManager.MoveMouseTo(header));
             AddStep("click", () => InputManager.Click(MouseButton.Left));
+            checkExpanded(false);
+
+            AddStep("move away", () => InputManager.MoveMouseTo(Vector2.One));
             checkExpanded(false);
         }
 
         [Test]
-        public void TestHoverExpandsAndCollapsesWhenHeaderClicked()
+        public void TestHoverExpandsAndKeepExpandWhenHeaderClicked()
         {
             AddStep("add customisable mod", () =>
             {
@@ -154,7 +156,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             checkExpanded(true);
 
             AddStep("click", () => InputManager.Click(MouseButton.Left));
-            checkExpanded(false);
+            checkExpanded(true);
         }
 
         private void checkExpanded(bool expanded)

--- a/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationHeader.cs
@@ -118,8 +118,8 @@ namespace osu.Game.Overlays.Mods
             {
                 ExpandedState.Value = ExpandedState.Value switch
                 {
-                    ModCustomisationPanelState.Collapsed => ModCustomisationPanelState.Expanded,
-                    _ => ModCustomisationPanelState.Collapsed
+                    ModCustomisationPanelState.Expanded => ModCustomisationPanelState.Collapsed,
+                    _ => ModCustomisationPanelState.Expanded
                 };
             }
 


### PR DESCRIPTION
related https://github.com/ppy/osu/discussions/29457

https://github.com/user-attachments/assets/55f258c0-353c-4400-abe1-d7432dbc4d88

I haven't tested the touch screen environment, I hope there is no problem