### PR TITLE
Fix intermittent beatmap recommendations test

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -191,7 +191,7 @@ namespace osu.Game.Tests.Visual.SongSelect
         {
             AddStep("present beatmap", () => Game.PresentBeatmap(getImport()));
 
-            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect);
+            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
             AddUntilStep("recommended beatmap displayed", () => Game.Beatmap.Value.BeatmapInfo.MatchesOnlineID(getImport().Beatmaps[expectedDiff - 1]));
         }
     }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -10,9 +10,12 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Extensions;
+using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
@@ -193,6 +196,37 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect select && select.BeatmapSetsLoaded);
             AddUntilStep("recommended beatmap displayed", () => Game.Beatmap.Value.BeatmapInfo.MatchesOnlineID(getImport().Beatmaps[expectedDiff - 1]));
+        }
+
+        protected override TestOsuGame CreateTestGame() => new NoBeatmapUpdateGame(LocalStorage, API);
+
+        private class NoBeatmapUpdateGame : TestOsuGame
+        {
+            public NoBeatmapUpdateGame(Storage storage, IAPIProvider api, string[] args = null)
+                : base(storage, api, args)
+            {
+            }
+
+            protected override IBeatmapUpdater CreateBeatmapUpdater() => new TestBeatmapUpdater();
+
+            private class TestBeatmapUpdater : IBeatmapUpdater
+            {
+                public void Queue(Live<BeatmapSetInfo> beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst)
+                {
+                }
+
+                public void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst)
+                {
+                }
+
+                public void ProcessObjectCounts(BeatmapInfo beatmapInfo, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst)
+                {
+                }
+
+                public void Dispose()
+                {
+                }
+            }
         }
     }
 }

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         protected override TestOsuGame CreateTestGame() => new NoBeatmapUpdateGame(LocalStorage, API);
 
