### PR TITLE
Implement sheared text box with filter count and use in multi/playlists lounge

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
@@ -23,6 +24,7 @@ namespace osu.Game.Tests.Visual.Playlists
         protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
 
         private TestLoungeSubScreen loungeScreen;
+        private IDisposable loadingOperation;
 
         public override void SetUpSteps()
         {
@@ -104,6 +106,16 @@ namespace osu.Game.Tests.Visual.Playlists
             AddStep("search for room 1", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().Current.Value = "room 1");
 
             AddUntilStep("filter text is 1 match", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().FilterText.ToString(), () => Is.EqualTo("1 match"));
+
+            AddStep("begin loading operation", () => loadingOperation = OngoingOperationTracker.BeginOperation());
+
+            AddAssert("filter text is loading...", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().FilterText.ToString(), () => Is.EqualTo("loading..."));
+
+            AddStep("finish loading operation", () =>
+            {
+                loadingOperation?.Dispose();
+                loadingOperation = null;
+            });
         }
 
         private bool checkRoomVisible(DrawableRoom room) =>

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsLoungeSubScreen.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.OnlinePlay.Playlists;
@@ -89,6 +90,20 @@ namespace osu.Game.Tests.Visual.Playlists
 
             AddAssert("selected room is non-null", () => loungeScreen.SelectedRoom.Value != null);
             AddAssert("selected room is disabled", () => loungeScreen.SelectedRoom.Disabled);
+        }
+
+        [Test]
+        public void TestFilterTextCount()
+        {
+            AddAssert("filter text is 0 matches", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().FilterText.ToString(), () => Is.EqualTo("0 matches"));
+
+            AddStep("add 10 rooms", () => RoomManager.AddRooms(10));
+
+            AddAssert("filter text is 10 matches", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().FilterText.ToString(), () => Is.EqualTo("10 matches"));
+
+            AddStep("search for room 1", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().Current.Value = "room 1");
+
+            AddUntilStep("filter text is 1 match", () => this.ChildrenOfType<ShearedFilterTextBox>().Single().FilterText.ToString(), () => Is.EqualTo("1 match"));
         }
 
         private bool checkRoomVisible(DrawableRoom room) =>

--- a/osu.Game/Graphics/UserInterface/ShearedFilterTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedFilterTextBox.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Graphics.UserInterface
+{
+    public partial class ShearedFilterTextBox : ShearedSearchTextBox
+    {
+        private const float filter_text_size = 12;
+
+        public LocalisableString FilterText
+        {
+            get => ((InnerFilterTextBox)TextBox).FilterText.Text;
+            set => ((InnerFilterTextBox)TextBox).FilterText.Text = value;
+        }
+
+        public ShearedFilterTextBox()
+        {
+            Height += filter_text_size;
+        }
+
+        protected override InnerSearchTextBox CreateInnerTextBox() => new InnerFilterTextBox();
+
+        protected partial class InnerFilterTextBox : InnerSearchTextBox
+        {
+            public OsuSpriteText FilterText { get; private set; } = null!;
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                TextContainer.Add(FilterText = new OsuSpriteText
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.TopLeft,
+                    Font = OsuFont.Default.With(size: filter_text_size, weight: FontWeight.SemiBold),
+                    Margin = new MarginPadding { Top = 2, Left = 2 },
+                    Colour = colours.Yellow
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                TextContainer.Height *= (DrawHeight - filter_text_size) / DrawHeight;
+                TextContainer.Margin = new MarginPadding { Bottom = filter_text_size };
+            }
+        }
+    }
+}

--- a/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/ShearedSearchTextBox.cs
@@ -21,33 +21,33 @@ namespace osu.Game.Graphics.UserInterface
         private const float corner_radius = 7;
 
         private readonly Box background;
-        private readonly SearchTextBox textBox;
+        protected readonly InnerSearchTextBox TextBox;
 
         public Bindable<string> Current
         {
-            get => textBox.Current;
-            set => textBox.Current = value;
+            get => TextBox.Current;
+            set => TextBox.Current = value;
         }
 
         public bool HoldFocus
         {
-            get => textBox.HoldFocus;
-            set => textBox.HoldFocus = value;
+            get => TextBox.HoldFocus;
+            set => TextBox.HoldFocus = value;
         }
 
         public LocalisableString PlaceholderText
         {
-            get => textBox.PlaceholderText;
-            set => textBox.PlaceholderText = value;
+            get => TextBox.PlaceholderText;
+            set => TextBox.PlaceholderText = value;
         }
 
-        public new bool HasFocus => textBox.HasFocus;
+        public new bool HasFocus => TextBox.HasFocus;
 
-        public void TakeFocus() => textBox.TakeFocus();
+        public void TakeFocus() => TextBox.TakeFocus();
 
-        public void KillFocus() => textBox.KillFocus();
+        public void KillFocus() => TextBox.KillFocus();
 
-        public bool SelectAll() => textBox.SelectAll();
+        public bool SelectAll() => TextBox.SelectAll();
 
         public ShearedSearchTextBox()
         {
@@ -69,13 +69,7 @@ namespace osu.Game.Graphics.UserInterface
                     {
                         new Drawable[]
                         {
-                            textBox = new InnerSearchTextBox
-                            {
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                RelativeSizeAxes = Axes.Both,
-                                Size = Vector2.One
-                            },
+                            TextBox = CreateInnerTextBox(),
                             new SpriteIcon
                             {
                                 Icon = FontAwesome.Solid.Search,
@@ -101,10 +95,20 @@ namespace osu.Game.Graphics.UserInterface
             background.Colour = colourProvider.Background3;
         }
 
-        public override bool HandleNonPositionalInput => textBox.HandleNonPositionalInput;
+        public override bool HandleNonPositionalInput => TextBox.HandleNonPositionalInput;
 
-        private partial class InnerSearchTextBox : SearchTextBox
+        protected virtual InnerSearchTextBox CreateInnerTextBox() => new InnerSearchTextBox();
+
+        protected partial class InnerSearchTextBox : SearchTextBox
         {
+            public InnerSearchTextBox()
+            {
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+                RelativeSizeAxes = Axes.Both;
+                Size = Vector2.One;
+            }
+
             [BackgroundDependencyLoader]
             private void load(OverlayColourProvider colourProvider)
             {

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomsContainer.cs
@@ -29,6 +29,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         public IReadOnlyList<DrawableRoom> Rooms => roomFlow.FlowingChildren.Cast<DrawableRoom>().ToArray();
 
+        public Bindable<int> VisibleRoomCount = new Bindable<int>();
+
         private readonly IBindableList<Room> rooms = new BindableList<Room>();
         private readonly FillFlowContainer<DrawableLoungeRoom> roomFlow;
 
@@ -93,6 +95,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                     r.MatchingFilter = matchingFilter;
                 }
             });
+
+            VisibleRoomCount.Value = roomFlow.Count(r => r.MatchingFilter);
 
             static bool matchPermissions(DrawableLoungeRoom room, RoomPermissionsFilter accessType)
             {


### PR DESCRIPTION
To be used in song select redesign also, but demonstrating it in playlists/multi as that has the newer `OverlayColourProvider`/sheared design, and may look out of place in current song select design:

<img width="1673" alt="Screenshot 2024-09-17 at 8 16 24 PM" src="https://github.com/user-attachments/assets/e507a6d6-5dd7-434e-b736-a3fdbf67befa">

Unsure about the code. Made a separate `ShearedFilterTextBox` instead of incorporating it into the base as there may be cases where the filter count doesn't make sense. Like maybe `ModSelectOverlay` unless it makes sense to add the count there too.