### PR TITLE
Fix text in `FormFileSelector` bleeding through the border

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -244,6 +244,9 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Child = new Container
                 {
                     Size = new Vector2(600, 400),
+                    // simplest solution to avoid underlying text to bleed through the bottom border
+                    // https://github.com/ppy/osu/pull/30005#issuecomment-2378884430
+                    Padding = new MarginPadding { Bottom = 1 },
                     Child = new OsuFileSelector(chooserPath, handledExtensions)
                     {
                         RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Simplest fix to the issue mentioned in https://github.com/ppy/osu/pull/30005#issuecomment-2378377444.
![Снимок экрана 2024-09-28 223612](https://github.com/user-attachments/assets/4cbbddb7-277f-4075-b0c5-24ea7b026125)
