### PR TITLE
Fix oversight in osu! pause input handling

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using osuTK.Graphics;
-using TagLib.Flac;
 
 namespace osu.Game.Rulesets.Osu.UI
 {

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -36,9 +37,11 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             OsuResumeOverlayInputBlocker? inputBlocker = null;
 
-            if (drawableRuleset != null)
+            var drawableOsuRuleset = (DrawableOsuRuleset?)drawableRuleset;
+
+            if (drawableOsuRuleset != null)
             {
-                var osuPlayfield = (OsuPlayfield)drawableRuleset.Playfield;
+                var osuPlayfield = drawableOsuRuleset.Playfield;
                 osuPlayfield.AttachResumeOverlayInputBlocker(inputBlocker = new OsuResumeOverlayInputBlocker());
             }
 
@@ -46,13 +49,14 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 Child = clickToResumeCursor = new OsuClickToResumeCursor
                 {
-                    ResumeRequested = () =>
+                    ResumeRequested = action =>
                     {
                         // since the user had to press a button to tap the resume cursor,
                         // block that press event from potentially reaching a hit circle that's behind the cursor.
                         // we cannot do this from OsuClickToResumeCursor directly since we're in a different input manager tree than the gameplay one,
                         // so we rely on a dedicated input blocking component that's implanted in there to do that for us.
-                        if (inputBlocker != null)
+                        // note this only matters when the user didn't pause while they were holding the same key that they are resuming with.
+                        if (inputBlocker != null && !drawableOsuRuleset.AsNonNull().KeyBindingInputManager.PressedActions.Contains(action))
                             inputBlocker.BlockNextPress = true;
 
                         Resume();
@@ -95,7 +99,7 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             public override bool HandlePositionalInput => true;
 
-            public Action? ResumeRequested;
+            public Action<OsuAction>? ResumeRequested;
             private Container scaleTransitionContainer = null!;
 
             public OsuClickToResumeCursor()
@@ -137,7 +141,7 @@ namespace osu.Game.Rulesets.Osu.UI
                             return false;
 
                         scaleTransitionContainer.ScaleTo(2, TRANSITION_TIME, Easing.OutQuint);
-                        ResumeRequested?.Invoke();
+                        ResumeRequested?.Invoke(e.Action);
                         return true;
                 }
 
@@ -173,13 +177,12 @@ namespace osu.Game.Rulesets.Osu.UI
                 Depth = float.MinValue;
             }
 
-            protected override void Update()
+            public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
             {
-                base.Update();
+                bool block = BlockNextPress;
                 BlockNextPress = false;
+                return block;
             }
-
-            public bool OnPressed(KeyBindingPressEvent<OsuAction> e) => BlockNextPress;
 
             public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)
             {

--- a/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuResumeOverlay.cs
@@ -13,6 +13,7 @@ using osu.Game.Rulesets.Osu.UI.Cursor;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Play;
 using osuTK.Graphics;
+using TagLib.Flac;
 
 namespace osu.Game.Rulesets.Osu.UI
 {
@@ -172,12 +173,13 @@ namespace osu.Game.Rulesets.Osu.UI
                 Depth = float.MinValue;
             }
 
-            public bool OnPressed(KeyBindingPressEvent<OsuAction> e)
+            protected override void Update()
             {
-                bool block = BlockNextPress;
+                base.Update();
                 BlockNextPress = false;
-                return block;
             }
+
+            public bool OnPressed(KeyBindingPressEvent<OsuAction> e) => BlockNextPress;
 
             public void OnReleased(KeyBindingReleaseEvent<OsuAction> e)
             {

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePauseInputHandling.cs
@@ -52,6 +52,11 @@ namespace osu.Game.Tests.Visual.Gameplay
                 {
                     Position = OsuPlayfield.BASE_SIZE / 2,
                     StartTime = 10000,
+                },
+                new HitCircle
+                {
+                    Position = OsuPlayfield.BASE_SIZE / 2,
+                    StartTime = 15000,
                 }
             }
         };
@@ -261,7 +266,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestOsuRegisterInputFromPressingOrangeCursorButPressIsBlocked()
+        public void TestOsuHitCircleNotReceivingInputOnResume()
         {
             KeyCounter counter = null!;
 
@@ -287,7 +292,7 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestOsuRegisterInputFromPressingOrangeCursorButPressIsBlocked_PauseWhileHolding()
+        public void TestOsuHitCircleNotReceivingInputOnResume_PauseWhileHoldingSameKey()
         {
             KeyCounter counter = null!;
 
@@ -316,6 +321,32 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
             checkKey(() => counter, 2, false);
+        }
+
+        [Test]
+        public void TestOsuHitCircleNotReceivingInputOnResume_PauseWhileHoldingOtherKey()
+        {
+            loadPlayer(() => new OsuRuleset());
+
+            AddStep("press X", () => InputManager.PressKey(Key.X));
+            AddAssert("circle hit", () => Player.ScoreProcessor.HighestCombo.Value, () => Is.EqualTo(1));
+
+            seekTo(5000);
+
+            AddStep("pause", () => Player.Pause());
+            AddStep("release X", () => InputManager.ReleaseKey(Key.X));
+
+            AddStep("resume", () => Player.Resume());
+            AddStep("go to resume cursor", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuResumeOverlay.OsuClickToResumeCursor>().Single()));
+            AddStep("press Z to resume", () => InputManager.PressKey(Key.Z));
+            AddStep("release Z", () => InputManager.ReleaseKey(Key.Z));
+
+            AddAssert("circle not hit", () => Player.ScoreProcessor.HighestCombo.Value, () => Is.EqualTo(1));
+
+            AddStep("press X", () => InputManager.PressKey(Key.X));
+            AddStep("release X", () => InputManager.ReleaseKey(Key.X));
+
+            AddAssert("circle hit", () => Player.ScoreProcessor.HighestCombo.Value, () => Is.EqualTo(2));
         }
 
         private void loadPlayer(Func<Ruleset> createRuleset)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29483

Issue is pretty simple. The user pauses with the key held, then on resume the resume overlay sets `BlockNextPress`, but it doesn't get reset until the next press which is when the user uses the key again.

The idea of `BlockNextPress` is to block any press event in the same frame as the resume operation, so just do that instead (by resetting the flag in `Update()`).