### PR TITLE
fixed issue with large ammounts of collections not displaying properly

### DIFF
--- a/osu.Game/Screens/Ranking/CollectionPopover.cs
+++ b/osu.Game/Screens/Ranking/CollectionPopover.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Screens.Ranking
             {
                 new OsuMenu(Direction.Vertical, true)
                 {
+                    MaxHeight = 500,
                     Items = items,
                 },
             };


### PR DESCRIPTION
Adding MaxHeight to the OsuMenu allowed the menu to become scrollable