### PR TITLE
Remove "leftover files" notification when migration partly fails

### DIFF
--- a/osu.Game/Localisation/MaintenanceSettingsStrings.cs
+++ b/osu.Game/Localisation/MaintenanceSettingsStrings.cs
@@ -35,11 +35,6 @@ namespace osu.Game.Localisation
         public static LocalisableString ProhibitedInteractDuringMigration => new TranslatableString(getKey(@"prohibited_interact_during_migration"), @"Please avoid interacting with the game!");
 
         /// <summary>
-        /// "Some files couldn't be cleaned up during migration. Clicking this notification will open the folder so you can manually clean things up."
-        /// </summary>
-        public static LocalisableString FailedCleanupNotification => new TranslatableString(getKey(@"failed_cleanup_notification"), @"Some files couldn't be cleaned up during migration. Clicking this notification will open the folder so you can manually clean things up.");
-
-        /// <summary>
         /// "Please select a new location"
         /// </summary>
         public static LocalisableString SelectNewLocation => new TranslatableString(getKey(@"select_new_location"), @"Please select a new location");

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -515,6 +515,12 @@ namespace osu.Game
         /// <returns>Whether a restart operation was queued.</returns>
         public virtual bool RestartAppWhenExited() => false;
 
+        /// <summary>
+        /// Perform migration of user data to a specified path.
+        /// </summary>
+        /// <param name="path">The path to migrate to.</param>
+        /// <returns>Whether migration succeeded to completion. If <c>false</c>, some files were left behind.</returns>
+        /// <exception cref="TimeoutException"></exception>
         public bool Migrate(string path)
         {
             Logger.Log($@"Migrating osu! data from ""{Storage.GetFullPath(string.Empty)}"" to ""{path}""...");
@@ -542,10 +548,10 @@ namespace osu.Game
                 if (!readyToRun.Wait(30000) || !success)
                     throw new TimeoutException("Attempting to block for migration took too long.");
 
-                bool? cleanupSucceded = (Storage as OsuStorage)?.Migrate(Host.GetStorage(path));
+                bool? cleanupSucceeded = (Storage as OsuStorage)?.Migrate(Host.GetStorage(path));
 
                 Logger.Log(@"Migration complete!");
-                return cleanupSucceded != false;
+                return cleanupSucceeded != false;
             }
             finally
             {

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -26,12 +25,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
 
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
-
-        [Resolved]
-        private Storage storage { get; set; }
-
-        [Resolved]
-        private GameHost host { get; set; }
 
         public override bool AllowBackButton => false;
 

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -28,9 +28,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         private OsuGame game { get; set; }
 
         [Resolved]
-        private INotificationOverlay notifications { get; set; }
-
-        [Resolved]
         private Storage storage { get; set; }
 
         [Resolved]
@@ -96,8 +93,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
             };
 
             Beatmap.Value = Beatmap.Default;
-
-            var originalStorage = new NativeStorage(storage.GetFullPath(string.Empty), host);
 
             migrationTask = Task.Run(PerformMigration)
                                 .ContinueWith(task =>

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -16,7 +15,6 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
-using osu.Game.Overlays.Notifications;
 using osu.Game.Screens;
 using osuTK;
 

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -108,18 +108,6 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                                     {
                                         Logger.Error(task.Exception, $"Error during migration: {task.Exception?.Message}");
                                     }
-                                    else if (!task.GetResultSafely())
-                                    {
-                                        notifications.Post(new SimpleNotification
-                                        {
-                                            Text = MaintenanceSettingsStrings.FailedCleanupNotification,
-                                            Activated = () =>
-                                            {
-                                                originalStorage.PresentExternally();
-                                                return true;
-                                            }
-                                        });
-                                    }
 
                                     Schedule(this.Exit);
                                 });


### PR DESCRIPTION
People were deleting files they shouldn't, causing osu! to lose track of where the real user files are.

For now let's just keep things simple and not let the users know that some files got left behind. Usually the files which are left behind are minimal and it should be fine to leave this up to the user.

Closes https://github.com/ppy/osu/issues/29505.