### PR TITLE
Add `DifficultyCalculationUtils`

### DIFF
--- a/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/Skills/Strain.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mania.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 
@@ -73,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Difficulty.Skills
             // 0.0 +--------+-+---------------> Release Difference / ms
             //         release_threshold
             if (isOverlapping)
-                holdAddition = 1 / (1 + Math.Exp(0.27 * (release_threshold - closestEndTime)));
+                holdAddition = DifficultyCalculationUtils.Logistic(x: closestEndTime, multiplier: 0.27, midpointOffset: release_threshold);
 
             // Decay and increase individualStrains in own column
             individualStrains[column] = applyDecay(individualStrains[column], startTime - startTimes[column], individual_decay_base);

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 
@@ -120,7 +121,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
                                 islandCount.Count++;
 
                             // repeated island (ex: triplet -> triplet)
-                            double power = logistic(island.Delta, 2.75, 0.24, 14);
+                            double power = DifficultyCalculationUtils.Logistic(island.Delta, maxValue: 2.75, multiplier: 0.24, midpointOffset: 58.33);
                             effectiveRatio *= Math.Min(3.0 / islandCount.Count, Math.Pow(1.0 / islandCount.Count, power));
 
                             islandCounts[countIndex] = (islandCount.Island, islandCount.Count);
@@ -171,8 +172,6 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 
             return Math.Sqrt(4 + rhythmComplexitySum * rhythm_overall_multiplier) / 2.0; // produces multiplier that can be applied to strain. range [1, infinity) (not really though)
         }
-
-        private static double logistic(double x, double maxValue, double multiplier, double offset) => (maxValue / (1 + Math.Pow(Math.E, offset - (multiplier * x))));
 
         private class Island : IEquatable<Island>
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/SpeedEvaluator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
 
