### PR TITLE
Timed Difficulty Attributes calculation optimization

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -82,13 +82,25 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(beatmap.Difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
             double drainRate = beatmap.Difficulty.DrainRate;
 
-            ProgressiveCalculationBeatmap pcBeatmap = beatmap as ProgressiveCalculationBeatmap;
+            int maxCombo;
+            int hitCirclesCount, sliderCount, spinnerCount;
 
-            int maxCombo = pcBeatmap != null ? pcBeatmap.GetMaxCombo() : beatmap.GetMaxCombo();
+            if (beatmap is ProgressiveCalculationBeatmap pcBeatmap)
+            {
+                maxCombo = pcBeatmap.GetMaxCombo();
 
-            int hitCirclesCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(HitCircle)) : beatmap.HitObjects.Count(h => h is HitCircle);
-            int sliderCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(Slider)) : beatmap.HitObjects.Count(h => h is Slider);
-            int spinnerCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(Spinner)) : beatmap.HitObjects.Count(h => h is Spinner);
+                hitCirclesCount = pcBeatmap.GetHitObjectCountOf(typeof(HitCircle));
+                sliderCount = pcBeatmap.GetHitObjectCountOf(typeof(Slider));
+                spinnerCount = pcBeatmap.GetHitObjectCountOf(typeof(Spinner));
+            }
+            else
+            {
+                maxCombo = beatmap.GetMaxCombo();
+
+                hitCirclesCount = beatmap.HitObjects.Count(h => h is HitCircle);
+                sliderCount = beatmap.HitObjects.Count(h => h is Slider);
+                spinnerCount = beatmap.HitObjects.Count(h => h is Spinner);
+            }
 
             HitWindows hitWindows = new OsuHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -82,25 +82,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(beatmap.Difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
             double drainRate = beatmap.Difficulty.DrainRate;
 
-            int maxCombo;
-            int hitCirclesCount, sliderCount, spinnerCount;
+            int maxCombo = beatmap.GetMaxCombo();
 
-            if (beatmap is ProgressiveCalculationBeatmap pcBeatmap)
-            {
-                maxCombo = pcBeatmap.GetMaxCombo();
-
-                hitCirclesCount = pcBeatmap.GetHitObjectCountOf(typeof(HitCircle));
-                sliderCount = pcBeatmap.GetHitObjectCountOf(typeof(Slider));
-                spinnerCount = pcBeatmap.GetHitObjectCountOf(typeof(Spinner));
-            }
-            else
-            {
-                maxCombo = beatmap.GetMaxCombo();
-
-                hitCirclesCount = beatmap.HitObjects.Count(h => h is HitCircle);
-                sliderCount = beatmap.HitObjects.Count(h => h is Slider);
-                spinnerCount = beatmap.HitObjects.Count(h => h is Spinner);
-            }
+            int hitCirclesCount = beatmap.GetHitObjectCountOf(typeof(HitCircle));
+            int sliderCount = beatmap.GetHitObjectCountOf(typeof(Slider));
+            int spinnerCount = beatmap.GetHitObjectCountOf(typeof(Spinner));
 
             HitWindows hitWindows = new OsuHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -81,11 +81,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double preempt = IBeatmapDifficultyInfo.DifficultyRange(beatmap.Difficulty.ApproachRate, 1800, 1200, 450) / clockRate;
             double drainRate = beatmap.Difficulty.DrainRate;
-            int maxCombo = beatmap.GetMaxCombo();
 
-            int hitCirclesCount = beatmap.HitObjects.Count(h => h is HitCircle);
-            int sliderCount = beatmap.HitObjects.Count(h => h is Slider);
-            int spinnerCount = beatmap.HitObjects.Count(h => h is Spinner);
+            ProgressiveCalculationBeatmap pcBeatmap = beatmap as ProgressiveCalculationBeatmap;
+
+            int maxCombo = pcBeatmap != null ? pcBeatmap.GetMaxCombo() : beatmap.GetMaxCombo();
+
+            int hitCirclesCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(HitCircle)) : beatmap.HitObjects.Count(h => h is HitCircle);
+            int sliderCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(Slider)) : beatmap.HitObjects.Count(h => h is Slider);
+            int spinnerCount = pcBeatmap != null ? pcBeatmap.GetHitObjectCountOf(typeof(Spinner)) : beatmap.HitObjects.Count(h => h is Spinner);
 
             HitWindows hitWindows = new OsuHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
