### PR TITLE
Show daily challenge intro screen once per session

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Game.Configuration;
@@ -10,11 +9,14 @@ using osu.Game.Online.API;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.Menu;
 using osu.Game.Screens.OnlinePlay.DailyChallenge;
-using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.Metadata;
 using osu.Game.Tests.Visual.OnlinePlay;
+using osuTK.Graphics;
+using osuTK.Input;
 using CreateRoomRequest = osu.Game.Online.Rooms.CreateRoomRequest;
 
 namespace osu.Game.Tests.Visual.DailyChallenge
@@ -32,23 +34,27 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         [BackgroundDependencyLoader]
         private void load()
         {
-            base.Content.Add(notificationOverlay);
-            base.Content.Add(metadataClient);
+            Add(notificationOverlay);
+            Add(metadataClient);
+
+            // add button to observe for daily challenge changes and perform its logic.
+            Add(new DailyChallengeButton(@"button-default-select", new Color4(102, 68, 204, 255), _ => { }, 0, Key.D));
         }
 
         [Test]
         public void TestDailyChallenge()
         {
-            startChallenge();
+            startChallenge(1234);
             AddStep("push screen", () => LoadScreen(new DailyChallengeIntro(room)));
         }
 
         [Test]
         public void TestPlayIntroOnceFlag()
         {
+            startChallenge(1234);
             AddStep("set intro played flag", () => Dependencies.Get<SessionStatics>().SetValue(Static.DailyChallengeIntroPlayed, true));
 
-            startChallenge();
+            startChallenge(1235);
 
             AddAssert("intro played flag reset", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed), () => Is.False);
 
@@ -56,25 +62,28 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             AddUntilStep("intro played flag set", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed), () => Is.True);
         }
 
-        private void startChallenge()
+        private void startChallenge(int roomId)
         {
-            room = new Room
+            AddStep("add room", () =>
             {
-                RoomID = { Value = 1234 },
-                Name = { Value = "Daily Challenge: June 4, 2024" },
-                Playlist =
+                API.Perform(new CreateRoomRequest(room = new Room
                 {
-                    new PlaylistItem(TestResources.CreateTestBeatmapSetInfo().Beatmaps.First())
+                    RoomID = { Value = roomId },
+                    Name = { Value = "Daily Challenge: June 4, 2024" },
+                    Playlist =
                     {
-                        RequiredMods = [new APIMod(new OsuModTraceable())],
-                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
-                    }
-                },
-                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
-                Category = { Value = RoomCategory.DailyChallenge }
-            };
-
-            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
+                        new PlaylistItem(CreateAPIBeatmap(new OsuRuleset().RulesetInfo))
+                        {
+                            RequiredMods = [new APIMod(new OsuModTraceable())],
+                            AllowedMods = [new APIMod(new OsuModDoubleTime())]
+                        }
+                    },
+                    StartDate = { Value = DateTimeOffset.Now },
+                    EndDate = { Value = DateTimeOffset.Now.AddHours(24) },
+                    Category = { Value = RoomCategory.DailyChallenge }
+                }));
+            });
+            AddStep("signal client", () => metadataClient.DailyChallengeUpdated(new DailyChallengeInfo { RoomID = roomId }));
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
@@ -5,13 +5,12 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Screens;
-using osu.Framework.Testing;
 using osu.Game.Online.API;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens.OnlinePlay.DailyChallenge;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual.Metadata;
 using osu.Game.Tests.Visual.OnlinePlay;
@@ -27,6 +26,8 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         [Cached(typeof(INotificationOverlay))]
         private NotificationOverlay notificationOverlay = new NotificationOverlay();
 
+        private Room room = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -35,33 +36,15 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         }
 
         [Test]
-        [Solo]
         public void TestDailyChallenge()
         {
-            var room = new Room
-            {
-                RoomID = { Value = 1234 },
-                Name = { Value = "Daily Challenge: June 4, 2024" },
-                Playlist =
-                {
-                    new PlaylistItem(CreateAPIBeatmapSet().Beatmaps.First())
-                    {
-                        RequiredMods = [new APIMod(new OsuModTraceable())],
-                        AllowedMods = [new APIMod(new OsuModDoubleTime())]
-                    }
-                },
-                EndDate = { Value = DateTimeOffset.Now.AddHours(12) },
-                Category = { Value = RoomCategory.DailyChallenge }
-            };
-
-            AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
-            AddStep("push screen", () => LoadScreen(new Screens.OnlinePlay.DailyChallenge.DailyChallengeIntro(room)));
+            startChallenge();
+            AddStep("push screen", () => LoadScreen(new DailyChallengeIntro(room)));
         }
 
