### PR TITLE
Fix file associations not updating or uninstalling

### DIFF
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using osu.Desktop.LegacyIpc;
 using osu.Desktop.Windows;
 using osu.Framework;
@@ -170,28 +171,18 @@ namespace osu.Desktop
         {
             var app = VelopackApp.Build();
 
-            app.WithFirstRun(_ =>
-            {
-                if (OperatingSystem.IsWindows())
-                    WindowsAssociationManager.InstallAssociations();
-            });
-
             if (OperatingSystem.IsWindows())
-            {
-                app.WithAfterUpdateFastCallback(_ =>
-                {
-                    if (OperatingSystem.IsWindows())
-                        WindowsAssociationManager.UpdateAssociations();
-                });
-
-                app.WithBeforeUninstallFastCallback(_ =>
-                {
-                    if (OperatingSystem.IsWindows())
-                        WindowsAssociationManager.UninstallAssociations();
-                });
-            }
+                configureWindows(app);
 
             app.Run();
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static void configureWindows(VelopackApp app)
+        {
+            app.WithFirstRun(_ => WindowsAssociationManager.InstallAssociations());
+            app.WithAfterUpdateFastCallback(_ => WindowsAssociationManager.UpdateAssociations());
+            app.WithBeforeUninstallFastCallback(_ => WindowsAssociationManager.UninstallAssociations());
         }
     }
 }

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -168,12 +168,30 @@ namespace osu.Desktop
 
         private static void setupVelopack()
         {
-            VelopackApp
-                .Build()
-                .WithFirstRun(v =>
+            var app = VelopackApp.Build();
+
+            app.WithFirstRun(_ =>
+            {
+                if (OperatingSystem.IsWindows())
+                    WindowsAssociationManager.InstallAssociations();
+            });
+
+            if (OperatingSystem.IsWindows())
+            {
+                app.WithAfterUpdateFastCallback(_ =>
                 {
-                    if (OperatingSystem.IsWindows()) WindowsAssociationManager.InstallAssociations();
-                }).Run();
+                    if (OperatingSystem.IsWindows())
+                        WindowsAssociationManager.UpdateAssociations();
+                });
+
+                app.WithBeforeUninstallFastCallback(_ =>
+                {
+                    if (OperatingSystem.IsWindows())
+                        WindowsAssociationManager.UninstallAssociations();
+                });
+            }
+
+            app.Run();
         }
     }
 }


### PR DESCRIPTION
Closes #29730 

This PR fixes file associations not being updated and not uninstalling properly post-velopack.

This isn't really the "big file association refactor" that I had planned to do. Primarily because I'm unsure of where the core team stands on https://github.com/ppy/osu/discussions/29603. If it's something that we would like, I'm happy to make another PR adding it in. Please let me know what you'd like to do there. The association logic looks good to me otherwise so this is all I'll be doing for now.

### Testing Checklist
- [x] Properly sets associations on installation
- [x] Properly updates incorrect or outdated associations
- [x] Properly uninstalls associations

### Notes
- The *update associations on game update* logic should only be added for two releases, then removed. The first release should roll out the logic. The second update should fix the associations (if not already done by the first release). By then, most users should have their associations pointing to the `current` directory, in which the logic can be safely removed (or kept if you don't care about the unnecessary overhead)
- This might be something you'd want to hotfix for (since file associations are effectively broken at the moment)