### PR TITLE
Fix beatmap selection being lost during update process

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -322,6 +322,11 @@ namespace osu.Game.Screens.Select
         {
             try
             {
+                // To handle the beatmap update flow, attempt to track selection changes across delete-insert transactions.
+                // When an update occurs, the previous beatmap set is either soft or hard deleted.
+                // Check if the current selection was potentially deleted by re-querying its validity.
+                bool selectedSetMarkedDeleted = SelectedBeatmapSet != null && fetchFromID(SelectedBeatmapSet.ID)?.DeletePending != false;
+
                 foreach (var set in setsRequiringRemoval) removeBeatmapSet(set.ID);
 
                 foreach (var set in setsRequiringUpdate) updateBeatmapSet(set);
@@ -330,11 +335,6 @@ namespace osu.Game.Screens.Select
                 {
                     // If SelectedBeatmapInfo is non-null, the set should also be non-null.
                     Debug.Assert(SelectedBeatmapSet != null);
-
-                    // To handle the beatmap update flow, attempt to track selection changes across delete-insert transactions.
-                    // When an update occurs, the previous beatmap set is either soft or hard deleted.
-                    // Check if the current selection was potentially deleted by re-querying its validity.
-                    bool selectedSetMarkedDeleted = fetchFromID(SelectedBeatmapSet.ID)?.DeletePending != false;
 
                     if (selectedSetMarkedDeleted && setsRequiringUpdate.Any())
                     {


### PR DESCRIPTION
Broke due to something changing in the way we handle realm things in the carousel. The deselection happens in `updateBeatmapSet` so we need to store / check the original selection before this occurs.

Doesn't seem this had test coverage? Probably implies that the overhead of adding a test was very large, so maybe best to leave it that way. I tested by manually changing the `OnlineMd5Hash` in the realm file while at song select, then performing an update and ensuring the selection doesn't change.

Closes https://github.com/ppy/osu/issues/30384.