### PR TITLE
Add hover background back to `ClickablePlaceholder`

### DIFF
--- a/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
+++ b/osu.Game/Online/Placeholders/ClickablePlaceholder.cs
@@ -17,17 +17,19 @@ namespace osu.Game.Online.Placeholders
 
         public ClickablePlaceholder(LocalisableString actionMessage, IconUsage icon)
         {
+            OsuAnimatedButton button;
             OsuTextFlowContainer textFlow;
 
-            AddArbitraryDrawable(new OsuAnimatedButton
+            AddArbitraryDrawable(button = new OsuAnimatedButton
             {
                 AutoSizeAxes = Framework.Graphics.Axes.Both,
-                Child = textFlow = new OsuTextFlowContainer(cp => cp.Font = cp.Font.With(size: TEXT_SIZE))
-                {
-                    AutoSizeAxes = Framework.Graphics.Axes.Both,
-                    Margin = new Framework.Graphics.MarginPadding(5)
-                },
                 Action = () => Action?.Invoke()
+            });
+
+            button.Add(textFlow = new OsuTextFlowContainer(cp => cp.Font = cp.Font.With(size: TEXT_SIZE))
+            {
+                AutoSizeAxes = Framework.Graphics.Axes.Both,
+                Margin = new Framework.Graphics.MarginPadding(5)
             });
 
             textFlow.AddIcon(icon, i =>


### PR DESCRIPTION
By adding this, users can tell the real clickable area of the placeholder, and make use of its function to refresh the leader board or log in to the server.

This is caused by `Child` being overwritten by `ClickablePlaceHolder`, so I chose to *add* the `OsuTextFlowContainer` to it instead.

Fixes #30378.
