### PR TITLE
Redesign timing table tracking

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -115,40 +115,6 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestTrackingCurrentTimeWhileRunning()
-        {
-            AddStep("Select first effect point", () =>
-            {
-                InputManager.MoveMouseTo(Child.ChildrenOfType<EffectRowAttribute>().First());
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
-            AddUntilStep("Ensure seeked to correct time", () => EditorClock.CurrentTimeAccurate == 54670);
-
-            AddStep("Seek to just before next point", () => EditorClock.Seek(69000));
-            AddStep("Start clock", () => EditorClock.Start());
-
-            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
-        }
-
-        [Test]
-        public void TestTrackingCurrentTimeWhilePaused()
-        {
-            AddStep("Select first effect point", () =>
-            {
-                InputManager.MoveMouseTo(Child.ChildrenOfType<EffectRowAttribute>().First());
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 54670);
-            AddUntilStep("Ensure seeked to correct time", () => EditorClock.CurrentTimeAccurate == 54670);
-
-            AddStep("Seek to later", () => EditorClock.Seek(80000));
-            AddUntilStep("Selection changed", () => timingScreen.SelectedGroup.Value.Time == 69670);
-        }
-
-        [Test]
         public void TestScrollControlGroupIntoView()
         {
             AddStep("Add many control points", () =>

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -46,6 +46,26 @@ namespace osu.Game.Screens.Edit.Timing
                 new FillFlowContainer
                 {
                     AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Direction = FillDirection.Horizontal,
+                    Margin = new MarginPadding(margins),
+                    Spacing = new Vector2(5),
+                    Children = new Drawable[]
+                    {
+                        new RoundedButton
+                        {
+                            Text = "Select closest to current time",
+                            Action = goToCurrentGroup,
+                            Size = new Vector2(220, 30),
+                            Anchor = Anchor.BottomRight,
+                            Origin = Anchor.BottomRight,
+                        },
+                    }
+                },
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
                     Direction = FillDirection.Horizontal,
@@ -66,15 +86,6 @@ namespace osu.Game.Screens.Edit.Timing
                         {
                             Action = addNew,
                             Size = new Vector2(160, 30),
-                            Anchor = Anchor.BottomRight,
-                            Origin = Anchor.BottomRight,
-                            BackgroundColour = colours.Green3,
-                        },
-                        new RoundedButton
-                        {
-                            Text = "Go to current time",
-                            Action = goToCurrentGroup,
-                            Size = new Vector2(140, 30),
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
                         },

--- a/osu.Game/Screens/Edit/Timing/ControlPointList.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointList.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osuTK;
@@ -30,7 +31,7 @@ namespace osu.Game.Screens.Edit.Timing
         private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuColour colours)
         {
             RelativeSizeAxes = Axes.Both;
 
@@ -59,6 +60,7 @@ namespace osu.Game.Screens.Edit.Timing
                             Action = delete,
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
+                            BackgroundColour = colours.Red3,
                         },
                         addButton = new RoundedButton
                         {
@@ -66,6 +68,7 @@ namespace osu.Game.Screens.Edit.Timing
                             Size = new Vector2(160, 30),
                             Anchor = Anchor.BottomRight,
                             Origin = Anchor.BottomRight,
+                            BackgroundColour = colours.Green3,
                         },
                         new RoundedButton
                         {

--- a/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
+++ b/osu.Game/Screens/Edit/Timing/ControlPointTable.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Shapes;
@@ -27,9 +28,26 @@ namespace osu.Game.Screens.Edit.Timing
     {
         public BindableList<ControlPointGroup> Groups { get; } = new BindableList<ControlPointGroup>();
 
+        [Cached]
+        private Bindable<TimingControlPoint?> activeTimingPoint { get; } = new Bindable<TimingControlPoint?>();
+
+        [Cached]
+        private Bindable<EffectControlPoint?> activeEffectPoint { get; } = new Bindable<EffectControlPoint?>();
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; } = null!;
+
+        [Resolved]
+        private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
+
+        [Resolved]
+        private EditorClock editorClock { get; set; } = null!;
+
         private const float timing_column_width = 300;
         private const float row_height = 25;
         private const float row_horizontal_padding = 20;
+
+        private ControlPointRowList list = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colours)
@@ -65,7 +83,7 @@ namespace osu.Game.Screens.Edit.Timing
                         {
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
-                            Margin = new MarginPadding { Left = ControlPointTable.timing_column_width }
+                            Margin = new MarginPadding { Left = timing_column_width }
                         },
                     }
                 },
@@ -73,7 +91,7 @@ namespace osu.Game.Screens.Edit.Timing
                 {
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Top = row_height },
-                    Child = new ControlPointRowList
+                    Child = list = new ControlPointRowList
                     {
                         RelativeSizeAxes = Axes.Both,
                         RowData = { BindTarget = Groups, },
@@ -82,40 +100,63 @@ namespace osu.Game.Screens.Edit.Timing
             };
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            selectedGroup.BindValueChanged(_ => scrollToMostRelevantRow(force: true), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            scrollToMostRelevantRow(force: false);
+        }
+
+        private void scrollToMostRelevantRow(bool force)
+        {
+            double accurateTime = editorClock.CurrentTimeAccurate;
+
+            activeTimingPoint.Value = beatmap.ControlPointInfo.TimingPointAt(accurateTime);
+            activeEffectPoint.Value = beatmap.ControlPointInfo.EffectPointAt(accurateTime);
+
+            double latestActiveTime = Math.Max(activeTimingPoint.Value?.Time ?? double.NegativeInfinity, activeEffectPoint.Value?.Time ?? double.NegativeInfinity);
+            var groupToShow = selectedGroup.Value ?? beatmap.ControlPointInfo.GroupAt(latestActiveTime);
+            list.ScrollTo(groupToShow, force);
+        }
+
         private partial class ControlPointRowList : VirtualisedListContainer<ControlPointGroup, DrawableControlGroup>
         {
-            [Resolved]
-            private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
-
             public ControlPointRowList()
                 : base(row_height, 50)
             {
             }
 
-            protected override ScrollContainer<Drawable> CreateScrollContainer() => new OsuScrollContainer();
+            protected override ScrollContainer<Drawable> CreateScrollContainer() => new UserTrackingScrollContainer();
 
-            protected override void LoadComplete()
+            protected new UserTrackingScrollContainer Scroll => (UserTrackingScrollContainer)base.Scroll;
+
+            public void ScrollTo(ControlPointGroup group, bool force)
             {
-                base.LoadComplete();
+                if (Scroll.UserScrolling && !force)
+                    return;
 
-                selectedGroup.BindValueChanged(val =>
-                {
-                    // can't use `.ScrollIntoView()` here because of the list virtualisation not giving
-                    // child items valid coordinates from the start, so ballpark something similar
-                    // using estimated row height.
-                    var row = Items.FlowingChildren.SingleOrDefault(item => item.Row.Equals(val.NewValue));
+                // can't use `.ScrollIntoView()` here because of the list virtualisation not giving
+                // child items valid coordinates from the start, so ballpark something similar
+                // using estimated row height.
+                var row = Items.FlowingChildren.SingleOrDefault(item => item.Row.Equals(group));
 
-                    if (row == null)
-                        return;
+                if (row == null)
+                    return;
 
-                    float minPos = row.Y;
-                    float maxPos = minPos + row_height;
+                float minPos = row.Y;
+                float maxPos = minPos + row_height;
 
-                    if (minPos < Scroll.Current)
-                        Scroll.ScrollTo(minPos);
-                    else if (maxPos > Scroll.Current + Scroll.DisplayableContent)
-                        Scroll.ScrollTo(maxPos - Scroll.DisplayableContent);
-                });
+                if (minPos < Scroll.Current)
+                    Scroll.ScrollTo(minPos);
+                else if (maxPos > Scroll.Current + Scroll.DisplayableContent)
+                    Scroll.ScrollTo(maxPos - Scroll.DisplayableContent);
             }
         }
 
@@ -130,12 +171,22 @@ namespace osu.Game.Screens.Edit.Timing
             private readonly BindableWithCurrent<ControlPointGroup> current = new BindableWithCurrent<ControlPointGroup>();
 
             private Box background = null!;
+            private Box currentIndicator = null!;
 
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
 
             [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            [Resolved]
             private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
+
+            [Resolved]
+            private Bindable<TimingControlPoint?> activeTimingPoint { get; set; } = null!;
+
+            [Resolved]
+            private Bindable<EffectControlPoint?> activeEffectPoint { get; set; } = null!;
 
             [Resolved]
             private EditorClock editorClock { get; set; } = null!;
@@ -151,6 +202,12 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         RelativeSizeAxes = Axes.Both,
                         Colour = colourProvider.Background1,
+                        Alpha = 0,
+                    },
+                    currentIndicator = new Box
+                    {
+                        RelativeSizeAxes = Axes.Y,
+                        Width = 5,
                         Alpha = 0,
                     },
                     new Container
@@ -174,7 +231,9 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 base.LoadComplete();
 
-                selectedGroup.BindValueChanged(_ => updateState(), true);
+                selectedGroup.BindValueChanged(_ => updateState());
+                activeEffectPoint.BindValueChanged(_ => updateState());
+                activeTimingPoint.BindValueChanged(_ => updateState(), true);
                 FinishTransforms(true);
             }
 
@@ -213,12 +272,31 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 bool isSelected = selectedGroup.Value?.Equals(current.Value) == true;
 
+                bool hasCurrentTimingPoint = activeTimingPoint.Value != null && current.Value.ControlPoints.Contains(activeTimingPoint.Value);
+                bool hasCurrentEffectPoint = activeEffectPoint.Value != null && current.Value.ControlPoints.Contains(activeEffectPoint.Value);
+
                 if (IsHovered || isSelected)
                     background.FadeIn(100, Easing.OutQuint);
+                else if (hasCurrentTimingPoint || hasCurrentEffectPoint)
+                    background.FadeTo(0.2f, 100, Easing.OutQuint);
                 else
                     background.FadeOut(100, Easing.OutQuint);
 
                 background.Colour = isSelected ? colourProvider.Colour3 : colourProvider.Background1;
+
+                if (hasCurrentTimingPoint || hasCurrentEffectPoint)
+                {
+                    currentIndicator.FadeIn(100, Easing.OutQuint);
+
+                    if (hasCurrentTimingPoint && hasCurrentEffectPoint)
+                        currentIndicator.Colour = ColourInfo.GradientVertical(activeTimingPoint.Value!.GetRepresentingColour(colours), activeEffectPoint.Value!.GetRepresentingColour(colours));
+                    else if (hasCurrentTimingPoint)
+                        currentIndicator.Colour = activeTimingPoint.Value!.GetRepresentingColour(colours);
+                    else
+                        currentIndicator.Colour = activeEffectPoint.Value!.GetRepresentingColour(colours);
+                }
+                else
+                    currentIndicator.FadeOut(100, Easing.OutQuint);
             }
         }
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/29531
- Closes https://github.com/ppy/osu/pull/23197

