### PR TITLE
Prevent key bind conflict popup when default key is assigned to secondary binding

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneKeyBindingPanel.cs
@@ -414,11 +414,7 @@ namespace osu.Game.Tests.Visual.Settings
             });
             AddStep("move mouse to centre", () => InputManager.MoveMouseTo(panel.ScreenSpaceDrawQuad.Centre));
             scrollToAndStartBinding("Left (centre)");
-            AddStep("clear binding", () =>
-            {
-                var row = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == "Left (centre)"));
-                row.ChildrenOfType<KeyBindingRow.ClearButton>().Single().TriggerClick();
-            });
+            clearBinding();
             scrollToAndStartBinding("Left (rim)");
             AddStep("bind M1", () => InputManager.Click(MouseButton.Left));
 
@@ -429,6 +425,45 @@ namespace osu.Game.Tests.Visual.Settings
             });
             AddWaitStep("wait a bit", 3);
             AddUntilStep("conflict popover not shown", () => panel.ChildrenOfType<KeyBindingConflictPopover>().SingleOrDefault(), () => Is.Null);
+        }
+
+        [Test]
+        public void TestResettingRowCannotConflictWithItself()
+        {
+            AddStep("reset taiko section to default", () =>
+            {
+                var section = panel.ChildrenOfType<VariantBindingsSubsection>().First(section => new TaikoRuleset().RulesetInfo.Equals(section.Ruleset));
+                section.ChildrenOfType<ResetButton>().Single().TriggerClick();
+            });
+            AddStep("move mouse to centre", () => InputManager.MoveMouseTo(panel.ScreenSpaceDrawQuad.Centre));
+
+            scrollToAndStartBinding("Left (centre)");
+            clearBinding();
+            scrollToAndStartBinding("Left (centre)", 1);
+            clearBinding();
+
+            scrollToAndStartBinding("Left (centre)");
+            AddStep("bind F", () => InputManager.Key(Key.F));
+            scrollToAndStartBinding("Left (centre)", 1);
+            AddStep("bind M1", () => InputManager.Click(MouseButton.Left));
+
+            AddStep("revert row to default", () =>
+            {
+                var row = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == "Left (centre)"));
+                InputManager.MoveMouseTo(row.ChildrenOfType<RevertToDefaultButton<bool>>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddWaitStep("wait a bit", 3);
+            AddUntilStep("conflict popover not shown", () => panel.ChildrenOfType<KeyBindingConflictPopover>().SingleOrDefault(), () => Is.Null);
+        }
+
+        private void clearBinding()
+        {
+            AddStep("clear binding", () =>
+            {
+                var row = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == "Left (centre)"));
+                row.ChildrenOfType<KeyBindingRow.ClearButton>().Single().TriggerClick();
+            });
         }
 
         private void checkBinding(string name, string keyName)
@@ -442,23 +477,23 @@ namespace osu.Game.Tests.Visual.Settings
             }, () => Is.EqualTo(keyName));
         }
 
-        private void scrollToAndStartBinding(string name)
+        private void scrollToAndStartBinding(string name, int bindingIndex = 0)
         {
-            KeyBindingRow.KeyButton firstButton = null;
+            KeyBindingRow.KeyButton targetButton = null;
 
             AddStep($"Scroll to {name}", () =>
             {
                 var firstRow = panel.ChildrenOfType<KeyBindingRow>().First(r => r.ChildrenOfType<OsuSpriteText>().Any(s => s.Text.ToString() == name));
-                firstButton = firstRow.ChildrenOfType<KeyBindingRow.KeyButton>().First();
+                targetButton = firstRow.ChildrenOfType<KeyBindingRow.KeyButton>().ElementAt(bindingIndex);
 
-                panel.ChildrenOfType<SettingsPanel.SettingsSectionsContainer>().First().ScrollTo(firstButton);
+                panel.ChildrenOfType<SettingsPanel.SettingsSectionsContainer>().First().ScrollTo(targetButton);
             });
 
             AddWaitStep("wait for scroll", 5);
 
             AddStep("click to bind", () =>
             {
-                InputManager.MoveMouseTo(firstButton);
+                InputManager.MoveMouseTo(targetButton);
                 InputManager.Click(MouseButton.Left);
             });
         }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -222,7 +222,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 var button = buttons[i++];
                 button.UpdateKeyCombination(d);
 
