### PR TITLE
Save custom sound banks to beatmap

### DIFF
--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -43,8 +43,6 @@ namespace osu.Game.Beatmaps.Formats
         private LegacySampleBank defaultSampleBank;
         private int defaultSampleVolume = 100;
 
-        public static List<string> AvailableSampleBanks = ["normal", "soft", "drum"];
-
         public static void Register()
         {
             AddDecoder<Beatmap>(@"osu file format v", m => new LegacyBeatmapDecoder(Parsing.ParseInt(m.Split('v').Last())));
@@ -622,9 +620,9 @@ namespace osu.Game.Beatmaps.Formats
 
         private void handleCustomSoundBanks(string line)
         {
-            if (!AvailableSampleBanks.Contains(line))
+            if (!parser.AvailableSampleBanks.Contains(line))
             {
-                AvailableSampleBanks.Add(line);
+                parser.AvailableSampleBanks.Add(line);
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -620,6 +620,9 @@ namespace osu.Game.Beatmaps.Formats
 
         private void handleCustomSoundBanks(string line)
         {
+            // If the ruleset wasn't specified, assume the osu!standard ruleset.
+            parser ??= new Rulesets.Objects.Legacy.Osu.ConvertHitObjectParser(getOffsetTime(), FormatVersion);
+
             if (!parser.AvailableSampleBanks.Contains(line))
             {
                 parser.AvailableSampleBanks.Add(line);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -43,6 +43,8 @@ namespace osu.Game.Beatmaps.Formats
         private LegacySampleBank defaultSampleBank;
         private int defaultSampleVolume = 100;
 
+        public static List<string> AvailableSampleBanks = ["none", "normal", "soft", "drum"];
+
         public static void Register()
         {
             AddDecoder<Beatmap>(@"osu file format v", m => new LegacyBeatmapDecoder(Parsing.ParseInt(m.Split('v').Last())));
@@ -218,6 +220,10 @@ namespace osu.Game.Beatmaps.Formats
 
                 case Section.TimingPoints:
                     handleTimingPoint(line);
+                    return;
+
+                case Section.CustomSoundBanks:
+                    handleCustomSoundBanks(line);
                     return;
 
                 case Section.HitObjects:
@@ -612,6 +618,14 @@ namespace osu.Game.Beatmaps.Formats
 
             pendingControlPoints.Clear();
             pendingControlPointTypes.Clear();
+        }
+
+        private void handleCustomSoundBanks(string line)
+        {
+            if (!AvailableSampleBanks.Contains(line))
+            {
+                AvailableSampleBanks.Add(line);
+            }
         }
 
         private void handleHitObject(string line)

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -43,7 +43,7 @@ namespace osu.Game.Beatmaps.Formats
         private LegacySampleBank defaultSampleBank;
         private int defaultSampleVolume = 100;
 
-        public static List<string> AvailableSampleBanks = ["none", "normal", "soft", "drum"];
+        public static List<string> AvailableSampleBanks = ["normal", "soft", "drum"];
 
         public static void Register()
         {

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -398,7 +398,7 @@ namespace osu.Game.Beatmaps.Formats
             {
                 foreach (List<HitSampleInfo> node in hr.NodeSamples)
                 {
-                    if (!customSoundBanks.Contains(node[0].Bank)
+                    if (node.Count > 0 && !customSoundBanks.Contains(node[0].Bank)
                         && node[0].Bank != "none" && node[0].Bank != "normal" && node[0].Bank != "soft" && node[0].Bank != "drum")
                     {
                         customSoundBanks.Add(node[0].Bank);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -88,7 +88,7 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine(FormattableString.Invariant($"PreviewTime: {beatmap.Metadata.PreviewTime}"));
             writer.WriteLine(FormattableString.Invariant($"Countdown: {(int)beatmap.BeatmapInfo.Countdown}"));
             writer.WriteLine(FormattableString.Invariant(
-                $"SampleSet: {toLegacySampleBank(((beatmap.ControlPointInfo as LegacyControlPointInfo)?.SamplePoints.FirstOrDefault() ?? SampleControlPoint.DEFAULT).SampleBank)}"));
+                $"SampleSet: {(LegacySampleBank)toLegacySampleBank(((beatmap.ControlPointInfo as LegacyControlPointInfo)?.SamplePoints.FirstOrDefault() ?? SampleControlPoint.DEFAULT).SampleBank)}"));
             writer.WriteLine(FormattableString.Invariant($"StackLeniency: {beatmap.BeatmapInfo.StackLeniency}"));
             writer.WriteLine(FormattableString.Invariant($"Mode: {onlineRulesetID}"));
             writer.WriteLine(FormattableString.Invariant($"LetterboxInBreaks: {(beatmap.BeatmapInfo.LetterboxInBreaks ? '1' : '0')}"));
@@ -240,7 +240,7 @@ namespace osu.Game.Beatmaps.Formats
                 {
                     SliderVelocity = difficultyPoint.SliderVelocity,
                     TimingSignature = timingPoint.TimeSignature.Numerator,
-                    SampleBank = updateSampleBank ? (int)toLegacySampleBank(tempHitSample.Bank) : lastControlPointProperties.SampleBank,
+                    SampleBank = updateSampleBank ? toLegacySampleBank(tempHitSample.Bank) : lastControlPointProperties.SampleBank,
                     // Inherit the previous custom sample bank if the current custom sample bank is not set
                     CustomSampleBank = customSampleBank >= 0 ? customSampleBank : lastControlPointProperties.CustomSampleBank,
                     SampleVolume = tempHitSample.Volume,

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -16,6 +16,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Platform.MacOS;
 
 namespace osu.Game.Beatmaps.Formats
 {
@@ -391,6 +392,18 @@ namespace osu.Game.Beatmaps.Formats
                 && bank != "none" && bank != "normal" && bank != "soft" && bank != "drum")
             {
                 customSoundBanks.Add(bank);
+            }
+
+            if (h is IHasRepeats hr)
+            {
+                foreach (List<HitSampleInfo> node in hr.NodeSamples)
+                {
+                    if (!customSoundBanks.Contains(node[0].Bank)
+                        && node[0].Bank != "none" && node[0].Bank != "normal" && node[0].Bank != "soft" && node[0].Bank != "drum")
+                    {
+                        customSoundBanks.Add(node[0].Bank);
+                    }
+                }
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -70,10 +70,10 @@ namespace osu.Game.Beatmaps.Formats
             handleControlPoints(writer);
 
             writer.WriteLine();
-            handleColours(writer);
+            handleCustomSoundBanks(writer);
 
             writer.WriteLine();
-            handleCustomSoundBanks(writer);
+            handleColours(writer);
 
             writer.WriteLine();
             handleHitObjects(writer);

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -73,10 +73,11 @@ namespace osu.Game.Beatmaps.Formats
             handleColours(writer);
 
             writer.WriteLine();
-            handleHitObjects(writer);
+            handleCustomSoundBanks(writer);
 
             writer.WriteLine();
-            handleCustomSoundBanks(writer, customSoundBanks);
+            handleHitObjects(writer);
+
         }
 
         private void handleGeneral(TextWriter writer)
@@ -369,13 +370,27 @@ namespace osu.Game.Beatmaps.Formats
 
         }
 
-        private void handleCustomSoundBanks(TextWriter writer, List<string> banks)
+        private void handleCustomSoundBanks(TextWriter writer)
         {
             writer.WriteLine("[CustomSoundBanks]");
 
-            foreach (string s in banks)
+            if (beatmap.HitObjects.Count == 0)
+                return;
+
+            foreach (var h in beatmap.HitObjects)
+                checkCustomSoundBank(h);
+
+            foreach (string s in customSoundBanks)
             {
                 writer.WriteLine(s);
+            }
+        }
+
+        private void checkCustomSoundBank(HitObject h)
+        {
+            if (!customSoundBanks.Contains(h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank))
+            {
+                customSoundBanks.Add(h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank);
             }
         }
 
@@ -626,10 +641,6 @@ namespace osu.Game.Beatmaps.Formats
                     return (int)LegacySampleBank.Drum;
 
                 default:
-                    if (!customSoundBanks.Contains(sampleBankLower))
-                    {
-                        customSoundBanks.Add(sampleBankLower);
-                    }
                     return customSoundBanks.IndexOf(sampleBankLower) + 4;
 
             }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Beatmaps.Formats
 
         private readonly int onlineRulesetID;
 
-        private List<string> customSoundBanks = new List<string>();
+        private readonly List<string> customSoundBanks = new List<string>();
 
         /// <summary>
         /// Creates a new <see cref="LegacyBeatmapEncoder"/>.
@@ -387,6 +387,7 @@ namespace osu.Game.Beatmaps.Formats
         private void checkCustomSoundBank(HitObject h)
         {
             string? bank = h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank;
+
             if (bank != null
                 && !customSoundBanks.Contains(bank)
                 && bank != "none" && bank != "normal" && bank != "soft" && bank != "drum")
@@ -396,10 +397,10 @@ namespace osu.Game.Beatmaps.Formats
 
             if (h is IHasRepeats hr)
             {
-                foreach (List<HitSampleInfo> node in hr.NodeSamples)
+                foreach (IList<HitSampleInfo> node in hr.NodeSamples)
                 {
-                    if (node.Count > 0 && !customSoundBanks.Contains(node[0].Bank)
-                        && node[0].Bank != "none" && node[0].Bank != "normal" && node[0].Bank != "soft" && node[0].Bank != "drum")
+                    if (node.Count > 0 && !customSoundBanks.Contains(node[0].Bank) &&
+                        node[0].Bank != "none" && node[0].Bank != "normal" && node[0].Bank != "soft" && node[0].Bank != "drum")
                     {
                         customSoundBanks.Add(node[0].Bank);
                     }
@@ -640,8 +641,8 @@ namespace osu.Game.Beatmaps.Formats
 
         private int toLegacySampleBank(string? sampleBank)
         {
-
             string? sampleBankLower = sampleBank?.ToLowerInvariant();
+
             switch (sampleBankLower)
             {
                 case HitSampleInfo.BANK_NORMAL:
@@ -655,6 +656,7 @@ namespace osu.Game.Beatmaps.Formats
 
                 default:
                     if (sampleBankLower != null) return customSoundBanks.IndexOf(sampleBankLower) + 4;
+
                     return 0;
             }
         }

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -386,8 +386,9 @@ namespace osu.Game.Beatmaps.Formats
 
         private void checkCustomSoundBank(HitObject h)
         {
-            string bank = h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank;
-            if (!customSoundBanks.Contains(bank)
+            string? bank = h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank;
+            if (bank != null
+                && !customSoundBanks.Contains(bank)
                 && bank != "none" && bank != "normal" && bank != "soft" && bank != "drum")
             {
                 customSoundBanks.Add(bank);
@@ -653,7 +654,8 @@ namespace osu.Game.Beatmaps.Formats
                     return (int)LegacySampleBank.Drum;
 
                 default:
-                    return customSoundBanks.IndexOf(sampleBankLower) + 4;
+                    if (sampleBankLower != null) return customSoundBanks.IndexOf(sampleBankLower) + 4;
+                    return 0;
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -16,7 +16,6 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Platform.MacOS;
 
 namespace osu.Game.Beatmaps.Formats
 {

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -386,9 +386,11 @@ namespace osu.Game.Beatmaps.Formats
 
         private void checkCustomSoundBank(HitObject h)
         {
-            if (!customSoundBanks.Contains(h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank))
+            string bank = h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank;
+            if (!customSoundBanks.Contains(bank)
+                && bank != "none" && bank != "normal" && bank != "soft" && bank != "drum")
             {
-                customSoundBanks.Add(h.Samples.SingleOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank);
+                customSoundBanks.Add(bank);
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -77,7 +77,6 @@ namespace osu.Game.Beatmaps.Formats
 
             writer.WriteLine();
             handleHitObjects(writer);
-
         }
 
         private void handleGeneral(TextWriter writer)
@@ -367,7 +366,6 @@ namespace osu.Game.Beatmaps.Formats
 
             foreach (var h in beatmap.HitObjects)
                 handleHitObject(writer, h);
-
         }
 
         private void handleCustomSoundBanks(TextWriter writer)
@@ -642,7 +640,6 @@ namespace osu.Game.Beatmaps.Formats
 
                 default:
                     return customSoundBanks.IndexOf(sampleBankLower) + 4;
-
             }
         }
 

--- a/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyDecoder.cs
@@ -168,6 +168,7 @@ namespace osu.Game.Beatmaps.Formats
             Events,
             TimingPoints,
             Colours,
+            CustomSoundBanks,
             HitObjects,
             Variables,
             Fonts,

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -194,11 +194,11 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             string[] split = str.Split(':');
 
-
             string bank = (Parsing.ParseInt(split[0]) > AvailableSampleBanks.Count - 1) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[0])];
             string addBank = (Parsing.ParseInt(split[1]) > AvailableSampleBanks.Count - 1) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[1])];
 
-            if (bank == @"none") { bank = null; };
+            if (bank == @"none") { bank = null; }
+
             if (addBank == @"none") { addBank = null; }
 
             bankInfo.BankForNormal = bank;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
         protected bool FirstObject { get; private set; } = true;
 
-        public List<string> AvailableSampleBanks = ["normal", "soft", "drum"];
+        public List<string> AvailableSampleBanks = ["none", "normal", "soft", "drum"];
 
         protected ConvertHitObjectParser(double offset, int formatVersion)
         {
@@ -194,8 +194,12 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             string[] split = str.Split(':');
 
-            string bank = AvailableSampleBanks[Parsing.ParseInt(split[0]) - 1];
-            string addBank = AvailableSampleBanks[Parsing.ParseInt(split[1]) - 1];
+
+            string bank = (Parsing.ParseInt(split[0]) > AvailableSampleBanks.Count) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[0])];
+            string addBank = (Parsing.ParseInt(split[1]) > AvailableSampleBanks.Count) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[1])];
+
+            if (bank == @"none") { bank = null; };
+            if (addBank == @"none") { addBank = null; }
 
             bankInfo.BankForNormal = bank;
             bankInfo.BankForAdditions = string.IsNullOrEmpty(addBank) ? bank : addBank;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -194,8 +194,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             List<string> availableSampleBanks = LegacyBeatmapDecoder.AvailableSampleBanks;
 
-            string bank = availableSampleBanks[Parsing.ParseInt(split[0])];
-            string addBank = availableSampleBanks[Parsing.ParseInt(split[1])];
+            string bank = availableSampleBanks[Parsing.ParseInt(split[0]) - 1];
+            string addBank = availableSampleBanks[Parsing.ParseInt(split[1]) - 1];
 
             bankInfo.BankForNormal = bank;
             bankInfo.BankForAdditions = string.IsNullOrEmpty(addBank) ? bank : addBank;

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -195,8 +195,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
             string[] split = str.Split(':');
 
 
-            string bank = (Parsing.ParseInt(split[0]) > AvailableSampleBanks.Count) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[0])];
-            string addBank = (Parsing.ParseInt(split[1]) > AvailableSampleBanks.Count) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[1])];
+            string bank = (Parsing.ParseInt(split[0]) > AvailableSampleBanks.Count - 1) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[0])];
+            string addBank = (Parsing.ParseInt(split[1]) > AvailableSampleBanks.Count - 1) ? "normal" : AvailableSampleBanks[Parsing.ParseInt(split[1])];
 
             if (bank == @"none") { bank = null; };
             if (addBank == @"none") { addBank = null; }

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -192,23 +192,13 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             string[] split = str.Split(':');
 
