### PR TITLE
Preload song select instances in multiplayer / playlists

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -277,11 +276,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                                                             RelativeSizeAxes = Axes.X,
                                                             Height = 40,
                                                             Text = "Select beatmap",
-                                                            Action = () =>
-                                                            {
-                                                                if (matchSubScreen.IsCurrentScreen())
-                                                                    matchSubScreen.Push(new MultiplayerMatchSongSelect(matchSubScreen.Room));
-                                                            }
+                                                            Action = () => matchSubScreen.OpenSongSelection()
                                                         }
                                                     }
                                                 }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSongSelect.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         private OngoingOperationTracker operationTracker { get; set; } = null!;
 
         private readonly IBindable<bool> operationInProgress = new Bindable<bool>();
-        private readonly PlaylistItem? itemToEdit;
 
         private LoadingLayer loadingLayer = null!;
         private IDisposable? selectionOperation;
@@ -34,11 +33,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// Construct a new instance of multiplayer song select.
         /// </summary>
         /// <param name="room">The room.</param>
-        /// <param name="itemToEdit">The item to be edited. May be null, in which case a new item will be added to the playlist.</param>
-        public MultiplayerMatchSongSelect(Room room, PlaylistItem? itemToEdit = null)
-            : base(room, itemToEdit)
+        public MultiplayerMatchSongSelect(Room room)
+            : base(room)
         {
-            this.itemToEdit = itemToEdit;
         }
 
         [BackgroundDependencyLoader]
@@ -79,7 +76,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
                 var multiplayerItem = new MultiplayerPlaylistItem
                 {
-                    ID = itemToEdit?.ID ?? 0,
+                    ID = PlaylistItem?.ID ?? 0,
                     BeatmapID = item.Beatmap.OnlineID,
                     BeatmapChecksum = item.Beatmap.MD5Hash,
                     RulesetID = item.RulesetID,
@@ -87,7 +84,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                     AllowedMods = item.AllowedMods.ToArray()
                 };
 
-                Task task = itemToEdit != null ? client.EditPlaylistItem(multiplayerItem) : client.AddPlaylistItem(multiplayerItem);
+                Task task = PlaylistItem != null ? client.EditPlaylistItem(multiplayerItem) : client.AddPlaylistItem(multiplayerItem);
 
                 task.FireAndForget(onSuccess: () =>
                 {

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
 
         private MatchLeaderboard leaderboard;
         private SelectionPollingComponent selectionPollingComponent;
+        private PlaylistsSongSelect songSelect;
 
         private FillFlowContainer progressSection;
 
@@ -52,6 +53,22 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 isIdle.BindTo(idleTracker.IsIdle);
 
             AddInternal(selectionPollingComponent = new SelectionPollingComponent(Room));
+            preloadSongSelect();
+        }
+
+        private void preloadSongSelect()
+        {
+            if (songSelect == null)
+                LoadComponentAsync(songSelect = new PlaylistsSongSelect(Room));
+        }
+
+        private PlaylistsSongSelect consumeSongSelect()
+        {
+            var s = songSelect;
+            Debug.Assert(s != null);
+
+            songSelect = null;
+            return s;
         }
 
         protected override void LoadComplete()
@@ -234,7 +251,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
             EditPlaylist = () =>
             {
                 if (this.IsCurrentScreen())
-                    this.Push(new PlaylistsSongSelect(Room));
+                    this.Push(consumeSongSelect());
             },
         };
 
@@ -248,5 +265,12 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
         {
             Exited = () => leaderboard.RefetchScores()
         });
+
+        public override void OnResuming(ScreenTransitionEvent e)
+        {
+            base.OnResuming(e);
+
+            preloadSongSelect();
+        }
     }
 }


### PR DESCRIPTION
RFC.

Off the back of some very old feedback: https://www.reddit.com/r/osugame/comments/1dga6m5/comment/l8ot8qy/

Maybe resolves some of https://github.com/ppy/osu/issues/21952, too (definitely not all of it, state is still lost even with this).

Mirrors the setup `MainMenu` does. It's not really possible to just keep one instance around since `ScreenStack` protests when trying to push an already-loaded screen.

Results in testing with a few huge databases are... not as good as I'd hoped, but if given enough time to preload, it *is* better, so maybe fine? Anything more complex than this is probably going to be _painful_.