### PR TITLE
Hide pinned comment replies initially to match web

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneCommentsContainer.cs
@@ -17,6 +17,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.Comments;
+using osu.Game.Overlays.Comments.Buttons;
 
 namespace osu.Game.Tests.Visual.Online
 {
@@ -58,6 +59,11 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("show comments", () => commentsContainer.ShowComments(CommentableType.Beatmapset, 123));
             AddUntilStep("show more button hidden",
                 () => commentsContainer.ChildrenOfType<CommentsShowMoreButton>().Single().Alpha == 0);
+
+            if (withPinned)
+                AddAssert("pinned comment replies collapsed", () => commentsContainer.ChildrenOfType<ShowRepliesButton>().First().Expanded.Value, () => Is.False);
+            else
+                AddAssert("first comment replies expanded", () => commentsContainer.ChildrenOfType<ShowRepliesButton>().First().Expanded.Value, () => Is.True);
         }
 
         [TestCase(false)]
@@ -302,7 +308,7 @@ namespace osu.Game.Tests.Visual.Online
                 bundle.Comments.Add(new Comment
                 {
                     Id = 20,
-                    Message = "Reply to pinned comment",
+                    Message = "Reply to pinned comment initially hidden",
                     LegacyName = "AbandonedUser",
                     CreatedAt = DateTimeOffset.Now,
                     VotesCount = 0,

--- a/osu.Game/Overlays/Comments/DrawableComment.cs
+++ b/osu.Game/Overlays/Comments/DrawableComment.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Overlays.Comments
 
         public readonly BindableList<DrawableComment> Replies = new BindableList<DrawableComment>();
 
-        private readonly BindableBool childrenExpanded = new BindableBool(true);
+        private readonly BindableBool childrenExpanded;
 
         private int currentPage;
 
@@ -92,6 +92,8 @@ namespace osu.Game.Overlays.Comments
         {
             Comment = comment;
             Meta = meta;
+
+            childrenExpanded = new BindableBool(!comment.Pinned);
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
On lazer, I noticed that the pinned comment on the latest release was screen-filled with spam replies. Web hides them initially on the pinned comment, so I matched that.