### PR TITLE
Improve song select load and reload with large beatmap databases

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -18,6 +18,7 @@ using osu.Framework.Screens;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -48,12 +49,17 @@ namespace osu.Game.Tests.Visual.Background
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             manager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
+
+            Add(detachedBeatmapStore);
 
             Beatmap.SetDefault();
         }

--- a/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Tests.Visual.Editing
                 () => Is.EqualTo(1));
 
             AddStep("enter song select", () => Game.ChildrenOfType<ButtonSystem>().Single().OnSolo?.Invoke());
-            AddUntilStep("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
+            AddUntilStep("entered song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect && songSelect.BeatmapSetsLoaded);
 
             addStepClickLink("00:00:000 (1)", waitForSeek: false);
             AddUntilStep("received 'must be in edit'",
@@ -138,7 +138,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("Wait for song select", () =>
                 Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
                 && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
-                && songSelect.IsLoaded
+                && songSelect.BeatmapSetsLoaded
             );
             AddStep("Switch ruleset", () => Game.Ruleset.Value = ruleset);
             AddStep("Open editor for ruleset", () =>

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
@@ -45,9 +46,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
             Dependencies.Cache(Realm);
+
+            Add(detachedBeatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -19,6 +19,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
@@ -65,9 +66,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, API, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
             Dependencies.Cache(Realm);
+
+            Add(detachedBeatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -45,11 +45,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             importedBeatmapSet = manager.Import(TestResources.CreateTestBeatmapSetInfo(8, rulesets.AvailableRulesets.ToArray()));
+
+            Add(detachedBeatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -33,13 +34,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             var beatmapSet = TestResources.CreateTestBeatmapSetInfo();
 
             manager.Import(beatmapSet);
+
+            Add(detachedBeatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneBeatmapEditorNavigation.cs
@@ -165,16 +165,19 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        [Solo]
         public void TestEditorGameplayTestAlwaysUsesOriginalRuleset()
         {
             prepareBeatmap();
 
-            AddStep("switch ruleset", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);
+            AddStep("switch ruleset at song select", () => Game.Ruleset.Value = new ManiaRuleset().RulesetInfo);
 
             AddStep("open editor", () => ((PlaySongSelect)Game.ScreenStack.CurrentScreen).Edit(beatmapSet.Beatmaps.First(beatmap => beatmap.Ruleset.OnlineID == 0)));
-            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
-            AddStep("test gameplay", () => getEditor().TestGameplay());
 
+            AddUntilStep("wait for editor open", () => Game.ScreenStack.CurrentScreen is Editor editor && editor.ReadyForUse);
+            AddAssert("editor ruleset is osu!", () => Game.Ruleset.Value, () => Is.EqualTo(new OsuRuleset().RulesetInfo));
+
+            AddStep("test gameplay", () => getEditor().TestGameplay());
             AddUntilStep("wait for player", () =>
             {
                 // notifications may fire at almost any inopportune time and cause annoying test failures.
@@ -183,8 +186,7 @@ namespace osu.Game.Tests.Visual.Navigation
                 Game.CloseAllOverlays();
                 return Game.ScreenStack.CurrentScreen is EditorPlayer editorPlayer && editorPlayer.IsLoaded;
             });
-
-            AddAssert("current ruleset is osu!", () => Game.Ruleset.Value.Equals(new OsuRuleset().RulesetInfo));
+            AddAssert("gameplay ruleset is osu!", () => Game.Ruleset.Value, () => Is.EqualTo(new OsuRuleset().RulesetInfo));
 
             AddStep("exit to song select", () => Game.PerformFromScreen(_ => { }, typeof(PlaySongSelect).Yield()));
             AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is PlaySongSelect);
@@ -352,7 +354,7 @@ namespace osu.Game.Tests.Visual.Navigation
             AddUntilStep("wait for song select",
                 () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet)
                       && Game.ScreenStack.CurrentScreen is PlaySongSelect songSelect
-                      && songSelect.IsLoaded);
+                      && songSelect.BeatmapSetsLoaded);
         }
 
         private void openEditor()

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -176,6 +176,12 @@ namespace osu.Game.Tests.Visual.Navigation
 
         private void confirmBeatmapInSongSelect(Func<BeatmapSetInfo> getImport)
         {
+            AddUntilStep("wait for carousel loaded", () =>
+            {
+                var songSelect = (Screens.Select.SongSelect)Game.ScreenStack.CurrentScreen;
+                return songSelect.ChildrenOfType<BeatmapCarousel>().SingleOrDefault()?.IsLoaded == true;
+            });
+
             AddUntilStep("beatmap in song select", () =>
             {
                 var songSelect = (Screens.Select.SongSelect)Game.ScreenStack.CurrentScreen;

--- a/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestScenePresentBeatmap.cs
@@ -193,7 +193,7 @@ namespace osu.Game.Tests.Visual.Navigation
         {
             AddStep("present beatmap", () => Game.PresentBeatmap(getImport()));
 
-            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect songSelect && songSelect.IsLoaded);
+            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect songSelect && songSelect.BeatmapSetsLoaded);
             AddUntilStep("correct beatmap displayed", () => Game.Beatmap.Value.BeatmapSetInfo.OnlineID, () => Is.EqualTo(getImport().OnlineID));
             AddAssert("correct ruleset selected", () => Game.Ruleset.Value, () => Is.EqualTo(getImport().Beatmaps.First().Ruleset));
         }
@@ -203,7 +203,7 @@ namespace osu.Game.Tests.Visual.Navigation
             Predicate<BeatmapInfo> pred = b => b.OnlineID == importedID * 1024 + 2;
             AddStep("present difficulty", () => Game.PresentBeatmap(getImport(), pred));
 
-            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect songSelect && songSelect.IsLoaded);
+            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect songSelect && songSelect.BeatmapSetsLoaded);
             AddUntilStep("correct beatmap displayed", () => Game.Beatmap.Value.BeatmapInfo.OnlineID, () => Is.EqualTo(importedID * 1024 + 2));
             AddAssert("correct ruleset selected", () => Game.Ruleset.Value.OnlineID, () => Is.EqualTo(expectedRulesetOnlineID ?? getImport().Beatmaps.First().Ruleset.OnlineID));
         }

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -1035,9 +1035,11 @@ namespace osu.Game.Tests.Visual.Navigation
         [Test]
         public void TestTouchScreenDetectionInGame()
         {
+            BeatmapSetInfo beatmapSet = null;
+
             PushAndConfirm(() => new TestPlaySongSelect());
-            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
-            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+            AddStep("import beatmap", () => beatmapSet = BeatmapImportHelper.LoadQuickOszIntoOsu(Game).GetResultSafely());
+            AddUntilStep("wait for selected", () => Game.Beatmap.Value.BeatmapSetInfo.Equals(beatmapSet));
             AddStep("select", () => InputManager.Key(Key.Enter));
 
             Player player = null;

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -1389,6 +1389,11 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private partial class TestBeatmapCarousel : BeatmapCarousel
         {
+            public TestBeatmapCarousel()
+                : base(new FilterCriteria())
+            {
+            }
+
             public bool PendingFilterTask => PendingFilter != null;
 
             public IEnumerable<DrawableCarouselItem> Items

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -52,11 +52,11 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             createCarousel(new List<BeatmapSetInfo>());
 
-            AddStep("filter to ruleset 0", () => carousel.Filter(new FilterCriteria
+            AddStep("filter to ruleset 0", () => carousel.FilterImmediately(new FilterCriteria
             {
                 Ruleset = rulesets.AvailableRulesets.ElementAt(0),
                 AllowConvertedBeatmaps = true,
-            }, false));
+            }));
 
             AddStep("add mixed ruleset beatmapset", () =>
             {
@@ -78,11 +78,11 @@ namespace osu.Game.Tests.Visual.SongSelect
                        && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item)!.BeatmapInfo.Ruleset.OnlineID == 0) == 1;
             });
 
-            AddStep("filter to ruleset 1", () => carousel.Filter(new FilterCriteria
+            AddStep("filter to ruleset 1", () => carousel.FilterImmediately(new FilterCriteria
             {
                 Ruleset = rulesets.AvailableRulesets.ElementAt(1),
                 AllowConvertedBeatmaps = true,
-            }, false));
+            }));
 
             AddUntilStep("wait for filtered difficulties", () =>
             {
@@ -93,11 +93,11 @@ namespace osu.Game.Tests.Visual.SongSelect
                        && visibleBeatmapPanels.Count(p => ((CarouselBeatmap)p.Item)!.BeatmapInfo.Ruleset.OnlineID == 1) == 1;
             });
 
-            AddStep("filter to ruleset 2", () => carousel.Filter(new FilterCriteria
+            AddStep("filter to ruleset 2", () => carousel.FilterImmediately(new FilterCriteria
             {
                 Ruleset = rulesets.AvailableRulesets.ElementAt(2),
                 AllowConvertedBeatmaps = true,
-            }, false));
+            }));
 
             AddUntilStep("wait for filtered difficulties", () =>
             {
@@ -344,7 +344,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             // basic filtering
             setSelected(1, 1);
 
-            AddStep("Filter", () => carousel.Filter(new FilterCriteria { SearchText = carousel.BeatmapSets.ElementAt(2).Metadata.Title }, false));
+            AddStep("Filter", () => carousel.FilterImmediately(new FilterCriteria { SearchText = carousel.BeatmapSets.ElementAt(2).Metadata.Title }));
             checkVisibleItemCount(diff: false, count: 1);
             checkVisibleItemCount(diff: true, count: 3);
             waitForSelection(3, 1);
@@ -360,13 +360,13 @@ namespace osu.Game.Tests.Visual.SongSelect
             // test filtering some difficulties (and keeping current beatmap set selected).
 
             setSelected(1, 2);
-            AddStep("Filter some difficulties", () => carousel.Filter(new FilterCriteria { SearchText = "Normal" }, false));
+            AddStep("Filter some difficulties", () => carousel.FilterImmediately(new FilterCriteria { SearchText = "Normal" }));
             waitForSelection(1, 1);
 
-            AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
+            AddStep("Un-filter", () => carousel.FilterImmediately(new FilterCriteria()));
             waitForSelection(1, 1);
 
-            AddStep("Filter all", () => carousel.Filter(new FilterCriteria { SearchText = "Dingo" }, false));
+            AddStep("Filter all", () => carousel.FilterImmediately(new FilterCriteria { SearchText = "Dingo" }));
 
             checkVisibleItemCount(false, 0);
             checkVisibleItemCount(true, 0);
@@ -378,7 +378,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             advanceSelection(false);
             AddAssert("Selection is null", () => currentSelection == null);
 
-            AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
+            AddStep("Un-filter", () => carousel.FilterImmediately(new FilterCriteria()));
 
             AddAssert("Selection is non-null", () => currentSelection != null);
 
@@ -399,7 +399,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             setSelected(1, 3);
 
-            AddStep("Apply a range filter", () => carousel.Filter(new FilterCriteria
+            AddStep("Apply a range filter", () => carousel.FilterImmediately(new FilterCriteria
             {
                 SearchText = searchText,
                 StarDifficulty = new FilterCriteria.OptionalRange<double>
@@ -408,7 +408,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                     Max = 5.5,
                     IsLowerInclusive = true
                 }
-            }, false));
+            }));
 
             // should reselect the buffered selection.
             waitForSelection(3, 2);
