### PR TITLE
Add button to centre editor grid to current hit object

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -202,12 +202,6 @@ namespace osu.Game.Rulesets.Osu.Edit
                 gridLinesRotationSlider.ExpandedLabelText = $"Rotation: {rotation.NewValue:#,0.##}";
             }, true);
 
-            expandingContainer?.Expanded.BindValueChanged(v =>
-            {
-                gridTypeButtons.FadeTo(v.NewValue ? 1f : 0f, 500, Easing.OutQuint);
-                gridTypeButtons.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
-            }, true);
-
             GridType.BindValueChanged(v =>
             {
                 GridLinesRotation.Disabled = v.NewValue == PositionSnapGridType.Circle;
@@ -229,12 +223,20 @@ namespace osu.Game.Rulesets.Osu.Edit
             }, true);
 
             editorBeatmap.BeatmapReprocessed += updateEnabledStates;
-            editorBeatmap.SelectedHitObjects.BindCollectionChanged((_, _) => updateEnabledStates(), true);
+            editorBeatmap.SelectedHitObjects.BindCollectionChanged((_, _) => updateEnabledStates());
+            expandingContainer?.Expanded.BindValueChanged(v =>
+            {
+                gridTypeButtons.FadeTo(v.NewValue ? 1f : 0f, 500, Easing.OutQuint);
+                gridTypeButtons.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
+                updateEnabledStates();
+            }, true);
         }
 
         private void updateEnabledStates()
         {
-            useSelectedObjectPositionButton.Enabled.Value = editorBeatmap.SelectedHitObjects.Count == 1 && StartPosition.Value != ((IHasPosition)editorBeatmap.SelectedHitObjects.Single()).Position;
+            useSelectedObjectPositionButton.Enabled.Value = expandingContainer?.Expanded.Value == true
+                                                            && editorBeatmap.SelectedHitObjects.Count == 1
+                                                            && StartPosition.Value != ((IHasPosition)editorBeatmap.SelectedHitObjects.Single()).Position;
         }
 
         private void nextGridSize()

--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -14,6 +14,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.RadioButtons;
@@ -90,6 +91,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         private ExpandableSlider<float> gridLinesRotationSlider = null!;
         private EditorRadioButtonCollection gridTypeButtons = null!;
 
+        private ExpandableButton useSelectedObjectPositionButton = null!;
+
         public OsuGridToolboxGroup()
             : base("grid")
         {
@@ -111,6 +114,19 @@ namespace osu.Game.Rulesets.Osu.Edit
                 {
                     Current = StartPositionY,
                     KeyboardStep = 1,
+                },
+                useSelectedObjectPositionButton = new ExpandableButton
+                {
+                    ExpandedLabelText = "Centre on selected object",
+                    Action = () =>
+                    {
+                        if (editorBeatmap.SelectedHitObjects.Count != 1)
+                            return;
+
+                        StartPosition.Value = ((IHasPosition)editorBeatmap.SelectedHitObjects.Single()).Position;
+                        updateEnabledStates();
+                    },
+                    RelativeSizeAxes = Axes.X,
                 },
                 spacingSlider = new ExpandableSlider<float>
                 {
@@ -211,6 +227,14 @@ namespace osu.Game.Rulesets.Osu.Edit
                         break;
                 }
             }, true);
+
+            editorBeatmap.BeatmapReprocessed += updateEnabledStates;
+            editorBeatmap.SelectedHitObjects.BindCollectionChanged((_, _) => updateEnabledStates(), true);
+        }
+
+        private void updateEnabledStates()
+        {
+            useSelectedObjectPositionButton.Enabled.Value = editorBeatmap.SelectedHitObjects.Count == 1 && StartPosition.Value != ((IHasPosition)editorBeatmap.SelectedHitObjects.Single()).Position;
         }
 
         private void nextGridSize()

--- a/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
+++ b/osu.Game.Tests/Editing/TestSceneHitObjectComposerDistanceSnapping.cs
@@ -230,23 +230,26 @@ namespace osu.Game.Tests.Editing
         [Test]
         public void TestUseCurrentSnap()
         {
+            ExpandableButton getCurrentSnapButton() => composer.ChildrenOfType<EditorToolboxGroup>().Single(g => g.Name == "snapping")
+                                                               .ChildrenOfType<ExpandableButton>().Single();
+
             AddStep("add objects to beatmap", () =>
             {
                 editorBeatmap.Add(new HitCircle { StartTime = 1000 });
                 editorBeatmap.Add(new HitCircle { Position = new Vector2(100), StartTime = 2000 });
             });
 
-            AddStep("hover use current snap button", () => InputManager.MoveMouseTo(composer.ChildrenOfType<ExpandableButton>().Single()));
-            AddUntilStep("use current snap expanded", () => composer.ChildrenOfType<ExpandableButton>().Single().Expanded.Value, () => Is.True);
+            AddStep("hover use current snap button", () => InputManager.MoveMouseTo(getCurrentSnapButton()));
+            AddUntilStep("use current snap expanded", () => getCurrentSnapButton().Expanded.Value, () => Is.True);
 
             AddStep("seek before first object", () => EditorClock.Seek(0));
-            AddUntilStep("use current snap not available", () => composer.ChildrenOfType<ExpandableButton>().Single().Enabled.Value, () => Is.False);
+            AddUntilStep("use current snap not available", () => getCurrentSnapButton().Enabled.Value, () => Is.False);
 
             AddStep("seek to between objects", () => EditorClock.Seek(1500));
-            AddUntilStep("use current snap available", () => composer.ChildrenOfType<ExpandableButton>().Single().Enabled.Value, () => Is.True);
+            AddUntilStep("use current snap available", () => getCurrentSnapButton().Enabled.Value, () => Is.True);
 
             AddStep("seek after last object", () => EditorClock.Seek(2500));
-            AddUntilStep("use current snap not available", () => composer.ChildrenOfType<ExpandableButton>().Single().Enabled.Value, () => Is.False);
+            AddUntilStep("use current snap not available", () => getCurrentSnapButton().Enabled.Value, () => Is.False);
         }
 
         private void assertSnapDistance(float expectedDistance, HitObject? referenceObject, bool includeSliderVelocity)

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Rulesets.Edit
 
             toolboxContainer.Add(toolboxGroup = new EditorToolboxGroup("snapping")
             {
+                Name = "snapping",
                 Alpha = DistanceSpacingMultiplier.Disabled ? 0 : 1,
                 Children = new Drawable[]
                 {

--- a/osu.Game/Rulesets/Edit/ExpandableButton.cs
+++ b/osu.Game/Rulesets/Edit/ExpandableButton.cs
@@ -11,7 +11,7 @@ using osu.Game.Graphics.UserInterfaceV2;
 
 namespace osu.Game.Rulesets.Edit
 {
-    internal partial class ExpandableButton : RoundedButton, IExpandable
+    public partial class ExpandableButton : RoundedButton, IExpandable
     {
         private float actualHeight;
 


### PR DESCRIPTION
Just a quick one. Maybe needs a keyboard shortcut? Maybe also in context menu? But also probably fine to get this in as a first step and see how often it's used?


https://github.com/user-attachments/assets/80d86956-e7bd-4b45-a358-e54f5d407858


Addresses https://github.com/ppy/osu/discussions/29818