### PR TITLE
Implement stamina consideration for Mono (single-coloured) patterns.

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -1,33 +1,51 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Difficulty.Evaluators;
+using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
 {
     /// <summary>
     /// Calculates the stamina coefficient of taiko difficulty.
     /// </summary>
-    public class Stamina : StrainDecaySkill
+    public class Stamina : StrainSkill
     {
-        protected override double SkillMultiplier => 1.1;
-        protected override double StrainDecayBase => 0.4;
+        private double skillMultiplier => 1.1;
+        private double strainDecayBase => 0.4;
+
+        private bool onlyMono;
+
+        private double currentStrain;
 
         /// <summary>
         /// Creates a <see cref="Stamina"/> skill.
         /// </summary>
         /// <param name="mods">Mods for use in skill calculations.</param>
-        public Stamina(Mod[] mods)
+        /// <param name="onlyMono">I hate strangeprogram</param>
+        public Stamina(Mod[] mods, bool onlyMono)
             : base(mods)
         {
+            this.onlyMono = onlyMono;
         }
 
-        protected override double StrainValueOf(DifficultyHitObject current)
+        private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
+
+        protected override double StrainValueAt(DifficultyHitObject current)
         {
-            return StaminaEvaluator.EvaluateDifficultyOf(current);
+            currentStrain *= strainDecay(current.DeltaTime);
+            currentStrain += StaminaEvaluator.EvaluateDifficultyOf(current) * skillMultiplier;
+
+            if (onlyMono)
+                return ((TaikoDifficultyHitObject)current).Colour.MonoStreak?.RunLength >= 16 ? currentStrain : 0;
+
+            return currentStrain;
         }
+
+        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => onlyMono ? 0 : currentStrain * strainDecay(time - current.Previous(0).StartTime);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         private double skillMultiplier => 1.1;
         private double strainDecayBase => 0.4;
 
-        private bool singleColourStamina;
+        private readonly bool singleColourStamina;
 
         private double currentStrain;
 
@@ -40,8 +40,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             currentStrain *= strainDecay(current.DeltaTime);
             currentStrain += StaminaEvaluator.EvaluateDifficultyOf(current) * skillMultiplier;
 
+            // Safely prevents previous strains from shifting as new notes are added.
+            var currentObject = current as TaikoDifficultyHitObject;
+            int index = currentObject?.Colour.MonoStreak?.HitObjects.IndexOf(currentObject) ?? 0;
+
             if (singleColourStamina)
-                return ((TaikoDifficultyHitObject)current).Colour.MonoStreak?.RunLength >= 16 ? currentStrain : 0;
+                return currentStrain / (1 + Math.Exp(-(index - 10) / 2.0));
 
             return currentStrain;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Stamina.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         private double skillMultiplier => 1.1;
         private double strainDecayBase => 0.4;
 
-        private bool onlyMono;
+        private bool singleColourStamina;
 
         private double currentStrain;
 
@@ -26,11 +26,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         /// Creates a <see cref="Stamina"/> skill.
         /// </summary>
         /// <param name="mods">Mods for use in skill calculations.</param>
-        /// <param name="onlyMono">I hate strangeprogram</param>
-        public Stamina(Mod[] mods, bool onlyMono)
+        /// <param name="singleColourStamina">Reads when Stamina is from a single coloured pattern.</param>
+        public Stamina(Mod[] mods, bool singleColourStamina)
             : base(mods)
         {
-            this.onlyMono = onlyMono;
+            this.singleColourStamina = singleColourStamina;
         }
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
@@ -40,12 +40,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             currentStrain *= strainDecay(current.DeltaTime);
             currentStrain += StaminaEvaluator.EvaluateDifficultyOf(current) * skillMultiplier;
 
-            if (onlyMono)
+            if (singleColourStamina)
                 return ((TaikoDifficultyHitObject)current).Colour.MonoStreak?.RunLength >= 16 ? currentStrain : 0;
 
             return currentStrain;
         }
 
-        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => onlyMono ? 0 : currentStrain * strainDecay(time - current.Previous(0).StartTime);
+        protected override double CalculateInitialStrain(double time, DifficultyHitObject current) => singleColourStamina ? 0 : currentStrain * strainDecay(time - current.Previous(0).StartTime);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -17,6 +17,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public double StaminaDifficulty { get; set; }
 
         /// <summary>
+        /// The ratio of stamina difficulty from mono-color streams to total stamina difficulty.
+        /// </summary>
+        [JsonProperty("mono_stamina_factor")]
+        public double MonoStaminaFactor { get; set; }
+
+        /// <summary>
         /// The difficulty corresponding to the rhythm skill.
         /// </summary>
         [JsonProperty("rhythm_difficulty")]

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public double StaminaDifficulty { get; set; }
 
         /// <summary>
-        /// The ratio of stamina difficulty from mono-color streams to total stamina difficulty.
+        /// The ratio of stamina difficulty from mono-color (single colour) streams to total stamina difficulty.
         /// </summary>
         [JsonProperty("mono_stamina_factor")]
         public double MonoStaminaFactor { get; set; }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -66,6 +66,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             yield return (ATTRIB_ID_DIFFICULTY, StarRating);
             yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
             yield return (ATTRIB_ID_OK_HIT_WINDOW, OkHitWindow);
+            yield return (ATTRIB_ID_MONO_STAMINA_FACTOR, MonoStaminaFactor);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
@@ -75,6 +76,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             StarRating = values[ATTRIB_ID_DIFFICULTY];
             GreatHitWindow = values[ATTRIB_ID_GREAT_HIT_WINDOW];
             OkHitWindow = values[ATTRIB_ID_OK_HIT_WINDOW];
+            MonoStaminaFactor = values[ATTRIB_ID_MONO_STAMINA_FACTOR];
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -80,12 +80,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             Colour colour = (Colour)skills.First(x => x is Colour);
             Rhythm rhythm = (Rhythm)skills.First(x => x is Rhythm);
             Stamina stamina = (Stamina)skills.First(x => x is Stamina);
-            Stamina staminaMonos = (Stamina)skills.Last(x => x is Stamina);
+            Stamina singleColourStamina = (Stamina)skills.Last(x => x is Stamina);
 
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
-            double monoStaminaRating = staminaMonos.DifficultyValue() * stamina_skill_multiplier;
+            double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
 
             double monoStaminaFactor = Math.Pow(monoStaminaRating / staminaRating, 5);
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -86,8 +86,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
-
-            double monoStaminaFactor = Math.Pow(monoStaminaRating / staminaRating, 5);
+            double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
 
             double combinedRating = combinedDifficultyValue(rhythm, colour, stamina);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -38,7 +38,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             {
                 new Rhythm(mods),
                 new Colour(mods),
-                new Stamina(mods)
+                new Stamina(mods, false),
+                new Stamina(mods, true)
             };
         }
 
