### PR TITLE
Differentiate lazer in windows menus

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
     <AssemblyName>osu!</AssemblyName>
-    <AssemblyTitle>osu!lazer</AssemblyTitle>
+    <AssemblyTitle>osu!(lazer)</AssemblyTitle>
     <Title>osu!</Title>
     <Product>osu!(lazer)</Product>
     <ApplicationIcon>lazer.ico</ApplicationIcon>

--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>A free-to-win rhythm game. Rhythm is just a *click* away!</Description>
     <AssemblyName>osu!</AssemblyName>
+    <AssemblyTitle>osu!lazer</AssemblyTitle>
     <Title>osu!</Title>
     <Product>osu!(lazer)</Product>
     <ApplicationIcon>lazer.ico</ApplicationIcon>


### PR DESCRIPTION
Windows has a really unorthodox way of generating human readable names for exe's. To put it simply, it reads the `Description` attribute of the .exe file. This also is not documented anywhere except for a really [obscure reference](https://arc.net/l/quote/hzlimqce).

Lazer, prior to this PR, would default to setting the `Description` of the exe to "osu!". This PR changes it so that the exe's `Description` is osu!lazer. This helps to differentiate between osu!lazer and osu!stable, because nobody wants to deal with this
![image](https://github.com/user-attachments/assets/17a3fbef-85bb-45be-b923-0d9d9d8ef905)

Here's how it'll look with this PR
![CleanShot 2024-09-09 at 12 47 33@2x](https://github.com/user-attachments/assets/ee07b867-2415-4f01-bc8e-d2cf90922e5c)

*Tested and confirmed to work on Windows 11 23h2*