### PR TITLE
Fix high performance session potentially getting stuck after multiplayer spectator

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -573,6 +573,9 @@ namespace osu.Game.Screens.Play
                 // if the player never got pushed, we should explicitly dispose it.
                 DisposalTask = LoadTask?.ContinueWith(_ => CurrentPlayer?.Dispose());
             }
+
+            highPerformanceSession?.Dispose();
+            highPerformanceSession = null;
         }
 
         #endregion


### PR DESCRIPTION
Thanks to @smoogipoo for the call on this. All makes sense now.

Closes https://github.com/ppy/osu/issues/29088.

Can easily see this going wrong by searching `runtime.log` for "Ending high performance session" and noticing it never occurs after multiplayer spectator.