-                tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false, restoringBinding: true);
+                tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false, restoringDefaults: true);
             }
 
             isDefault.Value = true;
@@ -489,12 +489,25 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             base.OnFocusLost(e);
         }
 
-        private void tryPersistKeyBinding(RealmKeyBinding keyBinding, bool advanceToNextBinding, bool restoringBinding = false)
+        private bool isConflictingBinding(RealmKeyBinding first, RealmKeyBinding second, bool restoringDefaults)
+        {
+            if (first.ID == second.ID)
+                return false;
+
+            // ignore conflicts with same action bindings during revert. the assumption is that the other binding will be reverted subsequently in the same higher-level operation.
+            // this happens if the bindings for an action are rebound to the same keys, but the ordering of the bindings itself is different.
+            if (restoringDefaults && first.ActionInt == second.ActionInt)
+                return false;
+
+            return first.KeyCombination.Equals(second.KeyCombination);
+        }
+
+        private void tryPersistKeyBinding(RealmKeyBinding keyBinding, bool advanceToNextBinding, bool restoringDefaults = false)
         {
             List<RealmKeyBinding> bindings = GetAllSectionBindings();
             RealmKeyBinding? existingBinding = keyBinding.KeyCombination.Equals(new KeyCombination(InputKey.None))
                 ? null
-                : bindings.FirstOrDefault(other => other.ID != keyBinding.ID && other.KeyCombination.Equals(keyBinding.KeyCombination) && (!restoringBinding || other.ActionInt != keyBinding.ActionInt));
+                : bindings.FirstOrDefault(other => isConflictingBinding(keyBinding, other, restoringDefaults));
 
             if (existingBinding == null)
             {

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -495,6 +495,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             RealmKeyBinding? existingBinding = keyBinding.KeyCombination.Equals(new KeyCombination(InputKey.None))
                 ? null
                 : bindings.FirstOrDefault(other => other.ID != keyBinding.ID && other.KeyCombination.Equals(keyBinding.KeyCombination) && (!restoringBinding || other.ActionInt != keyBinding.ActionInt));
+
             if (existingBinding == null)
             {
                 realm.Write(r => r.Find<RealmKeyBinding>(keyBinding.ID)!.KeyCombinationString = keyBinding.KeyCombination.ToString());

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -222,7 +222,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 var button = buttons[i++];
                 button.UpdateKeyCombination(d);
 
-                tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false);
+                tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false, restoringBinding: true);
             }
 
             isDefault.Value = true;
@@ -489,13 +489,12 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             base.OnFocusLost(e);
         }
 
-        private void tryPersistKeyBinding(RealmKeyBinding keyBinding, bool advanceToNextBinding)
+        private void tryPersistKeyBinding(RealmKeyBinding keyBinding, bool advanceToNextBinding, bool restoringBinding = false)
         {
             List<RealmKeyBinding> bindings = GetAllSectionBindings();
             RealmKeyBinding? existingBinding = keyBinding.KeyCombination.Equals(new KeyCombination(InputKey.None))
                 ? null
-                : bindings.FirstOrDefault(other => other.ID != keyBinding.ID && other.KeyCombination.Equals(keyBinding.KeyCombination));
-
+                : bindings.FirstOrDefault(other => other.ID != keyBinding.ID && other.KeyCombination.Equals(keyBinding.KeyCombination) && (!restoringBinding || other.ActionInt != keyBinding.ActionInt));
             if (existingBinding == null)
             {
                 realm.Write(r => r.Find<RealmKeyBinding>(keyBinding.ID)!.KeyCombinationString = keyBinding.KeyCombination.ToString());


### PR DESCRIPTION
- Fixes ppy/osu#30430

Now when restoring key binds to defaults, doesn't check for conflicting key binds from the same action.

## Before

https://github.com/user-attachments/assets/13b1a36b-70c8-483b-ae86-aeef438071f4

## After
https://github.com/user-attachments/assets/d86098e0-42ae-4a60-818f-f0d9b6c61899

(Also my first PR so please let me know if I'm doing anything wrong!)