RFC. This change reverts some behaviours of the timing screen that were (in my view) causing overall jankness, and manifested in actual issues such as https://github.com/ppy/osu/issues/23147. The general spirit of the change is "don't try to do *too* much for the user".

The reason why I went in this direction is that rather than layer *additional* silent mechanics onto this screen such as "locking rows" or whatever, I'd like to try *removing* automation first and seeing how that gets received. Something something, "perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away".

- On entering the screen, the timing point active at the current instant of the map is selected. This is the *only* time where the selected point is changed automatically for the user.

- The ongoing automatic tracking of the relevant point after the initial selection is *gone*. Even knowing the fact that it was supposed to track the supposedly relevant "last selected type" of control point, I always found the tracking to be fairly arbitrary in how it works. Removing this behaviour also incidentally fixes https://github.com/ppy/osu/issues/23147.

  In its stead, to indicate which timing groups are having an effect, they receive an indicator line on the left (coloured using the relevant control points' representing colours), as well as a slight highlight effect.

- If there is no control point selected, the table will autoscroll to the latest timing group, unless the user manually scrolled the table before.

- If the selected control point changes, the table will autoscroll to the newly selected point, *regardless* of whether the user manually scrolled the table before.

- A new button is added which permits the user to select the latest timing group. As per the point above, this will autoscroll the user to that group at the same time.

Additional test coverage for these behaviours can be added once I'm sure this PR won't get immediately dumpstered on sight.

![1724146059](https://github.com/user-attachments/assets/94a23229-5e2a-4cfc-8b03-da06676ff61b)