### PR TITLE
Prioritize selecting exact searched acronym with select keybind

### DIFF
--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -67,8 +66,9 @@ namespace osu.Game.Overlays.Mods
                     Content.EdgeEffect = new EdgeEffectParameters
                     {
                         Type = EdgeEffectType.Glow,
-                        Colour = AccentColour.Opacity(0.5f),
-                        Radius = 10,
+                        Colour = AccentColour,
+                        Hollow = true,
+                        Radius = 2,
                     };
                 }
                 else

--- a/osu.Game/Overlays/Mods/ModPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPanel.cs
@@ -4,8 +4,10 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
@@ -58,6 +60,20 @@ namespace osu.Game.Overlays.Mods
 
             modState.ValidForSelection.BindValueChanged(_ => updateFilterState());
             modState.MatchingTextFilter.BindValueChanged(_ => updateFilterState(), true);
+            modState.Preselected.BindValueChanged(b =>
+            {
+                if (b.NewValue)
+                {
+                    Content.EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Colour = AccentColour.Opacity(0.5f),
+                        Radius = 10,
+                    };
+                }
+                else
+                    Content.EdgeEffect = default;
+            }, true);
         }
 
         protected override void Select()

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -590,9 +590,16 @@ namespace osu.Game.Overlays.Mods
                         return true;
                     }
 
+                    //matchingMod ensures that if an exact mod acronym is typed, it will be selected when Select is pressed (as opposed to being prioritized in arbitrary column order)
                     ModState? firstMod = columnFlow.Columns.OfType<ModColumn>().FirstOrDefault(m => m.IsPresent)?.AvailableMods.FirstOrDefault(x => x.Visible);
+                    ModState? matchingMod = columnFlow.Columns.OfType<ModColumn>().SelectMany(m => m.AvailableMods).FirstOrDefault(x => x.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase));
 
-                    if (firstMod is not null)
+                    if (matchingMod is not null)
+                    {
+                        matchingMod.Active.Value = !matchingMod.Active.Value;
+                        SearchTextBox.SelectAll();
+                    }
+                    else if (firstMod is not null)
                     {
                         firstMod.Active.Value = !firstMod.Active.Value;
                         SearchTextBox.SelectAll();

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -243,6 +243,9 @@ namespace osu.Game.Overlays.Mods
             {
                 foreach (var column in columnFlow.Columns)
                     column.SearchTerm = query.NewValue;
+
+                if (SearchTextBox.HasFocus)
+                    preselectMod();
             }, true);
 
             // Start scrolling from the end, to give the user a sense that
@@ -252,6 +255,26 @@ namespace osu.Game.Overlays.Mods
                 columnScroll.ScrollToEnd(false);
                 columnScroll.ScrollTo(0);
             });
+        }
+
+        private void preselectMod()
+        {
+            var visibleMods = columnFlow.Columns.OfType<ModColumn>().Where(c => c.IsPresent).SelectMany(c => c.AvailableMods.Where(m => m.Visible));
+
+            // Search for an exact acronym or name match, or otherwise default to the first visible mod.
+            ModState? matchingMod =
+                visibleMods.FirstOrDefault(m => m.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase) || m.Mod.Name.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase))
+                ?? visibleMods.FirstOrDefault();
+            var preselectedMod = matchingMod;
+
+            foreach (var mod in AllAvailableMods)
+                mod.Preselected.Value = mod == preselectedMod && SearchTextBox.Current.Value.Length > 0;
+        }
+
+        private void clearPreselection()
+        {
+            foreach (var mod in AllAvailableMods)
+                mod.Preselected.Value = false;
         }
 
         public new ModSelectFooterContent? DisplayedFooterContent => base.DisplayedFooterContent as ModSelectFooterContent;
@@ -383,7 +406,7 @@ namespace osu.Game.Overlays.Mods
             {
                 columnScroll.FadeColour(OsuColour.Gray(0.5f), 400, Easing.OutQuint);
                 SearchTextBox.FadeColour(OsuColour.Gray(0.5f), 400, Easing.OutQuint);
-                SearchTextBox.KillFocus();
+                setTextBoxFocus(false);
             }
             else
             {
@@ -590,12 +613,7 @@ namespace osu.Game.Overlays.Mods
                         return true;
                     }
 
