### PR TITLE
Add colour customisation to layout editor

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual.Settings
         {
             Children = new Drawable[]
             {
-                new PopoverContainer()
+                new PopoverContainer
                 {
                     RelativeSizeAxes = Axes.Both,
                     Child = new FillFlowContainer
@@ -73,7 +73,7 @@ namespace osu.Game.Tests.Visual.Settings
             public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>();
 
             [SettingSource("Sample colour", "Change the colour", SettingControlType = typeof(SettingsColour))]
-            public BindableColour4 ColourBindable { get; } = new BindableColour4()
+            public BindableColour4 ColourBindable { get; } = new BindableColour4
             {
                 Default = Colour4.White,
                 Value = Colour4.Red

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Overlays.Settings;
@@ -19,16 +20,20 @@ namespace osu.Game.Tests.Visual.Settings
         {
             Children = new Drawable[]
             {
-                new FillFlowContainer
+                new PopoverContainer()
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(20),
-                    Width = 0.5f,
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Padding = new MarginPadding(50),
-                    ChildrenEnumerable = new TestTargetClass().CreateSettingsControls()
+                    Child = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(20),
+                        Width = 0.5f,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Padding = new MarginPadding(50),
+                        ChildrenEnumerable = new TestTargetClass().CreateSettingsControls()
+                    },
                 },
             };
         }
@@ -66,6 +71,13 @@ namespace osu.Game.Tests.Visual.Settings
 
             [SettingSource("Sample number textbox", "Textbox number entry", SettingControlType = typeof(SettingsNumberBox))]
             public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>();
+
+            [SettingSource("Sample colour", "Change the colour", SettingControlType = typeof(SettingsColour))]
+            public BindableColour4 ColourBindable { get; } = new BindableColour4()
+            {
+                Default = Colour4.White,
+                Value = Colour4.Red
+            };
         }
 
         private enum TestEnum

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -19,14 +17,14 @@ namespace osu.Game.Tests.Visual.UserInterface
 {
     public partial class TestSceneSettingsColour : OsuManualInputManagerTestScene
     {
-        private SettingsColour component;
+        private SettingsColour? component;
 
         [Test]
         public void TestColour()
         {
             createContent();
 
-            AddRepeatStep("set random colour", () => component.Current.Value = randomColour(), 4);
+            AddRepeatStep("set random colour", () => component!.Current.Value = randomColour(), 4);
         }
 
         [Test]
@@ -36,7 +34,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("click colour", () =>
             {
-                InputManager.MoveMouseTo(component);
+                InputManager.MoveMouseTo(component!);
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
@@ -45,24 +45,27 @@ namespace osu.Game.Tests.Visual.UserInterface
 
         private void createContent()
         {
-            Child = new PopoverContainer
+            AddStep("create component", () =>
             {
-                RelativeSizeAxes = Axes.Both,
-                Child = new FillFlowContainer
+                Child = new PopoverContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Width = 500,
-                    AutoSizeAxes = Axes.Y,
-                    Children = new Drawable[]
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new FillFlowContainer
                     {
-                        component = new SettingsColour
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Width = 500,
+                        AutoSizeAxes = Axes.Y,
+                        Children = new Drawable[]
                         {
-                            LabelText = "a sample component",
+                            component = new SettingsColour
+                            {
+                                LabelText = "a sample component",
+                            },
                         },
                     },
-                },
-            };
+                };
+            });
         }
 
         private Colour4 randomColour() => new Color4(

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSettingsColour.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays.Settings;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.UserInterface
+{
+    public partial class TestSceneSettingsColour : OsuManualInputManagerTestScene
+    {
+        private SettingsColour component;
+
+        [Test]
+        public void TestColour()
+        {
+            createContent();
+
+            AddRepeatStep("set random colour", () => component.Current.Value = randomColour(), 4);
+        }
+
+        [Test]
+        public void TestUserInteractions()
+        {
+            createContent();
+
+            AddStep("click colour", () =>
+            {
+                InputManager.MoveMouseTo(component);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("colour picker spawned", () => this.ChildrenOfType<OsuColourPicker>().Any());
+        }
+
+        private void createContent()
+        {
+            Child = new PopoverContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Width = 500,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
+                    {
+                        component = new SettingsColour
+                        {
+                            LabelText = "a sample component",
+                        },
+                    },
+                },
+            };
+        }
+
+        private Colour4 randomColour() => new Color4(
+            RNG.NextSingle(),
+            RNG.NextSingle(),
+            RNG.NextSingle(),
+            1);
+    }
+}

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -186,6 +186,16 @@ namespace osu.Game.Configuration
 
                         break;
 
+                    case BindableColour4 bColour:
+                        yield return new SettingsColour
+                        {
+                            LabelText = attr.Label,
+                            TooltipText = attr.Description,
+                            Current = bColour
+                        };
+
+                        break;
+
                     case IBindable bindable:
                         var dropdownType = typeof(ModSettingsEnumDropdown<>).MakeGenericType(bindable.GetType().GetGenericArguments()[0]);
                         var dropdown = (Drawable)Activator.CreateInstance(dropdownType)!;
@@ -226,6 +236,9 @@ namespace osu.Game.Configuration
 
                 case Bindable<bool> b:
                     return b.Value;
+
+                case BindableColour4 c:
+                    return c.Value.ToHex();
 
                 case IBindable u:
                     // An unknown (e.g. enum) generic type.

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -70,14 +70,14 @@ namespace osu.Game.Localisation.SkinComponents
         public static LocalisableString ColourDescription => new TranslatableString(getKey(@"colour_description"), @"The colour of the component.");
 
         /// <summary>
-        /// "Font colour"
+        /// "Text colour"
         /// </summary>
-        public static LocalisableString FontColour => new TranslatableString(getKey(@"font_colour"), @"Font colour");
+        public static LocalisableString TextColour => new TranslatableString(getKey(@"text_colour"), @"Text colour");
 
         /// <summary>
-        /// "The colour of the font."
+        /// "The colour of the text."
         /// </summary>
-        public static LocalisableString FontColourDescription => new TranslatableString(getKey(@"font_colour_description"), @"The colour of the font.");
+        public static LocalisableString TextColourDescription => new TranslatableString(getKey(@"text_colour_description"), @"The colour of the text.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
+++ b/osu.Game/Localisation/SkinComponents/SkinnableComponentStrings.cs
@@ -59,6 +59,26 @@ namespace osu.Game.Localisation.SkinComponents
         /// </summary>
         public static LocalisableString ShowLabelDescription => new TranslatableString(getKey(@"show_label_description"), @"Whether the component's label should be shown.");
 
+        /// <summary>
+        /// "Colour"
+        /// </summary>
+        public static LocalisableString Colour => new TranslatableString(getKey(@"colour"), @"Colour");
+
+        /// <summary>
+        /// "The colour of the component."
+        /// </summary>
+        public static LocalisableString ColourDescription => new TranslatableString(getKey(@"colour_description"), @"The colour of the component.");
+
+        /// <summary>
+        /// "Font colour"
+        /// </summary>
+        public static LocalisableString FontColour => new TranslatableString(getKey(@"font_colour"), @"Font colour");
+
+        /// <summary>
+        /// "The colour of the font."
+        /// </summary>
+        public static LocalisableString FontColourDescription => new TranslatableString(getKey(@"font_colour_description"), @"The colour of the font.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsColour.cs
+++ b/osu.Game/Overlays/Settings/SettingsColour.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+
+namespace osu.Game.Overlays.Settings
+{
+    public partial class SettingsColour : SettingsItem<Colour4>
+    {
+        protected override Drawable CreateControl() => new ColourControl();
+
+        public partial class ColourControl : OsuClickableContainer, IHasPopover, IHasCurrentValue<Colour4>
+        {
+            private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
+
+            public Bindable<Colour4> Current
+            {
+                get => current.Current;
+                set => current.Current = value;
+            }
+
+            private readonly Box fill;
+            private readonly OsuSpriteText colourHexCode;
+
+            public ColourControl()
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = 40;
+                CornerRadius = 20;
+                Masking = true;
+                Action = this.ShowPopover;
+
+                Children = new Drawable[]
+                {
+                    fill = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    colourHexCode = new OsuSpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Font = OsuFont.Default.With(size: 20)
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Current.BindValueChanged(_ => updateColour(), true);
+            }
+
+            private void updateColour()
+            {
+                fill.Colour = Current.Value;
+                colourHexCode.Text = Current.Value.ToHex();
+                colourHexCode.Colour = OsuColour.ForegroundTextColourFor(Current.Value);
+            }
+
+            public Popover GetPopover() => new OsuPopover(false)
+            {
+                Child = new OsuColourPicker
+                {
+                    Current = { BindTarget = Current }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/SettingsColour.cs
+++ b/osu.Game/Overlays/Settings/SettingsColour.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings
 
         public partial class ColourControl : OsuClickableContainer, IHasPopover, IHasCurrentValue<Colour4>
         {
-            private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
+            private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>(Colour4.White);
 
             public Bindable<Colour4> Current
             {

--- a/osu.Game/Overlays/Settings/SettingsColour.cs
+++ b/osu.Game/Overlays/Settings/SettingsColour.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
+
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -121,110 +121,110 @@ namespace osu.Game.Overlays.SkinEditor
                 RelativeSizeAxes = Axes.Both,
                 Child = new PopoverContainer
                 {
-                RelativeSizeAxes = Axes.Both,
-                Child = new GridContainer
-                {
                     RelativeSizeAxes = Axes.Both,
-                    RowDimensions = new[]
+                    Child = new GridContainer
                     {
-                        new Dimension(GridSizeMode.AutoSize),
-                        new Dimension(GridSizeMode.AutoSize),
-                        new Dimension(),
-                    },
+                        RelativeSizeAxes = Axes.Both,
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(),
+                        },
 
-                    Content = new[]
-                    {
-                        new Drawable[]
+                        Content = new[]
                         {
-                            new Container
+                            new Drawable[]
                             {
-                                Name = @"Menu container",
-                                RelativeSizeAxes = Axes.X,
-                                Depth = float.MinValue,
-                                Height = MENU_HEIGHT,
-                                Children = new Drawable[]
+                                new Container
                                 {
-                                    new EditorMenuBar
+                                    Name = @"Menu container",
+                                    RelativeSizeAxes = Axes.X,
+                                    Depth = float.MinValue,
+                                    Height = MENU_HEIGHT,
+                                    Children = new Drawable[]
                                     {
-                                        Anchor = Anchor.CentreLeft,
-                                        Origin = Anchor.CentreLeft,
-                                        RelativeSizeAxes = Axes.Both,
-                                        Items = new[]
+                                        new EditorMenuBar
                                         {
-                                            new MenuItem(CommonStrings.MenuBarFile)
-                                            {
-                                                Items = new OsuMenuItem[]
-                                                {
-                                                    new EditorMenuItem(Web.CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
-                                                    new EditorMenuItem(CommonStrings.Export, MenuItemType.Standard, () => skins.ExportCurrentSkin()) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
-                                                    new OsuMenuItemSpacer(),
-                                                    new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, () => dialogOverlay?.Push(new RevertConfirmDialog(revert))),
-                                                    new OsuMenuItemSpacer(),
-                                                    new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, () => skinEditorOverlay?.Hide()),
-                                                },
-                                            },
-                                            new MenuItem(CommonStrings.MenuBarEdit)
-                                            {
-                                                Items = new OsuMenuItem[]
-                                                {
-                                                    undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo),
-                                                    redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo),
-                                                    new OsuMenuItemSpacer(),
-                                                    cutMenuItem = new EditorMenuItem(CommonStrings.Cut, MenuItemType.Standard, Cut),
-                                                    copyMenuItem = new EditorMenuItem(CommonStrings.Copy, MenuItemType.Standard, Copy),
-                                                    pasteMenuItem = new EditorMenuItem(CommonStrings.Paste, MenuItemType.Standard, Paste),
-                                                    cloneMenuItem = new EditorMenuItem(CommonStrings.Clone, MenuItemType.Standard, Clone),
-                                                }
-                                            },
-                                        }
-                                    },
-                                    headerText = new OsuTextFlowContainer
-                                    {
-                                        TextAnchor = Anchor.TopRight,
-                                        Padding = new MarginPadding(5),
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
-                                        AutoSizeAxes = Axes.X,
-                                        RelativeSizeAxes = Axes.Y,
-                                    },
-                                },
-                            },
-                        },
-                        new Drawable[]
-                        {
-                            new SkinEditorSceneLibrary
-                            {
-                                RelativeSizeAxes = Axes.X,
-                            },
-                        },
-                        new Drawable[]
-                        {
-                            new GridContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                ColumnDimensions = new[]
-                                {
-                                    new Dimension(GridSizeMode.AutoSize),
-                                    new Dimension(),
-                                    new Dimension(GridSizeMode.AutoSize),
-                                },
-                                Content = new[]
-                                {
-                                    new Drawable[]
-                                    {
-                                        componentsSidebar = new EditorSidebar(),
-                                        content = new Container
-                                        {
-                                            Depth = float.MaxValue,
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
                                             RelativeSizeAxes = Axes.Both,
+                                            Items = new[]
+                                            {
+                                                new MenuItem(CommonStrings.MenuBarFile)
+                                                {
+                                                    Items = new OsuMenuItem[]
+                                                    {
+                                                        new EditorMenuItem(Web.CommonStrings.ButtonsSave, MenuItemType.Standard, () => Save()),
+                                                        new EditorMenuItem(CommonStrings.Export, MenuItemType.Standard, () => skins.ExportCurrentSkin()) { Action = { Disabled = !RuntimeInfo.IsDesktop } },
+                                                        new OsuMenuItemSpacer(),
+                                                        new EditorMenuItem(CommonStrings.RevertToDefault, MenuItemType.Destructive, () => dialogOverlay?.Push(new RevertConfirmDialog(revert))),
+                                                        new OsuMenuItemSpacer(),
+                                                        new EditorMenuItem(CommonStrings.Exit, MenuItemType.Standard, () => skinEditorOverlay?.Hide()),
+                                                    },
+                                                },
+                                                new MenuItem(CommonStrings.MenuBarEdit)
+                                                {
+                                                    Items = new OsuMenuItem[]
+                                                    {
+                                                        undoMenuItem = new EditorMenuItem(CommonStrings.Undo, MenuItemType.Standard, Undo),
+                                                        redoMenuItem = new EditorMenuItem(CommonStrings.Redo, MenuItemType.Standard, Redo),
+                                                        new OsuMenuItemSpacer(),
+                                                        cutMenuItem = new EditorMenuItem(CommonStrings.Cut, MenuItemType.Standard, Cut),
+                                                        copyMenuItem = new EditorMenuItem(CommonStrings.Copy, MenuItemType.Standard, Copy),
+                                                        pasteMenuItem = new EditorMenuItem(CommonStrings.Paste, MenuItemType.Standard, Paste),
+                                                        cloneMenuItem = new EditorMenuItem(CommonStrings.Clone, MenuItemType.Standard, Clone),
+                                                    }
+                                                },
+                                            }
                                         },
-                                        settingsSidebar = new EditorSidebar(),
+                                        headerText = new OsuTextFlowContainer
+                                        {
+                                            TextAnchor = Anchor.TopRight,
+                                            Padding = new MarginPadding(5),
+                                            Anchor = Anchor.TopRight,
+                                            Origin = Anchor.TopRight,
+                                            AutoSizeAxes = Axes.X,
+                                            RelativeSizeAxes = Axes.Y,
+                                        },
+                                    },
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new SkinEditorSceneLibrary
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                },
+                            },
+                            new Drawable[]
+                            {
+                                new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    ColumnDimensions = new[]
+                                    {
+                                        new Dimension(GridSizeMode.AutoSize),
+                                        new Dimension(),
+                                        new Dimension(GridSizeMode.AutoSize),
+                                    },
+                                    Content = new[]
+                                    {
+                                        new Drawable[]
+                                        {
+                                            componentsSidebar = new EditorSidebar(),
+                                            content = new Container
+                                            {
+                                                Depth = float.MaxValue,
+                                                RelativeSizeAxes = Axes.Both,
+                                            },
+                                            settingsSidebar = new EditorSidebar(),
+                                        }
                                     }
                                 }
-                            }
-                        },
+                            },
+                        }
                     }
-                }
                 }
             };
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditor.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditor.cs
@@ -33,6 +33,7 @@ using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Edit.Components.Menus;
 using osu.Game.Skinning;
+using osu.Framework.Graphics.Cursor;
 
 namespace osu.Game.Overlays.SkinEditor
 {
@@ -117,6 +118,9 @@ namespace osu.Game.Overlays.SkinEditor
 
             InternalChild = new OsuContextMenuContainer
             {
+                RelativeSizeAxes = Axes.Both,
+                Child = new PopoverContainer
+                {
                 RelativeSizeAxes = Axes.Both,
                 Child = new GridContainer
                 {
@@ -220,6 +224,7 @@ namespace osu.Game.Overlays.SkinEditor
                             }
                         },
                     }
+                }
                 }
             };
 

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Play.HUD
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
-        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
+        public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]
         private Player? player { get; set; }
