### PR TITLE
Ignore casing when matching mods acronyms

### DIFF
--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets
         /// <param name="acronym">The acronym to query for .</param>
         public Mod? CreateModFromAcronym(string acronym)
         {
-            return AllMods.FirstOrDefault(m => m.Acronym == acronym)?.CreateInstance();
+            return AllMods.FirstOrDefault(m => string.Equals(m.Acronym, acronym, StringComparison.OrdinalIgnoreCase))?.CreateInstance();
         }
 
         /// <summary>


### PR DESCRIPTION
This is used internally by `APIMod`, which in turn is consumed by `osu-tools` to create mods from user input.

If this can't be agreed on for a quick merge, then I'm fine with the alternative of upper-casing in osu-tools itself.