### PR TITLE
Fix osu!catch fruits not resizing on texture change

### DIFF
--- a/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyCatchHitObjectPiece.cs
+++ b/osu.Game.Rulesets.Catch/Skinning/Legacy/LegacyCatchHitObjectPiece.cs
@@ -85,9 +85,25 @@ namespace osu.Game.Rulesets.Catch.Skinning.Legacy
 
         protected void SetTexture(Texture? texture, Texture? overlayTexture)
         {
-            colouredSprite.Texture = texture;
-            overlaySprite.Texture = overlayTexture;
-            hyperSprite.Texture = texture;
+            // Sizes are reset due to an arguable osu!framework bug where Sprite retains the size of the first set texture.
+
+            if (colouredSprite.Texture != texture)
+            {
+                colouredSprite.Size = Vector2.Zero;
+                colouredSprite.Texture = texture;
+            }
+
+            if (overlaySprite.Texture != overlayTexture)
+            {
+                overlaySprite.Size = Vector2.Zero;
+                overlaySprite.Texture = overlayTexture;
+            }
+
+            if (hyperSprite.Texture != texture)
+            {
+                hyperSprite.Size = Vector2.Zero;
+                hyperSprite.Texture = texture;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/29447

Fixing this locally for now because it's really an o!f bug. Fixing it requires going through all usages and seeing if there's special cases like:
```
new Sprite
{
    RelativeSizeAxes = Axes.Both,
    Texture = ...,
    Size = Vector2.One
}
```