### PR TITLE
Fix rate change hotkeys sometimes losing track of adjust pitch setting

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -175,6 +175,20 @@ namespace osu.Game.Tests.Visual.SongSelect
             increaseModSpeed();
             AddAssert("adaptive speed still active", () => songSelect!.Mods.Value.First() is ModAdaptiveSpeed);
 
+            OsuModDoubleTime dtWithAdjustPitch = new OsuModDoubleTime
+            {
+                SpeedChange = { Value = 1.05 },
+                AdjustPitch = { Value = true },
+            };
+            changeMods(dtWithAdjustPitch);
+
+            decreaseModSpeed();
+            AddAssert("no mods selected", () => songSelect!.Mods.Value.Count == 0);
+
+            decreaseModSpeed();
+            AddAssert("half time activated at 0.95x", () => songSelect!.Mods.Value.OfType<ModHalfTime>().Single().SpeedChange.Value, () => Is.EqualTo(0.95).Within(0.005));
+            AddAssert("half time has adjust pitch active", () => songSelect!.Mods.Value.OfType<ModHalfTime>().Single().AdjustPitch.Value, () => Is.True);
+
             void increaseModSpeed() => AddStep("increase mod speed", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -189,6 +189,15 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddAssert("half time activated at 0.95x", () => songSelect!.Mods.Value.OfType<ModHalfTime>().Single().SpeedChange.Value, () => Is.EqualTo(0.95).Within(0.005));
             AddAssert("half time has adjust pitch active", () => songSelect!.Mods.Value.OfType<ModHalfTime>().Single().AdjustPitch.Value, () => Is.True);
 
+            AddStep("turn off adjust pitch", () => songSelect!.Mods.Value.OfType<ModHalfTime>().Single().AdjustPitch.Value = false);
+
+            increaseModSpeed();
+            AddAssert("no mods selected", () => songSelect!.Mods.Value.Count == 0);
+
+            increaseModSpeed();
+            AddAssert("double time activated at 1.05x", () => songSelect!.Mods.Value.OfType<ModDoubleTime>().Single().SpeedChange.Value, () => Is.EqualTo(1.05).Within(0.005));
+            AddAssert("double time has adjust pitch inactive", () => songSelect!.Mods.Value.OfType<ModDoubleTime>().Single().AdjustPitch.Value, () => Is.False);
+
             void increaseModSpeed() => AddStep("increase mod speed", () =>
             {
                 InputManager.PressKey(Key.ControlLeft);

--- a/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
+++ b/osu.Game/Screens/Select/ModSpeedHotkeyHandler.cs
@@ -27,6 +27,7 @@ namespace osu.Game.Screens.Select
         private OnScreenDisplay? onScreenDisplay { get; set; }
 
         private ModRateAdjust? lastActiveRateAdjustMod;
+        private ModSettingChangeTracker? settingChangeTracker;
 
         protected override void LoadComplete()
         {
@@ -34,8 +35,17 @@ namespace osu.Game.Screens.Select
 
             selectedMods.BindValueChanged(val =>
             {
-                lastActiveRateAdjustMod = val.NewValue.OfType<ModRateAdjust>().SingleOrDefault() ?? lastActiveRateAdjustMod;
+                storeLastActiveRateAdjustMod();
+
+                settingChangeTracker?.Dispose();
+                settingChangeTracker = new ModSettingChangeTracker(val.NewValue);
+                settingChangeTracker.SettingChanged += _ => storeLastActiveRateAdjustMod();
             }, true);
+        }
+
+        private void storeLastActiveRateAdjustMod()
+        {
+            lastActiveRateAdjustMod = (ModRateAdjust?)selectedMods.Value.OfType<ModRateAdjust>().SingleOrDefault()?.DeepClone() ?? lastActiveRateAdjustMod;
         }
 
         public bool ChangeSpeed(double delta, IEnumerable<Mod> availableMods)


### PR DESCRIPTION
Fixes https://osu.ppy.sh/community/forums/topics/1983327.

The cause of the bug is a bit convoluted, and stems from the fact that the mod select overlay controls all of the game-global mod instances if present. `ModSpeedHotkeyHandler` would store the last spotted instance of a rate adjust mod - which in this case is a problem, because on deselection of a mod, the mod select overlay resets its settings to defaults:

https://github.com/ppy/osu/blob/a258059d4338b999b8e065e48b952d14a6d14fb8/osu.Game/Overlays/Mods/ModSelectOverlay.cs#L424-L425

A way to defend against this is a clone, but this reveals another issue, in that the existing code was *relying* on the reference to the mod remaining the same in any other case, to read the latest valid settings of the mod. This basically only mattered in the edge case wherein Double Time would swap places with Half Time and vice versa (think [0.95,1.05] range). Therefore, track mod settings too explicitly to ensure that the stored clone is as up-to-date as possible.