### PR TITLE
Fix event leak in `Multiplayer` implementation

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Multiplayer.cs
@@ -108,7 +108,10 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             base.Dispose(isDisposing);
 
             if (client.IsNotNull())
+            {
                 client.RoomUpdated -= onRoomUpdated;
+                client.GameplayAborted -= onGameplayAborted;
+            }
         }
     }
 }


### PR DESCRIPTION
Ouch.

Very likely closes #29088. It's the only thing I could find odd in the memory dump.