@@ -118,7 +118,7 @@ namespace osu.Game.Screens.Play.HUD
             base.Update();
             content.Height = bar.Height + bar_height + info.Height;
             graphContainer.Height = bar.Height;
-            base.Colour = Colour.Value;
+            Colour = AccentColour.Value;
         }
 
         protected override void UpdateProgress(double progress, bool isIntro)

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -98,6 +98,7 @@ namespace osu.Game.Screens.Play.HUD
             Interactive.BindValueChanged(_ => bar.Interactive = Interactive.Value, true);
             ShowGraph.BindValueChanged(_ => updateGraphVisibility(), true);
             ShowTime.BindValueChanged(_ => info.FadeTo(ShowTime.Value ? 1 : 0, 200, Easing.In), true);
+            AccentColour.BindValueChanged(_ => Colour = AccentColour.Value, true);
         }
 
         protected override void UpdateObjects(IEnumerable<HitObject> objects)
@@ -118,7 +119,6 @@ namespace osu.Game.Screens.Play.HUD
             base.Update();
             content.Height = bar.Height + bar_height + info.Height;
             graphContainer.Height = bar.Height;
-            Colour = AccentColour.Value;
         }
 
         protected override void UpdateProgress(double progress, bool isIntro)

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Localisation.HUD;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Screens.Play.HUD
@@ -28,6 +29,8 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]
         private Player? player { get; set; }
