### PR TITLE
Fix collections overflowing in the results screen

### DIFF
--- a/osu.Game/Screens/Ranking/CollectionPopover.cs
+++ b/osu.Game/Screens/Ranking/CollectionPopover.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.Ranking
                 new OsuMenu(Direction.Vertical, true)
                 {
                     Items = items,
+                    MaxHeight = 375,
                 },
             };
         }


### PR DESCRIPTION
- Fixes #29736.

I took inspiration for this fix from the behaviour of the CollectionDropdownMenu in the song select screen.

The number I chose should be safe for maximum UI scaling too.