### PR TITLE
Fix catcher size and hyperdashes indication on adjusting CircleSize

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -8,7 +8,6 @@ namespace osu.Game.Rulesets.Catch.Edit
 {
     public partial class CatchEditorPlayfield : CatchPlayfield
     {
-        // TODO fixme: the size of the catcher is not changed when circle size is changed in setup screen.
         public CatchEditorPlayfield(IBeatmapDifficultyInfo difficulty)
             : base(difficulty)
         {
@@ -22,6 +21,11 @@ namespace osu.Game.Rulesets.Catch.Edit
             Catcher.CatchFruitOnPlate = false;
 
             // TODO: disable hit lighting as well
+        }
+
+        public void ApplyCircleSizeToCatcher(IBeatmapDifficultyInfo difficulty)
+        {
+            Catcher.SetScaleAndCatchWidth(difficulty);
         }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchEditorPlayfield.cs
@@ -22,10 +22,5 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             // TODO: disable hit lighting as well
         }
-
-        public void ApplyCircleSizeToCatcher(IBeatmapDifficultyInfo difficulty)
-        {
-            Catcher.SetScaleAndCatchWidth(difficulty);
-        }
     }
 }

--- a/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
+++ b/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
@@ -2,16 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {
     public partial class DrawableCatchEditorRuleset : DrawableCatchRuleset
     {
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
+
         public readonly BindableDouble TimeRangeMultiplier = new BindableDouble(1);
 
         public DrawableCatchEditorRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
@@ -27,6 +33,23 @@ namespace osu.Game.Rulesets.Catch.Edit
             float playfieldStretch = Playfield.DrawHeight / CatchPlayfield.HEIGHT;
             TimeRange.Value = gamePlayTimeRange * TimeRangeMultiplier.Value * playfieldStretch;
         }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            editorBeatmap.BeatmapReprocessed += onBeatmapReprocessed;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (editorBeatmap.IsNotNull())
+                editorBeatmap.BeatmapReprocessed -= onBeatmapReprocessed;
+        }
+
+        private void onBeatmapReprocessed() => (Playfield as CatchEditorPlayfield)?.ApplyCircleSizeToCatcher(editorBeatmap.Difficulty);
 
         protected override Playfield CreatePlayfield() => new CatchEditorPlayfield(Beatmap.Difficulty);
 

--- a/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
+++ b/osu.Game.Rulesets.Catch/Edit/DrawableCatchEditorRuleset.cs
@@ -49,7 +49,14 @@ namespace osu.Game.Rulesets.Catch.Edit
                 editorBeatmap.BeatmapReprocessed -= onBeatmapReprocessed;
         }
 
-        private void onBeatmapReprocessed() => (Playfield as CatchEditorPlayfield)?.ApplyCircleSizeToCatcher(editorBeatmap.Difficulty);
+        private void onBeatmapReprocessed()
+        {
+            if (Playfield is CatchEditorPlayfield catchPlayfield)
+            {
+                catchPlayfield.Catcher.ApplyDifficulty(editorBeatmap.Difficulty);
+                catchPlayfield.CatcherArea.CatcherTrails.UpdateCatcherTrailsScale(catchPlayfield.Catcher.BodyScale);
+            }
+        }
 
         protected override Playfield CreatePlayfield() => new CatchEditorPlayfield(Beatmap.Difficulty);
 

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Width of the area that can be used to attempt catches during gameplay.
         /// </summary>
-        public float CatchWidth;
+        public float CatchWidth { get; private set; }
 
         private readonly SkinnableCatcher body;
 
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             Size = new Vector2(BASE_SIZE);
 
