### PR TITLE
Add daily challenge animation to daily challenge notification

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -5,11 +5,13 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Configuration;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
 using osu.Game.Localisation;
+
 
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
@@ -24,14 +26,18 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             this.room = room;
         }
 
+
         [BackgroundDependencyLoader]
-        private void load(OsuGame? game)
+        private void load(OsuGame? game, SessionStatics statics)
         {
             Text = DailyChallengeStrings.ChallengeLiveNotification;
             Content.Add(card = new BeatmapCardNano((APIBeatmapSet)room.Playlist.Single().Beatmap.BeatmapSet!));
             Activated = () =>
             {
-                game?.PerformFromScreen(s => s.Push(new DailyChallenge(room)), [typeof(MainMenu)]);
+                if(statics.Get<bool>(Static.DailyChallengeIntroPlayed))
+                    game?.PerformFromScreen(s => s.Push(new DailyChallenge(room)), [typeof(MainMenu)]);
+                else
+                    game?.PerformFromScreen(s => s.Push(new DailyChallengeIntro(room)), [typeof(MainMenu)]);
                 return true;
             };
         }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -12,7 +12,6 @@ using osu.Game.Overlays.Notifications;
 using osu.Game.Screens.Menu;
 using osu.Game.Localisation;
 
-
 namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 {
     public partial class NewDailyChallengeNotification : SimpleNotification
@@ -38,6 +37,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     game?.PerformFromScreen(s => s.Push(new DailyChallenge(room)), [typeof(MainMenu)]);
                 else
                     game?.PerformFromScreen(s => s.Push(new DailyChallengeIntro(room)), [typeof(MainMenu)]);
+
                 return true;
             };
         }

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -25,7 +25,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             this.room = room;
         }
 
-
         [BackgroundDependencyLoader]
         private void load(OsuGame? game, SessionStatics statics)
         {

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/NewDailyChallengeNotification.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
             Content.Add(card = new BeatmapCardNano((APIBeatmapSet)room.Playlist.Single().Beatmap.BeatmapSet!));
             Activated = () =>
             {
-                if(statics.Get<bool>(Static.DailyChallengeIntroPlayed))
+                if (statics.Get<bool>(Static.DailyChallengeIntroPlayed))
                     game?.PerformFromScreen(s => s.Push(new DailyChallenge(room)), [typeof(MainMenu)]);
                 else
                     game?.PerformFromScreen(s => s.Push(new DailyChallengeIntro(room)), [typeof(MainMenu)]);


### PR DESCRIPTION
Added if conditional similar to main menu if conditional to activate DailyChallengeNotification if the user opens the Daily Challenge from the notification. Potentially excessively verbose, however this is future proof in the scenario that the Daily challenge is opened from the menu and then opened again from the notification menu.

resolves #29747