### PR TITLE
Remove hold-to-confirm delay when pausing using keyboard shortcuts

### DIFF
--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -299,7 +299,7 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     case GlobalAction.Back:
                         if (!pendingAnimation)
-                            BeginConfirm();
+                            Confirm();
                         return true;
 
                     case GlobalAction.PauseGameplay:
@@ -307,7 +307,7 @@ namespace osu.Game.Screens.Play.HUD
                         if (ReplayLoaded.Value) return false;
 
                         if (!pendingAnimation)
-                            BeginConfirm();
+                            Confirm();
                         return true;
                 }
 


### PR DESCRIPTION
This keeps coming up ([latest case](https://github.com/ppy/osu/discussions/30305)) so I think we need to listen to users and make this change. Matches stable behaviour.