### PR TITLE
Use same hitcircle radius for all skins

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCircleOverlapMarker.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCircleOverlapMarker.cs
@@ -49,6 +49,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components
                     ring = new RingPiece
                     {
                         BorderThickness = 4,
+                        Size = OsuHitObject.OBJECT_DIMENSIONS
                     }
                 }
             };

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/Components/HitCirclePiece.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles.Components
         {
             Origin = Anchor.Centre;
 
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             CornerRadius = Size.X / 2;
             CornerExponent = 2;

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -367,10 +367,6 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SliderBody?.ReceivePositionalInputAt(screenSpacePos) ?? base.ReceivePositionalInputAt(screenSpacePos);
 
-        private partial class DefaultSliderBody : PlaySliderBody
-        {
-        }
-
         #region FOR EDITOR USE ONLY, DO NOT USE FOR ANY OTHER PURPOSE
 
         internal void SuppressHitAnimations()

--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -22,9 +22,21 @@ namespace osu.Game.Rulesets.Osu.Objects
         public const float OBJECT_RADIUS = 64;
 
         /// <summary>
+        /// On osu-stable, hitcircles have 5 pixels of transparent padding on each side to allow for shadows etc.
+        /// Their hittable area is 128px, but the actual circle portion is 118px.
+        /// We must account for some gameplay elements such as slider bodies, where this padding is not present.
+        /// </summary>
+        public const float VISUAL_OBJECT_RADIUS = OBJECT_RADIUS - 5;
+
+        /// <summary>
         /// The width and height any element participating in display of a hitcircle (or similarly sized object) should be.
         /// </summary>
         public static readonly Vector2 OBJECT_DIMENSIONS = new Vector2(OBJECT_RADIUS * 2);
+
+        /// <summary>
+        /// The visual width and height any element participating in display of a hitcircle (or similarly sized object) should be.
+        /// </summary>
+        public static readonly Vector2 VISUAL_OBJECT_DIMENSIONS = new Vector2(VISUAL_OBJECT_RADIUS * 2);
 
         /// <summary>
         /// Scoring distance with a speed-adjusted beat length of 1 second (ie. the speed slider balls move through their track).

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -24,11 +24,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 {
     public partial class ArgonMainCirclePiece : CompositeDrawable
     {
-        public const float BORDER_THICKNESS = (OsuHitObject.OBJECT_RADIUS * 2) * (2f / 58);
+        public const float BORDER_THICKNESS = (OsuHitObject.VISUAL_OBJECT_RADIUS * 2) * (2f / 58);
 
         public const float GRADIENT_THICKNESS = BORDER_THICKNESS * 2.5f;
 
-        public const float OUTER_GRADIENT_SIZE = (OsuHitObject.OBJECT_RADIUS * 2) - BORDER_THICKNESS * 4;
+        public const float OUTER_GRADIENT_SIZE = (OsuHitObject.VISUAL_OBJECT_RADIUS * 2) - BORDER_THICKNESS * 4;
 
         public const float INNER_GRADIENT_SIZE = OUTER_GRADIENT_SIZE - GRADIENT_THICKNESS * 2;
         public const float INNER_FILL_SIZE = INNER_GRADIENT_SIZE - GRADIENT_THICKNESS * 2;
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         private Bindable<bool> configHitLighting = null!;
 
-        private static readonly Vector2 circle_size = OsuHitObject.OBJECT_DIMENSIONS;
+        private static readonly Vector2 circle_size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
         [Resolved]
         private DrawableHitObject drawableObject { get; set; } = null!;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             InternalChildren = new Drawable[]
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/CirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/CirclePiece.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         public CirclePiece()
         {
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
             Masking = true;
 
             CornerRadius = Size.X / 2;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultApproachCircle.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultApproachCircle.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Skinning;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
@@ -24,11 +23,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         private void load(TextureStore textures)
         {
             Texture = textures.Get(@"Gameplay/osu/approachcircle").WithMaximumSize(OsuHitObject.OBJECT_DIMENSIONS * 2);
-
-            // In triangles and argon skins, we expanded hitcircles to take up the full 128 px which are clickable,
-            // but still use the old approach circle sprite. To make it feel correct (ie. disappear as it collides
-            // with the hitcircle, *not when it overlaps the border*) we need to expand it slightly.
-            Scale = new Vector2(128 / 118f);
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultReverseArrow.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             InternalChild = new SpriteIcon
             {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBall.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBall.cs
@@ -27,13 +27,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         {
             RelativeSizeAxes = Axes.Both;
 
-            float radius = skin.GetConfig<OsuSkinConfiguration, float>(OsuSkinConfiguration.SliderPathRadius)?.Value ?? OsuHitObject.OBJECT_RADIUS;
-
             InternalChild = new CircularContainer
             {
                 Masking = true,
                 RelativeSizeAxes = Axes.Both,
-                Scale = new Vector2(radius / OsuHitObject.OBJECT_RADIUS),
+                Scale = new Vector2(OsuHitObject.VISUAL_OBJECT_RADIUS / OsuHitObject.OBJECT_RADIUS),
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Blending = BlendingParameters.Additive,

--- a/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/DefaultSliderBody.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Osu.Objects;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Osu.Skinning.Default
+{
+    public partial class DefaultSliderBody : SliderBody
+    {
+        protected override DrawableSliderPath CreateSliderPath() => new DefaultDrawableSliderPath();
+
+        private partial class DefaultDrawableSliderPath : DrawableSliderPath
+        {
+            private const float opacity_at_centre = 0.3f;
+            private const float opacity_at_edge = 0.8f;
+
+            protected override Color4 ColourAt(float position)
+            {
+                const float actual_to_visual_radius = OsuHitObject.OBJECT_RADIUS / OsuHitObject.VISUAL_OBJECT_RADIUS;
+
+                position = 1 - (1 - position) * actual_to_visual_radius;
+
+                if (position < 0.0)
+                    return Color4.Transparent;
+
+                if (CalculatedBorderPortion != 0f && position <= CalculatedBorderPortion)
+                    return BorderColour;
+
+                position -= CalculatedBorderPortion;
+                return new Color4(AccentColour.R, AccentColour.G, AccentColour.B, (opacity_at_edge - (opacity_at_edge - opacity_at_centre) * position / GRADIENT_PORTION) * AccentColour.A);
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Skinning/Default/ExplodePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/ExplodePiece.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         public ExplodePiece()
         {
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/FlashPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/FlashPiece.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     {
         public FlashPiece()
         {
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/GlowPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/GlowPiece.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Default
 {
@@ -27,7 +28,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 Origin = Anchor.Centre,
                 Texture = textures.Get("Gameplay/osu/ring-glow"),
                 Blending = BlendingParameters.Additive,
-                Alpha = 0.5f
+                Alpha = 0.5f,
+                Scale = new Vector2(118f / 128f)
             };
         }
     }

--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
         public MainCirclePiece()
         {
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/ManualSliderBody.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     /// <summary>
     /// A <see cref="SliderBody"/> with the ability to set the drawn vertices manually.
     /// </summary>
-    public partial class ManualSliderBody : SliderBody
+    public partial class ManualSliderBody : DefaultSliderBody
     {
         public ManualSliderBody()
         {

--- a/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/RingPiece.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
     {
         public RingPiece(float thickness = 9)
         {
-            Size = OsuHitObject.OBJECT_DIMENSIONS;
+            Size = OsuHitObject.VISUAL_OBJECT_DIMENSIONS;
 
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/OsuLegacySkinTransformer.cs
@@ -235,12 +235,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 case OsuSkinConfiguration osuLookup:
                     switch (osuLookup)
                     {
-                        case OsuSkinConfiguration.SliderPathRadius:
-                            if (hasHitCircle.Value)
-                                return SkinUtils.As<TValue>(new BindableFloat(LEGACY_CIRCLE_RADIUS));
-
-                            break;
-
                         case OsuSkinConfiguration.HitCircleOverlayAboveNumber:
                             // See https://osu.ppy.sh/help/wiki/Skinning/skin.ini#%5Bgeneral%5D
                             // HitCircleOverlayAboveNumer (with typo) should still be supported for now.

--- a/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/OsuSkinConfiguration.cs
@@ -5,7 +5,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
 {
     public enum OsuSkinConfiguration
     {
-        SliderPathRadius,
         CursorCentre,
         CursorExpand,
         CursorRotate,

--- a/osu.Game.Rulesets.Osu/Skinning/SliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SliderBody.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osuTK;
 using osuTK.Graphics;
@@ -119,6 +120,13 @@ namespace osu.Game.Rulesets.Osu.Skinning
 
             protected override Color4 ColourAt(float position)
             {
+                const float actual_to_visual_radius = OsuHitObject.OBJECT_RADIUS / OsuHitObject.VISUAL_OBJECT_RADIUS;
+
+                position = 1 - (1 - position) * actual_to_visual_radius;
+
+                if (position < 0.0)
+                    return Color4.Transparent;
+
                 if (CalculatedBorderPortion != 0f && position <= CalculatedBorderPortion)
                     return BorderColour;
 

--- a/osu.Game.Rulesets.Osu/Skinning/SliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SliderBody.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osuTK;
 using osuTK.Graphics;
@@ -111,28 +110,6 @@ namespace osu.Game.Rulesets.Osu.Skinning
         /// <param name="vertices">The vertices</param>
         protected void SetVertices(IReadOnlyList<Vector2> vertices) => path.Vertices = vertices;
 
-        protected virtual DrawableSliderPath CreateSliderPath() => new DefaultDrawableSliderPath();
-
-        private partial class DefaultDrawableSliderPath : DrawableSliderPath
-        {
-            private const float opacity_at_centre = 0.3f;
-            private const float opacity_at_edge = 0.8f;
-
-            protected override Color4 ColourAt(float position)
-            {
-                const float actual_to_visual_radius = OsuHitObject.OBJECT_RADIUS / OsuHitObject.VISUAL_OBJECT_RADIUS;
-
-                position = 1 - (1 - position) * actual_to_visual_radius;
-
-                if (position < 0.0)
-                    return Color4.Transparent;
-
-                if (CalculatedBorderPortion != 0f && position <= CalculatedBorderPortion)
-                    return BorderColour;
-
-                position -= CalculatedBorderPortion;
-                return new Color4(AccentColour.R, AccentColour.G, AccentColour.B, (opacity_at_edge - (opacity_at_edge - opacity_at_centre) * position / GRADIENT_PORTION) * AccentColour.A);
-            }
-        }
+        protected abstract DrawableSliderPath CreateSliderPath();
     }
 }


### PR DESCRIPTION
As discussed in #30012 

Removes the size-difference between the selection overlay & the hitobjects in the editor by making sure that all skins as well as the selection blueprints use the same radius as stable.
 For argon skin I wasn't 100% sure how this is supposed to affect sliderbodies since they have a different radius compared to circles, so I made them scale down as well, to maintain their overall appearance.

https://github.com/user-attachments/assets/901ad15a-aa03-428b-bee3-73e60d48b1fa

