### PR TITLE
Create a variable to check if slider accuracy was used in a score

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
-	private bool usingClassicSliderAccuracy;
-	
+	    private bool usingClassicSliderAccuracy;
+     
         private double accuracy;
         private int scoreMaxCombo;
         private int countGreat;
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
-	    usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
+	        usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
 	    
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -16,6 +16,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
+	private bool usingClassicSliderAccuracy;
+	
         private double accuracy;
         private int scoreMaxCombo;
         private int countGreat;
@@ -34,6 +36,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
+	    usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
+	    
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;
             countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
     {
         public const double PERFORMANCE_BASE_MULTIPLIER = 1.14; // This is being adjusted to keep the final pp value scaled around what it used to be when changing things.
 
-	    private bool usingClassicSliderAccuracy;
-     
+        private bool usingClassicSliderAccuracy;
+
         private double accuracy;
         private int scoreMaxCombo;
         private int countGreat;
@@ -36,8 +36,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var osuAttributes = (OsuDifficultyAttributes)attributes;
 
-	        usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
-	    
+            usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
+
             accuracy = score.Accuracy;
             scoreMaxCombo = score.MaxCombo;
             countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);


### PR DESCRIPTION
Currently there's no standard for how to check if slider accuracy is used. Some people use variables with differing names, others just do the check when they need it. This PR exists solely to create that variable and have it not be held up by actual changes to pp so that it can be PRed quickly.

In other words...
![standards_2x](https://github.com/user-attachments/assets/440170be-25af-46df-85ad-f31d783ea361)
