### PR TITLE
 Fix crash on attempting to edit particular beatmaps

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Legacy;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -336,7 +337,7 @@ namespace osu.Game.Beatmaps.Formats
                     break;
 
                 case @"BeatDivisor":
-                    beatmap.BeatmapInfo.BeatDivisor = Parsing.ParseInt(pair.Value);
+                    beatmap.BeatmapInfo.BeatDivisor = Math.Clamp(Parsing.ParseInt(pair.Value), BindableBeatDivisor.MINIMUM_DIVISOR, BindableBeatDivisor.MAXIMUM_DIVISOR);
                     break;
 
                 case @"GridSize":

--- a/osu.Game/Screens/Edit/BindableBeatDivisor.cs
+++ b/osu.Game/Screens/Edit/BindableBeatDivisor.cs
@@ -16,6 +16,9 @@ namespace osu.Game.Screens.Edit
     {
         public static readonly int[] PREDEFINED_DIVISORS = { 1, 2, 3, 4, 6, 8, 12, 16 };
 
+        public const int MINIMUM_DIVISOR = 1;
+        public const int MAXIMUM_DIVISOR = 64;
+
         public Bindable<BeatDivisorPresetCollection> ValidDivisors { get; } = new Bindable<BeatDivisorPresetCollection>(BeatDivisorPresetCollection.COMMON);
 
         public BindableBeatDivisor(int value = 1)
@@ -30,8 +33,12 @@ namespace osu.Game.Screens.Edit
         /// </summary>
         /// <param name="divisor">The intended divisor.</param>
         /// <param name="preferKnownPresets">Forces changing the valid divisors to a known preset.</param>
-        public void SetArbitraryDivisor(int divisor, bool preferKnownPresets = false)
+        /// <returns>Whether the divisor was successfully set.</returns>
+        public bool SetArbitraryDivisor(int divisor, bool preferKnownPresets = false)
         {
+            if (divisor < MINIMUM_DIVISOR || divisor > MAXIMUM_DIVISOR)
+                return false;
+
             // If the current valid divisor range doesn't contain the proposed value, attempt to find one which does.
             if (preferKnownPresets || !ValidDivisors.Value.Presets.Contains(divisor))
             {
@@ -44,6 +51,7 @@ namespace osu.Game.Screens.Edit
             }
 
             Value = divisor;
+            return true;
         }
 
         private void updateBindableProperties()

--- a/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BeatDivisorControl.cs
@@ -330,13 +330,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             private void setPresetsFromTextBoxEntry()
             {
-                if (!int.TryParse(divisorTextBox.Text, out int divisor) || divisor < 1 || divisor > 64)
+                if (!int.TryParse(divisorTextBox.Text, out int divisor) || !BeatDivisor.SetArbitraryDivisor(divisor))
                 {
+                    // the text either didn't parse as a divisor, or the divisor was not set due to being out of range.
+                    // force a state update to reset the text box's value to the last sane value.
                     updateState();
                     return;
                 }
-
-                BeatDivisor.SetArbitraryDivisor(divisor);
 
                 this.HidePopover();
             }


### PR DESCRIPTION
## [Fix crash on attempting to edit particular beatmaps](https://github.com/ppy/osu/commit/bb964e32fa5a1e5f2aeb1b3f14308f9c85be02ea)

Closes https://github.com/ppy/osu/issues/29492.

I'm not immediately sure why this happened, but some old locally modified beatmaps in my local realm database have a `BeatDivisor` of 0 stored, which is then passed to `BindableBeatDivisor.SetArbitraryDivisor()`, which then blows up.

To stop this from happening, just refuse to use values outside of a sane range.

## [Clamp beat divisor to sane range when decoding](https://github.com/ppy/osu/commit/c2dd2ad9783412d61a819805a42f1fa4a9dfd12a)

In my view this is a nice change, but do note that on its own it does nothing to fix https://github.com/ppy/osu/issues/29492, because of `BeatmapInfo` reference management foibles when opening the editor. See also: https://github.com/ppy/osu/issues/20883#issuecomment-1288149271, https://github.com/ppy/osu/pull/28473.