### PR TITLE
Recommend C# Dev Kit extension on VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-dotnettools.csharp"
+        "editorconfig.editorconfig",
+        "ms-dotnettools.csdevkit"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please make sure you have the following prerequisites:
 
 - A desktop platform with the [.NET 8.0 SDK](https://dotnet.microsoft.com/download) installed.
 
-When working with the codebase, we recommend using an IDE with intelligent code completion and syntax highlighting, such as the latest version of [Visual Studio](https://visualstudio.microsoft.com/vs/), [JetBrains Rider](https://www.jetbrains.com/rider/), or [Visual Studio Code](https://code.visualstudio.com/) with the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) plugin installed.
+When working with the codebase, we recommend using an IDE with intelligent code completion and syntax highlighting, such as the latest version of [Visual Studio](https://visualstudio.microsoft.com/vs/), [JetBrains Rider](https://www.jetbrains.com/rider/), or [Visual Studio Code](https://code.visualstudio.com/) with the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) and [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) plugin installed.
 
 ### Downloading the source code
 


### PR DESCRIPTION
~Needed for the localisation analyser to work on VSCode.~ The dev kit already includes the C# extension and has more features.

Actually no if you set up the solution manually, the dev kit seems to do that automatically. One of the features does add a test explorer, which is nice. The C# extension even recommends the dev kit:
> While it is possible to use the C# extension as a standalone extension, we highly recommend using [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit).