### PR TITLE
Completely disable Velopack when using an external updater

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -95,11 +95,11 @@ namespace osu.Desktop
                 return key?.OpenSubKey(WindowsAssociationManager.SHELL_OPEN_COMMAND)?.GetValue(string.Empty)?.ToString()?.Split('"')[1].Replace("osu!.exe", "");
         }
 
+        public static bool IsPackageManaged => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_PROVIDER"));
+
         protected override UpdateManager CreateUpdateManager()
         {
-            string? packageManaged = Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_PROVIDER");
-
-            if (!string.IsNullOrEmpty(packageManaged))
+            if (IsPackageManaged)
                 return new NoActionUpdateManager();
 
             return new VelopackUpdateManager();

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -168,6 +168,14 @@ namespace osu.Desktop
 
         private static void setupVelopack()
         {
+            string? packageManaged = Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_PROVIDER");
+
+            if (!string.IsNullOrEmpty(packageManaged))
+            {
+                Logger.Log("Updates are being managed by an external provider. Skipping Velopack setup");
+                return;
+            }
+
             VelopackApp
                 .Build()
                 .WithFirstRun(v =>

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -171,7 +171,7 @@ namespace osu.Desktop
         {
             if (OsuGameDesktop.IsPackageManaged)
             {
-                Logger.Log("Updates are being managed by an external provider. Skipping Velopack setup");
+                Logger.Log("Updates are being managed by an external provider. Skipping Velopack setup.");
                 return;
             }
 

--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -169,9 +169,7 @@ namespace osu.Desktop
 
         private static void setupVelopack()
         {
-            string? packageManaged = Environment.GetEnvironmentVariable("OSU_EXTERNAL_UPDATE_PROVIDER");
-
-            if (!string.IsNullOrEmpty(packageManaged))
+            if (OsuGameDesktop.IsPackageManaged)
             {
                 Logger.Log("Updates are being managed by an external provider. Skipping Velopack setup");
                 return;


### PR DESCRIPTION
This PR will completely disable Velopack if `OSU_EXTERNAL_UPDATE_PROVIDER` is provided. The morale for this PR was caesay's reponse [here](https://github.com/NixOS/nixpkgs/pull/340125#issuecomment-2335713181).

### Testing Checklist
- [x] Test if Velopack gets disabled after passing environment variable
![image](https://github.com/user-attachments/assets/cb30a12c-8daf-4884-80bc-1f5f4b5a5675)
- [x] Test if Velopack gets enabled if the environment variable is not passed
![image](https://github.com/user-attachments/assets/94912aa2-4613-44f9-be4c-6ceec760b17d)
(added a custom logger to notify if setup runs correctly)

Opening as a draft since I haven't tested it yet & have to fix conflicts, but I'll get around to it soon.