### PR TITLE
Fix restart notifications appearing every 30 minutes in some cases

### DIFF
--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -105,6 +105,7 @@ namespace osu.Desktop.Updater
                 catch (Exception e)
                 {
                     // In the case of an error, a separate notification will be displayed.
+                    scheduleRecheck = true;
                     notification.FailDownload();
                     Logger.Error(e, @"update failed!");
                 }

--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -45,14 +45,17 @@ namespace osu.Desktop.Updater
 
         private async Task<bool> checkForUpdateAsync(UpdateProgressNotification? notification = null)
         {
-            // should we schedule a retry on completion of this check?
-            bool scheduleRecheck = true;
+            // whether to check again in 30 minutes. generally only if there's an error or no update was found (yet).
+            bool scheduleRecheck = false;
 
             try
             {
                 // Avoid any kind of update checking while gameplay is running.
                 if (localUserInfo?.IsPlaying.Value == true)
+                {
+                    scheduleRecheck = true;
                     return false;
+                }
 
                 // TODO: we should probably be checking if there's a more recent update, rather than shortcutting here.
                 // Velopack does support this scenario (see https://github.com/ppy/osu/pull/28743#discussion_r1743495975).
@@ -67,17 +70,20 @@ namespace osu.Desktop.Updater
                             return true;
                         }
                     });
+
                     return true;
                 }
 
                 pendingUpdate = await updateManager.CheckForUpdatesAsync().ConfigureAwait(false);
 
-                // Handle no updates available.
+                // No update is available. We'll check again later.
                 if (pendingUpdate == null)
+                {
+                    scheduleRecheck = true;
                     return false;
+                }
 
-                scheduleRecheck = false;
-
+                // An update is found, let's notify the user and start downloading it.
                 if (notification == null)
                 {
                     notification = new UpdateProgressNotification
@@ -113,7 +119,6 @@ namespace osu.Desktop.Updater
             {
                 if (scheduleRecheck)
                 {
-                    // check again in 30 minutes.
                     Scheduler.AddDelayed(() => Task.Run(async () => await checkForUpdateAsync().ConfigureAwait(false)), 60000 * 30);
                 }
             }


### PR DESCRIPTION
If a user was to manually check for updates via the button, the recheck would have been fired. This is a recent regression.

I kinda want to reorganise this code (the button press for check for udpates shouldn't even get close to the recheck code IMO) but for now this seems like one we should quickly fix.

I've tested normal update flow still works okay. I haven't waited 30 minutes to check this works, but don't see why it wouldn't.

Addresses https://github.com/ppy/osu/discussions/29774.