### PR TITLE
Adjust `played` song select filter to accept a boolean value

### DIFF
--- a/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
+++ b/osu.Game.Tests/NonVisual/Filtering/FilterQueryParserTest.cs
@@ -537,7 +537,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [TestCaseSource(nameof(correct_date_query_examples))]
         public void TestValidDateQueries(string dateQuery)
         {
-            string query = $"played<{dateQuery} time";
+            string query = $"lastplayed<{dateQuery} time";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
@@ -571,7 +571,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestGreaterDateQuery()
         {
-            const string query = "played>50";
+            const string query = "lastplayed>50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.That(filterCriteria.LastPlayed.Max, Is.Not.Null);
@@ -584,7 +584,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestLowerDateQuery()
         {
-            const string query = "played<50";
+            const string query = "lastplayed<50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.That(filterCriteria.LastPlayed.Max, Is.Null);
@@ -597,7 +597,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestBothSidesDateQuery()
         {
-            const string query = "played>3M played<1y6M";
+            const string query = "lastplayed>3M lastplayed<1y6M";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.That(filterCriteria.LastPlayed.Min, Is.Not.Null);
@@ -611,7 +611,7 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestEqualDateQuery()
         {
-            const string query = "played=50";
+            const string query = "lastplayed=50";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual(false, filterCriteria.LastPlayed.HasFilter);
@@ -620,11 +620,34 @@ namespace osu.Game.Tests.NonVisual.Filtering
         [Test]
         public void TestOutOfRangeDateQuery()
         {
-            const string query = "played<10000y";
+            const string query = "lastplayed<10000y";
             var filterCriteria = new FilterCriteria();
             FilterQueryParser.ApplyQueries(filterCriteria, query);
             Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
             Assert.AreEqual(DateTimeOffset.MinValue.AddMilliseconds(1), filterCriteria.LastPlayed.Min);
+        }
+
+        private static readonly object[] played_query_tests =
+        {
+            new object[] { "0", DateTimeOffset.MinValue, true },
+            new object[] { "0", DateTimeOffset.Now, false },
+            new object[] { "false", DateTimeOffset.MinValue, true },
+            new object[] { "false", DateTimeOffset.Now, false },
+
+            new object[] { "1", DateTimeOffset.MinValue, false },
+            new object[] { "1", DateTimeOffset.Now, true },
+            new object[] { "true", DateTimeOffset.MinValue, false },
+            new object[] { "true", DateTimeOffset.Now, true },
+        };
+
+        [Test]
+        [TestCaseSource(nameof(played_query_tests))]
+        public void TestPlayedQuery(string query, DateTimeOffset reference, bool matched)
+        {
+            var filterCriteria = new FilterCriteria();
+            FilterQueryParser.ApplyQueries(filterCriteria, $"played={query}");
+            Assert.AreEqual(true, filterCriteria.LastPlayed.HasFilter);
+            Assert.AreEqual(matched, filterCriteria.LastPlayed.IsInRange(reference));
         }
     }
 }

--- a/osu.Game/Screens/Select/FilterQueryParser.cs
+++ b/osu.Game/Screens/Select/FilterQueryParser.cs
@@ -62,9 +62,30 @@ namespace osu.Game.Screens.Select
                 case "length":
                     return tryUpdateLengthRange(criteria, op, value);
 
-                case "played":
                 case "lastplayed":
                     return tryUpdateDateAgoRange(ref criteria.LastPlayed, op, value);
+
+                case "played":
+                    if (!tryParseBool(value, out bool played))
+                        return false;
+
+                    // Unplayed beatmaps are filtered on DateTimeOffset.MinValue.
+
+                    if (played)
+                    {
+                        criteria.LastPlayed.Min = DateTimeOffset.MinValue;
+                        criteria.LastPlayed.Max = DateTimeOffset.MaxValue;
+                        criteria.LastPlayed.IsLowerInclusive = false;
+                    }
+                    else
+                    {
+                        criteria.LastPlayed.Min = DateTimeOffset.MinValue;
+                        criteria.LastPlayed.Max = DateTimeOffset.MinValue;
+                        criteria.LastPlayed.IsLowerInclusive = true;
+                        criteria.LastPlayed.IsUpperInclusive = true;
+                    }
+
+                    return true;
 
                 case "divisor":
                     return TryUpdateCriteriaRange(ref criteria.BeatDivisor, op, value, tryParseInt);
@@ -132,6 +153,23 @@ namespace osu.Game.Screens.Select
 
         private static bool tryParseInt(string value, out int result) =>
             int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+
+        private static bool tryParseBool(string value, out bool result)
+        {
+            switch (value)
+            {
+                case "1":
+                    result = true;
+                    return true;
+
+                case "0":
+                    result = false;
+                    return true;
+
+                default:
+                    return bool.TryParse(value, out result);
+            }
+        }
 
         private static bool tryParseEnum<TEnum>(string value, out TEnum result) where TEnum : struct
         {


### PR DESCRIPTION
Supersedes / closes https://github.com/ppy/osu/pull/29638
Resolves Resolves https://github.com/ppy/osu/issues/29568

Currently, the `played` filter is an acronym for `lastplayed`. This PR changes it to be a boolean value.

`played=0` / `played=false` -> beatmap has never been played.  
`played=1` / `played=true` -> beatmap has been played sometime.
