### PR TITLE
Fix several issues with beatmap online ID management

### DIFF
--- a/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
@@ -383,58 +383,5 @@ namespace osu.Game.Tests.Beatmaps
 
             Assert.That(beatmapSet.Status, Is.EqualTo(BeatmapOnlineStatus.None));
         }
-
-        [Test]
-        public void TestPartiallyMaliciousSet([Values] bool preferOnlineFetch)
-        {
-            var firstResult = new OnlineBeatmapMetadata
-            {
-                BeatmapID = 654321,
-                BeatmapStatus = BeatmapOnlineStatus.Ranked,
-                BeatmapSetStatus = BeatmapOnlineStatus.Ranked,
-                MD5Hash = @"cafebabe"
-            };
-            var secondResult = new OnlineBeatmapMetadata
-            {
-                BeatmapStatus = BeatmapOnlineStatus.Ranked,
-                BeatmapSetStatus = BeatmapOnlineStatus.Ranked,
-                MD5Hash = @"dededede"
-            };
-
-            var targetMock = preferOnlineFetch ? apiMetadataSourceMock : localCachedMetadataSourceMock;
-            targetMock.Setup(src => src.Available).Returns(true);
-            targetMock.Setup(src => src.TryLookup(It.Is<BeatmapInfo>(bi => bi.OnlineID == 654321), out firstResult))
-                      .Returns(true);
-            targetMock.Setup(src => src.TryLookup(It.Is<BeatmapInfo>(bi => bi.OnlineID == 666666), out secondResult))
-                      .Returns(true);
-
-            var firstBeatmap = new BeatmapInfo
-            {
-                OnlineID = 654321,
-                MD5Hash = @"cafebabe",
-            };
-            var secondBeatmap = new BeatmapInfo
-            {
-                OnlineID = 666666,
-                MD5Hash = @"deadbeef"
-            };
-            var beatmapSet = new BeatmapSetInfo(new[]
-            {
-                firstBeatmap,
-                secondBeatmap
-            });
-            firstBeatmap.BeatmapSet = beatmapSet;
-            secondBeatmap.BeatmapSet = beatmapSet;
-
-            metadataLookup.Update(beatmapSet, preferOnlineFetch);
-
-            Assert.That(firstBeatmap.Status, Is.EqualTo(BeatmapOnlineStatus.Ranked));
-            Assert.That(firstBeatmap.OnlineID, Is.EqualTo(654321));
-
-            Assert.That(secondBeatmap.Status, Is.EqualTo(BeatmapOnlineStatus.None));
-            Assert.That(secondBeatmap.OnlineID, Is.EqualTo(-1));
-
-            Assert.That(beatmapSet.Status, Is.EqualTo(BeatmapOnlineStatus.None));
-        }
     }
 }

--- a/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
@@ -241,8 +241,8 @@ namespace osu.Game.Tests.Beatmaps
 
             metadataLookup.Update(beatmapSet, preferOnlineFetch);
 
-            Assert.That(beatmap.Status, Is.EqualTo(BeatmapOnlineStatus.None));
-            Assert.That(beatmap.OnlineID, Is.EqualTo(-1));
+            Assert.That(beatmap.Status, Is.EqualTo(BeatmapOnlineStatus.Ranked));
+            Assert.That(beatmap.OnlineID, Is.EqualTo(654321));
         }
 
         [Test]

--- a/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
+++ b/osu.Game.Tests/Beatmaps/BeatmapUpdaterMetadataLookupTest.cs
@@ -274,34 +274,6 @@ namespace osu.Game.Tests.Beatmaps
         }
 
         [Test]
