### PR TITLE
Respect "Prefer metadata in original language" toggle in beatmap deletion dialog

### DIFF
--- a/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
+++ b/osu.Game/Screens/Select/BeatmapDeleteDialog.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Screens.Select
         public BeatmapDeleteDialog(BeatmapSetInfo beatmapSet)
         {
             this.beatmapSet = beatmapSet;
-            BodyText = $@"{beatmapSet.Metadata.Artist} - {beatmapSet.Metadata.Title}";
+            BodyText = beatmapSet.Metadata.GetDisplayTitleRomanisable(false);
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
This commit fixes #30242. This fix maintains the format from before, but supports the original unicode metadata.