### PR TITLE
Add breathing room to seek back between control points in editor

### DIFF
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1098,7 +1098,7 @@ namespace osu.Game.Screens.Edit
 
         private void seekControlPoint(int direction)
         {
-            // Gives 350 ms margin to seek back after last control point
+            // Gives margin to seek back after last control point
             double seekMargin = 0;
             if (clock.IsRunning) 
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1106,7 +1106,7 @@ namespace osu.Game.Screens.Edit
             }
             
             var found = direction < 1
-                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime)
+                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - seekMargin)
                 : editorBeatmap.ControlPointInfo.AllControlPoints.FirstOrDefault(p => p.Time > clock.CurrentTime);
 
             if (found != null)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1102,13 +1102,12 @@ namespace osu.Game.Screens.Edit
             double seekMargin = 0;
             if (clock.IsRunning) 
             {
-                seekMargin = 450;
+                IAdjustableClock adjustableClock = clock;
+                seekMargin = 450 * adjustableClock.Rate;
             }
-            
-           IAdjustableClock adjustableClock = clock;
 
             var found = direction < 1
-                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - (seekMargin * adjustableClock.Rate))
+                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - seekMargin)
                 : editorBeatmap.ControlPointInfo.AllControlPoints.FirstOrDefault(p => p.Time > clock.CurrentTime);
 
             if (found != null)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1098,6 +1098,13 @@ namespace osu.Game.Screens.Edit
 
         private void seekControlPoint(int direction)
         {
+            // Gives 350 ms margin to seek back after last control point
+            double seekMargin = 0;
+            if (clock.IsRunning) 
+            {
+                seekMargin = 350;
+            }
+            
             var found = direction < 1
                 ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime)
                 : editorBeatmap.ControlPointInfo.AllControlPoints.FirstOrDefault(p => p.Time > clock.CurrentTime);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1098,17 +1098,12 @@ namespace osu.Game.Screens.Edit
 
         private void seekControlPoint(int direction)
         {
-            // Gives margin to seek back after last control point
-            double seekMargin = 0;
-            
-            if (clock.IsRunning) 
-            {
-                IAdjustableClock adjustableClock = clock;
-                seekMargin = 450 * adjustableClock.Rate;
-            }
+            // In the case of a backwards seek while playing, it can be hard to jump before a timing point.
+            // Adding some lenience here makes it more user-friendly.
+            double seekLenience = clock.IsRunning ? 1000 * ((IAdjustableClock)clock).Rate : 0;
 
-            var found = direction < 1
-                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - seekMargin)
+            ControlPoint found = direction < 1
+                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - seekLenience)
                 : editorBeatmap.ControlPointInfo.AllControlPoints.FirstOrDefault(p => p.Time > clock.CurrentTime);
 
             if (found != null)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1100,6 +1100,7 @@ namespace osu.Game.Screens.Edit
         {
             // Gives margin to seek back after last control point
             double seekMargin = 0;
+            
             if (clock.IsRunning) 
             {
                 IAdjustableClock adjustableClock = clock;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1102,11 +1102,13 @@ namespace osu.Game.Screens.Edit
             double seekMargin = 0;
             if (clock.IsRunning) 
             {
-                seekMargin = 350;
+                seekMargin = 450;
             }
             
+           IAdjustableClock adjustableClock = clock;
+
             var found = direction < 1
-                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - seekMargin)
+                ? editorBeatmap.ControlPointInfo.AllControlPoints.LastOrDefault(p => p.Time < clock.CurrentTime - (seekMargin * adjustableClock.Rate))
                 : editorBeatmap.ControlPointInfo.AllControlPoints.FirstOrDefault(p => p.Time > clock.CurrentTime);
 
             if (found != null)


### PR DESCRIPTION
closes #28885 (and #30070)

gives 450 ms to seek back after last control point in editor.