### PR TITLE
Add parallax to beatmap carousel items

### DIFF
--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Beatmaps
     public class BeatmapPanelBackgroundTextureLoaderStore : IResourceStore<TextureUpload>
     {
         // The aspect ratio of SetPanelBackground at its maximum size (very tall window).
-        private const float minimum_display_ratio = 512 / 80f;
+        private const float minimum_display_ratio = 512 / 120f;
 
         private readonly IResourceStore<TextureUpload>? textureStore;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1162,7 +1162,7 @@ namespace osu.Game.Screens.Select
 
         private float getParallaxAt(float position)
         {
-            float parallaxCenter = Scroll.Current + DrawHeight / 2f;
+            float parallaxCenter = Scroll.Current + (DrawHeight / 2f);
 
             return parallaxEnabled.Value ? (parallaxCenter - position) / visibleHalfHeight : 0f;
         }

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselBeatmapSet.cs
@@ -23,6 +23,7 @@ using osu.Game.Overlays;
 
 namespace osu.Game.Screens.Select.Carousel
 {
+    [Cached]
     public partial class DrawableCarouselBeatmapSet : DrawableCarouselItem, IHasContextMenu
     {
         public const float HEIGHT = MAX_HEIGHT;
@@ -182,6 +183,11 @@ namespace osu.Game.Screens.Select.Carousel
 
         [Resolved]
         private BeatmapCarousel.CarouselScrollContainer scrollContainer { get; set; } = null!;
+
+        /**
+         * Parallax to apply to the header's beatmap cover, ranging from -1 to 1.
+         */
+        public float Parallax = 0f;
 
         private void loadContentIfRequired()
         {

--- a/osu.Game/Screens/Select/Carousel/SetPanelBackground.cs
+++ b/osu.Game/Screens/Select/Carousel/SetPanelBackground.cs
@@ -17,13 +17,12 @@ namespace osu.Game.Screens.Select.Carousel
     public partial class SetPanelBackground : BufferedContainer
     {
         public SetPanelBackground(IWorkingBeatmap working)
-            : base(cachedFrameBuffer: true)
         {
             RedrawOnScale = false;
 
             Children = new Drawable[]
             {
-                new PanelBeatmapBackground(working)
+                background = new PanelBeatmapBackground(working)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
@@ -69,6 +68,25 @@ namespace osu.Game.Screens.Select.Carousel
                     }
                 },
             };
+        }
+
+        [Resolved(canBeNull: true)]
+        private DrawableCarouselBeatmapSet? carouselBeatmapSet { get; set; }
+
+        private readonly PanelBeatmapBackground background;
+
+        private const float parallax_strength = 35;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (carouselBeatmapSet != null)
+            {
+                float maxParallax = (background.DrawHeight - DrawHeight) / 2f;
+
+                background.Y = Math.Clamp(carouselBeatmapSet.Parallax, -1f, 1f) * Math.Min(maxParallax, parallax_strength);
+            }
         }
 
         public partial class PanelBeatmapBackground : Sprite


### PR DESCRIPTION
RFC. Adds a parallax effect to the mapset headers in the beatmap carousel.

https://github.com/user-attachments/assets/a0d531fa-b775-4b3a-9939-2bc6a3811a23

The amount of parallax might need a bit more tweaking. I tried to make it small enough to not be distracting, but still noticeable.

Right now it enables/disables with the preexisting parallax setting, though maybe a separate setting might be needed since that is already controlling something else.