-        private class NoBeatmapUpdateGame : TestOsuGame
+        private partial class NoBeatmapUpdateGame : TestOsuGame
         {
             public NoBeatmapUpdateGame(Storage storage, IAPIProvider api, string[] args = null)
                 : base(storage, api, args)

--- a/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
+++ b/osu.Game/Beatmaps/BeatmapOnlineChangeIngest.cs
@@ -13,11 +13,11 @@ namespace osu.Game.Beatmaps
     /// </summary>
     public partial class BeatmapOnlineChangeIngest : Component
     {
-        private readonly BeatmapUpdater beatmapUpdater;
+        private readonly IBeatmapUpdater beatmapUpdater;
         private readonly RealmAccess realm;
         private readonly MetadataClient metadataClient;
 
-        public BeatmapOnlineChangeIngest(BeatmapUpdater beatmapUpdater, RealmAccess realm, MetadataClient metadataClient)
+        public BeatmapOnlineChangeIngest(IBeatmapUpdater beatmapUpdater, RealmAccess realm, MetadataClient metadataClient)
         {
             this.beatmapUpdater = beatmapUpdater;
             this.realm = realm;

--- a/osu.Game/Beatmaps/BeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/BeatmapUpdater.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,10 +14,7 @@ using osu.Game.Rulesets.Objects.Types;
 
 namespace osu.Game.Beatmaps
 {
-    /// <summary>
-    /// Handles all processing required to ensure a local beatmap is in a consistent state with any changes.
-    /// </summary>
-    public class BeatmapUpdater : IDisposable
+    public class BeatmapUpdater : IBeatmapUpdater
     {
         private readonly IWorkingBeatmapCache workingBeatmapCache;
 
@@ -38,11 +34,6 @@ namespace osu.Game.Beatmaps
             metadataLookup = new BeatmapUpdaterMetadataLookup(api, storage);
         }
 
-        /// <summary>
-        /// Queue a beatmap for background processing.
-        /// </summary>
-        /// <param name="beatmapSet">The managed beatmap set to update. A transaction will be opened to apply changes.</param>
-        /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
         public void Queue(Live<BeatmapSetInfo> beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst)
         {
             Logger.Log($"Queueing change for local beatmap {beatmapSet}");
@@ -50,11 +41,6 @@ namespace osu.Game.Beatmaps
                 updateScheduler);
         }
 
-        /// <summary>
-        /// Run all processing on a beatmap immediately.
-        /// </summary>
-        /// <param name="beatmapSet">The managed beatmap set to update. A transaction will be opened to apply changes.</param>
-        /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
         public void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst) => beatmapSet.Realm!.Write(_ =>
         {
             // Before we use below, we want to invalidate.

--- a/osu.Game/Beatmaps/IBeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/IBeatmapUpdater.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Database;
+
+namespace osu.Game.Beatmaps
+{
+    /// <summary>
+    /// Handles all processing required to ensure a local beatmap is in a consistent state with any changes.
+    /// </summary>
+    public interface IBeatmapUpdater : IDisposable
+    {
+        /// <summary>
+        /// Queue a beatmap for background processing.
+        /// </summary>
+        /// <param name="beatmapSet">The managed beatmap set to update. A transaction will be opened to apply changes.</param>
+        /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
+        void Queue(Live<BeatmapSetInfo> beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
+
+        /// <summary>
+        /// Run all processing on a beatmap immediately.
+        /// </summary>
+        /// <param name="beatmapSet">The managed beatmap set to update. A transaction will be opened to apply changes.</param>
+        /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
+        void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
+
+        void ProcessObjectCounts(BeatmapInfo beatmapInfo, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
+    }
+}

--- a/osu.Game/Beatmaps/IBeatmapUpdater.cs
+++ b/osu.Game/Beatmaps/IBeatmapUpdater.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Beatmaps
         /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
         void Process(BeatmapSetInfo beatmapSet, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
 
+        /// <summary>
+        /// Runs a subset of processing focused on updating any cached beatmap object counts.
+        /// </summary>
+        /// <param name="beatmapInfo">The managed beatmap to update. A transaction will be opened to apply changes.</param>
+        /// <param name="lookupScope">The preferred scope to use for metadata lookup.</param>
         void ProcessObjectCounts(BeatmapInfo beatmapInfo, MetadataLookupScope lookupScope = MetadataLookupScope.LocalCacheFirst);
     }
 }

--- a/osu.Game/Database/BackgroundDataStoreProcessor.cs
+++ b/osu.Game/Database/BackgroundDataStoreProcessor.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Database
         private RealmAccess realmAccess { get; set; } = null!;
 
         [Resolved]
-        private BeatmapUpdater beatmapUpdater { get; set; } = null!;
+        private IBeatmapUpdater beatmapUpdater { get; set; } = null!;
 
         [Resolved]
         private IBindable<WorkingBeatmap> gameBeatmap { get; set; } = null!;

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -198,7 +198,7 @@ namespace osu.Game
         public readonly Bindable<Dictionary<ModType, IReadOnlyList<Mod>>> AvailableMods = new Bindable<Dictionary<ModType, IReadOnlyList<Mod>>>(new Dictionary<ModType, IReadOnlyList<Mod>>());
 
         private BeatmapDifficultyCache difficultyCache;
-        private BeatmapUpdater beatmapUpdater;
+        private IBeatmapUpdater beatmapUpdater;
 
         private UserLookupCache userCache;
         private BeatmapLookupCache beatmapCache;
@@ -324,7 +324,7 @@ namespace osu.Game
             base.Content.Add(difficultyCache);
 
             // TODO: OsuGame or OsuGameBase?
-            dependencies.CacheAs(beatmapUpdater = new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage));
+            dependencies.CacheAs(beatmapUpdater = CreateBeatmapUpdater());
             dependencies.CacheAs(SpectatorClient = new OnlineSpectatorClient(endpoints));
             dependencies.CacheAs(MultiplayerClient = new OnlineMultiplayerClient(endpoints));
             dependencies.CacheAs(metadataClient = new OnlineMetadataClient(endpoints));
@@ -562,6 +562,8 @@ namespace osu.Game
                 realmBlocker?.Dispose();
             }
         }
+
+        protected virtual IBeatmapUpdater CreateBeatmapUpdater() => new BeatmapUpdater(BeatmapManager, difficultyCache, API, Storage);
 
         protected override UserInputManager CreateUserInputManager() => new OsuUserInputManager();
 


### PR DESCRIPTION
This has been failing for a while now and it's really annoying.

What I speculate (more on this later...) is:
1. The test asserts the correct beatmap is selected based on the game's beatmap.
2. Song select _does not_ finish loading prior to either of the two beatmaps being presented - the global beatmap/ruleset bindable being changed by `OsuGame.PresentBeatmap()`.
3. After the _second_ beatmap is presented, the carousel finishes loading and triggers `carouselBeatmapsLoaded()` and somehow loads the _first_ presented beatmap.
4. Sometimes the test passes because song select loads in time. Sometimes the test passes because song select _never finishes loading_.

Here's some annotated logs from https://github.com/ppy/osu/actions/runs/11699524005/job/32581685084?pr=30525:

```
[verbose]: 🔸 Step #8 all sets imported

----- Presenting first beatmap: 89457bfa (osu!).

[verbose]: 🔸 Step #9 present beatmap
[verbose]: Beginning PresentBeatmap with beatmap Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5)
[verbose]: MainMenu completing PresentBeatmap with beatmap Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5) [SR1] ruleset osu!
[verbose]: Game-wide working beatmap updated to Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5) [SR1]
[verbose]: 📺 OsuScreenStack#303(depth:3) suspended MainMenu#510 (waiting on PlaySongSelect#553)
[verbose]: 📺 OsuScreenStack#303(depth:4) loading PlaySongSelect#553
[verbose]: decoupled ruleset transferred ("" -> "osu!")

----- Song select is now loading and has transferred the ruleset (happens during its BDL).

[verbose]: 🔸 Step #10 wait for song select

----- Even though we've "waited for song select", it is still not loaded.

[verbose]: 🔸 Step #11 recommended beatmap displayed
[verbose]: 📺 OsuScreenStack#303(depth:4) entered PlaySongSelect#553

----- First assertion passes, song select is loaded, but the carousel has not finished loading yet.
----- Presenting second beatmap: 13b38cfd (osu!catch).

[verbose]: 🔸 Step #12 present beatmap
[verbose]: Beginning PresentBeatmap with beatmap Some Artist 4 - Some Song (set id 7528) 13b38cfd-12bf-47c9-aeaa-0998aff2e4bf (Some Guy 7)
[verbose]: Game-wide working beatmap updated to Some Artist 4 - Some Song (set id 7528) 13b38cfd-12bf-47c9-aeaa-0998aff2e4bf (Some Guy 7) [SR2]
[verbose]: Completing PresentBeatmap with beatmap Some Artist 4 - Some Song (set id 7528) 13b38cfd-12bf-47c9-aeaa-0998aff2e4bf (Some Guy 7) ruleset osu!catch

----- Weirdly, it manages to transfer the ruleset here.
      I assume this is happening via LogoArriving(). 

[verbose]: decoupled ruleset transferred ("osu!" -> "osu!catch")
[verbose]: 🔸 Step #13 wait for song select

----- Carousel now finishes loading and selects a random beatmap via carouselBeatmapsLoaded().
      This ends up in 89457bfa (osu!).

[verbose]: Song select updating selection with beatmap: Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5) [SR1] 027a2e93-5a40-47b3-924d-3df2082948be ruleset:fruits
[verbose]: Song select changing beatmap from "Some Artist 4 - Some Song (set id 7528) 13b38cfd-12bf-47c9-aeaa-0998aff2e4bf (Some Guy 7) [SR2]" to "Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5) [SR1]"
[verbose]: Game-wide working beatmap updated to Some Artist 3 - Some Song (set id 7527) 89457bfa-d0ef-4a31-8194-c1b8b7945cca (Some Guy 5) [SR1]

----- Boom.

[verbose]: 🔸 Step #14 recommended beatmap displayed
[verbose]: 💥 Failed (on attempt 1,661)
```

I don't know how to write a practical test nor can I even test my solution, but here's how I've reproduced it (**run only the single test**):
```diff
diff --git a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
index 16c8bc1a6b..fa20b30559 100644
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -10,6 +10,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Extensions;
@@ -18,6 +19,7 @@
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Screens.Select;
 using osu.Game.Tests.Resources;
 using osu.Game.Users;
 
@@ -127,6 +129,7 @@ public void TestBestRulesetIsRecommended()
             presentAndConfirm(() => mixedSet, 3);
         }
 
+        [Solo]
         [Test]
         public void TestSecondBestRulesetIsRecommended()
         {
@@ -141,7 +144,7 @@ public void TestSecondBestRulesetIsRecommended()
             presentAndConfirm(() => osuSet, 1);
 
             // Present mixed difficulty set, expect ruleset with second highest star difficulty
-            presentAndConfirm(() => mixedSet, 2);
+            presentAndConfirm(() => mixedSet, 2, true);
         }
 
         [Test]
@@ -187,11 +190,20 @@ private BeatmapSetInfo importBeatmapSet(IEnumerable<RulesetInfo> difficultyRules
 
         private bool ensureAllBeatmapSetsImported(IEnumerable<BeatmapSetInfo> beatmapSets) => beatmapSets.All(set => set != null);
 
-        private void presentAndConfirm(Func<BeatmapSetInfo> getImport, int expectedDiff)
+        private void presentAndConfirm(Func<BeatmapSetInfo> getImport, int expectedDiff, bool broken = false)
         {
             AddStep("present beatmap", () => Game.PresentBeatmap(getImport()));
 
-            AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect);
+            if (broken)
+            {
+                AddStep("allow load", () => BeatmapCarousel.AllowLoad.Set());
+                AddUntilStep("wait for song select",
+                    () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect ss
+                          && ss.ChildrenOfType<BeatmapCarousel>().SingleOrDefault()?.IsLoaded == true);
+            }
+            else
+                AddUntilStep("wait for song select", () => Game.ScreenStack.CurrentScreen is Screens.Select.SongSelect);
+
             AddUntilStep("recommended beatmap displayed", () => Game.Beatmap.Value.BeatmapInfo.MatchesOnlineID(getImport().Beatmaps[expectedDiff - 1]));
         }
     }
diff --git a/osu.Game/Screens/Select/BeatmapCarousel.cs b/osu.Game/Screens/Select/BeatmapCarousel.cs
index 44f91b4df1..c949a5ec29 100644
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -242,9 +242,15 @@ public BeatmapCarousel(FilterCriteria initialCriterial)
             activeCriteria = initialCriterial;
         }
 
+        public static ManualResetEventSlim AllowLoad = new ManualResetEventSlim();
+
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, AudioManager audio, CancellationToken? cancellationToken)
         {
+#pragma warning disable RS0030
+            AllowLoad.Wait();
+#pragma warning restore RS0030
+
             spinSample = audio.Samples.Get("SongSelect/random-spin");
             randomSelectSample = audio.Samples.Get(@"SongSelect/select-random");
 

```

Could this happen in practice? Maybe? I'm not sure what the resolution is - would likely need @peppy to take over.