-            var bank = (LegacySampleBank)Parsing.ParseInt(split[0]);
-            if (!Enum.IsDefined(bank))
-                bank = LegacySampleBank.Normal;
+            List<string> availableSampleBanks = LegacyBeatmapDecoder.AvailableSampleBanks;
 
-            var addBank = (LegacySampleBank)Parsing.ParseInt(split[1]);
-            if (!Enum.IsDefined(addBank))
-                addBank = LegacySampleBank.Normal;
+            string bank = availableSampleBanks[Parsing.ParseInt(split[0])];
+            string addBank = availableSampleBanks[Parsing.ParseInt(split[1])];
 
-            string stringBank = bank.ToString().ToLowerInvariant();
-            if (stringBank == @"none")
-                stringBank = null;
-            string stringAddBank = addBank.ToString().ToLowerInvariant();
-            if (stringAddBank == @"none")
-                stringAddBank = null;
-
-            bankInfo.BankForNormal = stringBank;
-            bankInfo.BankForAdditions = string.IsNullOrEmpty(stringAddBank) ? stringBank : stringAddBank;
+            bankInfo.BankForNormal = bank;
+            bankInfo.BankForAdditions = string.IsNullOrEmpty(addBank) ? bank : addBank;
 
             if (banksOnly) return;
 

