### PR TITLE
Redesign directory & file selector

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneDirectorySelector.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneDirectorySelector.cs
@@ -9,6 +9,11 @@ namespace osu.Game.Tests.Visual.Settings
 {
     public partial class TestSceneDirectorySelector : ThemeComparisonTestScene
     {
+        public TestSceneDirectorySelector()
+            : base(false)
+        {
+        }
+
         protected override Drawable CreateContent() => new OsuDirectorySelector
         {
             RelativeSizeAxes = Axes.Both

--- a/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneFileSelector.cs
@@ -1,37 +1,49 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osu.Game.Tests.Visual.UserInterface;
 
 namespace osu.Game.Tests.Visual.Settings
 {
     public partial class TestSceneFileSelector : ThemeComparisonTestScene
     {
-        [Resolved]
-        private OsuColour colours { get; set; } = null!;
+        public TestSceneFileSelector()
+            : base(false)
+        {
+        }
 
         [Test]
         public void TestJpgFilesOnly()
         {
             AddStep("create", () =>
             {
-                ContentContainer.Children = new Drawable[]
+                var colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
+                ContentContainer.Child = new DependencyProvidingContainer
                 {
-                    new Box
+                    RelativeSizeAxes = Axes.Both,
+                    CachedDependencies = new (Type, object)[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeaFoam
+                        (typeof(OverlayColourProvider), colourProvider)
                     },
-                    new OsuFileSelector(validFileExtensions: new[] { ".jpg" })
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                    },
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = colourProvider.Background3
+                        },
+                        new OsuFileSelector(validFileExtensions: new[] { ".jpg" })
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                    }
                 };
             });
         }

--- a/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
+++ b/osu.Game.Tournament/Screens/Setup/StablePathSelectScreen.cs
@@ -27,6 +27,9 @@ namespace osu.Game.Tournament.Screens.Setup
         [Resolved]
         private MatchIPCInfo ipc { get; set; } = null!;
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
         private OsuDirectorySelector directorySelector = null!;
         private DialogOverlay? overlay;
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelector.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -20,7 +18,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private Box hiddenToggleBackground = null!;
 
-        public OsuDirectorySelector(string initialPath = null)
+        public OsuDirectorySelector(string? initialPath = null)
             : base(initialPath)
         {
         }
@@ -68,7 +66,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new OsuDirectorySelectorParentDirectory(directory);
 
-        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new OsuDirectorySelectorDirectory(directory, displayName);
+        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string? displayName = null) => new OsuDirectorySelectorDirectory(directory, displayName);
 
         protected override void NotifySelectionError() => this.FlashColour(Colour4.Red, 300);
     }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelector.cs
@@ -7,14 +7,18 @@ using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Containers;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class OsuDirectorySelector : DirectorySelector
     {
-        public const float ITEM_HEIGHT = 20;
+        public const float ITEM_HEIGHT = 16;
+
+        private Box hiddenToggleBackground = null!;
 
         public OsuDirectorySelector(string initialPath = null)
             : base(initialPath)
@@ -22,16 +26,45 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider colourProvider)
         {
-            Padding = new MarginPadding(10);
+            AddInternal(new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Background5,
+                Depth = float.MaxValue,
+            });
+
+            hiddenToggleBackground.Colour = colourProvider.Background4;
         }
 
