### PR TITLE
Don't delete scores when deleting beatmaps

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -376,10 +376,6 @@ namespace osu.Game.Database
                     {
                         foreach (var beatmap in beatmapSet.Beatmaps)
                         {
-                            // Cascade delete related scores, else they will have a null beatmap against the model's spec.
-                            foreach (var score in beatmap.Scores)
-                                realm.Remove(score);
-
                             realm.Remove(beatmap.Metadata);
                             realm.Remove(beatmap);
                         }


### PR DESCRIPTION
The score model's spec allows for null `BeatmapInfo` so the reasoning of the inline comment is no longer valid. We match based on hash these days.