### PR TITLE
Remove extra box in `OnlinePlayBackgroundScreen`

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/OnlinePlayBackgroundScreen.cs
@@ -3,10 +3,8 @@
 
 using System.Threading;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Rooms;
@@ -19,16 +17,6 @@ namespace osu.Game.Screens.OnlinePlay.Components
     {
         private CancellationTokenSource? cancellationSource;
         private PlaylistItemBackground? background;
-
-        protected OnlinePlayBackgroundScreen()
-        {
-            AddInternal(new Box
-            {
-                RelativeSizeAxes = Axes.Both,
-                Depth = float.MinValue,
-                Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(0.9f), Color4.Black.Opacity(0.6f))
-            });
-        }
 
         [BackgroundDependencyLoader]
         private void load()
@@ -83,6 +71,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
             }
 
             newBackground.Depth = newDepth;
+            newBackground.Colour = ColourInfo.GradientVertical(new Color4(0.1f, 0.1f, 0.1f, 1f), new Color4(0.4f, 0.4f, 0.4f, 1f));
             newBackground.BlurTo(new Vector2(10));
 
             AddInternal(background = newBackground);


### PR DESCRIPTION
Drawing this full-screen box is one of the most expensive draw calls in this scene (at least with my hardware).
Since its colour is just black with opacity, we can have the exact same effect by just using `Colour` property directly (with other colours that wouldn't be the case, so we are lucky here, I guess)
|master|pr|
|---|---|
|![master](https://github.com/user-attachments/assets/dc720c06-6912-4b0b-91ab-eaeb5907afe7)|![pr](https://github.com/user-attachments/assets/fef06e9b-b7de-4b81-bd19-8d4ca38a9a87)|
|![master](https://github.com/user-attachments/assets/bb81185e-ce92-43ab-80e0-b630f2730c11)|![pr](https://github.com/user-attachments/assets/8db0855d-a726-4745-a975-2755707d646b)|

(notice the exact same bg colour and casual +100 fps)