@@ -445,13 +445,13 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("ensure repeat", () => selectedSets.Contains(carousel.SelectedBeatmapSet));
 
             AddStep("Add set with 100 difficulties", () => carousel.UpdateBeatmapSet(TestResources.CreateTestBeatmapSetInfo(100, rulesets.AvailableRulesets.ToArray())));
-            AddStep("Filter Extra", () => carousel.Filter(new FilterCriteria { SearchText = "Extra 10" }, false));
+            AddStep("Filter Extra", () => carousel.FilterImmediately(new FilterCriteria { SearchText = "Extra 10" }));
             checkInvisibleDifficultiesUnselectable();
             checkInvisibleDifficultiesUnselectable();
             checkInvisibleDifficultiesUnselectable();
             checkInvisibleDifficultiesUnselectable();
             checkInvisibleDifficultiesUnselectable();
-            AddStep("Un-filter", () => carousel.Filter(new FilterCriteria(), false));
+            AddStep("Un-filter", () => carousel.FilterImmediately(new FilterCriteria()));
         }
 
         [Test]
@@ -527,7 +527,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(setCount: local_set_count, diffCount: local_diff_count);
 
-            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+            AddStep("Sort by difficulty", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty }));
 
             checkVisibleItemCount(false, local_set_count * local_diff_count);
 
@@ -566,7 +566,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             loadBeatmaps(sets, () => new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(0) });
 
             AddStep("Set non-empty mode filter", () =>
-                carousel.Filter(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(1) }, false));
+                carousel.FilterImmediately(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(1) }));
 
             AddAssert("Something is selected", () => carousel.SelectedBeatmapInfo != null);
         }
@@ -601,7 +601,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by date submitted", () => carousel.Filter(new FilterCriteria { Sort = SortMode.DateSubmitted }, false));
+            AddStep("Sort by date submitted", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.DateSubmitted }));
             checkVisibleItemCount(diff: false, count: 10);
             checkVisibleItemCount(diff: true, count: 5);
 
@@ -610,11 +610,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("rest are at start", () => carousel.Items.OfType<DrawableCarouselBeatmapSet>().TakeWhile(i => i.Item is CarouselBeatmapSet s && s.BeatmapSet.DateSubmitted != null).Count(),
                 () => Is.EqualTo(6));
 
