### PR TITLE
Remember origin for editor scale/rotation popover

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -103,6 +103,11 @@ namespace osu.Game.Rulesets.Osu.Edit
             });
             angleInput.Current.BindValueChanged(angle => rotationInfo.Value = rotationInfo.Value with { Degrees = angle.NewValue });
 
+            rotationHandler.CanRotateAroundSelectionOrigin.BindValueChanged(e =>
+            {
+                selectionCentreButton.Selected.Disabled = !e.NewValue;
+            }, true);
+
             bool didSelect = false;
 
             configRotationOrigin.BindValueChanged(val =>
@@ -153,11 +158,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 if (b.NewValue) configRotationOrigin.Value = EditorOrigin.SelectionCentre;
             });
-
-            rotationHandler.CanRotateAroundSelectionOrigin.BindValueChanged(e =>
-            {
-                selectionCentreButton.Selected.Disabled = !e.NewValue;
-            }, true);
 
             rotationInfo.BindValueChanged(rotation =>
             {

--- a/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseRotationPopover.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private readonly OsuGridToolboxGroup gridToolbox;
 
-        private readonly Bindable<PreciseRotationInfo> rotationInfo = new Bindable<PreciseRotationInfo>(new PreciseRotationInfo(0, RotationOrigin.GridCentre));
+        private readonly Bindable<PreciseRotationInfo> rotationInfo = new Bindable<PreciseRotationInfo>(new PreciseRotationInfo(0, EditorOrigin.GridCentre));
 
         private SliderWithTextBoxInput<float> angleInput = null!;
         private EditorRadioButtonCollection rotationOrigin = null!;
@@ -67,13 +67,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                         Items = new[]
                         {
                             new RadioButton("Grid centre",
-                                () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.GridCentre },
+                                () => rotationInfo.Value = rotationInfo.Value with { Origin = EditorOrigin.GridCentre },
                                 () => new SpriteIcon { Icon = FontAwesome.Regular.PlusSquare }),
                             new RadioButton("Playfield centre",
-                                () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.PlayfieldCentre },
+                                () => rotationInfo.Value = rotationInfo.Value with { Origin = EditorOrigin.PlayfieldCentre },
                                 () => new SpriteIcon { Icon = FontAwesome.Regular.Square }),
                             selectionCentreButton = new RadioButton("Selection centre",
-                                () => rotationInfo.Value = rotationInfo.Value with { Origin = RotationOrigin.SelectionCentre },
+                                () => rotationInfo.Value = rotationInfo.Value with { Origin = EditorOrigin.SelectionCentre },
                                 () => new SpriteIcon { Icon = FontAwesome.Solid.VectorSquare })
                         }
                     }
@@ -111,9 +111,9 @@ namespace osu.Game.Rulesets.Osu.Edit
         private Vector2? getOriginPosition(PreciseRotationInfo rotation) =>
             rotation.Origin switch
             {
-                RotationOrigin.GridCentre => gridToolbox.StartPosition.Value,
-                RotationOrigin.PlayfieldCentre => OsuPlayfield.BASE_SIZE / 2,
-                RotationOrigin.SelectionCentre => null,
+                EditorOrigin.GridCentre => gridToolbox.StartPosition.Value,
+                EditorOrigin.PlayfieldCentre => OsuPlayfield.BASE_SIZE / 2,
+                EditorOrigin.SelectionCentre => null,
                 _ => throw new ArgumentOutOfRangeException(nameof(rotation))
             };
 
@@ -143,12 +143,5 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
     }
 
-    public enum RotationOrigin
-    {
-        GridCentre,
-        PlayfieldCentre,
-        SelectionCentre
-    }
-
-    public record PreciseRotationInfo(float Degrees, RotationOrigin Origin);
+    public record PreciseRotationInfo(float Degrees, EditorOrigin Origin);
 }

--- a/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PreciseScalePopover.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Input.Bindings;
@@ -18,6 +19,7 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Components.RadioButtons;
+using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
@@ -28,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private readonly OsuGridToolboxGroup gridToolbox;
 
