### PR TITLE
Don't change the playback pitch along the playback speed

### DIFF
--- a/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
+++ b/osu.Game/Screens/Play/MasterGameplayClockContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Screens.Play
 
         public readonly BindableNumber<double> UserPlaybackRate = new BindableDouble(1)
         {
-            MinValue = 0.05,
+            MinValue = 0.1,
             MaxValue = 2,
             Precision = 0.01,
         };
@@ -207,7 +207,7 @@ namespace osu.Game.Screens.Play
             musicController.ResetTrackAdjustments();
 
             track.BindAdjustments(AdjustmentsFromMods);
-            track.AddAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
+            track.AddAdjustment(AdjustableProperty.Tempo, UserPlaybackRate);
 
             speedAdjustmentsApplied = true;
         }
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             track.UnbindAdjustments(AdjustmentsFromMods);
-            track.RemoveAdjustment(AdjustableProperty.Frequency, UserPlaybackRate);
+            track.RemoveAdjustment(AdjustableProperty.Tempo, UserPlaybackRate);
 
             speedAdjustmentsApplied = false;
         }

--- a/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/PlaybackSettings.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Screens.Play.PlayerSettings
 
         public readonly Bindable<double> UserPlaybackRate = new BindableDouble(1)
         {
-            MinValue = 0.05,
+            MinValue = 0.1,
             MaxValue = 2,
             Precision = 0.01,
         };


### PR DESCRIPTION
Solved: #29596 

# Drawback
The minimum playback speed is limited to 0.1x(rather than 0.05). This is because of the BASS library doesn't support the tempo that's equal to or less than 0.5
