### PR TITLE
Send mods in spectator frame headers

### DIFF
--- a/osu.Game/Online/Spectator/FrameHeader.cs
+++ b/osu.Game/Online/Spectator/FrameHeader.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MessagePack;
 using Newtonsoft.Json;
+using osu.Game.Online.API;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -57,6 +59,17 @@ namespace osu.Game.Online.Spectator
         public DateTimeOffset ReceivedTime { get; set; }
 
         /// <summary>
+        /// The set of mods currently active.
+        /// </summary>
+        /// <remarks>
+        /// Nullable for backwards compatibility with older clients
+        /// (these structures are also used server-side, and <see langword="null"/> will be used as marker that the data isn't there).
+        /// can be made non-nullable 20250407
+        /// </remarks>
+        [Key(7)]
+        public APIMod[]? Mods { get; set; }
+
+        /// <summary>
         /// Construct header summary information from a point-in-time reference to a score which is actively being played.
         /// </summary>
         /// <param name="score">The score for reference.</param>
@@ -69,6 +82,7 @@ namespace osu.Game.Online.Spectator
             MaxCombo = score.MaxCombo;
             // copy for safety
             Statistics = new Dictionary<HitResult, int>(score.Statistics);
+            Mods = score.APIMods.ToArray();
 
             ScoreProcessorStatistics = statistics;
         }


### PR DESCRIPTION
The rationale for this is https://github.com/ppy/osu/issues/29817. TL;DR: with the touch input detection in place since https://github.com/ppy/osu/pull/25348, mods can change during a play, and the spectator server needs to know about it to encode replays correctly.

When it comes to the overhead that this produces, the theory is as such that for each frame bundle the added overhead is:

- 1 byte for `fixarray` header (assuming under 15 mods, more is unlikely)
- for each mod:
	- 1 byte for `fixstr` header
	- 2 bytes for the acronym string
	- 1 byte for `fixarray` header (assuming under 15 settings, more is unlikely)
	- for each setting:
		- setting name as string: either `fixstr` (length + 1 bytes) or `str8` (length + 2 bytes)
		- setting value as appropriate primitive, type-dependent

In the baseline scenario of going from nomod to touch device that is extra 5 bytes per frame. For contrast, measuring organoleptically, frame bundles right now appear to hit sizes of ~330 B each. Thus while this structure does have the potential to grow quite a bit in the long tail, I believe it to be *relatively* safe to include in such a manner; if there are disagreements on this, I can revert something like a bool flag instead.

I did an empirical test wherein I started a play with NF and debug-enabled touch midway through, and weirdly enough average frame bundle size rose from ~330 to ~340 B, but I believe that might be just because of things shifting elsewhere (it appears that due to messagepack's range tiering of various data types to save on space, frames will naturally grow larger in time as you send out larger numbers and longer strings inside).

Also for reference, the ~37 second drain time beatmap I was testing on ended up producing ~205 frame bundles, which is somewhere in the ballpark of 5 bundles a second, which does match theory:

https://github.com/ppy/osu/blob/6596d30fb9555973a3afd57293ce537d7182107e/osu.Game/Online/Spectator/SpectatorClient.cs#L27-L30