### PR TITLE
Fix various distance snap grid weirdness around unsnapped objects

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -401,7 +401,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (state == SliderPlacementState.Drawing)
                 HitObject.Path.ExpectedDistance.Value = (float)HitObject.Path.CalculatedDistance;
             else
-                HitObject.Path.ExpectedDistance.Value = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)HitObject.Path.CalculatedDistance) ?? (float)HitObject.Path.CalculatedDistance;
+                HitObject.Path.ExpectedDistance.Value = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)HitObject.Path.CalculatedDistance, DistanceSnapTarget.Start) ?? (float)HitObject.Path.CalculatedDistance;
 
             bodyPiece.UpdateFrom(HitObject);
             headCirclePiece.UpdateFrom(HitObject.HeadCircle);

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -269,7 +269,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             {
                 double minDistance = distanceSnapProvider?.GetBeatSnapDistanceAt(HitObject, false) * oldVelocityMultiplier ?? 1;
                 // Add a small amount to the proposed distance to make it easier to snap to the full length of the slider.
-                proposedDistance = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)proposedDistance + 1) ?? proposedDistance;
+                proposedDistance = distanceSnapProvider?.FindSnappedDistance(HitObject, (float)proposedDistance + 1, DistanceSnapTarget.Start) ?? proposedDistance;
                 proposedDistance = MathHelper.Clamp(proposedDistance, minDistance, HitObject.Path.CalculatedDistance);
             }
 

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -298,7 +298,7 @@ namespace osu.Game.Tests.Editing
             => AddAssert($"distance = {distance} -> duration = {expectedDuration} (snapped)", () => composer.DistanceSnapProvider.FindSnappedDuration(referenceObject ?? new HitObject(), distance), () => Is.EqualTo(expectedDuration).Within(Precision.FLOAT_EPSILON));
 
         private void assertSnappedDistance(float distance, float expectedDistance, HitObject? referenceObject = null)
-            => AddAssert($"distance = {distance} -> distance = {expectedDistance} (snapped)", () => composer.DistanceSnapProvider.FindSnappedDistance(referenceObject ?? new HitObject(), distance), () => Is.EqualTo(expectedDistance).Within(Precision.FLOAT_EPSILON));
+            => AddAssert($"distance = {distance} -> distance = {expectedDistance} (snapped)", () => composer.DistanceSnapProvider.FindSnappedDistance(referenceObject ?? new HitObject(), distance, DistanceSnapTarget.End), () => Is.EqualTo(expectedDistance).Within(Precision.FLOAT_EPSILON));
 
         private partial class TestHitObjectComposer : OsuHitObjectComposer
         {

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -228,6 +228,42 @@ namespace osu.Game.Tests.Editing
         }
 
         [Test]
+        public void TestUnsnappedObject()
+        {
+            var slider = new Slider
+            {
+                StartTime = 0,
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(),
+                        // simulate object snapped to 1/3rds
+                        // this object's end time will be 2000 / 3 = 666.66... ms
+                        new PathControlPoint(new Vector2(200 / 3f, 0)),
+                    }
+                }
+            };
+
+            AddStep("add slider", () => composer.EditorBeatmap.Add(slider));
+            AddStep("set snap to 1/4", () => BeatDivisor.Value = 4);
+
+            // with default beat length of 1000ms and snap at 1/4, the valid snap times are 500ms, 750ms, and 1000ms
+            // with default settings, the snapped distance will be a tenth of the difference of the time delta
+
+            // (500 - 666.66...) / 10 = -16.66... = -100 / 6
+            assertSnappedDistance(0, -100 / 6f, slider);
+            assertSnappedDistance(7, -100 / 6f, slider);
+
+            // (750 - 666.66...) / 10 = 8.33... = 100 / 12
+            assertSnappedDistance(9, 100 / 12f, slider);
+            assertSnappedDistance(33, 100 / 12f, slider);
+
+            // (1000 - 666.66...) / 10 = 33.33... = 100 / 3
+            assertSnappedDistance(34, 100 / 3f, slider);
+        }
+
+        [Test]
         public void TestUseCurrentSnap()
         {
             AddStep("add objects to beatmap", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDistanceSnapGrid.cs
@@ -199,7 +199,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             public double FindSnappedDuration(HitObject referenceObject, float distance) => 0;
 
-            public float FindSnappedDistance(HitObject referenceObject, float distance) => 0;
+            public float FindSnappedDistance(HitObject referenceObject, float distance, DistanceSnapTarget target) => 0;
         }
     }
 }

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -280,22 +280,36 @@ namespace osu.Game.Rulesets.Edit
         public virtual double FindSnappedDuration(HitObject referenceObject, float distance)
             => beatSnapProvider.SnapTime(referenceObject.StartTime + DistanceToDuration(referenceObject, distance), referenceObject.StartTime) - referenceObject.StartTime;
 
