### PR TITLE
Add remove buttons for mod entries in custom preset lists

### DIFF
--- a/osu.Game/Localisation/ModSelectOverlayStrings.cs
+++ b/osu.Game/Localisation/ModSelectOverlayStrings.cs
@@ -46,6 +46,16 @@ namespace osu.Game.Localisation
         public static LocalisableString UseCurrentMods => new TranslatableString(getKey(@"use_current_mods"), @"Use current mods");
 
         /// <summary>
+        /// "Remove this mod"
+        /// </summary>
+        public static LocalisableString RemoveThisMod => new TranslatableString(getKey(@"remove_this_mod"), @"Remove this mod");
+
+        /// <summary>
+        /// "Add this mod"
+        /// </summary>
+        public static LocalisableString AddThisMod => new TranslatableString(getKey(@"add_this_mod"), @"Add this mod");
+
+        /// <summary>
         /// "tab to search..."
         /// </summary>
         public static LocalisableString TabToSearch => new TranslatableString(getKey(@"tab_to_search"), @"tab to search...");

--- a/osu.Game/Overlays/Mods/EditPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/EditPresetPopover.cs
@@ -220,15 +220,15 @@ namespace osu.Game.Overlays.Mods
             availableModContent.Children = new Drawable[]
             {
                 new MiniModSection(ModType.DifficultyReduction,
-                    availableMods?.Where(mod => mod.Type == ModType.DifficultyReduction && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                    availableMods?.Where(mod => !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
                 new MiniModSection(ModType.DifficultyIncrease,
-                    availableMods?.Where(mod => mod.Type == ModType.DifficultyIncrease && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                    availableMods?.Where(mod => !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
                 new MiniModSection(ModType.Automation,
-                    availableMods?.Where(mod => mod.Type == ModType.Automation && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                    availableMods?.Where(mod => !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
                 new MiniModSection(ModType.Conversion,
-                    availableMods?.Where(mod => mod.Type == ModType.Conversion && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                    availableMods?.Where(mod => !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
                 new MiniModSection(ModType.Fun,
-                    availableMods?.Where(mod => mod.Type == ModType.Fun && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                    availableMods?.Where(mod => !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
             };
 
             useCurrentModsButton.Enabled.Value = checkSelectedModsDiffersFromSaved();

--- a/osu.Game/Overlays/Mods/EditPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/EditPresetPopover.cs
@@ -219,11 +219,16 @@ namespace osu.Game.Overlays.Mods
             currentModContent.ChildrenEnumerable = saveableMods.Value.AsOrdered().Select(mod => new ModPresetRow(mod, saveableMods.Value, ModRowMode.Remove));
             availableModContent.Children = new Drawable[]
             {
-                new MiniModSection(ModType.DifficultyReduction, availableMods?.Where(mod => mod.Type == ModType.DifficultyReduction && !saveableMods.Value.Contains(mod)).ToHashSet()),
-                new MiniModSection(ModType.DifficultyIncrease, availableMods?.Where(mod => mod.Type == ModType.DifficultyIncrease && !saveableMods.Value.Contains(mod)).ToHashSet()),
-                new MiniModSection(ModType.Automation, availableMods?.Where(mod => mod.Type == ModType.Automation && !saveableMods.Value.Contains(mod)).ToHashSet()),
-                new MiniModSection(ModType.Conversion, availableMods?.Where(mod => mod.Type == ModType.Conversion && !saveableMods.Value.Contains(mod)).ToHashSet()),
-                new MiniModSection(ModType.Fun, availableMods?.Where(mod => mod.Type == ModType.Fun && !saveableMods.Value.Contains(mod)).ToHashSet()),
+                new MiniModSection(ModType.DifficultyReduction,
+                    availableMods?.Where(mod => mod.Type == ModType.DifficultyReduction && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                new MiniModSection(ModType.DifficultyIncrease,
+                    availableMods?.Where(mod => mod.Type == ModType.DifficultyIncrease && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                new MiniModSection(ModType.Automation,
+                    availableMods?.Where(mod => mod.Type == ModType.Automation && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                new MiniModSection(ModType.Conversion,
+                    availableMods?.Where(mod => mod.Type == ModType.Conversion && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
+                new MiniModSection(ModType.Fun,
+                    availableMods?.Where(mod => mod.Type == ModType.Fun && !saveableMods.Value.Contains(mod)).ToHashSet(), saveableMods.Value),
             };
 
             useCurrentModsButton.Enabled.Value = checkSelectedModsDiffersFromSaved();

--- a/osu.Game/Overlays/Mods/EditPresetPopover.cs
+++ b/osu.Game/Overlays/Mods/EditPresetPopover.cs
@@ -159,7 +159,7 @@ namespace osu.Game.Overlays.Mods
 
         private void updateState()
         {
-            scrollContent.ChildrenEnumerable = saveableMods.AsOrdered().Select(mod => new ModPresetRow(mod));
+            scrollContent.ChildrenEnumerable = saveableMods.AsOrdered().Select(mod => new ModPresetRow(mod, saveableMods));
             useCurrentModsButton.Enabled.Value = checkSelectedModsDiffersFromSaved();
         }
 

--- a/osu.Game/Overlays/Mods/MiniModSection.cs
+++ b/osu.Game/Overlays/Mods/MiniModSection.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Humanizer;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Overlays.Mods
+{
+    public partial class MiniModSection : CompositeDrawable
+    {
+        public readonly ModType ModType;
+
+        private readonly IReadOnlyList<ModState> availableMods = Array.Empty<ModState>();
+        private readonly HashSet<Mod>? rootSet;
+
+        private OsuSpriteText sectionHeader = null!;
+        private FillFlowContainer modFlowContainer = null!;
+
+        public MiniModSection(ModType modType, HashSet<Mod>? rootSet)
+        {
+            ModType = modType;
+            this.rootSet = rootSet;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    sectionHeader = new OsuSpriteText
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Text = ModType.Humanize(LetterCasing.Title),
+                        Colour = colours.ForModType(ModType),
+                        Font = OsuFont.TorusAlternate.With(size: 16, weight: FontWeight.SemiBold),
+                    },
+                    modFlowContainer = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Margin = new MarginPadding
+                        {
+                            Left = 5,
+                        }
+                    }
+                }
+            };
+
+            if (rootSet != null)
+            {
+                modFlowContainer.ChildrenEnumerable = rootSet.Where(m => m.Type == ModType)
+                                                             .Select(m => new ModPresetRow(m, rootSet, ModRowMode.Add));
+            }
+        }
+
+        private void updateState()
+        {
+            Alpha = availableMods.All(mod => !mod.Visible) ? 0 : 1;
+        }
+    }
+}

--- a/osu.Game/Overlays/Mods/MiniModSection.cs
+++ b/osu.Game/Overlays/Mods/MiniModSection.cs
@@ -20,14 +20,13 @@ namespace osu.Game.Overlays.Mods
 
         private readonly IReadOnlyList<ModState> availableMods = Array.Empty<ModState>();
         private readonly HashSet<Mod>? rootSet;
+        private readonly HashSet<Mod>? saveSet;
 
-        private OsuSpriteText sectionHeader = null!;
-        private FillFlowContainer modFlowContainer = null!;
-
-        public MiniModSection(ModType modType, HashSet<Mod>? rootSet)
+        public MiniModSection(ModType modType, HashSet<Mod>? rootSet, HashSet<Mod>? saveSet)
         {
             ModType = modType;
             this.rootSet = rootSet;
+            this.saveSet = saveSet;
         }
 
         [BackgroundDependencyLoader]
@@ -35,35 +34,35 @@ namespace osu.Game.Overlays.Mods
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
-            InternalChild = new FillFlowContainer
+
+            if (rootSet != null && rootSet.Count(m => m.Type == ModType) != 0)
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Children = new Drawable[]
+                InternalChild = new FillFlowContainer
                 {
-                    sectionHeader = new OsuSpriteText
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.X,
-                        Text = ModType.Humanize(LetterCasing.Title),
-                        Colour = colours.ForModType(ModType),
-                        Font = OsuFont.TorusAlternate.With(size: 16, weight: FontWeight.SemiBold),
-                    },
-                    modFlowContainer = new FillFlowContainer
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Margin = new MarginPadding
+                        new OsuSpriteText
                         {
-                            Left = 5,
+                            RelativeSizeAxes = Axes.X,
+                            Text = ModType.Humanize(LetterCasing.Title),
+                            Colour = colours.ForModType(ModType),
+                            Font = OsuFont.TorusAlternate.With(size: 16, weight: FontWeight.SemiBold),
+                        },
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Margin = new MarginPadding
+                            {
+                                Left = 5,
+                            },
+                            ChildrenEnumerable = rootSet.Where(m => m.Type == ModType)
+                                                        .Select(m => new ModPresetRow(m, rootSet, ModRowMode.Add, saveSet))
                         }
                     }
-                }
-            };
-
-            if (rootSet != null)
-            {
-                modFlowContainer.ChildrenEnumerable = rootSet.Where(m => m.Type == ModType)
-                                                             .Select(m => new ModPresetRow(m, rootSet, ModRowMode.Add));
+                };
             }
         }
 

--- a/osu.Game/Overlays/Mods/ModPresetColumn.cs
+++ b/osu.Game/Overlays/Mods/ModPresetColumn.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,6 +26,8 @@ namespace osu.Game.Overlays.Mods
 
         [Resolved]
         private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+
+        public IReadOnlyList<Mod>? AllAvailableMods;
 
         private const float contracted_width = WIDTH - 120;
 
@@ -79,7 +82,7 @@ namespace osu.Game.Overlays.Mods
                 return;
             }
 
-            latestLoadTask = LoadComponentsAsync(presets.Select(p => new ModPresetPanel(p.ToLive(realm))
+            latestLoadTask = LoadComponentsAsync(presets.Select(p => new ModPresetPanel(p.ToLive(realm), AllAvailableMods)
             {
                 Shear = Vector2.Zero
             }), loaded =>

--- a/osu.Game/Overlays/Mods/ModPresetPanel.cs
+++ b/osu.Game/Overlays/Mods/ModPresetPanel.cs
@@ -30,14 +30,18 @@ namespace osu.Game.Overlays.Mods
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
 
+        public IReadOnlyList<Mod>? AvailableMods;
+
         private ModSettingChangeTracker? settingChangeTracker;
 
-        public ModPresetPanel(Live<ModPreset> preset)
+        public ModPresetPanel(Live<ModPreset> preset, IReadOnlyList<Mod>? availableMods = null)
         {
             Preset = preset;
 
             Title = preset.Value.Name;
             Description = preset.Value.Description;
+
+            AvailableMods = availableMods;
         }
 
         [BackgroundDependencyLoader]
@@ -128,6 +132,6 @@ namespace osu.Game.Overlays.Mods
             settingChangeTracker?.Dispose();
         }
 
-        public Popover GetPopover() => new EditPresetPopover(Preset);
+        public Popover GetPopover() => new EditPresetPopover(Preset, AvailableMods);
     }
 }

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -14,7 +17,7 @@ namespace osu.Game.Overlays.Mods
 {
     public partial class ModPresetRow : FillFlowContainer
     {
-        public ModPresetRow(Mod mod)
+        public ModPresetRow(Mod mod, HashSet<Mod>? rootSet = null)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -30,6 +33,18 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(7),
                     Children = new Drawable[]
                     {
+                        new IconButton
+                        {
+                            Icon = FontAwesome.Solid.TimesCircle,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Enabled = { Value = !(rootSet == null || rootSet.Count <= 1) },
+                            Action = () => Scheduler.AddOnce(() =>
+                            {
+                                this.FadeOut(200, Easing.OutQuint).Then().Expire();
+                                rootSet?.Remove(mod);
+                            })
+                        },
                         new ModSwitchTiny(mod)
                         {
                             Active = { Value = true },
@@ -41,8 +56,8 @@ namespace osu.Game.Overlays.Mods
                         {
                             Text = mod.Name,
                             Font = OsuFont.Default.With(size: 16, weight: FontWeight.SemiBold),
-                            Origin = Anchor.CentreLeft,
                             Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
                             Margin = new MarginPadding { Bottom = 2 }
                         }
                     }

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Overlays.Mods
 {
@@ -43,8 +44,13 @@ namespace osu.Game.Overlays.Mods
                                 TooltipText = "Remove this mod",
                                 Action = () => Scheduler.AddOnce(() =>
                                 {
-                                    this.FadeOut(200, Easing.OutQuint).Then().Expire();
-                                    rootSet.Remove(mod);
+                                    if (rootSet.Count <= 1)
+                                        this.FlashColour(Color4.Red, 300);
+                                    else
+                                    {
+                                        this.FadeOut(200, Easing.OutQuint).Then().Expire();
+                                        rootSet.Remove(mod);
+                                    }
                                 })
                             }
                             : new Container(),

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -9,6 +9,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.UI;
 using osuTK;
@@ -18,7 +19,7 @@ namespace osu.Game.Overlays.Mods
 {
     public partial class ModPresetRow : FillFlowContainer
     {
-        public ModPresetRow(Mod mod, HashSet<Mod>? rootSet = null)
+        public ModPresetRow(Mod mod, HashSet<Mod>? rootSet = null, ModRowMode mode = ModRowMode.None)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -34,24 +35,25 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(7),
                     Children = new Drawable[]
                     {
-                        rootSet != null
+                        rootSet != null && mode != ModRowMode.None
                             ? new IconButton
                             {
-                                Icon = FontAwesome.Solid.TimesCircle,
+                                Icon = mode == ModRowMode.Remove ? FontAwesome.Solid.TimesCircle : FontAwesome.Solid.PlusCircle,
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
-                                Enabled = { Value = rootSet.Count > 1 },
-                                TooltipText = "Remove this mod",
-                                Action = () => Scheduler.AddOnce(() =>
-                                {
-                                    if (rootSet.Count <= 1)
-                                        this.FlashColour(Color4.Red, 300);
-                                    else
+                                TooltipText = mode == ModRowMode.Remove ? ModSelectOverlayStrings.RemoveThisMod : ModSelectOverlayStrings.AddThisMod,
+                                Action = mode == ModRowMode.Remove
+                                    ? () => Scheduler.AddOnce(() =>
                                     {
-                                        this.FadeOut(200, Easing.OutQuint).Then().Expire();
-                                        rootSet.Remove(mod);
-                                    }
-                                })
+                                        if (rootSet.Count <= 1)
+                                            this.FlashColour(Color4.Red, 300);
+                                        else
+                                        {
+                                            this.FadeOut(200, Easing.OutQuint).Then().Expire();
+                                            rootSet.Remove(mod);
+                                        }
+                                    })
+                                    : () => Scheduler.AddOnce(() => rootSet.Add(mod))
                             }
                             : new Container(),
                         new ModSwitchTiny(mod)
@@ -84,5 +86,12 @@ namespace osu.Game.Overlays.Mods
                 });
             }
         }
+    }
+
+    public enum ModRowMode
+    {
+        None,
+        Remove,
+        Add
     }
 }

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Overlays.Mods
 {
     public partial class ModPresetRow : FillFlowContainer
     {
-        public ModPresetRow(Mod mod, HashSet<Mod>? rootSet = null, ModRowMode mode = ModRowMode.None)
+        public ModPresetRow(Mod mod, HashSet<Mod>? rootSet = null, ModRowMode mode = ModRowMode.None, HashSet<Mod>? saveSet = null)
         {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
@@ -55,7 +55,19 @@ namespace osu.Game.Overlays.Mods
                                             rootSet.Remove(mod);
                                         }
                                     })
-                                    : () => Scheduler.AddOnce(() => rootSet.Add(mod))
+                                    : () => Scheduler.AddOnce(() =>
+                                    {
+                                        if (saveSet != null)
+                                        {
+                                            if (mod.IncompatibleMods.Any(c => saveSet.Any(c.IsInstanceOfType)))
+                                                this.FlashColour(Color4.Red, 300);
+                                            else
+                                            {
+                                                this.FadeOut(200, Easing.OutQuint).Then().Expire();
+                                                saveSet.Add(mod);
+                                            }
+                                        }
+                                    })
                             }
                             : new Container(),
                         new ModSwitchTiny(mod)

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -40,10 +40,11 @@ namespace osu.Game.Overlays.Mods
                                 Anchor = Anchor.CentreLeft,
                                 Origin = Anchor.CentreLeft,
                                 Enabled = { Value = rootSet.Count > 1 },
+                                TooltipText = "Remove this mod",
                                 Action = () => Scheduler.AddOnce(() =>
                                 {
                                     this.FadeOut(200, Easing.OutQuint).Then().Expire();
-                                    rootSet?.Remove(mod);
+                                    rootSet.Remove(mod);
                                 })
                             }
                             : new Container(),

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -33,18 +33,20 @@ namespace osu.Game.Overlays.Mods
                     Spacing = new Vector2(7),
                     Children = new Drawable[]
                     {
-                        new IconButton
-                        {
-                            Icon = FontAwesome.Solid.TimesCircle,
-                            Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Enabled = { Value = !(rootSet == null || rootSet.Count <= 1) },
-                            Action = () => Scheduler.AddOnce(() =>
+                        rootSet != null
+                            ? new IconButton
                             {
-                                this.FadeOut(200, Easing.OutQuint).Then().Expire();
-                                rootSet?.Remove(mod);
-                            })
-                        },
+                                Icon = FontAwesome.Solid.TimesCircle,
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                Enabled = { Value = rootSet.Count > 1 },
+                                Action = () => Scheduler.AddOnce(() =>
+                                {
+                                    this.FadeOut(200, Easing.OutQuint).Then().Expire();
+                                    rootSet?.Remove(mod);
+                                })
+                            }
+                            : new Container(),
                         new ModSwitchTiny(mod)
                         {
                             Active = { Value = true },

--- a/osu.Game/Overlays/Mods/ModPresetRow.cs
+++ b/osu.Game/Overlays/Mods/ModPresetRow.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
@@ -75,15 +77,25 @@ namespace osu.Game.Overlays.Mods
                 }
             };
 
-            if (!string.IsNullOrEmpty(mod.SettingDescription))
+            if (mode == ModRowMode.None)
             {
-                AddInternal(new OsuTextFlowContainer
+                if (!string.IsNullOrEmpty(mod.SettingDescription))
                 {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding { Left = 14 },
-                    Text = mod.SettingDescription
-                });
+                    AddInternal(new OsuTextFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding { Left = 14 },
+                        Text = mod.SettingDescription
+                    });
+                }
+            }
+            else
+            {
+                var settings = mod.CreateSettingsControls().ToList();
+
+                if (settings.Count > 0)
+                    AddRange(settings);
             }
         }
     }

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -116,6 +116,8 @@ namespace osu.Game.Overlays.Mods
         private Container aboveColumnsContent = null!;
         private ModCustomisationPanel customisationPanel = null!;
 
+        private ModPresetColumn presetColumn = null!;
+
         protected virtual SelectAllModsButton? SelectAllModsButton => null;
 
         private Sample? columnAppearSample;
@@ -295,7 +297,7 @@ namespace osu.Game.Overlays.Mods
         {
             if (ShowPresets)
             {
-                yield return new ColumnDimContainer(new ModPresetColumn
+                yield return new ColumnDimContainer(presetColumn = new ModPresetColumn
                 {
                     Margin = new MarginPadding { Right = 10 }
                 });
@@ -340,6 +342,8 @@ namespace osu.Game.Overlays.Mods
 
             foreach (var column in columnFlow.Columns.OfType<ModColumn>())
                 column.AvailableMods = AvailableMods.Value.GetValueOrDefault(column.ModType, Array.Empty<ModState>());
+
+            presetColumn.AllAvailableMods = AllAvailableMods.Select(mod => mod.Mod).ToList();
         }
 
         private void filterMods()

--- a/osu.Game/Overlays/Mods/ModSelectOverlay.cs
+++ b/osu.Game/Overlays/Mods/ModSelectOverlay.cs
@@ -116,7 +116,7 @@ namespace osu.Game.Overlays.Mods
         private Container aboveColumnsContent = null!;
         private ModCustomisationPanel customisationPanel = null!;
 
-        private ModPresetColumn presetColumn = null!;
+        private ModPresetColumn? presetColumn;
 
         protected virtual SelectAllModsButton? SelectAllModsButton => null;
 
@@ -343,7 +343,10 @@ namespace osu.Game.Overlays.Mods
             foreach (var column in columnFlow.Columns.OfType<ModColumn>())
                 column.AvailableMods = AvailableMods.Value.GetValueOrDefault(column.ModType, Array.Empty<ModState>());
 
-            presetColumn.AllAvailableMods = AllAvailableMods.Select(mod => mod.Mod).ToList();
+            if (presetColumn != null)
+            {
+                presetColumn.AllAvailableMods = AllAvailableMods.Select(mod => mod.Mod).ToList();
+            }
         }
 
         private void filterMods()


### PR DESCRIPTION
## Changes

To make it easier for users to remove unwanted mods in a custom mod preset.

![Preview](https://github.com/user-attachments/assets/af7f505b-6c32-4013-9d94-64b54c3da641)

- Add remove buttons to the left of a mod entry, with a static tooltip
- Block removing action and make the entry flash red when there is only one mode left in a preset

---

By the way should we consider add a `Use current mods` in the context menu? Thus we don't need to open the editor popup to apply mods to a preset.

## Known Problems

- [x] Since we pass a fixed hashset to the mod row, it's unable to change the state of the remove button. I'm considering using a `Bindable<Hashset<Mod>>` for that.
- [x] The use of `LocalisableString` for tooltip text is being considered.
- [ ] Update both flow containers upon mod change
- [ ] Layout adjustment
