### PR TITLE
Fix editor sidebar resizing on hover repeatedly when polygon popover is opened

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
@@ -53,6 +53,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
+            AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight };
+
             Child = new FillFlowContainer
             {
                 Width = 220,


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/29511

The other popovers in the sidebar (scale and rotate) had `AllowableAnchors` set, so they didn't have the issue.