### PR TITLE
Fix scaling sliders ignoring the scale origin

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSelectionScaleHandler.cs
@@ -105,9 +105,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             // is not looking to change the duration of the slider but expand the whole pattern.
             if (objectsInScale.Count == 1 && objectsInScale.First().Key is Slider slider)
             {
-                var originalInfo = objectsInScale[slider];
-                Debug.Assert(originalInfo.PathControlPointPositions != null && originalInfo.PathControlPointTypes != null);
-                scaleSlider(slider, scale, originalInfo.PathControlPointPositions, originalInfo.PathControlPointTypes, axisRotation);
+                scaleSlider(slider, scale, actualOrigin, objectsInScale[slider], axisRotation);
             }
             else
             {
@@ -159,20 +157,24 @@ namespace osu.Game.Rulesets.Osu.Edit
             return scale;
         }
 
-        private void scaleSlider(Slider slider, Vector2 scale, Vector2[] originalPathPositions, PathType?[] originalPathTypes, float axisRotation = 0)
+        private void scaleSlider(Slider slider, Vector2 scale, Vector2 origin, OriginalHitObjectState originalInfo, float axisRotation = 0)
         {
+            Debug.Assert(originalInfo.PathControlPointPositions != null && originalInfo.PathControlPointTypes != null);
+
             scale = Vector2.ComponentMax(scale, new Vector2(Precision.FLOAT_EPSILON));
 
             // Maintain the path types in case they were defaulted to bezier at some point during scaling
             for (int i = 0; i < slider.Path.ControlPoints.Count; i++)
             {
-                slider.Path.ControlPoints[i].Position = GeometryUtils.GetScaledPosition(scale, Vector2.Zero, originalPathPositions[i], axisRotation);
-                slider.Path.ControlPoints[i].Type = originalPathTypes[i];
+                slider.Path.ControlPoints[i].Position = GeometryUtils.GetScaledPosition(scale, Vector2.Zero, originalInfo.PathControlPointPositions[i], axisRotation);
+                slider.Path.ControlPoints[i].Type = originalInfo.PathControlPointTypes[i];
             }
 
             // Snap the slider's length to the current beat divisor
             // to calculate the final resulting duration / bounding box before the final checks.
             slider.SnapTo(snapProvider);
+
+            slider.Position = GeometryUtils.GetScaledPosition(scale, origin, originalInfo.Position, axisRotation);
 
             //if sliderhead or sliderend end up outside playfield, revert scaling.
             Quad scaledQuad = GeometryUtils.GetSurroundingQuad(new OsuHitObject[] { slider });
@@ -182,7 +184,9 @@ namespace osu.Game.Rulesets.Osu.Edit
                 return;
 
             for (int i = 0; i < slider.Path.ControlPoints.Count; i++)
-                slider.Path.ControlPoints[i].Position = originalPathPositions[i];
+                slider.Path.ControlPoints[i].Position = originalInfo.PathControlPointPositions[i];
+
+            slider.Position = originalInfo.Position;
 
             // Snap the slider's length again to undo the potentially-invalid length applied by the previous snap.
             slider.SnapTo(snapProvider);

--- a/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
@@ -10,7 +10,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.RadioButtons;
 using osuTK;
 
@@ -35,6 +38,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         private OsuCheckbox xCheckBox = null!;
         private OsuCheckbox yCheckBox = null!;
 
+        private BindableList<HitObject> selectedItems { get; } = new BindableList<HitObject>();
+
         public PreciseScalePopover(OsuSelectionScaleHandler scaleHandler, OsuGridToolboxGroup gridToolbox)
         {
             this.scaleHandler = scaleHandler;
@@ -44,8 +49,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(EditorBeatmap editorBeatmap)
         {
+            selectedItems.BindTo(editorBeatmap.SelectedHitObjects);
+
             Child = new FillFlowContainer
             {
                 Width = 220,
@@ -196,6 +203,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 ScaleOrigin.GridCentre => gridToolbox.StartPosition.Value,
                 ScaleOrigin.PlayfieldCentre => OsuPlayfield.BASE_SIZE / 2,
+                ScaleOrigin.SelectionCentre when selectedItems.Count == 1 && selectedItems.First() is Slider slider => slider.Position,
                 ScaleOrigin.SelectionCentre => null,
                 _ => throw new ArgumentOutOfRangeException(nameof(scale))
             };

--- a/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
@@ -198,15 +198,26 @@ namespace osu.Game.Rulesets.Osu.Edit
             updateAxisCheckBoxesEnabled();
         }
 
-        private Vector2? getOriginPosition(PreciseScaleInfo scale) =>
-            scale.Origin switch
+        private Vector2? getOriginPosition(PreciseScaleInfo scale)
+        {
+            switch (scale.Origin)
             {
-                ScaleOrigin.GridCentre => gridToolbox.StartPosition.Value,
-                ScaleOrigin.PlayfieldCentre => OsuPlayfield.BASE_SIZE / 2,
-                ScaleOrigin.SelectionCentre when selectedItems.Count == 1 && selectedItems.First() is Slider slider => slider.Position,
-                ScaleOrigin.SelectionCentre => null,
-                _ => throw new ArgumentOutOfRangeException(nameof(scale))
-            };
+                case ScaleOrigin.GridCentre:
+                    return gridToolbox.StartPosition.Value;
+
+                case ScaleOrigin.PlayfieldCentre:
+                    return OsuPlayfield.BASE_SIZE / 2;
+
+                case ScaleOrigin.SelectionCentre:
+                    if (selectedItems.Count == 1 && selectedItems.First() is Slider slider)
+                        return slider.Position;
+
+                    return null;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(scale));
+            }
+        }
 
         private Axes getAdjustAxis(PreciseScaleInfo scale) => scale.XAxis ? scale.YAxis ? Axes.Both : Axes.X : Axes.Y;
 


### PR DESCRIPTION
Makes sure that when scaling sliders with the scale box, they are scaled relatively to the scale origin instead of the slider head.

In the second commit I'm restoring the previous behavior when scaling using the dedicated scale tool, to keep it matching stable's scale behavior, which scales relative to the slider head. If this is not wanted feel free to revert the second commit.

Before:

https://github.com/user-attachments/assets/f5eca11e-2fac-4fa9-957a-fa6055327379

After:

https://github.com/user-attachments/assets/c35672b2-1775-4211-a063-b8d94fb023bf
