### PR TITLE
Remove opacity from old style dropdown menus

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuDropdown.cs
+++ b/osu.Game/Graphics/UserInterface/OsuDropdown.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Graphics.UserInterface
             [BackgroundDependencyLoader(true)]
             private void load(OverlayColourProvider? colourProvider, OsuColour colours, AudioManager audio)
             {
-                BackgroundColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
+                BackgroundColour = colourProvider?.Background5 ?? Color4.Black;
                 HoverColour = colourProvider?.Light4 ?? colours.PinkDarker;
                 SelectionColour = colourProvider?.Background3 ?? colours.PinkDarker.Opacity(0.5f);
 
@@ -397,7 +397,7 @@ namespace osu.Game.Graphics.UserInterface
             {
                 bool hovered = Enabled.Value && IsHovered;
                 var hoveredColour = colourProvider?.Light4 ?? colours.PinkDarker;
-                var unhoveredColour = colourProvider?.Background5 ?? Color4.Black.Opacity(0.5f);
+                var unhoveredColour = colourProvider?.Background5 ?? Color4.Black;
 
                 Colour = Color4.White;
                 Alpha = Enabled.Value ? 1 : 0.3f;


### PR DESCRIPTION
These aren't used in many places, but we've since moved away from opacity in UI elements like this, so let's just nuke it here for legibility.

Addresses https://github.com/ppy/osu/discussions/29906.

| Before | After |
| :---: | :---: |
| ![osu! 2024-09-18 at 04 51 43](https://github.com/user-attachments/assets/03646c0e-18e1-4e98-9b42-45d9ee5a76c6) | ![osu! 2024-09-18 at 04 51 21](https://github.com/user-attachments/assets/42002042-043a-468e-850e-4344c8d7ffc1) |