### PR TITLE
Move setup screen background preview to appropriate form control

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFileSelector.cs
@@ -68,6 +68,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public LocalisableString PlaceholderText { get; init; }
 
+        public Container PreviewContainer { get; private set; } = null!;
+
         private Box background = null!;
 
         private FormFieldCaption caption = null!;
@@ -89,7 +91,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void load()
         {
             RelativeSizeAxes = Axes.X;
-            Height = 50;
+            AutoSizeAxes = Axes.Y;
 
             Masking = true;
             CornerRadius = 5;
@@ -101,9 +103,23 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     RelativeSizeAxes = Axes.Both,
                     Colour = colourProvider.Background5,
                 },
+                PreviewContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding
+                    {
+                        Horizontal = 1.5f,
+                        Top = 1.5f,
+                        Bottom = 50
+                    },
+                },
                 new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 50,
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
                     Padding = new MarginPadding(9),
                     Children = new Drawable[]
                     {

--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -35,12 +35,17 @@ namespace osu.Game.Screens.Edit.Setup
         [Resolved]
         private Editor? editor { get; set; }
 
-        [Resolved]
-        private SetupScreenHeaderBackground headerBackground { get; set; } = null!;
+        private SetupScreenHeaderBackground headerBackground = null!;
 
         [BackgroundDependencyLoader]
         private void load()
         {
+            headerBackground = new SetupScreenHeaderBackground
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = 110,
+            };
+
             Children = new Drawable[]
             {
                 backgroundChooser = new FormFileSelector(".jpg", ".jpeg", ".png")
@@ -54,6 +59,8 @@ namespace osu.Game.Screens.Edit.Setup
                     PlaceholderText = EditorSetupStrings.ClickToSelectTrack,
                 },
             };
+
+            backgroundChooser.PreviewContainer.Add(headerBackground);
 
             if (!string.IsNullOrEmpty(working.Value.Metadata.BackgroundFile))
                 backgroundChooser.Current.Value = new FileInfo(working.Value.Metadata.BackgroundFile);

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -24,9 +24,6 @@ namespace osu.Game.Screens.Edit.Setup
         {
         }
 
-        [Cached]
-        private SetupScreenHeaderBackground background = new SetupScreenHeaderBackground { RelativeSizeAxes = Axes.Both, };
-
         private OsuScrollContainer scroll = null!;
         private FillFlowContainer flow = null!;
 
@@ -42,43 +39,24 @@ namespace osu.Game.Screens.Edit.Setup
                     RelativeSizeAxes = Axes.Both,
                     Colour = colourProvider.Background3,
                 },
-                new GridContainer
+                scroll = new OsuScrollContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    RowDimensions =
-                    [
-                        new Dimension(GridSizeMode.Absolute, 110),
-                        new Dimension()
-                    ],
-                    Content = new[]
+                    Padding = new MarginPadding(15),
+                    Child = flow = new FillFlowContainer
                     {
-                        new Drawable[]
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Full,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Spacing = new Vector2(25),
+                        ChildrenEnumerable = ruleset.CreateEditorSetupSections().Select(section => section.With(s =>
                         {
-                            background,
-                        },
-                        new Drawable[]
-                        {
-                            scroll = new OsuScrollContainer
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding(15),
-                                Child = flow = new FillFlowContainer
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Direction = FillDirection.Full,
-                                    Anchor = Anchor.TopCentre,
-                                    Origin = Anchor.TopCentre,
-                                    Spacing = new Vector2(25),
-                                    ChildrenEnumerable = ruleset.CreateEditorSetupSections().Select(section => section.With(s =>
-                                    {
-                                        s.Width = 450;
-                                        s.Anchor = Anchor.TopCentre;
-                                        s.Origin = Anchor.TopCentre;
-                                    })),
-                                }
-                            }
-                        }
+                            s.Width = 450;
+                            s.Anchor = Anchor.TopCentre;
+                            s.Origin = Anchor.TopCentre;
+                        })),
                     }
                 }
             };

--- a/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreenHeaderBackground.cs
@@ -29,7 +29,8 @@ namespace osu.Game.Screens.Edit.Setup
             InternalChild = content = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Masking = true
+                Masking = true,
+                CornerRadius = 3.5f,
             };
         }
 


### PR DESCRIPTION
See https://discord.com/channels/188630481301012481/188630652340404224/1291361342971707463.

https://github.com/user-attachments/assets/5ce19cbe-b7ca-4eaf-9219-bdb7cd83d66d

I'm not super happy with the background colour now clashing with the menu bar, but...

- I can't make the menu bar lighter without either having the menu items have the same colour as the background, or running out of `BackgroundX` shades
- Making the setup screen background darker causes disabled textboxes to clash with the background.