### PR TITLE
Fix legacy combo counter bounce animation not always playing

### DIFF
--- a/osu.Game/Skinning/LegacyDefaultComboCounter.cs
+++ b/osu.Game/Skinning/LegacyDefaultComboCounter.cs
@@ -41,9 +41,6 @@ namespace osu.Game.Skinning
 
         protected override void OnCountIncrement()
         {
-            scheduledPopOut?.Cancel();
-            scheduledPopOut = null;
-
             DisplayedCountText.Show();
 
             PopOutCountText.Text = FormatCount(Current.Value);


### PR DESCRIPTION
As mentioned [in discord](https://discord.com/channels/188630481301012481/1097318920991559880/1274231995261649006).