### PR TITLE
End high performance session when showing results screen

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -58,6 +58,11 @@ namespace osu.Game.Screens.Play
 
         public override bool AllowUserExit => false; // handled by HoldForMenuButton
 
+        /// <summary>
+        /// Raised after all gameplay has finished.
+        /// </summary>
+        public event Action OnShowingResults;
+
         protected override bool PlayExitSound => !isRestarting;
 
         protected override UserActivity InitialActivity => new UserActivity.InSoloGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
@@ -873,6 +878,7 @@ namespace osu.Game.Screens.Play
                     // This player instance may already be in the process of exiting.
                     return;
 
+                OnShowingResults?.Invoke();
                 this.Push(CreateResults(prepareScoreForDisplayTask.GetResultSafely()));
             }, Time.Current + delay, 50);
 


### PR DESCRIPTION
I did this in the safest way (not moving the start call) to avoid breaking what we know already works.

Closes https://github.com/ppy/osu/issues/32600.

Before:

https://github.com/user-attachments/assets/169ed093-26b8-40aa-a73a-43a28d867a1c

After:

https://github.com/user-attachments/assets/0ffa3c69-6bec-41ad-879c-221fe395e900


