### PR TITLE
Fix score being cloned in async method causing random errors (again)

### DIFF
--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -234,9 +234,12 @@ namespace osu.Game.Screens.Play
         {
             if (LoadedBeatmapSuccessfully)
             {
+                // compare: https://github.com/ppy/osu/blob/ccf1acce56798497edfaf92d3ece933469edcf0a/osu.Game/Screens/Play/Player.cs#L848-L851
+                var scoreCopy = Score.DeepClone();
+
                 Task.Run(async () =>
                 {
-                    await submitScore(Score.DeepClone()).ConfigureAwait(false);
+                    await submitScore(scoreCopy).ConfigureAwait(false);
                     spectatorClient.EndPlaying(GameplayState);
                 }).FireAndForget();
             }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29953 (probably).

Compare: https://github.com/ppy/osu/pull/24548.

I don't have a reproduction scenario (judging from the stack trace of the crash it's likely to be nigh-impossible to concoct a reliable one), but there is some circumstantial evidence that this might help, namely that that previous fix above worked, and the pathway that's failing here is similarly async to the one that pull fixed. So I'm just gonna start with that and hope that it does the job.