### PR TITLE
Improve flexibility of skin layout editor player avatar

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerAvatar.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerAvatar.cs
@@ -39,14 +39,23 @@ namespace osu.Game.Screens.Play.HUD
 
         private IBindable<APIUser>? apiUser;
 
+        private readonly Container cornerContainer;
+
         public PlayerAvatar()
         {
             Size = new Vector2(default_size);
 
-            InternalChild = avatar = new UpdateableAvatar(isInteractive: false)
+            InternalChild = cornerContainer = new Container
             {
+                Masking = true,
                 RelativeSizeAxes = Axes.Both,
-                Masking = true
+                Child = avatar = new UpdateableAvatar(isInteractive: false)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fill,
+                }
             };
         }
 
@@ -66,7 +75,7 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            CornerRadius.BindValueChanged(e => avatar.CornerRadius = e.NewValue * default_size, true);
+            CornerRadius.BindValueChanged(e => cornerContainer.CornerRadius = e.NewValue * default_size, true);
         }
 
         public bool UsesFixedAnchor { get; set; }


### PR DESCRIPTION
I've also made this handle resizing better, so now you can have non-square avatar displays.

![osu! 2024-09-19 at 07 53 16](https://github.com/user-attachments/assets/577ca644-bd7c-4126-bb1e-2fecd93a2263)

Closes #29919.
