### PR TITLE
Add progress tooltip for ArgonSongProgressBar

### DIFF
--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -35,13 +35,13 @@ namespace osu.Game.Screens.Play.HUD
 
         private double trackTime => (EndTime - StartTime) * Progress;
 
-        private float relativePositionX;
+        private float lastMouseX;
 
         public LocalisableString TooltipText
         {
             get
             {
-                double progress = Math.Clamp(relativePositionX, 0, DrawWidth) / DrawWidth;
+                double progress = Math.Clamp(lastMouseX, 0, DrawWidth) / DrawWidth;
 
                 TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress));
 
@@ -107,10 +107,8 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.OnMouseMove(e);
 
-            var cursorPosition = e.ScreenSpaceMousePosition;
-            relativePositionX = ToLocalSpace(cursorPosition).X;
-
-            return true;
+            lastMouseX = e.MousePosition.X;
+            return false;
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -20,7 +20,6 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class ArgonSongProgressBar : SongProgressBar, IHasTooltip
     {
-
         // Parent will handle restricting the area of valid input.
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -37,7 +37,20 @@ namespace osu.Game.Screens.Play.HUD
 
         private float relativePositionX;
 
-        public LocalisableString TooltipText => updateTooltip();
+        public LocalisableString TooltipText
+        {
+            get
+            {
+                double progress = Math.Clamp(relativePositionX, 0, DrawWidth) / DrawWidth;
+
+                TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress));
+
+                int seconds = currentSpan.Duration().Seconds;
+                int minutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);
+
+                return $"{minutes}:{seconds:D2} ({progress:P0})";
+            }
+        }
 
         public ArgonSongProgressBar(float barHeight)
         {
@@ -80,19 +93,6 @@ namespace osu.Game.Screens.Play.HUD
         private void load(OsuColour colours)
         {
             catchUpColour = colours.BlueDark;
-        }
-
-        private LocalisableString updateTooltip()
-        {
-            // clamping in case the cursor lays out of the progress bar horizontally
-            double progress = Math.Clamp(relativePositionX, 0, DrawWidth) / DrawWidth;
-
-            TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress));
-            int currentSeconds = currentSpan.Duration().Seconds;
-            // merging hours and minutes, e.g. 1:15:55 -> 75:55
-            int currentMinutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);
-
-            return $"{currentMinutes}:{currentSeconds:D2} - {progress:P1}";
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
-using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osuTK;
 
@@ -38,8 +37,9 @@ namespace osu.Game.Screens.Play.HUD
 
         private float relativePositionX;
 
-        public LocalisableString TooltipText => $"{(relativePositionX > 0 ? (EndTime - StartTime) * relativePositionX / DrawWidth : relativePositionX > DrawWidth ? EndTime : 0).ToEditorFormattedString()}"
-                                                + $" - {(relativePositionX > 0 ? Math.Round(relativePositionX / DrawWidth * 100, 2) : relativePositionX > DrawWidth ? 100 : 0)}%";
+        public LocalisableString TooltipText => $"{formatTime(TimeSpan.FromSeconds(relativePositionX > 0 ? Math.Round((EndTime - StartTime) * relativePositionX / DrawWidth / 1000)
+            : relativePositionX > DrawWidth ? Math.Round(EndTime / 1000) : 0))}"
+                                                + $" - {(relativePositionX > 0 ? Math.Round(relativePositionX / DrawWidth * 100, 1) : relativePositionX > DrawWidth ? 100 : 0)}%";
 
         public ArgonSongProgressBar(float barHeight)
         {
@@ -191,5 +191,7 @@ namespace osu.Game.Screens.Play.HUD
                 set => fill.Colour = value;
             }
         }
+
+        private string formatTime(TimeSpan timeSpan) => $"{(timeSpan < TimeSpan.Zero ? "-" : "")}{Math.Floor(timeSpan.Duration().TotalMinutes)}:{timeSpan.Duration().Seconds:D2}";
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
@@ -38,8 +37,6 @@ namespace osu.Game.Screens.Play.HUD
         private double trackTime => (EndTime - StartTime) * Progress;
 
         private float relativePositionX;
-
-        private InputManager? inputManager;
 
         public LocalisableString TooltipText => $"{(relativePositionX > 0 ? (EndTime - StartTime) * relativePositionX / DrawWidth : relativePositionX > DrawWidth ? EndTime : 0).ToEditorFormattedString()}"
                                                 + $" - {(relativePositionX > 0 ? Math.Round(relativePositionX / DrawWidth * 100, 2) : relativePositionX > DrawWidth ? 100 : 0)}%";
@@ -85,7 +82,6 @@ namespace osu.Game.Screens.Play.HUD
         private void load(OsuColour colours)
         {
             catchUpColour = colours.BlueDark;
-            inputManager = GetContainingInputManager();
         }
 
         protected override void LoadComplete()
