### PR TITLE
Fix cursor rotating with barrel roll mod active

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModBarrelRoll.cs
@@ -2,10 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.UI;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
@@ -24,6 +27,15 @@ namespace osu.Game.Rulesets.Osu.Mods
                         break;
                 }
             };
+        }
+
+        public override void Update(Playfield playfield)
+        {
+            base.Update(playfield);
+            OsuPlayfield osuPlayfield = (OsuPlayfield)playfield;
+            Debug.Assert(osuPlayfield.Cursor != null);
+
+            osuPlayfield.Cursor.ActiveCursor.Rotation = -CurrentRotation;
         }
     }
 }

--- a/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
+++ b/osu.Game/Rulesets/Mods/ModBarrelRoll.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Mods
 
         private PlayfieldAdjustmentContainer playfieldAdjustmentContainer = null!;
 
-        public void Update(Playfield playfield)
+        public virtual void Update(Playfield playfield)
         {
             playfieldAdjustmentContainer.Rotation = CurrentRotation = (Direction.Value == RotationDirection.Counterclockwise ? -1 : 1) * 360 * (float)(playfield.Time.Current / 60000 * SpinSpeed.Value);
         }


### PR DESCRIPTION
Closes #28693 

Some may argue that cursor rotation is intended behavior but it looks odd and feels pretty janky, especially on abnormal cursors like the issue describes. Would be better if cursor rotation could be adjusted in existing switch statement but didn't want to mess with existing implementation to allow that and this way is simple and readable as well. 