### PR TITLE
Allow seeking via music controller overlay on more screens

### DIFF
--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Overlays
             seekDelegate?.Cancel();
             seekDelegate = Schedule(() =>
             {
-                if (beatmap.Disabled || !AllowTrackControl.Value)
+                if (!AllowTrackControl.Value)
                     return;
 
                 CurrentTrack.Seek(position);


### PR DESCRIPTION
In testing I can't find a reason for this to exist. Blaming back shows that it existed before we had `AllowTrackControl` and was likely being used as a stop-gap measure to achieve the same thing. It's existed since over 6 years ago.

Let's give removing it a try to fix some usability concerns?

Closes https://github.com/ppy/osu/issues/29563.