### PR TITLE
Add support for ruleset-specific blueprints in editor timeline

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/ManiaTimelineBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaTimelineBlueprintContainer.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+
+namespace osu.Game.Rulesets.Mania.Edit
+{
+    public partial class ManiaTimelineBlueprintContainer : TimelineBlueprintContainer
+    {
+        public ManiaTimelineBlueprintContainer(HitObjectComposer composer)
+            : base(composer)
+        {
+        }
+
+        public override TimelineHitObjectBlueprint? CreateTimelineBlueprintFor(HitObject hitObject)
+        {
+            return null;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -35,6 +35,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -63,6 +64,8 @@ namespace osu.Game.Rulesets.Mania
         public override string RulesetAPIVersionSupported => CURRENT_RULESET_API_VERSION;
 
         public override HitObjectComposer CreateHitObjectComposer() => new ManiaHitObjectComposer(this);
+
+        public override TimelineBlueprintContainer CreateTimelineBlueprintContainer(HitObjectComposer composer) => new ManiaTimelineBlueprintContainer(composer);
 
         public override IBeatmapVerifier CreateBeatmapVerifier() => new ManiaBeatmapVerifier();
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerTimelineBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerTimelineBlueprint.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+
+namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
+{
+    public partial class SpinnerTimelineBlueprint : TimelineHitObjectBlueprint
+    {
+        public SpinnerTimelineBlueprint(HitObject item)
+            : base(item)
+        {
+            SamplePointPiece.X = 1;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/OsuTimelineBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuTimelineBlueprintContainer.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+
+namespace osu.Game.Rulesets.Osu.Edit
+{
+    public partial class OsuTimelineBlueprintContainer : TimelineBlueprintContainer
+    {
+        public OsuTimelineBlueprintContainer(HitObjectComposer composer)
+            : base(composer)
+        {
+        }
+
+        public override TimelineHitObjectBlueprint? CreateTimelineBlueprintFor(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                case Spinner spinner:
+                    return new SpinnerTimelineBlueprint(spinner);
+            }
+
+            return base.CreateTimelineBlueprintFor(hitObject);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -36,6 +36,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -234,6 +235,8 @@ namespace osu.Game.Rulesets.Osu
         public override PerformanceCalculator CreatePerformanceCalculator() => new OsuPerformanceCalculator();
 
         public override HitObjectComposer CreateHitObjectComposer() => new OsuHitObjectComposer(this);
+
+        public override TimelineBlueprintContainer CreateTimelineBlueprintContainer(HitObjectComposer composer) => new OsuTimelineBlueprintContainer(composer);
 
         public override IBeatmapVerifier CreateBeatmapVerifier() => new OsuBeatmapVerifier();
 

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -26,6 +26,7 @@ using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
@@ -269,6 +270,8 @@ namespace osu.Game.Rulesets
         public virtual PerformanceCalculator? CreatePerformanceCalculator() => null;
 
         public virtual HitObjectComposer? CreateHitObjectComposer() => null;
+
+        public virtual TimelineBlueprintContainer CreateTimelineBlueprintContainer(HitObjectComposer composer) => new TimelineBlueprintContainer(composer);
 
         public virtual IBeatmapVerifier? CreateBeatmapVerifier() => null;
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -25,7 +26,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 {
-    internal partial class TimelineBlueprintContainer : EditorBlueprintContainer
+    public partial class TimelineBlueprintContainer : EditorBlueprintContainer
     {
         [Resolved(CanBeNull = true)]
         private Timeline timeline { get; set; }
@@ -163,13 +164,13 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TimelineSelectionHandler();
 
-        protected override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject item)
+        protected sealed override SelectionBlueprint<HitObject> CreateBlueprintFor(HitObject item)
         {
-            return new TimelineHitObjectBlueprint(item)
-            {
-                OnDragHandled = e => hitObjectDragged = e != null,
-            };
+            return CreateTimelineBlueprintFor(item)?.With(b => b.OnDragHandled = e => hitObjectDragged = e != null);
         }
+
+        [CanBeNull]
+        public virtual TimelineHitObjectBlueprint CreateTimelineBlueprintFor(HitObject hitObject) => new TimelineHitObjectBlueprint(hitObject);
 
         protected sealed override DragBox CreateDragBox() => new TimelineDragBox();
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineHitObjectBlueprint.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private readonly Container colouredComponents;
         private readonly Container sampleComponents;
         private readonly OsuSpriteText comboIndexText;
-        private readonly SamplePointPiece samplePointPiece;
+        protected readonly SamplePointPiece SamplePointPiece;
         private readonly DifficultyPointPiece? difficultyPointPiece;
 
         [Resolved]
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         },
                     }
                 },
-                samplePointPiece = new SamplePointPiece(Item)
+                SamplePointPiece = new SamplePointPiece(Item)
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.TopCentre,
@@ -258,7 +258,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 });
             }
 
-            samplePointPiece.X = 1f / (repeats.RepeatCount + 1) / 2;
+            SamplePointPiece.X = 1f / (repeats.RepeatCount + 1) / 2;
         }
 
         protected override bool ShouldBeConsideredForInput(Drawable child) => true;
@@ -281,7 +281,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             // If the component is considered masked away, we'll use children to create an extended quad that encapsulates all parts of this blueprint
             // to ensure it doesn't pop in and out of existence abruptly when scrolling the timeline.
             var rect = RectangleF.Union(ScreenSpaceDrawQuad.AABBFloat, circle.ScreenSpaceDrawQuad.AABBFloat);
-            rect = RectangleF.Union(rect, samplePointPiece.ScreenSpaceDrawQuad.AABBFloat);
+            rect = RectangleF.Union(rect, SamplePointPiece.ScreenSpaceDrawQuad.AABBFloat);
 
             if (difficultyPointPiece != null)
                 rect = RectangleF.Union(rect, difficultyPointPiece.ScreenSpaceDrawQuad.AABBFloat);

--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Edit.Compose
                     // We want to display this below hitobjects to better expose placement objects visually.
                     // It needs to be above the blueprint container to handle drags on breaks though.
                     breakDisplay.CreateProxy(),
-                    new TimelineBlueprintContainer(composer),
+                    ruleset.CreateTimelineBlueprintContainer(composer),
                     breakDisplay
                 }
             });


