### PR TITLE
Keep editor sidebars expanded by default

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/DrawableTaikoEditorRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/DrawableTaikoEditorRuleset.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Rulesets.UI;
 using osu.Game.Rulesets.UI.Scrolling;
 
 namespace osu.Game.Rulesets.Taiko.Edit
@@ -19,6 +20,8 @@ namespace osu.Game.Rulesets.Taiko.Edit
             : base(ruleset, beatmap, mods)
         {
         }
+
+        protected override Playfield CreatePlayfield() => new TaikoEditorPlayfield();
 
         protected override void LoadComplete()
         {

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Taiko.UI;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Taiko.Edit
+{
+    public partial class TaikoEditorPlayfield : TaikoPlayfield
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // This is the simplest way to extend the taiko playfield beyond the left of the drum area.
+            // Required in the editor to not look weird underneath left toolbox area.
+            AddInternal(new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.PlayfieldBackgroundRight), _ => new PlayfieldBackgroundRight())
+            {
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopRight,
+            });
+        }
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -206,6 +206,8 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorTimelineShowTimingChanges, true);
             SetDefault(OsuSetting.EditorTimelineShowTicks, true);
 
+            SetDefault(OsuSetting.EditorContractSidebars, false);
+
             SetDefault(OsuSetting.AlwaysShowHoldForMenuButton, false);
         }
 
@@ -431,6 +433,7 @@ namespace osu.Game.Configuration
         HideCountryFlags,
         EditorTimelineShowTimingChanges,
         EditorTimelineShowTicks,
-        AlwaysShowHoldForMenuButton
+        AlwaysShowHoldForMenuButton,
+        EditorContractSidebars
     }
 }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Localisation
         public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limited_distance_snap_grid"), @"Limit distance snap placement to current time");
 
         /// <summary>
+        /// "Contract sidebars when not hovered"
+        /// </summary>
+        public static LocalisableString ContractSidebars => new TranslatableString(getKey(@"contract_sidebars"), @"Contract sidebars when not hovered");
+
+        /// <summary>
         /// "Must be in edit mode to handle editor links"
         /// </summary>
         public static LocalisableString MustBeInEditorToHandleLinks => new TranslatableString(getKey(@"must_be_in_editor_to_handle_links"), @"Must be in edit mode to handle editor links");

--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Graphics.Containers;
+using osu.Game.Screens.Edit;
 using osuTK;
 
 namespace osu.Game.Rulesets.Edit
@@ -12,6 +16,15 @@ namespace osu.Game.Rulesets.Edit
     {
         protected override double HoverExpansionDelay => 250;
 
+        protected override bool ExpandOnHover => expandOnHover;
+
+        private readonly Bindable<bool> contractSidebars = new Bindable<bool>();
+
+        private bool expandOnHover;
+
+        [Resolved]
+        private Editor? editor { get; set; }
+
         public ExpandingToolboxContainer(float contractedWidth, float expandedWidth)
             : base(contractedWidth, expandedWidth)
         {
@@ -19,6 +32,27 @@ namespace osu.Game.Rulesets.Edit
 
             FillFlow.Spacing = new Vector2(5);
             FillFlow.Padding = new MarginPadding { Vertical = 5 };
+
+            Expanded.Value = true;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            config.BindWith(OsuSetting.EditorContractSidebars, contractSidebars);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            bool requireContracting = contractSidebars.Value || editor?.DrawSize.X / editor?.DrawSize.Y < 1.7f;
+
+            if (expandOnHover != requireContracting)
+            {
+                expandOnHover = requireContracting;
+                Expanded.Value = !expandOnHover;
+            }
         }
 
         protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => base.ReceivePositionalInputAtSubTree(screenSpacePos) && anyToolboxHovered(screenSpacePos);

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -303,8 +303,8 @@ namespace osu.Game.Rulesets.Edit
                 PlayfieldContentContainer.Anchor = Anchor.CentreLeft;
                 PlayfieldContentContainer.Origin = Anchor.CentreLeft;
 
-                PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth) - (TOOLBOX_CONTRACTED_SIZE_LEFT + TOOLBOX_CONTRACTED_SIZE_RIGHT);
-                PlayfieldContentContainer.X = TOOLBOX_CONTRACTED_SIZE_LEFT;
+                PlayfieldContentContainer.Width = Math.Max(1024, DrawWidth);
+                PlayfieldContentContainer.X = LeftToolbox.DrawWidth;
             }
 
             composerFocusMode.Value = PlayfieldContentContainer.Contains(InputManager.CurrentState.Mouse.Position)

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -215,6 +215,7 @@ namespace osu.Game.Screens.Edit
         private Bindable<bool> editorLimitedDistanceSnap;
         private Bindable<bool> editorTimelineShowTimingChanges;
         private Bindable<bool> editorTimelineShowTicks;
+        private Bindable<bool> editorContractSidebars;
 
         /// <summary>
         /// This controls the opacity of components like the timelines, sidebars, etc.
@@ -323,6 +324,7 @@ namespace osu.Game.Screens.Edit
             editorLimitedDistanceSnap = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
             editorTimelineShowTimingChanges = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
             editorTimelineShowTicks = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
+            editorContractSidebars = config.GetBindable<bool>(OsuSetting.EditorContractSidebars);
 
             AddInternal(new OsuContextMenuContainer
             {
@@ -402,7 +404,11 @@ namespace osu.Game.Screens.Edit
                                             new ToggleMenuItem(EditorStrings.LimitedDistanceSnap)
                                             {
                                                 State = { BindTarget = editorLimitedDistanceSnap },
-                                            }
+                                            },
+                                            new ToggleMenuItem(EditorStrings.ContractSidebars)
+                                            {
+                                                State = { BindTarget = editorContractSidebars }
+                                            },
                                         }
                                     },
                                     new MenuItem(EditorStrings.Timing)


### PR DESCRIPTION
They will not only contract if the user chooses to have them contract (new setting in the `View` menu) or if the game isn't wide enough to allow full interaction with the playfield while they are expanded.

Addresses https://github.com/ppy/osu/discussions/28970.