### PR TITLE
Allow copying beatmap link in song select carousel context menu

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapInfoExtensions.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Localisation;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
 using osu.Game.Screens.Select;
 
 namespace osu.Game.Beatmaps
@@ -48,5 +50,16 @@ namespace osu.Game.Beatmaps
         }
 
         private static string getVersionString(IBeatmapInfo beatmapInfo) => string.IsNullOrEmpty(beatmapInfo.DifficultyName) ? string.Empty : $"[{beatmapInfo.DifficultyName}]";
+
+        /// <summary>
+        /// Get the beatmap info page URL, or <c>null</c> if unavailable.
+        /// </summary>
+        public static string? GetOnlineURL(this IBeatmapInfo beatmapInfo, IAPIProvider api, IRulesetInfo? ruleset = null)
+        {
+            if (beatmapInfo.OnlineID <= 0 || beatmapInfo.BeatmapSet == null)
+                return null;
+
+            return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{ruleset?.ShortName ?? beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}";
+        }
     }
 }

--- a/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
+++ b/osu.Game/Beatmaps/BeatmapSetInfoExtensions.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using osu.Game.Database;
 using osu.Game.Extensions;
 using osu.Game.Models;
+using osu.Game.Online.API;
+using osu.Game.Rulesets;
 
 namespace osu.Game.Beatmaps
 {
@@ -29,5 +31,19 @@ namespace osu.Game.Beatmaps
         /// <param name="filename">The name of the file to get the storage path of.</param>
         public static RealmNamedFileUsage? GetFile(this IHasRealmFiles model, string filename) =>
             model.Files.SingleOrDefault(f => string.Equals(f.Filename, filename, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Get the beatmapset info page URL, or <c>null</c> if unavailable.
+        /// </summary>
+        public static string? GetOnlineURL(this IBeatmapSetInfo beatmapSetInfo, IAPIProvider api, IRulesetInfo? ruleset = null)
+        {
+            if (beatmapSetInfo.OnlineID <= 0)
+                return null;
+
+            if (ruleset != null)
+                return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}#{ruleset.ShortName}";
+
+            return $@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSetInfo.OnlineID}";
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -86,7 +86,7 @@ namespace osu.Game.Graphics.UserInterface
                 if (Link != null)
                 {
                     items.Add(new OsuMenuItem("Open", MenuItemType.Highlighted, () => host.OpenUrlExternally(Link)));
-                    items.Add(new OsuMenuItem("Copy URL", MenuItemType.Standard, copyUrl));
+                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, copyUrl));
                 }
 
                 return items.ToArray();

--- a/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
+++ b/osu.Game/Graphics/UserInterface/ExternalLinkButton.cs
@@ -10,9 +10,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
-using osu.Framework.Platform;
-using osu.Game.Overlays;
-using osu.Game.Overlays.OSD;
 using osuTK;
 using osuTK.Graphics;
 
@@ -25,13 +22,7 @@ namespace osu.Game.Graphics.UserInterface
         private Color4 hoverColour;
 
         [Resolved]
-        private GameHost host { get; set; } = null!;
-
-        [Resolved]
-        private Clipboard clipboard { get; set; } = null!;
-
-        [Resolved]
-        private OnScreenDisplay? onScreenDisplay { get; set; }
+        private OsuGame? game { get; set; }
 
         private readonly SpriteIcon linkIcon;
 
@@ -71,7 +62,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (Link != null)
-                host.OpenUrlExternally(Link);
+                game?.OpenUrlExternally(Link);
             return true;
         }
 
@@ -85,7 +76,7 @@ namespace osu.Game.Graphics.UserInterface
 
                 if (Link != null)
                 {
-                    items.Add(new OsuMenuItem("Open", MenuItemType.Highlighted, () => host.OpenUrlExternally(Link)));
+                    items.Add(new OsuMenuItem("Open", MenuItemType.Highlighted, () => game?.OpenUrlExternally(Link)));
                     items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, copyUrl));
                 }
 
