### PR TITLE
Keep mod customisation panel open when dragging outside

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModCustomisationPanel.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModCustomisationPanel.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Rulesets.Mods;
@@ -154,6 +156,27 @@ namespace osu.Game.Tests.Visual.UserInterface
             checkExpanded(true);
 
             AddStep("click", () => InputManager.Click(MouseButton.Left));
+            checkExpanded(false);
+        }
+
+        [Test]
+        public void TestDraggingKeepsPanelExpanded()
+        {
+            AddStep("add customisable mod", () =>
+            {
+                SelectedMods.Value = new[] { new OsuModDoubleTime() };
+                panel.Enabled.Value = true;
+            });
+
+            AddStep("hover header", () => InputManager.MoveMouseTo(header));
+            checkExpanded(true);
+
+            AddStep("hover slider bar nub", () => InputManager.MoveMouseTo(panel.ChildrenOfType<OsuSliderBar<double>>().First().ChildrenOfType<Nub>().Single()));
+            AddStep("hold", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag outside", () => InputManager.MoveMouseTo(Vector2.Zero));
+            checkExpanded(true);
+
+            AddStep("release", () => InputManager.ReleaseButton(MouseButton.Left));
             checkExpanded(false);
         }
 

--- a/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
@@ -214,15 +215,23 @@ namespace osu.Game.Overlays.Mods
                 this.panel = panel;
             }
 
-            protected override void OnHoverLost(HoverLostEvent e)
-            {
-                if (ExpandedState.Value is ModCustomisationPanelState.ExpandedByHover
-                    && !ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-                {
-                    ExpandedState.Value = ModCustomisationPanelState.Collapsed;
-                }
+            private InputManager? inputManager;
 
-                base.OnHoverLost(e);
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                inputManager = GetContainingInputManager();
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (ExpandedState.Value == ModCustomisationPanelState.ExpandedByHover)
+                {
+                    if (!ReceivePositionalInputAt(inputManager!.CurrentState.Mouse.Position) && inputManager.DraggedDrawable == null)
+                        ExpandedState.Value = ModCustomisationPanelState.Collapsed;
+                }
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
@@ -215,12 +215,12 @@ namespace osu.Game.Overlays.Mods
                 this.panel = panel;
             }
 
-            private InputManager? inputManager;
+            private InputManager inputManager = null!;
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                inputManager = GetContainingInputManager();
+                inputManager = GetContainingInputManager()!;
             }
 
             protected override void Update()
@@ -229,7 +229,7 @@ namespace osu.Game.Overlays.Mods
 
                 if (ExpandedState.Value == ModCustomisationPanelState.ExpandedByHover)
                 {
-                    if (!ReceivePositionalInputAt(inputManager!.CurrentState.Mouse.Position) && inputManager.DraggedDrawable == null)
+                    if (!ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position) && inputManager.DraggedDrawable == null)
                         ExpandedState.Value = ModCustomisationPanelState.Collapsed;
                 }
             }

--- a/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
+++ b/osu.Game/Overlays/Mods/ModCustomisationPanel.cs
@@ -227,10 +227,11 @@ namespace osu.Game.Overlays.Mods
             {
                 base.Update();
 
-                if (ExpandedState.Value == ModCustomisationPanelState.ExpandedByHover)
+                if (ExpandedState.Value == ModCustomisationPanelState.ExpandedByHover
+                    && !ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position)
+                    && inputManager.DraggedDrawable == null)
                 {
-                    if (!ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position) && inputManager.DraggedDrawable == null)
-                        ExpandedState.Value = ModCustomisationPanelState.Collapsed;
+                    ExpandedState.Value = ModCustomisationPanelState.Collapsed;
                 }
             }
         }


### PR DESCRIPTION
- Closes #29461

Really wish hover is not being eaten from the `FocusGrabbingContainer` so we don't have to do `ReceivePositionalInputAt` but I don't think it's worth checking on that.