-        [Test]
-        public void TestNotifications()
+        private void startChallenge()
         {
-            var room = new Room
+            room = new Room
             {
                 RoomID = { Value = 1234 },
                 Name = { Value = "Daily Challenge: June 4, 2024" },
@@ -78,12 +61,6 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             };
 
             AddStep("add room", () => API.Perform(new CreateRoomRequest(room)));
-            AddStep("set daily challenge info", () => metadataClient.DailyChallengeInfo.Value = new DailyChallengeInfo { RoomID = 1234 });
-
-            Screens.OnlinePlay.DailyChallenge.DailyChallenge screen = null!;
-            AddStep("push screen", () => LoadScreen(screen = new Screens.OnlinePlay.DailyChallenge.DailyChallenge(room)));
-            AddUntilStep("wait for screen", () => screen.IsCurrentScreen());
-            AddStep("daily challenge ended", () => metadataClient.DailyChallengeInfo.Value = null);
         }
     }
 }

--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallengeIntro.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Game.Configuration;
 using osu.Game.Online.API;
 using osu.Game.Online.Metadata;
 using osu.Game.Online.Rooms;
@@ -40,6 +41,19 @@ namespace osu.Game.Tests.Visual.DailyChallenge
         {
             startChallenge();
             AddStep("push screen", () => LoadScreen(new DailyChallengeIntro(room)));
+        }
+
+        [Test]
+        public void TestPlayIntroOnceFlag()
+        {
+            AddStep("set intro played flag", () => Dependencies.Get<SessionStatics>().SetValue(Static.DailyChallengeIntroPlayed, true));
+
+            startChallenge();
+
+            AddAssert("intro played flag reset", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed), () => Is.False);
+
+            AddStep("push screen", () => LoadScreen(new DailyChallengeIntro(room)));
+            AddUntilStep("intro played flag set", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed), () => Is.True);
         }
 
         private void startChallenge()

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneMainMenuButton.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -72,7 +71,6 @@ namespace osu.Game.Tests.Visual.UserInterface
             NotificationOverlay notificationOverlay = null!;
             DependencyProvidingContainer buttonContainer = null!;
 
-            AddStep("set intro played flag", () => Dependencies.Get<SessionStatics>().SetValue(Static.DailyChallengeIntroPlayed, true));
             AddStep("beatmap of the day active", () => metadataClient.DailyChallengeUpdated(new DailyChallengeInfo
             {
                 RoomID = 1234,
@@ -98,7 +96,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                     },
                 };
             });
-            AddAssert("intro played flag reset", () => !Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed));
             AddAssert("notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.EqualTo(1));
 
             AddStep("clear notifications", () =>
@@ -107,11 +104,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                     notification.Close(runFlingAnimation: false);
             });
 
-            AddStep("set intro played flag", () => Dependencies.Get<SessionStatics>().SetValue(Static.DailyChallengeIntroPlayed, true));
-
             AddStep("beatmap of the day not active", () => metadataClient.DailyChallengeUpdated(null));
             AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
-            AddAssert("intro played flag still set", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed));
 
             AddStep("hide button's parent", () => buttonContainer.Hide());
 
@@ -120,7 +114,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                 RoomID = 1234,
             }));
             AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
-            AddAssert("intro played flag still set", () => Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed));
         }
 
         [Test]
@@ -178,13 +171,11 @@ namespace osu.Game.Tests.Visual.UserInterface
                 };
             });
 
-            AddStep("set intro played flag", () => Dependencies.Get<SessionStatics>().SetValue(Static.DailyChallengeIntroPlayed, true));
             AddStep("beatmap of the day active", () => metadataClient.DailyChallengeUpdated(new DailyChallengeInfo
             {
                 RoomID = 1234
             }));
             AddAssert("no notification posted", () => notificationOverlay.AllNotifications.Count(), () => Is.Zero);
-            AddAssert("intro played flag reset", () => !Dependencies.Get<SessionStatics>().Get<bool>(Static.DailyChallengeIntroPlayed));
         }
     }
 }

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -80,5 +80,11 @@ namespace osu.Game.Configuration
         /// Stores the local user's last score (can be completed or aborted).
         /// </summary>
         LastLocalUserScore,
+
+        /// <summary>
+        /// Whether the intro animation for the daily challenge screen has been played once.
+        /// This is reset when a new challenge is up.
+        /// </summary>
+        DailyChallengeIntroPlayed,
     }
 }

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Threading;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
@@ -45,6 +46,9 @@ namespace osu.Game.Screens.Menu
 
         [Resolved]
         private INotificationOverlay? notificationOverlay { get; set; }
+
+        [Resolved]
+        private SessionStatics statics { get; set; } = null!;
 
         public DailyChallengeButton(string sampleName, Color4 colour, Action<MainMenuButton>? clickAction = null, params Key[] triggerKeys)
             : base(ButtonSystemStrings.DailyChallenge, sampleName, OsuIcon.DailyChallenge, colour, clickAction, triggerKeys)