@@ -95,11 +86,9 @@ namespace osu.Game.Graphics.UserInterface
 
         private void copyUrl()
         {
-            if (Link != null)
-            {
-                clipboard.SetText(Link);
-                onScreenDisplay?.Display(new CopyUrlToast());
-            }
+            if (Link == null) return;
+
+            game?.CopyUrlToClipboard(Link);
         }
     }
 }

--- a/osu.Game/Localisation/ToastStrings.cs
+++ b/osu.Game/Localisation/ToastStrings.cs
@@ -45,9 +45,9 @@ namespace osu.Game.Localisation
         public static LocalisableString SkinSaved => new TranslatableString(getKey(@"skin_saved"), @"Skin saved");
 
         /// <summary>
-        /// "URL copied"
+        /// "Link copied to clipboard"
         /// </summary>
-        public static LocalisableString UrlCopied => new TranslatableString(getKey(@"url_copied"), @"URL copied");
+        public static LocalisableString UrlCopied => new TranslatableString(getKey(@"url_copied"), @"Link copied to clipboard");
 
         /// <summary>
         /// "Speed changed to {0:N2}x"

--- a/osu.Game/Online/Chat/ExternalLinkOpener.cs
+++ b/osu.Game/Online/Chat/ExternalLinkOpener.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Online.Chat
                     },
                     new PopupDialogCancelButton
                     {
-                        Text = @"Copy URL to the clipboard",
+                        Text = @"Copy link",
                         Action = copyExternalLinkAction
                     },
                     new PopupDialogCancelButton

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -54,6 +54,7 @@ using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Music;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Overlays.OSD;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Overlays.Volume;
@@ -141,6 +142,8 @@ namespace osu.Game
         protected Container ScreenOffsetContainer { get; private set; }
 
         private Container overlayOffsetContainer;
+
+        private OnScreenDisplay onScreenDisplay;
 
         [Resolved]
         private FrameworkConfigManager frameworkConfig { get; set; }
@@ -495,6 +498,12 @@ namespace osu.Game
                 default:
                     throw new NotImplementedException($"This {nameof(LinkAction)} ({link.Action.ToString()}) is missing an associated action.");
             }
