### PR TITLE
Fix split control point context menu option not showing up on newly created control points

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/Components/PathControlPointVisualiser.cs
@@ -178,7 +178,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders.Components
 
         private bool isSplittable(PathControlPointPiece<T> p) =>
             // A hit object can only be split on control points which connect two different path segments.
-            p.ControlPoint.Type.HasValue && p != Pieces.FirstOrDefault() && p != Pieces.LastOrDefault();
+            p.ControlPoint.Type.HasValue && p.ControlPoint != controlPoints.FirstOrDefault() && p.ControlPoint != controlPoints.LastOrDefault();
 
         private void onControlPointsChanged(object sender, NotifyCollectionChangedEventArgs e)
         {


### PR DESCRIPTION
The `Pieces` collection does not maintain the same ordering as the `controlPoints` so if you insert a new control point and dont deselect and reselect the slider, the `PathControlPointPiece` will be at the end of the `Pieces` list even though its not the last control point. This mistakenly causes the `isSplittable` to think you want to split the last control point which isn't possible.