### PR TITLE
Fix old looping samples not stopping when replacing a `SkinnableSound`'s `Samples`

### DIFF
--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -154,6 +154,9 @@ namespace osu.Game.Skinning
         {
             bool wasPlaying = IsPlaying;
 
+            if (wasPlaying && Looping)
+                Stop();
+
             // Remove all pooled samples (return them to the pool), and dispose the rest.
             samplesContainer.RemoveAll(s => s.IsInPool, false);
             samplesContainer.Clear();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30365.