### PR TITLE
Improve diffcalc workflow with explicit wait + logs

### DIFF
--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -341,9 +341,12 @@ jobs:
           sed -i 's/^GH_TOKEN=.*$/GH_TOKEN=${{ github.token }}/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
 
           cd "${{ needs.directory.outputs.GENERATOR_DIR }}"
-          docker-compose up --build generator
 
-          link=$(docker-compose logs generator -n 10 | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
+          docker compose up --build --detach
+          docker compose logs --follow &
+          docker compose wait generator
+
+          link=$(docker compose logs generator --tail 10 | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
           target=$(cat "${{ needs.directory.outputs.GENERATOR_ENV }}" | grep -E '^OSU_B=' | cut -d '=' -f2-)
 
           echo "TARGET=${target}" >> "${GITHUB_OUTPUT}"
@@ -353,7 +356,7 @@ jobs:
         if: ${{ always() }}
         run: |
           cd "${{ needs.directory.outputs.GENERATOR_DIR }}"
-          docker-compose down -v
+          docker compose down --volumes
 
   output-cli:
     name: Output info


### PR DESCRIPTION
In https://github.com/ppy/osu/actions/runs/11377686506/job/31652339821, the console only contains logs from the `generator` container. I haven't investigated exactly why, but I believe recent versions of `docker` have changed `docker compose up <container>` to only follow logs from the specific container.

I'm hoping to resolve this by using explicit start/follow-logs/wait steps.