-using System.Linq;
 using osu.Framework.Utils;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
@@ -70,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
                 weight *= DecayWeight;
             }
 
-           return difficulty * DifficultyMultiplier;
+            return difficulty * DifficultyMultiplier;
         }
 
         public static double DifficultyToPerformance(double difficulty) => Math.Pow(5.0 * Math.Max(1.0, difficulty / 0.0675) - 4.0, 3.0) / 100000.0;

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -10,6 +10,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using Newtonsoft.Json;
 using osu.Framework.Lists;
 using osu.Game.IO.Serialization.Converters;
+using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Beatmaps
 {
@@ -114,6 +115,25 @@ namespace osu.Game.Beatmaps
 
             return mostCommon.beatLength;
         }
+
+        public int GetMaxCombo()
+        {
+            int combo = 0;
+            foreach (var h in HitObjects)
+                addCombo(h, ref combo);
+            return combo;
+
+            static void addCombo(HitObject hitObject, ref int combo)
+            {
+                if (hitObject.Judgement.MaxResult.AffectsCombo())
+                    combo++;
+
+                foreach (var nested in hitObject.NestedHitObjects)
+                    addCombo(nested, ref combo);
+            }
+        }
+
+        public int GetHitObjectCountOf(Type type) => HitObjects.Count(h => h.GetType() == type);
 
         IBeatmap IBeatmap.Clone() => Clone();
 

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -8,7 +8,6 @@ using osu.Framework.Lists;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Beatmaps
 {
@@ -74,6 +73,16 @@ namespace osu.Game.Beatmaps
         /// </summary>
         /// <returns>The shallow-cloned beatmap.</returns>
         IBeatmap Clone();
+
+        /// <summary>
+        /// Finds the maximum achievable combo by hitting all <see cref="HitObject"/>s in a beatmap.
+        /// </summary>
+        int GetMaxCombo();
+
+        /// <summary>
+        /// Finds amount of <see cref="HitObject"/>s that have given type.
+        /// </summary>
+        int GetHitObjectCountOf(Type type);
     }
 
     /// <summary>
