### PR TITLE
Improve mod icon contrast and mod acronym readability

### DIFF
--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -140,7 +140,7 @@ namespace osu.Game.Rulesets.UI
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                             Alpha = 0,
-                            Font = OsuFont.Numeric.With(null, 22f),
+                            Font = OsuFont.Numeric.With(size: 22f, weight: FontWeight.Black),
                             UseFullGlyphHeight = false,
                             Text = mod.Acronym
                         },

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Localisation;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -204,7 +205,7 @@ namespace osu.Game.Rulesets.UI
 
         private void updateColour()
         {
-            modAcronym.Colour = modIcon.Colour = OsuColour.Gray(84);
+            modAcronym.Colour = modIcon.Colour = Interpolation.ValueAt<Colour4>(0.1f, Colour4.Black, backgroundColour, 0, 1);
 
             extendedText.Colour = background.Colour = Selected.Value ? backgroundColour.Lighten(0.2f) : backgroundColour;
             extendedBackground.Colour = Selected.Value ? backgroundColour.Darken(2.4f) : backgroundColour.Darken(2.8f);


### PR DESCRIPTION
migrating some styles from ModSwitchTiny that imo improve regular mod icons as well.

| Before | After |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/37032b30-b1d7-49da-98a0-f84b2285b1d6) | ![image](https://github.com/user-attachments/assets/f1c7e290-f46d-448c-8187-b284a48cbc73) |