@@ -10,8 +11,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
 {
     public static class SpeedEvaluator
     {
-        private const double single_spacing_threshold = 125; // 1.25 circles distance between centers
-        private const double min_speed_bonus = 75; // ~200BPM
+        private const double single_spacing_threshold = OsuDifficultyHitObject.NORMALISED_DIAMETER * 1.25; // 1.25 circles distance between centers
+        private const double min_speed_bonus = 200; // 200 BPM 1/4th
         private const double speed_balancing_factor = 40;
         private const double distance_multiplier = 0.94;
 
@@ -43,8 +44,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators
             double speedBonus = 0.0;
 
             // Add additional scaling bonus for streams/bursts higher than 200bpm
-            if (strainTime < min_speed_bonus)
-                speedBonus = 0.75 * Math.Pow((min_speed_bonus - strainTime) / speed_balancing_factor, 2);
+            if (DifficultyCalculationUtils.MillisecondsToBPM(strainTime) > min_speed_bonus)
+                speedBonus = 0.75 * Math.Pow((DifficultyCalculationUtils.BPMToMilliseconds(min_speed_bonus) - strainTime) / speed_balancing_factor, 2);
 
             double travelDistance = osuPrevObj?.TravelDistance ?? 0;
             double distance = travelDistance + osuCurrObj.MinimumJumpDistance;

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         /// A distance by which all distances should be scaled in order to assume a uniform circle size.
         /// </summary>
         public const int NORMALISED_RADIUS = 50; // Change radius to 50 to make 100 the diameter. Easier for mental maths.
+
         public const int NORMALISED_DIAMETER = NORMALISED_RADIUS * 2;
 
         public const int MIN_DELTA_TIME = 25;

--- a/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Preprocessing/OsuDifficultyHitObject.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Preprocessing
         /// A distance by which all distances should be scaled in order to assume a uniform circle size.
         /// </summary>
         public const int NORMALISED_RADIUS = 50; // Change radius to 50 to make 100 the diameter. Easier for mental maths.
+        public const int NORMALISED_DIAMETER = NORMALISED_RADIUS * 2;
 
         public const int MIN_DELTA_TIME = 25;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Colour;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Colour.Data;
@@ -12,25 +13,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
     public class ColourEvaluator
     {
         /// <summary>
-        /// A sigmoid function. It gives a value between (middle - height/2) and (middle + height/2).
-        /// </summary>
-        /// <param name="val">The input value.</param>
-        /// <param name="center">The center of the sigmoid, where the largest gradient occurs and value is equal to middle.</param>
-        /// <param name="width">The radius of the sigmoid, outside of which values are near the minimum/maximum.</param>
-        /// <param name="middle">The middle of the sigmoid output.</param>
-        /// <param name="height">The height of the sigmoid output. This will be equal to max value - min value.</param>
-        private static double sigmoid(double val, double center, double width, double middle, double height)
-        {
-            double sigmoid = Math.Tanh(Math.E * -(val - center) / width);
-            return sigmoid * (height / 2) + middle;
-        }
-
-        /// <summary>
         /// Evaluate the difficulty of the first note of a <see cref="MonoStreak"/>.
         /// </summary>
         public static double EvaluateDifficultyOf(MonoStreak monoStreak)
         {
-            return sigmoid(monoStreak.Index, 2, 2, 0.5, 1) * EvaluateDifficultyOf(monoStreak.Parent) * 0.5;
+            return DifficultyCalculationUtils.Logistic(exponent: Math.E * monoStreak.Index - 2 * Math.E) * EvaluateDifficultyOf(monoStreak.Parent) * 0.5;
         }
 
         /// <summary>
@@ -38,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// </summary>
         public static double EvaluateDifficultyOf(AlternatingMonoPattern alternatingMonoPattern)
         {
-            return sigmoid(alternatingMonoPattern.Index, 2, 2, 0.5, 1) * EvaluateDifficultyOf(alternatingMonoPattern.Parent);
+            return DifficultyCalculationUtils.Logistic(exponent: Math.E * alternatingMonoPattern.Index - 2 * Math.E) * EvaluateDifficultyOf(alternatingMonoPattern.Parent);
         }
 
         /// <summary>
@@ -46,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// </summary>
         public static double EvaluateDifficultyOf(RepeatingHitPatterns repeatingHitPattern)
         {
-            return 2 * (1 - sigmoid(repeatingHitPattern.RepetitionInterval, 2, 2, 0.5, 1));
+            return 2 * (1 - DifficultyCalculationUtils.Logistic(exponent: Math.E * repeatingHitPattern.RepetitionInterval - 2 * Math.E));
         }
 
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)

--- a/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs
+++ b/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Difficulty.Utils
         /// <param name="multiplier">Growth rate of the function</param>
         /// <param name="midpointOffset">How much the function midpoint is offset from zero <paramref name="x"/></param>
         /// <returns>The output of logistic function of <paramref name="x"/></returns>
-        public static double Logistic(double x, double maxValue = 1, double multiplier = 1, double midpointOffset = 0) => maxValue / (1 + Math.Exp(multiplier * (midpointOffset - x)));
+        public static double Logistic(double x, double midpointOffset, double multiplier, double maxValue = 1) => maxValue / (1 + Math.Exp(multiplier * (midpointOffset - x)));
 
         /// <summary>
         /// Calculates a S-shaped logistic function (https://en.wikipedia.org/wiki/Logistic_function)

--- a/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs
+++ b/osu.Game/Rulesets/Difficulty/Utils/DifficultyCalculationUtils.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Game.Rulesets.Difficulty.Utils
+{
+    public static class DifficultyCalculationUtils
+    {
+        /// <summary>
+        /// Converts BPM value into milliseconds
+        /// </summary>
+        /// <param name="bpm">Beats per minute</param>
+        /// <param name="delimiter">Which rhythm delimiter to use, default is 1/4</param>
+        /// <returns>BPM conveted to milliseconds</returns>
+        public static double BPMToMilliseconds(double bpm, int delimiter = 4)
+        {
+            return 60000.0 / delimiter / bpm;
+        }
+
+        /// <summary>
+        /// Converts milliseconds value into a BPM value
+        /// </summary>
+        /// <param name="ms">Milliseconds</param>
+        /// <param name="delimiter">Which rhythm delimiter to use, default is 1/4</param>
+        /// <returns>Milliseconds conveted to beats per minute</returns>
+        public static double MillisecondsToBPM(double ms, int delimiter = 4)
+        {
+            return 60000.0 / (ms * delimiter);
+        }
+
+        /// <summary>
+        /// Calculates a S-shaped logistic function (https://en.wikipedia.org/wiki/Logistic_function)
+        /// </summary>
+        /// <param name="x">Value to calculate the function for</param>
+        /// <param name="maxValue">Maximum value returnable by the function</param>
+        /// <param name="multiplier">Growth rate of the function</param>
+        /// <param name="midpointOffset">How much the function midpoint is offset from zero <paramref name="x"/></param>
+        /// <returns>The output of logistic function of <paramref name="x"/></returns>
+        public static double Logistic(double x, double maxValue = 1, double multiplier = 1, double midpointOffset = 0) => maxValue / (1 + Math.Exp(multiplier * (midpointOffset - x)));
+
+        /// <summary>
+        /// Calculates a S-shaped logistic function (https://en.wikipedia.org/wiki/Logistic_function)
+        /// </summary>
+        /// <param name="maxValue">Maximum value returnable by the function</param>
+        /// <param name="exponent">Exponent</param>
+        /// <returns>The output of logistic function</returns>
+        public static double Logistic(double exponent, double maxValue = 1) => maxValue / (1 + Math.Exp(exponent));
+    }
+}


### PR DESCRIPTION
This refactors some common confusion points (strain to bpm conversions, circle-size-based distances) and adds a common sigmoid implementation. Sigmoid curves were kept the same which resulted in some _unusual_ exponents like `ex-2e`, but values shouldn't change at all (from my limited testing they did not)