### PR TITLE
Expose no-op constructors as `protected`

### DIFF
--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Beatmaps
         }
 
         [UsedImplicitly]
-        private BeatmapInfo()
+        protected BeatmapInfo()
         {
         }
 

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -165,7 +165,7 @@ namespace osu.Game.Scoring
         }
 
         [UsedImplicitly] // Realm
-        private ScoreInfo()
+        protected ScoreInfo()
         {
         }
 


### PR DESCRIPTION
This allows bypassing the population of `Guid` based IDs, which can have considerable overhead in batch usage cases, where we are 100% sure we aren't ever storing to realm:

![image](https://github.com/user-attachments/assets/c9c201bd-d7fa-48c6-8f90-4b92818ac070)
![image](https://github.com/user-attachments/assets/ac2c23cf-b5a2-4298-b419-209494827635)

Consumption looks like this:

```diff
diff --git a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
index a649708..260ad39 100644
--- a/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
+++ b/osu.Server.Queues.ScoreStatisticsProcessor/Models/SoloScore.cs
@@ -84,19 +84,20 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
         public ScoreInfo ToScoreInfo()
         {
             var ruleset = LegacyRulesetHelper.GetRulesetFromLegacyId(ruleset_id);
+            var beatmapInfo = new LightweightBeatmapInfo
+            {
+                OnlineID = (int)beatmap_id,
+                Ruleset = new RulesetInfo { OnlineID = beatmap!.playmode }
+            };
 
-            return new ScoreInfo
+            return new LightweightScoreInfo
             {
                 OnlineID = (long)id,
                 LegacyOnlineID = (long?)legacy_score_id ?? -1,
                 IsLegacyScore = is_legacy_score,
                 User = new APIUser { Id = (int)user_id },
-                BeatmapInfo = new BeatmapInfo
-                {
-                    OnlineID = (int)beatmap_id,
-                    Ruleset = new RulesetInfo { OnlineID = beatmap!.playmode }
-                },
                 Ruleset = new RulesetInfo { OnlineID = ruleset_id },
+                BeatmapInfo = beatmapInfo,
                 Passed = passed,
                 TotalScore = total_score,
                 LegacyTotalScore = legacy_total_score,
@@ -112,5 +113,13 @@ namespace osu.Server.Queues.ScoreStatisticsProcessor.Models
                 Ranked = ranked,
             };
         }
+
+        private class LightweightBeatmapInfo : BeatmapInfo
+        {
+        }
+
+        private class LightweightScoreInfo : ScoreInfo
+        {
+        }
     }
 }

```

