### PR TITLE
Fix replay analysis marker depth when rewinding

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/ReplayAnalysis/AnalysisMarker.cs
+++ b/osu.Game.Rulesets.Osu/UI/ReplayAnalysis/AnalysisMarker.cs
@@ -22,6 +22,7 @@ namespace osu.Game.Rulesets.Osu.UI.ReplayAnalysis
         protected override void OnApply(AnalysisFrameEntry entry)
         {
             Position = entry.Position;
+            Depth = -(float)entry.LifetimeEnd;
         }
     }
 }


### PR DESCRIPTION
Fixes a bug where rewinding in the replay would place earlier markers on top.

Before:

https://github.com/user-attachments/assets/087b62fa-50f5-43d0-bb65-9684db0ee87a

After:

https://github.com/user-attachments/assets/7e39fb77-7326-48db-bc92-9af0919ce422
