### PR TITLE
 Only allow seek to next/previous object via keybinding if there is no selection

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets;
@@ -78,7 +79,7 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestNudgeSelection()
+        public void TestNudgeSelectionTime()
         {
             HitCircle[] addedObjects = null!;
 
@@ -97,6 +98,51 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("nudge backwards", () => InputManager.Key(Key.J));
             AddAssert("objects reverted to original position", () => addedObjects[0].StartTime == 100);
+        }
+
+        [Test]
+        public void TestNudgeSelectionPosition()
+        {
+            HitCircle addedObject = null!;
+
+            AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[]
+            {
+                addedObject = new HitCircle { StartTime = 200, Position = new Vector2(100) },
+            }));
+
+            AddStep("select object", () => EditorBeatmap.SelectedHitObjects.Add(addedObject));
+
+            AddStep("nudge up", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Up);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("object position moved up", () => addedObject.Position.Y, () => Is.EqualTo(99).Within(Precision.FLOAT_EPSILON));
+
+            AddStep("nudge down", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Down);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("object position moved down", () => addedObject.Position.Y, () => Is.EqualTo(100).Within(Precision.FLOAT_EPSILON));
+
+            AddStep("nudge left", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Left);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("object position moved left", () => addedObject.Position.X, () => Is.EqualTo(99).Within(Precision.FLOAT_EPSILON));
+
+            AddStep("nudge right", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Key(Key.Right);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("object position moved right", () => addedObject.Position.X, () => Is.EqualTo(100).Within(Precision.FLOAT_EPSILON));
         }
 
         [Test]

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -721,10 +721,16 @@ namespace osu.Game.Screens.Edit
             switch (e.Action)
             {
                 case GlobalAction.EditorSeekToPreviousHitObject:
+                    if (editorBeatmap.SelectedHitObjects.Any())
+                        return false;
+
                     seekHitObject(-1);
                     return true;
 
                 case GlobalAction.EditorSeekToNextHitObject:
+                    if (editorBeatmap.SelectedHitObjects.Any())
+                        return false;
+
                     seekHitObject(1);
                     return true;
 


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/29803. cc/ @OliBomby.

Passes tests so hopefully fine. Our code is notoriously ungreppable for this sort of thing. Additionally features extended test coverage for both clashing features which was not there.