-        protected override ScrollContainer<Drawable> CreateScrollContainer() => new OsuScrollContainer();
+        protected override ScrollContainer<Drawable> CreateScrollContainer() => new OsuScrollContainer
+        {
+            Padding = new MarginPadding
+            {
+                Horizontal = 20,
+                Vertical = 15,
+            }
+        };
 
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new OsuDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new OsuDirectorySelectorHiddenToggle { Current = { BindTarget = ShowHiddenItems } };
+        protected override Drawable CreateHiddenToggleButton() => new Container
+        {
+            RelativeSizeAxes = Axes.Y,
+            AutoSizeAxes = Axes.X,
+            Children = new Drawable[]
+            {
+                hiddenToggleBackground = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuDirectorySelectorHiddenToggle
+                {
+                    Current = { BindTarget = ShowHiddenItems },
+                },
+            }
+        };
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new OsuDirectorySelectorParentDirectory(directory);
 

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorBreadcrumbDisplay.cs
@@ -6,28 +6,48 @@
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
     internal partial class OsuDirectorySelectorBreadcrumbDisplay : DirectorySelectorBreadcrumbDisplay
     {
-        protected override Drawable CreateCaption() => new OsuSpriteText
+        public const float HEIGHT = 45;
+        public const float HORIZONTAL_PADDING = 20;
+
+        protected override Drawable CreateCaption() => Empty().With(d =>
         {
-            Text = "Current Directory: ",
-            Font = OsuFont.Default.With(size: OsuDirectorySelector.ITEM_HEIGHT),
-        };
+            d.Origin = Anchor.CentreLeft;
+            d.Anchor = Anchor.CentreLeft;
+            d.Alpha = 0;
+        });
 
         protected override DirectorySelectorDirectory CreateRootDirectoryItem() => new OsuBreadcrumbDisplayComputer();
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new OsuBreadcrumbDisplayDirectory(directory, displayName);
 
-        public OsuDirectorySelectorBreadcrumbDisplay()
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
         {
-            Padding = new MarginPadding(15);
+            ((FillFlowContainer)InternalChild).Padding = new MarginPadding
+            {
+                Horizontal = HORIZONTAL_PADDING,
+                Vertical = 10,
+            };
+
+            AddInternal(new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Background4,
+                Depth = 1,
+            });
         }
 
         private partial class OsuBreadcrumbDisplayComputer : OsuBreadcrumbDisplayDirectory
@@ -40,26 +60,67 @@ namespace osu.Game.Graphics.UserInterfaceV2
             }
         }
 
-        private partial class OsuBreadcrumbDisplayDirectory : OsuDirectorySelectorDirectory
+        private partial class OsuBreadcrumbDisplayDirectory : DirectorySelectorDirectory
         {
             public OsuBreadcrumbDisplayDirectory(DirectoryInfo directory, string displayName = null)
                 : base(directory, displayName)
             {
             }
 
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; }
+
             [BackgroundDependencyLoader]
             private void load()
             {
+                Anchor = Anchor.CentreLeft;
+                Origin = Anchor.CentreLeft;
+
+                Flow.AutoSizeAxes = Axes.X;
+                Flow.Height = 25;
+                Flow.Margin = new MarginPadding { Horizontal = 10, };
+
+                AddRangeInternal(new Drawable[]
+                {
+                    new Background
+                    {
+                        Depth = 1
+                    },
+                    new HoverClickSounds(),
+                });
+
                 Flow.Add(new SpriteIcon
                 {
                     Anchor = Anchor.CentreLeft,
                     Origin = Anchor.CentreLeft,
                     Icon = FontAwesome.Solid.ChevronRight,
-                    Size = new Vector2(FONT_SIZE / 2)
+                    Size = new Vector2(FONT_SIZE / 2),
+                    Margin = new MarginPadding { Left = 5, },
                 });
+                Flow.Colour = colourProvider.Light3;
             }
 
-            protected override IconUsage? Icon => Directory.Name.Contains(Path.DirectorySeparatorChar) ? base.Icon : null;
+            protected override SpriteText CreateSpriteText() => new OsuSpriteText().With(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold));
+
+            protected override IconUsage? Icon => Directory.Name.Contains(Path.DirectorySeparatorChar) ? FontAwesome.Solid.Database : null;
+
+            internal partial class Background : CompositeDrawable
+            {
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider overlayColourProvider)
+                {
+                    RelativeSizeAxes = Axes.Both;
+
+                    Masking = true;
+                    CornerRadius = 5;
+
+                    InternalChild = new Box
+                    {
+                        Colour = overlayColourProvider.Background3,
+                        RelativeSizeAxes = Axes.Both,
+                    };
+                }
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorBreadcrumbDisplay.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -31,7 +29,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected override DirectorySelectorDirectory CreateRootDirectoryItem() => new OsuBreadcrumbDisplayComputer();
 