@@ -94,6 +90,16 @@ namespace osu.Game.Screens.Play.HUD
 
             background.FadeTo(0.3f, 200, Easing.In);
             playfieldBar.TransformTo(nameof(playfieldBar.AccentColour), mainColour, 200, Easing.In);
+        }
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            base.OnMouseMove(e);
+
+            var cursorPosition = e.ScreenSpaceMousePosition;
+            relativePositionX = ToLocalSpace(cursorPosition).X;
+
+            return true;
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -113,18 +119,6 @@ namespace osu.Game.Screens.Play.HUD
         protected override void Update()
         {
             base.Update();
-
-            if (inputManager != null)
-            {
-                // Update the cursor position in time
-                var cursorPosition = inputManager.CurrentState.Mouse.Position;
-                relativePositionX = ToLocalSpace(cursorPosition).X;
-            }
-            else
-            {
-                // If null (e.g. before the game starts), try getting the input manager again
-                inputManager = GetContainingInputManager();
-            }
 
             playfieldBar.Length = (float)Interpolation.Lerp(playfieldBar.Length, Progress, Math.Clamp(Time.Elapsed / 40, 0, 1));
             audioBar.Length = (float)Interpolation.Lerp(audioBar.Length, AudioProgress, Math.Clamp(Time.Elapsed / 40, 0, 1));

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -37,9 +37,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private float relativePositionX;
 
-        public LocalisableString TooltipText => $"{formatTime(TimeSpan.FromSeconds(relativePositionX > 0 ? Math.Round((EndTime - StartTime) * relativePositionX / DrawWidth / 1000)
-            : relativePositionX > DrawWidth ? Math.Round(EndTime / 1000) : 0))}"
-                                                + $" - {(relativePositionX > 0 ? Math.Round(relativePositionX / DrawWidth * 100, 1) : relativePositionX > DrawWidth ? 100 : 0)}%";
+        public LocalisableString TooltipText => updateTooltip();
 
         public ArgonSongProgressBar(float barHeight)
         {
@@ -82,6 +80,19 @@ namespace osu.Game.Screens.Play.HUD
         private void load(OsuColour colours)
         {
             catchUpColour = colours.BlueDark;
+        }
+
+        private LocalisableString updateTooltip()
+        {
+            // clamping in case the cursor lays out of the progress bar horizontally
+            double progress = Math.Clamp(relativePositionX, 0, DrawWidth) / DrawWidth;
+
+            TimeSpan currentSpan = TimeSpan.FromMilliseconds(Math.Round((EndTime - StartTime) * progress));
+            int currentSeconds = currentSpan.Duration().Seconds;
+            // merging hours and minutes, e.g. 1:15:55 -> 75:55
+            int currentMinutes = (int)Math.Floor(currentSpan.Duration().TotalMinutes);
+
+            return $"{currentMinutes}:{currentSeconds:D2} - {progress:P1}";
         }
 
         protected override void LoadComplete()
@@ -191,7 +202,5 @@ namespace osu.Game.Screens.Play.HUD
                 set => fill.Colour = value;
             }
         }
-
-        private string formatTime(TimeSpan timeSpan) => $"{(timeSpan < TimeSpan.Zero ? "-" : "")}{Math.Floor(timeSpan.Duration().TotalMinutes)}:{timeSpan.Duration().Seconds:D2}";
     }
 }

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgressBar.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private InputManager? inputManager;
 
-        public LocalisableString TooltipText => $"{(relativePositionX > 0 ? Math.Round(EndTime * relativePositionX / DrawWidth, 2) : relativePositionX > DrawWidth ? EndTime : 0).ToEditorFormattedString()}"
+        public LocalisableString TooltipText => $"{(relativePositionX > 0 ? (EndTime - StartTime) * relativePositionX / DrawWidth : relativePositionX > DrawWidth ? EndTime : 0).ToEditorFormattedString()}"
                                                 + $" - {(relativePositionX > 0 ? Math.Round(relativePositionX / DrawWidth * 100, 2) : relativePositionX > DrawWidth ? 100 : 0)}%";
 
         public ArgonSongProgressBar(float barHeight)


### PR DESCRIPTION
Just referred to the beatmap editor tooltip for implementation and styles.

![Tooltip style example](https://github.com/user-attachments/assets/938cb685-e649-495a-ad0e-5729cf8dc2ee)

This is a possibly simple implementation of #30077.

## Principle

Since ArgonSongProgressBar takes up all of the DrawWidth, we can use `GetContainingInputManager` for the X position of the cursor, then converting into the relative X position to the progress bar with `ToLocalSpace`.
