### PR TITLE
Do not fall back to beatmap's original ruleset if conversion fails

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/JudgementTest.cs
@@ -43,6 +43,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             AddStep("load player", () =>
             {
                 Beatmap.Value = CreateWorkingBeatmap(beatmap);
+                Ruleset.Value = new TaikoRuleset().RulesetInfo;
                 SelectedMods.Value = mods ?? Array.Empty<Mod>();
 
                 var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -562,11 +562,8 @@ namespace osu.Game.Screens.Play
                 }
                 catch (BeatmapInvalidForRulesetException)
                 {
-                    // A playable beatmap may not be creatable with the user's preferred ruleset, so try using the beatmap's default ruleset
-                    rulesetInfo = Beatmap.Value.BeatmapInfo.Ruleset;
-                    ruleset = rulesetInfo.CreateInstance();
-
-                    playable = Beatmap.Value.GetPlayableBeatmap(rulesetInfo, gameplayMods, cancellationToken);
+                    Logger.Log($"The current beatmap is not playable in {ruleset.RulesetInfo.Name}!", level: LogLevel.Important);
+                    return null;
                 }
 
                 if (playable.HitObjects.Count == 0)


### PR DESCRIPTION
Came up when investigating https://github.com/ppy/osu/issues/30415. This diff does nothing to prevent that issue from happening, mind, it's just one more layer of the poop sandwich that I spotted in passing.

I don't know why this was ever a good idea, and would say that we want this to fail *hard* not soft. If things ever get in this state, things have gone *seriously* wrong elsewhere, and need to be fixed there.