### PR TITLE
Improve draw performance of editor grids

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
@@ -2,15 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components
 {
-    public abstract partial class PositionSnapGrid : CompositeDrawable
+    public abstract partial class PositionSnapGrid : BufferedContainer
     {
         /// <summary>
         /// The position of the origin of this <see cref="PositionSnapGrid"/> in local coordinates.
@@ -20,7 +22,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected readonly LayoutValue GridCache = new LayoutValue(Invalidation.RequiredParentSizeToFit);
 
         protected PositionSnapGrid()
+            : base(cachedFrameBuffer: true)
         {
+            BackgroundColour = Color4.White.Opacity(0);
+
             StartPosition.BindValueChanged(_ => GridCache.Invalidate());
 
             AddLayout(GridCache);
@@ -30,7 +35,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.Update();
 
-            if (GridCache.IsValid) return;
+            if (GridCache.IsValid)
+                return;
 
             ClearInternal();
 
@@ -38,6 +44,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 CreateContent();
 
             GridCache.Validate();
+            ForceRedraw();
         }
 
         protected abstract void CreateContent();
@@ -53,7 +60,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 {
                     Colour = Colour4.White,
                     Alpha = 0.3f,
-                    Origin = Anchor.CentreLeft,
                     RelativeSizeAxes = Axes.X,
                     Height = lineWidth,
                     Y = 0,
@@ -62,28 +68,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 {
                     Colour = Colour4.White,
                     Alpha = 0.3f,
-                    Origin = Anchor.CentreLeft,
+                    Origin = Anchor.BottomLeft,
+                    Anchor = Anchor.BottomLeft,
                     RelativeSizeAxes = Axes.X,
-                    Height = lineWidth,
-                    Y = drawSize.Y,
+                    Height = lineWidth
                 },
                 new Box
                 {
                     Colour = Colour4.White,
                     Alpha = 0.3f,
-                    Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.Y,
-                    Width = lineWidth,
-                    X = 0,
+                    Width = lineWidth
                 },
                 new Box
                 {
                     Colour = Colour4.White,
                     Alpha = 0.3f,
-                    Origin = Anchor.TopCentre,
+                    Origin = Anchor.TopRight,
+                    Anchor = Anchor.TopRight,
                     RelativeSizeAxes = Axes.Y,
-                    Width = lineWidth,
-                    X = drawSize.X,
+                    Width = lineWidth
                 },
             });
         }


### PR DESCRIPTION
Performance difference is most noticeable with circular grid.
|master|pr|
|---|---|
|![master-circle](https://github.com/user-attachments/assets/72c3684b-ae8d-41b5-9120-9b1745225b11)|![pr-circle](https://github.com/user-attachments/assets/da3739a3-2742-451e-9e48-b928761af215)|
|![master-rect](https://github.com/user-attachments/assets/67f73594-ef02-44db-b2d8-cdb79e25a051)|![pr-rect](https://github.com/user-attachments/assets/d71087a3-d9cd-4004-8551-e45df62b8a63)|
|![master-triangle](https://github.com/user-attachments/assets/d96841e4-ff80-4d45-9bde-acb642397848)|![pr-triangle](https://github.com/user-attachments/assets/9f2fb0d9-fce3-49af-a22d-a8f6d36d4469)|

Upon closer inspection you may see that grid alignment is slightly different. This is caused by the fact that grid line position may land between pixels and in that case grid isn't perfect as seen here (master)
![master-rect](https://github.com/user-attachments/assets/459b5932-6d31-4b9f-adbe-f0ccf52c57e5)
Unfortunately, same issue occurs with this pr, but in different places, thus causing the visual difference and I'm not sure whether this can be fixed completely.