### PR TITLE
Change the map name from Romanized to Unicode in the map deletion dialog

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Select
         public BeatmapDeleteDialog(BeatmapSetInfo beatmapSet)
         {
             this.beatmapSet = beatmapSet;
-            BodyText = $@"{beatmapSet.Metadata.Artist} - {beatmapSet.Metadata.Title}";
+            BodyText = $@"{beatmapSet.Metadata.Artist} - {beatmapSet.Metadata.TitleUnicode}";
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
#30242 I think just changing “Title” to “TitleUnicode” within the file that handles the dialog should solve the problem.