-        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new OsuBreadcrumbDisplayDirectory(directory, displayName);
+        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string? displayName = null) => new OsuBreadcrumbDisplayDirectory(directory, displayName);
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -62,13 +60,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private partial class OsuBreadcrumbDisplayDirectory : DirectorySelectorDirectory
         {
-            public OsuBreadcrumbDisplayDirectory(DirectoryInfo directory, string displayName = null)
+            public OsuBreadcrumbDisplayDirectory(DirectoryInfo? directory, string? displayName = null)
                 : base(directory, displayName)
             {
             }
 
             [Resolved]
-            private OverlayColourProvider colourProvider { get; set; }
+            private OverlayColourProvider colourProvider { get; set; } = null!;
 
             [BackgroundDependencyLoader]
             private void load()

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -15,7 +13,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 {
     internal partial class OsuDirectorySelectorDirectory : DirectorySelectorDirectory
     {
-        public OsuDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
+        public OsuDirectorySelectorDirectory(DirectoryInfo directory, string? displayName = null)
             : base(directory, displayName)
         {
         }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorDirectory.cs
@@ -6,13 +6,10 @@
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
-using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -24,43 +21,23 @@ namespace osu.Game.Graphics.UserInterfaceV2
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuColour colours)
         {
             Flow.AutoSizeAxes = Axes.X;
             Flow.Height = OsuDirectorySelector.ITEM_HEIGHT;
 
             AddRangeInternal(new Drawable[]
             {
-                new Background
-                {
-                    Depth = 1
-                },
                 new HoverClickSounds()
             });
+
+            Colour = colours.Orange1;
         }
 
-        protected override SpriteText CreateSpriteText() => new OsuSpriteText();
+        protected override SpriteText CreateSpriteText() => new OsuSpriteText().With(t => t.Font = OsuFont.Default.With(weight: FontWeight.Bold));
 
         protected override IconUsage? Icon => Directory.Name.Contains(Path.DirectorySeparatorChar)
             ? FontAwesome.Solid.Database
             : FontAwesome.Regular.Folder;
-
-        internal partial class Background : CompositeDrawable
-        {
-            [BackgroundDependencyLoader(true)]
-            private void load(OverlayColourProvider overlayColourProvider, OsuColour colours)
-            {
-                RelativeSizeAxes = Axes.Both;
-
-                Masking = true;
-                CornerRadius = 5;
-
-                InternalChild = new Box
-                {
-                    Colour = overlayColourProvider?.Background5 ?? colours.GreySeaFoamDarker,
-                    RelativeSizeAxes = Axes.Both,
-                };
-            }
-        }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorHiddenToggle.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorHiddenToggle.cs
@@ -16,7 +16,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             RelativeSizeAxes = Axes.None;
             AutoSizeAxes = Axes.None;
-            Size = new Vector2(100, 50);
+            Size = new Vector2(100, OsuDirectorySelectorBreadcrumbDisplay.HEIGHT);
+            Margin = new MarginPadding { Right = OsuDirectorySelectorBreadcrumbDisplay.HORIZONTAL_PADDING, };
             Anchor = Anchor.CentreLeft;
             Origin = Anchor.CentreLeft;
             LabelTextFlowContainer.Anchor = Anchor.CentreLeft;

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorHiddenToggle.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorHiddenToggle.cs
@@ -16,13 +16,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
         {
             RelativeSizeAxes = Axes.None;
             AutoSizeAxes = Axes.None;
-            Size = new Vector2(100, OsuDirectorySelectorBreadcrumbDisplay.HEIGHT);
+            Size = new Vector2(140, OsuDirectorySelectorBreadcrumbDisplay.HEIGHT);
             Margin = new MarginPadding { Right = OsuDirectorySelectorBreadcrumbDisplay.HORIZONTAL_PADDING, };
             Anchor = Anchor.CentreLeft;
             Origin = Anchor.CentreLeft;
             LabelTextFlowContainer.Anchor = Anchor.CentreLeft;
             LabelTextFlowContainer.Origin = Anchor.CentreLeft;
             LabelText = @"Show hidden";
+
+            Scale = new Vector2(0.8f);
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorParentDirectory.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuDirectorySelectorParentDirectory.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.IO;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -13,6 +15,12 @@ namespace osu.Game.Graphics.UserInterfaceV2
         public OsuDirectorySelectorParentDirectory(DirectoryInfo directory)
             : base(directory, "..")
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            Colour = colourProvider.Content1;
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -8,32 +8,64 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
     public partial class OsuFileSelector : FileSelector
     {
+        private Box hiddenToggleBackground = null!;
+
         public OsuFileSelector(string initialPath = null, string[] validFileExtensions = null)
-            : base(initialPath, validFileExtensions)
         {
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider colourProvider)
         {
-            Padding = new MarginPadding(10);
+            AddInternal(new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Background5,
+                Depth = float.MaxValue,
+            });
+
+            hiddenToggleBackground.Colour = colourProvider.Background4;
         }
 
-        protected override ScrollContainer<Drawable> CreateScrollContainer() => new OsuScrollContainer();
+        protected override ScrollContainer<Drawable> CreateScrollContainer() => new OsuScrollContainer
+        {
+            Padding = new MarginPadding
+            {
+                Horizontal = 20,
+                Vertical = 15,
+            }
+        };
 
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new OsuDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new OsuDirectorySelectorHiddenToggle { Current = { BindTarget = ShowHiddenItems } };
+        protected override Drawable CreateHiddenToggleButton() => new Container
+        {
+            RelativeSizeAxes = Axes.Y,
+            AutoSizeAxes = Axes.X,
+            Children = new Drawable[]
+            {
+                hiddenToggleBackground = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new OsuDirectorySelectorHiddenToggle
+                {
+                    Current = { BindTarget = ShowHiddenItems },
+                },
+            }
+        };
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new OsuDirectorySelectorParentDirectory(directory);
 
@@ -51,19 +83,17 @@ namespace osu.Game.Graphics.UserInterfaceV2
             }
 
             [BackgroundDependencyLoader]
-            private void load()
+            private void load(OverlayColourProvider colourProvider)
             {
                 Flow.AutoSizeAxes = Axes.X;
                 Flow.Height = OsuDirectorySelector.ITEM_HEIGHT;
 
                 AddRangeInternal(new Drawable[]
                 {
-                    new OsuDirectorySelectorDirectory.Background
-                    {
-                        Depth = 1
-                    },
                     new HoverClickSounds()
                 });
+
+                Colour = colourProvider.Light3;
             }
 
             protected override IconUsage? Icon
@@ -91,7 +121,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 }
             }
 
