### PR TITLE
Increase chat font size again

### DIFF
--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -205,7 +205,6 @@ namespace osu.Game.Online.Chat
 
         protected partial class StandAloneMessage : ChatLine
         {
-            protected override float FontSize => 13;
             protected override float Spacing => 5;
             protected override float UsernameWidth => 90;
 

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Overlays.Chat
 
         public IReadOnlyCollection<Drawable> DrawableContentFlow => drawableContentFlow;
 
-        protected virtual float FontSize => 12;
+        private const float font_size = 13;
 
         protected virtual float Spacing => 15;
 
@@ -183,13 +183,13 @@ namespace osu.Game.Overlays.Chat
                                 Anchor = Anchor.TopLeft,
                                 Origin = Anchor.TopLeft,
                                 Spacing = new Vector2(-1, 0),
-                                Font = OsuFont.GetFont(size: FontSize, weight: FontWeight.SemiBold, fixedWidth: true),
+                                Font = OsuFont.GetFont(size: font_size, weight: FontWeight.SemiBold, fixedWidth: true),
                                 AlwaysPresent = true,
                             },
                             drawableUsername = new DrawableChatUsername(message.Sender)
                             {
                                 Width = UsernameWidth,
-                                FontSize = FontSize,
+                                FontSize = font_size,
                                 AutoSizeAxes = Axes.Y,
                                 Origin = Anchor.TopRight,
                                 Anchor = Anchor.TopRight,
@@ -258,7 +258,7 @@ namespace osu.Game.Overlays.Chat
         private void styleMessageContent(SpriteText text)
         {
             text.Shadow = false;
-            text.Font = text.Font.With(size: FontSize, italics: Message.IsAction, weight: isMention ? FontWeight.SemiBold : FontWeight.Medium);
+            text.Font = text.Font.With(size: font_size, italics: Message.IsAction, weight: isMention ? FontWeight.SemiBold : FontWeight.Medium);
 
             Color4 messageColour = colourProvider?.Content1 ?? Colour4.White;
 


### PR DESCRIPTION
I don't think we can use size 12 without it being `SemiBold`. And yes this is reverting a recent change I made, but I wasn't too sure about the change at the time.

Addresses https://github.com/ppy/osu/discussions/30065.