### PR TITLE
Add search textbox to friends display

### DIFF
--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -6,14 +6,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Resources.Localisation.Web;
 using osu.Game.Users;
 using osuTK;
 
@@ -35,7 +38,8 @@ namespace osu.Game.Overlays.Dashboard.Friends
 
         private CancellationTokenSource cancellationToken;
 
-        private Drawable currentContent;
+        [CanBeNull]
+        private SearchContainer currentContent = null;
 
         private FriendOnlineStreamControl onlineStreamControl;
         private Box background;
@@ -43,6 +47,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
         private UserListToolbar userListToolbar;
         private Container itemsPlaceholder;
         private LoadingLayer loading;
+        private BasicSearchTextBox searchTextBox;
 
         private readonly IBindableList<APIUser> apiFriends = new BindableList<APIUser>();
 
@@ -104,7 +109,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                 Margin = new MarginPadding { Bottom = 20 },
                                 Children = new Drawable[]
                                 {
-                                    new Container
+                                    new GridContainer
                                     {
                                         RelativeSizeAxes = Axes.X,
                                         AutoSizeAxes = Axes.Y,
@@ -113,11 +118,38 @@ namespace osu.Game.Overlays.Dashboard.Friends
                                             Horizontal = 40,
                                             Vertical = 20
                                         },
-                                        Child = userListToolbar = new UserListToolbar
+                                        ColumnDimensions = new[]
                                         {
-                                            Anchor = Anchor.CentreRight,
-                                            Origin = Anchor.CentreRight,
-                                        }
+                                            new Dimension(),
+                                            new Dimension(GridSizeMode.Absolute, 50),
+                                            new Dimension(GridSizeMode.AutoSize),
+                                        },
+                                        RowDimensions = new[]
+                                        {
+                                            new Dimension(GridSizeMode.AutoSize),
+                                        },
+                                        Content = new[]
+                                        {
+                                            new[]
+                                            {
+                                                searchTextBox = new BasicSearchTextBox
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    Anchor = Anchor.CentreLeft,
+                                                    Origin = Anchor.CentreLeft,
+                                                    Height = 40,
+                                                    ReleaseFocusOnCommit = false,
+                                                    HoldFocus = true,
+                                                    PlaceholderText = HomeStrings.SearchPlaceholder,
+                                                },
+                                                Empty(),
+                                                userListToolbar = new UserListToolbar
+                                                {
+                                                    Anchor = Anchor.CentreRight,
+                                                    Origin = Anchor.CentreRight,
+                                                },
+                                            },
+                                        },
                                     },
                                     new Container
                                     {
@@ -155,6 +187,11 @@ namespace osu.Game.Overlays.Dashboard.Friends
             onlineStreamControl.Current.BindValueChanged(_ => recreatePanels());
             userListToolbar.DisplayStyle.BindValueChanged(_ => recreatePanels());
             userListToolbar.SortCriteria.BindValueChanged(_ => recreatePanels());
+            searchTextBox.Current.BindValueChanged(_ =>
+            {
+                if (currentContent.IsNotNull())
+                    currentContent.SearchTerm = searchTextBox.Current.Value;
+            });
         }
 
         private void recreatePanels()
@@ -188,7 +225,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
             }
         }
 
-        private void addContentToPlaceholder(Drawable content)
+        private void addContentToPlaceholder(SearchContainer content)
         {
             loading.Hide();
 
@@ -204,16 +241,17 @@ namespace osu.Game.Overlays.Dashboard.Friends
             currentContent.FadeIn(200, Easing.OutQuint);
         }
 
-        private FillFlowContainer createTable(List<APIUser> users)
+        private SearchContainer createTable(List<APIUser> users)
         {
             var style = userListToolbar.DisplayStyle.Value;
 
-            return new FillFlowContainer
+            return new SearchContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Spacing = new Vector2(style == OverlayPanelDisplayStyle.Card ? 10 : 2),
-                Children = users.Select(u => createUserPanel(u, style)).ToList()
+                Children = users.Select(u => createUserPanel(u, style)).ToList(),
+                SearchTerm = searchTextBox.Current.Value,
             };
         }
 

--- a/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
+++ b/osu.Game/Overlays/Dashboard/Friends/FriendDisplay.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Overlays.Dashboard.Friends
         private CancellationTokenSource cancellationToken;
 
         [CanBeNull]
-        private SearchContainer currentContent = null;
+        private SearchContainer currentContent;
 
         private FriendOnlineStreamControl onlineStreamControl;
         private Box background;

--- a/osu.Game/Users/UserPanel.cs
+++ b/osu.Game/Users/UserPanel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -13,6 +14,7 @@ using osu.Game.Overlays;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterface;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Localisation;
 using osu.Framework.Screens;
 using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
@@ -28,7 +30,7 @@ using osuTK;
 
 namespace osu.Game.Users
 {
-    public abstract partial class UserPanel : OsuClickableContainer, IHasContextMenu
+    public abstract partial class UserPanel : OsuClickableContainer, IHasContextMenu, IFilterable
     {
         public readonly APIUser User;
 
@@ -162,5 +164,20 @@ namespace osu.Game.Users
                 return items.ToArray();
             }
         }
+
+        public IEnumerable<LocalisableString> FilterTerms => [User.Username];
+
+        public bool MatchingFilter
+        {
+            set
+            {
+                if (value)
+                    Show();
+                else
+                    Hide();
+            }
+        }
+
+        public bool FilteringActive { get; set; }
     }
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/a19d607a-d0aa-45b2-a184-c32f30782090

Random user feature request that made sense to me because the same thing is in currently online display.

Yes web doesn't have this, but web is in a browser where you can Ctrl-F. You can't do that in the client.

Design taken out of posterior because I can't be bothered waiting for design cycles for this. cc @ppy/team-design if you want to veto this I guess.