@@ -90,26 +99,6 @@ namespace osu.Game.Beatmaps
 
     public static class BeatmapExtensions
     {
-        /// <summary>
-        /// Finds the maximum achievable combo by hitting all <see cref="HitObject"/>s in a beatmap.
-        /// </summary>
-        public static int GetMaxCombo(this IBeatmap beatmap)
-        {
-            int combo = 0;
-            foreach (var h in beatmap.HitObjects)
-                addCombo(h, ref combo);
-            return combo;
-
-            static void addCombo(HitObject hitObject, ref int combo)
-            {
-                if (hitObject.Judgement.MaxResult.AffectsCombo())
-                    combo++;
-
-                foreach (var nested in hitObject.NestedHitObjects)
-                    addCombo(nested, ref combo);
-            }
-        }
-
         /// <summary>
         /// Find the total milliseconds between the first and last hittable objects.
         /// </summary>

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Rulesets.Difficulty
         /// <summary>
         /// Used to calculate timed difficulty attributes, where only a subset of hitobjects should be visible at any point in time.
         /// </summary>
-        protected class ProgressiveCalculationBeatmap : IBeatmap
+        private class ProgressiveCalculationBeatmap : IBeatmap
         {
             private readonly IBeatmap baseBeatmap;
 
@@ -317,15 +317,15 @@ namespace osu.Game.Rulesets.Difficulty
                 hitObjectsCounts[objectType]++;
 
                 addCombo(hitObject);
+            }
 
-                void addCombo(HitObject hitObject)
-                {
-                    if (hitObject.Judgement.MaxResult.AffectsCombo())
-                        maxCombo++;
+            private void addCombo(HitObject hitObject)
+            {
+                if (hitObject.Judgement.MaxResult.AffectsCombo())
+                    maxCombo++;
 
-                    foreach (var nested in hitObject.NestedHitObjects)
-                        addCombo(nested);
-                };
+                foreach (var nested in hitObject.NestedHitObjects)
+                    addCombo(nested);
             }
 
             private readonly List<HitObject> hitObjects = new List<HitObject>();

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -315,13 +315,14 @@ namespace osu.Game.Rulesets.Difficulty
 
             private readonly List<HitObject> hitObjects = new List<HitObject>();
 
-            private Dictionary<Type, int> hitObjectsCounts = new Dictionary<Type, int>();
+            private readonly Dictionary<Type, int> hitObjectsCounts = new Dictionary<Type, int>();
 
             public int GetHitObjectCountOf(Type type) => hitObjectsCounts.GetValueOrDefault(type);
 
             IReadOnlyList<HitObject> IBeatmap.HitObjects => hitObjects;
 
-            private int comboObjectIndex = 0, combo = 0;
+            private int comboObjectIndex, combo;
+
             public int GetMaxCombo()
             {
                 for (; comboObjectIndex < hitObjects.Count; comboObjectIndex++)

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -303,6 +303,10 @@ namespace osu.Game.Rulesets.Difficulty
                 this.baseBeatmap = baseBeatmap;
             }
 
+            private int maxCombo;
+
+            public int GetMaxCombo() => maxCombo;
+
             public void AddHitObject(HitObject hitObject)
             {
                 hitObjects.Add(hitObject);
@@ -311,6 +315,17 @@ namespace osu.Game.Rulesets.Difficulty
                 if (!hitObjectsCounts.ContainsKey(objectType))
                     hitObjectsCounts[objectType] = 0; // Initialize to 0 if not present
                 hitObjectsCounts[objectType]++;
+
+                addCombo(hitObject);
+
+                void addCombo(HitObject hitObject)
+                {
+                    if (hitObject.Judgement.MaxResult.AffectsCombo())
+                        maxCombo++;
+
+                    foreach (var nested in hitObject.NestedHitObjects)
+                        addCombo(nested);
+                };
             }
 
             private readonly List<HitObject> hitObjects = new List<HitObject>();
@@ -320,24 +335,6 @@ namespace osu.Game.Rulesets.Difficulty
             public int GetHitObjectCountOf(Type type) => hitObjectsCounts.GetValueOrDefault(type);
 
             IReadOnlyList<HitObject> IBeatmap.HitObjects => hitObjects;
-
-            private int comboObjectIndex, combo;
-
-            public int GetMaxCombo()
-            {
-                for (; comboObjectIndex < hitObjects.Count; comboObjectIndex++)
-                    addCombo(hitObjects[comboObjectIndex], ref combo);
-                return combo;
-
-                static void addCombo(HitObject hitObject, ref int combo)
-                {
-                    if (hitObject.Judgement.MaxResult.AffectsCombo())
-                        combo++;
-
-                    foreach (var nested in hitObject.NestedHitObjects)
-                        addCombo(nested, ref combo);
-                }
-            }
 
             #region Delegated IBeatmap implementation
 

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -133,7 +133,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
 
                 savedSortedStrains = new List<double>(strains);
                 amountOfStrainsAddedSinceSave = 0;
-                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                savedCurrentStrain = currentSectionPeak;
                 isSavedCurrentStrainRelevant = true;
             }
             // If several sections were added since last save - insert them into saved strains list
@@ -146,11 +146,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 strains = new List<double>(savedSortedStrains);
 
                 amountOfStrainsAddedSinceSave = 0;
-                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                savedCurrentStrain = currentSectionPeak;
                 isSavedCurrentStrainRelevant = true;
             }
             // If no section was added, but last one was changed - find it and replace it with new one
-            else if (!isSavedCurrentStrainRelevant && savedCurrentStrain != -1)
+            else if (!isSavedCurrentStrainRelevant && savedCurrentStrain > 0)
             {
                 int invalidStrainIndex = savedSortedStrains.BinarySearch(savedCurrentStrain, new ReverseComparer());
                 savedSortedStrains.RemoveAt(invalidStrainIndex);
@@ -158,7 +158,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
 
                 strains = new List<double>(savedSortedStrains);
 
-                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                savedCurrentStrain = currentSectionPeak;
                 isSavedCurrentStrainRelevant = true;
             }
             // Otherwise - just use saved strains
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         }
 
         private List<double>? savedSortedStrains;
