### PR TITLE
Fix resume overlay appearing behind HUD/skip overlays

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -442,7 +442,6 @@ namespace osu.Game.Screens.Play
                     },
                     // display the cursor above some HUD elements.
                     DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),
-                    DrawableRuleset.ResumeOverlay?.CreateProxy() ?? new Container(),
                     HUDOverlay = new HUDOverlay(DrawableRuleset, GameplayState.Mods, Configuration.AlwaysShowLeaderboard)
                     {
                         HoldToQuit =
@@ -470,6 +469,7 @@ namespace osu.Game.Screens.Play
                         RequestSkip = () => progressToResults(false),
                         Alpha = 0
                     },
+                    DrawableRuleset.ResumeOverlay?.CreateProxy() ?? new Container(),
                     PauseOverlay = new PauseOverlay
                     {
                         OnResume = Resume,


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29517

I don't see any reason why it's done this way. Blaming back shows that it was just done this way for the intent of making the resume overlay appear *over* the cursor, it's not intended to appear behind HUD overlay. See https://github.com/ppy/osu/commit/7ca51d3866657302a2c30f90b5e7a757bdb3fe93.