@@ -114,6 +117,7 @@ namespace osu.Game.Screens.Play.HUD
             base.Update();
             content.Height = bar.Height + bar_height + info.Height;
             graphContainer.Height = bar.Height;
+            base.Colour = Colour.Value;
         }
 
         protected override void UpdateProgress(double progress, bool isIntro)

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
         public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
 

--- a/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
@@ -41,7 +41,6 @@ namespace osu.Game.Screens.Play.HUD
             InternalChild = new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = ColourInfo.GradientVertical(AccentColour.Value.Opacity(0.0f), AccentColour.Value.Opacity(0.25f)),
             };
         }
 
@@ -50,7 +49,7 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             InvertShear.BindValueChanged(v => Shear = new Vector2(0.8f, 0f) * (v.NewValue ? -1 : 1), true);
-            AccentColour.BindValueChanged(c => InternalChild.Colour = ColourInfo.GradientVertical(AccentColour.Value.Opacity(0.0f), AccentColour.Value.Opacity(0.25f)));
+            AccentColour.BindValueChanged(c => InternalChild.Colour = ColourInfo.GradientVertical(AccentColour.Value.Opacity(0.0f), AccentColour.Value.Opacity(0.25f)), true);
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Screens.Play.HUD
         public BindableBool InvertShear { get; } = new BindableBool();
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
-        public new BindableColour4 Colour { get; } = new BindableColour4(Color4Extensions.FromHex("#66CCFF"));
+        public BindableColour4 AccentColour { get; } = new BindableColour4(Color4Extensions.FromHex("#66CCFF"));
 
         public ArgonWedgePiece()
         {
@@ -41,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
             InternalChild = new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = ColourInfo.GradientVertical(Colour.Value.Opacity(0.0f), Colour.Value.Opacity(0.25f)),
+                Colour = ColourInfo.GradientVertical(AccentColour.Value.Opacity(0.0f), AccentColour.Value.Opacity(0.25f)),
             };
         }
 
