### PR TITLE
Add Total Participation stat to users profile Daily Challenge Tooltip

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileDailyChallenge.cs
@@ -66,8 +66,8 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestPlayCountRankingTier()
         {
-            AddAssert("1 before silver", () => DailyChallengeStatsDisplay.TierForPlayCount(30) == RankingTier.Bronze);
-            AddAssert("first silver", () => DailyChallengeStatsDisplay.TierForPlayCount(31) == RankingTier.Silver);
+            AddAssert("1 before silver", () => DailyChallengeStatsTooltip.TierForPlayCount(30) == RankingTier.Bronze);
+            AddAssert("first silver", () => DailyChallengeStatsTooltip.TierForPlayCount(31) == RankingTier.Silver);
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -14,7 +13,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Localisation;
 using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Scoring;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
@@ -114,17 +112,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
             }
 
             dailyPlayCount.Text = DailyChallengeStatsDisplayStrings.UnitDay(stats.PlayCount.ToLocalisableString("N0"));
-            dailyPlayCount.Colour = colours.ForRankingTier(TierForPlayCount(stats.PlayCount));
+            dailyPlayCount.Colour = colours.ForRankingTier(DailyChallengeStatsTooltip.TierForPlayCount(stats.PlayCount));
 
             TooltipContent = new DailyChallengeTooltipData(colourProvider, stats);
 
             Show();
         }
