### PR TITLE
Change wording on search results info text when no search term is entered

### DIFF
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -960,7 +960,15 @@ namespace osu.Game.Screens.Select
             // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
             // but also in this case we want support for formatting a number within a string).
             int carouselCountDisplayed = Carousel.CountDisplayed;
-            FilterControl.InformationalText = carouselCountDisplayed != 1 ? $"{carouselCountDisplayed:#,0} matches" : $"{carouselCountDisplayed:#,0} match";
+
+            if (FilterControl.CurrentTextSearch.Value == string.Empty)
+            {
+                FilterControl.InformationalText = $"{carouselCountDisplayed} beatmaps loaded";
+            }
+            else
+            {
+                FilterControl.InformationalText = carouselCountDisplayed != 1 ? $"{carouselCountDisplayed:#,0} matches" : $"{carouselCountDisplayed:#,0} match";
+            }
         }
 
         private bool boundLocalBindables;

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -957,8 +957,6 @@ namespace osu.Game.Screens.Select
 
         private void updateVisibleBeatmapCount()
         {
-            // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
-            // but also in this case we want support for formatting a number within a string).
             int carouselCountDisplayed = Carousel.CountDisplayed;
 
             if (FilterControl.CurrentTextSearch.Value == string.Empty)
@@ -967,6 +965,8 @@ namespace osu.Game.Screens.Select
             }
             else
             {
+                // Intentionally not localised until we have proper support for this (see https://github.com/ppy/osu-framework/pull/4918
+                // but also in this case we want support for formatting a number within a string).
                 FilterControl.InformationalText = carouselCountDisplayed != 1 ? $"{carouselCountDisplayed:#,0} matches" : $"{carouselCountDisplayed:#,0} match";
             }
         }

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -963,7 +963,7 @@ namespace osu.Game.Screens.Select
 
             if (FilterControl.CurrentTextSearch.Value == string.Empty)
             {
-                FilterControl.InformationalText = $"{carouselCountDisplayed} beatmaps loaded";
+                FilterControl.InformationalText = $"{carouselCountDisplayed} beatmaps available";
             }
             else
             {


### PR DESCRIPTION
The wording "X matches" being used when you didn't search for anything always bothered me, this also matches stable (though in stable the X beatmaps available text is in a different location).