@@ -50,7 +50,7 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             InvertShear.BindValueChanged(v => Shear = new Vector2(0.8f, 0f) * (v.NewValue ? -1 : 1), true);
-            Colour.BindValueChanged(c => InternalChild.Colour = ColourInfo.GradientVertical(Colour.Value.Opacity(0.0f), Colour.Value.Opacity(0.25f)));
+            AccentColour.BindValueChanged(c => InternalChild.Colour = ColourInfo.GradientVertical(AccentColour.Value.Opacity(0.0f), AccentColour.Value.Opacity(0.25f)));
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonWedgePiece.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Configuration;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -20,6 +21,9 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource("Inverted shear")]
         public BindableBool InvertShear { get; } = new BindableBool();
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public new BindableColour4 Colour { get; } = new BindableColour4(Color4Extensions.FromHex("#66CCFF"));
 
         public ArgonWedgePiece()
         {
@@ -37,7 +41,7 @@ namespace osu.Game.Screens.Play.HUD
             InternalChild = new Box
             {
                 RelativeSizeAxes = Axes.Both,
-                Colour = ColourInfo.GradientVertical(Color4Extensions.FromHex("#66CCFF").Opacity(0.0f), Color4Extensions.FromHex("#66CCFF").Opacity(0.25f)),
+                Colour = ColourInfo.GradientVertical(Colour.Value.Opacity(0.0f), Colour.Value.Opacity(0.25f)),
             };
         }
 
