### PR TITLE
Change slider leniency in diffcalc to match lazer (it matched stable before)

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -215,19 +215,12 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
             if (slider.LazyEndPosition != null)
                 return;
 
-            // TODO: This commented version is actually correct by the new lazer implementation, but intentionally held back from
-            // difficulty calculator to preserve known behaviour.
-            // double trackingEndTime = Math.Max(
-            //     // SliderTailCircle always occurs at the final end time of the slider, but the player only needs to hold until within a lenience before it.
-            //     slider.Duration + SliderEventGenerator.TAIL_LENIENCY,
-            //     // There's an edge case where one or more ticks/repeats fall within that leniency range.
-            //     // In such a case, the player needs to track until the final tick or repeat.
-            //     slider.NestedHitObjects.LastOrDefault(n => n is not SliderTailCircle)?.StartTime ?? double.MinValue
-            // );
-
             double trackingEndTime = Math.Max(
+                // SliderTailCircle always occurs at the final end time of the slider, but the player only needs to hold until within a lenience before it.
                 slider.StartTime + slider.Duration + SliderEventGenerator.TAIL_LENIENCY,
-                slider.StartTime + slider.Duration / 2
+                // There's an edge case where one or more ticks/repeats fall within that leniency range.
+                // In such a case, the player needs to track until the final tick or repeat.
+                slider.NestedHitObjects.LastOrDefault(n => n is not SliderTailCircle)?.StartTime ?? double.MinValue
             );
 
             IList<HitObject> nestedObjects = slider.NestedHitObjects;


### PR DESCRIPTION
This uncomments the `TODO` sentiment, but there's a mistake in it, someone forgot to add `slider.StartTime`
This change do nothing except nerfing some techy maps like Trinity Homerun, so there's no real point in merging it now

Opening the PR to start a discussion about future of this change
My opinion is that it should be merged when big portion of players are moved to lazer and someone is abusing more lenient sliders on maps like mentioned earlier Trinity Homerun

Also I would ask for sheet to see all affected maps