### PR TITLE
Make `BeatmapAttributeText` show values inclusive of mods

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -1,14 +1,28 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Models;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
 using osu.Game.Skinning.Components;
 using osu.Game.Tests.Beatmaps;
 
@@ -30,6 +44,8 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void Setup() => Schedule(() =>
         {
+            SelectedMods.SetDefault();
+            Ruleset.SetDefault();
             Beatmap.Value = CreateWorkingBeatmap(new TestBeatmap(new OsuRuleset().RulesetInfo)
             {
                 BeatmapInfo =
@@ -93,6 +109,126 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddAssert("check new title", getText, () => Is.EqualTo("Title: Another"));
         }
 
+        [Test]
+        public void TestWithMods()
+        {
+            AddStep("set beatmap", () => Beatmap.Value = CreateWorkingBeatmap(new TestBeatmap(new OsuRuleset().RulesetInfo)
+            {
+                BeatmapInfo =
+                {
+                    BPM = 100,
+                    Length = 30000,
+                    Difficulty =
+                    {
+                        ApproachRate = 10,
+                        CircleSize = 9
+                    }
+                }
+            }));
+
+            test(BeatmapAttribute.BPM, new OsuModDoubleTime(), "BPM: 100.00", "BPM: 150.00");
+            test(BeatmapAttribute.Length, new OsuModDoubleTime(), "Length: 00:30", "Length: 00:20");
+            test(BeatmapAttribute.ApproachRate, new OsuModDoubleTime(), "Approach Rate: 10.00", "Approach Rate: 11.00");
+            test(BeatmapAttribute.CircleSize, new OsuModHardRock(), "Circle Size: 9.00", "Circle Size: 10.00");
+
+            void test(BeatmapAttribute attribute, Mod mod, string before, string after)
+            {
+                AddStep($"set attribute: {attribute}", () => text.Attribute.Value = attribute);
+                AddAssert("check text is correct", getText, () => Is.EqualTo(before));
+
+                AddStep("add DT mod", () => SelectedMods.Value = new[] { mod });
+                AddAssert("check text is correct", getText, () => Is.EqualTo(after));
+                AddStep("clear mods", () => SelectedMods.SetDefault());
+            }
+        }
+
+        [Test]
+        public void TestStarRating()
+        {
+            AddStep("set test ruleset", () => Ruleset.Value = new TestRuleset().RulesetInfo);
+            AddStep("set star rating attribute", () => text.Attribute.Value = BeatmapAttribute.StarRating);
+            AddAssert("check star rating is 0", getText, () => Is.EqualTo("Star Rating: 0.00"));
+
+            // Adding mod
+            TestMod mod = null!;
+            AddStep("add mod with difficulty 1", () => SelectedMods.Value = new[] { mod = new TestMod { Difficulty = { Value = 1 } } });
+            AddUntilStep("check star rating is 1", getText, () => Is.EqualTo("Star Rating: 1.00"));
+
+            // Changing mod setting
+            AddStep("change mod difficulty to 2", () => mod.Difficulty.Value = 2);
+            AddUntilStep("check star rating is 2", getText, () => Is.EqualTo("Star Rating: 2.00"));
+        }
+
         private string getText() => text.ChildrenOfType<SpriteText>().Single().Text.ToString();
+
+        private class TestRuleset : Ruleset
+        {
+            public override IEnumerable<Mod> GetModsFor(ModType type) => new[]
+            {
+                new TestMod()
+            };
+
+            public override IBeatmapConverter CreateBeatmapConverter(IBeatmap beatmap)
+                => new OsuRuleset().CreateBeatmapConverter(beatmap);
+
+            public override DifficultyCalculator CreateDifficultyCalculator(IWorkingBeatmap beatmap)
+                => new TestDifficultyCalculator(new TestRuleset().RulesetInfo, beatmap);
+
+            public override PerformanceCalculator CreatePerformanceCalculator()
+                => new TestPerformanceCalculator(new TestRuleset());
+
+            public override DrawableRuleset CreateDrawableRulesetWith(IBeatmap beatmap, IReadOnlyList<Mod>? mods = null)
+                => null!;
+
+            public override string Description => string.Empty;
+            public override string ShortName => string.Empty;
+        }
+
+        private class TestDifficultyCalculator : DifficultyCalculator
+        {
+            public TestDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap beatmap)
+                : base(ruleset, beatmap)
+            {
+            }
+
+            protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills, double clockRate)
+                => new DifficultyAttributes(mods, mods.OfType<TestMod>().SingleOrDefault()?.Difficulty.Value ?? 0);
+
+            protected override IEnumerable<DifficultyHitObject> CreateDifficultyHitObjects(IBeatmap beatmap, double clockRate)
+                => Array.Empty<DifficultyHitObject>();
+
+            protected override Skill[] CreateSkills(IBeatmap beatmap, Mod[] mods, double clockRate)
+                => Array.Empty<Skill>();
+        }
+
+        private class TestPerformanceCalculator : PerformanceCalculator
+        {
+            public TestPerformanceCalculator(Ruleset ruleset)
+                : base(ruleset)
+            {
+            }
+
+            protected override PerformanceAttributes CreatePerformanceAttributes(ScoreInfo score, DifficultyAttributes attributes)
+                => new PerformanceAttributes { Total = score.Mods.OfType<TestMod>().SingleOrDefault()?.Performance.Value ?? 0 };
+        }
+
+        private class TestMod : Mod
+        {
+            [SettingSource("difficulty")]
+            public BindableDouble Difficulty { get; } = new BindableDouble(0);
+
+            [SettingSource("performance")]
+            public BindableDouble Performance { get; } = new BindableDouble(0);
+
+            [JsonConstructor]
+            public TestMod()
+            {
+            }
+
+            public override string Name => string.Empty;
+            public override LocalisableString Description => string.Empty;
+            public override double ScoreMultiplier => 1.0;
+            public override string Acronym => "Test";
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         public void Setup() => Schedule(() =>
         {
             SelectedMods.SetDefault();
-            Ruleset.SetDefault();
+            Ruleset.Value = new OsuRuleset().RulesetInfo;
             Beatmap.Value = CreateWorkingBeatmap(new TestBeatmap(new OsuRuleset().RulesetInfo)
             {
                 BeatmapInfo =

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -181,13 +181,13 @@ namespace osu.Game.Skinning.Components
                     return beatmap.Value.BeatmapInfo.Metadata.Source;
 
                 case BeatmapAttribute.Length:
-                    return TimeSpan.FromMilliseconds(beatmap.Value.BeatmapInfo.Length).ToFormattedDuration();
+                    return Math.Round(beatmap.Value.BeatmapInfo.Length / ModUtils.CalculateRateWithMods(mods.Value)).ToFormattedDuration();
 
                 case BeatmapAttribute.RankedStatus:
                     return beatmap.Value.BeatmapInfo.Status.GetLocalisableDescription();
 
                 case BeatmapAttribute.BPM:
-                    return beatmap.Value.BeatmapInfo.BPM.ToLocalisableString(@"F2");
+                    return FormatUtils.RoundBPM(beatmap.Value.BeatmapInfo.BPM, ModUtils.CalculateRateWithMods(mods.Value)).ToLocalisableString(@"F2");
 
                 case BeatmapAttribute.CircleSize:
                     return computeDifficulty().CircleSize.ToLocalisableString(@"F2");

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -257,6 +257,8 @@ namespace osu.Game.Skinning.Components
             difficultyCancellationSource?.Cancel();
             difficultyCancellationSource?.Dispose();
             difficultyCancellationSource = null;
+
+            modSettingTracker?.Dispose();
         }
     }
 

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -51,6 +51,7 @@ namespace osu.Game.Skinning.Components
         private IBindable<StarDifficulty?>? difficultyBindable;
         private CancellationTokenSource? difficultyCancellationSource;
         private ModSettingChangeTracker? modSettingTracker;
+        private StarDifficulty? starDifficulty;
 
         public BeatmapAttributeText()
         {
@@ -80,7 +81,11 @@ namespace osu.Game.Skinning.Components
 
                 difficultyBindable?.UnbindAll();
                 difficultyBindable = difficultyCache.GetBindableDifficulty(b.NewValue.BeatmapInfo, difficultyCancellationSource.Token);
-                difficultyBindable.BindValueChanged(_ => updateText());
+                difficultyBindable.BindValueChanged(d =>
+                {
+                    starDifficulty = d.NewValue;
+                    updateText();
+                });
 
                 updateText();
             }, true);
@@ -213,9 +218,7 @@ namespace osu.Game.Skinning.Components
                     return computeDifficulty().ApproachRate.ToLocalisableString(@"F2");
 
                 case BeatmapAttribute.StarRating:
-                    return difficultyBindable?.Value is StarDifficulty starDifficulty
-                        ? starDifficulty.Stars.ToLocalisableString(@"F2")
-                        : @"...";
+                    return (starDifficulty?.Stars ?? 0).ToLocalisableString(@"F2");
 
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -50,6 +50,7 @@ namespace osu.Game.Skinning.Components
         private readonly OsuSpriteText text;
         private IBindable<StarDifficulty?>? difficultyBindable;
         private CancellationTokenSource? difficultyCancellationSource;
+        private ModSettingChangeTracker? modSettingTracker;
 
         public BeatmapAttributeText()
         {
@@ -84,7 +85,17 @@ namespace osu.Game.Skinning.Components
                 updateText();
             }, true);
 
-            mods.BindValueChanged(_ => updateText());
+            mods.BindValueChanged(m =>
+            {
+                modSettingTracker?.Dispose();
+                modSettingTracker = new ModSettingChangeTracker(m.NewValue)
+                {
+                    SettingChanged = _ => updateText()
+                };
+
+                updateText();
+            }, true);
+
             ruleset.BindValueChanged(_ => updateText());
 
             updateText();


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/30320

Supersedes / closes https://github.com/ppy/osu/pull/29151 (discussed below)

As I've been playing a lot more osu! these days, I found it a pretty big issue that this component is not showing mod-inclusive values, to the point that I preferred to remove it from my skin rather than being misled.

There is already a PR for this (https://github.com/ppy/osu/pull/29151) but I found it unmanageable. While this PR doesn't have the "max performance" part of that one, the two PRs are incompatible and I believe that part can be done much better.

I considered adding a mods checkbox to the component, but I believe it to be unnecessary based on my own experience with the component, and it would add some additional complexity that I don't think is yet warranted.