### PR TITLE
Fix selection being dropped when changing carousel sort mode from difficulty sort

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -520,7 +520,6 @@ namespace osu.Game.Tests.Visual.SongSelect
             waitForSelection(set_count);
         }
 
-        [Solo]
         [Test]
         public void TestDifficultiesSplitOutOnLoad()
         {
@@ -1130,6 +1129,32 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // always returns to same selection as long as it's available.
             AddAssert("Selection was remembered", () => eagerSelectedIDs.Count == 1);
+        }
+
+        [Test]
+        public void TestCarouselRetainsSelectionFromDifficultySort()
+        {
+            List<BeatmapSetInfo> manySets = new List<BeatmapSetInfo>();
+
+            AddStep("Populate beatmap sets", () =>
+            {
+                manySets.Clear();
+
+                for (int i = 1; i <= 50; i++)
+                    manySets.Add(TestResources.CreateTestBeatmapSetInfo(diff_count));
+            });
+
+            loadBeatmaps(manySets);
+
+            BeatmapInfo chosenBeatmap = null!;
+            AddStep("select given beatmap", () => carousel.SelectBeatmap(chosenBeatmap = manySets[20].Beatmaps[0]));
+            AddUntilStep("selection changed", () => carousel.SelectedBeatmapInfo, () => Is.EqualTo(chosenBeatmap));
+
+            AddStep("sort by difficulty", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Difficulty }));
+            AddAssert("selection retained", () => carousel.SelectedBeatmapInfo, () => Is.EqualTo(chosenBeatmap));
+
+            AddStep("sort by title", () => carousel.FilterImmediately(new FilterCriteria { Sort = SortMode.Title }));
+            AddAssert("selection retained", () => carousel.SelectedBeatmapInfo, () => Is.EqualTo(chosenBeatmap));
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -143,7 +143,7 @@ namespace osu.Game.Screens.Select
             // We'll catch up on changes via subscriptions anyway.
             BeatmapSetInfo[] loadableSets = detachedBeatmapSets!.ToArray();
 
-            if (selectedBeatmapSet != null && !loadableSets.Contains(selectedBeatmapSet.BeatmapSet))
+            if (selectedBeatmapSet != null && !loadableSets.Contains(selectedBeatmapSet.BeatmapSet, EqualityComparer<BeatmapSetInfo>.Default))
                 selectedBeatmapSet = null;
 
             var selectedBeatmapBefore = selectedBeatmap?.BeatmapInfo;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29738.

This "regressed" in https://github.com/ppy/osu/pull/29639, but if I didn't know better, I'd go as far as saying that this looks like a .NET bug, because the fact that PR broke it looks not sane.

The TL;DR on this is that before the pull in question, the offending `.Contains()` check that this commit modifies was called on a `List<BeatmapSetInfo>`. The pull changed the collection type to `BeatmapSetInfo[]`. That said, the call is a LINQ call, so all good, right?

Not really. First off, the default overload resolution order means that the previous code would call `List<T>.Contains()`, and not `Enumerable.Contains<T>()`. Then again, why would that matter? In both cases `T` is still `BeatmapSetInfo`, right? Well... about that...

It is difficult to tell for sure what precisely is happening here, because of what looks like runtime magic. The end *symptom* is that the old code ended up calling `Array<BeatmapSetInfo>.IndexOf()`, and the new code ends up calling... `Array<object>.IndexOf()`.

So while yes, `BeatmapSetInfo` implements `IEquatable` and the expectation would be that `Equals<BeatmapSetInfo>()` should be getting called, the type elision to `object` means that we're back to reference equality semantics, because that's what `EqualityComparer.Default<object>` is.

A five-minute github search across dotnet/runtime yields [this](https://github.com/dotnet/runtime/blob/c4792a228ea36792b90f87ddf7fce2477e827822/src/coreclr/vm/array.cpp#L984-L990). Now again, if I didn't know better, I'd see that "OPTIMIZATION:" comment, see what transpired in this scenario, and call that optimisation invalid, because it changes semantics. But I *probably* know that the dotnet team knows better and am probably just going to take it for what it is, because blame on that code looks to be years old and it's probably not a new behaviour. (I haven't tested empirically if it is.)

Instead the fix is just to tell the `.Contains()` method to use the correct comparer.