### PR TITLE
Fix crashes when attempting to change from a custom ruleset with mods selected to another

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneAdvancedStats.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select EZ mod", () =>
             {
                 var ruleset = advancedStats.BeatmapInfo.Ruleset.CreateInstance().AsNonNull();
-                SelectedMods.Value = new[] { ruleset.CreateMod<ModEasy>() };
+                advancedStats.Mods.Value = new[] { ruleset.CreateMod<ModEasy>() };
             });
 
             AddAssert("circle size bar is blue", () => barIsBlue(advancedStats.FirstValue));
@@ -101,7 +101,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("select HR mod", () =>
             {
                 var ruleset = advancedStats.BeatmapInfo.Ruleset.CreateInstance().AsNonNull();
-                SelectedMods.Value = new[] { ruleset.CreateMod<ModHardRock>() };
+                advancedStats.Mods.Value = new[] { ruleset.CreateMod<ModHardRock>() };
             });
 
             AddAssert("circle size bar is red", () => barIsRed(advancedStats.FirstValue));
@@ -120,7 +120,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 var ruleset = advancedStats.BeatmapInfo.Ruleset.CreateInstance().AsNonNull();
                 var difficultyAdjustMod = ruleset.CreateMod<ModDifficultyAdjust>().AsNonNull();
                 difficultyAdjustMod.ReadFromDifficulty(advancedStats.BeatmapInfo.Difficulty);
-                SelectedMods.Value = new[] { difficultyAdjustMod };
+                advancedStats.Mods.Value = new[] { difficultyAdjustMod };
             });
 
             AddAssert("circle size bar is white", () => barIsWhite(advancedStats.FirstValue));
@@ -143,7 +143,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                 difficultyAdjustMod.ReadFromDifficulty(originalDifficulty);
                 difficultyAdjustMod.DrainRate.Value = originalDifficulty.DrainRate - 0.5f;
                 difficultyAdjustMod.ApproachRate.Value = originalDifficulty.ApproachRate + 2.2f;
-                SelectedMods.Value = new[] { difficultyAdjustMod };
+                advancedStats.Mods.Value = new[] { difficultyAdjustMod };
             });
 
             AddAssert("circle size bar is white", () => barIsWhite(advancedStats.FirstValue));

--- a/osu.Game/Overlays/BeatmapSetOverlay.cs
+++ b/osu.Game/Overlays/BeatmapSetOverlay.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -16,8 +14,6 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays.BeatmapSet;
 using osu.Game.Overlays.BeatmapSet.Scores;
 using osu.Game.Overlays.Comments;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Screens.Select.Details;
 using osuTK;
 using osuTK.Graphics;
 
@@ -36,14 +32,6 @@ namespace osu.Game.Overlays
         private IBindable<APIUser> apiUser;
 
         private (BeatmapSetLookupType type, int id)? lastLookup;
-
-        /// <remarks>
-        /// Isolates the beatmap set overlay from the game-wide selected mods bindable
-        /// to avoid affecting the beatmap details section (i.e. <see cref="AdvancedStats.StatisticRow"/>).
-        /// </remarks>
-        [Cached]
-        [Cached(typeof(IBindable<IReadOnlyList<Mod>>))]
-        protected readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>(Array.Empty<Mod>());
 
         public BeatmapSetOverlay()
             : base(OverlayColourScheme.Blue)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -610,11 +610,6 @@ namespace osu.Game.Screens.Select
                 beatmapInfoPrevious = beatmap;
             }
 
-            // we can't run this in the debounced run due to the selected mods bindable not being debounced,
-            // since mods could be updated to the new ruleset instances while the decoupled bindable is held behind,
-            // therefore resulting in performing difficulty calculation with invalid states.
-            advancedStats.Ruleset.Value = ruleset;
-
             void run()
             {
                 // clear pending task immediately to track any potential nested debounce operation.
@@ -878,6 +873,8 @@ namespace osu.Game.Screens.Select
             ModSelect.Beatmap.Value = beatmap;
 
             advancedStats.BeatmapInfo = beatmap.BeatmapInfo;
+            advancedStats.Mods.Value = selectedMods.Value;
+            advancedStats.Ruleset.Value = Ruleset.Value;
 
             bool beatmapSelected = beatmap is not DummyWorkingBeatmap;
 
@@ -989,6 +986,12 @@ namespace osu.Game.Screens.Select
             decoupledRuleset.DisabledChanged += r => Ruleset.Disabled = r;
 
             Beatmap.BindValueChanged(updateCarouselSelection);
+
+            selectedMods.BindValueChanged(_ =>
+            {
+                if (decoupledRuleset.Value.Equals(rulesetNoDebounce))
+                    advancedStats.Mods.Value = selectedMods.Value;
+            }, true);
 
             boundLocalBindables = true;
         }


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/30163.

If I'm to be blunt, the decoupled stuff in song select makes my head spin. I spent a solid 20 minutes thinking how I was going to fix this one but then finally realised that generally most of the cause there was the fact that `AdvancedStats` was seeing the new rulesets *before* the "ensure global selected mods are valid for current ruleset" logic, and so decided to just _delay_ that until the decoupled transfer thingamajig happens.

I was honestly considering combining `BeatmapInfo`, `Ruleset`, and `Mods` into one property on `AdvancedStats`. I figured I'd rather not push my luck and try the baseline version first, but I honestly think that direction is going to be required at some point to properly corral all of the decoupled madness taking place in song select.

The nice thing is that due to this, one previous hack is now removable after `AdvancedStats` has been weaned off the global mods bindable. I think this is a win all things considered? But I'm unsure of how ugly this in general is compared to the current state...