### PR TITLE
Allow decimal degrees angle in rotation popover

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     angleInput = new SliderWithTextBoxInput<float>("Angle (degrees):")
                     {
-                        Current = new BindableNumber<float>
+                        SliderCurrent = new BindableNumber<float>
                         {
                             MinValue = -360,
                             MaxValue = 360,

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -45,9 +45,12 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     angleInput = new SliderWithTextBoxInput<float>("Angle (degrees):")
                     {
+                        Current = new BindableNumber<float>
+                        {
+                            MinValue = -360,
+                            MaxValue = 360,
+                        },
                         SliderPrecision = 1,
-                        SliderMinValue = -360,
-                        SliderMaxValue = 360,
                         Instantaneous = true
                     },
                     rotationOrigin = new EditorRadioButtonCollection

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -45,12 +45,9 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     angleInput = new SliderWithTextBoxInput<float>("Angle (degrees):")
                     {
-                        SliderCurrent = new BindableNumber<float>
-                        {
-                            MinValue = -360,
-                            MaxValue = 360,
-                            Precision = 1
-                        },
+                        SliderPrecision = 1,
+                        SliderMinValue = -360,
+                        SliderMaxValue = 360,
                         Instantaneous = true
                     },
                     rotationOrigin = new EditorRadioButtonCollection

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -131,12 +131,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [Test]
         public void TestMultiPrecision()
         {
-            AddStep("set slider precision to 1", () => sliderWithTextBoxInput.SliderCurrent = new BindableNumber<float>
-            {
-                MinValue = -5,
-                MaxValue = 5,
-                Precision = 1f
-            });
+            AddStep("set slider precision to 1", () => sliderWithTextBoxInput.SliderPrecision = 1f);
 
             AddStep("focus textbox", () => ((IFocusManager)InputManager).ChangeFocus(textBox));
             AddStep("change text", () => textBox.Text = "3.4");

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -145,13 +145,13 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("commit text", () => InputManager.Key(Key.Enter));
             AddAssert("slider moved", () => slider.Current.Value, () => Is.EqualTo(3));
-            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3.4));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3.4).Within(0.01));
 
             AddStep("move mouse to nub", () => InputManager.MoveMouseTo(nub));
             AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
             AddStep("move mouse to minimum", () => InputManager.MoveMouseTo(sliderWithTextBoxInput.ScreenSpaceDrawQuad.BottomLeft));
-            AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("3"));
-            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+            AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("3.4"));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3.4).Within(0.01));
 
             AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
             AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSliderWithTextBoxInput.cs
@@ -127,5 +127,43 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("slider not moved", () => slider.Current.Value, () => Is.EqualTo(-5));
             AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
         }
