### PR TITLE
Double-quote in beatmap listing when searching by artist/title

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Overlays.BeatmapSet
                     title.Clear();
                     artist.Clear();
 
-                    title.AddLink(titleText, LinkAction.SearchBeatmapSet, "title=\"\"" + titleText + "\"\"");
+                    title.AddLink(titleText, LinkAction.SearchBeatmapSet, $@"title=""""{titleText}""""");
 
                     title.AddArbitraryDrawable(Empty().With(d => d.Width = 5));
                     title.AddArbitraryDrawable(externalLink = new ExternalLinkButton());
@@ -259,7 +259,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         title.AddArbitraryDrawable(new SpotlightBeatmapBadge());
                     }
 
-                    artist.AddLink(artistText, LinkAction.SearchBeatmapSet, "artist=\"\"" + artistText + "\"\"");
+                    artist.AddLink(artistText, LinkAction.SearchBeatmapSet, $@"artist=""""{artistText}""""");
 
                     if (setInfo.NewValue.TrackId != null)
                     {

--- a/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapSetHeaderContent.cs
@@ -242,7 +242,7 @@ namespace osu.Game.Overlays.BeatmapSet
                     title.Clear();
                     artist.Clear();
 
-                    title.AddLink(titleText, LinkAction.SearchBeatmapSet, titleText);
+                    title.AddLink(titleText, LinkAction.SearchBeatmapSet, "title=\"\"" + titleText + "\"\"");
 
                     title.AddArbitraryDrawable(Empty().With(d => d.Width = 5));
                     title.AddArbitraryDrawable(externalLink = new ExternalLinkButton());
@@ -259,7 +259,7 @@ namespace osu.Game.Overlays.BeatmapSet
                         title.AddArbitraryDrawable(new SpotlightBeatmapBadge());
                     }
 
-                    artist.AddLink(artistText, LinkAction.SearchBeatmapSet, artistText);
+                    artist.AddLink(artistText, LinkAction.SearchBeatmapSet, "artist=\"\"" + artistText + "\"\"");
 
                     if (setInfo.NewValue.TrackId != null)
                     {


### PR DESCRIPTION
Changed the way the links on beatmap headers worked by adding the required filter and quotation marks to the search from beatmap. This recreates the way beatmap search occurs on web. 

Resolves #29708