### PR TITLE
Freeze select box buttons position on press

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
@@ -284,8 +285,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 Action = action
             };
 
+            button.OperationStarted += freezeButtonPosition;
+            button.HoverLost += unfreezeButtonPosition;
+
             button.OperationStarted += operationStarted;
             button.OperationEnded += operationEnded;
+
             buttons.Add(button);
 
             return button;
@@ -357,8 +362,29 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 OperationStarted?.Invoke();
         }
 
+        private Quad? frozenButtonsDrawQuad;
+
+        private void freezeButtonPosition()
+        {
+            frozenButtonsDrawQuad = buttons.ScreenSpaceDrawQuad;
+        }
+
+        private void unfreezeButtonPosition()
+        {
+            frozenButtonsDrawQuad = null;
+        }
+
         private void ensureButtonsOnScreen()
         {
+            if (frozenButtonsDrawQuad != null)
+            {
+                buttons.Anchor = Anchor.TopLeft;
+                buttons.Origin = Anchor.TopLeft;
+
+                buttons.Position = ToLocalSpace(frozenButtonsDrawQuad.Value.TopLeft) - new Vector2(button_padding);
+                return;
+            }
+
             buttons.Position = Vector2.Zero;
 
             var thisQuad = ScreenSpaceDrawQuad;

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBox.cs
@@ -6,7 +6,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
@@ -362,26 +361,26 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 OperationStarted?.Invoke();
         }
 
-        private Quad? frozenButtonsDrawQuad;
+        private Vector2? frozenButtonsPosition;
 
         private void freezeButtonPosition()
         {
-            frozenButtonsDrawQuad = buttons.ScreenSpaceDrawQuad;
+            frozenButtonsPosition = buttons.ScreenSpaceDrawQuad.TopLeft;
         }
 
         private void unfreezeButtonPosition()
         {
-            frozenButtonsDrawQuad = null;
+            frozenButtonsPosition = null;
         }
 
         private void ensureButtonsOnScreen()
         {
-            if (frozenButtonsDrawQuad != null)
+            if (frozenButtonsPosition != null)
             {
                 buttons.Anchor = Anchor.TopLeft;
                 buttons.Origin = Anchor.TopLeft;
 
-                buttons.Position = ToLocalSpace(frozenButtonsDrawQuad.Value.TopLeft) - new Vector2(button_padding);
+                buttons.Position = ToLocalSpace(frozenButtonsPosition.Value) - new Vector2(button_padding);
                 return;
             }
 

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionBoxButton.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         public Action? Action;
 
+        public event Action? HoverLost;
+
         public SelectionBoxButton(IconUsage iconUsage, string tooltip)
         {
             this.iconUsage = iconUsage;
@@ -59,6 +61,13 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             base.UpdateHoverState();
             icon.FadeColour(!IsHeld && IsHovered ? Color4.White : Color4.Black, TRANSFORM_DURATION, Easing.OutQuint);
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            base.OnHoverLost(e);
+
+            HoverLost?.Invoke();
         }
 
         public LocalisableString TooltipText { get; }


### PR DESCRIPTION
Will freeze the position of the `SelectBox` buttons in place when one of the buttons was clicked until the clicked button is no longer hovered. This ensures that buttons can be pressed repeatedly without having to reposition the mouse on every click.

Especially when rotating the selection by 90 degrees, the buttons moving around on each press was a major pain point for me since I often wanna rotate by 180 degrees and just wanna double click the button for that.

After:

https://github.com/user-attachments/assets/45602cc7-30e7-472c-a52e-5c3bffaef60e

Before:

https://github.com/user-attachments/assets/70f9c099-5184-4e85-844e-d247e0df8ad6

