### PR TITLE
Clean up `GetDrawableComponent` path fallbacks

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/CatchLegacySkinTransformer.cs
@@ -33,11 +33,11 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                 case GlobalSkinnableContainerLookup containerLookup:
                     // Only handle per ruleset defaults here.
                     if (containerLookup.Ruleset == null)
-                        return base.GetDrawableComponent(lookup);
+                        break;
 
                     // we don't have enough assets to display these components (this is especially the case on a "beatmap" skin).
                     if (!IsProvidingLegacyResources)
-                        return null;
+                        break;
 
                     // Our own ruleset components default.
                     switch (containerLookup.Lookup)
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                             };
                     }
 
-                    return null;
+                    break;
 
                 case CatchSkinComponentLookup catchSkinComponent:
                     switch (catchSkinComponent.Component)
@@ -73,19 +73,19 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                             if (hasPear)
                                 return new LegacyFruitPiece();
 
-                            return null;
+                            break;
 
                         case CatchSkinComponents.Banana:
                             if (GetTexture("fruit-bananas") != null)
                                 return new LegacyBananaPiece();
 
-                            return null;
+                            break;
 
                         case CatchSkinComponents.Droplet:
                             if (GetTexture("fruit-drop") != null)
                                 return new LegacyDropletPiece();
 
-                            return null;
+                            break;
 
                         case CatchSkinComponents.Catcher:
                             decimal version = GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value ?? 1;
@@ -99,23 +99,25 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
                             if (hasNewStyleCatcherSprite())
                                 return new LegacyCatcherNew();
 
-                            return null;
+                            break;
 
                         case CatchSkinComponents.CatchComboCounter:
                             if (providesComboCounter)
                                 return new LegacyCatchComboCounter();
 
-                            return null;
+                            break;
 
                         case CatchSkinComponents.HitExplosion:
                             if (hasOldStyleCatcherSprite() || hasNewStyleCatcherSprite())
                                 return new LegacyHitExplosion();
 
-                            return null;
+                            break;
 
                         default:
                             throw new UnsupportedSkinComponentException(lookup);
                     }
+
+                    break;
             }
 
             return base.GetDrawableComponent(lookup);

--- a/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Argon/ManiaArgonSkinTransformer.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Mania.Skinning.Argon
                             };
                     }
 
-                    return null;
+                    break;
 
                 case SkinComponentLookup<HitResult> resultComponent:
                     // This should eventually be moved to a skin setting, when supported.

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -83,11 +83,11 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                 case GlobalSkinnableContainerLookup containerLookup:
                     // Modifications for global components.
                     if (containerLookup.Ruleset == null)
-                        return base.GetDrawableComponent(lookup);
+                        break;
 
                     // we don't have enough assets to display these components (this is especially the case on a "beatmap" skin).
                     if (!IsProvidingLegacyResources)
-                        return null;
+                        break;
 
                     switch (containerLookup.Lookup)
                     {
@@ -108,14 +108,14 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                             };
                     }
 
-                    return null;
+                    break;
 
                 case SkinComponentLookup<HitResult> resultComponent:
                     return getResult(resultComponent.Component);
 
                 case ManiaSkinComponentLookup maniaComponent:
                     if (!isLegacySkin.Value || !hasKeyTexture.Value)
-                        return null;
+                        break;
 
                     switch (maniaComponent.Component)
                     {
@@ -152,11 +152,13 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                             return new LegacyStageForeground();
 
                         case ManiaSkinComponents.BarLine:
-                            return null; // Not yet implemented.
+                            break; // Not yet implemented.
 
                         default:
                             throw new UnsupportedSkinComponentException(lookup);
                     }
+
+                    break;
             }
 
             return base.GetDrawableComponent(lookup);