@@ -148,6 +152,9 @@ namespace osu.Game.Screens.Menu
 
                 roomRequest.Success += room =>
                 {
+                    // force showing intro on the first time when a new daily challenge is up.
+                    statics.SetValue(Static.DailyChallengeIntroPlayed, false);
+
                     Room = room;
                     cover.OnlineInfo = TooltipContent = room.Playlist.FirstOrDefault()?.Beatmap.BeatmapSet as APIBeatmapSet;
 

--- a/osu.Game/Screens/Menu/DailyChallengeButton.cs
+++ b/osu.Game/Screens/Menu/DailyChallengeButton.cs
@@ -132,7 +132,7 @@ namespace osu.Game.Screens.Menu
             }
         }
 
-        private long? lastNotifiedDailyChallengeRoomId;
+        private long? lastDailyChallengeRoomID;
 
         private void dailyChallengeChanged(ValueChangedEvent<DailyChallengeInfo?> _)
         {
@@ -152,19 +152,19 @@ namespace osu.Game.Screens.Menu
 
                 roomRequest.Success += room =>
                 {
-                    // force showing intro on the first time when a new daily challenge is up.
-                    statics.SetValue(Static.DailyChallengeIntroPlayed, false);
-
                     Room = room;
                     cover.OnlineInfo = TooltipContent = room.Playlist.FirstOrDefault()?.Beatmap.BeatmapSet as APIBeatmapSet;
 
-                    // We only want to notify the user if a new challenge recently went live.
-                    if (room.StartDate.Value != null
-                        && Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 1800
-                        && room.RoomID.Value != lastNotifiedDailyChallengeRoomId)
+                    if (room.StartDate.Value != null && room.RoomID.Value != lastDailyChallengeRoomID)
                     {
-                        lastNotifiedDailyChallengeRoomId = room.RoomID.Value;
-                        notificationOverlay?.Post(new NewDailyChallengeNotification(room));
+                        lastDailyChallengeRoomID = room.RoomID.Value;
+
+                        // new challenge is live, reset intro played static.
+                        statics.SetValue(Static.DailyChallengeIntroPlayed, false);
+
+                        // we only want to notify the user if the new challenge just went live.
+                        if (Math.Abs((DateTimeOffset.Now - room.StartDate.Value!.Value).TotalSeconds) < 1800)
+                            notificationOverlay?.Post(new NewDailyChallengeNotification(room));
                     }
 
                     updateCountdown();

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -150,7 +150,10 @@ namespace osu.Game.Screens.Menu
                             OnPlaylists = () => this.Push(new Playlists()),
                             OnDailyChallenge = room =>
                             {
-                                this.Push(new DailyChallengeIntro(room));
+                                if (statics.Get<bool>(Static.DailyChallengeIntroPlayed))
+                                    this.Push(new DailyChallenge(room));
+                                else
+                                    this.Push(new DailyChallengeIntro(room));
                             },
                             OnExit = () =>
                             {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -70,6 +70,9 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
         [Resolved]
         private MusicController musicController { get; set; } = null!;
 
+        [Resolved]
+        private SessionStatics statics { get; set; } = null!;
+
         private Sample? dateWindupSample;
         private Sample? dateImpactSample;
         private Sample? beatmapWindupSample;
@@ -461,6 +464,8 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                         {
                             Schedule(() =>
                             {
+                                statics.SetValue(Static.DailyChallengeIntroPlayed, true);
+
                                 if (this.IsCurrentScreen())
                                     this.Push(new DailyChallenge(room));
                             });

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -18,6 +18,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.OnlinePlay.Components;
 using osu.Game.Tests.Beatmaps;
+using osu.Game.Utils;
 
 namespace osu.Game.Tests.Visual.OnlinePlay
 {
@@ -277,11 +278,18 @@ namespace osu.Game.Tests.Visual.OnlinePlay
             var result = JsonConvert.DeserializeObject<Room>(JsonConvert.SerializeObject(source));
             Debug.Assert(result != null);
 
-            // Playlist item IDs aren't serialised.
+            // Playlist item IDs and beatmaps aren't serialised.
             if (source.CurrentPlaylistItem.Value != null)
+            {
+                result.CurrentPlaylistItem.Value = result.CurrentPlaylistItem.Value.With(new Optional<IBeatmapInfo>(source.CurrentPlaylistItem.Value.Beatmap));
                 result.CurrentPlaylistItem.Value.ID = source.CurrentPlaylistItem.Value.ID;
+            }
+
             for (int i = 0; i < source.Playlist.Count; i++)
+            {
+                result.Playlist[i] = result.Playlist[i].With(new Optional<IBeatmapInfo>(source.Playlist[i].Beatmap));
                 result.Playlist[i].ID = source.Playlist[i].ID;
+            }
 
             return result;
         }

--- a/osu.Game/Utils/Optional.cs
+++ b/osu.Game/Utils/Optional.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Utils
         /// </remarks>
         public readonly bool HasValue;
 
-        private Optional(T value)
+        public Optional(T value)
         {
             Value = value;
             HasValue = true;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/29463
- [x] Need to test whether the flag actually resets when the daily challenge is updated

https://github.com/user-attachments/assets/f9da2667-8b73-44f3-97c6-cd6eb3f8f641

Adding tests for this one will be a bit bothersome, but I can do it on request.