### PR TITLE
Fix chat line background shifting with every new message at max history

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -648,6 +648,49 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("Info message displayed", () => channelManager.CurrentChannel.Value.Messages.Last(), () => Is.InstanceOf(typeof(InfoMessage)));
         }
 
+        [Test]
+        public void TestAlternatingBackgroundDoesNotChange()
+        {
+            AddStep("show overlay with channel", () =>
+            {
+                for (int i = 0; i < Channel.MAX_HISTORY; i++)
+                {
+                    testChannel1.AddNewMessages(new Message
+                    {
+                        ChannelId = testChannel1.Id,
+                        Content = $"Message {i}",
+                        Timestamp = DateTimeOffset.Now,
+                        Sender = testUser,
+                    });
+                }
+
+                chatOverlay.Show();
+                channelManager.CurrentChannel.Value = channelManager.JoinChannel(testChannel1);
+            });
+
+            AddAssert("Overlay is visible", () => chatOverlay.State.Value == Visibility.Visible);
+            waitForChannel1Visible();
+
+            ChatLine lastLine = null;
+            bool lastLineAlternatingBackground = false;
+
+            AddStep("grab last line", () =>
+            {
+                lastLine = currentDrawableChannel.ChildrenOfType<ChatLine>().Last();
+                lastLineAlternatingBackground = lastLine.AlternatingBackground;
+            });
+
+            AddStep("add another message", () => testChannel1.AddNewMessages(new Message
+            {
+                ChannelId = testChannel1.Id,
+                Content = $"One final message",
+                Timestamp = DateTimeOffset.Now,
+                Sender = testUser,
+            }));
+
+            AddAssert("second-last message has same background", () => lastLine.AlternatingBackground, () => Is.EqualTo(lastLineAlternatingBackground));
+        }
+
         private void joinTestChannel(int i)
         {
             AddStep($"Join test channel {i}", () => channelManager.JoinChannel(testChannels[i]));

--- a/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChatOverlay.cs
@@ -683,7 +683,7 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("add another message", () => testChannel1.AddNewMessages(new Message
             {
                 ChannelId = testChannel1.Id,
-                Content = $"One final message",
+                Content = "One final message",
                 Timestamp = DateTimeOffset.Now,
                 Sender = testUser,
             }));

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -84,25 +84,6 @@ namespace osu.Game.Overlays.Chat
             highlightedMessage.BindValueChanged(_ => processMessageHighlighting(), true);
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            long? lastMinutes = null;
-
-            for (int i = 0; i < ChatLineFlow.Count; i++)
-            {
-                if (ChatLineFlow[i] is ChatLine chatline)
-                {
-                    long minutes = chatline.Message.Timestamp.ToUnixTimeSeconds() / 60;
-
-                    chatline.AlternatingBackground = i % 2 == 0;
-                    chatline.RequiresTimestamp = minutes != lastMinutes;
-                    lastMinutes = minutes;
-                }
-            }
-        }
-
         /// <summary>
         /// Processes any pending message in <see cref="highlightedMessage"/>.
         /// </summary>
@@ -149,13 +130,24 @@ namespace osu.Game.Overlays.Chat
             // Add up to last Channel.MAX_HISTORY messages
             var displayMessages = newMessages.Skip(Math.Max(0, newMessages.Count() - Channel.MAX_HISTORY));
 
-            Message lastMessage = chatLines.LastOrDefault()?.Message;
+            ChatLine lastLine = chatLines.LastOrDefault();
+            Message lastMessage = lastLine?.Message;
 
             foreach (var message in displayMessages)
             {
                 addDaySeparatorIfRequired(lastMessage, message);
 
-                ChatLineFlow.Add(CreateChatLine(message));
+                ChatLine line = CreateChatLine(message);
+
+                long minutes = line.Message.Timestamp.ToUnixTimeSeconds() / 60;
+                long? lastMinutes = lastLine?.Message.Timestamp.ToUnixTimeSeconds() / 60;
+
+                line.AlternatingBackground = !lastLine?.AlternatingBackground ?? false;
+                line.RequiresTimestamp = minutes != lastMinutes;
+
+                ChatLineFlow.Add(line);
+
+                lastLine = line;
                 lastMessage = message;
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/29572

Fix is pretty straightforward - only run when a new message arrives.