--- a/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
+++ b/osu.Game/Rulesets/Objects/Legacy/ConvertHitObjectParser.cs
@@ -38,6 +38,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
         protected bool FirstObject { get; private set; } = true;
 
+        public List<string> AvailableSampleBanks = ["normal", "soft", "drum"];
+
         protected ConvertHitObjectParser(double offset, int formatVersion)
         {
             Offset = offset;
@@ -192,10 +194,8 @@ namespace osu.Game.Rulesets.Objects.Legacy
 
             string[] split = str.Split(':');
 
-            List<string> availableSampleBanks = LegacyBeatmapDecoder.AvailableSampleBanks;
-
-            string bank = availableSampleBanks[Parsing.ParseInt(split[0]) - 1];
-            string addBank = availableSampleBanks[Parsing.ParseInt(split[1]) - 1];
+            string bank = AvailableSampleBanks[Parsing.ParseInt(split[0]) - 1];
+            string addBank = AvailableSampleBanks[Parsing.ParseInt(split[1]) - 1];
 
             bankInfo.BankForNormal = bank;
             bankInfo.BankForAdditions = string.IsNullOrEmpty(addBank) ? bank : addBank;


### PR DESCRIPTION
- Closes #29312 

[PR-SaveCustomSoundBanks.webm](https://github.com/user-attachments/assets/08c5dff1-5f3e-4a17-8f08-9d6d04b32a0b)

Saves custom sound banks to beatmap by writing a new section to `.osu` file "CustomSoundBanks", and writing any HitObjects with a custom sound bank as a new number > 3.

![image](https://github.com/user-attachments/assets/ab1e7c64-8d71-41ca-afaf-00a95a3fb8ef)

## Issues
- ~~**Not compatible with Stable** - trying to import a beatmap in Stable with a custom sound bank > 3 fails:~~ Resolved with [785ef22](https://github.com/ppy/osu/pull/29566/commits/785ef22403ab70949182adf7556f0f78dfcc52d4)
- ~~Doesn't consistently work with sliders - the end of the video shows this, I'm not sure why it's inconsistent~~ Resolved with [a790127](https://github.com/ppy/osu/pull/29566/commits/a790127a1b8b693fa07652a5caee07fd20ddb7a3)
- After loading, HitObjects with custom sample banks no longer fall back to Normal if a file for the sample doesn't exist
- May need to be refactored depending on #20883  