-
-        // Rounding up is needed here to ensure the overlay shows the same colour as osu-web for the play count.
-        // This is because, for example, 31 / 3 > 10 in JavaScript because floats are used, while here it would
-        // get truncated to 10 with an integer division and show a lower tier.
-        public static RankingTier TierForPlayCount(int playCount) => DailyChallengeStatsTooltip.TierForDaily((int)Math.Ceiling(playCount / 3.0d));
 
         public ITooltip<DailyChallengeTooltipData> GetCustomTooltip() => new DailyChallengeStatsTooltip();
     }

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -99,7 +99,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
         private void updateDisplay()
         {
-            if (User.Value == null || User.Value.Ruleset.OnlineID != 0)
+            if (User.Value == null)
             {
                 Hide();
                 return;

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -107,6 +107,12 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
             APIUserDailyChallengeStatistics stats = User.Value.User.DailyChallengeStatistics;
 
+            if (stats.PlayCount == 0)
+            {
+                Hide();
+                return;
+            }
+
             dailyPlayCount.Text = DailyChallengeStatsDisplayStrings.UnitDay(stats.PlayCount.ToLocalisableString("N0"));
             dailyPlayCount.Colour = colours.ForRankingTier(TierForPlayCount(stats.PlayCount));
 

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
@@ -116,7 +117,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             topBackground.Colour = colourProvider.Background5;
 
             totalParticipation.Value = DailyChallengeStatsDisplayStrings.UnitDay(statistics.PlayCount.ToLocalisableString(@"N0"));
-            totalParticipation.ValueColour = colours.ForRankingTier(TierForDaily(statistics.PlayCount));
+            totalParticipation.ValueColour = colours.ForRankingTier(TierForPlayCount(statistics.PlayCount));
 
             currentDaily.Value = DailyChallengeStatsDisplayStrings.UnitDay(content.Statistics.DailyStreakCurrent.ToLocalisableString(@"N0"));
             currentDaily.ValueColour = colours.ForRankingTier(TierForDaily(statistics.DailyStreakCurrent));
@@ -137,7 +138,13 @@ namespace osu.Game.Overlays.Profile.Header.Components
             topFifty.ValueColour = colourProvider.Content2;
         }
 
-        // reference: https://github.com/ppy/osu-web/blob/8206e0e91eeea80ccf92f0586561346dd40e085e/resources/js/profile-page/daily-challenge.tsx#L13-L43
+        // reference: https://github.com/ppy/osu-web/blob/adf1e94754ba9625b85eba795f4a310caf169eec/resources/js/profile-page/daily-challenge.tsx#L13-L47
+
+        // Rounding up is needed here to ensure the overlay shows the same colour as osu-web for the play count.
+        // This is because, for example, 31 / 3 > 10 in JavaScript because floats are used, while here it would
+        // get truncated to 10 with an integer division and show a lower tier.
+        public static RankingTier TierForPlayCount(int playCount) => TierForDaily((int)Math.Ceiling(playCount / 3.0d));
+
         public static RankingTier TierForDaily(int daily)
         {
             if (daily > 360)

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
     {
         private StreakPiece currentDaily = null!;
         private StreakPiece currentWeekly = null!;
+        private StreakPiece totalParticipation = null!;
         private StatisticsPiece bestDaily = null!;
         private StatisticsPiece bestWeekly = null!;
         private StatisticsPiece topTen = null!;
@@ -70,7 +71,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             {
                                 topBackground = new Box
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    RelativeSizeAxes = Axes.None,
                                 },
                                 new FillFlowContainer
                                 {
@@ -78,8 +79,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
                                     Direction = FillDirection.Horizontal,
                                     Padding = new MarginPadding(15f),
                                     Spacing = new Vector2(30f),
-                                    Children = new[]
+                                    Children = new Drawable[]
                                     {
+                                        totalParticipation = new StreakPiece(UsersStrings.ShowDailyChallengePlaycount),
                                         currentDaily = new StreakPiece(UsersStrings.ShowDailyChallengeDailyStreakCurrent),
                                         currentWeekly = new StreakPiece(UsersStrings.ShowDailyChallengeWeeklyStreakCurrent),
                                     }
@@ -112,6 +114,9 @@ namespace osu.Game.Overlays.Profile.Header.Components
 
             background.Colour = colourProvider.Background4;
             topBackground.Colour = colourProvider.Background5;
+
+            totalParticipation.Value = DailyChallengeStatsDisplayStrings.UnitDay(statistics.PlayCount.ToLocalisableString(@"N0"));
+            totalParticipation.ValueColour = colourProvider.Content2;
 
             currentDaily.Value = DailyChallengeStatsDisplayStrings.UnitDay(content.Statistics.DailyStreakCurrent.ToLocalisableString(@"N0"));
             currentDaily.ValueColour = colours.ForRankingTier(TierForDaily(statistics.DailyStreakCurrent));

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             {
                                 topBackground = new Box
                                 {
-                                    RelativeSizeAxes = Axes.None,
+                                    RelativeSizeAxes = Axes.Both,
                                 },
                                 new FillFlowContainer
                                 {

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                                     Direction = FillDirection.Horizontal,
                                     Padding = new MarginPadding(15f),
                                     Spacing = new Vector2(30f),
-                                    Children = new Drawable[]
+                                    Children = new[]
                                     {
                                         totalParticipation = new StreakPiece(UsersStrings.ShowDailyChallengePlaycount),
                                         currentDaily = new StreakPiece(UsersStrings.ShowDailyChallengeDailyStreakCurrent),

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsTooltip.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
             topBackground.Colour = colourProvider.Background5;
 
             totalParticipation.Value = DailyChallengeStatsDisplayStrings.UnitDay(statistics.PlayCount.ToLocalisableString(@"N0"));
-            totalParticipation.ValueColour = colourProvider.Content2;
+            totalParticipation.ValueColour = colours.ForRankingTier(TierForDaily(statistics.PlayCount));
 
             currentDaily.Value = DailyChallengeStatsDisplayStrings.UnitDay(content.Statistics.DailyStreakCurrent.ToLocalisableString(@"N0"));
             currentDaily.ValueColour = colours.ForRankingTier(TierForDaily(statistics.DailyStreakCurrent));


### PR DESCRIPTION
Closes #29706 by adding Total Participation to tooltip.

<img width="548" alt="image" src="https://github.com/user-attachments/assets/05c94220-dfc0-41fd-a68d-18af87c2a7c5">
