### PR TITLE
Fix HUD elements shifting in unintended manner when partially off-screen flipped skin elements are present

### DIFF
--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -300,7 +300,9 @@ namespace osu.Game.Screens.Play
                     if (element is LegacyHealthDisplay)
                         return;
 
-                    float bottom = drawable.ScreenSpaceDrawQuad.BottomRight.Y;
+                    // AABB is used here because the drawable can be flipped/rotated arbitrarily,
+                    // so the "bottom right" corner of the raw SSDQ might not necessarily be where one expects it to be.
+                    float bottom = drawable.ScreenSpaceDrawQuad.AABBFloat.BottomRight.Y;
 
                     bool isRelativeX = drawable.RelativeSizeAxes == Axes.X;
 
@@ -319,7 +321,7 @@ namespace osu.Game.Screens.Play
                 // and align bottom-right components with the top-edge of the highest bottom-anchored hud element.
                 else if (drawable.Anchor.HasFlag(Anchor.BottomRight) || (drawable.Anchor.HasFlag(Anchor.y2) && drawable.RelativeSizeAxes == Axes.X))
                 {
-                    var topLeft = element.ScreenSpaceDrawQuad.TopLeft;
+                    var topLeft = element.ScreenSpaceDrawQuad.AABBFloat.TopLeft;
                     if (highestBottomScreenSpace == null || topLeft.Y < highestBottomScreenSpace.Value.Y)
                         highestBottomScreenSpace = topLeft;
                 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30286.