-            AddStep("Sort by date submitted and string", () => carousel.Filter(new FilterCriteria
+            AddStep("Sort by date submitted and string", () => carousel.FilterImmediately(new FilterCriteria
             {
                 Sort = SortMode.DateSubmitted,
                 SearchText = zzz_string
-            }, false));
+            }));
             checkVisibleItemCount(diff: false, count: 5);
             checkVisibleItemCount(diff: true, count: 5);
 
@@ -658,10 +658,10 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by author", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Author }, false));
+            AddStep("Sort by author", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Author }));
             AddAssert($"Check {zzz_uppercase} is last", () => carousel.BeatmapSets.Last().Metadata.Author.Username == zzz_uppercase);
             AddAssert($"Check {zzz_lowercase} is second last", () => carousel.BeatmapSets.SkipLast(1).Last().Metadata.Author.Username == zzz_lowercase);
-            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddStep("Sort by artist", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Artist }));
             AddAssert($"Check {zzz_uppercase} is last", () => carousel.BeatmapSets.Last().Metadata.Artist == zzz_uppercase);
             AddAssert($"Check {zzz_lowercase} is second last", () => carousel.BeatmapSets.SkipLast(1).Last().Metadata.Artist == zzz_lowercase);
         }
@@ -703,7 +703,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddStep("Sort by artist", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Artist }));
             AddAssert("Check last item", () =>
             {
                 var lastItem = carousel.BeatmapSets.Last();
@@ -746,10 +746,10 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by title", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false));
+            AddStep("Sort by title", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Title }));
             AddAssert("Items remain in descending added order", () => carousel.BeatmapSets.Select(s => s.DateAdded), () => Is.Ordered.Descending);
 
-            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddStep("Sort by artist", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Artist }));
             AddAssert("Items remain in descending added order", () => carousel.BeatmapSets.Select(s => s.DateAdded), () => Is.Ordered.Descending);
         }
 
@@ -786,7 +786,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddStep("Sort by artist", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Artist }));
 
             AddAssert("Items in descending added order", () => carousel.BeatmapSets.Select(s => s.DateAdded), () => Is.Ordered.Descending);
             AddStep("Save order", () => originalOrder = carousel.BeatmapSets.Select(s => s.ID).ToArray());
@@ -796,7 +796,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddAssert("Order didn't change", () => carousel.BeatmapSets.Select(s => s.ID), () => Is.EqualTo(originalOrder));
 
-            AddStep("Sort by title", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false));
+            AddStep("Sort by title", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Title }));
             AddAssert("Order didn't change", () => carousel.BeatmapSets.Select(s => s.ID), () => Is.EqualTo(originalOrder));
         }
 
@@ -833,7 +833,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by artist", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Artist }, false));
+            AddStep("Sort by artist", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Artist }));
 
             AddAssert("Items in descending added order", () => carousel.BeatmapSets.Select(s => s.DateAdded), () => Is.Ordered.Descending);
             AddStep("Save order", () => originalOrder = carousel.BeatmapSets.Select(s => s.ID).ToArray());
@@ -858,7 +858,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddAssert("Order didn't change", () => carousel.BeatmapSets.Select(s => s.ID), () => Is.EqualTo(originalOrder));
 
-            AddStep("Sort by title", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false));
+            AddStep("Sort by title", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Title }));
             AddAssert("Order didn't change", () => carousel.BeatmapSets.Select(s => s.ID), () => Is.EqualTo(originalOrder));
         }
 
@@ -885,12 +885,12 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(sets);
 
-            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+            AddStep("Sort by difficulty", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty }));
 
             checkVisibleItemCount(false, local_set_count * local_diff_count);
             checkVisibleItemCount(true, 1);
 
-            AddStep("Filter to normal", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Normal" }, false));
+            AddStep("Filter to normal", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Normal" }));
             checkVisibleItemCount(false, local_set_count);
             checkVisibleItemCount(true, 1);
 
@@ -901,7 +901,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                                .Count(p => ((CarouselBeatmapSet)p.Item)!.Beatmaps.Single().BeatmapInfo.DifficultyName.StartsWith("Normal", StringComparison.Ordinal)) == local_set_count;
             });
 
-            AddStep("Filter to insane", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Insane" }, false));
+            AddStep("Filter to insane", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty, SearchText = "Insane" }));
             checkVisibleItemCount(false, local_set_count);
             checkVisibleItemCount(true, 1);
 
@@ -1022,7 +1022,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 carousel.UpdateBeatmapSet(testMixed);
             });
             AddStep("filter to ruleset 0", () =>
-                carousel.Filter(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(0) }, false));
+                carousel.FilterImmediately(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(0) }));
             AddStep("select filtered map skipping filtered", () => carousel.SelectBeatmap(testMixed.Beatmaps[1], false));
             AddAssert("unfiltered beatmap not selected", () => carousel.SelectedBeatmapInfo?.Ruleset.OnlineID == 0);
 
@@ -1068,12 +1068,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 AddStep("Toggle non-matching filter", () =>
                 {
-                    carousel.Filter(new FilterCriteria { SearchText = Guid.NewGuid().ToString() }, false);
+                    carousel.FilterImmediately(new FilterCriteria { SearchText = Guid.NewGuid().ToString() });
                 });
 
                 AddStep("Restore no filter", () =>
                 {
-                    carousel.Filter(new FilterCriteria(), false);
+                    carousel.FilterImmediately(new FilterCriteria());
                     eagerSelectedIDs.Add(carousel.SelectedBeatmapSet!.ID);
                 });
             }
@@ -1097,7 +1097,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             loadBeatmaps(manySets);
 
-            AddStep("Sort by difficulty", () => carousel.Filter(new FilterCriteria { Sort = SortMode.Difficulty }, false));
+            AddStep("Sort by difficulty", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty }));
 
             advanceSelection(direction: 1, diff: false);
 
@@ -1105,12 +1105,12 @@ namespace osu.Game.Tests.Visual.SongSelect
             {
                 AddStep("Toggle non-matching filter", () =>
                 {
-                    carousel.Filter(new FilterCriteria { SearchText = Guid.NewGuid().ToString() }, false);
+                    carousel.FilterImmediately(new FilterCriteria { SearchText = Guid.NewGuid().ToString() });
                 });
 
                 AddStep("Restore no filter", () =>
                 {
-                    carousel.Filter(new FilterCriteria(), false);
+                    carousel.FilterImmediately(new FilterCriteria());
                     eagerSelectedIDs.Add(carousel.SelectedBeatmapSet!.ID);
                 });
             }