-        private readonly Bindable<PreciseScaleInfo> scaleInfo = new Bindable<PreciseScaleInfo>(new PreciseScaleInfo(1, ScaleOrigin.GridCentre, true, true));
+        private readonly Bindable<PreciseScaleInfo> scaleInfo = new Bindable<PreciseScaleInfo>(new PreciseScaleInfo(1, EditorOrigin.GridCentre, true, true));
 
         private SliderWithTextBoxInput<float> scaleInput = null!;
         private BindableNumber<float> scaleInputBindable = null!;
@@ -41,6 +43,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         private OsuCheckbox xCheckBox = null!;
         private OsuCheckbox yCheckBox = null!;
 
+        private Bindable<EditorOrigin> configScaleOrigin = null!;
+
         private BindableList<HitObject> selectedItems { get; } = new BindableList<HitObject>();
 
         public PreciseScalePopover(OsuSelectionScaleHandler scaleHandler, OsuGridToolboxGroup gridToolbox)
@@ -52,9 +56,11 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
 
         [BackgroundDependencyLoader]
-        private void load(EditorBeatmap editorBeatmap)
+        private void load(EditorBeatmap editorBeatmap, OsuConfigManager config)
         {
             selectedItems.BindTo(editorBeatmap.SelectedHitObjects);
+
+            configScaleOrigin = config.GetBindable<EditorOrigin>(OsuSetting.EditorScaleOrigin);
 
             Child = new FillFlowContainer
             {
@@ -82,13 +88,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                         Items = new[]
                         {
                             gridCentreButton = new RadioButton("Grid centre",
-                                () => setOrigin(ScaleOrigin.GridCentre),
+                                () => setOrigin(EditorOrigin.GridCentre),
                                 () => new SpriteIcon { Icon = FontAwesome.Regular.PlusSquare }),
                             playfieldCentreButton = new RadioButton("Playfield centre",
-                                () => setOrigin(ScaleOrigin.PlayfieldCentre),
+                                () => setOrigin(EditorOrigin.PlayfieldCentre),
                                 () => new SpriteIcon { Icon = FontAwesome.Regular.Square }),
                             selectionCentreButton = new RadioButton("Selection centre",
-                                () => setOrigin(ScaleOrigin.SelectionCentre),
+                                () => setOrigin(EditorOrigin.SelectionCentre),
                                 () => new SpriteIcon { Icon = FontAwesome.Solid.VectorSquare })
                         }
                     },
@@ -165,7 +171,56 @@ namespace osu.Game.Rulesets.Osu.Edit
             playfieldCentreButton.Selected.Disabled = scaleHandler.IsScalingSlider.Value && !selectionCentreButton.Selected.Disabled;
             gridCentreButton.Selected.Disabled = playfieldCentreButton.Selected.Disabled;
 
-            scaleOrigin.Items.First(b => !b.Selected.Disabled).Select();
+            bool didSelect = false;
+
+            configScaleOrigin.BindValueChanged(val =>
+            {
+                switch (configScaleOrigin.Value)
+                {
+                    case EditorOrigin.GridCentre:
+                        if (!gridCentreButton.Selected.Disabled)
+                        {
+                            gridCentreButton.Select();
+                            didSelect = true;
+                        }
+
+                        break;
+
+                    case EditorOrigin.PlayfieldCentre:
+                        if (!playfieldCentreButton.Selected.Disabled)
+                        {
+                            playfieldCentreButton.Select();
+                            didSelect = true;
+                        }
+
+                        break;
+
+                    case EditorOrigin.SelectionCentre:
+                        if (!selectionCentreButton.Selected.Disabled)
+                        {
+                            selectionCentreButton.Select();
+                            didSelect = true;
+                        }
+
+                        break;
+                }
+            }, true);
+
+            if (!didSelect)
+                scaleOrigin.Items.First(b => !b.Selected.Disabled).Select();
+
+            gridCentreButton.Selected.BindValueChanged(b =>
+            {
+                if (b.NewValue) configScaleOrigin.Value = EditorOrigin.GridCentre;
+            });
+            playfieldCentreButton.Selected.BindValueChanged(b =>
+            {
+                if (b.NewValue) configScaleOrigin.Value = EditorOrigin.PlayfieldCentre;
+            });
+            selectionCentreButton.Selected.BindValueChanged(b =>
+            {
+                if (b.NewValue) configScaleOrigin.Value = EditorOrigin.SelectionCentre;
+            });
 
             scaleInfo.BindValueChanged(scale =>
             {
@@ -182,7 +237,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private void updateAxisCheckBoxesEnabled()
         {
-            if (scaleInfo.Value.Origin != ScaleOrigin.SelectionCentre)
+            if (scaleInfo.Value.Origin != EditorOrigin.SelectionCentre)
             {
                 toggleAxisAvailable(xCheckBox.Current, true);
                 toggleAxisAvailable(yCheckBox.Current, true);
@@ -230,7 +285,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             scaleInputBindable.MinValue = MathF.Min(1, MathF.Max(scale.X, scale.Y));
         }
 
-        private void setOrigin(ScaleOrigin origin)
+        private void setOrigin(EditorOrigin origin)
         {
             scaleInfo.Value = scaleInfo.Value with { Origin = origin };
             updateMinMaxScale();
@@ -241,13 +296,13 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             switch (scale.Origin)
             {
-                case ScaleOrigin.GridCentre:
+                case EditorOrigin.GridCentre:
                     return gridToolbox.StartPosition.Value;
 
-                case ScaleOrigin.PlayfieldCentre:
+                case EditorOrigin.PlayfieldCentre:
                     return OsuPlayfield.BASE_SIZE / 2;
 
-                case ScaleOrigin.SelectionCentre:
+                case EditorOrigin.SelectionCentre:
                     if (selectedItems.Count == 1 && selectedItems.First() is Slider slider)
                         return slider.Position;
 
@@ -271,7 +326,7 @@ namespace osu.Game.Rulesets.Osu.Edit
             return result;
         }
 
-        private float getRotation(PreciseScaleInfo scale) => scale.Origin == ScaleOrigin.GridCentre ? gridToolbox.GridLinesRotation.Value : 0;
+        private float getRotation(PreciseScaleInfo scale) => scale.Origin == EditorOrigin.GridCentre ? gridToolbox.GridLinesRotation.Value : 0;
 
         protected override void PopIn()
         {
@@ -299,12 +354,5 @@ namespace osu.Game.Rulesets.Osu.Edit
         }
     }
 
-    public enum ScaleOrigin
-    {
-        GridCentre,
-        PlayfieldCentre,
-        SelectionCentre
-    }
-
-    public record PreciseScaleInfo(float Scale, ScaleOrigin Origin, bool XAxis, bool YAxis);
+    public record PreciseScaleInfo(float Scale, EditorOrigin Origin, bool XAxis, bool YAxis);
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);
             SetDefault(OsuSetting.EditorShowSpeedChanges, false);
             SetDefault(OsuSetting.EditorScaleOrigin, EditorOrigin.GridCentre);
-            SetDefault(OsuSetting.EditorRotateOrigin, EditorOrigin.GridCentre);
+            SetDefault(OsuSetting.EditorRotationOrigin, EditorOrigin.GridCentre);
 
             SetDefault(OsuSetting.HideCountryFlags, false);
 
@@ -438,6 +438,7 @@ namespace osu.Game.Configuration
         EditorTimelineShowTicks,
         AlwaysShowHoldForMenuButton,
         EditorContractSidebars,
-        EditorScaleOrigin
+        EditorScaleOrigin,
+        EditorRotationOrigin
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -17,6 +17,7 @@ using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods.Input;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
@@ -193,6 +194,8 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorAutoSeekOnPlacement, true);
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);
             SetDefault(OsuSetting.EditorShowSpeedChanges, false);
+            SetDefault(OsuSetting.EditorScaleOrigin, EditorOrigin.GridCentre);
+            SetDefault(OsuSetting.EditorRotateOrigin, EditorOrigin.GridCentre);
 
             SetDefault(OsuSetting.HideCountryFlags, false);
 
@@ -434,6 +437,7 @@ namespace osu.Game.Configuration
         EditorTimelineShowTimingChanges,
         EditorTimelineShowTicks,
         AlwaysShowHoldForMenuButton,
-        EditorContractSidebars
+        EditorContractSidebars,
+        EditorScaleOrigin
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/EditorOrigin.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorOrigin.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public enum EditorOrigin
+    {
+        GridCentre,
+        PlayfieldCentre,
+        SelectionCentre
+    }
+}


### PR DESCRIPTION
Seems like a legitimate request.

Question of whether both dialogs should use the same setting, but I think it's safest to remember per usage.