### PR TITLE
Add visual effect for slider bar focus state

### DIFF
--- a/osu.Game/Graphics/UserInterface/Nub.cs
+++ b/osu.Game/Graphics/UserInterface/Nub.cs
@@ -77,30 +77,40 @@ namespace osu.Game.Graphics.UserInterface
             Current.BindValueChanged(onCurrentValueChanged, true);
         }
 
-        private bool glowing;
+        private int glow;
 
-        public bool Glowing
+        public int Glow
         {
-            get => glowing;
+            get => glow;
             set
             {
-                glowing = value;
-
-                if (value)
+                if (value > 0)
                 {
-                    main.FadeColour(GlowingAccentColour.Lighten(0.5f), 40, Easing.OutQuint)
-                        .Then()
-                        .FadeColour(GlowingAccentColour, 800, Easing.OutQuint);
+                    float extraGlow = (value - 1) * 0.10f;
 
-                    main.FadeEdgeEffectTo(Color4.White.Opacity(0.1f), 40, Easing.OutQuint)
-                        .Then()
-                        .FadeEdgeEffectTo(GlowColour.Opacity(0.1f), 800, Easing.OutQuint);
+                    if (value > glow)
+                    {
+                        main.FadeColour(GlowingAccentColour.Lighten(0.5f), 40, Easing.OutQuint)
+                            .Then()
+                            .FadeColour(GlowingAccentColour.Lighten(extraGlow), 800, Easing.OutQuint);
+
+                        main.FadeEdgeEffectTo(Color4.White.Opacity(0.1f), 40, Easing.OutQuint)
+                            .Then()
+                            .FadeEdgeEffectTo(GlowColour.Lighten(extraGlow).Opacity(0.1f), 800, Easing.OutQuint);
+                    }
+                    else
+                    {
+                        main.FadeColour(GlowingAccentColour.Lighten(extraGlow), 800, Easing.OutQuint);
+                        main.FadeEdgeEffectTo(GlowColour.Lighten(extraGlow).Opacity(0.1f), 800, Easing.OutQuint);
+                    }
                 }
                 else
                 {
                     main.FadeEdgeEffectTo(GlowColour.Opacity(0), 800, Easing.OutQuint);
                     main.FadeColour(AccentColour, 800, Easing.OutQuint);
                 }
+
+                glow = value;
             }
         }
 
@@ -126,7 +136,7 @@ namespace osu.Game.Graphics.UserInterface
             set
             {
                 accentColour = value;
-                if (!Glowing)
+                if (Glow == 0)
                     main.Colour = value;
             }
         }
@@ -139,7 +149,7 @@ namespace osu.Game.Graphics.UserInterface
             set
             {
                 glowingAccentColour = value;
-                if (Glowing)
+                if (Glow > 0)
                     main.Colour = value;
             }
         }
@@ -154,7 +164,7 @@ namespace osu.Game.Graphics.UserInterface
                 glowColour = value;
 
                 var effect = main.EdgeEffect;
-                effect.Colour = Glowing ? value : value.Opacity(0);
+                effect.Colour = Glow > 0 ? value : value.Opacity(0);
                 main.EdgeEffect = effect;
             }
         }

--- a/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuCheckbox.cs
@@ -97,13 +97,13 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool OnHover(HoverEvent e)
         {
-            Nub.Glowing = true;
+            Nub.Glow = 1;
             return base.OnHover(e);
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            Nub.Glowing = false;
+            Nub.Glow = 0;
             base.OnHoverLost(e);
         }
 

--- a/osu.Game/Graphics/UserInterface/RoundedSliderBar.cs
+++ b/osu.Game/Graphics/UserInterface/RoundedSliderBar.cs
@@ -156,9 +156,31 @@ namespace osu.Game.Graphics.UserInterface
             base.OnDragEnd(e);
         }
 
+        protected override void OnFocus(FocusEvent e)
+        {
+            updateGlow();
+            base.OnFocus(e);
+        }
+
+        protected override void OnFocusLost(FocusLostEvent e)
+        {
+            updateGlow();
+            base.OnFocusLost(e);
+        }
+
         private void updateGlow()
         {
-            Nub.Glowing = !Current.Disabled && (IsHovered || IsDragged);
+            int glow = 0;
+
+            if (!Current.Disabled)
+            {
+                if (IsHovered || IsDragged)
+                    glow++;
+                if (HasFocus)
+                    glow++;
+            }
+
+            Nub.Glow = glow;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -382,11 +382,30 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 base.OnHoverLost(e);
             }
 
+            protected override void OnFocus(FocusEvent e)
+            {
+                updateState();
+                base.OnFocus(e);
+            }
+
+            protected override void OnFocusLost(FocusLostEvent e)
+            {
+                updateState();
+                base.OnFocusLost(e);
+            }
+
             private void updateState()
             {
+                int glow = 0;
+
+                if (IsHovered || IsDragged)
+                    glow++;
+                if (HasFocus)
+                    glow++;
+
                 rightBox.Colour = colourProvider.Background6;
-                leftBox.Colour = IsHovered || IsDragged ? colourProvider.Highlight1.Opacity(0.5f) : colourProvider.Dark2;
-                nub.Colour = IsHovered || IsDragged ? colourProvider.Highlight1 : colourProvider.Light4;
+                leftBox.Colour = glow >= 2 ? colourProvider.Highlight1.Opacity(0.5f) : glow >= 1 ? colourProvider.Colour2.Opacity(0.5f) : colourProvider.Dark2;
+                nub.Colour = glow >= 2 ? colourProvider.Highlight1 : glow >= 1 ? colourProvider.Colour2 : colourProvider.Light4;
             }
 
             protected override void UpdateValue(float value)


### PR DESCRIPTION
Depends on
- [ ] https://github.com/ppy/osu-framework/pull/6390

Shows the `HasFocus` state on slider bars using the same glow effect as hover state. When the slider bar has focus and hover state the glow effect stacks.


https://github.com/user-attachments/assets/97b59be3-bded-4609-a965-008e13ef91ad


https://github.com/user-attachments/assets/ff5b00a2-5a72-4c41-8af4-43b1fcaf0b7f