@@ -1185,7 +1185,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 AddStep($"Set ruleset to {rulesetInfo.ShortName}", () =>
                 {
-                    carousel.Filter(new FilterCriteria { Ruleset = rulesetInfo, Sort = SortMode.Title }, false);
+                    carousel.FilterImmediately(new FilterCriteria { Ruleset = rulesetInfo, Sort = SortMode.Title });
                 });
                 waitForSelection(i + 1, 1);
             }
@@ -1223,12 +1223,12 @@ namespace osu.Game.Tests.Visual.SongSelect
                 setSelected(i, 1);
                 AddStep("Set ruleset to taiko", () =>
                 {
-                    carousel.Filter(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(1), Sort = SortMode.Title }, false);
+                    carousel.FilterImmediately(new FilterCriteria { Ruleset = rulesets.AvailableRulesets.ElementAt(1), Sort = SortMode.Title });
                 });
                 waitForSelection(i - 1, 1);
                 AddStep("Remove ruleset filter", () =>
                 {
-                    carousel.Filter(new FilterCriteria { Sort = SortMode.Title }, false);
+                    carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Title });
                 });
             }
 
@@ -1414,6 +1414,12 @@ namespace osu.Game.Tests.Visual.SongSelect
                         }
                     }
                 }
+            }
+
+            public void FilterImmediately(FilterCriteria newCriteria)
+            {
+                Filter(newCriteria);
+                FlushPendingFilterOperations();
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -1268,26 +1269,23 @@ namespace osu.Game.Tests.Visual.SongSelect
                 }
             }
 
-            createCarousel(beatmapSets, c =>
+            createCarousel(beatmapSets, initialCriteria, c =>
             {
-                carouselAdjust?.Invoke(c);
-
-                carousel.Filter(initialCriteria?.Invoke() ?? new FilterCriteria());
                 carousel.BeatmapSetsChanged = () => changed = true;
-                carousel.BeatmapSets = beatmapSets;
+                carouselAdjust?.Invoke(c);
             });
 
             AddUntilStep("Wait for load", () => changed);
         }
 
-        private void createCarousel(List<BeatmapSetInfo> beatmapSets, Action<BeatmapCarousel> carouselAdjust = null, Container target = null)
+        private void createCarousel(List<BeatmapSetInfo> beatmapSets, [CanBeNull] Func<FilterCriteria> initialCriteria = null, Action<BeatmapCarousel> carouselAdjust = null, Container target = null)
         {
             AddStep("Create carousel", () =>
             {
                 selectedSets.Clear();
                 eagerSelectedIDs.Clear();
 
-                carousel = new TestBeatmapCarousel
+                carousel = new TestBeatmapCarousel(initialCriteria?.Invoke() ?? new FilterCriteria())
                 {
                     RelativeSizeAxes = Axes.Both,
                 };
@@ -1389,8 +1387,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private partial class TestBeatmapCarousel : BeatmapCarousel
         {
-            public TestBeatmapCarousel()
-                : base(new FilterCriteria())
+            public TestBeatmapCarousel(FilterCriteria criteria)
+                : base(criteria)
             {
             }
 

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -1397,8 +1397,6 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             public Action? StartRequested;
 
-            public new Bindable<RulesetInfo> Ruleset => base.Ruleset;
-
             public new FilterControl FilterControl => base.FilterControl;
 
             public WorkingBeatmap CurrentBeatmap => Beatmap.Value;
@@ -1408,18 +1406,18 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             public new void PresentScore(ScoreInfo score) => base.PresentScore(score);
 
+            public int FilterCount;
+
             protected override bool OnStart()
             {
                 StartRequested?.Invoke();
                 return base.OnStart();
             }
 
-            public int FilterCount;
-
-            protected override void ApplyFilterToCarousel(FilterCriteria criteria)
+            [BackgroundDependencyLoader]
+            private void load()
             {
-                FilterCount++;
-                base.ApplyFilterToCarousel(criteria);
+                FilterControl.FilterChanged += _ => FilterCount++;
             }
         }
     }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -56,16 +56,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
+            DetachedBeatmapStore detachedBeatmapStore;
+
             // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
             // At a point we have isolated interactive test runs enough, this can likely be removed.
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(Realm);
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
+            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
 
             Dependencies.Cache(music = new MusicController());
 
             // required to get bindables attached
             Add(music);
+            Add(detachedBeatmapStore);
 
             Dependencies.Cache(config = new OsuConfigManager(LocalStorage));
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             createSongSelect();
 
-            AddAssert("filter count is 1", () => songSelect?.FilterCount == 1);
+            AddAssert("filter count is 0", () => songSelect?.FilterCount, () => Is.EqualTo(0));
         }
 
         [Test]
@@ -366,7 +366,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("return", () => songSelect!.MakeCurrent());
             AddUntilStep("wait for current", () => songSelect!.IsCurrentScreen());
-            AddAssert("filter count is 1", () => songSelect!.FilterCount == 1);
+            AddAssert("filter count is 0", () => songSelect!.FilterCount, () => Is.EqualTo(0));
         }
 
         [Test]
@@ -386,7 +386,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddStep("return", () => songSelect!.MakeCurrent());
             AddUntilStep("wait for current", () => songSelect!.IsCurrentScreen());
-            AddAssert("filter count is 2", () => songSelect!.FilterCount == 2);
+            AddAssert("filter count is 1", () => songSelect!.FilterCount, () => Is.EqualTo(1));
         }
 
         [Test]
@@ -1274,11 +1274,11 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // Mod that is guaranteed to never re-filter.
             AddStep("add non-filterable mod", () => SelectedMods.Value = new Mod[] { new OsuModCinema() });
-            AddAssert("filter count is 1", () => songSelect!.FilterCount, () => Is.EqualTo(1));
+            AddAssert("filter count is 0", () => songSelect!.FilterCount, () => Is.EqualTo(0));
 
             // Removing the mod should still not re-filter.
             AddStep("remove non-filterable mod", () => SelectedMods.Value = Array.Empty<Mod>());
-            AddAssert("filter count is 1", () => songSelect!.FilterCount, () => Is.EqualTo(1));
+            AddAssert("filter count is 0", () => songSelect!.FilterCount, () => Is.EqualTo(0));
         }
 
         [Test]
@@ -1290,35 +1290,35 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // Change to mania ruleset.
             AddStep("filter to mania ruleset", () => Ruleset.Value = rulesets.AvailableRulesets.First(r => r.OnlineID == 3));