-            protected override SpriteText CreateSpriteText() => new OsuSpriteText();
+            protected override SpriteText CreateSpriteText() => new OsuSpriteText().With(t => t.Font = OsuFont.Default.With(weight: FontWeight.SemiBold));
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/OsuFileSelector.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -22,7 +20,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
     {
         private Box hiddenToggleBackground = null!;
 
-        public OsuFileSelector(string initialPath = null, string[] validFileExtensions = null)
+        public OsuFileSelector(string? initialPath = null, string[]? validFileExtensions = null)
+            : base(initialPath, validFileExtensions)
         {
         }
 
@@ -69,7 +68,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new OsuDirectorySelectorParentDirectory(directory);
 
-        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new OsuDirectorySelectorDirectory(directory, displayName);
+        protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string? displayName = null) => new OsuDirectorySelectorDirectory(directory, displayName);
 
         protected override DirectoryListingFile CreateFileItem(FileInfo file) => new OsuDirectoryListingFile(file);
 

--- a/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenImportFromStable.cs
@@ -314,6 +314,7 @@ namespace osu.Game.Overlays.FirstRunSetup
             private partial class DirectoryChooserPopover : OsuPopover
             {
                 public DirectoryChooserPopover(Bindable<DirectoryInfo?> currentDirectory)
+                    : base(false)
                 {
                     Child = new Container
                     {
@@ -324,6 +325,13 @@ namespace osu.Game.Overlays.FirstRunSetup
                             CurrentPath = { BindTarget = currentDirectory }
                         },
                     };
+                }
+
+                [BackgroundDependencyLoader]
+                private void load(OverlayColourProvider colourProvider)
+                {
+                    Body.BorderColour = colourProvider.Highlight1;
+                    Body.BorderThickness = 2;
                 }
             }
         }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/DirectorySelectScreen.cs
