### PR TITLE
Fix skin editor legacy components not displaying correctly when used with non-legacy skins

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchPlayerLegacySkin.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Tests
                 CreateTest();
             }
 
-            AddAssert("legacy HUD combo counter not added", () => !Player.ChildrenOfType<LegacyDefaultComboCounter>().Any());
+            AddAssert("legacy HUD combo counter not added", () => Player.ChildrenOfType<LegacyDefaultComboCounter>(), () => Is.Empty);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSkinFallbacks.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => lookupFunction(this) ? this : null;
 
-            public IEnumerable<ISkin> AllSources => new[] { this };
+            public IEnumerable<ISkin> AllSources => Array.Empty<ISkin>();
 
             [CanBeNull]
             public event Action SourceChanged;

--- a/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
@@ -3,27 +3,60 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Audio;
+using osu.Game.Database;
+using osu.Game.IO;
 using osu.Game.Skinning;
 using osu.Game.Tests.Visual;
 
 namespace osu.Game.Tests.Skins
 {
     [HeadlessTest]
-    public partial class TestSceneSkinProvidingContainer : OsuTestScene
+    public partial class TestSceneSkinProvidingContainer : OsuTestScene, IStorageResourceProvider
     {
         [Resolved]
         private IRenderer renderer { get; set; }
+
+        private static Type[] testSkinTypes = new[]
+        {
+            null,
+            typeof(DefaultLegacySkin),
+            typeof(TrianglesSkin),
+            typeof(ArgonSkin),
+            typeof(TestSkin),
+        };
+
+        /// <summary>
+        /// A <see cref="SkinProvidingContainer"/> should always have fallbacks for skin resource lookups.
+        /// This is to allow placeable components from various skin iterations to resolve their resources.
+        /// </summary>
+        [TestCaseSource(nameof(testSkinTypes))]
+        public void TestLegacyTextureFallbackLookups(Type skinType)
+        {
+            ISkin skin = (ISkin)(skinType == null ? null : Activator.CreateInstance(skinType, this));
+
+            SkinProvidingContainer provider = null;
+
+            AddStep("setup sources", () => Child = provider = new SkinProvidingContainer(skin));
+
+            // This resource is used by `LegacyKeyCounterDisplay`.
+            AddAssert("test classic default lookup", () => provider.FindProvider(s => s.GetTexture(@"inputoverlay-background") != null) is DefaultLegacySkin);
+        }
 
         /// <summary>
         /// Ensures that the first inserted skin after resetting (via source change)
@@ -59,6 +92,20 @@ namespace osu.Game.Tests.Skins
             });
         }
 
+        #region IResourceStorageProvider
+
+        [Resolved]
+        private GameHost host { get; set; }
+
+        public IRenderer Renderer => host.Renderer;
+        public AudioManager AudioManager => Audio;
+        public IResourceStore<byte[]> Files => null!;
+        public new IResourceStore<byte[]> Resources => base.Resources;
+        public IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore) => host.CreateTextureLoaderStore(underlyingStore);
+        RealmAccess IStorageResourceProvider.RealmAccess => null!;
+
+        #endregion
+
         private partial class TestSkinProvidingContainer : SkinProvidingContainer
         {
             private readonly IEnumerable<ISkin> sources;
@@ -82,12 +129,16 @@ namespace osu.Game.Tests.Skins
 
             private readonly IRenderer renderer;
 
+            public TestSkin([CanBeNull] IStorageResourceProvider _)
+            {
+            }
+
             public TestSkin(IRenderer renderer)
             {
                 this.renderer = renderer;
             }
 
-            public Drawable GetDrawableComponent(ISkinComponentLookup lookup) => throw new System.NotImplementedException();
+            public Drawable GetDrawableComponent(ISkinComponentLookup lookup) => throw new NotImplementedException();
 
             public Texture GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT)
             {
@@ -97,9 +148,9 @@ namespace osu.Game.Tests.Skins
                 return null;
             }
 
-            public ISample GetSample(ISampleInfo sampleInfo) => throw new System.NotImplementedException();
+            public ISample GetSample(ISampleInfo sampleInfo) => throw new NotImplementedException();
 
-            public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new System.NotImplementedException();
+            public IBindable<TValue> GetConfig<TLookup, TValue>(TLookup lookup) => throw new NotImplementedException();
         }
     }
 }

--- a/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
+++ b/osu.Game.Tests/Skins/TestSceneSkinProvidingContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Tests.Skins
         [Resolved]
         private IRenderer renderer { get; set; }
 
