### PR TITLE
Fix osu!catch fruit rotation being applied too late

### DIFF
--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -44,10 +44,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         private float startAngle;
         private float endAngle;
 
-        protected override void OnApply()
+        protected override void UpdateInitialTransforms()
         {
-            base.OnApply();
+            base.UpdateInitialTransforms();
 
+            // Important to have this in UpdateInitialTransforms() to it is re-triggered by RefreshStateTransforms().
             const float end_scale = 0.6f;
             const float random_scale_range = 1.6f;
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -64,7 +64,12 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             base.Update();
 
-            double preemptProgress = Math.Min(1, (Time.Current - (HitObject.StartTime - InitialLifetimeOffset)) / HitObject.TimePreempt);
+            double preemptProgress = (Time.Current - (HitObject.StartTime - InitialLifetimeOffset)) / HitObject.TimePreempt;
+
+            // Clamp scale and rotation at the point of bananas being caught, else let them freely extrapolate.
+            if (Result.IsHit)
+                preemptProgress = Math.Min(1, preemptProgress);
+
             ScalingContainer.Scale = new Vector2(HitObject.Scale * (float)Interpolation.Lerp(startScale, endScale, preemptProgress));
             ScalingContainer.Rotation = (float)Interpolation.Lerp(startAngle, endAngle, preemptProgress);
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableBanana.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Skinning.Default;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Catch.Objects.Drawables
 {
@@ -36,21 +38,35 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
             StartTimeBindable.BindValueChanged(_ => UpdateComboColour());
         }
 
-        protected override void UpdateInitialTransforms()
+        private float startScale;
+        private float endScale;
+
+        private float startAngle;
+        private float endAngle;
+
+        protected override void OnApply()
         {
-            base.UpdateInitialTransforms();
+            base.OnApply();
 
             const float end_scale = 0.6f;
             const float random_scale_range = 1.6f;
 
-            ScalingContainer.ScaleTo(HitObject.Scale * (end_scale + random_scale_range * RandomSingle(3)))
-                            .Then().ScaleTo(HitObject.Scale * end_scale, HitObject.TimePreempt);
+            startScale = end_scale + random_scale_range * RandomSingle(3);
+            endScale = end_scale;
 
-            ScalingContainer.RotateTo(getRandomAngle(1))
-                            .Then()
-                            .RotateTo(getRandomAngle(2), HitObject.TimePreempt);
+            startAngle = getRandomAngle(1);
+            endAngle = getRandomAngle(2);
 
             float getRandomAngle(int series) => 180 * (RandomSingle(series) * 2 - 1);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            double preemptProgress = Math.Min(1, (Time.Current - (HitObject.StartTime - InitialLifetimeOffset)) / HitObject.TimePreempt);
+            ScalingContainer.Scale = new Vector2(HitObject.Scale * (float)Interpolation.Lerp(startScale, endScale, preemptProgress));
+            ScalingContainer.Rotation = (float)Interpolation.Lerp(startAngle, endAngle, preemptProgress);
         }
 
         public override void PlaySamples()

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -30,11 +30,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
 
         private float startRotation;
 
-        protected override void OnApply()
+        protected override void UpdateInitialTransforms()
         {
-            base.OnApply();
+            base.UpdateInitialTransforms();
 
-            // roughly matches osu-stable
+            // Important to have this in UpdateInitialTransforms() to it is re-triggered by RefreshStateTransforms().
             startRotation = RandomSingle(1) * 20;
         }
 

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Skinning.Default;
 using osu.Game.Skinning;
 
@@ -28,15 +28,22 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 _ => new DropletPiece());
         }
 
-        protected override void UpdateInitialTransforms()
+        private float startRotation;
+
+        protected override void OnApply()
         {
-            base.UpdateInitialTransforms();
+            base.OnApply();
 
             // roughly matches osu-stable
-            float startRotation = RandomSingle(1) * 20;
-            double duration = HitObject.TimePreempt + 2000;
+            startRotation = RandomSingle(1) * 20;
+        }
 
-            ScalingContainer.RotateTo(startRotation).RotateTo(startRotation + 720, duration);
+        protected override void Update()
+        {
+            base.Update();
+
+            double preemptProgress = (Time.Current - (HitObject.StartTime - InitialLifetimeOffset)) / (HitObject.TimePreempt + 2000);
+            ScalingContainer.Rotation = (float)Interpolation.Lerp(startRotation, startRotation + 720, preemptProgress);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableDroplet.cs
@@ -42,6 +42,8 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
         {
             base.Update();
 
+            // No clamping for droplets. They should be considered indefinitely spinning regardless of time.
+            // They also never end up on the plate, so they shouldn't stop spinning when caught.
             double preemptProgress = (Time.Current - (HitObject.StartTime - InitialLifetimeOffset)) / (HitObject.TimePreempt + 2000);
             ScalingContainer.Rotation = (float)Interpolation.Lerp(startRotation, startRotation + 720, preemptProgress);
         }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -27,9 +27,11 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 _ => new FruitPiece());
         }
 
-        protected override void OnApply()
+        protected override void UpdateInitialTransforms()
         {
-            base.OnApply();
+            base.UpdateInitialTransforms();
+
+            // Important to have this in UpdateInitialTransforms() to it is re-triggered by RefreshStateTransforms().
             ScalingContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
         }
     }

--- a/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
+++ b/osu.Game.Rulesets.Catch/Objects/Drawables/DrawableFruit.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Skinning.Default;
 using osu.Game.Skinning;
 
@@ -28,11 +27,10 @@ namespace osu.Game.Rulesets.Catch.Objects.Drawables
                 _ => new FruitPiece());
         }
 
-        protected override void UpdateInitialTransforms()
+        protected override void OnApply()
         {
-            base.UpdateInitialTransforms();
-
-            ScalingContainer.RotateTo((RandomSingle(1) - 0.5f) * 40);
+            base.OnApply();
+            ScalingContainer.Rotation = (RandomSingle(1) - 0.5f) * 40;
         }
     }
 }


### PR DESCRIPTION
In passing

https://github.com/user-attachments/assets/6fe12440-4834-4417-b02c-b39a71455da5

https://github.com/user-attachments/assets/83de94ec-b3cb-443b-a30a-4c7d669ab788

I still think we should do more hitobject animations using this style. Really gets rid of the mental overhead of transform / rewind gymnastics.
