### PR TITLE
Make osu editor blueprint radius match skin radius

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/OsuArgonSkinTransformer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
@@ -77,6 +78,17 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             }
 
             return base.GetDrawableComponent(lookup);
+        }
+
+        public override IBindable<TValue>? GetConfig<TLookup, TValue>(TLookup lookup)
+        {
+            switch (lookup)
+            {
+                case OsuSkinConfiguration.EditorBlueprintRadius:
+                    return SkinUtils.As<TValue>(new BindableFloat(ArgonMainCirclePiece.OUTER_GRADIENT_SIZE * 0.5f));
+            }
+
+            return base.GetConfig<TLookup, TValue>(lookup);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
@@ -1,10 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Skinning;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
@@ -28,6 +31,34 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 Alpha = 0,
                 RelativeSizeAxes = Axes.Both
             };
+        }
+
+        [Resolved(canBeNull: true)]
+        private ISkinSource? skin { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (skin != null)
+            {
+                skin.SourceChanged += skinChanged;
+                skinChanged();
+            }
+        }
+
+        private void skinChanged()
+        {
+            float radius = skin?.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.EditorBlueprintRadius)?.Value ?? OsuHitObject.OBJECT_RADIUS;
+
+            Size = new Vector2(radius * 2);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (skin != null)
+                skin.SourceChanged -= skinChanged;
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -236,6 +236,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     switch (osuLookup)
                     {
                         case OsuSkinConfiguration.SliderPathRadius:
+                        case OsuSkinConfiguration.EditorBlueprintRadius:
                             if (hasHitCircle.Value)
                                 return SkinUtils.As<TValue>(new BindableFloat(LEGACY_CIRCLE_RADIUS));
 

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -10,6 +10,7 @@ namespace osu.Game.Rulesets.Osu.Skinning
         CursorExpand,
         CursorRotate,
         HitCircleOverlayAboveNumber,
+        EditorBlueprintRadius,
 
         // ReSharper disable once IdentifierTypo
         HitCircleOverlayAboveNumer, // Some old skins will have this typo


### PR DESCRIPTION
Makes the outer radius of the editor blueprint match the skin's object radius in osu ruleset.


https://github.com/user-attachments/assets/154651a1-cd6f-41c9-8241-3d9077d4d71f

The non-matching radius made it difficult to judge what the object actually looks like behind the blueprint,
This is an issue with every skin except `Triangles (2017)`, with the radius difference even being big enough to have a (barely) visibile gap between the slider & the blueprint on argon skin.

![image](https://github.com/user-attachments/assets/c309142b-16e0-4bce-9204-8e6c3a97280e)
