### PR TITLE
Apply current cursor expansion scale to trail parts

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneCursorTrail.cs
@@ -88,6 +88,21 @@ namespace osu.Game.Rulesets.Osu.Tests
             AddAssert("trail is disjoint", () => this.ChildrenOfType<LegacyCursorTrail>().Single().DisjointTrail, () => Is.True);
         }
 
+        [Test]
+        public void TestClickExpand()
+        {
+            createTest(() => new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Scale = new Vector2(10),
+                Child = new CursorTrail(),
+            });
+
+            AddStep("expand", () => this.ChildrenOfType<CursorTrail>().Single().NewPartScale = new Vector2(3));
+            AddWaitStep("let the cursor trail draw a bit", 5);
+            AddStep("contract", () => this.ChildrenOfType<CursorTrail>().Single().NewPartScale = Vector2.One);
+        }
+
         private void createTest(Func<Drawable> createContent) => AddStep("create trail", () =>
         {
             Clear();

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -38,6 +38,11 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         private double timeOffset;
         private float time;
 
+        /// <summary>
+        /// The scale used on creation of a new trail part.
+        /// </summary>
+        public Vector2 NewPartScale = Vector2.One;
+
         private Anchor trailOrigin = Anchor.Centre;
 
         protected Anchor TrailOrigin
@@ -188,6 +193,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             parts[currentIndex].Position = localSpacePosition;
             parts[currentIndex].Time = time + 1;
+            parts[currentIndex].Scale = NewPartScale;
             ++parts[currentIndex].InvalidationID;
 
             currentIndex = (currentIndex + 1) % max_sprites;
@@ -199,6 +205,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             public Vector2 Position;
             public float Time;
+            public Vector2 Scale;
             public long InvalidationID;
         }
 
@@ -280,7 +287,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y)),
+                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X * part.Scale.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y) * part.Scale.Y),
                         TexturePosition = textureRect.BottomLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.BottomLeft.Linear,
@@ -289,7 +296,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X), part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y)),
+                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X) * part.Scale.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y) * part.Scale.Y),
                         TexturePosition = textureRect.BottomRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.BottomRight.Linear,
@@ -298,7 +305,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X), part.Position.Y - texture.DisplayHeight * originPosition.Y),
+                        Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X) * part.Scale.X, part.Position.Y - texture.DisplayHeight * originPosition.Y * part.Scale.Y),
                         TexturePosition = textureRect.TopRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.TopRight.Linear,
@@ -307,7 +314,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
                     vertexBatch.Add(new TexturedTrailVertex
                     {
-                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X, part.Position.Y - texture.DisplayHeight * originPosition.Y),
+                        Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X * part.Scale.X, part.Position.Y - texture.DisplayHeight * originPosition.Y * part.Scale.Y),
                         TexturePosition = textureRect.TopLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
                         Colour = DrawColourInfo.Colour.TopLeft.Linear,

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursor.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private SkinnableCursor skinnableCursor => (SkinnableCursor)cursorSprite.Drawable;
 
+        /// <summary>
+        /// The current expanded scale of the cursor.
+        /// </summary>
+        public Vector2 CurrentExpandedScale => skinnableCursor.ExpandTarget?.Scale ?? Vector2.One;
+
         public IBindable<float> CursorScale => cursorScale;
 
         private readonly Bindable<float> cursorScale = new BindableFloat(1);

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -82,8 +82,8 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         {
             base.Update();
 
-            // We can direct cast here because the cursor trail is always a derived class of CursorTrail.
-            ((CursorTrail)cursorTrail.Drawable).NewPartScale = ActiveCursor.CurrentExpandedScale;
+            if (cursorTrail.Drawable is CursorTrail trail)
+                trail.NewPartScale = ActiveCursor.CurrentExpandedScale;
         }
 
         public bool OnPressed(KeyBindingPressEvent<OsuAction> e)

--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -23,14 +23,13 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
         public new OsuCursor ActiveCursor => (OsuCursor)base.ActiveCursor;
 
         protected override Drawable CreateCursor() => new OsuCursor();
-
         protected override Container<Drawable> Content => fadeContainer;
 
         private readonly Container<Drawable> fadeContainer;
 
         private readonly Bindable<bool> showTrail = new Bindable<bool>(true);
 
-        private readonly Drawable cursorTrail;
+        private readonly SkinnableDrawable cursorTrail;
 
         private readonly CursorRippleVisualiser rippleVisualiser;
 
@@ -39,7 +38,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             InternalChild = fadeContainer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Children = new[]
+                Children = new CompositeDrawable[]
                 {
                     cursorTrail = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.CursorTrail), _ => new DefaultCursorTrail(), confineMode: ConfineMode.NoScaling),
                     rippleVisualiser = new CursorRippleVisualiser(),
@@ -77,6 +76,14 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                 ActiveCursor.Expand();
             else
                 ActiveCursor.Contract();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // We can direct cast here because the cursor trail is always a derived class of CursorTrail.
+            ((CursorTrail)cursorTrail.Drawable).NewPartScale = ActiveCursor.CurrentExpandedScale;
         }
 
         public bool OnPressed(KeyBindingPressEvent<OsuAction> e)


### PR DESCRIPTION
Currently, lazer does not apply the current cursor expansion scale to trail parts which doesn't match stable behaviour.
This PR changes it so when a trail part is created, the current cursor expansion scale is applied.

| Current | Stable | PR |
| --- | --- | --- |
| ![current-trail](https://github.com/user-attachments/assets/da21937b-82da-49ef-a372-f0b519d31959) | ![stable-trail](https://github.com/user-attachments/assets/9c91a46d-edf7-47da-a556-af754bebc793) | ![pull-request-trail](https://github.com/user-attachments/assets/f42a7a72-a3cb-4906-a53c-cd1d3273767d)

Just a note that I'm not very familiar with the code base, so apologies if there is a more efficient way of implementing this behaviour.

Also note that this does change the behaviour of both the argon and triangles skin, both of which never had cursor trail expanding. I'm unsure if you'd like this to be addressed or not, but I've kept it in as 1) I expect it to work this way and 2) it's how the default skin behaves in stable.