### PR TITLE
Fix argument order in diffcalc workflow

### DIFF
--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -346,7 +346,7 @@ jobs:
           docker compose logs --follow &
           docker compose wait generator
 
-          link=$(docker compose logs generator --tail 10 | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
+          link=$(docker compose logs --tail 10 generator | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
           target=$(cat "${{ needs.directory.outputs.GENERATOR_ENV }}" | grep -E '^OSU_B=' | cut -d '=' -f2-)
 
           echo "TARGET=${target}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
See: https://github.com/ppy/osu/actions/runs/11377686506/job/31652339821

```
No such service: -n
```

Previously this code was `-n 10`, and I guess it's now strict about the ordering of args:

```sh
> docker compose logs --help
Usage:  docker compose logs [OPTIONS] [SERVICE...]
```