### PR TITLE
Improve grid lines visibility on higher resolutions

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/CircularPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/CircularPositionSnapGrid.cs
@@ -45,8 +45,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void generateCircles(int count)
         {
-            // Make lines the same width independent of display resolution.
-            float lineWidth = 2 * DrawWidth / ScreenSpaceDrawQuad.Width;
+            float lineWidth = 2f * GetLineWidth();
 
             List<CircularProgress> generatedCircles = new List<CircularProgress>();
 

--- a/osu.Game/Screens/Edit/Compose/Components/LinedPositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/LinedPositionSnapGrid.cs
@@ -20,8 +20,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             int index = 0;
 
-            // Make lines the same width independent of display resolution.
-            float lineWidth = DrawWidth / ScreenSpaceDrawQuad.Width;
+            float lineWidth = GetLineWidth();
             float rotation = MathHelper.RadiansToDegrees(MathF.Atan2(step.Y, step.X));
 
             List<Box> generatedLines = new List<Box>();

--- a/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
@@ -59,8 +59,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         {
             float fixedWidth = DrawWidth / ScreenSpaceDrawQuad.Width; // the width at which screen-space thickness will be 1px
 
-            // Resolution is low enough
-            if (fixedWidth > 0.4f)
+            // At 4k the grid (with 512px draw width) will be around 2167 pixels wide, let's use 2000px as a nice round value to increase thickness at.
+            if (ScreenSpaceDrawQuad.Width < 2000)
                 return fixedWidth;
 
             return fixedWidth * 2f;

--- a/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -49,10 +50,17 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected abstract void CreateContent();
 
+        /// <summary>
+        /// Computes the line thickness of this <see cref="PositionSnapGrid"/> independent of display resolution.
+        /// </summary>
+        /// <remarks>
+        /// Unless resolution is high enough, in which case thickness will remain the same.
+        /// </remarks>
+        protected float GetLineWidth() => Math.Max(DrawWidth / ScreenSpaceDrawQuad.Width, 0.4f);
+
         protected void GenerateOutline(Vector2 drawSize)
         {
-            // Make lines the same width independent of display resolution.
-            float lineWidth = DrawWidth / ScreenSpaceDrawQuad.Width;
+            float lineWidth = GetLineWidth();
 
             AddRangeInternal(new[]
             {

--- a/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PositionSnapGrid.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -51,12 +50,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
         protected abstract void CreateContent();
 
         /// <summary>
-        /// Computes the line thickness of this <see cref="PositionSnapGrid"/> independent of display resolution.
+        /// Computes the line thickness of this <see cref="PositionSnapGrid"/> which will result in 1px screen-space thickness independent of display resolution.
         /// </summary>
         /// <remarks>
-        /// Unless resolution is high enough, in which case thickness will remain the same.
+        /// Unless resolution is high enough, in which case thickness will be 2px.
         /// </remarks>
-        protected float GetLineWidth() => Math.Max(DrawWidth / ScreenSpaceDrawQuad.Width, 0.4f);
+        protected float GetLineWidth()
+        {
+            float fixedWidth = DrawWidth / ScreenSpaceDrawQuad.Width; // the width at which screen-space thickness will be 1px
+
+            // Resolution is low enough
+            if (fixedWidth > 0.4f)
+                return fixedWidth;
+
+            return fixedWidth * 2f;
+        }
 
         protected void GenerateOutline(Vector2 drawSize)
         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30072

Currently grid line thickness remain the same across all resolutions by adjusting it's draw size so that it's screen-space size is always 1px. In this pr I've added a lower limit so with higher resolutions (2k-ish and higher) thickness will be 2px.

Comparison at around 4k:
|master|pr|
|---|---|
|![master](https://github.com/user-attachments/assets/a3ca7423-9700-4c67-bac2-ec51792f9fb1)|![pr](https://github.com/user-attachments/assets/4be5e776-fc93-49e6-912d-04fa7f230b7d)|