### PR TITLE
Fix legacy key counter position not matching stable

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -56,10 +56,8 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                                 {
                                     // set the anchor to top right so that it won't squash to the return button to the top
                                     keyCounter.Anchor = Anchor.CentreRight;
-                                    keyCounter.Origin = Anchor.CentreRight;
-                                    keyCounter.X = 0;
-                                    // 340px is the default height inherit from stable
-                                    keyCounter.Y = container.ToLocalSpace(new Vector2(0, container.ScreenSpaceDrawQuad.Centre.Y - 340f)).Y;
+                                    keyCounter.Origin = Anchor.TopRight;
+                                    keyCounter.Position = new Vector2(0, -40) * 1.6f;
                                 }
                             })
                             {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -69,10 +69,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                                 {
                                     // set the anchor to top right so that it won't squash to the return button to the top
                                     keyCounter.Anchor = Anchor.CentreRight;
-                                    keyCounter.Origin = Anchor.CentreRight;
-                                    keyCounter.X = 0;
-                                    // 340px is the default height inherit from stable
-                                    keyCounter.Y = container.ToLocalSpace(new Vector2(0, container.ScreenSpaceDrawQuad.Centre.Y - 340f)).Y;
+                                    keyCounter.Origin = Anchor.TopRight;
+                                    keyCounter.Position = new Vector2(0, -40) * 1.6f;
                                 }
 
                                 var combo = container.OfType<LegacyDefaultComboCounter>().FirstOrDefault();


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29420

In stable, the key counter display is positioned to the centre right of the screen pushed 40 pixels upwards in a 640x480 coordinates system (i.e. stable's coordinates system):
https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Input/Drawable/InputOverlay.cs#L40-L41

To achieve the same behaviour, we use `CentreRight` anchor, `TopRight` origin, and push the key counter upwards by *64* pixels (that is, 40 pixels but multiplied by the 1.6 constant).

Precedents of using the 1.6 constant can be seen in `LegacyHealthDisplay`. The reason why the constant is applied there is because stable works in a 640x480 system, meanwhile lazer works in a 1024x768 system, therefore we have to multiply by 1.6 to translate the delta across.