@@ -79,10 +80,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             Colour colour = (Colour)skills.First(x => x is Colour);
             Rhythm rhythm = (Rhythm)skills.First(x => x is Rhythm);
             Stamina stamina = (Stamina)skills.First(x => x is Stamina);
+            Stamina staminaMonos = (Stamina)skills.Last(x => x is Stamina);
 
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
+            double monoStaminaRating = staminaMonos.DifficultyValue() * stamina_skill_multiplier;
+
+            double monoStaminaFactor = Math.Pow(monoStaminaRating / staminaRating, 5);
 
             double combinedRating = combinedDifficultyValue(rhythm, colour, stamina);
             double starRating = rescale(combinedRating * 1.4);
@@ -95,6 +100,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 StarRating = starRating,
                 Mods = mods,
                 StaminaDifficulty = staminaRating,
+                MonoStaminaFactor = monoStaminaFactor,
                 RhythmDifficulty = rhythmRating,
                 ColourDifficulty = colourRating,
                 PeakDifficulty = combinedRating,

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -95,7 +95,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (estimatedUnstableRate == null)
                 return 0;
 
-            return difficultyValue * Math.Pow(SpecialFunctions.Erf(400 / (Math.Sqrt(2) * estimatedUnstableRate.Value)), 2.0);
+            // Scale accuracy more harshly on nearly-completely mono speed maps.
+            double accScalingExponent = 2 + attributes.MonoStaminaFactor;
+            double accScalingShift = 300 - 100 * attributes.MonoStaminaFactor;
+
+            return difficultyValue * Math.Pow(SpecialFunctions.Erf(accScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), accScalingExponent);
         }
 
         private double computeAccuracyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -47,11 +47,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             double multiplier = 1.13;
 
-            if (score.Mods.Any(m => m is ModHidden))
+            if (score.Mods.Any(m => m is ModHidden) && !isConvert)
                 multiplier *= 1.075;
 
             if (score.Mods.Any(m => m is ModEasy))