-        private double savedCurrentStrain = -1;
+        private double savedCurrentStrain = 0;
         private bool isSavedCurrentStrainRelevant = false;
         private int amountOfStrainsAddedSinceSave = 0;
 

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -60,6 +60,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             }
 
             double currentStrain = StrainValueAt(current);
+
             if (currentSectionPeak < currentStrain)
             {
                 currentSectionPeak = currentStrain;
@@ -171,9 +172,9 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         }
 
         private List<double>? savedSortedStrains;
-        private double savedCurrentStrain = 0;
-        private bool isSavedCurrentStrainRelevant = false;
-        private int amountOfStrainsAddedSinceSave = 0;
+        private double savedCurrentStrain;
+        private bool isSavedCurrentStrainRelevant;
+        private int amountOfStrainsAddedSinceSave;
 
         protected static void InsertElementInReverseSortedList(List<double> list, double element)
         {

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -55,9 +55,16 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 saveCurrentPeak();
                 startNewSectionFrom(currentSectionEnd, current);
                 currentSectionEnd += SectionLength;
+
+                amountOfStrainsAddedSinceSave++;
             }
 
-            currentSectionPeak = Math.Max(StrainValueAt(current), currentSectionPeak);
+            double currentStrain = StrainValueAt(current);
+            if (currentSectionPeak < currentStrain)
+            {
+                currentSectionPeak = currentStrain;
+                isSavedCurrentStrainRelevant = false;
+            }
         }
 
         /// <summary>
@@ -102,19 +109,84 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             double difficulty = 0;
             double weight = 1;
 
-            // Sections with 0 strain are excluded to avoid worst-case time complexity of the following sort (e.g. /b/2351871).
-            // These sections will not contribute to the difficulty.
-            var peaks = GetCurrentStrainPeaks().Where(p => p > 0);
-
             // Difficulty is the weighted sum of the highest strains from every section.
             // We're sorting from highest to lowest strain.
-            foreach (double strain in peaks.OrderDescending())
+            foreach (double strain in GetCurrentStrainsSorted())
             {
                 difficulty += strain * weight;
                 weight *= DecayWeight;
             }
 
             return difficulty;
+        }
+
+        protected List<double> GetCurrentStrainsSorted()
+        {
+            List<double> strains;
+
+            // If no saved strains - calculate them from 0, and save them after that
+            if (savedSortedStrains == null || savedSortedStrains.Count == 0)
+            {
+                var peaks = GetCurrentStrainPeaks().Where(p => p > 0);
+
+                strains = peaks.OrderDescending().ToList();
+
+                savedSortedStrains = new List<double>(strains);
+                amountOfStrainsAddedSinceSave = 0;
+                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                isSavedCurrentStrainRelevant = true;
+            }
+            // If several sections were added since last save - insert them into saved strains list
+            else if (amountOfStrainsAddedSinceSave > 0)
+            {
+                var newPeaks = GetCurrentStrainPeaks().TakeLast(amountOfStrainsAddedSinceSave).Where(p => p > 0);
+                foreach (double newPeak in newPeaks)
+                    InsertElementInReverseSortedList(savedSortedStrains, newPeak);
+
+                strains = new List<double>(savedSortedStrains);
+
+                amountOfStrainsAddedSinceSave = 0;
+                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                isSavedCurrentStrainRelevant = true;
+            }
+            // If no section was added, but last one was changed - find it and replace it with new one
+            else if (!isSavedCurrentStrainRelevant && savedCurrentStrain != -1)
+            {
+                int invalidStrainIndex = savedSortedStrains.BinarySearch(savedCurrentStrain, new ReverseComparer());
+                savedSortedStrains.RemoveAt(invalidStrainIndex);
+                InsertElementInReverseSortedList(savedSortedStrains, currentSectionPeak);
+
+                strains = new List<double>(savedSortedStrains);
+
+                savedCurrentStrain = currentSectionPeak > 0 ? currentSectionPeak : -1;
+                isSavedCurrentStrainRelevant = true;
+            }
+            // Otherwise - just use saved strains
+            else
+            {
+                strains = new List<double>(savedSortedStrains);
+            }
+
+            return strains;
+        }
+
+        private List<double>? savedSortedStrains;
+        private double savedCurrentStrain = -1;
+        private bool isSavedCurrentStrainRelevant = false;
+        private int amountOfStrainsAddedSinceSave = 0;
+
+        protected static void InsertElementInReverseSortedList(List<double> list, double element)
+        {
+            int indexToInsert = list.BinarySearch(element, new ReverseComparer());
+            if (indexToInsert < 0)
+                indexToInsert = ~indexToInsert;
+
+            list.Insert(indexToInsert, element);
+        }
+
+        private class ReverseComparer : IComparer<double>
+        {
+            public int Compare(double x, double y) => Comparer<double>.Default.Compare(y, x);
         }
     }
 }

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -198,6 +198,10 @@ namespace osu.Game.Screens.Edit
 
         public double GetMostCommonBeatLength() => PlayableBeatmap.GetMostCommonBeatLength();
 
