### PR TITLE
Remove default keybind for "Toggle FPS counter"

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -93,8 +93,9 @@ namespace osu.Game.Database
         /// 40   2023-12-21    Add ScoreInfo.Version to keep track of which build scores were set on.
         /// 41   2024-04-17    Add ScoreInfo.TotalScoreWithoutMods for future mod multiplier rebalances.
         /// 42   2024-08-07    Update mania key bindings to reflect changes to ManiaAction
+        /// 43   2024-10-14    Reset keybind for toggling FPS display to avoid conflict with "convert to stream" in the editor, if not already changed by user.
         /// </summary>
-        private const int schema_version = 42;
+        private const int schema_version = 43;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1192,6 +1193,21 @@ namespace osu.Game.Database
                     }
 
                     break;
+
+                case 43:
+                {
+                    // Clear default bindings for "Toggle FPS Display",
+                    // as it conflicts with "Convert to Stream" in the editor.
+                    // Only apply change if set to the conflicting bind
+                    // i.e. has been manually rebound by the user.
+                    var keyBindings = migration.NewRealm.All<RealmKeyBinding>();
+
+                    var toggleFpsBind = keyBindings.FirstOrDefault(bind => bind.ActionInt == (int)GlobalAction.ToggleFPSDisplay);
+                    if (toggleFpsBind != null && toggleFpsBind.KeyCombination.Keys.SequenceEqual(new[] { InputKey.Control, InputKey.Shift, InputKey.F }))
+                        migration.NewRealm.Remove(toggleFpsBind);
+
+                    break;
+                }
             }
 
             Logger.Log($"Migration completed in {stopwatch.ElapsedMilliseconds}ms");

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -1203,7 +1203,7 @@ namespace osu.Game.Database
                     var keyBindings = migration.NewRealm.All<RealmKeyBinding>();
 
                     var toggleFpsBind = keyBindings.FirstOrDefault(bind => bind.ActionInt == (int)GlobalAction.ToggleFPSDisplay);
-                    if (toggleFpsBind != null && toggleFpsBind.KeyCombination.Keys.SequenceEqual(new[] { InputKey.Control, InputKey.Shift, InputKey.F }))
+                    if (toggleFpsBind != null && toggleFpsBind.KeyCombination.Keys.SequenceEqual(new[] { InputKey.Shift, InputKey.Control, InputKey.F }))
                         migration.NewRealm.Remove(toggleFpsBind);
 
                     break;

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Input.Bindings
 
             new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
 
-            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.C }, GlobalAction.ToggleFPSDisplay),
+            new KeyBinding(new[] { InputKey.None }, GlobalAction.ToggleFPSDisplay),
             new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
 

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Input.Bindings
 
             new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
 
-            new KeyBinding(new[] { InputKey.None }, GlobalAction.ToggleFPSDisplay),
+            new KeyBinding(InputKey.None, GlobalAction.ToggleFPSDisplay),
             new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
 

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Input.Bindings
 
             new KeyBinding(new[] { InputKey.Alt, InputKey.Home }, GlobalAction.Home),
 
-            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, GlobalAction.ToggleFPSDisplay),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.C }, GlobalAction.ToggleFPSDisplay),
             new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, GlobalAction.ToggleSkinEditor),
 


### PR DESCRIPTION
Closes #30169

Referring to #30252. ~~As per peppy's suggestion I changed the keybind for toggling the FPS counter~~. As per peppy's new suggestion I removed the default keybind for toggling the FPS counter. This is done in order to avoid conflicts with the keybind for converting a slider to a stream in the editor.

## ~~Why Ctrl-Alt-C?~~

- ~~`Ctrl-Shift-C` is copying without formatting~~
- ~~Same goes for `Ctrl-Shift-X`~~
- ~~`Ctrl-Alt-F` is used to fullscreen windows in certain desktop environments~~
-  ~~The other combinations that are in reach are in use by the game~~
- ~~`Ctrl-Alt-C` holds *some* semantic meaning in the sense that "C" is short for "counter".~~