### PR TITLE
Add default value for input boxes in tournament editor screens

### DIFF
--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -38,6 +38,12 @@ namespace osu.Game.Tournament.Screens.Editors
             {
                 Model = round;
 
+                Model.Name.Default = Model.Name.Value;
+                Model.Description.Default = Model.Description.Value;
+                Model.StartDate.Default = Model.StartDate.Value;
+                Model.BanCount.Default = Model.BanCount.Value;
+                Model.BestOf.Default = Model.BestOf.Value;
+
                 Masking = true;
                 CornerRadius = 10;
 
@@ -232,7 +238,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        beatmapId.Value = Model.ID;
+                        beatmapId.Default = beatmapId.Value = Model.ID;
                         beatmapId.BindValueChanged(id =>
                         {
                             Model.ID = id.NewValue ?? 0;
@@ -263,7 +269,7 @@ namespace osu.Game.Tournament.Screens.Editors
                             API.Queue(req);
                         }, true);
 
-                        mods.Value = Model.Mods;
+                        mods.Default = mods.Value = Model.Mods;
                         mods.BindValueChanged(modString => Model.Mods = modString.NewValue);
                     }
 

--- a/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/RoundEditorScreen.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Tournament.Screens.Editors
 
         public partial class RoundRow : CompositeDrawable, IModelBacked<TournamentRound>
         {
+            [Resolved]
+            private TournamentGameBase? game { get; set; }
+
             public TournamentRound Model { get; }
 
             [Resolved]
@@ -128,6 +131,22 @@ namespace osu.Game.Tournament.Screens.Editors
                 AutoSizeAxes = Axes.Y;
             }
 
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // TournamentGameBase won't be loaded so early, probably binding the event here
+                game?.IsSaveTriggered.BindValueChanged(state =>
+                {
+                    if (!state.NewValue) return;
+
+                    Model.Name.Default = Model.Name.Value;
+                    Model.Description.Default = Model.Description.Value;
+                    Model.StartDate.Default = Model.StartDate.Value;
+                    Model.BanCount.Default = Model.BanCount.Value;
+                    Model.BestOf.Default = Model.BestOf.Value;
+                });
+            }
+
             public partial class RoundBeatmapEditor : CompositeDrawable
             {
                 private readonly TournamentRound round;
@@ -160,6 +179,9 @@ namespace osu.Game.Tournament.Screens.Editors
 
                 public partial class RoundBeatmapRow : CompositeDrawable
                 {
+                    [Resolved]
+                    private TournamentGameBase? game { get; set; }
+
                     public RoundBeatmap Model { get; }
 
                     [Resolved]
@@ -271,6 +293,14 @@ namespace osu.Game.Tournament.Screens.Editors
 
                         mods.Default = mods.Value = Model.Mods;
                         mods.BindValueChanged(modString => Model.Mods = modString.NewValue);
+
+                        game?.IsSaveTriggered.BindValueChanged(state =>
+                        {
+                            if (!state.NewValue) return;
+
+                            beatmapId.Default = beatmapId.Value;
+                            mods.Default = mods.Value;
+                        });
                     }
 
                     private void updatePanel() => Schedule(() =>

--- a/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
@@ -221,7 +221,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        beatmapId.Value = Model.ID;
+                        beatmapId.Default = beatmapId.Value = Model.ID;
                         beatmapId.BindValueChanged(id =>
                         {
                             Model.ID = id.NewValue ?? 0;

--- a/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/SeedingEditorScreen.cs
@@ -34,9 +34,15 @@ namespace osu.Game.Tournament.Screens.Editors
         {
             public SeedingResult Model { get; }
 
+            [Resolved]
+            private TournamentGameBase? game { get; set; }
+
             public SeedingResultRow(TournamentTeam team, SeedingResult round)
             {
                 Model = round;
+
+                Model.Mod.Default = Model.Mod.Value;
+                Model.Seed.Default = Model.Seed.Value;
 
                 Masking = true;
                 CornerRadius = 10;
@@ -104,6 +110,18 @@ namespace osu.Game.Tournament.Screens.Editors
                 AutoSizeAxes = Axes.Y;
             }
 
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                game?.IsSaveTriggered.BindValueChanged(state =>
+                {
+                    if (!state.NewValue) return;
+
+                    Model.Mod.Default = Model.Mod.Value;
+                    Model.Seed.Default = Model.Seed.Value;
+                });
+            }
+
             public partial class SeedingBeatmapEditor : CompositeDrawable
             {
                 private readonly SeedingResult round;
@@ -136,6 +154,9 @@ namespace osu.Game.Tournament.Screens.Editors
                 {
                     private readonly SeedingResult result;
                     public SeedingBeatmap Model { get; }
+
+                    [Resolved]
+                    private TournamentGameBase? game { get; set; }
 
                     [Resolved]
                     protected IAPIProvider API { get; private set; } = null!;
@@ -252,8 +273,19 @@ namespace osu.Game.Tournament.Screens.Editors
                             API.Queue(req);
                         }, true);
 
-                        score.Value = Model.Score.ToString();
+                        Model.Seed.Default = Model.Seed.Value;
+
+                        score.Default = score.Value = Model.Score.ToString();
                         score.BindValueChanged(str => long.TryParse(str.NewValue, out Model.Score));
+
+                        game?.IsSaveTriggered.BindValueChanged(state =>
+                        {
+                            if (!state.NewValue) return;
+
+                            beatmapId.Default = beatmapId.Value;
+                            Model.Seed.Default = Model.Seed.Value;
+                            score.Default = score.Value;
+                        });
                     }
 
                     private void updatePanel()

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -71,9 +71,18 @@ namespace osu.Game.Tournament.Screens.Editors
             [Resolved]
             private LadderInfo ladderInfo { get; set; } = null!;
 
+            [Resolved]
+            private TournamentGameBase? game { get; set; }
+
             public TeamRow(TournamentTeam team, TournamentScreen parent)
             {
                 Model = team;
+
+                Model.FullName.Default = Model.FullName.Value;
+                Model.Acronym.Default = Model.Acronym.Value;
+                Model.FlagName.Default = Model.FlagName.Value;
+                Model.LastYearPlacing.Default = Model.LastYearPlacing.Value;
+                Model.Seed.Default = Model.Seed.Value;
 
                 Masking = true;
                 CornerRadius = 10;
@@ -175,6 +184,22 @@ namespace osu.Game.Tournament.Screens.Editors
                         }
                     },
                 };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // TournamentGameBase won't be loaded so early, probably binding the event here
+                game?.IsSaveTriggered.BindValueChanged(state =>
+                {
+                    if (!state.NewValue) return;
+
+                    Model.FullName.Default = Model.FullName.Value;
+                    Model.Acronym.Default = Model.Acronym.Value;
+                    Model.FlagName.Default = Model.FlagName.Value;
+                    Model.LastYearPlacing.Default = Model.LastYearPlacing.Value;
+                    Model.Seed.Default = Model.Seed.Value;
+                });
             }
 
             private partial class LastYearPlacementSlider : RoundedSliderBar<int>
