### PR TITLE
Fix reflection-related iOS crashes

### DIFF
--- a/osu.Game.Tests/Utils/BindableValueAccessorTest.cs
+++ b/osu.Game.Tests/Utils/BindableValueAccessorTest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Game.Utils;
+
+namespace osu.Game.Tests.Utils
+{
+    [TestFixture]
+    public class BindableValueAccessorTest
+    {
+        [Test]
+        public void GetValue()
+        {
+            const int value = 1337;
+
+            BindableInt bindable = new BindableInt(value);
+            Assert.That(BindableValueAccessor.GetValue(bindable), Is.EqualTo(value));
+        }
+
+        [Test]
+        public void SetValue()
+        {
+            const int value = 1337;
+
+            BindableInt bindable = new BindableInt();
+            BindableValueAccessor.SetValue(bindable, value);
+
+            Assert.That(bindable.Value, Is.EqualTo(value));
+        }
+
+        [Test]
+        public void GetInvalidBindable()
+        {
+            BindableList<object> list = new BindableList<object>();
+            Assert.That(BindableValueAccessor.GetValue(list), Is.EqualTo(list));
+        }
+
+        [Test]
+        public void SetInvalidBindable()
+        {
+            const int value = 1337;
+
+            BindableList<int> list = new BindableList<int> { value };
+            BindableValueAccessor.SetValue(list, 2);
+
+            Assert.That(list, Has.Exactly(1).Items);
+            Assert.That(list[0], Is.EqualTo(value));
+        }
+    }
+}

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -198,6 +198,7 @@ namespace osu.Game.Beatmaps
 
             if (beatmapSet.OnlineID > 0)
             {
+                // Required local for iOS. Will cause runtime crash if inlined.
                 int onlineId = beatmapSet.OnlineID;
 
                 // OnlineID should really be unique, but to avoid catastrophic failure let's iterate just to be sure.

--- a/osu.Game/Beatmaps/BeatmapImporter.cs
+++ b/osu.Game/Beatmaps/BeatmapImporter.cs
@@ -198,8 +198,10 @@ namespace osu.Game.Beatmaps
 
             if (beatmapSet.OnlineID > 0)
             {
+                int onlineId = beatmapSet.OnlineID;
+
                 // OnlineID should really be unique, but to avoid catastrophic failure let's iterate just to be sure.
-                foreach (var existingSetWithSameOnlineID in realm.All<BeatmapSetInfo>().Where(b => b.OnlineID == beatmapSet.OnlineID))
+                foreach (var existingSetWithSameOnlineID in realm.All<BeatmapSetInfo>().Where(b => b.OnlineID == onlineId))
                 {
                     existingSetWithSameOnlineID.DeletePending = true;
                     existingSetWithSameOnlineID.OnlineID = -1;

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -15,6 +14,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays.Settings;
+using osu.Game.Utils;
 
 namespace osu.Game.Configuration
 {
@@ -228,10 +228,7 @@ namespace osu.Game.Configuration
                     return b.Value;
 
                 case IBindable u:
-                    // An unknown (e.g. enum) generic type.
-                    var valueMethod = u.GetType().GetProperty(nameof(IBindable<int>.Value));
-                    Debug.Assert(valueMethod != null);
-                    return valueMethod.GetValue(u)!;
+                    return BindableValueAccessor.GetValue(u);
 
                 default:
                     // fall back for non-bindable cases.

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -40,7 +40,9 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == TrackedItem.OnlineID && !s.DeletePending), (items, _) =>
+            int onlineId = TrackedItem.OnlineID;
+
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == onlineId && !s.DeletePending), (items, _) =>
             {
                 if (items.Any())
                     Schedule(() => UpdateState(DownloadState.LocallyAvailable));

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Online
             // Used to interact with manager classes that don't support interface types. Will eventually be replaced.
             var beatmapSetInfo = new BeatmapSetInfo { OnlineID = TrackedItem.OnlineID };
 
+            // Required local for iOS. Will cause runtime crash if inlined.
             int onlineId = TrackedItem.OnlineID;
 
             realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == onlineId && !s.DeletePending), (items, _) =>

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -46,6 +46,7 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
+            // Required local for iOS. Will cause runtime crash if inlined.
             long onlineId = TrackedItem.OnlineID;
             long legacyOnlineId = TrackedItem.LegacyOnlineID;
             string hash = TrackedItem.Hash;

--- a/osu.Game/Online/ScoreDownloadTracker.cs
+++ b/osu.Game/Online/ScoreDownloadTracker.cs
@@ -46,10 +46,14 @@ namespace osu.Game.Online
             Downloader.DownloadBegan += downloadBegan;
             Downloader.DownloadFailed += downloadFailed;
 
+            long onlineId = TrackedItem.OnlineID;
+            long legacyOnlineId = TrackedItem.LegacyOnlineID;
+            string hash = TrackedItem.Hash;
+
             realmSubscription = realm.RegisterForNotifications(r => r.All<ScoreInfo>().Where(s =>
-                ((s.OnlineID > 0 && s.OnlineID == TrackedItem.OnlineID)
-                 || (s.LegacyOnlineID > 0 && s.LegacyOnlineID == TrackedItem.LegacyOnlineID)
-                 || (!string.IsNullOrEmpty(s.Hash) && s.Hash == TrackedItem.Hash))
+                ((s.OnlineID > 0 && s.OnlineID == onlineId)
+                 || (s.LegacyOnlineID > 0 && s.LegacyOnlineID == legacyOnlineId)
+                 || (!string.IsNullOrEmpty(s.Hash) && s.Hash == hash))
                 && !s.DeletePending), (items, _) =>
             {
                 if (items.Any())

--- a/osu.Game/Rulesets/Mods/Mod.cs
+++ b/osu.Game/Rulesets/Mods/Mod.cs
@@ -266,8 +266,7 @@ namespace osu.Game.Rulesets.Mods
 
                 // TODO: special case for handling number types
 
-                PropertyInfo property = targetSetting.GetType().GetProperty(nameof(Bindable<bool>.Value))!;
-                property.SetValue(targetSetting, property.GetValue(sourceSetting));
+                BindableValueAccessor.SetValue(targetSetting, BindableValueAccessor.GetValue(sourceSetting));
             }
         }
 

--- a/osu.Game/Skinning/RealmBackedResourceStore.cs
+++ b/osu.Game/Skinning/RealmBackedResourceStore.cs
@@ -29,7 +29,9 @@ namespace osu.Game.Skinning
             invalidateCache();
             Debug.Assert(fileToStoragePathMapping != null);
 
-            realmSubscription = realm?.RegisterForNotifications(r => r.All<T>().Where(s => s.ID == source.ID), skinChanged);
+            Guid id = source.ID;
+
+            realmSubscription = realm?.RegisterForNotifications(r => r.All<T>().Where(s => s.ID == id), skinChanged);
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Game/Skinning/RealmBackedResourceStore.cs
+++ b/osu.Game/Skinning/RealmBackedResourceStore.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Skinning
             invalidateCache();
             Debug.Assert(fileToStoragePathMapping != null);
 
+            // Required local for iOS. Will cause runtime crash if inlined.
             Guid id = source.ID;
 
             realmSubscription = realm?.RegisterForNotifications(r => r.All<T>().Where(s => s.ID == id), skinChanged);

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -131,9 +131,11 @@ namespace osu.Game.Skinning
         {
             Realm.Run(r =>
             {
+                Guid currentSkinId = CurrentSkinInfo.Value.ID;
+
                 // choose from only user skins, removing the current selection to ensure a new one is chosen.
                 var randomChoices = r.All<SkinInfo>()
-                                     .Where(s => !s.DeletePending && s.ID != CurrentSkinInfo.Value.ID)
+                                     .Where(s => !s.DeletePending && s.ID != currentSkinId)
                                      .ToArray();
 
                 if (randomChoices.Length == 0)

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -131,6 +131,7 @@ namespace osu.Game.Skinning
         {
             Realm.Run(r =>
             {
+                // Required local for iOS. Will cause runtime crash if inlined.
                 Guid currentSkinId = CurrentSkinInfo.Value.ID;
 
                 // choose from only user skins, removing the current selection to ensure a new one is chosen.

--- a/osu.Game/Utils/BindableValueAccessor.cs
+++ b/osu.Game/Utils/BindableValueAccessor.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Utils
 
         public static object GetValue(IBindable bindable)
         {
-            Type? bindableWithValueType = bindable.GetType().GetInterfaces().FirstOrDefault(isBindableT);
+            Type? bindableWithValueType = bindable.GetType().GetInterfaces().FirstOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(IBindable<>));
             if (bindableWithValueType == null)
                 return bindable;
 
@@ -25,17 +25,12 @@ namespace osu.Game.Utils
 
         public static void SetValue(IBindable bindable, object value)
         {
-            Type? bindableWithValueType = bindable.GetType().EnumerateBaseTypes().FirstOrDefault(isBindableT);
+            Type? bindableWithValueType = bindable.GetType().EnumerateBaseTypes().SingleOrDefault(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Bindable<>));
             if (bindableWithValueType == null)
                 return;
 
             set_method.MakeGenericMethod(bindableWithValueType.GenericTypeArguments[0]).Invoke(null, [bindable, value]);
         }
-
-        private static bool isBindableT(Type type)
-            => type.IsGenericType
-               && (type.GetGenericTypeDefinition() == typeof(Bindable<>)
-                   || type.GetGenericTypeDefinition() == typeof(IBindable<>));
 
         private static object getValue<T>(object bindable) => ((IBindable<T>)bindable).Value!;
 

--- a/osu.Game/Utils/BindableValueAccessor.cs
+++ b/osu.Game/Utils/BindableValueAccessor.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
+
+namespace osu.Game.Utils
+{
+    internal static class BindableValueAccessor
+    {
+        private static readonly MethodInfo get_method = typeof(BindableValueAccessor).GetMethod(nameof(getValue), BindingFlags.Static | BindingFlags.NonPublic)!;
+        private static readonly MethodInfo set_method = typeof(BindableValueAccessor).GetMethod(nameof(setValue), BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        public static object GetValue(IBindable bindable)
+        {
+            Type? bindableWithValueType = bindable.GetType().GetInterfaces().FirstOrDefault(isBindableT);
+            if (bindableWithValueType == null)
+                return bindable;
+
+            return get_method.MakeGenericMethod(bindableWithValueType.GenericTypeArguments[0]).Invoke(null, [bindable])!;
+        }
+
+        public static void SetValue(IBindable bindable, object value)
+        {
+            Type? bindableWithValueType = bindable.GetType().EnumerateBaseTypes().FirstOrDefault(isBindableT);
+            if (bindableWithValueType == null)
+                return;
+
+            set_method.MakeGenericMethod(bindableWithValueType.GenericTypeArguments[0]).Invoke(null, [bindable, value]);
+        }
+
+        private static bool isBindableT(Type type)
+            => type.IsGenericType
+               && (type.GetGenericTypeDefinition() == typeof(Bindable<>)
+                   || type.GetGenericTypeDefinition() == typeof(IBindable<>));
+
+        private static object getValue<T>(object bindable) => ((IBindable<T>)bindable).Value!;
+
+        private static object setValue<T>(object bindable, object value) => ((Bindable<T>)bindable).Value = (T)value;
+    }
+}


### PR DESCRIPTION
This is one half of the fixes required to get iOS to run.

The crashes can be reproed on device or simulator by running in Release configuration (with `<MtouchUseLlvm>false</MtouchUseLlvm>` to reduce compile time, but also fails without it), and trying to do certain actions:
- Opening the beatmap listing.
- Downloading a beatmap (e.g. via first run overlay)
- Finishing a play and/or going to the results screen.
- Turning on a mod with settings (e.g. `DoubleTime`, `ModAccuracyChallenge`, `ModDifficultyAdjust`).
- Transferring a mod with _non-default_ settings between rulesets.

All these cases are fixed with this change. Additional to the above, I've also tested the following extra scenarios:
- Creating a skin.
- Changing skins (including to a custom one).
- Editing a beatmap.
- Copying mods from the leaderboard.
- Entering multiplayer, entering gameplay.
- Downloading a score + playing the replay.

---

<details>
<summary>The stack trace always ends up in some sort of reflection</summary>

```
#00x000000010f25d4ac in mono_interp_exec_method at /Users/runner/work/1/s/src/mono/mono/mini/interp/interp.c:4116
#10x000000010f25a800 in interp_entry_from_trampoline at /Users/runner/work/1/s/src/mono/mono/mini/interp/interp.c:3088
#20x000000010edba548 in wrapper_other_object___interp_lmf_mono_interp_entry_from_trampoline_intptr_intptr ()
#30x000000010ee02b78 in native_to_interp_trampoline ()
#40x000000010edfe30c in gsharedvt_out_trampoline ()
#50x000000010ed36448 in System_Reflection_RuntimePropertyInfo_GetterAdapterFrame_T_GSHAREDVT_R_GSHAREDVT_System_Reflection_RuntimePropertyInfo_Getter_2_T_GSHAREDVT_R_GSHAREDVT_object ()
#60x000000010eafb5a4 in System_Reflection_RuntimePropertyInfo_GetValue_object_object__ ()
#70x000000010eb0f2f4 in System_Reflection_PropertyInfo_GetValue_object ()
#80x000000010ba279ec in Realms_RealmResultsVisitor_TryExtractConstantValue_System_Linq_Expressions_Expression_object_ at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResultsVisitor.cs:582
#90x000000010ba28198 in Realms_RealmResultsVisitor_VisitBinary_System_Linq_Expressions_BinaryExpression at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResultsVisitor.cs:623
#100x000000010d963040 in System_Linq_Expressions_BinaryExpression_Accept_System_Linq_Expressions_ExpressionVisitor at /<unknown>:1
#110x000000010d987090 in System_Linq_Expressions_ExpressionVisitor_Visit_System_Linq_Expressions_Expression at /<unknown>:1
#120x000000010ba27588 in Realms_RealmResultsVisitor_VisitCombination_System_Linq_Expressions_BinaryExpression_System_Action_1_Realms_QueryHandle at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResultsVisitor.cs:535
#130x000000010ba27bec in Realms_RealmResultsVisitor_VisitBinary_System_Linq_Expressions_BinaryExpression at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResultsVisitor.cs:596
#140x000000010d963040 in System_Linq_Expressions_BinaryExpression_Accept_System_Linq_Expressions_ExpressionVisitor at /<unknown>:1
#150x000000010d987090 in System_Linq_Expressions_ExpressionVisitor_Visit_System_Linq_Expressions_Expression at /<unknown>:1
#160x000000010ba241a0 in Realms_RealmResultsVisitor_VisitMethodCall_System_Linq_Expressions_MethodCallExpression at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResultsVisitor.cs:205
#170x000000010d98f4d0 in System_Linq_Expressions_MethodCallExpression_Accept_System_Linq_Expressions_ExpressionVisitor at /<unknown>:1
#180x000000010d987090 in System_Linq_Expressions_ExpressionVisitor_Visit_System_Linq_Expressions_Expression at /<unknown>:1
#190x000000010ba22748 in Realms_RealmResults_1_T_REF_GetOrCreateHandle at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Linq\RealmResults.cs:75
#200x000000010e8d9f40 in System_Lazy_1_T_REF_ViaFactory_System_Threading_LazyThreadSafetyMode ()
#210x000000010e8da15c in System_Lazy_1_T_REF_ExecutionAndPublication_System_LazyHelper_bool ()
#220x000000010e8da5d8 in System_Lazy_1_T_REF_CreateValue ()
#230x000000010e8da770 in System_Lazy_1_T_REF_get_Value ()
#240x000000010ba77798 in Realms_NotificationCallbacks_1__c__DisplayClass3_0_T_REF__Addb__0 at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\DatabaseTypes\RealmCollectionBase.cs:630
#250x000000010ba325c0 in Realms_Realm_ExecuteOutsideTransaction_System_Action at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\Realm.cs:1341
#260x000000010b9fc0c0 in Realms_NotificationCallbacks_1_T_REF_Add_Realms_NotificationCallbackDelegate_1_T_REF_bool at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\DatabaseTypes\RealmCollectionBase.cs:624
#270x000000010b9f8858 in Realms_RealmCollectionBase_1_T_REF_SubscribeForNotificationsImpl_Realms_NotificationCallbackDelegate_1_T_REF_bool at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\DatabaseTypes\RealmCollectionBase.cs:180
#280x000000010b9f8750 in Realms_RealmCollectionBase_1_T_REF_SubscribeForNotifications_Realms_NotificationCallbackDelegate_1_T_REF at /D:\a\realm-dotnet\realm-dotnet\Realm\Realm\DatabaseTypes\RealmCollectionBase.cs:175
#290x000000010d040578 in osu_Game_Database_RealmObjectExtensions_QueryAsyncWithNotifications_T_REF_Realms_IRealmCollection_1_T_REF_Realms_NotificationCallbackDelegate_1_T_REF at /Users/smgi/Repos/osu/osu.Game/Database/RealmObjectExtensions.cs:296
#300x000000010d040658 in osu_Game_Database_RealmObjectExtensions_QueryAsyncWithNotifications_T_REF_System_Linq_IQueryable_1_T_REF_Realms_NotificationCallbackDelegate_1_T_REF at /Users/smgi/Repos/osu/osu.Game/Database/RealmObjectExtensions.cs:339
```

</details>

This would be a .NET/Mono regression, but I haven't isolated/reported it yet. The bindable-related commit lends perhaps a hint as to why this is happening - in the case of `IBindable<>`, the interface can be implemented multiple times on leaf objects so the runtime is unsure which property to resolve, even if there is only one matching implementation in the leaf type.

I gather similar is happening with `IHasOnlineID<>` leading to the Realm issue, though in that case (and because it's the first issue I resolved) I've taken a sledgehammer to it by avoiding any inner references.

The bindable change can continue existing going into the future, because, while it's not trying to cover for every possible use-case ever, it's also adding a bit of safety for truly undefined scenarios.

I will be reporting the issue later, time-provided.