### PR TITLE
Fix conflicting keybind for "convert to stream" in editor

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             {
                 InputManager.PressKey(Key.LControl);
                 InputManager.PressKey(Key.LShift);
-                InputManager.Key(Key.F);
+                InputManager.Key(Key.Z);
                 InputManager.ReleaseKey(Key.LShift);
                 InputManager.ReleaseKey(Key.LControl);
             });

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderStreamConversion.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             {
                 InputManager.PressKey(Key.LControl);
                 InputManager.PressKey(Key.LShift);
-                InputManager.Key(Key.Z);
+                InputManager.Key(Key.X);
                 InputManager.ReleaseKey(Key.LShift);
                 InputManager.ReleaseKey(Key.LControl);
             });

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -391,7 +391,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             if (!IsSelected)
                 return false;
 
-            if (e.Key == Key.F && e.ControlPressed && e.ShiftPressed)
+            if (e.Key == Key.X && e.ControlPressed && e.ShiftPressed)
             {
                 convertToStream();
                 return true;
@@ -600,7 +600,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             },
             new OsuMenuItem("Convert to stream", MenuItemType.Destructive, convertToStream)
             {
-                Hotkey = new Hotkey(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Z))
+                Hotkey = new Hotkey(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.X))
             },
         };
 

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderSelectionBlueprint.cs
@@ -600,7 +600,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
             },
             new OsuMenuItem("Convert to stream", MenuItemType.Destructive, convertToStream)
             {
-                Hotkey = new Hotkey(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.F))
+                Hotkey = new Hotkey(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Z))
             },
         };
 


### PR DESCRIPTION
Closes #30169

`Ctrl-Shift-F` is now `Ctrl-Shift-Z`.

## Why Z?

`Ctrl-Shift-S` and `Ctrl-Shift-A` were already in use. `Ctrl-Shift-D` is used to close windows in GNOME by default. The "G" key in `Ctrl-Shift-G` is too far away, in my opinion. Using "Z" seemed like the best option, although not ideal.

