### PR TITLE
Bring back convert nerf to fix overweighted taiko difficulty

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -87,6 +87,15 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double combinedRating = combinedDifficultyValue(rhythm, colour, stamina);
             double starRating = rescale(combinedRating * 1.4);
 
+            // TODO: This is temporary measure as we don't detect abuse of multiple-input playstyles of converts within the current system.
+            if (beatmap.BeatmapInfo.Ruleset.OnlineID == 0)
+            {
+                starRating *= 0.925;
+                // For maps with low colour variance and high stamina requirement, multiple inputs are more likely to be abused.
+                if (colourRating < 2 && staminaRating > 8)
+                    starRating *= 0.80;
+            }
+
             HitWindows hitWindows = new TaikoHitWindows();
             hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
 


### PR DESCRIPTION
See discussion leading on from: https://discord.com/channels/188630481301012481/542532479626772500/1300899520023892030

In particular, scores like https://osu.ppy.sh/scores/3769125529 are worth 1400pp and are now the PP record.

This reverts the convert-related diffcalc change in https://github.com/ppy/osu/pull/20558 .