-        private static Type[] testSkinTypes = new[]
+        private static Type[] testSkinTypes =
         {
             null,
             typeof(DefaultLegacySkin),

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Logging;
 using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
@@ -183,7 +184,7 @@ namespace osu.Game.Screens.Play
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, INotificationOverlay notificationOverlay)
+        private void load(OsuConfigManager config, INotificationOverlay notificationOverlay, ISkinSource skinSource)
         {
             if (drawableRuleset != null)
             {
@@ -208,6 +209,27 @@ namespace osu.Game.Screens.Play
 
             // start all elements hidden
             hideTargets.ForEach(d => d.Hide());
+
+            logSkinLookupHierarchy(skinSource);
+        }
+
+        private void logSkinLookupHierarchy(ISkinSource skinSource)
+        {
+            Logger.Log("Skin lookup hierarchy for HUD:");
+            Logger.Log(string.Empty);
+
+            log(skinSource);
+
+            void log(ISkin s, int depth = 0)
+            {
+                Logger.Log(new string('-', depth) + $"| {s}");
+
+                if (s is ISkinSource ss)
+                {
+                    foreach (var nestedSource in ss.AllSources)
+                        log(nestedSource, depth + 1);
+                }
+            }
         }
 
         public override void Hide() =>

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -67,28 +66,13 @@ namespace osu.Game.Skinning
             // Populate a local list first so we can adjust the returned order as we go.
             var sources = new List<ISkin>();
 
-            Debug.Assert(ParentSource != null);
-
-            foreach (var source in ParentSource.AllSources)
-            {
-                switch (source)
-                {
-                    case Skin skin:
-                        sources.Add(GetRulesetTransformedSkin(skin));
-                        break;
-                }
-            }
-
-            // TODO: check
-            int lastDefaultSkinIndex = sources.IndexOf(sources.OfType<TrianglesSkin>().LastOrDefault());
+            // We want to transform the current user's skin for the current ruleset.
+            // Assume it's the first skin provided by the parent source (generally the case for both SkinManager and tests).
+            if (ParentSource?.AllSources.FirstOrDefault() is ISkin skin)
+                sources.Add(GetRulesetTransformedSkin(skin));
 
             // Ruleset resources should be given the ability to override game-wide defaults
-            // This is achieved by placing them before the last instance of DefaultSkin.
-            // Note that DefaultSkin may not be present in some test scenes.
-            if (lastDefaultSkinIndex >= 0)
-                sources.Insert(lastDefaultSkinIndex, rulesetResourcesSkin);
-            else
-                sources.Add(rulesetResourcesSkin);
+            sources.Add(rulesetResourcesSkin);
 
             SetSources(sources);
         }

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -76,10 +76,6 @@ namespace osu.Game.Skinning
                     case Skin skin:
                         sources.Add(GetRulesetTransformedSkin(skin));
                         break;
-
-                    default:
-                        sources.Add(source);
-                        break;
                 }
             }
 

--- a/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/RulesetSkinProvidingContainer.cs
@@ -31,12 +31,6 @@ namespace osu.Game.Skinning
         [CanBeNull]
         private readonly ISkin beatmapSkin;
 
-        /// <remarks>
-        /// This container already re-exposes all parent <see cref="ISkinSource"/> sources in a ruleset-usable form.
-        /// Therefore disallow falling back to any parent <see cref="ISkinSource"/> any further.
-        /// </remarks>
-        protected override bool AllowFallingBackToParent => false;
-
         protected override Container<Drawable> Content { get; } = new Container
         {
             RelativeSizeAxes = Axes.Both,

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -253,14 +253,10 @@ namespace osu.Game.Skinning
                 yield return CurrentSkin.Value;
 
                 // Skin manager provides default fallbacks.
-                // This handles cases where a user skin doesn't have the required resources for complete display of
-                // certain elements.
-
-                if (CurrentSkin.Value != DefaultClassicSkin)
-                    yield return DefaultClassicSkin;
-
-                if (CurrentSkin.Value != trianglesSkin)
-                    yield return trianglesSkin;
+                // This handles cases where a user skin doesn't have the required resources for complete display of certain elements, ie. textures.
+                if (CurrentSkin.Value != DefaultClassicSkin) yield return DefaultClassicSkin;
+                if (CurrentSkin.Value != argonSkin) yield return argonSkin;
+                if (CurrentSkin.Value != trianglesSkin) yield return trianglesSkin;
             }
         }
 

--- a/osu.Game/Skinning/SkinManager.cs
+++ b/osu.Game/Skinning/SkinManager.cs
@@ -256,7 +256,7 @@ namespace osu.Game.Skinning
                 // This handles cases where a user skin doesn't have the required resources for complete display of
                 // certain elements.
 
-                if (CurrentSkin.Value is LegacySkin && CurrentSkin.Value != DefaultClassicSkin)
+                if (CurrentSkin.Value != DefaultClassicSkin)
                     yield return DefaultClassicSkin;
 
                 if (CurrentSkin.Value != trianglesSkin)

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -99,10 +99,7 @@ namespace osu.Game.Skinning
                     yield return i.skin;
 
                 if (ParentSource != null)
-                {
-                    foreach (var skin in ParentSource.AllSources)
-                        yield return skin;
-                }
+                    yield return ParentSource;
             }
         }
 

--- a/osu.Game/Skinning/SkinProvidingContainer.cs
+++ b/osu.Game/Skinning/SkinProvidingContainer.cs
@@ -30,11 +30,6 @@ namespace osu.Game.Skinning
 
         protected ISkinSource? ParentSource { get; private set; }
 