@@ -46,6 +50,7 @@ namespace osu.Game.Screens.Play.HUD
             base.LoadComplete();
 
             InvertShear.BindValueChanged(v => Shear = new Vector2(0.8f, 0f) * (v.NewValue ? -1 : 1), true);
+            Colour.BindValueChanged(c => InternalChild.Colour = ColourInfo.GradientVertical(Colour.Value.Opacity(0.0f), Colour.Value.Opacity(0.25f)));
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -90,6 +90,7 @@ namespace osu.Game.Screens.Play.HUD
             Interactive.BindValueChanged(_ => updateBarVisibility(), true);
             ShowGraph.BindValueChanged(_ => updateGraphVisibility(), true);
             ShowTime.BindValueChanged(_ => updateTimeVisibility(), true);
+            AccentColour.BindValueChanged(_ => Colour = AccentColour.Value, true);
 
             base.LoadComplete();
         }
@@ -118,8 +119,6 @@ namespace osu.Game.Screens.Play.HUD
 
             if (!Precision.AlmostEquals(Height, newHeight, 5f))
                 content.Height = newHeight;
-
-            Colour = AccentColour.Value;
         }
 
         private void updateBarVisibility()

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -10,6 +10,7 @@ using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Localisation.HUD;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Rulesets.Objects;
 using osuTK;
 
