### PR TITLE
Fix incorrect osu!catch snap display when last object is a juice stream

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapProvider.cs
@@ -18,7 +18,9 @@ namespace osu.Game.Rulesets.Catch.Edit
             // The implementation below is probably correct but should be checked if/when exposed via controls.
 
             float expectedDistance = DurationToDistance(before, after.StartTime - before.GetEndTime());
-            float actualDistance = Math.Abs(((CatchHitObject)before).EffectiveX - ((CatchHitObject)after).EffectiveX);
+
+            float previousEndX = (before as JuiceStream)?.EndX ?? ((CatchHitObject)before).EffectiveX;
+            float actualDistance = Math.Abs(previousEndX - ((CatchHitObject)after).EffectiveX);
 
             return actualDistance / expectedDistance;
         }


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/29678.