-        /// <summary>
-        /// Whether falling back to parent <see cref="ISkinSource"/>s is allowed in this container.
-        /// </summary>
-        protected virtual bool AllowFallingBackToParent => true;
-
         protected virtual bool AllowDrawableLookup(ISkinComponentLookup lookup) => true;
 
         protected virtual bool AllowTextureLookup(string componentName) => true;
@@ -93,9 +88,6 @@ namespace osu.Game.Skinning
                     return skin;
             }
 
-            if (!AllowFallingBackToParent)
-                return null;
-
             return ParentSource?.FindProvider(lookupFunction);
         }
 
@@ -106,7 +98,7 @@ namespace osu.Game.Skinning
                 foreach (var i in skinSources)
                     yield return i.skin;
 
-                if (AllowFallingBackToParent && ParentSource != null)
+                if (ParentSource != null)
                 {
                     foreach (var skin in ParentSource.AllSources)
                         yield return skin;
@@ -123,9 +115,6 @@ namespace osu.Game.Skinning
                     return sourceDrawable;
             }
 
-            if (!AllowFallingBackToParent)
-                return null;
-
             return ParentSource?.GetDrawableComponent(lookup);
         }
 
@@ -138,9 +127,6 @@ namespace osu.Game.Skinning
                     return sourceTexture;
             }
 
-            if (!AllowFallingBackToParent)
-                return null;
-
             return ParentSource?.GetTexture(componentName, wrapModeS, wrapModeT);
         }
 
@@ -152,9 +138,6 @@ namespace osu.Game.Skinning
                 if ((sourceSample = lookupWrapper.GetSample(sampleInfo)) != null)
                     return sourceSample;
             }
-
-            if (!AllowFallingBackToParent)
-                return null;
 
             return ParentSource?.GetSample(sampleInfo);
         }
@@ -173,9 +156,6 @@ namespace osu.Game.Skinning
                     if ((bindable = lookupWrapper.GetConfig<TLookup, TValue>(lookup)) != null)
                         return bindable;
                 }
-
-                if (!AllowFallingBackToParent)
-                    return null;
 
                 return ParentSource?.GetConfig<TLookup, TValue>(lookup);
             }

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -28,9 +28,9 @@ namespace osu.Game.Skinning
 
         public virtual Drawable? GetDrawableComponent(ISkinComponentLookup lookup) => Skin.GetDrawableComponent(lookup);
 
-        public virtual Texture? GetTexture(string componentName) => GetTexture(componentName, default, default);
+        public Texture? GetTexture(string componentName) => GetTexture(componentName, default, default);
 
-        public virtual Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
+        public Texture? GetTexture(string componentName, WrapMode wrapModeS, WrapMode wrapModeT) => Skin.GetTexture(componentName, wrapModeS, wrapModeT);
 
         public virtual ISample? GetSample(ISampleInfo sampleInfo) => Skin.GetSample(sampleInfo);
 

--- a/osu.Game/Skinning/SkinTransformer.cs
+++ b/osu.Game/Skinning/SkinTransformer.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
 using osu.Game.Audio;
@@ -47,6 +48,6 @@ namespace osu.Game.Skinning
             }
         }
 
-        public override string ToString() => $"{nameof(SkinTransformer)} {{ Skin: {Skin} }}";
+        public override string ToString() => $"{GetType().ReadableName()} {{ Skin: {Skin} }}";
     }
 }

--- a/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
+++ b/osu.Game/Tests/Beatmaps/LegacyBeatmapSkinColourTest.cs
@@ -161,7 +161,7 @@ namespace osu.Game.Tests.Beatmaps
 
             public ISkin FindProvider(Func<ISkin, bool> lookupFunction) => lookupFunction(this) ? this : null;
 
-            public IEnumerable<ISkin> AllSources => new[] { this };
+            public IEnumerable<ISkin> AllSources => Array.Empty<ISkin>();
         }
     }
 }


### PR DESCRIPTION
This is what I'd call a stepping-stone change in the direction of simplifying skinning lookups. I almost aborted the issue with a "requires larger refactor" call, but this change looks to improve from status-quo and I believe it will aid in making future refactors simpler.

The actual fix here is that a `LegacyDefaultSkin` is now always provided by `SkinManager` regardless of the user's skin choice. Doing this previously would have caused gameplay elements to leak from the legacy skin into argon skins (consider the case of `SliderTailHitCircle`).

This is because, previously, we were wrapping all fallback providers inside ruleset transformers, but I argue that this is not correct (or at least, not necessary). The rationale is that ruleset transformers are there to transform **known concepts** in gameplay. It is assumed that every skin implementation has a solid idea of what it wants, and wouldn't expect any fallback lookups to happen. Any exceptions to this rule can be handled locally (as the sole example see `BeatmapSkinProvidingContainer`).

So now, only the *beatmap* skin (if a beatmap provides a skin) and the *user* skin are wrapped.

As a result, we simplify the lookup process. `RulesetSkinProvidingContainer` no longer creates its own local lookup and blocks hierarchical lookup.

Closes https://github.com/ppy/osu/issues/29317.