### PR TITLE
Fix mania combo counter positioning break on centre anchor

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/ManiaSkinnableTestScene.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
     public abstract partial class ManiaSkinnableTestScene : SkinnableTestScene
     {
         [Cached(Type = typeof(IScrollingInfo))]
-        private readonly TestScrollingInfo scrollingInfo = new TestScrollingInfo();
+        protected readonly TestScrollingInfo ScrollingInfo = new TestScrollingInfo();
 
         [Cached]
         private readonly StageDefinition stage = new StageDefinition(4);
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
 
         protected ManiaSkinnableTestScene()
         {
-            scrollingInfo.Direction.Value = ScrollingDirection.Down;
+            ScrollingInfo.Direction.Value = ScrollingDirection.Down;
 
             Add(new Box
             {
@@ -43,16 +43,16 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
         [Test]
         public void TestScrollingDown()
         {
-            AddStep("change direction to down", () => scrollingInfo.Direction.Value = ScrollingDirection.Down);
+            AddStep("change direction to down", () => ScrollingInfo.Direction.Value = ScrollingDirection.Down);
         }
 
         [Test]
         public void TestScrollingUp()
         {
-            AddStep("change direction to up", () => scrollingInfo.Direction.Value = ScrollingDirection.Up);
+            AddStep("change direction to up", () => ScrollingInfo.Direction.Value = ScrollingDirection.Up);
         }
 
-        private class TestScrollingInfo : IScrollingInfo
+        protected class TestScrollingInfo : IScrollingInfo
         {
             public readonly Bindable<ScrollingDirection> Direction = new Bindable<ScrollingDirection>();
 

--- a/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneComboCounter.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Skinning/TestSceneComboCounter.cs
@@ -1,13 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mania.Skinning.Argon;
 using osu.Game.Rulesets.Mania.Skinning.Legacy;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Mania.Tests.Skinning
@@ -17,22 +21,75 @@ namespace osu.Game.Rulesets.Mania.Tests.Skinning
         [Cached]
         private ScoreProcessor scoreProcessor = new ScoreProcessor(new ManiaRuleset());
 
-        [SetUpSteps]
-        public void SetUpSteps()
+        [Test]
+        public void TestDisplay()
         {
-            AddStep("setup", () => SetContents(s =>
-            {
-                if (s is ArgonSkin)
-                    return new ArgonManiaComboCounter();
-
-                if (s is LegacySkin)
-                    return new LegacyManiaComboCounter();
-
-                return new LegacyManiaComboCounter();
-            }));
-
+            setup(Anchor.Centre);
             AddRepeatStep("perform hit", () => scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new Judgement()) { Type = HitResult.Great }), 20);
             AddStep("perform miss", () => scoreProcessor.ApplyResult(new JudgementResult(new HitObject(), new Judgement()) { Type = HitResult.Miss }));
+        }
+
+        [Test]
+        public void TestAnchorOrigin()
+        {
+            AddStep("set direction down", () => ScrollingInfo.Direction.Value = ScrollingDirection.Down);
+            setup(Anchor.TopCentre, 20);
+            AddStep("set direction up", () => ScrollingInfo.Direction.Value = ScrollingDirection.Up);
+            check(Anchor.BottomCentre, -20);
+
+            AddStep("set direction up", () => ScrollingInfo.Direction.Value = ScrollingDirection.Up);
+            setup(Anchor.BottomCentre, -20);
+            AddStep("set direction down", () => ScrollingInfo.Direction.Value = ScrollingDirection.Down);
+            check(Anchor.TopCentre, 20);
+
+            AddStep("set direction down", () => ScrollingInfo.Direction.Value = ScrollingDirection.Down);
+            setup(Anchor.Centre, 20);
+            AddStep("set direction up", () => ScrollingInfo.Direction.Value = ScrollingDirection.Up);
+            check(Anchor.Centre, 20);
+
+            AddStep("set direction up", () => ScrollingInfo.Direction.Value = ScrollingDirection.Up);
+            setup(Anchor.Centre, -20);
+            AddStep("set direction down", () => ScrollingInfo.Direction.Value = ScrollingDirection.Down);
+            check(Anchor.Centre, -20);
+        }
+
+        private void setup(Anchor anchor, float y = 0)
+        {
+            AddStep($"setup {anchor} {y}", () => SetContents(s =>
+            {
+                var container = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                if (s is ArgonSkin)
+                    container.Add(new ArgonManiaComboCounter());
+                else if (s is LegacySkin)
+                    container.Add(new LegacyManiaComboCounter());
+                else
+                    container.Add(new LegacyManiaComboCounter());
+
+                container.Child.Anchor = anchor;
+                container.Child.Origin = Anchor.Centre;
+                container.Child.Y = y;
+
+                return container;
+            }));
+        }
+
+        private void check(Anchor anchor, float y)
+        {
+            AddAssert($"check {anchor} {y}", () =>
+            {
+                foreach (var combo in this.ChildrenOfType<ISerialisableDrawable>())
+                {
+                    var drawableCombo = (Drawable)combo;
+                    if (drawableCombo.Anchor != anchor || drawableCombo.Y != y)
+                        return false;
+                }
+
+                return true;
+            });
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonManiaComboCounter.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ArgonManiaComboCounter.cs
@@ -38,11 +38,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
         private void updateAnchor()
         {
             // if the anchor isn't a vertical center, set top or bottom anchor based on scroll direction
-            if (!Anchor.HasFlag(Anchor.y1))
-            {
-                Anchor &= ~(Anchor.y0 | Anchor.y2);
-                Anchor |= direction.Value == ScrollingDirection.Up ? Anchor.y2 : Anchor.y0;
-            }
+            if (Anchor.HasFlag(Anchor.y1))
+                return;
+
+            Anchor &= ~(Anchor.y0 | Anchor.y2);
+            Anchor |= direction.Value == ScrollingDirection.Up ? Anchor.y2 : Anchor.y0;
 
             // change the sign of the Y coordinate in line with the scrolling direction.
             // i.e. if the user changes direction from down to up, the anchor is changed from top to bottom, and the Y is flipped from positive to negative here.

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaComboCounter.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyManiaComboCounter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -44,16 +45,15 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
         private void updateAnchor()
         {
             // if the anchor isn't a vertical center, set top or bottom anchor based on scroll direction
-            if (!Anchor.HasFlag(Anchor.y1))
-            {
-                Anchor &= ~(Anchor.y0 | Anchor.y2);
-                Anchor |= direction.Value == ScrollingDirection.Up ? Anchor.y2 : Anchor.y0;
-            }
+            if (Anchor.HasFlag(Anchor.y1))
+                return;
 
-            // since we flip the vertical anchor when changing scroll direction,
-            // we can use the sign of the Y value as an indicator to make the combo counter displayed correctly.
-            if ((Y < 0 && direction.Value == ScrollingDirection.Down) || (Y > 0 && direction.Value == ScrollingDirection.Up))
-                Y = -Y;
+            Anchor &= ~(Anchor.y0 | Anchor.y2);
+            Anchor |= direction.Value == ScrollingDirection.Up ? Anchor.y2 : Anchor.y0;
+
+            // change the sign of the Y coordinate in line with the scrolling direction.
+            // i.e. if the user changes direction from down to up, the anchor is changed from top to bottom, and the Y is flipped from positive to negative here.
+            Y = Math.Abs(Y) * (direction.Value == ScrollingDirection.Up ? -1 : 1);
         }
 
         protected override void OnCountIncrement()


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/29499
- Closes https://github.com/ppy/osu/issues/29495

The Y coordinate should not be touched if the user set a centered anchor...I guess.

Alternative would be to disable anchors entirely for this component, if this sounds too broke.

Other alternative would be to remove this positioning logic entirely and let the user manually move their combo counter when the direction is changed

Other other alternative would be to try and have a skinning layer that flips when the scrolling direction is changed.

Lots of options to explore.