-            AddAssert("filter count is 2", () => songSelect!.FilterCount, () => Is.EqualTo(2));
+            AddAssert("filter count is 2", () => songSelect!.FilterCount, () => Is.EqualTo(1));
 
             // Apply a mod, but this should NOT re-filter because there's no search text.
             AddStep("add filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey3() });
-            AddAssert("filter count is 2", () => songSelect!.FilterCount, () => Is.EqualTo(2));
+            AddAssert("filter count is 1", () => songSelect!.FilterCount, () => Is.EqualTo(1));
 
             // Set search text. Should re-filter.
             AddStep("set search text to match mods", () => songSelect!.FilterControl.CurrentTextSearch.Value = "keys=3");
-            AddAssert("filter count is 3", () => songSelect!.FilterCount, () => Is.EqualTo(3));
+            AddAssert("filter count is 2", () => songSelect!.FilterCount, () => Is.EqualTo(2));
 
             // Change filterable mod. Should re-filter.
             AddStep("change new filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey5() });
-            AddAssert("filter count is 4", () => songSelect!.FilterCount, () => Is.EqualTo(4));
+            AddAssert("filter count is 3", () => songSelect!.FilterCount, () => Is.EqualTo(3));
 
             // Add non-filterable mod. Should NOT re-filter.
             AddStep("apply non-filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModNoFail(), new ManiaModKey5() });
-            AddAssert("filter count is 4", () => songSelect!.FilterCount, () => Is.EqualTo(4));
+            AddAssert("filter count is 3", () => songSelect!.FilterCount, () => Is.EqualTo(3));
 
             // Remove filterable mod. Should re-filter.
             AddStep("remove filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModNoFail() });
-            AddAssert("filter count is 5", () => songSelect!.FilterCount, () => Is.EqualTo(5));
+            AddAssert("filter count is 4", () => songSelect!.FilterCount, () => Is.EqualTo(4));
 
             // Remove non-filterable mod. Should NOT re-filter.
             AddStep("remove filterable mod", () => SelectedMods.Value = Array.Empty<Mod>());
-            AddAssert("filter count is 5", () => songSelect!.FilterCount, () => Is.EqualTo(5));
+            AddAssert("filter count is 4", () => songSelect!.FilterCount, () => Is.EqualTo(4));
 
             // Add filterable mod. Should re-filter.
             AddStep("add filterable mod", () => SelectedMods.Value = new Mod[] { new ManiaModKey3() });
-            AddAssert("filter count is 6", () => songSelect!.FilterCount, () => Is.EqualTo(6));
+            AddAssert("filter count is 5", () => songSelect!.FilterCount, () => Is.EqualTo(5));
         }
 
         private void waitForInitialSelection()

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private BeatmapCarousel createCarousel()
         {
-            return carousel = new BeatmapCarousel
+            return carousel = new BeatmapCarousel(new FilterCriteria())
             {
                 RelativeSizeAxes = Axes.Both,
                 BeatmapSets = new List<BeatmapSetInfo>

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -1,0 +1,117 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using Realms;
+
+namespace osu.Game.Database
+{
+    // TODO: handle realm migration
+    public partial class DetachedBeatmapStore : Component
+    {
+        private readonly ManualResetEventSlim loaded = new ManualResetEventSlim();
+
+        private List<BeatmapSetInfo> originalBeatmapSetsDetached = new List<BeatmapSetInfo>();
+
+        private IDisposable? subscriptionSets;
+
+        /// <summary>
+        /// Track GUIDs of all sets in realm to allow handling deletions.
+        /// </summary>
+        private readonly List<Guid> realmBeatmapSets = new List<Guid>();
+
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        public IReadOnlyList<BeatmapSetInfo> GetDetachedBeatmaps()
+        {
+            if (!loaded.Wait(60000))
+                Logger.Error(new TimeoutException("Beatmaps did not load in an acceptable time"), $"{nameof(DetachedBeatmapStore)} fell over");
+
+            return originalBeatmapSetsDetached;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            subscriptionSets = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
+        }
+
+        private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
+        {
+            if (changes == null)
+            {
+                if (originalBeatmapSetsDetached.Count > 0 && sender.Count == 0)
+                {
+                    // Usually we'd reset stuff here, but doing so triggers a silly flow which ends up deadlocking realm.
+                    // Additionally, user should not be at song select when realm is blocking all operations in the first place.
+                    //
+                    // Note that due to the catch-up logic below, once operations are restored we will still be in a roughly
+                    // correct state. The only things that this return will change is the carousel will not empty *during* the blocking
+                    // operation.
+                    return;
+                }
+
+                originalBeatmapSetsDetached = sender.Detach();
+
+                realmBeatmapSets.Clear();
+                realmBeatmapSets.AddRange(sender.Select(r => r.ID));
+
+                loaded.Set();
+                return;
+            }
+
+            HashSet<Guid> setsRequiringUpdate = new HashSet<Guid>();
+            HashSet<Guid> setsRequiringRemoval = new HashSet<Guid>();
+
+            foreach (int i in changes.DeletedIndices.OrderDescending())
+            {
+                Guid id = realmBeatmapSets[i];
+
+                setsRequiringRemoval.Add(id);
+                setsRequiringUpdate.Remove(id);
+
+                realmBeatmapSets.RemoveAt(i);
+            }
+
+            foreach (int i in changes.InsertedIndices)
+            {
+                Guid id = sender[i].ID;
+
+                setsRequiringRemoval.Remove(id);
+                setsRequiringUpdate.Add(id);
+
+                realmBeatmapSets.Insert(i, id);
+            }
+
+            foreach (int i in changes.NewModifiedIndices)
+                setsRequiringUpdate.Add(sender[i].ID);
+
+            // deletions
+            foreach (Guid g in setsRequiringRemoval)
+                originalBeatmapSetsDetached.RemoveAll(set => set.ID == g);
+
+            // updates
+            foreach (Guid g in setsRequiringUpdate)
+            {
+                originalBeatmapSetsDetached.RemoveAll(set => set.ID == g);
+                originalBeatmapSetsDetached.Add(fetchFromID(g)!);
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            subscriptionSets?.Dispose();
+        }
+
+        private IQueryable<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);
+    }
+}

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -133,7 +133,9 @@ namespace osu.Game.Database
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
             loaded.Set();
+            loaded.Dispose();
             realmSubscription?.Dispose();
         }
 

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
+using osu.Game.Online.Multiplayer;
 using Realms;
 
 namespace osu.Game.Database
@@ -59,15 +60,21 @@ namespace osu.Game.Database
 
                 Task.Factory.StartNew(() =>
                 {
-                    realm.Run(_ =>
+                    try
                     {
-                        var detached = frozenSets.Detach();
+                        realm.Run(_ =>
+                        {
+                            var detached = frozenSets.Detach();
 
-                        detachedBeatmapSets.Clear();
-                        detachedBeatmapSets.AddRange(detached);
+                            detachedBeatmapSets.Clear();
+                            detachedBeatmapSets.AddRange(detached);
+                        });
+                    }
+                    finally
+                    {
                         loaded.Set();
-                    });
-                }, TaskCreationOptions.LongRunning);
+                    }
+                }, TaskCreationOptions.LongRunning).FireAndForget();
 
                 return;
             }

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using Realms;
 