-            SetScaleAndCatchWidth(difficulty);
+            ApplyDifficulty(difficulty);
 
             InternalChildren = new Drawable[]
             {
@@ -312,7 +312,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Set the scale and catch width.
         /// </summary>
-        public void SetScaleAndCatchWidth(IBeatmapDifficultyInfo? difficulty)
+        public void ApplyDifficulty(IBeatmapDifficultyInfo? difficulty)
         {
             if (difficulty != null)
                 Scale = calculateScale(difficulty);

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <summary>
         /// Width of the area that can be used to attempt catches during gameplay.
         /// </summary>
-        public readonly float CatchWidth;
+        public float CatchWidth;
 
         private readonly SkinnableCatcher body;
 
@@ -142,10 +142,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
             Size = new Vector2(BASE_SIZE);
 
-            if (difficulty != null)
-                Scale = calculateScale(difficulty);
-
-            CatchWidth = CalculateCatchWidth(Scale);
+            SetScaleAndCatchWidth(difficulty);
 
             InternalChildren = new Drawable[]
             {
@@ -310,6 +307,17 @@ namespace osu.Game.Rulesets.Catch.UI
 
                 lastHyperDashStartTime = Time.Current;
             }
+        }
+
+        /// <summary>
+        /// Set the scale and catch width.
+        /// </summary>
+        public void SetScaleAndCatchWidth(IBeatmapDifficultyInfo? difficulty)
+        {
+            if (difficulty != null)
+                Scale = calculateScale(difficulty);
+
+            CatchWidth = CalculateCatchWidth(Scale);
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherArea.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.UI
 
         private readonly CatchComboDisplay comboDisplay;
 
-        private readonly CatcherTrailDisplay catcherTrails;
+        public readonly CatcherTrailDisplay CatcherTrails;
 
         private Catcher catcher = null!;
 
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.UI
             Children = new Drawable[]
             {
                 catcherContainer = new Container<Catcher> { RelativeSizeAxes = Axes.Both },
-                catcherTrails = new CatcherTrailDisplay(),
+                CatcherTrails = new CatcherTrailDisplay(),
                 comboDisplay = new CatchComboDisplay
                 {
                     RelativeSizeAxes = Axes.None,
@@ -112,7 +112,7 @@ namespace osu.Game.Rulesets.Catch.UI
             {
                 const double trail_generation_interval = 16;
 
-                if (Time.Current - catcherTrails.LastDashTrailTime >= trail_generation_interval)
+                if (Time.Current - CatcherTrails.LastDashTrailTime >= trail_generation_interval)
                     displayCatcherTrail(Catcher.HyperDashing ? CatcherTrailAnimation.HyperDashing : CatcherTrailAnimation.Dashing);
             }
 
@@ -170,6 +170,6 @@ namespace osu.Game.Rulesets.Catch.UI
             }
         }
 
-        private void displayCatcherTrail(CatcherTrailAnimation animation) => catcherTrails.Add(new CatcherTrailEntry(Time.Current, Catcher.CurrentState, Catcher.X, Catcher.BodyScale, animation));
+        private void displayCatcherTrail(CatcherTrailAnimation animation) => CatcherTrails.Add(new CatcherTrailEntry(Time.Current, Catcher.CurrentState, Catcher.X, Catcher.BodyScale, animation));
     }
 }

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -64,7 +64,12 @@ namespace osu.Game.Rulesets.Catch.UI
         {
             applyScaleChange(scale, dashTrails);
             applyScaleChange(scale, hyperDashTrails);
-            applyScaleChange(scale, hyperDashAfterImages);
+
+            foreach (var afterImage in hyperDashAfterImages)
+            {
+                afterImage.Hide();
+                afterImage.Expire();
+            }
         }
 
         private void applyScaleChange(Vector2 scale, Container<CatcherTrail> trails)

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Catch.Skinning;
 using osu.Game.Rulesets.Objects.Pooling;
 using osu.Game.Skinning;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Catch.UI
@@ -53,6 +54,25 @@ namespace osu.Game.Rulesets.Catch.UI
                 hyperDashTrails = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
                 hyperDashAfterImages = new Container<CatcherTrail> { RelativeSizeAxes = Axes.Both, Colour = Catcher.DEFAULT_HYPER_DASH_COLOUR },
             };
+        }
+
+        /// <summary>
+        /// Update the scale of all trails.
+        /// </summary>
+        /// <param name="scale">The new body scale of the Catcher</param>
+        public void UpdateCatcherTrailsScale(Vector2 scale)
+        {
+            applyScaleChange(scale, dashTrails);
+            applyScaleChange(scale, hyperDashTrails);
+            applyScaleChange(scale, hyperDashAfterImages);
+        }
+
+        private void applyScaleChange(Vector2 scale, Container<CatcherTrail> trails)
+        {
+            foreach (var trail in trails)
+            {
+                trail.Scale = scale;
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
+++ b/osu.Game.Rulesets.Catch/UI/CatcherTrailDisplay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -62,21 +63,16 @@ namespace osu.Game.Rulesets.Catch.UI
         /// <param name="scale">The new body scale of the Catcher</param>
         public void UpdateCatcherTrailsScale(Vector2 scale)
         {
-            applyScaleChange(scale, dashTrails);
-            applyScaleChange(scale, hyperDashTrails);
+            var oldEntries = Entries.ToList();
 
-            foreach (var afterImage in hyperDashAfterImages)
-            {
-                afterImage.Hide();
-                afterImage.Expire();
-            }
-        }
+            Clear();
 
-        private void applyScaleChange(Vector2 scale, Container<CatcherTrail> trails)
-        {
-            foreach (var trail in trails)
+            foreach (var oldEntry in oldEntries)
             {
-                trail.Scale = scale;
+                // use magnitude of the new scale while preserving the sign of the old one in the X direction.
+                // the end effect is preserving the direction in which the trail sprites face, which is important.
+                var targetScale = new Vector2(Math.Abs(scale.X) * Math.Sign(oldEntry.Scale.X), Math.Abs(scale.Y));
+                Add(new CatcherTrailEntry(oldEntry.LifetimeStart, oldEntry.CatcherState, oldEntry.Position, targetScale, oldEntry.Animation));
             }
         }
 


### PR DESCRIPTION
The TODO that ekr left actually caused two issues when editing the CircleSize of a catch beatmap:

1. The catcher scale is not changed. (as mentioned in the TODO)
2. The hyperdash indication would not adjust as they should adjust based on the size of the fruits.

I've fixed this similarly to how we currently apply circle size changes in the osu editor ruleset.