### PR TITLE
Add snapping to skin elements in skin layout editor

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -113,6 +113,11 @@ namespace osu.Game.Overlays.SkinEditor
                         .ToArray()
             };
 
+            yield return new OsuMenuItem("Snap")
+            {
+                Items = createSnapItems(applySnaps).ToArray()
+            };
+
             yield return originMenu = new OsuMenuItem("Origin");
 
             closestItem.State.BindValueChanged(s =>
@@ -184,6 +189,26 @@ namespace osu.Game.Overlays.SkinEditor
                     };
                 });
             }
+
+            IEnumerable<OsuMenuItem> createSnapItems(Action<Anchor> applyFunction)
+            {
+                var displayableSnaps = new[]
+                {
+                    Anchor.TopLeft,
+                    Anchor.TopCentre,
+                    Anchor.TopRight,
+                    Anchor.CentreLeft,
+                    Anchor.Centre,
+                    Anchor.CentreRight,
+                    Anchor.BottomLeft,
+                    Anchor.BottomCentre,
+                    Anchor.BottomRight,
+                };
+                return displayableSnaps.Select(snap =>
+                {
+                    return new OsuMenuItem(snap.ToString(), MenuItemType.Standard, () => applyFunction(snap));
+                });
+            }
         }
 
         private static void updateDrawablePosition(Drawable drawable, Vector2 screenSpacePosition)
@@ -226,6 +251,21 @@ namespace osu.Game.Overlays.SkinEditor
 
                 item.UsesFixedAnchor = true;
                 applyAnchor(drawable, anchor);
+            }
+
+            OnOperationEnded();
+        }
+
+        private void applySnaps(Anchor anchor)
+        {
+            OnOperationBegan();
+
+            foreach (var item in SelectedItems)
+            {
+                var drawable = (Drawable)(item);
+
+                item.UsesFixedAnchor = true;
+                applySnap(drawable, anchor);
             }
 
             OnOperationEnded();
@@ -282,6 +322,13 @@ namespace osu.Game.Overlays.SkinEditor
             var previousAnchor = drawable.AnchorPosition;
             drawable.Anchor = anchor;
             drawable.Position -= drawable.AnchorPosition - previousAnchor;
+        }
+
+        private static void applySnap(Drawable drawable, Anchor anchor)
+        {
+            applyAnchor(drawable, anchor);
+            applyOrigin(drawable, anchor);
+            drawable.Position = Vector2.Zero;
         }
 
         private static void applyOrigin(Drawable drawable, Anchor screenSpaceOrigin)


### PR DESCRIPTION
This PR adds a snapping feature to all skin elements in the skin layout editor.
The main motivation behind this was the inability to perfectly center skin elements.

https://github.com/user-attachments/assets/75b1040a-808d-428b-ad0f-05b7b20d10b0

Also, was tempted to factor out `displayableAnchors` and `displayableSnaps` (inside `createAnchorItems` and `createSnapItems` respectively) to one common array, but did not do it to ask you maintainers if it was a fine change.