@@ -24,11 +23,9 @@ namespace osu.Game.Database
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps()
+        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps(CancellationToken cancellationToken)
         {
-            if (!loaded.Wait(60000))
-                Logger.Error(new TimeoutException("Beatmaps did not load in an acceptable time"), $"{nameof(DetachedBeatmapStore)} fell over");
-
+            loaded.Wait(cancellationToken);
             return detachedBeatmapSets.GetBoundCopy();
         }
 
@@ -75,6 +72,7 @@ namespace osu.Game.Database
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+            loaded.Set();
             realmSubscription?.Dispose();
         }
 

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -24,17 +24,16 @@ namespace osu.Game.Database
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps(CancellationToken cancellationToken)
+        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps(CancellationToken? cancellationToken)
         {
-            loaded.Wait(cancellationToken);
+            loaded.Wait(cancellationToken ?? CancellationToken.None);
             return detachedBeatmapSets.GetBoundCopy();
         }
 
         [BackgroundDependencyLoader]
-        private void load(CancellationToken cancellationToken)
+        private void load()
         {
             realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected), beatmapSetsChanged);
-            loaded.Wait(cancellationToken);
         }
 
         private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -2,10 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Logging;
 using osu.Game.Beatmaps;
@@ -13,42 +13,36 @@ using Realms;
 
 namespace osu.Game.Database
 {
-    // TODO: handle realm migration
     public partial class DetachedBeatmapStore : Component
     {
         private readonly ManualResetEventSlim loaded = new ManualResetEventSlim();
 
-        private List<BeatmapSetInfo> originalBeatmapSetsDetached = new List<BeatmapSetInfo>();
+        private readonly BindableList<BeatmapSetInfo> detachedBeatmapSets = new BindableList<BeatmapSetInfo>();
 
-        private IDisposable? subscriptionSets;
-
-        /// <summary>
-        /// Track GUIDs of all sets in realm to allow handling deletions.
-        /// </summary>
-        private readonly List<Guid> realmBeatmapSets = new List<Guid>();
+        private IDisposable? realmSubscription;
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public IReadOnlyList<BeatmapSetInfo> GetDetachedBeatmaps()
+        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps()
         {
             if (!loaded.Wait(60000))
                 Logger.Error(new TimeoutException("Beatmaps did not load in an acceptable time"), $"{nameof(DetachedBeatmapStore)} fell over");
 
-            return originalBeatmapSetsDetached;
+            return detachedBeatmapSets.GetBoundCopy();
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            subscriptionSets = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
+            realmSubscription = realm.RegisterForNotifications(getBeatmapSets, beatmapSetsChanged);
         }
 
         private void beatmapSetsChanged(IRealmCollection<BeatmapSetInfo> sender, ChangeSet? changes)
         {
             if (changes == null)
             {
-                if (originalBeatmapSetsDetached.Count > 0 && sender.Count == 0)
+                if (detachedBeatmapSets.Count > 0 && sender.Count == 0)
                 {
                     // Usually we'd reset stuff here, but doing so triggers a silly flow which ends up deadlocking realm.
                     // Additionally, user should not be at song select when realm is blocking all operations in the first place.
@@ -59,57 +53,29 @@ namespace osu.Game.Database
                     return;
                 }
 
-                originalBeatmapSetsDetached = sender.Detach();
-
-                realmBeatmapSets.Clear();
-                realmBeatmapSets.AddRange(sender.Select(r => r.ID));
+                detachedBeatmapSets.Clear();
+                detachedBeatmapSets.AddRange(sender.Detach());
 
                 loaded.Set();
                 return;
             }
 
-            HashSet<Guid> setsRequiringUpdate = new HashSet<Guid>();
-            HashSet<Guid> setsRequiringRemoval = new HashSet<Guid>();
-
             foreach (int i in changes.DeletedIndices.OrderDescending())
-            {
-                Guid id = realmBeatmapSets[i];
-
-                setsRequiringRemoval.Add(id);
-                setsRequiringUpdate.Remove(id);
-
-                realmBeatmapSets.RemoveAt(i);
-            }
+                detachedBeatmapSets.RemoveAt(i);
 
             foreach (int i in changes.InsertedIndices)
             {
-                Guid id = sender[i].ID;
-
-                setsRequiringRemoval.Remove(id);
-                setsRequiringUpdate.Add(id);
-
-                realmBeatmapSets.Insert(i, id);
+                detachedBeatmapSets.Insert(i, sender[i].Detach());
             }
 
             foreach (int i in changes.NewModifiedIndices)
-                setsRequiringUpdate.Add(sender[i].ID);
-
-            // deletions
-            foreach (Guid g in setsRequiringRemoval)
-                originalBeatmapSetsDetached.RemoveAll(set => set.ID == g);
-
-            // updates
-            foreach (Guid g in setsRequiringUpdate)
-            {
-                originalBeatmapSetsDetached.RemoveAll(set => set.ID == g);
-                originalBeatmapSetsDetached.Add(fetchFromID(g)!);
-            }
+                detachedBeatmapSets.ReplaceRange(i, 1, new[] { sender[i].Detach() });
         }
 
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-            subscriptionSets?.Dispose();
+            realmSubscription?.Dispose();
         }
 
         private IQueryable<BeatmapSetInfo> getBeatmapSets(Realm realm) => realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending && !s.Protected);

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1141,6 +1141,7 @@ namespace osu.Game
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
+            loadComponentSingleFile(new DetachedBeatmapStore(), Add, true);
 
             Add(difficultyRecommender);
             Add(externalLinkOpener = new ExternalLinkOpener());

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -54,8 +54,6 @@ namespace osu.Game.Screens.Menu
 
         public override bool? AllowGlobalTrackControl => true;
 
-        private Screen songSelect;
-
         private MenuSideFlashes sideFlashes;
 
         protected ButtonSystem Buttons;
@@ -220,26 +218,11 @@ namespace osu.Game.Screens.Menu
             Buttons.OnBeatmapListing = () => beatmapListing?.ToggleVisibility();
 
             reappearSampleSwoosh = audio.Samples.Get(@"Menu/reappear-swoosh");
-
-            preloadSongSelect();
         }
 
         public void ReturnToOsuLogo() => Buttons.State = ButtonSystemState.Initial;
 
