### PR TITLE
Support scaling around center when scaling with select box

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -114,6 +114,26 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Repeat)
+                return false;
+
+            handleToggleViaKey(e);
+            return base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyUpEvent e)
+        {
+            handleToggleViaKey(e);
+            base.OnKeyUp(e);
+        }
+
+        private void handleToggleViaKey(KeyboardEvent key)
+        {
+            DistanceSnapProvider.HandleToggleViaKey(key);
+        }
+
         public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition, SnapType snapType = SnapType.All)
         {
             var result = base.FindSnappedPositionAndTime(screenSpacePosition, snapType);

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -369,6 +369,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                 gridSnapMomentary = shiftPressed;
                 rectangularGridSnapToggle.Value = rectangularGridSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
             }
+
+            DistanceSnapProvider.HandleToggleViaKey(key);
         }
 
         private DistanceSnapGrid createDistanceSnapGrid(IEnumerable<HitObject> selectedHitObjects)

--- a/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneComposerSelection.cs
@@ -550,7 +550,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
 
-            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50)));
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
             AddStep("aspect ratio does not equal", () => Assert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
 
@@ -589,7 +589,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
 
-            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50)));
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
             AddStep("center does not equal", () => Assert.AreNotEqual(centerBeforeDrag, getCenter()));
 
@@ -633,7 +633,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("begin drag", () => InputManager.PressButton(MouseButton.Left));
 
-            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50)));
+            AddStep("move mouse", () => InputManager.MoveMouseTo(InputManager.CurrentState.Mouse.Position + new Vector2(50, 0)));
 
             AddStep("aspect ratio does not equal", () => Assert.AreNotEqual(aspectRatioBeforeDrag, getAspectRatio()));
 

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -195,22 +195,7 @@ namespace osu.Game.Rulesets.Edit
             new TernaryButton(DistanceSnapToggle, "Distance Snap", () => new SpriteIcon { Icon = OsuIcon.EditorDistanceSnap })
         };
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.Repeat)
-                return false;
-
-            handleToggleViaKey(e);
-            return base.OnKeyDown(e);
-        }
-
-        protected override void OnKeyUp(KeyUpEvent e)
-        {
-            handleToggleViaKey(e);
-            base.OnKeyUp(e);
-        }
-
-        private void handleToggleViaKey(KeyboardEvent key)
+        public void HandleToggleViaKey(KeyboardEvent key)
         {
             bool altPressed = key.AltPressed;
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
@@ -50,14 +50,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             rawScale = convertDragEventToScaleMultiplier(e);
 
-            applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed);
+            applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             if (IsDragged)
             {
-                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed);
+                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
                 return true;
             }
 
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.OnKeyUp(e);
 
             if (IsDragged)
-                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed);
+                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
         }
 
         protected override void OnDragEnd(DragEndEvent e)
@@ -100,13 +100,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if ((originalAnchor & Anchor.y0) > 0) scale.Y = -scale.Y;
         }
 
-        private void applyScale(bool shouldLockAspectRatio)
+        private void applyScale(bool shouldLockAspectRatio, bool ignoreAnchor = false)
         {
             var newScale = shouldLockAspectRatio
                 ? new Vector2((rawScale.X + rawScale.Y) * 0.5f)
                 : rawScale;
 
-            var scaleOrigin = originalAnchor.Opposite().PositionOnQuad(scaleHandler!.OriginalSurroundingQuad!.Value);
+            Vector2? scaleOrigin = ignoreAnchor ? null : originalAnchor.Opposite().PositionOnQuad(scaleHandler!.OriginalSurroundingQuad!.Value);
             scaleHandler!.Update(newScale, scaleOrigin, getAdjustAxis());
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxScaleHandle.cs
@@ -50,14 +50,14 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             rawScale = convertDragEventToScaleMultiplier(e);
 
-            applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
+            applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, useDefaultOrigin: e.AltPressed);
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             if (IsDragged)
             {
-                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
+                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, useDefaultOrigin: e.AltPressed);
                 return true;
             }
 
@@ -69,7 +69,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.OnKeyUp(e);
 
             if (IsDragged)
-                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, ignoreAnchor: e.AltPressed);
+                applyScale(shouldLockAspectRatio: isCornerAnchor(originalAnchor) && e.ShiftPressed, useDefaultOrigin: e.AltPressed);
         }
 
         protected override void OnDragEnd(DragEndEvent e)
@@ -100,13 +100,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if ((originalAnchor & Anchor.y0) > 0) scale.Y = -scale.Y;
         }
 
-        private void applyScale(bool shouldLockAspectRatio, bool ignoreAnchor = false)
+        private void applyScale(bool shouldLockAspectRatio, bool useDefaultOrigin = false)
         {
             var newScale = shouldLockAspectRatio
                 ? new Vector2((rawScale.X + rawScale.Y) * 0.5f)
                 : rawScale;
 
-            Vector2? scaleOrigin = ignoreAnchor ? null : originalAnchor.Opposite().PositionOnQuad(scaleHandler!.OriginalSurroundingQuad!.Value);
+            Vector2? scaleOrigin = useDefaultOrigin ? null : originalAnchor.Opposite().PositionOnQuad(scaleHandler!.OriginalSurroundingQuad!.Value);
             scaleHandler!.Update(newScale, scaleOrigin, getAdjustAxis());
         }
 


### PR DESCRIPTION
Will scale around the center when pressing alt while scaling things with the select box.

Had to move the event handling for toggling the distance snap grid to `(Osu/Catch)HitObjectComposer` so the event could be prevented by the scale handle, but since `OsuHitObjectComposer` already handles the grid snap toggle this should hopefully be fine.

https://github.com/user-attachments/assets/f50ce0c5-9a48-4918-a8f7-7c9ca1813f47


https://github.com/user-attachments/assets/7c279314-6a30-4c35-887b-18efbad253c5

