### PR TITLE
Various speed distance difficulty calculation changes

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -15,22 +15,22 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Osu.Tests";
 
-        [TestCase(6.710442985146793d, 239, "diffcalc-test")]
-        [TestCase(1.4386882251130073d, 54, "zero-length-sliders")]
-        [TestCase(0.42506480230838789d, 4, "very-fast-slider")]
-        [TestCase(0.14102693012101306d, 2, "nan-slider")]
+        [TestCase(6.7154251995274938d, 239, "diffcalc-test")]
+        [TestCase(1.4430610657612626d, 54, "zero-length-sliders")]
+        [TestCase(0.42630400627180914d, 4, "very-fast-slider")]
+        [TestCase(0.14143808967817237d, 2, "nan-slider")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(8.9742952703071666d, 239, "diffcalc-test")]
-        [TestCase(1.743180218215227d, 54, "zero-length-sliders")]
-        [TestCase(0.55071082800473514d, 4, "very-fast-slider")]
+        [TestCase(8.9808183779700208d, 239, "diffcalc-test")]
+        [TestCase(1.7483507893412422d, 54, "zero-length-sliders")]
+        [TestCase(0.55231632896800109d, 4, "very-fast-slider")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModDoubleTime());
 
-        [TestCase(6.710442985146793d, 239, "diffcalc-test")]
-        [TestCase(1.4386882251130073d, 54, "zero-length-sliders")]
-        [TestCase(0.42506480230838789d, 4, "very-fast-slider")]
+        [TestCase(6.7154251995274938d, 239, "diffcalc-test")]
+        [TestCase(1.4430610657612626d, 54, "zero-length-sliders")]
+        [TestCase(0.42630400627180914d, 4, "very-fast-slider")]
         public void TestClassicMod(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModClassic());
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double single_spacing_threshold = 125; // 1.25 circles distance between centers
         private const double min_speed_bonus = 75; // ~200BPM
         private const double speed_balancing_factor = 40;
-        private const double distance_multiplier = 0.95;
+        private const double distance_multiplier = 0.94;
 
         /// <summary>
         /// Evaluates the difficulty of tapping the current object, based on:
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             distance = Math.Min(distance, single_spacing_threshold);
 
             // Max distance bonus is 1 * `distance_multiplier` at single_spacing_threshold
-            double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.75) * distance_multiplier;
+            double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.95) * distance_multiplier;
 
             // Base difficulty with all bonuses
             double difficulty = (1 + speedBonus + distanceBonus) * 1000 / strainTime;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // 0.93 is derived from making sure 260bpm OD8 streams aren't nerfed harshly, whilst 0.92 limits the effect of the cap.
             strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindowGreat) / 0.93, 0.92, 1);
 
-            // speedBonus will be 1.0 for BPM < 200
+            // speedBonus will be 0.0 for BPM < 200
             double speedBonus = 0.0;
 
             // Add additional scaling bonus for streams/bursts higher than 200bpm

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -13,6 +13,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
         private const double single_spacing_threshold = 125; // 1.25 circles distance between centers
         private const double min_speed_bonus = 75; // ~200BPM
         private const double speed_balancing_factor = 40;
+        private const double distance_multiplier = 0.95;
 
         /// <summary>
         /// Evaluates the difficulty of tapping the current object, based on:
@@ -51,11 +52,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             strainTime /= Math.Clamp((strainTime / osuCurrObj.HitWindowGreat) / 0.93, 0.92, 1);
 
             // speedBonus will be 1.0 for BPM < 200
-            double speedBonus = 1.0;
+            double speedBonus = 0.0;
 
             // Add additional scaling bonus for streams/bursts higher than 200bpm
             if (strainTime < min_speed_bonus)
-                speedBonus = 1 + 0.75 * Math.Pow((min_speed_bonus - strainTime) / speed_balancing_factor, 2);
+                speedBonus = 0.75 * Math.Pow((min_speed_bonus - strainTime) / speed_balancing_factor, 2);
 
             double travelDistance = osuPrevObj?.TravelDistance ?? 0;
             double distance = travelDistance + osuCurrObj.MinimumJumpDistance;
@@ -64,10 +65,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             distance = Math.Min(distance, single_spacing_threshold);
 
             // Max distance bonus is 2 at single_spacing_threshold
-            double distanceBonus = 1 + Math.Pow(distance / single_spacing_threshold, 3.5);
+            double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.75) * distance_multiplier;
 
             // Base difficulty with all bonuses
-            double difficulty = speedBonus * distanceBonus * 1000 / strainTime;
+            double difficulty = (1 + speedBonus + distanceBonus) * 1000 / strainTime;
 
             // Apply penalty if there's doubletappable doubles
             return difficulty * doubletapness;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -64,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             // Cap distance at single_spacing_threshold
             distance = Math.Min(distance, single_spacing_threshold);
 
-            // Max distance bonus is 2 at single_spacing_threshold
+            // Max distance bonus is 1 * `distance_multiplier` at single_spacing_threshold
             double distanceBonus = Math.Pow(distance / single_spacing_threshold, 3.75) * distance_multiplier;
 
             // Base difficulty with all bonuses

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 {
     public class OsuPerformanceCalculator : PerformanceCalculator
     {
-        public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
+        public const double PERFORMANCE_BASE_MULTIPLIER = 1.15; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
         private double accuracy;
         private int scoreMaxCombo;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double currentStrain;
 
-        private double skillMultiplier => 24.963;
+        private double skillMultiplier => 24.983;
         private double strainDecayBase => 0.15;
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);


### PR DESCRIPTION
Intended to be a general nerf to flow aim.

Changes:
- Distance bonus on speed is now additive instead of being a multiplier
- Distance bonus power increased to scale differently for smaller spacing
- Introduced `distance_multiplier` to overall decrease the distance bonus
- Increase global multiplier and aim skill multiplier to help with balancing