### PR TITLE
Specify type of text input in most `TextBox` usages

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuNumberBox.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Input;
+
 namespace osu.Game.Graphics.UserInterface
 {
     public partial class OsuNumberBox : OsuTextBox
     {
-        protected override bool AllowIme => false;
-
         public OsuNumberBox()
         {
+            InputProperties = new TextInputProperties(TextInputType.Number, false);
             SelectAllOnFocus = true;
         }
-
-        protected override bool CanAddCharacter(char character) => char.IsAsciiDigit(character);
     }
 }

--- a/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuPasswordTextBox.cs
@@ -18,7 +18,7 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Graphics.UserInterface
 {
-    public partial class OsuPasswordTextBox : OsuTextBox, ISuppressKeyEventLogging
+    public partial class OsuPasswordTextBox : OsuTextBox
     {
         protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
         {
@@ -28,12 +28,6 @@ namespace osu.Game.Graphics.UserInterface
 
         protected override bool AllowUniqueCharacterSamples => false;
 
-        protected override bool AllowClipboardExport => false;
-
-        protected override bool AllowWordNavigation => false;
-
-        protected override bool AllowIme => false;
-
         private readonly CapsWarning warning;
 
         [Resolved]
@@ -41,6 +35,8 @@ namespace osu.Game.Graphics.UserInterface
 
         public OsuPasswordTextBox()
         {
+            InputProperties = new TextInputProperties(TextInputType.Password, false);
+
             Add(warning = new CapsWarning
             {
                 Size = new Vector2(20),

--- a/osu.Game/Graphics/UserInterfaceV2/FormNumberBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormNumberBox.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Globalization;
+using osu.Framework.Input;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -18,6 +19,11 @@ namespace osu.Game.Graphics.UserInterfaceV2
         internal partial class InnerNumberBox : InnerTextBox
         {
             public bool AllowDecimals { get; init; }
+
+            public InnerNumberBox()
+            {
+                InputProperties = new TextInputProperties(TextInputType.Number, false);
+            }
 
             protected override bool CanAddCharacter(char character)
                 => char.IsAsciiDigit(character) || (AllowDecimals && CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator.Contains(character));

--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -63,6 +64,7 @@ namespace osu.Game.Overlays.Login
                         },
                         username = new OsuTextBox
                         {
+                            InputProperties = new TextInputProperties(TextInputType.Username, false),
                             PlaceholderText = UsersStrings.LoginUsername.ToLower(),
                             RelativeSizeAxes = Axes.X,
                             Text = api.ProvidedUsername,

--- a/osu.Game/Overlays/Settings/SettingsNumberBox.cs
+++ b/osu.Game/Overlays/Settings/SettingsNumberBox.cs
@@ -5,6 +5,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 
 namespace osu.Game.Overlays.Settings
 {
@@ -66,7 +67,10 @@ namespace osu.Game.Overlays.Settings
 
         private partial class OutlinedNumberBox : OutlinedTextBox
         {
-            protected override bool AllowIme => false;
+            public OutlinedNumberBox()
+            {
+                InputProperties = new TextInputProperties(TextInputType.Number, false);
+            }
 
             protected override bool CanAddCharacter(char character) => char.IsAsciiDigit(character);
 

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -119,7 +120,10 @@ namespace osu.Game.Screens.Edit.Setup
 
             private partial class RomanisedTextBox : InnerTextBox
             {
-                protected override bool AllowIme => false;
+                public RomanisedTextBox()
+                {
+                    InputProperties = new TextInputProperties(TextInputType.Text, false);
+                }
 
                 protected override bool CanAddCharacter(char character)
                     => MetadataUtils.IsRomanised(character);


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6408
- [x] Depends on framework bump
- Closes #24041 

The updated usages are only what I was able to come up with off the top of my head and/or by some basic Rider search, if there are other usages that should be updated feel free to mention them here.