+
+        [Test]
+        public void TestMultiPrecision()
+        {
+            AddStep("set slider precision to 1", () => sliderWithTextBoxInput.SliderCurrent = new BindableNumber<float>
+            {
+                MinValue = -5,
+                MaxValue = 5,
+                Precision = 1f
+            });
+
+            AddStep("focus textbox", () => ((IFocusManager)InputManager).ChangeFocus(textBox));
+            AddStep("change text", () => textBox.Text = "3.4");
+            AddAssert("slider not moved", () => slider.Current.Value, () => Is.Zero);
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.Zero);
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("slider moved", () => slider.Current.Value, () => Is.EqualTo(3));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3.4));
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(nub));
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move mouse to minimum", () => InputManager.MoveMouseTo(sliderWithTextBoxInput.ScreenSpaceDrawQuad.BottomLeft));
+            AddAssert("textbox not changed", () => textBox.Current.Value, () => Is.EqualTo("3"));
+            AddAssert("current not changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(3));
+
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("-5"));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(-5));
+
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(nub));
+            AddStep("hold left mouse", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move mouse to 55%", () => InputManager.MoveMouseTo(sliderWithTextBoxInput.ScreenSpaceDrawQuad.BottomLeft * 0.45f + sliderWithTextBoxInput.ScreenSpaceDrawQuad.TopRight * 0.55f));
+
+            AddStep("release left mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("textbox changed", () => textBox.Current.Value, () => Is.EqualTo("1"));
+            AddAssert("current changed", () => sliderWithTextBoxInput.Current.Value, () => Is.EqualTo(1));
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -56,52 +56,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 sliderPrecision = value;
                 slider.Current = new BindableNumber<T>
                 {
-                    MinValue = sliderMinValue ?? current.MinValue,
-                    MaxValue = sliderMaxValue ?? current.MaxValue,
+                    MinValue = current.MinValue,
+                    MaxValue = current.MaxValue,
                     Default = current.Default,
                     Precision = value ?? current.Precision,
-                };
-            }
-        }
-
-        private T? sliderMinValue;
-
-        public T? SliderMinValue
-        {
-            get => sliderMinValue;
-            set
-            {
-                if (value.HasValue && value.Value < current.MinValue)
-                    throw new ArgumentException(@"Minimum value override must be greater than or equal to the current minimum value.");
-
-                sliderMinValue = value;
-                slider.Current = new BindableNumber<T>
-                {
-                    MinValue = value ?? current.MinValue,
-                    MaxValue = sliderMaxValue ?? current.MaxValue,
-                    Default = current.Default,
-                    Precision = sliderPrecision ?? current.Precision,
-                };
-            }
-        }
-
-        private T? sliderMaxValue;
-
-        public T? SliderMaxValue
-        {
-            get => sliderMaxValue;
-            set
-            {
-                if (value.HasValue && value.Value > current.MaxValue)
-                    throw new ArgumentException(@"Maximum value override must be less than or equal to the current maximum value.");
-
-                sliderMaxValue = value;
-                slider.Current = new BindableNumber<T>
-                {
-                    MinValue = sliderMinValue ?? current.MinValue,
-                    MaxValue = value ?? current.MaxValue,
-                    Default = current.Default,
-                    Precision = sliderPrecision ?? current.Precision,
                 };
             }
         }

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public bool SelectAll() => textBox.SelectAll();
 
         private bool updatingFromCurrent;
+        private bool updatingFromTextBox;
 
         private void textChanged(ValueChangedEvent<string> change)
         {
@@ -148,6 +149,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void tryUpdateCurrentFromTextBox()
         {
             if (updatingFromCurrent) return;
+
+            updatingFromTextBox = true;
 
             try
             {
@@ -171,6 +174,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 // ignore parsing failures.
                 // sane state will eventually be restored by a commit (either explicit, or implicit via focus loss).
             }
+
+            updatingFromTextBox = false;
         }
 
         private void updateCurrentFromSlider(ValueChangedEvent<T> _)
@@ -186,8 +191,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             slider.Current.Value = Current.Value;
 
-            decimal decimalValue = decimal.CreateTruncating(Current.Value);
-            textBox.Text = decimalValue.ToString($@"N{FormatUtils.FindPrecision(decimalValue)}");
+            if (!updatingFromTextBox)
+            {
+                decimal decimalValue = decimal.CreateTruncating(Current.Value);
+                textBox.Text = decimalValue.ToString($@"N{FormatUtils.FindPrecision(decimalValue)}");
+            }
 
             updatingFromCurrent = false;
         }

--- a/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/SliderWithTextBoxInput.cs
@@ -35,7 +35,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
             set
             {
                 current.Current = value;
-                slider.Current = value;
+                slider.Current = new BindableNumber<T>
+                {
+                    MinValue = current.MinValue,
+                    MaxValue = current.MaxValue,
+                    Default = current.Default,
+                    Precision = sliderPrecision ?? current.Precision,
+                };
             }
         }
 


### PR DESCRIPTION
Allows you to make patterns with precise angles and geometry, like a spiral that rotates 22.5 degrees for every circle.

I followed the suggestion by @bdach https://github.com/ppy/osu-framework/pull/6376#issuecomment-2357667053 to use a double bindable setup which bidirectionally linked with value change callbacks.

I let the `Current` bindable also change the `SliderCurrent` bindable so when you create a slider with textbox input with the old api it still functions the same way.