### PR TITLE
Fix drum rolls losing width on strong state toggle in editor

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -54,17 +54,17 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetStrongState(bool state)
         {
-            if (SelectedItems.OfType<Hit>().All(h => h.IsStrong == state))
+            if (SelectedItems.OfType<TaikoStrongableHitObject>().All(h => h.IsStrong == state))
                 return;
 
             EditorBeatmap.PerformOnSelection(h =>
             {
-                if (!(h is Hit taikoHit)) return;
+                if (h is not TaikoStrongableHitObject strongable) return;
 
-                if (taikoHit.IsStrong != state)
+                if (strongable.IsStrong != state)
                 {
-                    taikoHit.IsStrong = state;
-                    EditorBeatmap.Update(taikoHit);
+                    strongable.IsStrong = state;
+                    EditorBeatmap.Update(strongable);
                 }
             });
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -78,6 +78,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.RecreatePieces();
             updateColour();
+            Height = HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE;
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -12,6 +12,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -42,6 +43,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             base.OnApply();
 
             IsFirstTick.Value = HitObject.FirstTick;
+        }
+
+        protected override void RecreatePieces()
+        {
+            base.RecreatePieces();
+            Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -63,6 +64,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             updateActionsFromType();
             base.RecreatePieces();
+            Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -19,6 +19,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -33,6 +34,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         /// Offset away from the start time of the swell at which the ring starts appearing.
         /// </summary>
         private const double ring_appear_offset = 100;
+
+        private Vector2 baseSize;
 
         private readonly Container<DrawableSwellTick> ticks;
         private readonly Container bodyContainer;
@@ -140,6 +143,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
             });
+
+        protected override void RecreatePieces()
+        {
+            base.RecreatePieces();
+            Size = baseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
+        }
 
         protected override void OnFree()
         {
@@ -269,7 +278,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.Update();
 
-            Size = BaseSize * Parent!.RelativeChildSize;
+            Size = baseSize * Parent!.RelativeChildSize;
 
             // Make the swell stop at the hit target
             X = Math.Max(0, X);

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -130,7 +130,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public new TObject HitObject => (TObject)base.HitObject;
 
-        protected Vector2 BaseSize;
         protected SkinnableDrawable MainPiece;
 
         protected DrawableTaikoHitObject([CanBeNull] TObject hitObject)
@@ -152,8 +151,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected virtual void RecreatePieces()
         {
-            Size = BaseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
-
             if (MainPiece != null)
                 Content.Remove(MainPiece, true);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -42,13 +41,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             isStrong.UnbindFrom(HitObject.IsStrongBindable);
             // ensure the next application does not accidentally overwrite samples.
             isStrong.UnbindEvents();
-        }
-
-        protected override void RecreatePieces()
-        {
-            base.RecreatePieces();
-            if (HitObject.IsStrong)
-                Size = BaseSize = new Vector2(TaikoStrongableHitObject.DEFAULT_STRONG_SIZE);
         }
 
         protected override void AddNestedHitObject(DrawableHitObject hitObject)


### PR DESCRIPTION
## [Fix strong context menu operation not being written properly](https://github.com/ppy/osu/commit/5f1b6963877cff5f2c496056701b5bccf69d793d)

Noticed in passing. Decided to include here due to being vaguely relevant and me not wanting to add extra ceremony.

## [Fix drum rolls losing width on strong state toggle in editor](https://github.com/ppy/osu/commit/387fbc2214a37f70affd934c4e0f71761de78460)

Fixes https://github.com/ppy/osu/issues/30480.