### PR TITLE
Initialise colours section with default combo colours if none present

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneColoursSection.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneColoursSection.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Setup;
+using osu.Game.Skinning;
+using osuTK.Graphics;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    [HeadlessTest]
+    public partial class TestSceneColoursSection : OsuManualInputManagerTestScene
+    {
+        [Test]
+        public void TestNoBeatmapSkinColours()
+        {
+            LegacyBeatmapSkin skin = null!;
+            ColoursSection coloursSection = null!;
+
+            AddStep("create beatmap skin", () => skin = new LegacyBeatmapSkin(new BeatmapInfo(), null));
+            AddStep("create colours section", () => Child = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies =
+                [
+                    (typeof(EditorBeatmap), new EditorBeatmap(new Beatmap
+                    {
+                        BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo }
+                    }, skin)),
+                    (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Aquamarine))
+                ],
+                Child = coloursSection = new ColoursSection
+                {
+                    RelativeSizeAxes = Axes.X,
+                }
+            });
+            AddAssert("beatmap skin has no colours", () => skin.Configuration.CustomComboColours, () => Is.Empty);
+            AddAssert("section displays default combo colours",
+                () => coloursSection.ChildrenOfType<FormColourPalette>().Single().Colours,
+                () => Is.EquivalentTo(new Colour4[]
+                {
+                    SkinConfiguration.DefaultComboColours[1],
+                    SkinConfiguration.DefaultComboColours[2],
+                    SkinConfiguration.DefaultComboColours[3],
+                    SkinConfiguration.DefaultComboColours[0],
+                }));
+
+            AddStep("add a colour", () => coloursSection.ChildrenOfType<FormColourPalette>().Single().Colours.Add(Colour4.Aqua));
+            AddAssert("beatmap skin has colours",
+                () => skin.Configuration.CustomComboColours,
+                () => Is.EquivalentTo(new[]
+                {
+                    SkinConfiguration.DefaultComboColours[1],
+                    SkinConfiguration.DefaultComboColours[2],
+                    SkinConfiguration.DefaultComboColours[3],
+                    Color4.Aqua,
+                    SkinConfiguration.DefaultComboColours[0],
+                }));
+        }
+
+        [Test]
+        public void TestExistingColours()
+        {
+            LegacyBeatmapSkin skin = null!;
+            ColoursSection coloursSection = null!;
+
+            AddStep("create beatmap skin", () =>
+            {
+                skin = new LegacyBeatmapSkin(new BeatmapInfo(), null);
+                skin.Configuration.CustomComboColours = new List<Color4>
+                {
+                    Color4.Azure,
+                    Color4.Beige,
+                    Color4.Chartreuse
+                };
+            });
+            AddStep("create colours section", () => Child = new DependencyProvidingContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                CachedDependencies =
+                [
+                    (typeof(EditorBeatmap), new EditorBeatmap(new Beatmap
+                    {
+                        BeatmapInfo = { Ruleset = new OsuRuleset().RulesetInfo }
+                    }, skin)),
+                    (typeof(OverlayColourProvider), new OverlayColourProvider(OverlayColourScheme.Aquamarine))
+                ],
+                Child = coloursSection = new ColoursSection
+                {
+                    RelativeSizeAxes = Axes.X,
+                }
+            });
+            AddAssert("section displays combo colours",
+                () => coloursSection.ChildrenOfType<FormColourPalette>().Single().Colours,
+                () => Is.EquivalentTo(new[]
+                {
+                    Colour4.Beige,
+                    Colour4.Chartreuse,
+                    Colour4.Azure,
+                }));
+
+            AddStep("add a colour", () => coloursSection.ChildrenOfType<FormColourPalette>().Single().Colours.Add(Colour4.Aqua));
+            AddAssert("beatmap skin has colours",
+                () => skin.Configuration.CustomComboColours,
+                () => Is.EquivalentTo(new[]
+                {
+                    Color4.Azure,
+                    Color4.Beige,
+                    Color4.Aqua,
+                    Color4.Chartreuse
+                }));
+        }
+    }
+}

--- a/osu.Game/Screens/Edit/Setup/ColoursSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ColoursSection.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
             };
         }
 
-        private bool syncingColours = false;
+        private bool syncingColours;
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Edit/Setup/ColoursSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ColoursSection.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Skinning;
 
 namespace osu.Game.Screens.Edit.Setup
 {
@@ -25,9 +26,50 @@ namespace osu.Game.Screens.Edit.Setup
                     Caption = EditorSetupStrings.HitCircleSliderCombos,
                 }
             };
+        }
 
+        private bool syncingColours = false;
+
+        protected override void LoadComplete()
+        {
             if (Beatmap.BeatmapSkin != null)
-                comboColours.Colours.BindTo(Beatmap.BeatmapSkin.ComboColours);
+                comboColours.Colours.AddRange(Beatmap.BeatmapSkin.ComboColours);
+
+            if (comboColours.Colours.Count == 0)
+            {
+                // compare ctor of `EditorBeatmapSkin`
+                for (int i = 0; i < SkinConfiguration.DefaultComboColours.Count; ++i)
+                    comboColours.Colours.Add(SkinConfiguration.DefaultComboColours[(i + 1) % SkinConfiguration.DefaultComboColours.Count]);
+            }
+
+            comboColours.Colours.BindCollectionChanged((_, _) =>
+            {
+                if (Beatmap.BeatmapSkin != null)
+                {
+                    if (syncingColours)
+                        return;
+
+                    syncingColours = true;
+
+                    Beatmap.BeatmapSkin.ComboColours.Clear();
+                    Beatmap.BeatmapSkin.ComboColours.AddRange(comboColours.Colours);
+
+                    syncingColours = false;
+                }
+            });
+
+            Beatmap.BeatmapSkin?.ComboColours.BindCollectionChanged((_, _) =>
+            {
+                if (syncingColours)
+                    return;
+
+                syncingColours = true;
+
+                comboColours.Colours.Clear();
+                comboColours.Colours.AddRange(Beatmap.BeatmapSkin?.ComboColours);
+
+                syncingColours = false;
+            });
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30100.

This will look incorrect with argon skin because it overrides combo colours in a weird place:

https://github.com/ppy/osu/blob/2914a5b93b74f112d61c18ea0d0240fe8624a7fb/osu.Game/Skinning/ArgonSkin.cs#L52-L73

but I'm not super sure or even willing to figure out how to access that from within the editor.