+        public int GetMaxCombo() => PlayableBeatmap.GetMaxCombo();
+
+        public int GetHitObjectCountOf(Type type) => PlayableBeatmap.GetHitObjectCountOf(type);
+
         public IBeatmap Clone() => (EditorBeatmap)MemberwiseClone();
 
         private IList mutableHitObjects => (IList)PlayableBeatmap.HitObjects;


### PR DESCRIPTION
Timed Difficulty Attributes used for pp counter, and it's very slow on long maps because of O(n^2 * logn) time complexity

Test on full Because Maybe mapset (https://osu.ppy.sh/beatmapsets/773014#osu/2151273). Out of 152 seconds of main function call:
- 68 seconds on OsuStrainSkill.DifficultyValue()
- 52 seconds on IBeatmap.GetMaxCombo()
- 29 seconds on IBeatmap.HitObjects.Count(h => h is HitObject)
- 3 seconds on Speed.RelevantNoteCount()

Out of 68 seconds of OsuStrainSkill.DifficultyValue():
- 48 seconds on initial sort
- 17 seconds on second sort (after diffspike nerf)

After the optimization - out of 13 seconds (-91%) of main function call:
- 10 seconds (-85%) on OsuStrainSkill.DifficultyValue()
- 0.06 seconds (-99.9%) on IBeatmap.GetMaxCombo()
- 0.07 seconds (-99.8%) ( on IBeatmap.HitObjects.Count(h => h is HitObject)
- 3 seconds (not touched) on Speed.RelevantNoteCount()

Out of 10 seconds of OsuStrainSkill.DifficultyValue():
- 6 seconds (-87.5%) on initial sort, 5 seconds of which is creating a copy, and only 1 second is actual sorting. Considering this - speedup on actual sorting is 43x (-97.7%)
- 0.5 seconds (-97%) on the second sort (after diffspike nerf)

Optimization consists of two parts:
First part makes Max Combo and Objects Counts to be calculated progressively in the `ProgressiveBeatmap` beatmap class instead of from zero each time, reducing time complexity from O(n^2) to O(n).

Second part is all about `.DifficultyValue()`:
After the call of `DifficultyValue()` the sorted strains are saved in the Skill class. On the next call of `DifficultyValue` one of 4 things can happen:
1) There are no saved strains -> calculate normally
2) There are saved strains, but new ones were added since last save -> insert each strain in the sorted array
3) There are no new strains since save, but the last strain was changed -> replace old last strain with new one
4) No new strains and last strain is unchanged -> just use the saved strains
Those steps are reducing sort time complexity from O(n^2 * logn) to O(nlogn). Copying time complexity remains O(n^2), making it the slowest part of the calculation now.

The second sort after diffspike nerf is also changed. Unnecessary copy was removed and sorting is done via insertions now, decreasing O(n^2) for copy and O(n^2 * logn) for sort to just O(nlogn) for insertion.

Before:

https://github.com/user-attachments/assets/eb18f836-86e0-4e8f-a8eb-ef29897d6b27

After:

https://github.com/user-attachments/assets/98521e8d-f81f-4832-9bdf-95075f3a76c8

The other gamemodes aren't touched directly, but as they all use `StrainSkill` - they will be faster as well. Taiko needs additional work, as it's still have `TaikoDifficultyCalculator.combinedDifficultyValue` with O(n^2 * logn) time complexity.
