### PR TITLE
Fix occasional song select crash when entering gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -145,6 +145,22 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestEnterGameplayWhileFilteringToNoSelection()
+        {
+            TestPlaySongSelect songSelect = null;
+
+            PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+
+            AddStep("force selection", () =>
+            {
+                songSelect.FinaliseSelection();
+                songSelect.FilterControl.CurrentTextSearch.Value = "test";
+            });
+        }
+
+        [Test]
         public void TestSongSelectBackActionHandling()
         {
             TestPlaySongSelect songSelect = null;

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -150,6 +150,7 @@ namespace osu.Game.Tests.Visual.Navigation
             TestPlaySongSelect songSelect = null;
 
             PushAndConfirm(() => songSelect = new TestPlaySongSelect());
+            AddUntilStep("wait for song select", () => songSelect.BeatmapSetsLoaded);
             AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
             AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
 
@@ -158,6 +159,11 @@ namespace osu.Game.Tests.Visual.Navigation
                 songSelect.FinaliseSelection();
                 songSelect.FilterControl.CurrentTextSearch.Value = "test";
             });
+
+            AddUntilStep("wait for player", () => !songSelect.IsCurrentScreen());
+            AddStep("return to song select", () => songSelect.MakeCurrent());
+
+            AddUntilStep("wait for selection lost", () => songSelect.Beatmap.IsDefault);
         }
 
         [Test]

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -706,7 +706,7 @@ namespace osu.Game.Screens.Select
 
         private bool beatmapsSplitOut;
 
-        private void applyActiveCriteria(bool debounce, bool alwaysResetScrollPosition = true)
+        private void applyActiveCriteria(bool debounce)
         {
             PendingFilter?.Cancel();
             PendingFilter = null;
@@ -735,8 +735,7 @@ namespace osu.Game.Screens.Select
                 root.Filter(activeCriteria);
                 itemsCache.Invalidate();
 
-                if (alwaysResetScrollPosition || !Scroll.UserScrolling)
-                    ScrollToSelected(true);
+                ScrollToSelected(true);
 
                 FilterApplied?.Invoke();
             }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1036,7 +1036,7 @@ namespace osu.Game.Screens.Select
             itemsCache.Validate();
 
             // update and let external consumers know about selection loss.
-            if (BeatmapSetsLoaded)
+            if (BeatmapSetsLoaded && AllowSelection)
             {
                 bool selectionLost = selectedBeatmapSet != null && selectedBeatmapSet.State.Value != CarouselItemState.Selected;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/21120

This fix is two-part – the fix for the crash is a single liner (c192a6a1d54b69936c6e741e49c7b0524c0a2c8e), but this reveals that on returning to song select, there's a chance the active selection is not correctly cleared if the selected beatmap was filtered.

To make this work, I had to add a makeshift flag in `SongSelect`. I considered refactoring `BeatmapCarousel`'s filter application flow to fix this, but it felt like I would be going down a rabbit hole and spending multiple days on it. Would rather approach with a rewrite later on.

Main goal here is just to fix a crash that seemingly quite a few people are hitting.