### PR TITLE
Fix several issues in interactions between playfield-altering mods and the replay analysis feature

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -46,6 +46,7 @@ namespace osu.Game.Rulesets.Osu.UI
             {
                 ReplayAnalysisOverlay analysisOverlay;
                 PlayfieldAdjustmentContainer.Add(analysisOverlay = new ReplayAnalysisOverlay(replayPlayer.Score.Replay));
+                Overlays.Add(analysisOverlay.CreateProxy().With(p => p.Depth = float.NegativeInfinity));
                 replayPlayer.AddSettings(new ReplayAnalysisSettings(Config));
 
                 cursorHideEnabled = Config.GetBindable<bool>(OsuRulesetSetting.ReplayCursorHideEnabled);

--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Rulesets.Osu.UI
         {
             if (replayPlayer != null)
             {
-                PlayfieldAdjustmentContainer.Add(new ReplayAnalysisOverlay(replayPlayer.Score.Replay));
+                ReplayAnalysisOverlay analysisOverlay;
+                PlayfieldAdjustmentContainer.Add(analysisOverlay = new ReplayAnalysisOverlay(replayPlayer.Score.Replay));
                 replayPlayer.AddSettings(new ReplayAnalysisSettings(Config));
 
                 cursorHideEnabled = Config.GetBindable<bool>(OsuRulesetSetting.ReplayCursorHideEnabled);

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -40,9 +40,11 @@ namespace osu.Game.Rulesets.Mods
 
         public override string SettingDescription => $"{SpinSpeed.Value:N2} rpm {Direction.Value.GetDescription().ToLowerInvariant()}";
 
+        private PlayfieldAdjustmentContainer playfieldAdjustmentContainer = null!;
+
         public void Update(Playfield playfield)
         {
-            playfield.Rotation = CurrentRotation = (Direction.Value == RotationDirection.Counterclockwise ? -1 : 1) * 360 * (float)(playfield.Time.Current / 60000 * SpinSpeed.Value);
+            playfieldAdjustmentContainer.Rotation = CurrentRotation = (Direction.Value == RotationDirection.Counterclockwise ? -1 : 1) * 360 * (float)(playfield.Time.Current / 60000 * SpinSpeed.Value);
         }
 
         public void ApplyToDrawableRuleset(DrawableRuleset<TObject> drawableRuleset)
@@ -52,7 +54,9 @@ namespace osu.Game.Rulesets.Mods
             var playfieldSize = drawableRuleset.Playfield.DrawSize;
             float minSide = MathF.Min(playfieldSize.X, playfieldSize.Y);
             float maxSide = MathF.Max(playfieldSize.X, playfieldSize.Y);
-            drawableRuleset.Playfield.Scale = new Vector2(minSide / maxSide);
+
+            playfieldAdjustmentContainer = drawableRuleset.PlayfieldAdjustmentContainer;
+            playfieldAdjustmentContainer.Scale = new Vector2(minSide / maxSide);
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -83,8 +83,6 @@ namespace osu.Game.Rulesets.Mods
 
             flashlight.RelativeSizeAxes = Axes.Both;
             flashlight.Colour = Color4.Black;
-            // Flashlight mods should always draw above any other mod adding overlays.
-            flashlight.Depth = float.MinValue;
 
             flashlight.Combo.BindTo(Combo);
             flashlight.GetPlayfieldScale = () => drawableRuleset.Playfield.Scale;
@@ -95,6 +93,9 @@ namespace osu.Game.Rulesets.Mods
                 // workaround for 1px gaps on the edges of the playfield which would sometimes show with "gameplay" screen scaling active.
                 Padding = new MarginPadding(-1),
                 Child = flashlight,
+                // Flashlight mods should always draw above any other mod adding overlays.
+                // NegativeInfinity is not used to allow one more thing drawn on top (used in replay analysis overlay in osu!).
+                Depth = float.MinValue,
             });
         }
 


### PR DESCRIPTION
- Would close https://github.com/ppy/osu/issues/29839
- Would close https://github.com/ppy/osu/issues/29748

Treat this as an RFC though because I'm not really all that happy with the code.

| mods | master | this PR |
| :-: | :-: | :-: |
| FL | ![osu_2024-09-11_15-56-22](https://github.com/user-attachments/assets/607b42dc-ac57-4e9e-9399-e96e3e239f73) | ![osu_2024-09-11_16-10-14](https://github.com/user-attachments/assets/0dc81332-da5c-43ab-b583-86504e8fd251) |
| BL | ![osu_2024-09-11_15-56-52](https://github.com/user-attachments/assets/b3f107e8-06ac-4655-bb3c-78e9b3daea88) | ![osu_2024-09-11_16-10-32](https://github.com/user-attachments/assets/5b21bf7d-30fe-4d5b-89db-dcb2a811be59) |
| BU | ![osu_2024-09-11_15-57-12](https://github.com/user-attachments/assets/2cc8e404-e327-4ac6-852b-ebd7243400bc) | ![osu_2024-09-11_16-10-49](https://github.com/user-attachments/assets/64ff9652-ff7b-42b4-9ceb-944a22ebb2a7) |
| BU, FL | ![osu_2024-09-11_16-01-04](https://github.com/user-attachments/assets/7816303a-399c-47f9-bcb0-4217ed35a908) | ![osu_2024-09-11_16-11-05](https://github.com/user-attachments/assets/007c9604-17a2-4ac2-bc6a-b5edd828f3ca) |
| BR | ![osu_2024-09-11_16-03-45](https://github.com/user-attachments/assets/41df4f88-5b9a-448f-b62d-a74e8bbabf63) | ![osu_2024-09-11_16-11-26](https://github.com/user-attachments/assets/5606d839-fe2a-4c83-9ba6-563102e029ff) |

Of note:

- https://github.com/ppy/osu/commit/b78ef81bf1e5e4be82dac4302936d842f9d9bb6f fixes a regression of visuals when Bubbles and Flashlight are both active (inadvertently caused by yours truly)
- https://github.com/ppy/osu/commit/4a39873e2aac3a6fa71a3be06407d9afb7df8922 causes the playfield to shift slightly but I'm not sure how to avoid it. It's probably for the better anyhow since it appears it brings more of the playfield onto the screen?