### PR TITLE
Fix legacy combo counter sometimes miscount

### DIFF
--- a/osu.Game/Skinning/LegacyComboCounter.cs
+++ b/osu.Game/Skinning/LegacyComboCounter.cs
@@ -136,10 +136,9 @@ namespace osu.Game.Skinning
         /// </summary>
         protected virtual void OnCountIncrement()
         {
-            if (DisplayedCount < Current.Value - 1)
-                DisplayedCount++;
-
-            DisplayedCount++;
+            // Do not assume every OnCountIncrement event is actually an increment because
+            // for some reason this event may be fired multiple times on the same value.
+            DisplayedCount = Current.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #29727.

`LegacyDefaultComboCounter` correctly receives only 1 `OnCountIncrement`, so I'm not sure why `OnCountIncrement` on the base `LegacyComboCounter` sometimes get called 2 or more times for the same combo value (it should only be called once per combo, right?)
