### PR TITLE
Fix iOS CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,5 +135,8 @@ jobs:
       - name: Install .NET Workloads
         run: dotnet workload install maui-ios
 
+      - name: Select Xcode 16
+        run: sudo xcode-select -s /Applications/Xcode_16.app/Contents/Developer
+
       - name: Build
         run: dotnet build -c Debug osu.iOS


### PR DESCRIPTION
New .NET update that now depends on Xcode 16. Luckily, it's already included in the `macos-latest` runner, just not the default.

Run: https://github.com/smoogipoo/osu/actions/runs/11066384052/job/30747527955