-                multiplier *= 0.975;
+                multiplier *= 0.950;
 
             double difficultyValue = computeDifficultyValue(score, taikoAttributes, isConvert);
             double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert);
@@ -81,16 +81,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             difficultyValue *= Math.Pow(0.986, effectiveMissCount);
 
             if (score.Mods.Any(m => m is ModEasy))
-                difficultyValue *= 0.985;
+                difficultyValue *= 0.90;
 
-            if (score.Mods.Any(m => m is ModHidden) && !isConvert)
+            if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;
 
             if (score.Mods.Any(m => m is ModHardRock))
                 difficultyValue *= 1.10;
 
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
-                difficultyValue *= 1.050 * lengthBonus;
+                difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);
 
             if (estimatedUnstableRate == null)
                 return 0;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (totalSuccessfulHits > 0)
                 effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
 
-            // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calcuation.
+            // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calculation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
 
             double multiplier = 1.13;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (totalSuccessfulHits > 0)
                 effectiveMissCount = Math.Max(1.0, 1000.0 / totalSuccessfulHits) * countMiss;
 
-            // TODO: The detection of rulesets is temporary until the leftover old skills have been reworked.
+            // Converts are detected and omitted from mod-specific bonuses due to the scope of current difficulty calcuation.
             bool isConvert = score.BeatmapInfo!.Ruleset.OnlineID != 1;
 
             double multiplier = 1.13;
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModEasy))
                 multiplier *= 0.950;
 
-            double difficultyValue = computeDifficultyValue(score, taikoAttributes, isConvert);
+            double difficultyValue = computeDifficultyValue(score, taikoAttributes);
             double accuracyValue = computeAccuracyValue(score, taikoAttributes, isConvert);
             double totalValue =
                 Math.Pow(
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             };
         }
 
-        private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes, bool isConvert)
+        private double computeDifficultyValue(ScoreInfo score, TaikoDifficultyAttributes attributes)
         {
             double difficultyValue = Math.Pow(5 * Math.Max(1.0, attributes.StarRating / 0.115) - 4.0, 2.25) / 1150.0;
 
@@ -95,7 +95,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (estimatedUnstableRate == null)
                 return 0;
 
-            // Scale accuracy more harshly on nearly-completely mono speed maps.
+            // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
             double accScalingExponent = 2 + attributes.MonoStaminaFactor;
             double accScalingShift = 300 - 100 * attributes.MonoStaminaFactor;
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -29,6 +29,7 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_SPEED_DIFFICULT_STRAIN_COUNT = 23;
         protected const int ATTRIB_ID_AIM_DIFFICULT_STRAIN_COUNT = 25;
         protected const int ATTRIB_ID_OK_HIT_WINDOW = 27;
+        protected const int ATTRIB_ID_MONO_STAMINA_FACTOR = 29;
 
         /// <summary>
         /// The mods which were applied to the beatmap.


### PR DESCRIPTION
Upon the release of the most recent rework, stamina has once again been reworked with a fix for certain mapsets that contain stupidly high bpm, single coloured patterns out of the scope of the assumed concepts behind the stamina system.

- Introduces a monoStaminaFactor that essentially outputs a percentage of single-color (mono) patterns within a map. This factor is used to adjust the difficulty where mono patterns are identified by strain to be the only difficulty of the map (e.g., maps like StrangeProgram have a 100% monoStaminaFactor).
- Scaling now reflects this value, factoring in the monoStaminaFactor to penalise mono-heavy maps performance side. 
- Flashlight bonus multiplier is also now scaled by this attribute, if monoStaminaFactor is of a high value, less of a bonus will be applied
- Moved the isConvert bool outside of difficulty value only, and disables the specific global mod bonuses pertaining to converts.
- Easy has been given a harsher penalty, to adjust to the new statistical accuracy changes. 

The design is that maps without this very specific consideration are mostly unaffected, meaning that regular mapsets should see no change, returning either a very low value of monoStamina, or for most, a total value of 0.

Some examples of scores that are changed by this directly are:
Halti's [StrangeProgram](https://osu.ppy.sh/scores/3769125529) score
Live: 1410.7
Rework: 860.2
Change: -550.5

Ney's [Alive](https://osu.ppy.sh/scores/1873110816) score
Live: 1123.8
Rework: 823.5
Change: -300.3

Ney's [Mad Machine](https://osu.ppy.sh/scores/1873194839) score
Live: 843.2
Rework: 663.1 
Change: -180.1

Full credits to @Natelytle for the concepts of this fix. 