### PR TITLE
Ensure sliders are snapped when changing path types

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -353,6 +353,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
         {
             changeHandler?.BeginChange();
 
+            double originalDistance = hitObject.Path.Distance;
+
             foreach (var p in Pieces.Where(p => p.IsSelected.Value))
             {
                 var pointsInSegment = hitObject.Path.PointsInSegment(p.ControlPoint);
@@ -374,6 +376,11 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
             }
 
             EnsureValidPathTypes();
+
+            if (hitObject.Path.Distance < originalDistance)
+                hitObject.SnapTo(distanceSnapProvider);
+            else
+                hitObject.Path.ExpectedDistance.Value = originalDistance;
 
             changeHandler?.EndChange();
         }

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -112,6 +112,7 @@ namespace osu.Game.Tests.Editing
             {
                 SliderVelocityMultiplier = slider_velocity
             };
+            AddStep("add to beatmap", () => composer.EditorBeatmap.Add(referenceObject));
 
             assertSnapDistance(base_distance * slider_velocity, referenceObject, true);
             assertSnappedDistance(base_distance * slider_velocity + 10, base_distance * slider_velocity, referenceObject);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29915.

Uses behaviour suggested in https://github.com/ppy/osu/issues/29915#issuecomment-2361843011. @OliBomby you might be interested in double-checking if this is what you meant.