### PR TITLE
Do not add checkbox padding to the left of menu items if no item actually needs it

### DIFF
--- a/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -25,6 +26,8 @@ namespace osu.Game.Graphics.UserInterface
         public const int MARGIN_VERTICAL = 4;
         public const int TEXT_SIZE = 17;
         public const int TRANSITION_LENGTH = 80;
+
+        public BindableBool ShowCheckbox { get; } = new BindableBool();
 
         private TextContainer text;
         private HotkeyDisplay hotkey;
@@ -72,6 +75,7 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.LoadComplete();
 
+            ShowCheckbox.BindValueChanged(_ => updateState());
             Item.Action.BindDisabledChanged(_ => updateState(), true);
             FinishTransforms();
         }
@@ -138,6 +142,8 @@ namespace osu.Game.Graphics.UserInterface
                 text.BoldText.FadeOut(TRANSITION_LENGTH, Easing.OutQuint);
                 text.NormalText.FadeIn(TRANSITION_LENGTH, Easing.OutQuint);
             }
+
+            text.CheckboxContainer.Alpha = ShowCheckbox.Value ? 1 : 0;
         }
 
         protected sealed override Drawable CreateContent() => text = CreateTextContainer();

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -47,10 +46,19 @@ namespace osu.Game.Graphics.UserInterface
         {
             base.Update();
 
-            bool showCheckboxes = Items.Any(i => i is StatefulMenuItem);
+            bool showCheckboxes = false;
 
-            foreach (var drawableItem in ItemsContainer.OfType<DrawableOsuMenuItem>())
-                drawableItem.ShowCheckbox.Value = showCheckboxes;
+            foreach (var drawableItem in ItemsContainer)
+            {
+                if (drawableItem.Item is StatefulMenuItem)
+                    showCheckboxes = true;
+            }
+
+            foreach (var drawableItem in ItemsContainer)
+            {
+                if (drawableItem is DrawableOsuMenuItem osuItem)
+                    osuItem.ShowCheckbox.Value = showCheckboxes;
+            }
         }
 
         protected override void AnimateOpen()

--- a/osu.Game/Graphics/UserInterface/OsuMenu.cs
+++ b/osu.Game/Graphics/UserInterface/OsuMenu.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -40,6 +41,16 @@ namespace osu.Game.Graphics.UserInterface
         {
             sampleOpen = audio.Samples.Get(@"UI/dropdown-open");
             sampleClose = audio.Samples.Get(@"UI/dropdown-close");
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            bool showCheckboxes = Items.Any(i => i is StatefulMenuItem);
+
+            foreach (var drawableItem in ItemsContainer.OfType<DrawableOsuMenuItem>())
+                drawableItem.ShowCheckbox.Value = showCheckboxes;
         }
 
         protected override void AnimateOpen()


### PR DESCRIPTION
RFC. As per https://discord.com/channels/188630481301012481/188630652340404224/1291346164976980009.

https://github.com/user-attachments/assets/631a4e14-57b8-46d3-b5fd-4d6960a89d22

The diff is extremely dumb (linq in update method) but I tried a few smarter methods and they're either not fully correct or don't work. Primary problem is that menu items are mutable externally and there's no hook provided by the framework to know that items changed. One could probably be made but I'd prefer that this change be examined visually first before I engage in too much ceremony and start changing framework around. Measured overhead in profiling is ~16us per call.