### PR TITLE
Add default multiplier for mania key mods

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaKeyMod.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Mania.Mods
         public override string Acronym => Name;
         public abstract int KeyCount { get; }
         public override ModType Type => ModType.Conversion;
-        public override double ScoreMultiplier => 1; // TODO: Implement the mania key mod score multiplier
+        public override double ScoreMultiplier => 0.9;
         public override bool Ranked => UsesDefaultConfiguration;
 
         public void ApplyToBeatmapConverter(IBeatmapConverter beatmapConverter)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/30503

This doesn't go the full way. osu!stable will decrease the multiplier further if `new_keys < old_keys`, but this is hard to do here due to lack of ordering of calls to `IApplicableToDifficulty`.

- https://osu.ppy.sh/scores/3179253147

```
legacy: 859241
before: 959013
after: 863112
```

Those scoring values have been computed locally. Note that the "before" variant differs from the website because of a bug with not including mods correctly, that seems to have since been resolved but attributes haven't been reprocessed yet (https://github.com/ppy/osu/issues/29772).