### PR TITLE
Ensure selection is preserved when moving selection between columns

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaSelectionHandler.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mania.Objects;
+using osu.Game.Rulesets.Mania.UI;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual;
@@ -91,6 +92,31 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddAssert("first object flipped", () => first.StartTime, () => Is.EqualTo(2250));
             AddAssert("second object flipped", () => second.StartTime, () => Is.EqualTo(250));
             AddAssert("third object flipped", () => third.StartTime, () => Is.EqualTo(1250));
+        }
+
+        [Test]
+        public void TestOffScreenObjectsRemainSelectedOnColumnChange()
+        {
+            AddStep("create objects", () =>
+            {
+                for (int i = 0; i < 20; ++i)
+                    EditorBeatmap.Add(new Note { StartTime = 1000 * i, Column = 0 });
+            });
+
+            AddStep("select everything", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            AddStep("start drag", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<Column>().First());
+                InputManager.PressButton(MouseButton.Left);
+            });
+            AddStep("end drag", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<Column>().Last());
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+
+            AddAssert("all objects in last column", () => EditorBeatmap.HitObjects.All(ho => ((ManiaHitObject)ho).Column == 3));
+            AddAssert("all objects remain selected", () => EditorBeatmap.SelectedHitObjects.SequenceEqual(EditorBeatmap.HitObjects));
         }
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaSelectionHandler.cs
@@ -104,8 +104,10 @@ namespace osu.Game.Rulesets.Mania.Edit
             int minColumn = int.MaxValue;
             int maxColumn = int.MinValue;
 
+            var selectedObjects = EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>().ToArray();
+
             // find min/max in an initial pass before actually performing the movement.
-            foreach (var obj in EditorBeatmap.SelectedHitObjects.OfType<ManiaHitObject>())
+            foreach (var obj in selectedObjects)
             {
                 if (obj.Column < minColumn)
                     minColumn = obj.Column;
@@ -121,6 +123,13 @@ namespace osu.Game.Rulesets.Mania.Edit
                 ((ManiaHitObject)h).Column += columnDelta;
                 maniaPlayfield.Add(h);
             });
+
+            // `HitObjectUsageEventBuffer`'s usage transferal flows and the playfield's `SetKeepAlive()` functionality do not combine well with this operation's usage pattern,
+            // leading to selections being sometimes partially dropped if some of the objects being moved are off screen
+            // (check blame for detailed explanation).
+            // thus, ensure that selection is preserved manually.
+            EditorBeatmap.SelectedHitObjects.Clear();
+            EditorBeatmap.SelectedHitObjects.AddRange(selectedObjects);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29793.

I believe that the sequence of events that makes this happens is as follows:

- User selects a range of objects. Some of those objects are off-screen, and thus would be presumed to be not alive - except the blueprint container forces them to remain alive, because they're part of the selection.

- User moves the selection to another column, which is implemented by temporarily removing the objects from the playfield, changing their column, and re-adding them.

  This sort of pattern is supposed to kick off the `HitObjectUsageTransferred` flow in `HitObjectUsageEventBuffer` - and it does... for objects that are *currently visible on screen* and thus would be alive regardless of `SetKeepAlive()`. However, this does not hold for objects that are off-screen - nothing ensures they are kept alive again after re-adding, and thus they inadvertently become dead.

- Thus, this doesn't kick off the `BlueprintContainer` flows associated with transferring objects to another column, and instead fires the removal flows, which ensure that the off-screen objects that were being moved are instead deselected.

I tried a few other options but found no better resolution than this - calling `SetKeepAlive()` directly would require making it public, which seems like a bad idea. There's really no good way to generically handle this either, because it is the ruleset that decides that its way of implementing this operation will be a removal and re-add of objects, so...