@@ -35,6 +36,8 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]
         private Player? player { get; set; }
@@ -114,6 +117,8 @@ namespace osu.Game.Screens.Play.HUD
 
             if (!Precision.AlmostEquals(Height, newHeight, 5f))
                 content.Height = newHeight;
+
+            base.Colour = Colour.Value;
         }
 
         private void updateBarVisibility()

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Play.HUD
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
-        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
+        public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         [Resolved]
         private Player? player { get; set; }
@@ -119,7 +119,7 @@ namespace osu.Game.Screens.Play.HUD
             if (!Precision.AlmostEquals(Height, newHeight, 5f))
                 content.Height = newHeight;
 
-            base.Colour = Colour.Value;
+            Colour = AccentColour.Value;
         }
 
         private void updateBarVisibility()

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgress.cs
@@ -36,6 +36,7 @@ namespace osu.Game.Screens.Play.HUD
 
         [SettingSource(typeof(SongProgressStrings), nameof(SongProgressStrings.ShowTime), nameof(SongProgressStrings.ShowTimeDescription))]
         public Bindable<bool> ShowTime { get; } = new BindableBool(true);
+
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
         public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
 

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -124,7 +124,7 @@ namespace osu.Game.Skinning.Components
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
 
-        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
+        protected override void SetTextColour(Colour4 textColour) => text.Colour = textColour;
     }
 
     // WARNING: DO NOT ADD ANY VALUES TO THIS ENUM ANYWHERE ELSE THAN AT THE END.

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -123,6 +123,8 @@ namespace osu.Game.Skinning.Components
         }
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
+
+        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
     }
 
     // WARNING: DO NOT ADD ANY VALUES TO THIS ENUM ANYWHERE ELSE THAN AT THE END.

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Skinning.Components
         };
 
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
-        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
+        public BindableColour4 AccentColour { get; } = new BindableColour4(Colour4.White);
 
         public BoxElement()
         {
@@ -51,7 +51,7 @@ namespace osu.Game.Skinning.Components
             base.Update();
 
             base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight);
-            base.Colour = Colour.Value;
+            Colour = AccentColour.Value;
         }
     }
 }

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Skinning.Components
             Precision = 0.01f
         };
 
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public new BindableColour4 Colour { get; } = new BindableColour4(Colour4.White);
+
         public BoxElement()
         {
             Size = new Vector2(400, 80);
@@ -48,6 +51,7 @@ namespace osu.Game.Skinning.Components
             base.Update();
 
             base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight);
+            base.Colour = Colour.Value;
         }
     }
 }

--- a/osu.Game/Skinning/Components/BoxElement.cs
+++ b/osu.Game/Skinning/Components/BoxElement.cs
@@ -46,12 +46,18 @@ namespace osu.Game.Skinning.Components
             Masking = true;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AccentColour.BindValueChanged(_ => Colour = AccentColour.Value, true);
