### PR TITLE
Fix Autoplay not working in editor When time is set before Autoplay begins

### DIFF
--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -174,8 +174,8 @@ namespace osu.Game.Screens.Edit.GameplayTest
         }
 
         private double previousAutoTime = 0;
-        
-        private void SetupAutoplay()
+
+        private void setupAutoplay()
         {
             var autoplay = Ruleset.Value.CreateInstance().GetAutoplayMod();
             if (autoplay == null)
@@ -188,7 +188,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
             // remove past frames to prevent replay frame handler from seeking back to start in an attempt to play back the entirety of the replay.
             score.Replay.Frames.RemoveAll(f => f.Time <= GameplayClockContainer.CurrentTime);
-                
+
             DrawableRuleset.SetReplayScore(score);
             // Without this schedule, the `GlobalCursorDisplay.Update()` machinery will fade the gameplay cursor out, but we still want it to show.
             Schedule(() => DrawableRuleset.Cursor?.Show());

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -11,6 +10,7 @@ using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -175,6 +175,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
         }
 
         private double previousAutoTime;
+        private List<ReplayFrame> allAutoFrames = new List<ReplayFrame>();
 
         private void toggleAutoplay()
         {
@@ -188,6 +189,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
                 previousAutoTime = GameplayClockContainer.CurrentTime;
 
                 var score = autoplay.CreateScoreFromReplayData(GameplayState.Beatmap, new[] { autoplay });
+                allAutoFrames = score.Replay.Frames;
 
                 DrawableRuleset.SetReplayScore(score);
 
@@ -209,17 +211,10 @@ namespace osu.Game.Screens.Edit.GameplayTest
                 // compare currentTime with previousTime
                 if (GameplayClockContainer.CurrentTime < previousAutoTime)
                 {
-                    // here i am stuck on where to retrieve score, so i am just going to create it to see if it works and change it later when i figure it out
-                    var autoplay = Ruleset.Value.CreateInstance().GetAutoplayMod();
-                    if (autoplay == null)
-                        return;
-
-                    // retrieves frame (currently creating as i dont know how to retrieve)
-                    var allFrames = autoplay.CreateScoreFromReplayData(GameplayState.Beatmap, new[] { autoplay }).Replay.Frames;
                     var drawnFrames = DrawableRuleset.ReplayScore;
 
                     // find the frames from the original replay data that should be present based on the current time
-                    var missingFrames = allFrames.Where(f => f.Time >= GameplayClockContainer.CurrentTime && f.Time <= previousAutoTime).ToList();
+                    var missingFrames = allAutoFrames.Where(f => f.Time >= GameplayClockContainer.CurrentTime && f.Time <= previousAutoTime).ToList();
                     previousAutoTime = GameplayClockContainer.CurrentTime;
 
                     // add the missing frames back

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -198,7 +198,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
         {
             if (DrawableRuleset.ReplayScore == null)
             {
-                SetupAutoplay();
+                setupAutoplay();
             }
             else
                 DrawableRuleset.SetReplayScore(null);
@@ -214,7 +214,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
                 {
                     if (GameplayClockContainer.CurrentTime < previousAutoTime)
                     {
-                        SetupAutoplay();
+                        setupAutoplay();
                     }
                 }
             }

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
         private double previousAutoTime = 0;
         
-        public void SetupAutoplay()
+        private void SetupAutoplay()
         {
             var autoplay = Ruleset.Value.CreateInstance().GetAutoplayMod();
             if (autoplay == null)
@@ -206,6 +206,7 @@ namespace osu.Game.Screens.Edit.GameplayTest
 
         protected override void Update()
         {
+            // updates if there's a replay (autoplay)
             if (DrawableRuleset.ReplayScore != null)
             {
                 // compare currentTime with previousTime

--- a/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
+++ b/osu.Game/Screens/Edit/GameplayTest/EditorPlayer.cs
@@ -190,7 +190,6 @@ namespace osu.Game.Screens.Edit.GameplayTest
             score.Replay.Frames.RemoveAll(f => f.Time <= GameplayClockContainer.CurrentTime);
                 
             DrawableRuleset.SetReplayScore(score);
-
             // Without this schedule, the `GlobalCursorDisplay.Update()` machinery will fade the gameplay cursor out, but we still want it to show.
             Schedule(() => DrawableRuleset.Cursor?.Show());
         }


### PR DESCRIPTION
closes #30177

checks if currentTime is less then the time when autoplay starts, then ~~creates a new autoplay~~ slices frames on demand