@@ -48,8 +48,11 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         /// </summary>
         protected virtual DirectoryInfo InitialPath => null;
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        private void load()
         {
             InternalChild = new Container
             {
@@ -64,7 +67,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = colours.GreySeaFoamDark
+                        Colour = colourProvider.Background4,
                     },
                     new GridContainer
                     {

--- a/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
+++ b/osu.Game/Screens/Edit/Setup/LabelledFileChooser.cs
@@ -18,6 +18,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
@@ -118,6 +119,7 @@ namespace osu.Game.Screens.Edit.Setup
             protected override string PopOutSampleName => "UI/overlay-big-pop-out";
 
             public FileChooserPopover(string[] handledExtensions, Bindable<FileInfo?> currentFile, string? chooserPath)
+                : base(false)
             {
                 Child = new Container
                 {
@@ -128,6 +130,13 @@ namespace osu.Game.Screens.Edit.Setup
                         CurrentFile = { BindTarget = currentFile }
                     },
                 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OverlayColourProvider colourProvider)
+            {
+                Body.BorderColour = colourProvider.Highlight1;
+                Body.BorderThickness = 2;
             }
         }
     }

--- a/osu.Game/Screens/Import/FileImportScreen.cs
+++ b/osu.Game/Screens/Import/FileImportScreen.cs
@@ -15,6 +15,7 @@ using osu.Framework.Screens;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
 using osuTK;
 
 namespace osu.Game.Screens.Import
@@ -36,8 +37,8 @@ namespace osu.Game.Screens.Import
         [Resolved]
         private OsuGameBase game { get; set; }
 
-        [Resolved]
-        private OsuColour colours { get; set; }
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
 
         [BackgroundDependencyLoader(true)]
         private void load()
@@ -52,11 +53,6 @@ namespace osu.Game.Screens.Import
                 Size = new Vector2(0.9f, 0.8f),
                 Children = new Drawable[]
                 {
-                    new Box
-                    {
-                        Colour = colours.GreySeaFoamDark,
-                        RelativeSizeAxes = Axes.Both,
-                    },
                     fileSelector = new OsuFileSelector(validFileExtensions: game.HandledExtensions.ToArray())
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -72,7 +68,7 @@ namespace osu.Game.Screens.Import
                         {
                             new Box
                             {
-                                Colour = colours.GreySeaFoamDarker,
+                                Colour = colourProvider.Background4,
                                 RelativeSizeAxes = Axes.Both
                             },
                             new Container


### PR DESCRIPTION
Continuation of https://github.com/ppy/osu/issues/29643.

| master | this PR |
| :-: | :-: |
| ![osu_2024-09-24_15-03-06](https://github.com/user-attachments/assets/4011ec63-265f-474b-8a41-007b63b7c6dd) | ![osu_2024-09-24_15-04-51](https://github.com/user-attachments/assets/752c17d7-9120-457a-aa98-dbd80144aac0) |
| ![osu_2024-09-24_15-03-18](https://github.com/user-attachments/assets/fb97f35c-a2eb-40a0-b622-039abf2b85ce) | ![osu_2024-09-24_15-05-21](https://github.com/user-attachments/assets/a11b83e0-73c7-41d7-b836-7e75ad282f51) |
| ![osu_2024-09-24_15-03-28](https://github.com/user-attachments/assets/88956c66-21f5-4c4d-82da-ac13c39702e0) | ![osu_2024-09-24_15-05-43](https://github.com/user-attachments/assets/681331df-fdf2-487c-b21e-08eb9a3ef3cf) |
| ![osu_2024-09-24_15-03-37](https://github.com/user-attachments/assets/36166205-8ca6-4bf1-82e4-d15e056c8cca) | ![osu_2024-09-24_15-05-30](https://github.com/user-attachments/assets/e6ccfa43-ba6e-4499-b709-f09e78d83d39) |
| ![1727183052](https://github.com/user-attachments/assets/ae372b87-a2cc-4b88-8776-74abfda5fa51) | ![1727183168](https://github.com/user-attachments/assets/55bd7f55-8225-4f9d-9204-62a488d24652) |

Also contains some NRT sprinkled in.