### PR TITLE
Add ability to render frosted sliders

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -12,6 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
@@ -22,6 +23,7 @@ using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -111,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                         BlurContainer = new BackdropBlurContainer
                         {
                             RelativeSizeAxes = Axes.Both,
-                            BlurSigma = new Vector2(4f),
+                            BlurSigma = new Vector2(5f),
                             MaskCutoff = 0.25f,
                             EffectBufferScale = new Vector2(0.5f),
                             Child = Body = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling)
@@ -144,6 +146,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 foreach (var drawableHitObject in NestedHitObjects)
                     drawableHitObject.AccentColour.Value = colour.NewValue;
+                BlurContainer.EffectColour = Interpolation.ValueAt(0.5, colour.NewValue, Color4.White, 0, 1);
             }, true);
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -111,7 +111,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                         BlurContainer = new BackdropBlurContainer
                         {
                             RelativeSizeAxes = Axes.Both,
-                            BlurSigma = new Vector2(10f),
+                            BlurSigma = new Vector2(4f),
                             MaskCutoff = 0.25f,
                             EffectBufferScale = new Vector2(0.5f),
                             Child = Body = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling)

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -12,7 +12,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
-using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
@@ -23,7 +22,6 @@ using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Skinning;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -38,8 +36,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         [Cached]
         public DrawableSliderBall Ball { get; private set; }
-
-        public BackdropBlurContainer BlurContainer { get; private set; }
 
         public SkinnableDrawable Body { get; private set; }
 
@@ -110,14 +106,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     RelativeSizeAxes = Axes.Both,
                     Children = new[]
                     {
-                        BlurContainer = new BackdropBlurContainer
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            BlurSigma = new Vector2(5f),
-                            MaskCutoff = 0.25f,
-                            EffectBufferScale = new Vector2(0.5f),
-                            Child = Body = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling)
-                        },
+                        Body = new SkinnableDrawable(new OsuSkinComponentLookup(OsuSkinComponents.SliderBody), _ => new DefaultSliderBody(), confineMode: ConfineMode.NoScaling),
                         // proxied here so that the tail is drawn under repeats/ticks - legacy skins rely on this
                         tailContainer.CreateProxy(),
                         tickContainer = new Container<DrawableSliderTick> { RelativeSizeAxes = Axes.Both },
@@ -146,7 +135,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 foreach (var drawableHitObject in NestedHitObjects)
                     drawableHitObject.AccentColour.Value = colour.NewValue;
-                BlurContainer.EffectColour = Interpolation.ValueAt(0.5, colour.NewValue, Color4.White, 0, 1);
             }, true);
         }
 
@@ -294,8 +282,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
                 relativeAnchorPositionLayout.Validate();
             }
-
-            BlurContainer.MaskCutoff = Body.Alpha * 0.25f;
         }
 
         public override void OnKilled()
@@ -353,7 +339,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
             // The backdrop blur opacity should fade in quicker, but the overall alpha should fade in linearly.
             // By using OutQuad easing on both the blur container & the child, we end up getting a linear fade in.
-            BlurContainer.FadeInFromZero(HitObject.TimeFadeIn, Easing.OutQuad);
+            Body.FadeInFromZero(HitObject.TimeFadeIn, Easing.OutQuad);
             Body.FadeInFromZero(HitObject.TimeFadeIn, Easing.OutQuad);
         }
 
@@ -375,7 +361,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 case ArmedState.Hit:
                     if (HeadCircle.IsHit && SliderBody?.SnakingOut.Value == true)
-                        BlurContainer.FadeOut(40); // short fade to allow for any body colour to smoothly disappear.
+                        Body.FadeOut(40); // short fade to allow for any body colour to smoothly disappear.
                     break;
             }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -337,10 +337,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             base.UpdateInitialTransforms();
 