+        });
+
+        public void CopyUrlToClipboard(string url) => waitForReady(() => onScreenDisplay, _ =>
+        {
+            dependencies.Get<Clipboard>().SetText(url);
+            onScreenDisplay.Display(new CopyUrlToast());
         });
 
         public void OpenUrlExternally(string url, bool forceBypassExternalUrlWarning = false) => waitForReady(() => externalLinkOpener, _ =>
@@ -1078,7 +1087,7 @@ namespace osu.Game
 
             loadComponentSingleFile(volume = new VolumeOverlay(), leftFloatingOverlayContent.Add, true);
 
-            var onScreenDisplay = new OnScreenDisplay();
+            onScreenDisplay = new OnScreenDisplay();
 
             onScreenDisplay.BeginTracking(this, frameworkConfig);
             onScreenDisplay.BeginTracking(this, LocalConfig);

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -200,7 +200,8 @@ namespace osu.Game.Overlays.BeatmapSet
 
         private void updateExternalLink()
         {
-            if (externalLink != null) externalLink.Link = $@"{api.WebsiteRootUrl}/beatmapsets/{BeatmapSet.Value?.OnlineID}#{Picker.Beatmap.Value?.Ruleset.ShortName}/{Picker.Beatmap.Value?.OnlineID}";
+            if (externalLink != null)
+                externalLink.Link = Picker.Beatmap.Value?.GetOnlineURL(api) ?? BeatmapSet.Value?.GetOnlineURL(api);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -55,7 +55,6 @@ namespace osu.Game.Screens.Select.Carousel
 
         private Action<BeatmapInfo>? selectRequested;
         private Action<BeatmapInfo>? hideRequested;
-        private Action? copyBeatmapSetUrl;
 
         private Triangles triangles = null!;
 
@@ -82,6 +81,12 @@ namespace osu.Game.Screens.Select.Carousel
         [Resolved]
         private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
+        [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
         private IBindable<StarDifficulty?> starDifficultyBindable = null!;
         private CancellationTokenSource? starDifficultyCancellationSource;
 
@@ -92,7 +97,7 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapManager? manager, SongSelect? songSelect, Clipboard clipboard, IAPIProvider api)
+        private void load(BeatmapManager? manager, SongSelect? songSelect, IAPIProvider api)
         {
             Header.Height = height;
 
@@ -104,9 +109,6 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (manager != null)
                 hideRequested = manager.Hide;
-
-            if (beatmapInfo.BeatmapSet != null)
-                copyBeatmapSetUrl += () => clipboard.SetText($@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}");
 
             Header.Children = new Drawable[]
             {
@@ -294,7 +296,8 @@ namespace osu.Game.Screens.Select.Carousel
 
                 items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
 
-                items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
+                if (beatmapInfo.GetOnlineURL(api) is string url)
+                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => clipboard.SetText(url)));
 
                 if (hideRequested != null)
                     items.Add(new OsuMenuItem(CommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => hideRequested(beatmapInfo)));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -105,7 +105,8 @@ namespace osu.Game.Screens.Select.Carousel
             if (manager != null)
                 hideRequested = manager.Hide;
 
-            copyBeatmapSetUrl += () => clipboard.SetText($@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}");
+            if (beatmapInfo.BeatmapSet != null)
+                copyBeatmapSetUrl += () => clipboard.SetText($@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}");
 
             Header.Children = new Drawable[]
             {

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Collections;
@@ -25,6 +26,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
@@ -53,6 +55,7 @@ namespace osu.Game.Screens.Select.Carousel
 
         private Action<BeatmapInfo>? selectRequested;
         private Action<BeatmapInfo>? hideRequested;
+        private Action? copyBeatmapSetUrl;
 
         private Triangles triangles = null!;
 
@@ -89,7 +92,7 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapManager? manager, SongSelect? songSelect)
+        private void load(BeatmapManager? manager, SongSelect? songSelect, Clipboard clipboard, IAPIProvider api)
         {
             Header.Height = height;
 
@@ -101,6 +104,8 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (manager != null)
                 hideRequested = manager.Hide;
+
+            copyBeatmapSetUrl += () => clipboard.SetText($@"{api.WebsiteRootUrl}/beatmapsets/{beatmapInfo.BeatmapSet.OnlineID}#{beatmapInfo.Ruleset.ShortName}/{beatmapInfo.OnlineID}");
 
             Header.Children = new Drawable[]
             {
@@ -287,6 +292,8 @@ namespace osu.Game.Screens.Select.Carousel
                     collectionItems.Add(new OsuMenuItem("Manage...", MenuItemType.Standard, manageCollectionsDialog.Show));
 
                 items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
+
+                items.Add(new OsuMenuItem("Copy URL", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
 
                 if (hideRequested != null)
                     items.Add(new OsuMenuItem(CommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => hideRequested(beatmapInfo)));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -97,7 +97,7 @@ namespace osu.Game.Screens.Select.Carousel
         }
 
         [BackgroundDependencyLoader]
-        private void load(BeatmapManager? manager, SongSelect? songSelect, IAPIProvider api)
+        private void load(BeatmapManager? manager, SongSelect? songSelect)
         {
             Header.Height = height;
 

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Screens.Select.Carousel
 
                 items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
 
-                items.Add(new OsuMenuItem("Copy URL", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
+                items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
 
                 if (hideRequested != null)
                     items.Add(new OsuMenuItem(CommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => hideRequested(beatmapInfo)));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
-using osu.Framework.Platform;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Collections;
@@ -82,10 +81,10 @@ namespace osu.Game.Screens.Select.Carousel
         private IBindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         [Resolved]
-        private Clipboard clipboard { get; set; } = null!;
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; } = null!;
+        private OsuGame? game { get; set; }
 
         private IBindable<StarDifficulty?> starDifficultyBindable = null!;
         private CancellationTokenSource? starDifficultyCancellationSource;
@@ -297,7 +296,7 @@ namespace osu.Game.Screens.Select.Carousel
                 items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
 
                 if (beatmapInfo.GetOnlineURL(api) is string url)
-                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => clipboard.SetText(url)));
+                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => game?.CopyUrlToClipboard(url)));
 
                 if (hideRequested != null)
                     items.Add(new OsuMenuItem(CommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => hideRequested(beatmapInfo)));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmap.cs
@@ -295,7 +295,7 @@ namespace osu.Game.Screens.Select.Carousel
 
                 items.Add(new OsuMenuItem("Collections") { Items = collectionItems });
 
-                if (beatmapInfo.GetOnlineURL(api) is string url)
+                if (beatmapInfo.GetOnlineURL(api, ruleset.Value) is string url)
                     items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => game?.CopyUrlToClipboard(url)));
 
                 if (hideRequested != null)

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -294,7 +294,7 @@ namespace osu.Game.Screens.Select.Carousel
                 if (beatmapSet.Beatmaps.Any(b => b.Hidden))
                     items.Add(new OsuMenuItem("Restore all hidden", MenuItemType.Standard, () => restoreHiddenRequested(beatmapSet)));
 
-                items.Add(new OsuMenuItem("Copy URL", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
+                items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => copyBeatmapSetUrl?.Invoke()));
 
                 if (dialogOverlay != null)
                     items.Add(new OsuMenuItem("Delete...", MenuItemType.Destructive, () => dialogOverlay.Push(new BeatmapDeleteDialog(beatmapSet))));

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Platform;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
@@ -44,10 +43,10 @@ namespace osu.Game.Screens.Select.Carousel
         private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
-        private Clipboard clipboard { get; set; } = null!;
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private IAPIProvider api { get; set; } = null!;
+        private OsuGame? game { get; set; }
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
@@ -301,7 +300,7 @@ namespace osu.Game.Screens.Select.Carousel
                     items.Add(new OsuMenuItem("Restore all hidden", MenuItemType.Standard, () => restoreHiddenRequested(beatmapSet)));
 
                 if (beatmapSet.GetOnlineURL(api, ruleset.Value) is string url)
-                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => clipboard.SetText(url)));
+                    items.Add(new OsuMenuItem("Copy link", MenuItemType.Standard, () => game?.CopyUrlToClipboard(url)));
 
                 if (dialogOverlay != null)
                     items.Add(new OsuMenuItem("Delete...", MenuItemType.Destructive, () => dialogOverlay.Push(new BeatmapDeleteDialog(beatmapSet))));


### PR DESCRIPTION
# Why
This could be very useful when playing on mobile, which player won't need to open their browser to just get the link. At the other side, desktop players can reduce the step of getting URLs, they don't need to jump to the browser and copy the link, instead just do it inside the game

Though the /np command can send the current beatmap to the chat, it doesn't make a use on if we want to share through the other app, like if we want to send it to discord.

# Implementation
Add `Copy link` item into both `DrawableCarouselBeatmapSet` and `DrawableCarouselBeatmap`
While `DrawableCarouselBeatmapSet` Copy URL as `$@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSet.OnlineID}#{ruleset.ShortName}"` and `DrawableCarouselBeatmap` copy as `$@"{api.WebsiteRootUrl}/beatmapsets/{beatmapSet.OnlineID}#{ruleset.ShortName}/{beatmapInfo.OnlineID}"`

<img width="253" alt="Screenshot 2024-08-21 at 11 37 17 AM" src="https://github.com/user-attachments/assets/eab7f563-69fd-4a7a-85f5-048c6f376f56">
