### PR TITLE
Fix android screen orientation locking in portrait mode during gameplay when exiting/re-entering app

### DIFF
--- a/osu.Android/GameplayScreenRotationLocker.cs
+++ b/osu.Android/GameplayScreenRotationLocker.cs
@@ -5,7 +5,6 @@ using Android.Content.PM;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game;
 using osu.Game.Screens.Play;
 
 namespace osu.Android
@@ -28,7 +27,7 @@ namespace osu.Android
         {
             gameActivity.RunOnUiThread(() =>
             {
-                gameActivity.RequestedOrientation = userPlaying.NewValue != LocalUserPlayingState.NotPlaying ? ScreenOrientation.Locked : gameActivity.DefaultOrientation;
+                gameActivity.RequestedOrientation = userPlaying.NewValue == LocalUserPlayingState.Playing ? ScreenOrientation.Locked : gameActivity.DefaultOrientation;
             });
         }
     }


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu/pull/30073

When exiting the app, the home screen changes orientation to portrait and when re-entering, the `RequestedOrientation` would still be locked during `LocalUserPlayingState.Break` so it stays in portrait mode until exiting gameplay.

Before:

https://github.com/user-attachments/assets/0047f1e9-1d1c-4a34-9745-958f2404dc53

After:

https://github.com/user-attachments/assets/369b2749-455c-4920-992a-0ea2b7d17fc8

