### PR TITLE
Silence beatmap retrieval failures from results screen favourite button

### DIFF
--- a/osu.Game/Screens/Ranking/FavouriteButton.cs
+++ b/osu.Game/Screens/Ranking/FavouriteButton.cs
@@ -76,12 +76,13 @@ namespace osu.Game.Screens.Ranking
             };
             beatmapSetRequest.Failure += e =>
             {
-                Logger.Error(e, $"Failed to fetch beatmap info: {e.Message}");
+                Logger.Log($"Favourite button failed to fetch beatmap info: {e}", LoggingTarget.Network);
 
                 Schedule(() =>
                 {
                     loading.Hide();
                     Enabled.Value = false;
+                    TooltipText = "this beatmap cannot be favourited";
                 });
             };
             api.Queue(beatmapSetRequest);


### PR DESCRIPTION
As reported (very poorly) in https://github.com/ppy/osu/pull/28991#issuecomment-2331854970.

I believe this is a total edge case and is mostly visible on dev due to some beatmaps existing on `osu.ppy.sh` and not on `dev.ppy.sh`, but I tend to agree in general that these types of failures should not be firing very loud error notifications; logging to network and disabling the button with a tooltip adjustment should be enough.