--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/ManiaLegacySkinTransformer.cs
@@ -166,10 +166,10 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
 
         private Drawable getResult(HitResult result)
         {
-            if (!hit_result_mapping.ContainsKey(result))
+            if (!hit_result_mapping.TryGetValue(result, out var lookup))
                 return null;
 
-            string filename = this.GetManiaSkinConfig<string>(hit_result_mapping[result])?.Value
+            string filename = this.GetManiaSkinConfig<string>(lookup)?.Value
                               ?? default_hit_result_skin_filenames[result];
 
             var animation = this.GetAnimation(filename, true, true, frameLength: 1000 / 20d);

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -47,11 +47,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 case GlobalSkinnableContainerLookup containerLookup:
                     // Only handle per ruleset defaults here.
                     if (containerLookup.Ruleset == null)
-                        return base.GetDrawableComponent(lookup);
+                        break;
 
                     // we don't have enough assets to display these components (this is especially the case on a "beatmap" skin).
                     if (!IsProvidingLegacyResources)
-                        return null;
+                        break;
 
                     // Our own ruleset components default.
                     switch (containerLookup.Lookup)
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                             };
                     }
 
-                    return null;
+                    break;
 
                 case OsuSkinComponentLookup osuComponent:
                     switch (osuComponent.Component)
@@ -104,55 +104,55 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                             if (followCircleContent != null)
                                 return new LegacyFollowCircle(followCircleContent);
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.SliderBall:
                             if (GetTexture("sliderb") != null || GetTexture("sliderb0") != null)
                                 return new LegacySliderBall(this);
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.SliderBody:
                             if (hasHitCircle.Value)
                                 return new LegacySliderBody();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.SliderTailHitCircle:
                             if (hasHitCircle.Value)
                                 return new LegacyMainCirclePiece("sliderendcircle", false);
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.SliderHeadHitCircle:
                             if (hasHitCircle.Value)
                                 return new LegacySliderHeadHitCircle();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.ReverseArrow:
                             if (hasHitCircle.Value)
                                 return new LegacyReverseArrow();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.HitCircle:
                             if (hasHitCircle.Value)
                                 return new LegacyMainCirclePiece();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.Cursor:
                             if (GetTexture("cursor") != null)
                                 return new LegacyCursor(this);
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.CursorTrail:
                             if (GetTexture("cursortrail") != null)
                                 return new LegacyCursorTrail(this);
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.CursorRipple:
                             if (GetTexture("cursor-ripple") != null)
@@ -174,23 +174,23 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                                 return ripple;
                             }
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.CursorParticles:
                             if (GetTexture("star2") != null)
                                 return new LegacyCursorParticles();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.CursorSmoke:
                             if (GetTexture("cursor-smoke") != null)
                                 return new LegacySmokeSegment();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.HitCircleText:
                             if (!this.HasFont(LegacyFont.HitCircle))
-                                return null;
+                                break;
 
                             const float hitcircle_text_scale = 0.8f;
                             return new LegacySpriteText(LegacyFont.HitCircle)
@@ -208,21 +208,22 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                             else if (hasBackground)
                                 return new LegacyOldStyleSpinner();
 
-                            return null;
+                            break;
 
                         case OsuSkinComponents.ApproachCircle:
                             if (GetTexture(@"approachcircle") != null)
                                 return new LegacyApproachCircle();
 
-                            return null;
+                            break;
 
                         default:
                             throw new UnsupportedSkinComponentException(lookup);
                     }
 
-                default:
-                    return base.GetDrawableComponent(lookup);
+                    break;
             }
