### PR TITLE
Trigger request failure on receiving a null response for a typed `APIRequest`

### DIFF
--- a/osu.Game/Online/API/APIRequest.cs
+++ b/osu.Game/Online/API/APIRequest.cs
@@ -46,6 +46,9 @@ namespace osu.Game.Online.API
                 Response = ((OsuJsonWebRequest<T>)WebRequest).ResponseObject;
                 Logger.Log($"{GetType().ReadableName()} finished with response size of {WebRequest.ResponseStream.Length:#,0} bytes", LoggingTarget.Network);
             }
+
+            if (Response == null)
+                TriggerFailure(new ArgumentNullException(nameof(Response)));
         }
 
         internal void TriggerSuccess(T result)
@@ -151,6 +154,8 @@ namespace osu.Game.Online.API
             if (isFailing) return;
 
             PostProcess();
+
+            if (isFailing) return;
 
             TriggerSuccess();
         }


### PR DESCRIPTION
RFC. Seems like about what we'd want. Any kind of issue which results in deserialising not being feasible should be considered a failure for a typed `APIRequest` as far as I'm concerned.