### PR TITLE
Unranked if a metronome is used with ModMuted.

### DIFF
--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Mods
         public BindableBool InverseMuting { get; } = new BindableBool();
 
         [SettingSource("Enable metronome", "Add a metronome beat to help you keep track of the rhythm.")]
-        public BindableBool EnableMetronome { get; } = new BindableBool(true);
+        public BindableBool EnableMetronome { get; } = new BindableBool();
 
         [SettingSource("Final volume at combo", "The combo count at which point the track reaches its final volume.", SettingControlType = typeof(SettingsSlider<int, MuteComboSlider>))]
         public BindableInt MuteComboCount { get; } = new BindableInt(100)

--- a/osu.Game/Rulesets/Mods/ModMuted.cs
+++ b/osu.Game/Rulesets/Mods/ModMuted.cs
@@ -24,13 +24,13 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => FontAwesome.Solid.VolumeMute;
         public override LocalisableString Description => "Can you still feel the rhythm without music?";
         public override ModType Type => ModType.Fun;
-        public override double ScoreMultiplier => 1;
-        public override bool Ranked => true;
     }
 
     public abstract class ModMuted<TObject> : ModMuted, IApplicableToDrawableRuleset<TObject>, IApplicableToTrack, IApplicableToScoreProcessor
         where TObject : HitObject
     {
+        public override double ScoreMultiplier => EnableMetronome.Value ? 0.8 : 1;
+        public override bool Ranked => !EnableMetronome.Value;
         private readonly BindableNumber<double> mainVolumeAdjust = new BindableDouble(0.5);
         private readonly BindableNumber<double> metronomeVolumeAdjust = new BindableDouble(0.5);
 


### PR DESCRIPTION
Mentioned in https://github.com/ppy/osu/pull/27144#pullrequestreview-1875804893
And discussed in #29668

There may not be an obvious superior difference, but it actually changes the gameplay.

For now, I borrowed the 0.8 multiplier from Synesthesia, but I don't believe this is the final plan.
I don't think it would matter if it was 1x, but just in case.