-        private void preloadSongSelect()
-        {
-            if (songSelect == null)
-                LoadComponentAsync(songSelect = new PlaySongSelect());
-        }
-
-        private void loadSoloSongSelect() => this.Push(consumeSongSelect());
-
-        private Screen consumeSongSelect()
-        {
-            var s = songSelect;
-            songSelect = null;
-            return s;
-        }
+        private void loadSoloSongSelect() => this.Push(new PlaySongSelect());
 
         public override void OnEntering(ScreenTransitionEvent e)
         {
@@ -372,9 +355,6 @@ namespace osu.Game.Screens.Menu
             reappearSampleSwoosh?.Play();
 
             ApplyToBackground(b => (b as BackgroundScreenDefault)?.Next());
-
-            // we may have consumed our preloaded instance, so let's make another.
-            preloadSongSelect();
 
             musicController.EnsurePlayingSomething();
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -122,7 +122,7 @@ namespace osu.Game.Screens.Select
 
         private IEnumerable<CarouselBeatmapSet> beatmapSets => root.Items.OfType<CarouselBeatmapSet>();
 
-        public IEnumerable<BeatmapSetInfo> BeatmapSets
+        internal IEnumerable<BeatmapSetInfo> BeatmapSets
         {
             get => beatmapSets.Select(g => g.BeatmapSet);
             set

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -391,7 +391,7 @@ namespace osu.Game.Screens.Select
                 if (root.BeatmapSetsByID.TryGetValue(beatmapSet.ID, out var existingSets)
                     && existingSets.SelectMany(s => s.Beatmaps).All(b => b.BeatmapInfo.ID != beatmapInfo.ID))
                 {
-                    updateBeatmapSet(beatmapSet);
+                    updateBeatmapSet(beatmapSet.Detach());
                     changed = true;
                 }
             }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -170,12 +170,11 @@ namespace osu.Game.Screens.Select
             }
 
             root = newRoot;
+            root.Filter(activeCriteria);
 
             Scroll.Clear(false);
             itemsCache.Invalidate();
             ScrollToSelected();
-
-            applyActiveCriteria(false);
 
             // Restore selection
             if (selectedBeatmapBefore != null && newRoot.BeatmapSetsByID.TryGetValue(selectedBeatmapBefore.BeatmapSet!.ID, out var newSelectionCandidates))
@@ -215,7 +214,7 @@ namespace osu.Game.Screens.Select
 
         private int visibleSetsCount;
 
-        public BeatmapCarousel()
+        public BeatmapCarousel(FilterCriteria initialCriterial)
         {
             root = new CarouselRoot(this);
             InternalChild = new Container
@@ -237,6 +236,8 @@ namespace osu.Game.Screens.Select
                     noResultsPlaceholder = new NoResultsPlaceholder()
                 }
             };
+
+            activeCriteria = initialCriterial;
         }
 
         [BackgroundDependencyLoader]
@@ -662,7 +663,7 @@ namespace osu.Game.Screens.Select
             item.State.Value = CarouselItemState.Selected;
         }
 
-        private FilterCriteria activeCriteria = new FilterCriteria();
+        private FilterCriteria activeCriteria;
 
         protected ScheduledDelegate? PendingFilter;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -320,7 +320,6 @@ namespace osu.Game.Screens.Select
         {
             try
             {
-                // TODO: chekc whether we still need beatmap sets by ID
                 foreach (var set in setsRequiringRemoval) removeBeatmapSet(set.ID);
 
                 foreach (var set in setsRequiringUpdate) updateBeatmapSet(set);

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -241,7 +241,7 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, AudioManager audio, CancellationToken cancellationToken)
+        private void load(OsuConfigManager config, AudioManager audio, CancellationToken? cancellationToken)
         {
             spinSample = audio.Samples.Get("SongSelect/random-spin");
             randomSelectSample = audio.Samples.Get(@"SongSelect/select-random");
@@ -252,12 +252,12 @@ namespace osu.Game.Screens.Select
             RightClickScrollingEnabled.ValueChanged += enabled => Scroll.RightMouseScrollbar = enabled.NewValue;
             RightClickScrollingEnabled.TriggerChange();
 
-            if (!loadedTestBeatmaps)
+            if (!loadedTestBeatmaps && detachedBeatmapStore != null)
             {
                 // This is performing an unnecessary second lookup on realm (in addition to the subscription), but for performance reasons
                 // we require it to be separate: the subscription's initial callback (with `ChangeSet` of `null`) will run on the update
                 // thread. If we attempt to detach beatmaps in this callback the game will fall over (it takes time).
-                detachedBeatmapSets = detachedBeatmapStore!.GetDetachedBeatmaps(cancellationToken);
+                detachedBeatmapSets = detachedBeatmapStore.GetDetachedBeatmaps(cancellationToken);
                 detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);
                 loadBeatmapSets(detachedBeatmapSets);
             }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -274,30 +274,31 @@ namespace osu.Game.Screens.Select
             if (loadedTestBeatmaps)
                 return;
 
-            var newBeatmapSets = changed.NewItems!.Cast<BeatmapSetInfo>();
-            var newBeatmapSetIDs = newBeatmapSets.Select(s => s.ID).ToHashSet();
-
-            var oldBeatmapSets = changed.OldItems!.Cast<BeatmapSetInfo>();
-            var oldBeatmapSetIDs = oldBeatmapSets.Select(s => s.ID).ToHashSet();
+            IEnumerable<BeatmapSetInfo>? newBeatmapSets = changed.NewItems?.Cast<BeatmapSetInfo>();
 
             switch (changed.Action)
             {
                 case NotifyCollectionChangedAction.Add:
+                    HashSet<Guid> newBeatmapSetIDs = newBeatmapSets!.Select(s => s.ID).ToHashSet();
+
                     setsRequiringRemoval.RemoveWhere(s => newBeatmapSetIDs.Contains(s.ID));
-                    setsRequiringUpdate.AddRange(newBeatmapSets);
+                    setsRequiringUpdate.AddRange(newBeatmapSets!);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
+                    IEnumerable<BeatmapSetInfo> oldBeatmapSets = changed.OldItems!.Cast<BeatmapSetInfo>();
+                    HashSet<Guid> oldBeatmapSetIDs = oldBeatmapSets.Select(s => s.ID).ToHashSet();
+
                     setsRequiringUpdate.RemoveWhere(s => oldBeatmapSetIDs.Contains(s.ID));
                     setsRequiringRemoval.AddRange(oldBeatmapSets);
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
-                    setsRequiringUpdate.AddRange(newBeatmapSets);
+                    setsRequiringUpdate.AddRange(newBeatmapSets!);
                     break;
 
                 case NotifyCollectionChangedAction.Move:
-                    setsRequiringUpdate.AddRange(newBeatmapSets);
+                    setsRequiringUpdate.AddRange(newBeatmapSets!);
                     break;
 
                 case NotifyCollectionChangedAction.Reset:

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -137,6 +137,10 @@ namespace osu.Game.Screens.Select
 
         private void loadBeatmapSets(IEnumerable<BeatmapSetInfo> beatmapSets)
         {
+            // Ensure no changes are made to the list while we are initialising items.
+            // We'll catch up on changes via subscriptions anyway.
+            beatmapSets = beatmapSets.ToArray();
+
             if (selectedBeatmapSet != null && !beatmapSets.Contains(selectedBeatmapSet.BeatmapSet))
                 selectedBeatmapSet = null;
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -700,12 +700,12 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        public void Filter(FilterCriteria? newCriteria, bool debounce = true)
+        public void Filter(FilterCriteria? newCriteria)
         {
             if (newCriteria != null)
                 activeCriteria = newCriteria;
 
-            applyActiveCriteria(debounce);
+            applyActiveCriteria(true);
         }
 
         private bool beatmapsSplitOut;

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -235,7 +236,7 @@ namespace osu.Game.Screens.Select
         }
 
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, AudioManager audio, DetachedBeatmapStore beatmapStore)
+        private void load(OsuConfigManager config, AudioManager audio, CancellationToken cancellationToken)
         {
             spinSample = audio.Samples.Get("SongSelect/random-spin");
             randomSelectSample = audio.Samples.Get(@"SongSelect/select-random");
@@ -251,7 +252,7 @@ namespace osu.Game.Screens.Select
                 // This is performing an unnecessary second lookup on realm (in addition to the subscription), but for performance reasons
                 // we require it to be separate: the subscription's initial callback (with `ChangeSet` of `null`) will run on the update
                 // thread. If we attempt to detach beatmaps in this callback the game will fall over (it takes time).
-                detachedBeatmapSets = detachedBeatmapStore!.GetDetachedBeatmaps();
+                detachedBeatmapSets = detachedBeatmapStore!.GetDetachedBeatmaps(cancellationToken);
                 detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);
                 loadBeatmapSets(detachedBeatmapSets);
             }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -428,7 +428,8 @@ namespace osu.Game.Screens.Select
 
             // Forced refetch is important here to guarantee correct invalidation across all difficulties.
             Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo ?? beatmapInfoNoDebounce, true);