-        public void TestMetadataLookupForBeatmapWithoutPopulatedIDAndIncorrectHash([Values] bool preferOnlineFetch)
-        {
-            var lookupResult = new OnlineBeatmapMetadata
-            {
-                BeatmapID = 654321,
-                BeatmapStatus = BeatmapOnlineStatus.Ranked,
-                MD5Hash = @"cafebabe",
-            };
-
-            var targetMock = preferOnlineFetch ? apiMetadataSourceMock : localCachedMetadataSourceMock;
-            targetMock.Setup(src => src.Available).Returns(true);
-            targetMock.Setup(src => src.TryLookup(It.IsAny<BeatmapInfo>(), out lookupResult))
-                      .Returns(true);
-
-            var beatmap = new BeatmapInfo
-            {
-                MD5Hash = @"deadbeef"
-            };
-            var beatmapSet = new BeatmapSetInfo(beatmap.Yield());
-            beatmap.BeatmapSet = beatmapSet;
-
-            metadataLookup.Update(beatmapSet, preferOnlineFetch);
-
-            Assert.That(beatmap.Status, Is.EqualTo(BeatmapOnlineStatus.None));
-            Assert.That(beatmap.OnlineID, Is.EqualTo(-1));
-        }
-
-        [Test]
         public void TestReturnedMetadataHasDifferentHash([Values] bool preferOnlineFetch)
         {
             var lookupResult = new OnlineBeatmapMetadata

--- a/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Beatmaps
 
             Debug.Assert(beatmapInfo.BeatmapSet != null);
 
-            var req = new GetBeatmapRequest(beatmapInfo.MD5Hash);
+            var req = new GetBeatmapRequest(md5Hash: beatmapInfo.MD5Hash, filename: beatmapInfo.Path);
 
             try
             {

--- a/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/APIBeatmapMetadataSource.cs
@@ -33,7 +33,7 @@ namespace osu.Game.Beatmaps
 
             Debug.Assert(beatmapInfo.BeatmapSet != null);
 
-            var req = new GetBeatmapRequest(beatmapInfo);
+            var req = new GetBeatmapRequest(beatmapInfo.MD5Hash);
 
             try
             {

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -85,11 +85,11 @@ namespace osu.Game.Beatmaps
 
         private bool shouldDiscardLookupResult(OnlineBeatmapMetadata result, BeatmapInfo beatmapInfo)
         {
-            if (beatmapInfo.OnlineID > 0 && result.BeatmapID != beatmapInfo.OnlineID)
-            {
-                Logger.Log($"Discarding metadata lookup result due to mismatching online ID (expected: {beatmapInfo.OnlineID} actual: {result.BeatmapID})", LoggingTarget.Database);
-                return true;
-            }
+            // previously this used to check whether the `OnlineID` of the looked-up beatmap matches the local `OnlineID`.
+            // unfortunately it appears that historically stable mappers would apply crude hacks to fix unspecified "issues" with submission
+            // which would amount to reusing online IDs of other beatmaps.
+            // this means that the online ID in the `.osu` file is not reliable, and this cannot be fixed server-side
+            // because updating the maps retroactively would break stable (by losing all of users' local scores).
 
             if (beatmapInfo.OnlineID == -1 && result.MD5Hash != beatmapInfo.MD5Hash)
             {

--- a/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdaterMetadataLookup.cs
@@ -43,10 +43,15 @@ namespace osu.Game.Beatmaps
 
             foreach (var beatmapInfo in beatmapSet.Beatmaps)
             {
-                // note that it is KEY that the lookup here only uses MD5 inside
-                // (see implementations of underlying `IOnlineBeatmapMetadataSource`s).
-                // anything else like online ID or filename can be manipulated, thus being inherently unreliable,
-                // thus being unusable here for any purpose.
+                // note that these lookups DO NOT ACTUALLY FULLY GUARANTEE that the beatmap is what it claims it is,
+                // i.e. the correctness of this lookup should be treated as APPROXIMATE AT WORST.
+                // this is because the beatmap filename is used as a fallback in some scenarios where the MD5 of the beatmap may mismatch.
+                // this is considered to be an acceptable casualty so that things can continue to work as expected for users in some rare scenarios
+                // (stale beatmap files in beatmap packs, beatmap mirror desyncs).
+                // however, all this means that other places such as score submission ARE EXPECTED TO VERIFY THE MD5 OF THE BEATMAP AGAINST THE ONLINE ONE EXPLICITLY AGAIN.
+                //
+                // additionally note that the online ID stored to the map is EXPLICITLY NOT USED because some users in a silly attempt to "fix" things for themselves on stable
+                // would reuse online IDs of already submitted beatmaps, which means that information is pretty much expected to be bogus in a nonzero number of beatmapsets.
                 if (!tryLookup(beatmapInfo, preferOnlineFetch, out var res))
                     continue;
 

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -89,7 +89,8 @@ namespace osu.Game.Beatmaps
                 return false;
             }
 
-            if (string.IsNullOrEmpty(beatmapInfo.MD5Hash))
+            if (string.IsNullOrEmpty(beatmapInfo.MD5Hash)
+                && string.IsNullOrEmpty(beatmapInfo.Path))
             {
                 onlineMetadata = null;
                 return false;
@@ -238,9 +239,10 @@ namespace osu.Game.Beatmaps
             using var cmd = db.CreateCommand();
 
             cmd.CommandText =
-                @"SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash";
+                @"SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash OR filename = @Path";
 
             cmd.Parameters.Add(new SqliteParameter(@"@MD5Hash", beatmapInfo.MD5Hash));
+            cmd.Parameters.Add(new SqliteParameter(@"@Path", beatmapInfo.Path));
 
             using var reader = cmd.ExecuteReader();
 
@@ -277,10 +279,11 @@ namespace osu.Game.Beatmaps
                 SELECT `b`.`beatmapset_id`, `b`.`beatmap_id`, `b`.`approved`, `b`.`user_id`, `b`.`checksum`, `b`.`last_update`, `s`.`submit_date`, `s`.`approved_date`
                 FROM `osu_beatmaps` AS `b`
                 JOIN `osu_beatmapsets` AS `s` ON `s`.`beatmapset_id` = `b`.`beatmapset_id`
-                WHERE `b`.`checksum` = @MD5Hash
+                WHERE `b`.`checksum` = @MD5Hash OR `b`.`filename` = @Path
                 """;
 
             cmd.Parameters.Add(new SqliteParameter(@"@MD5Hash", beatmapInfo.MD5Hash));
+            cmd.Parameters.Add(new SqliteParameter(@"@Path", beatmapInfo.Path));
 
             using var reader = cmd.ExecuteReader();
 

--- a/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
+++ b/osu.Game/Beatmaps/LocalCachedBeatmapMetadataSource.cs
@@ -89,9 +89,7 @@ namespace osu.Game.Beatmaps
                 return false;
             }
 
-            if (string.IsNullOrEmpty(beatmapInfo.MD5Hash)
-                && string.IsNullOrEmpty(beatmapInfo.Path)
-                && beatmapInfo.OnlineID <= 0)
+            if (string.IsNullOrEmpty(beatmapInfo.MD5Hash))
             {
                 onlineMetadata = null;
                 return false;
@@ -240,11 +238,9 @@ namespace osu.Game.Beatmaps
             using var cmd = db.CreateCommand();
 
             cmd.CommandText =
-                @"SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash OR beatmap_id = @OnlineID OR filename = @Path";
+                @"SELECT beatmapset_id, beatmap_id, approved, user_id, checksum, last_update FROM osu_beatmaps WHERE checksum = @MD5Hash";
 
             cmd.Parameters.Add(new SqliteParameter(@"@MD5Hash", beatmapInfo.MD5Hash));
-            cmd.Parameters.Add(new SqliteParameter(@"@OnlineID", beatmapInfo.OnlineID));
-            cmd.Parameters.Add(new SqliteParameter(@"@Path", beatmapInfo.Path));
 
             using var reader = cmd.ExecuteReader();
 
@@ -281,12 +277,10 @@ namespace osu.Game.Beatmaps
                 SELECT `b`.`beatmapset_id`, `b`.`beatmap_id`, `b`.`approved`, `b`.`user_id`, `b`.`checksum`, `b`.`last_update`, `s`.`submit_date`, `s`.`approved_date`
                 FROM `osu_beatmaps` AS `b`
                 JOIN `osu_beatmapsets` AS `s` ON `s`.`beatmapset_id` = `b`.`beatmapset_id`
-                WHERE `b`.`checksum` = @MD5Hash OR `b`.`beatmap_id` = @OnlineID OR `b`.`filename` = @Path
+                WHERE `b`.`checksum` = @MD5Hash
                 """;
 
             cmd.Parameters.Add(new SqliteParameter(@"@MD5Hash", beatmapInfo.MD5Hash));
-            cmd.Parameters.Add(new SqliteParameter(@"@OnlineID", beatmapInfo.OnlineID));
-            cmd.Parameters.Add(new SqliteParameter(@"@Path", beatmapInfo.Path));
 
             using var reader = cmd.ExecuteReader();
 

--- a/osu.Game/Database/RealmArchiveModelImporter.cs
+++ b/osu.Game/Database/RealmArchiveModelImporter.cs
@@ -528,7 +528,7 @@ namespace osu.Game.Database
         /// <param name="model">The new model proposed for import.</param>
         /// <param name="realm">The current realm context.</param>
         /// <returns>An existing model which matches the criteria to skip importing, else null.</returns>
-        protected TModel? CheckForExisting(TModel model, Realm realm) => string.IsNullOrEmpty(model.Hash) ? null : realm.All<TModel>().FirstOrDefault(b => b.Hash == model.Hash);
+        protected TModel? CheckForExisting(TModel model, Realm realm) => string.IsNullOrEmpty(model.Hash) ? null : realm.All<TModel>().OrderBy(b => b.DeletePending).FirstOrDefault(b => b.Hash == model.Hash);
 
         /// <summary>
         /// Whether import can be skipped after finding an existing import early in the process.

--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Globalization;
 using osu.Framework.IO.Network;
 using osu.Game.Beatmaps;
 using osu.Game.Online.API.Requests.Responses;
@@ -9,23 +10,30 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapRequest : APIRequest<APIBeatmap>
     {
-        public readonly IBeatmapInfo BeatmapInfo;
-        public readonly string Filename;
+        public readonly int OnlineID = -1;
+        public readonly string? MD5Hash;
+        public readonly string? Filename;
 
         public GetBeatmapRequest(IBeatmapInfo beatmapInfo)
         {
-            BeatmapInfo = beatmapInfo;
+            OnlineID = beatmapInfo.OnlineID;
+            MD5Hash = beatmapInfo.MD5Hash;
             Filename = (beatmapInfo as BeatmapInfo)?.Path ?? string.Empty;
+        }
+
+        public GetBeatmapRequest(string md5Hash)
+        {
+            MD5Hash = md5Hash;
         }
 
         protected override WebRequest CreateWebRequest()
         {
             var request = base.CreateWebRequest();
 
-            if (BeatmapInfo.OnlineID > 0)
-                request.AddParameter(@"id", BeatmapInfo.OnlineID.ToString());
-            if (!string.IsNullOrEmpty(BeatmapInfo.MD5Hash))
-                request.AddParameter(@"checksum", BeatmapInfo.MD5Hash);
+            if (OnlineID > 0)
+                request.AddParameter(@"id", OnlineID.ToString(CultureInfo.InvariantCulture));
+            if (!string.IsNullOrEmpty(MD5Hash))
+                request.AddParameter(@"checksum", MD5Hash);
             if (!string.IsNullOrEmpty(Filename))
                 request.AddParameter(@"filename", Filename);
 

--- a/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
+++ b/osu.Game/Online/API/Requests/GetBeatmapRequest.cs
@@ -10,20 +10,20 @@ namespace osu.Game.Online.API.Requests
 {
     public class GetBeatmapRequest : APIRequest<APIBeatmap>
     {
-        public readonly int OnlineID = -1;
+        public readonly int OnlineID;
         public readonly string? MD5Hash;
         public readonly string? Filename;
 
         public GetBeatmapRequest(IBeatmapInfo beatmapInfo)
+            : this(onlineId: beatmapInfo.OnlineID, md5Hash: beatmapInfo.MD5Hash, filename: (beatmapInfo as BeatmapInfo)?.Path)
         {
-            OnlineID = beatmapInfo.OnlineID;
-            MD5Hash = beatmapInfo.MD5Hash;
-            Filename = (beatmapInfo as BeatmapInfo)?.Path ?? string.Empty;
         }
 
-        public GetBeatmapRequest(string md5Hash)
+        public GetBeatmapRequest(int onlineId = -1, string? md5Hash = null, string? filename = null)
         {
+            OnlineID = onlineId;
             MD5Hash = md5Hash;
+            Filename = filename;
         }
 
         protected override WebRequest CreateWebRequest()

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -188,7 +188,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
 
                 case GetBeatmapRequest getBeatmapRequest:
                 {
-                    getBeatmapRequest.TriggerSuccess(createResponseBeatmaps(getBeatmapRequest.BeatmapInfo.OnlineID).Single());
+                    getBeatmapRequest.TriggerSuccess(createResponseBeatmaps(getBeatmapRequest.OnlineID).Single());
                     return true;
                 }
 


### PR DESCRIPTION
RFC.

This is an all-in-one diff with assorted changes after today's daily challenge fiasco. Caution, wall of text incoming.

Taking it commit by commit:

## [Adjust test to match desired reality](https://github.com/ppy/osu/commit/40c2d4e942453b583ff3dc41368992b347a474dd)

Self-explanatory.

## [Remove problematic online ID check](https://github.com/ppy/osu/commit/1a2e323c11158aab0433f144d1595e06f7a1fe20)

Would "close" https://github.com/ppy/osu/issues/27332 by essentially throwing up hands and deciding that it's probably fine not to check the garbage IDs in the `.osu` file.

## [Only use MD5 when performing metadata lookups](https://github.com/ppy/osu/commit/776fabd77c5a6225e69a0b14e79b9e097692320c)

Both online and offline using the cache.

The rationale behind this change is that after 1a2e323c11158aab0433f144d1595e06f7a1fe20, `TestPartiallyMaliciousSet()` fails in a way that cannot be reconciled without this sort of change.

The test exercises a scenario where the beatmap being imported has an online ID in the `.osu` file, but its hash does not match the online hash of the beatmap. This turns out to be a more frequent scenario than envisioned because of users doing stupid things with manual file editing rather than reporting issues properly.

The scenario is realistic only because the behaviour of the endpoint responsible for looking up beatmaps is such that if multiple parameters are given (e.g. all three of beatmap MD5, online ID, and filename), [it will try the three in succession](https://github.com/ppy/osu-web/blob/f6b341813be270de59ec8f9698428aa6422bc8ae/app/Http/Controllers/BeatmapsController.php#L260-L266), and the local metadata cache implementation reflected this implementation.

Because online ID and filename are inherently unreliable in this scenario due to being directly manipulable by clueless or malicious users, neither should not be used as a fallback.

## [Remove no longer applicable test](https://github.com/ppy/osu/commit/2c2f307a63c1c4eee8ccbc0bc5d339ccaaf308af)

After https://github.com/ppy/osu/pull/30453/commits/2c2f307a63c1c4eee8ccbc0bc5d339ccaaf308af the behaviour set up on the mock in the test in question is no longer realistic. Online metadata lookups will no longer fall back to online ID or filename.

## [Prefer not deleted models when picking model instances for reuse when importing](https://github.com/ppy/osu/commit/0e52797f2948aa60c6b375f80239c091d1a3fb7a)

This fell out while investigating why the issue with online IDs mismatching in the `.osu` could be worked around by importing the map three times in total when starting from it not being available locally.

Here follows an explanation of why that "helped".

Import 1:
- The beatmap set is imported normally.
- Online metadata population sees the online ID mismatch and resets it on the problematic beatmap.

Import 2:
- The existing beatmap set is found, but deemed not reusable because of the single beatmap having its ID reset to -1.
- The existing beatmap set is marked deleted, and all the IDs of its beatmaps are reset to -1.
- The beatmap set is reimported afresh.
- Online metadata population still sees the online ID mismatch and resets it on the problematic beatmap.

Note that at this point the first import *is still physically present in the database* but marked deleted.

Import 3:
- When trying to find the existing beatmap set to see if it can be reused, *the one pending deletion and with its IDs reset - the remnant from import 1 - is returned*.
- Because of this, `validateOnlineIds()` resets online IDs *on the model representing the current reimport*.
- The beatmap set is reimported yet again.
- With the online ID reset, the online metadata population check for online ID mismatch does not run because *the IDs were reset to -1* earlier.

Preferring undeleted models when picking the model instance for reuse prevents this scenario.