### PR TITLE
Replace unsafe casting in `ManiaDifficultyCalculator` with generic column count calculation

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -19,6 +19,7 @@ using osu.Game.Rulesets.Mania.Scoring;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Scoring.Legacy;
 
 namespace osu.Game.Rulesets.Mania.Difficulty
 {

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -84,10 +84,16 @@ namespace osu.Game.Rulesets.Mania.Difficulty
         // Sorting is done in CreateDifficultyHitObjects, since the full list of hitobjects is required.
         protected override IEnumerable<DifficultyHitObject> SortObjects(IEnumerable<DifficultyHitObject> input) => input;
 
-        protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate) => new Skill[]
+        protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            new Strain(mods, ((ManiaBeatmap)Beatmap).TotalColumns)
-        };
+            var difficultyInfo = LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmap.BeatmapInfo);
+            int columnCount = ManiaBeatmapConverter.GetColumnCount(difficultyInfo, mods);
+
+            return new Skill[]
+            {
+                new Strain(mods, columnCount)
+            };
+        }
 
         protected override Mod[] DifficultyAdjustmentMods
         {

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs
@@ -87,7 +87,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty
 
         protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
         {
-            var difficultyInfo = LegacyBeatmapConversionDifficultyInfo.FromBeatmapInfo(beatmap.BeatmapInfo);
+            var difficultyInfo = LegacyBeatmapConversionDifficultyInfo.FromBeatmap(beatmap);
             int columnCount = ManiaBeatmapConverter.GetColumnCount(difficultyInfo, mods);
 
             return new Skill[]

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Difficulty
             cancellationToken.ThrowIfCancellationRequested();
             preProcess(mods, cancellationToken);
 
-            var skills = CreateSkills(Beatmap, playableMods, clockRate);
+            var skills = CreateSkills(beatmap.Beatmap, playableMods, clockRate);
 
             if (!Beatmap.HitObjects.Any())
                 return CreateDifficultyAttributes(Beatmap, playableMods, skills, clockRate);
@@ -106,7 +106,7 @@ namespace osu.Game.Rulesets.Difficulty
             if (!Beatmap.HitObjects.Any())
                 return attribs;
 
-            var skills = CreateSkills(Beatmap, playableMods, clockRate);
+            var skills = CreateSkills(beatmap.Beatmap, playableMods, clockRate);
             var progressiveBeatmap = new ProgressiveCalculationBeatmap(Beatmap);
             var difficultyObjects = getDifficultyHitObjects().ToArray();
 


### PR DESCRIPTION
This is a prerequisite for https://github.com/ppy/osu/pull/29989 to work
Makes this function work with any generic `IBeatmap`, not only `ManiaBeatmap`