@@ -299,6 +324,13 @@ namespace osu.Game.Tournament.Screens.Editors
 
                             game.PopulatePlayer(user, updatePanel, updatePanel);
                         }, true);
+
+                        game.IsSaveTriggered.BindValueChanged(state =>
+                        {
+                            if (!state.NewValue) return;
+
+                            playerId.Default = playerId.Value;
+                        });
                     }
 
                     private void updatePanel() => Scheduler.AddOnce(() =>

--- a/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
+++ b/osu.Game.Tournament/Screens/Editors/TeamEditorScreen.cs
@@ -283,7 +283,7 @@ namespace osu.Game.Tournament.Screens.Editors
                     [BackgroundDependencyLoader]
                     private void load()
                     {
-                        playerId.Value = user.OnlineID;
+                        playerId.Default = playerId.Value = user.OnlineID;
                         playerId.BindValueChanged(id =>
                         {
                             user.OnlineID = id.NewValue ?? 0;

--- a/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
+++ b/osu.Game.Tournament/Screens/TeamIntro/SeedingScreen.cs
@@ -63,6 +63,7 @@ namespace osu.Game.Tournament.Screens.TeamIntro
                         {
                             LabelText = "Show specific team",
                             Current = currentTeam,
+                            ShowsDefaultIndicator = false,
                         }
                     }
                 }

--- a/osu.Game.Tournament/TournamentGameBase.cs
+++ b/osu.Game.Tournament/TournamentGameBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Textures;
@@ -35,6 +36,8 @@ namespace osu.Game.Tournament
         private DependencyContainer dependencies = null!;
         private FileBasedIPC ipc = null!;
         private BeatmapLookupCache beatmapCache = null!;
+
+        public BindableBool IsSaveTriggered = new BindableBool(false);
 
         protected Task BracketLoadTask => bracketLoadTaskCompletionSource.Task;
 
@@ -329,7 +332,9 @@ namespace osu.Game.Tournament
                 return;
             }
 
+            IsSaveTriggered.Value = true;
             saveChanges();
+            IsSaveTriggered.Value = false;
         }
 
         private void saveChanges()


### PR DESCRIPTION
## Goal

In the current version of osu!lazer tournament client, there are small restore buttons that restore the current value of input boxes to their default. But most of them just revert to an empty string, which isn't so friendly in cases where we accidentally modified one and cannot easily undo this change unless restarting the client.

For this we can read values from the model, setting them default values on component loading. Then we can still access the initial value even after we save changes, as long as we haven't close the tournament client.