-                    IEnumerable<ModState> visibleMods = columnFlow.Columns.OfType<ModColumn>().Where(c => c.IsPresent).SelectMany(c => c.AvailableMods.Where(m => m.Visible));
-
-                    // Search for an exact acronym or name match, or otherwise default to the first visible mod.
-                    ModState? matchingMod =
-                        visibleMods.FirstOrDefault(m => m.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase) || m.Mod.Name.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase))
-                        ?? visibleMods.FirstOrDefault();
+                    var matchingMod = AllAvailableMods.SingleOrDefault(m => m.Preselected.Value);
 
                     if (matchingMod is not null)
                     {
@@ -653,9 +671,15 @@ namespace osu.Game.Overlays.Mods
         private void setTextBoxFocus(bool focus)
         {
             if (focus)
+            {
                 SearchTextBox.TakeFocus();
+                preselectMod();
+            }
             else
+            {
                 SearchTextBox.KillFocus();
+                clearPreselection();
+            }
         }
 
         #endregion

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -590,18 +590,16 @@ namespace osu.Game.Overlays.Mods
                         return true;
                     }
 
-                    //matchingMod ensures that if an exact mod acronym is typed, it will be selected when Select is pressed (as opposed to being prioritized in arbitrary column order)
-                    ModState? firstMod = columnFlow.Columns.OfType<ModColumn>().FirstOrDefault(m => m.IsPresent)?.AvailableMods.FirstOrDefault(x => x.Visible);
-                    ModState? matchingMod = columnFlow.Columns.OfType<ModColumn>().SelectMany(m => m.AvailableMods).FirstOrDefault(x => x.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase) | x.Mod.Name.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase));
+                    IEnumerable<ModState> visibleMods = columnFlow.Columns.OfType<ModColumn>().Where(c => c.IsPresent).SelectMany(c => c.AvailableMods.Where(m => m.Visible));
+
+                    // Search for an exact acronym or name match, or otherwise default to the first visible mod.
+                    ModState? matchingMod =
+                        visibleMods.FirstOrDefault(m => m.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase) || m.Mod.Name.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase))
+                        ?? visibleMods.FirstOrDefault();
 
                     if (matchingMod is not null)
                     {
                         matchingMod.Active.Value = !matchingMod.Active.Value;
-                        SearchTextBox.SelectAll();
-                    }
-                    else if (firstMod is not null)
-                    {
-                        firstMod.Active.Value = !firstMod.Active.Value;
                         SearchTextBox.SelectAll();
                     }
 

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -592,7 +592,7 @@ namespace osu.Game.Overlays.Mods
 
                     //matchingMod ensures that if an exact mod acronym is typed, it will be selected when Select is pressed (as opposed to being prioritized in arbitrary column order)
                     ModState? firstMod = columnFlow.Columns.OfType<ModColumn>().FirstOrDefault(m => m.IsPresent)?.AvailableMods.FirstOrDefault(x => x.Visible);
-                    ModState? matchingMod = columnFlow.Columns.OfType<ModColumn>().SelectMany(m => m.AvailableMods).FirstOrDefault(x => x.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase));
+                    ModState? matchingMod = columnFlow.Columns.OfType<ModColumn>().SelectMany(m => m.AvailableMods).FirstOrDefault(x => x.Mod.Acronym.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase) | x.Mod.Name.Equals(SearchTerm, StringComparison.OrdinalIgnoreCase));
 
                     if (matchingMod is not null)
                     {

--- a/osu.Game/Overlays/Mods/ModState.cs
+++ b/osu.Game/Overlays/Mods/ModState.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Overlays.Mods
         /// </summary>
         public BindableBool Active { get; } = new BindableBool();
 
+        public BindableBool Preselected { get; } = new BindableBool();
+
         /// <summary>
         /// Whether the mod requires further customisation.
         /// This flag is read by the <see cref="ModSelectOverlay"/> to determine if the customisation panel should be opened after a mod change


### PR DESCRIPTION
Addresses #30001 

Nice QOL change, before searching "SY" for the synesthesia mod and pressing enter would select EZ, since selection was prioritized by column/descending order instead of accuracy. This interaction was actually pretty common and is not exclusive to EZ/SY. Videos attached to explain. (Why EZ appears when SY is searched I truly have no idea. Sy does not appear in the description. Dark magic is likely involved). Also added support for exact name searching though I'm 99 percent sure it isn't ever relevant. 

https://github.com/user-attachments/assets/002e1a21-77c0-4f4d-b08a-e070a7816860


https://github.com/user-attachments/assets/1a4d1fd9-d056-4f64-b46f-55b4ed4ce9c0