-            this.Push(new EditorLoader());
+
+            FinaliseSelection(customStartAction: () => this.Push(new EditorLoader()));
         }
 
         /// <summary>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -328,7 +328,7 @@ namespace osu.Game.Screens.Select
                 GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
             }, c => carouselContainer.Child = c);
 
-            FilterControl.FilterChanged = ApplyFilterToCarousel;
+            FilterControl.FilterChanged = Carousel.Filter;
 
             if (ShowSongSelectFooter)
             {
@@ -402,14 +402,6 @@ namespace osu.Game.Screens.Select
         };
 
         protected virtual ModSelectOverlay CreateModSelectOverlay() => new SoloModSelectOverlay();
-
-        protected virtual void ApplyFilterToCarousel(FilterCriteria criteria)
-        {
-            // if not the current screen, we want to get carousel in a good presentation state before displaying (resume or enter).
-            bool shouldDebounce = this.IsCurrentScreen();
-
-            Carousel.Filter(criteria, shouldDebounce);
-        }
 
         private DependencyContainer dependencies = null!;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -162,20 +162,6 @@ namespace osu.Game.Screens.Select
                 ApplyToBackground(applyBlurToBackground);
             });
 
-            LoadComponentAsync(Carousel = new BeatmapCarousel
-            {
-                AllowSelection = false, // delay any selection until our bindables are ready to make a good choice.
-                Anchor = Anchor.CentreRight,
-                Origin = Anchor.CentreRight,
-                RelativeSizeAxes = Axes.Both,
-                BleedTop = FilterControl.HEIGHT,
-                BleedBottom = Select.Footer.HEIGHT,
-                SelectionChanged = updateSelectedBeatmap,
-                BeatmapSetsChanged = carouselBeatmapsLoaded,
-                FilterApplied = () => Scheduler.AddOnce(updateVisibleBeatmapCount),
-                GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
-            }, c => carouselContainer.Child = c);
-
             // initial value transfer is required for FilterControl (it uses our re-cached bindables in its async load for the initial filter).
             transferRulesetValue();
 
@@ -227,7 +213,6 @@ namespace osu.Game.Screens.Select
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = FilterControl.HEIGHT,
-                            FilterChanged = ApplyFilterToCarousel,
                         },
                         new GridContainer // used for max width implementation
                         {
@@ -327,6 +312,23 @@ namespace osu.Game.Screens.Select
                 },
                 modSpeedHotkeyHandler = new ModSpeedHotkeyHandler(),
             });
+
+            // Important to load this after the filter control is loaded (so we have initial filter criteria prepared).
+            LoadComponentAsync(Carousel = new BeatmapCarousel(FilterControl.CreateCriteria())
+            {
+                AllowSelection = false, // delay any selection until our bindables are ready to make a good choice.
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                RelativeSizeAxes = Axes.Both,
+                BleedTop = FilterControl.HEIGHT,
+                BleedBottom = Select.Footer.HEIGHT,
+                SelectionChanged = updateSelectedBeatmap,
+                BeatmapSetsChanged = carouselBeatmapsLoaded,
+                FilterApplied = () => Scheduler.AddOnce(updateVisibleBeatmapCount),
+                GetRecommendedBeatmap = s => recommender?.GetRecommendedBeatmap(s),
+            }, c => carouselContainer.Child = c);
+
+            FilterControl.FilterChanged = ApplyFilterToCarousel;
 
             if (ShowSongSelectFooter)
             {
@@ -992,7 +994,8 @@ namespace osu.Game.Screens.Select
 
             // if we have a pending filter operation, we want to run it now.
             // it could change selection (ie. if the ruleset has been changed).
-            Carousel.FlushPendingFilterOperations();
+            if (IsLoaded)
+                Carousel.FlushPendingFilterOperations();
 
             return true;
         }


### PR DESCRIPTION
Supersedes and closes https://github.com/ppy/osu/pull/29550.

Test video with 100k+ beatmaps (can provide database on request).

https://github.com/user-attachments/assets/1491282f-944f-4d44-8878-f34f9a088c21


- Detach is now asynchronous and global (removes ~1 s stutter / load time for song select)
 - As a result, we **no longer need to preload song select**. This has large benefits, including reduced memory pressure when not using song select (especially noticeable when exiting the game from song select – previously it would load another one while trying to exit the game, causing a delay in shut down by 1-5 seconds).
 - This also removes stutters seen when loading song select from places that aren't the main menu, resolving the performance part of #21952.
 - This also means that we are no longer requiring to query realm twice (`BeatmapCarousel` used to do an initial query in `load` followed by a second implicit one from the initial subscription callback; we now only use the callback).
- Initial filter operation is now asynchronous (removes ~500 ms stutter on carousel display)

Reviewer notes:

I've made quite a few (unavoidable) changes to `BeatmapCarousel` and `SongSelect`, but I stand behind them being steps-in-the-right-direction from what we had. Individual commits should hopefully make things easy to digest.

Commit dd4a1104e45ddd50015608555227fe17afdb6754 may be a bit hard to accept. If so, this commit can be removed. But it does reduce complexity if accepted.
