### PR TITLE
Implement beat-synchronized animation in skip overlay

### DIFF
--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -218,7 +218,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             float progress = (float)(gameplayClock.CurrentTime - displayTime) / (float)(fadeOutBeginTime - displayTime);
-            float newWidth = Math.Max(0, 1 - Math.Clamp(progress, 0, 1));
+            float newWidth = 1 - Math.Clamp(progress, 0, 1);
             remainingTimeBox.ResizeWidthTo(newWidth, timingPoint.BeatLength * 2, Easing.OutQuint);
         }
 

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -9,6 +9,7 @@ using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -16,6 +17,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -26,7 +28,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
 {
-    public partial class SkipOverlay : CompositeDrawable, IKeyBindingHandler<GlobalAction>
+    public partial class SkipOverlay : BeatSyncedContainer, IKeyBindingHandler<GlobalAction>
     {
         /// <summary>
         /// The total number of successful skips performed by this overlay.
@@ -36,10 +38,9 @@ namespace osu.Game.Screens.Play
         private readonly double startTime;
 
         public Action RequestSkip;
-
         private Button button;
         private ButtonContainer buttonContainer;
-        private Box remainingTimeBox;
+        private Circle remainingTimeBox;
 
         private FadeContainer fadeContainer;
         private double displayTime;
@@ -51,7 +52,6 @@ namespace osu.Game.Screens.Play
         private IGameplayClock gameplayClock { get; set; }
 
         internal bool IsButtonVisible => fadeContainer.State == Visibility.Visible && buttonContainer.State.Value == Visibility.Visible;
-
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
         /// <summary>
@@ -87,13 +87,13 @@ namespace osu.Game.Screens.Play
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
-                        remainingTimeBox = new Box
+                        remainingTimeBox = new Circle
                         {
                             Height = 5,
-                            RelativeSizeAxes = Axes.X,
-                            Colour = colours.Yellow,
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.BottomCentre,
+                            Colour = colours.Yellow,
+                            RelativeSizeAxes = Axes.X
                         }
                     }
                 }
@@ -208,6 +208,18 @@ namespace osu.Game.Screens.Play
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
+        }
+
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
+        {
+            base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+
+            if (fadeOutBeginTime <= gameplayClock.CurrentTime)
+                return;
+
+            float progress = (float)(gameplayClock.CurrentTime - displayTime) / (float)(fadeOutBeginTime - displayTime);
+            float newWidth = Math.Max(0, 1 - Math.Clamp(progress, 0, 1));
+            remainingTimeBox.ResizeWidthTo(newWidth, timingPoint.BeatLength * 2, Easing.OutQuint);
         }
 
         public partial class FadeContainer : Container, IStateful<Visibility>


### PR DESCRIPTION
I think the new beat-synced animation in the break overlay is really cool, so I implemented pretty much the same approach in the skip overlay.
I also rounded the corners by replacing the box with a circle.

Let me know what you think.

https://github.com/user-attachments/assets/87968642-6f15-4e30-a835-3ebd6c2d0d51