+        }
+
         protected override void Update()
         {
             base.Update();
 
             base.CornerRadius = CornerRadius.Value * Math.Min(DrawWidth, DrawHeight);
-            Colour = AccentColour.Value;
         }
     }
 }

--- a/osu.Game/Skinning/Components/PlayerName.cs
+++ b/osu.Game/Skinning/Components/PlayerName.cs
@@ -54,6 +54,6 @@ namespace osu.Game.Skinning.Components
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
 
-        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
+        protected override void SetTextColour(Colour4 textColour) => text.Colour = textColour;
     }
 }

--- a/osu.Game/Skinning/Components/PlayerName.cs
+++ b/osu.Game/Skinning/Components/PlayerName.cs
@@ -53,5 +53,7 @@ namespace osu.Game.Skinning.Components
         }
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
+
+        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
     }
 }

--- a/osu.Game/Skinning/Components/TextElement.cs
+++ b/osu.Game/Skinning/Components/TextElement.cs
@@ -37,6 +37,6 @@ namespace osu.Game.Skinning.Components
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
 
-        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
+        protected override void SetTextColour(Colour4 textColour) => text.Colour = textColour;
     }
 }

--- a/osu.Game/Skinning/Components/TextElement.cs
+++ b/osu.Game/Skinning/Components/TextElement.cs
@@ -36,5 +36,7 @@ namespace osu.Game.Skinning.Components
         }
 
         protected override void SetFont(FontUsage font) => text.Font = font.With(size: 40);
+
+        protected override void SetFontColour(Colour4 fontColour) => text.Colour = fontColour;
     }
 }

--- a/osu.Game/Skinning/FontAdjustableSkinComponent.cs
+++ b/osu.Game/Skinning/FontAdjustableSkinComponent.cs
@@ -21,15 +21,15 @@ namespace osu.Game.Skinning
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
         public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Torus);
 
-        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.FontColour), nameof(SkinnableComponentStrings.FontColourDescription))]
-        public BindableColour4 FontColour { get; } = new BindableColour4(Colour4.White);
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.TextColour), nameof(SkinnableComponentStrings.TextColourDescription))]
+        public BindableColour4 TextColour { get; } = new BindableColour4(Colour4.White);
 
         /// <summary>
         /// Implement to apply the user font selection to one or more components.
         /// </summary>
         protected abstract void SetFont(FontUsage font);
 
-        protected abstract void SetFontColour(Colour4 fontColour);
+        protected abstract void SetTextColour(Colour4 textColour);
 
         protected override void LoadComplete()
         {
@@ -44,7 +44,7 @@ namespace osu.Game.Skinning
                 SetFont(f);
             }, true);
 
-            FontColour.BindValueChanged(e => SetFontColour(e.NewValue), true);
+            TextColour.BindValueChanged(e => SetTextColour(e.NewValue), true);
         }
     }
 }

--- a/osu.Game/Skinning/FontAdjustableSkinComponent.cs
+++ b/osu.Game/Skinning/FontAdjustableSkinComponent.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Configuration;
@@ -20,10 +21,15 @@ namespace osu.Game.Skinning
         [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
         public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Torus);
 
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.FontColour), nameof(SkinnableComponentStrings.FontColourDescription))]
+        public BindableColour4 FontColour { get; } = new BindableColour4(Colour4.White);
+
         /// <summary>
         /// Implement to apply the user font selection to one or more components.
         /// </summary>
         protected abstract void SetFont(FontUsage font);
+
+        protected abstract void SetFontColour(Colour4 fontColour);
 
         protected override void LoadComplete()
         {
@@ -37,6 +43,8 @@ namespace osu.Game.Skinning
                 FontUsage f = OsuFont.GetFont(e.NewValue, weight: fontWeight);
                 SetFont(f);
             }, true);
+
+            FontColour.BindValueChanged(e => SetFontColour(e.NewValue), true);
         }
     }
 }


### PR DESCRIPTION
Allows you to change colour for:
- Argon wedge piece
- Box element
- Default and argon song progress
- Font adjustable components

https://github.com/user-attachments/assets/e8bdfb27-0bd5-403c-bd98-6a31f0f45b8f

I also implemented this to `FontAdjustableSkinComponent` because it makes sense but I'm not too sure.

I don't think there's design for button for adjusting colour, so I came up with my own.