-        public virtual float FindSnappedDistance(HitObject referenceObject, float distance)
+        public virtual float FindSnappedDistance(HitObject referenceObject, float distance, DistanceSnapTarget target)
         {
-            double startTime = referenceObject.StartTime;
+            double referenceTime;
 
-            double actualDuration = startTime + DistanceToDuration(referenceObject, distance);
+            switch (target)
+            {
+                case DistanceSnapTarget.Start:
+                    referenceTime = referenceObject.StartTime;
+                    break;
 
-            double snappedEndTime = beatSnapProvider.SnapTime(actualDuration, startTime);
+                case DistanceSnapTarget.End:
+                    referenceTime = referenceObject.GetEndTime();
+                    break;
 
-            double beatLength = beatSnapProvider.GetBeatLengthAtTime(startTime);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(target), target, $"Unknown {nameof(DistanceSnapTarget)} value");
+            }
+
+            double actualDuration = referenceTime + DistanceToDuration(referenceObject, distance);
+
+            double snappedTime = beatSnapProvider.SnapTime(actualDuration, referenceTime);
+
+            double beatLength = beatSnapProvider.GetBeatLengthAtTime(referenceTime);
 
             // we don't want to exceed the actual duration and snap to a point in the future.
             // as we are snapping to beat length via SnapTime (which will round-to-nearest), check for snapping in the forward direction and reverse it.
-            if (snappedEndTime > actualDuration + 1)
-                snappedEndTime -= beatLength;
+            if (snappedTime > actualDuration + 1)
+                snappedTime -= beatLength;
 
-            return DurationToDistance(referenceObject, snappedEndTime - startTime);
+            return DurationToDistance(referenceObject, snappedTime - referenceTime);
         }
 
         #endregion

--- a/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/IDistanceSnapProvider.cs
@@ -58,10 +58,17 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         /// <param name="referenceObject">An object to be used as a reference point for this operation.</param>
         /// <param name="distance">The distance to convert.</param>
+        /// <param name="target">Whether the distance measured should be from the start or the end of <paramref name="referenceObject"/>.</param>
         /// <returns>
         /// A value that represents <paramref name="distance"/> snapped to the closest beat of the timing point.
         /// The distance will always be less than or equal to the provided <paramref name="distance"/>.
         /// </returns>
-        float FindSnappedDistance(HitObject referenceObject, float distance);
+        float FindSnappedDistance(HitObject referenceObject, float distance, DistanceSnapTarget target);
+    }
+
+    public enum DistanceSnapTarget
+    {
+        Start,
+        End,
     }
 }

--- a/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
+++ b/osu.Game/Rulesets/Objects/SliderPathExtensions.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Objects
         public static void SnapTo<THitObject>(this THitObject hitObject, IDistanceSnapProvider? snapProvider)
             where THitObject : HitObject, IHasPath
         {
-            hitObject.Path.ExpectedDistance.Value = snapProvider?.FindSnappedDistance(hitObject, (float)hitObject.Path.CalculatedDistance) ?? hitObject.Path.CalculatedDistance;
+            hitObject.Path.ExpectedDistance.Value = snapProvider?.FindSnappedDistance(hitObject, (float)hitObject.Path.CalculatedDistance, DistanceSnapTarget.Start) ?? hitObject.Path.CalculatedDistance;
         }
 
         /// <summary>

--- a/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularDistanceSnapGrid.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // Picture the scenario where the user has just placed an object on a 1/2 snap, then changes to
             // 1/3 snap and expects to be able to place the next object on a valid 1/3 snap, regardless of the
             // fact that the 1/2 snap reference object is not valid for 1/3 snapping.
-            float offset = SnapProvider.FindSnappedDistance(ReferenceObject, 0);
+            float offset = SnapProvider.FindSnappedDistance(ReferenceObject, 0, DistanceSnapTarget.End);
 
             for (int i = 0; i < requiredCircles; i++)
             {
@@ -104,7 +104,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 ? SnapProvider.DurationToDistance(ReferenceObject, editorClock.CurrentTime - ReferenceObject.GetEndTime())
                 // When interacting with the resolved snap provider, the distance spacing multiplier should first be removed
                 // to allow for snapping at a non-multiplied ratio.
-                : SnapProvider.FindSnappedDistance(ReferenceObject, travelLength / distanceSpacingMultiplier);
+                : SnapProvider.FindSnappedDistance(ReferenceObject, travelLength / distanceSpacingMultiplier, DistanceSnapTarget.End);
 
             double snappedTime = StartTime + SnapProvider.DistanceToDuration(ReferenceObject, snappedDistance);
 

--- a/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/DistanceSnapGrid.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             var timingPoint = Beatmap.ControlPointInfo.TimingPointAt(StartTime);
             double beatLength = timingPoint.BeatLength / beatDivisor.Value;
-            int beatIndex = (int)Math.Round((StartTime - timingPoint.Time) / beatLength);
+            int beatIndex = (int)Math.Floor((StartTime - timingPoint.Time) / beatLength);
 
             var colour = BindableBeatDivisor.GetColourFor(BindableBeatDivisor.GetDivisorForBeatIndex(beatIndex + placementIndex + 1, beatDivisor.Value), Colours);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30023.

I am only *somewhat* confident of these changes, so take with several pillars of salt.

## [Fix distance spacing grid displaying incorrectly for unsnapped objects with duration](https://github.com/ppy/osu/commit/75fc57c34bb4efd1a05bfb1fda7bbe14471b499b)

As far as I can tell, this issue is specific to objects whose heads are snapped to the current beat divisor, but tails are not. `FindSnappedDistance()` seems to have presumed this to be impossible, and as such just used the head's start time, which is not correct, because it will behave as if a timing point was placed at the tail (or, in other words, objects will be snapped temporally using the correct beat length, but relative to the unsnapped tail).

## [Fix distance snap grid using wrong colour when reference object is unsnapped](https://github.com/ppy/osu/commit/11fc1f9a1c632b0ecac600d80e87cfe3345fd6f8)

This only reproduces if the unsnapped object lies on the latter half of a beat (think 700ms at beat length of 250ms). Rounding would thus shift the colours assigned up a beat.