### PR TITLE
Scaled the UI on the Daily Challenge Score Breakdown

### DIFF
--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeScoreBreakdown.cs
@@ -47,14 +47,6 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     Origin = Anchor.BottomCentre,
                 }
             };
-
-            for (int i = 0; i < bin_count; ++i)
-            {
-                barsContainer.Add(new Bar(100_000 * i, 100_000 * (i + 1) - 1)
-                {
-                    Width = 1f / bin_count,
-                });
-            }
         }
 
         protected override void LoadComplete()
@@ -139,8 +131,28 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
         private void updateCounts()
         {
+            int displayCutoff = Array.FindLastIndex(bins, x => x > 0) + 1;
+
+            if (displayCutoff > barsContainer.Count)
+            {
+                for (int i = 0; i < displayCutoff; i++)
+                {
+                    if (i < barsContainer.Count)
+                    {
+                        barsContainer[i].Width = 1f / displayCutoff;
+                    }
+                    else
+                    {
+                        barsContainer.Add(new Bar(100_000 * i, 100_000 * (i + 1) - 1)
+                        {
+                            Width = 1f / displayCutoff,
+                        });
+                    }
+                }
+            }
+
             long max = Math.Max(bins.Max(), 1);
-            for (int i = 0; i < bin_count; ++i)
+            for (int i = 0; i < displayCutoff; ++i)
                 barsContainer[i].UpdateCounts(bins[i], max);
         }
 


### PR DESCRIPTION
UI score bars on the Daily Challenge previously did not scale horizontally to the current maximum score if it is below the 1.2 Million maximum. 

- All changes were made in **updateCounts()**

`int displayCutoff = Array.FindLastIndex(bins, x => x > 0) + 1;`
- **displayCutoff** is an **Int** that is the highest value index that contains a score value > 0

- **barsContainer** will only add a new **Bar** to the list when  **displayCutoff > barsContainer.Count()**
- All **Bars** in **barsContainer[i].Width** = 1f / **displayCutoff** 

Before: All 13 score bars are present, even without any user scores
![image](https://github.com/user-attachments/assets/1b143741-6333-4c69-b60e-e429896a0c77)

After: Only display populated user scores
![image](https://github.com/user-attachments/assets/bd60d382-60cb-40e6-9086-8da98d8f718e)


![image](https://github.com/user-attachments/assets/5626f25a-df1b-4ad2-b2c8-02470d3c7577)

Testing was performed within the **osu!(Tests,Debug)** environment 