### PR TITLE
Fix several breakages with migration operation

### DIFF
--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Database
         {
             if (changes == null)
             {
-                if (detachedBeatmapSets.Count > 0 && sender.Count == 0)
+                if (sender is EmptyRealmSet<BeatmapSetInfo>)
                 {
                     // Usually we'd reset stuff here, but doing so triggers a silly flow which ends up deadlocking realm.
                     // Additionally, user should not be at song select when realm is blocking all operations in the first place.

--- a/osu.Game/Database/DetachedBeatmapStore.cs
+++ b/osu.Game/Database/DetachedBeatmapStore.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Database
         {
             if (changes == null)
             {
-                if (sender is EmptyRealmSet<BeatmapSetInfo>)
+                if (sender is RealmResetEmptySet<BeatmapSetInfo>)
                 {
                     // Usually we'd reset stuff here, but doing so triggers a silly flow which ends up deadlocking realm.
                     // Additionally, user should not be at song select when realm is blocking all operations in the first place.

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -568,7 +568,7 @@ namespace osu.Game.Database
             lock (notificationsResetMap)
             {
                 // Store an action which is used when blocking to ensure consumers don't use results of a stale changeset firing.
-                notificationsResetMap.Add(action, () => callback(new EmptyRealmSet<T>(), null));
+                notificationsResetMap.Add(action, () => callback(new RealmResetEmptySet<T>(), null));
             }
 
             return RegisterCustomSubscription(action);

--- a/osu.Game/Database/RealmResetEmptySet.cs
+++ b/osu.Game/Database/RealmResetEmptySet.cs
@@ -12,7 +12,13 @@ using Realms.Schema;
 
 namespace osu.Game.Database
 {
-    public class EmptyRealmSet<T> : IRealmCollection<T>
+    /// <summary>
+    /// This can arrive in <see cref="RealmAccess.RegisterForNotifications{T}"/> callbacks to imply that realm access has been reset.
+    /// </summary>
+    /// <remarks>
+    /// Usually implies that the original database may return soon and the callback can usually be silently ignored.
+    ///</remarks>
+    public class RealmResetEmptySet<T> : IRealmCollection<T>
     {
         private IList<T> emptySet => Array.Empty<T>();
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1137,7 +1137,6 @@ namespace osu.Game
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
-            loadComponentSingleFile(new DetachedBeatmapStore(), Add, true);
 
             Add(difficultyRecommender);
             Add(externalLinkOpener = new ExternalLinkOpener());

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -545,7 +545,10 @@ namespace osu.Game
                         realmBlocker = realm.BlockAllOperations("migration");
                         success = true;
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Attempting to block all operations failed: {ex}", LoggingTarget.Database);
+                    }
 
                     readyToRun.Set();
                 }, false);

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -377,6 +377,10 @@ namespace osu.Game
             dependencies.Cache(previewTrackManager = new PreviewTrackManager(BeatmapManager.BeatmapTrackStore));
             base.Content.Add(previewTrackManager);
 
+            var detachedBeatmapStore = new DetachedBeatmapStore();
+            base.Content.Add(detachedBeatmapStore);
+            dependencies.CacheAs(detachedBeatmapStore);
+
             base.Content.Add(MusicController = new MusicController());
             dependencies.CacheAs(MusicController);
 

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -63,9 +63,6 @@ namespace osu.Game.Overlays
 
         public DrawableTrack CurrentTrack { get; private set; } = new DrawableTrack(new TrackVirtual(1000));
 
-        [Resolved]
-        private RealmAccess realm { get; set; } = null!;
-
         private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
 
         private BindableNumber<double> sampleVolume = null!;

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
@@ -65,6 +66,8 @@ namespace osu.Game.Overlays
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
+        private IBindableList<BeatmapSetInfo> detachedBeatmaps = null!;
+
         private BindableNumber<double> sampleVolume = null!;
 
         private readonly BindableDouble audioDuckVolume = new BindableDouble(1);
@@ -76,13 +79,15 @@ namespace osu.Game.Overlays
         private int randomHistoryDirection;
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audio, OsuConfigManager configManager)
+        private void load(AudioManager audio, OsuConfigManager configManager, DetachedBeatmapStore detachedBeatmapStore, CancellationToken? cancellationToken)
         {
             AddInternal(audioDuckFilter = new AudioFilter(audio.TrackMixer));
             audio.Tracks.AddAdjustment(AdjustableProperty.Volume, audioDuckVolume);
             sampleVolume = audio.VolumeSample.GetBoundCopy();
 
             configManager.BindWith(OsuSetting.RandomSelectAlgorithm, randomSelectAlgorithm);
+
+            detachedBeatmaps = detachedBeatmapStore.GetDetachedBeatmaps(cancellationToken);
         }
 
         protected override void LoadComplete()
@@ -255,8 +260,8 @@ namespace osu.Game.Overlays
                 playableSet = getNextRandom(-1, allowProtectedTracks);
             else
             {
-                playableSet = getBeatmapSets().AsEnumerable().TakeWhile(i => !i.Equals(current?.BeatmapSetInfo)).LastOrDefault(s => !s.Protected || allowProtectedTracks)
-                              ?? getBeatmapSets().AsEnumerable().LastOrDefault(s => !s.Protected || allowProtectedTracks);
+                playableSet = getBeatmapSets().TakeWhile(i => !i.Equals(current?.BeatmapSetInfo)).LastOrDefault(s => !s.Protected || allowProtectedTracks)
+                              ?? getBeatmapSets().LastOrDefault(s => !s.Protected || allowProtectedTracks);
             }
 
             if (playableSet != null)
@@ -351,10 +356,10 @@ namespace osu.Game.Overlays
                 playableSet = getNextRandom(1, allowProtectedTracks);
             else
             {
-                playableSet = getBeatmapSets().AsEnumerable().SkipWhile(i => !i.Equals(current?.BeatmapSetInfo))
+                playableSet = getBeatmapSets().SkipWhile(i => !i.Equals(current?.BeatmapSetInfo))
                                               .Where(i => !i.Protected || allowProtectedTracks)
                                               .ElementAtOrDefault(1)
-                              ?? getBeatmapSets().AsEnumerable().FirstOrDefault(i => !i.Protected || allowProtectedTracks);
+                              ?? getBeatmapSets().FirstOrDefault(i => !i.Protected || allowProtectedTracks);
             }
 
             var playableBeatmap = playableSet?.Beatmaps.FirstOrDefault();
@@ -373,7 +378,7 @@ namespace osu.Game.Overlays
         {
             BeatmapSetInfo result;
 
-            var possibleSets = getBeatmapSets().AsEnumerable().Where(s => !s.Protected || allowProtectedTracks).ToArray();
+            var possibleSets = getBeatmapSets().Where(s => !s.Protected || allowProtectedTracks).ToArray();
 
             if (possibleSets.Length == 0)
                 return null;
@@ -432,7 +437,7 @@ namespace osu.Game.Overlays
 
         private TrackChangeDirection? queuedDirection;
 
-        private IQueryable<BeatmapSetInfo> getBeatmapSets() => realm.Realm.All<BeatmapSetInfo>().Where(s => !s.DeletePending);
+        private IEnumerable<BeatmapSetInfo> getBeatmapSets() => detachedBeatmaps.Where(s => !s.DeletePending);
 
         private void changeBeatmap(WorkingBeatmap newWorking)
         {
@@ -459,8 +464,8 @@ namespace osu.Game.Overlays
                 else
                 {
                     // figure out the best direction based on order in playlist.
-                    int last = getBeatmapSets().AsEnumerable().TakeWhile(b => !b.Equals(current.BeatmapSetInfo)).Count();
-                    int next = getBeatmapSets().AsEnumerable().TakeWhile(b => !b.Equals(newWorking.BeatmapSetInfo)).Count();
+                    int last = getBeatmapSets().TakeWhile(b => !b.Equals(current.BeatmapSetInfo)).Count();
+                    int next = getBeatmapSets().TakeWhile(b => !b.Equals(newWorking.BeatmapSetInfo)).Count();
 
                     direction = last > next ? TrackChangeDirection.Prev : TrackChangeDirection.Next;
                 }


### PR DESCRIPTION
## [Fix any and all migration attempts dying on `MusicController`](https://github.com/ppy/osu/commit/310eec69fcb30fd89d00b46d6ecb9e99c94f4314)

I'm not sure why this was "fine" for as long as it apparently was, but what `MusicController` was doing was completely incorrect and playing with fire (accessing raw managed realm objects), which went wrong somewhere around - admittedly - https://github.com/ppy/osu/pull/29917, likely because that one started *storing* these raw managed realm objects to fields, and you know what will happen to those after you do a migration and recycle realms.

To attempt to circumvent this, (ab)use `DetachedBeatmapStore` instead. Which does necessitate moving it to `OsuGameBase`, but it's the simplest way out I can see. I guess the alternative would be to faff around with `Live<T>` but it's ugly and I'm attempting to fix this relatively quick right now.

## [Fix `OsuGameBase.Migrate()` eating exception messages for breakfast](https://github.com/ppy/osu/commit/1633cbdb6619c78da388549555c49cf74a7138a1)

Whomst've thought this was an ok thing to do? How did this pass review? Let's leave these as rhetorical questions right now. Huge chances are I'd implicate myself with at least one of them.

## [Fix `DetachedBeatmapStore` special condition for detecting resets from blocking all operations failing on empty databases](https://github.com/ppy/osu/commit/b811b9baf653974092d0ef79952359203db59d1c)

See https://discord.com/channels/188630481301012481/188630652340404224/1293309912591368244.

Fixes https://github.com/ppy/osu/issues/30155