+
+            return base.GetDrawableComponent(lookup);
         }
 
         public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -44,62 +44,62 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         if (GetTexture("taiko-roll-middle") != null)
                             return new LegacyDrumRoll();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.InputDrum:
                         if (hasBarLeft)
                             return new LegacyInputDrum();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.DrumSamplePlayer:
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.CentreHit:
                     case TaikoSkinComponents.RimHit:
                         if (hasHitCircle)
                             return new LegacyHit(taikoComponent.Component);
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.DrumRollTick:
                         return this.GetAnimation("sliderscorepoint", false, false);
 
                     case TaikoSkinComponents.Swell:
                         // todo: support taiko legacy swell (https://github.com/ppy/osu/issues/13601).
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.HitTarget:
                         if (GetTexture("taikobigcircle") != null)
                             return new TaikoLegacyHitTarget();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.PlayfieldBackgroundRight:
                         if (GetTexture("taiko-bar-right") != null)
                             return new TaikoLegacyPlayfieldBackgroundRight();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.PlayfieldBackgroundLeft:
                         // This is displayed inside LegacyInputDrum. It is required to be there for layout purposes (can be seen on legacy skins).
                         if (GetTexture("taiko-bar-right") != null)
                             return Drawable.Empty();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.BarLine:
                         if (GetTexture("taiko-barline") != null)
                             return new LegacyBarLine();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.TaikoExplosionMiss:
                         var missSprite = this.GetAnimation(getHitName(taikoComponent.Component), true, false);
                         if (missSprite != null)
                             return new LegacyHitExplosion(missSprite);
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.TaikoExplosionOk:
                     case TaikoSkinComponents.TaikoExplosionGreat:
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                             return new LegacyHitExplosion(hitSprite, strongHitSprite);
                         }
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.TaikoExplosionKiai:
                         // suppress the default kiai explosion if the skin brings its own sprites.
@@ -121,13 +121,13 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         if (hasExplosion.Value)
                             return Drawable.Empty().With(d => d.Expire());
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.Scroller:
                         if (GetTexture("taiko-slider") != null)
                             return new LegacyTaikoScroller();
 
-                        return null;
+                        break;
 
                     case TaikoSkinComponents.Mascot:
                         return new DrawableTaikoMascot();
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         if (GetTexture("taiko-glow") != null)
                             return new LegacyKiaiGlow();
 
-                        return null;
+                        break;
 
                     default:
                         throw new UnsupportedSkinComponentException(lookup);

--- a/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Legacy/TaikoLegacySkinTransformer.cs
@@ -107,11 +107,7 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Legacy
                         var hitSprite = this.GetAnimation(hitName, true, false);
 
                         if (hitSprite != null)
-                        {
-                            var strongHitSprite = this.GetAnimation($"{hitName}k", true, false);
-
-                            return new LegacyHitExplosion(hitSprite, strongHitSprite);
-                        }
+                            return new LegacyHitExplosion(hitSprite, this.GetAnimation($"{hitName}k", true, false));
 
                         break;
 

--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -250,7 +250,7 @@ namespace osu.Game.Skinning
                             return mainHUDComponents;
                     }
 
-                    return null;
+                    break;
             }
 
             return base.GetDrawableComponent(lookup);

--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -421,7 +421,7 @@ namespace osu.Game.Skinning
                             };
                     }
 
-                    return null;
+                    break;
 
                 case SkinComponentLookup<HitResult> resultComponent:
 
@@ -439,7 +439,7 @@ namespace osu.Game.Skinning
                         return new LegacyJudgementPieceOld(resultComponent.Component, createDrawable);
                     }
 
-                    return null;
+                    break;
             }
 
             return base.GetDrawableComponent(lookup);

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Skinning
                 case GlobalSkinnableContainerLookup containerLookup:
                     // Only handle global level defaults for now.
                     if (containerLookup.Ruleset != null)
-                        return null;
+                        break;
 
                     switch (containerLookup.Lookup)
                     {
@@ -172,7 +172,7 @@ namespace osu.Game.Skinning
                             return skinnableTargetWrapper;
                     }
 
-                    return null;
+                    break;
             }
 
             return base.GetDrawableComponent(lookup);


### PR DESCRIPTION
The main theme here is to remove all `return null` handling, to simplify the `GetDrawableComponent` path.

Returning `null` should be saved for explicit cases that we want to block a base lookup. Which right now seems to be "never".

I believe this was agreed upon by everyone in the IRL conversation.