### PR TITLE
Fix usage of locked context without locking

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -183,7 +183,14 @@ namespace osu.Game.Beatmaps
 
         #region Beatmap
 
-        public virtual bool BeatmapLoaded => beatmapLoadTask?.IsCompleted ?? false;
+        public virtual bool BeatmapLoaded
+        {
+            get
+            {
+                lock (beatmapFetchLock)
+                    return beatmapLoadTask?.IsCompleted ?? false;
+            }
+        }
 
         public IBeatmap Beatmap
         {


### PR DESCRIPTION
Raised in the latest Rider EAP, seems valid enough.

![JetBrains Rider-EAP 2024-10-01 at 09 01 24](https://github.com/user-attachments/assets/329d96aa-a3e8-4889-a83d-6be5282335c7)
