### PR TITLE
Fix multiplayer song select not correctly applying filter sometimes

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -15,6 +16,7 @@ using osu.Framework.Platform;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Mods;
@@ -42,6 +44,9 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private Live<BeatmapSetInfo> importedBeatmapSet;
 
+        [Resolved]
+        private OsuConfigManager configManager { get; set; }
+
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
@@ -57,10 +62,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
             Add(detachedBeatmapStore);
         }
 
-        public override void SetUpSteps()
+        private void setUp()
         {
-            base.SetUpSteps();
-
             AddStep("reset", () =>
             {
                 Ruleset.Value = new OsuRuleset().RulesetInfo;
@@ -75,6 +78,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestSelectFreeMods()
         {
+            setUp();
+
             AddStep("set some freemods", () => songSelect.FreeMods.Value = new OsuRuleset().GetModsFor(ModType.Fun).ToArray());
             AddStep("set all freemods", () => songSelect.FreeMods.Value = new OsuRuleset().CreateAllMods().ToArray());
             AddStep("set no freemods", () => songSelect.FreeMods.Value = Array.Empty<Mod>());
@@ -84,6 +89,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         public void TestBeatmapConfirmed()
         {
             BeatmapInfo selectedBeatmap = null;
+
+            setUp();
 
             AddStep("change ruleset", () => Ruleset.Value = new TaikoRuleset().RulesetInfo);
             AddStep("select beatmap",
@@ -107,6 +114,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [TestCase(typeof(OsuModHidden), typeof(OsuModTraceable))] // Incompatible.
         public void TestAllowedModDeselectedWhenRequired(Type allowedMod, Type requiredMod)
         {
+            setUp();
+
             AddStep("change ruleset", () => Ruleset.Value = new OsuRuleset().RulesetInfo);
             AddStep($"select {allowedMod.ReadableName()} as allowed", () => songSelect.FreeMods.Value = new[] { (Mod)Activator.CreateInstance(allowedMod) });
             AddStep($"select {requiredMod.ReadableName()} as required", () => songSelect.Mods.Value = new[] { (Mod)Activator.CreateInstance(requiredMod) });
@@ -118,6 +127,30 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             assertFreeModNotShown(allowedMod);
             assertFreeModNotShown(requiredMod);
+        }
+
+        [Test]
+        public void TestChangeRulesetImmediatelyAfterLoadComplete()
+        {
+            AddStep("reset", () =>
+            {
+                configManager.SetValue(OsuSetting.ShowConvertedBeatmaps, false);
+                Beatmap.SetDefault();
+                SelectedMods.SetDefault();
+            });
+
+            AddStep("create song select", () =>
+            {
+                SelectedRoom.Value.Playlist.Single().RulesetID = 2;
+                songSelect = new TestMultiplayerMatchSongSelect(SelectedRoom.Value, SelectedRoom.Value.Playlist.Single());
+                songSelect.OnLoadComplete += _ => Ruleset.Value = new TaikoRuleset().RulesetInfo;
+                LoadScreen(songSelect);
+            });
+            AddUntilStep("wait for present", () => songSelect.IsCurrentScreen() && songSelect.BeatmapSetsLoaded);
+
+            AddStep("confirm selection", () => songSelect.FinaliseSelection());
+            AddAssert("beatmap is taiko", () => Beatmap.Value.BeatmapInfo.Ruleset.OnlineID, () => Is.EqualTo(1));
+            AddAssert("ruleset is taiko", () => Ruleset.Value.OnlineID, () => Is.EqualTo(1));
         }
 
         private void assertFreeModNotShown(Type type)
@@ -138,8 +171,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             public new BeatmapCarousel Carousel => base.Carousel;
 
-            public TestMultiplayerMatchSongSelect(Room room)
-                : base(room)
+            public TestMultiplayerMatchSongSelect(Room room, [CanBeNull] PlaylistItem itemToEdit = null)
+                : base(room, itemToEdit)
             {
             }
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -711,12 +711,6 @@ namespace osu.Game.Screens.Select
 
             Carousel.AllowSelection = true;
 
-            if (pendingFilterApplication)
-            {
-                Carousel.Filter(FilterControl.CreateCriteria());
-                pendingFilterApplication = false;
-            }
-
             BeatmapDetails.Refresh();
 
             beginLooping();
@@ -747,6 +741,17 @@ namespace osu.Game.Screens.Select
             wedgeBackground.ScaleTo(1, 500, Easing.OutQuint);
 
             FilterControl.Activate();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (Carousel.AllowSelection && pendingFilterApplication)
+            {
+                Carousel.Filter(FilterControl.CreateCriteria());
+                pendingFilterApplication = false;
+            }
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)


### PR DESCRIPTION
RFC. Fixes the root client-side failure causing https://github.com/ppy/osu/issues/30415.

Thread of breakage is as follows:

1. `SongSelect` loads the carousel. At this point, the ruleset is what the ambient ruleset would have been at the time of pushing song select, so most likely it will match the current ruleset. Notably, the carousel is loaded with `AllowSelection == false`.
2. `OnlinePlaySongSelect` sets the ruleset to the one taken from the relevant playlist item in `LoadComplete()`.
3. At any point between the previous and the next step, the user changes the ruleset manually.
4. `SongSelect.carouselBeatmapsLoaded()` is ran, which calls `transferRulesetValue()`, which calls `FilterControl.FilterChanged`. But at this stage `Carousel.AllowSelection` is still false, so the filter is not executed, but `pendingFilterApplication` is set instead. Unfortunately, the pending filter never gets applied after that. The only place that checks that flag is `OnEntering()`, which at this point has already ran.

To fix, move the `pendingFilterApplication` check to `Update()`, which seems like the most obvious and safe solution.