-            // The backdrop blur opacity should fade in quicker, but the overall alpha should fade in linearly.
-            // By using OutQuad easing on both the blur container & the child, we end up getting a linear fade in.
-            Body.FadeInFromZero(HitObject.TimeFadeIn, Easing.OutQuad);
-            Body.FadeInFromZero(HitObject.TimeFadeIn, Easing.OutQuad);
+            Body.FadeInFromZero(HitObject.TimeFadeIn);
         }
 
         protected override void UpdateStartTimeStateTransforms()

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Lines;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
@@ -13,6 +14,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         private const float border_max_size = 8f;
         private const float border_min_size = 0f;
+
+        protected DrawableSliderPath()
+        {
+            EffectBufferScale = new Vector2(0.25f);
+        }
 
         private Color4 borderColour = Color4.White;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DrawableSliderPath.cs
@@ -6,7 +6,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
-    public abstract partial class DrawableSliderPath : SmoothPath
+    public abstract partial class DrawableSliderPath : BackdropBlurPath
     {
         public const float BORDER_PORTION = 0.128f;
         public const float GRADIENT_PORTION = 1 - BORDER_PORTION;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -74,6 +74,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Alpha = priorityLookupPrefix == null ? 0.75f : 0.5f // TODO: this is kind of a dirty way to check if we're a hitcircle or a circle that's part of a slider.
                 },
                 OverlayLayer = new Container
                 {

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -7,6 +7,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osu.Game.Utils;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
@@ -23,6 +24,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         private partial class LegacyDrawableSliderPath : DrawableSliderPath
         {
+            public LegacyDrawableSliderPath()
+            {
+                BlurSigma = new Vector2(8f);
+
+                BackdropTintStrength = 0.5f;
+
+                // To prevent shadows from contributing to the background blur effect
+                MaskCutoff = 0.25f;
+            }
+
             protected override Color4 ColourAt(float position)
             {
                 // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             public LegacyDrawableSliderPath()
             {
-                BlurSigma = new Vector2(8f);
+                BlurSigma = new Vector2(16f);
 
                 BackdropTintStrength = 0.5f;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         protected override Color4 GetBodyAccentColour(ISkinSource skin, Color4 hitObjectAccentColour)
         {
             // legacy skins use a constant value for slider track alpha, regardless of the source colour.
-            return base.GetBodyAccentColour(skin, hitObjectAccentColour).Opacity(0.7f);
+            return base.GetBodyAccentColour(skin, hitObjectAccentColour).Opacity(0.6f);
         }
 
         private partial class LegacyDrawableSliderPath : DrawableSliderPath

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -994,7 +994,11 @@ namespace osu.Game
                             Children = new Drawable[]
                             {
                                 backReceptor = new ScreenFooter.BackReceptor(),
-                                ScreenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both },
+                                new RefCountedBackbufferProvider
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Child = ScreenStack = new OsuScreenStack { RelativeSizeAxes = Axes.Both }
+                                },
                                 BackButton = new BackButton(backReceptor)
                                 {
                                     Anchor = Anchor.BottomLeft,


### PR DESCRIPTION
RFC. I took [peppy's tweet](https://x.com/ppy/status/1765300648881562033) as a challenge to see if I can get this effect working in lazer. Since the "someone chooses to implement" part is done, I guess it is now time to figure out the "maybe" part.

Depends on ppy/osu-framework#6393

https://github.com/user-attachments/assets/e787f82d-c77e-497d-828d-89e81c4b5c93

This is primarily meant a proof of concept, so I only implemented this for legacy skins for now.

There is a lot of uncertainty about how this would actually work as part of the game, ux and stuff. Would it be a configurable property in skins? Perhaps a custom skin type? 

Right now I'm doing the blurring at 50% resolution (and drawing the content on full resolution), though I've also tested it at 33% and 25% resolution and didn't notice any huge impact visually with either. I tried to dial in some values for the effect that look pretty good for most maps, but some more adjustments are definitely still needed.

### Some screenshots

![image](https://github.com/user-attachments/assets/34aad70b-51c8-4f0c-bc84-9f7ec80aff70)

![image](https://github.com/user-attachments/assets/5f43573a-633e-4678-9187-db6077501e5b)

![image](https://github.com/user-attachments/assets/22b00dfe-2850-4aa6-98f3-b39736c056ab)
