### PR TITLE
Add ability to hide breaks from timeline

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -207,6 +207,7 @@ namespace osu.Game.Configuration
             SetDefault<UserStatus?>(OsuSetting.UserOnlineStatus, null);
 
             SetDefault(OsuSetting.EditorTimelineShowTimingChanges, true);
+            SetDefault(OsuSetting.EditorTimelineShowBreaks, true);
             SetDefault(OsuSetting.EditorTimelineShowTicks, true);
 
             SetDefault(OsuSetting.EditorContractSidebars, false);
@@ -439,6 +440,7 @@ namespace osu.Game.Configuration
         AlwaysShowHoldForMenuButton,
         EditorContractSidebars,
         EditorScaleOrigin,
-        EditorRotationOrigin
+        EditorRotationOrigin,
+        EditorTimelineShowBreaks,
     }
 }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -140,6 +140,11 @@ namespace osu.Game.Localisation
         public static LocalisableString TimelineShowTimingChanges => new TranslatableString(getKey(@"timeline_show_timing_changes"), @"Show timing changes");
 
         /// <summary>
+        /// "Show breaks"
+        /// </summary>
+        public static LocalisableString TimelineShowBreaks => new TranslatableString(getKey(@"timeline_show_breaks"), @"Show breaks");
+
+        /// <summary>
         /// "Show ticks"
         /// </summary>
         public static LocalisableString TimelineShowTicks => new TranslatableString(getKey(@"timeline_show_ticks"), @"Show ticks");

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBreakDisplay.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Configuration;
 using osu.Game.Screens.Edit.Components.Timelines.Summary.Parts;
 
 namespace osu.Game.Screens.Edit.Compose.Components.Timeline
@@ -26,6 +27,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private readonly Cached breakCache = new Cached();
 
         private readonly BindableList<BreakPeriod> breaks = new BindableList<BreakPeriod>();
+
+        private readonly BindableBool showBreaks = new BindableBool(true);
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager configManager)
+        {
+            configManager.BindWith(OsuSetting.EditorTimelineShowBreaks, showBreaks);
+            showBreaks.BindValueChanged(_ => breakCache.Invalidate());
+        }
 
         protected override void LoadBeatmap(EditorBeatmap beatmap)
         {
@@ -66,6 +76,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         private void recreateBreaks()
         {
             Clear();
+
+            if (!showBreaks.Value)
+                return;
 
             for (int i = 0; i < breaks.Count; i++)
             {

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -214,6 +214,7 @@ namespace osu.Game.Screens.Edit
         private Bindable<bool> editorAutoSeekOnPlacement;
         private Bindable<bool> editorLimitedDistanceSnap;
         private Bindable<bool> editorTimelineShowTimingChanges;
+        private Bindable<bool> editorTimelineShowBreaks;
         private Bindable<bool> editorTimelineShowTicks;
         private Bindable<bool> editorContractSidebars;
 
@@ -323,6 +324,7 @@ namespace osu.Game.Screens.Edit
             editorAutoSeekOnPlacement = config.GetBindable<bool>(OsuSetting.EditorAutoSeekOnPlacement);
             editorLimitedDistanceSnap = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
             editorTimelineShowTimingChanges = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
+            editorTimelineShowBreaks = config.GetBindable<bool>(OsuSetting.EditorTimelineShowBreaks);
             editorTimelineShowTicks = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
             editorContractSidebars = config.GetBindable<bool>(OsuSetting.EditorContractSidebars);
 
@@ -389,6 +391,10 @@ namespace osu.Game.Screens.Edit
                                                     new ToggleMenuItem(EditorStrings.TimelineShowTicks)
                                                     {
                                                         State = { BindTarget = editorTimelineShowTicks }
+                                                    },
+                                                    new ToggleMenuItem(EditorStrings.TimelineShowBreaks)
+                                                    {
+                                                        State = { BindTarget = editorTimelineShowBreaks }
                                                     },
                                                 ]
                                             },


### PR DESCRIPTION
This was another IRL request from a mapper / team member. The rationale here is that it can be very annoying to map with break time enabled if you have a large gap in the beatmap you are trying to fill with hitobjects, as you are placing objects on top of a very gray area:

https://github.com/user-attachments/assets/aa558994-62f3-48c9-b1b2-21e14614d894

Open to other suggestions if this won't fly. One argument would be that "if you disable this you might be unaware of breaks existing at all and forget to turn it back on", although given that it's a very explicit toggle maybe that's on the user.