### PR DESCRIPTION
RFC. This PR allows rulesets to customize how hit objects are represented in the timeline without having to modify the hit object classes or create additional interfaces.
The need for this has been expressed multiple times already in https://github.com/ppy/osu/pull/29441 and https://github.com/ppy/osu/pull/21566

The API is a bit limited because it expects objects of type `TimelineHitObjectBlueprint` which already defines all the layout and interactions. If more freedom is required, I think `TimelineHitObjectBlueprint` should not define layout and instead the parts of it should be split into separate classes which could be composited instead.

## Some examples of what could be possible with ruleset-specific timelines:
- Sample points at the tail end of spinners

![osu!_P5WhzZqmYk](https://github.com/user-attachments/assets/1b61a9c0-53ca-4568-9d6f-8d7b4ca81e11)

- No hitobjects timeline in mania (as in stable), and showing scroll speed changes (mania and taiko).

![mania timeline scroll speed](https://github.com/user-attachments/assets/c84f0349-c9d3-4058-bb9a-ce4fc8b25761)

- The `IHasDisplayColour` interface can also be eliminated in favour of taiko specific timeline blueprints. Maybe even show strong hits.

![taiko timeline](https://github.com/user-attachments/assets/dd9044f3-5155-4db9-a285-aec20268e7e8)

- More advanced editor tools that utilize the timeline.

![chrome_tRdayWep7D](https://github.com/user-attachments/assets/26419a38-999c-43b6-bfb3-8cf4975bbbe9)

