### PR TITLE
Implement `Reading` as a skill in osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
@@ -6,46 +6,61 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 {
     public class EffectiveBPMLoader
     {
-        private IBeatmap beatmap;
+        private readonly IBeatmap beatmap;
         private readonly IList<TaikoDifficultyHitObject> noteObjects;
-        private readonly IReadOnlyList<TimingControlPoint?> controlPoints;
-        private readonly double beatmapGlobalSv;
+        private readonly IReadOnlyList<TimingControlPoint?> timingControlPoints;
+        private readonly double globalSliderVelocity;
 
         public EffectiveBPMLoader(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
         {
-            controlPoints = beatmap.ControlPointInfo.TimingPoints;
-            beatmapGlobalSv = beatmap.Difficulty.SliderMultiplier;
             this.beatmap = beatmap;
             this.noteObjects = noteObjects;
+            timingControlPoints = beatmap.ControlPointInfo.TimingPoints;
+            globalSliderVelocity = beatmap.Difficulty.SliderMultiplier;
         }
 
+        /// <summary>
+        /// Calculates and sets the effective BPM for each note object, considering clock rate and scroll speed.
+        /// </summary>
         public void LoadEffectiveBPM(ControlPointInfo controlPointInfo, double clockRate)
         {
-            using IEnumerator<TimingControlPoint?> controlPointEnumerator = controlPoints.GetEnumerator();
+            using var controlPointEnumerator = timingControlPoints.GetEnumerator();
             controlPointEnumerator.MoveNext();
-            TimingControlPoint? currentControlPoint = controlPointEnumerator.Current;
-            TimingControlPoint? nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
-            using IEnumerator<TaikoDifficultyHitObject> noteObjectEnumerator = noteObjects.GetEnumerator();
+            var currentControlPoint = controlPointEnumerator.Current;
+            var nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
 
-            while (noteObjectEnumerator.MoveNext())
+            foreach (var currentNoteObject in noteObjects)
             {
-                TaikoDifficultyHitObject currentNoteObject = noteObjectEnumerator.Current;
+                currentControlPoint = getNextControlPoint(currentNoteObject, currentControlPoint, ref nextControlPoint, controlPointEnumerator);
+                setEffectiveBPMForObject(controlPointInfo, currentNoteObject, currentControlPoint, clockRate);
+            }
+        }
 
-                if (nextControlPoint != null && currentNoteObject.StartTime > nextControlPoint.Time)
-                {
-                    currentControlPoint = nextControlPoint;
-                    nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
-                }
+        /// <summary>
+        /// Advances to the next timing control point if the current note's start time exceeds the current control point's time.
+        /// </summary>
+        private TimingControlPoint? getNextControlPoint(TaikoDifficultyHitObject currentNoteObject, TimingControlPoint? currentControlPoint, ref TimingControlPoint? nextControlPoint, IEnumerator<TimingControlPoint?> controlPointEnumerator)
+        {
+            if (nextControlPoint != null && currentNoteObject.StartTime > nextControlPoint.Time)
+            {
+                currentControlPoint = nextControlPoint;
+                nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
+            }
 
-                // Find the active EffectControlPoint at the start time of the hit object.
-                EffectControlPoint activeEffectControlPoint = controlPointInfo.EffectPointAt(currentNoteObject.StartTime);
+            return currentControlPoint;
+        }
 
+        /// <summary>
+        /// Calculates and sets the effective BPM for the given note object based on the current control point and clock rate.
+        /// </summary>
+        private void setEffectiveBPMForObject(ControlPointInfo controlPointInfo, TaikoDifficultyHitObject currentNoteObject, TimingControlPoint? currentControlPoint, double clockRate)
+        {
+            if (currentControlPoint != null)
+            {
+                var activeEffectControlPoint = controlPointInfo.EffectPointAt(currentNoteObject.StartTime);
                 double currentSliderVelocity = (activeEffectControlPoint?.ScrollSpeed ?? 1.0) * clockRate;
 
-                if (currentControlPoint != null)
-                {
-                    currentNoteObject.EffectiveBPM = currentControlPoint.BPM * beatmapGlobalSv * currentSliderVelocity;
-                }
+                currentNoteObject.EffectiveBPM = currentControlPoint.BPM * globalSliderVelocity * currentSliderVelocity;
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
@@ -9,14 +9,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 {
     public class EffectiveBPMLoader
     {
-        private readonly IBeatmap beatmap;
         private readonly IList<TaikoDifficultyHitObject> noteObjects;
         private readonly IReadOnlyList<TimingControlPoint?> timingControlPoints;
         private readonly double globalSliderVelocity;
 
         public EffectiveBPMLoader(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
         {
-            this.beatmap = beatmap;
             this.noteObjects = noteObjects;
             timingControlPoints = beatmap.ControlPointInfo.TimingPoints;
             globalSliderVelocity = beatmap.Difficulty.SliderMultiplier;
@@ -64,7 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         private double calculateSliderVelocity(ControlPointInfo controlPointInfo, double startTime, double clockRate)
         {
             var activeEffectControlPoint = controlPointInfo.EffectPointAt(startTime);
-            return globalSliderVelocity * (activeEffectControlPoint?.ScrollSpeed ?? 1.0) * clockRate;
+            return globalSliderVelocity * (activeEffectControlPoint.ScrollSpeed) * clockRate;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
             this.noteObjects = noteObjects;
         }
 
-        public void LoadEffectiveBPM(ControlPointInfo controlPointInfo)
+        public void LoadEffectiveBPM(ControlPointInfo controlPointInfo, double clockRate)
         {
             using IEnumerator<TimingControlPoint?> controlPointEnumerator = controlPoints.GetEnumerator();
             controlPointEnumerator.MoveNext();
@@ -40,8 +40,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
                 // Find the active EffectControlPoint at the start time of the hit object.
                 EffectControlPoint activeEffectControlPoint = controlPointInfo.EffectPointAt(currentNoteObject.StartTime);
 
-                // Use the ScrollSpeed from the activeEffectControlPoint.
-                double currentSliderVelocity = activeEffectControlPoint?.ScrollSpeed ?? 1.0; // Fallback to 1.0 if null
+                double currentSliderVelocity = (activeEffectControlPoint?.ScrollSpeed ?? 1.0) * clockRate;
 
                 if (currentControlPoint != null)
                 {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
+
+namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
+{
+    public class EffectiveBPMLoader
+    {
+        private IBeatmap beatmap;
+        private readonly IList<TaikoDifficultyHitObject> noteObjects;
+        private readonly IReadOnlyList<TimingControlPoint?> controlPoints;
+        private readonly double beatmapGlobalSv;
+        private double sliderVelocity = 1.0;
+
+        public EffectiveBPMLoader(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
+        {
+            controlPoints = beatmap.ControlPointInfo.TimingPoints;
+            beatmapGlobalSv = beatmap.Difficulty.SliderMultiplier;
+            this.beatmap = beatmap;
+            this.noteObjects = noteObjects;
+        }
+
+        public void ScrollSpeed(ControlPointInfo controlPointInfo, HitObject hitObject)
+        {
+            // Find the active EffectControlPoint at the start time of the hit object.
+            EffectControlPoint activeEffectControlPoint = controlPointInfo.EffectPointAt(hitObject.StartTime);
+
+            // Use the ScrollSpeed from the activeEffectControlPoint.
+            sliderVelocity = activeEffectControlPoint?.ScrollSpeed ?? 1.0; // Fallback to 1.0 if null
+        }
+
+        public void LoadEffectiveBPM()
+        {
+            using IEnumerator<TimingControlPoint?> controlPointEnumerator = controlPoints.GetEnumerator();
+            controlPointEnumerator.MoveNext();
+            TimingControlPoint? currentControlPoint = controlPointEnumerator.Current;
+            TimingControlPoint? nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
+            using IEnumerator<TaikoDifficultyHitObject> noteObjectEnumerator = noteObjects.GetEnumerator();
+
+            while (noteObjectEnumerator.MoveNext())
+            {
+                TaikoDifficultyHitObject currentNoteObject = noteObjectEnumerator.Current;
+
+                if (nextControlPoint != null && currentNoteObject.StartTime > nextControlPoint.Time)
+                {
+                    currentControlPoint = nextControlPoint;
+                    nextControlPoint = controlPointEnumerator.MoveNext() ? controlPointEnumerator.Current : null;
+                }
+
+                if (currentControlPoint != null)
+                {
+                    currentNoteObject.EffectiveBPM = currentControlPoint.BPM * beatmapGlobalSv * sliderVelocity;
+                }
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMLoader.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
@@ -43,9 +42,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 
                 // Use the ScrollSpeed from the activeEffectControlPoint.
                 double currentSliderVelocity = activeEffectControlPoint?.ScrollSpeed ?? 1.0; // Fallback to 1.0 if null
-
-                // Print out the slider velocity for debugging.
-                Console.WriteLine($"Slider velocity for hit object at time {currentNoteObject.StartTime}: {currentSliderVelocity}");
 
                 if (currentControlPoint != null)
                 {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMPreprocessor.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMPreprocessor.cs
@@ -7,13 +7,13 @@ using osu.Game.Beatmaps.ControlPoints;
 
 namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
 {
-    public class EffectiveBPMLoader
+    public class EffectiveBPMPreprocessor
     {
         private readonly IList<TaikoDifficultyHitObject> noteObjects;
         private readonly IReadOnlyList<TimingControlPoint?> timingControlPoints;
         private readonly double globalSliderVelocity;
 
-        public EffectiveBPMLoader(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
+        public EffectiveBPMPreprocessor(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
         {
             this.noteObjects = noteObjects;
             timingControlPoints = beatmap.ControlPointInfo.TimingPoints;
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
                 double currentSliderVelocity = calculateSliderVelocity(controlPointInfo, currentNoteObject.StartTime, clockRate);
                 currentNoteObject.CurrentSliderVelocity = currentSliderVelocity;
 
-                setEffectiveBPMForObject(currentNoteObject, currentControlPoint, currentSliderVelocity);
+                calculateEffectiveBPM(currentNoteObject, currentControlPoint, currentSliderVelocity);
             }
         }
 
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         /// <summary>
         /// Sets the effective BPM for the given note object.
         /// </summary>
-        private void setEffectiveBPMForObject(TaikoDifficultyHitObject currentNoteObject, TimingControlPoint? currentControlPoint, double currentSliderVelocity)
+        private void calculateEffectiveBPM(TaikoDifficultyHitObject currentNoteObject, TimingControlPoint? currentControlPoint, double currentSliderVelocity)
         {
             if (currentControlPoint != null)
             {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMPreprocessor.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/EffectiveBPMPreprocessor.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         /// <summary>
         /// Calculates and sets the effective BPM and slider velocity for each note object, considering clock rate and scroll speed.
         /// </summary>
-        public void LoadEffectiveBPM(ControlPointInfo controlPointInfo, double clockRate)
+        public void ProcessEffectiveBPM(ControlPointInfo controlPointInfo, double clockRate)
         {
             foreach (var currentNoteObject in noteObjects)
             {

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -22,6 +22,9 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         /// </summary>
         private readonly IReadOnlyList<TaikoDifficultyHitObject>? monoDifficultyHitObjects;
 
+        /// Effective BPM of the object, required for reading difficulty calculation
+        public double EffectiveBPM;
+
         /// <summary>
         /// The index of this <see cref="TaikoDifficultyHitObject"/> in <see cref="monoDifficultyHitObjects"/>.
         /// </summary>
@@ -41,6 +44,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         /// The rhythm required to hit this hit object.
         /// </summary>
         public readonly TaikoDifficultyHitObjectRhythm Rhythm;
+
+        /// <summary>
+        /// The reading required to hit this hit object.
+        /// </summary>
+        public readonly TaikoDifficultyHitObject Reading;
 
         /// <summary>
         /// Colour data for this hit object. This is used by colour evaluator to calculate colour difficulty, but can be used

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -22,8 +22,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         /// </summary>
         private readonly IReadOnlyList<TaikoDifficultyHitObject>? monoDifficultyHitObjects;
 
-        /// Effective BPM of the object, required for reading difficulty calculation
+        // Effective BPM of this hit object.
         public double EffectiveBPM;
+
+        // Slider Velocity of this hit object.
+        public double CurrentSliderVelocity;
 
         /// <summary>
         /// The index of this <see cref="TaikoDifficultyHitObject"/> in <see cref="monoDifficultyHitObjects"/>.

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -46,11 +46,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         public readonly TaikoDifficultyHitObjectRhythm Rhythm;
 
         /// <summary>
-        /// The reading required to hit this hit object.
-        /// </summary>
-        public readonly TaikoDifficultyHitObject Reading;
-
-        /// <summary>
         /// Colour data for this hit object. This is used by colour evaluator to calculate colour difficulty, but can be used
         /// by other skills in the future.
         /// </summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -68,7 +68,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             const double density_max = 150;
             const double density_min = 50;
 
-            // The midpoint of the range for the sigmoid function, where the transition is most significant.
             const double center = 200;
             const double range = 300;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             TaikoDifficultyHitObject hitObject = (TaikoDifficultyHitObject)current;
 
             double sliderVelocityBonus = calculateHighVelocityBonus(hitObject.EffectiveBPM);
-            ObjectDensity = calculateObjectDensity(current.DeltaTime);
+            ObjectDensity = calculateObjectDensity(current.DeltaTime, hitObject.EffectiveBPM);
 
             return high_sv_multiplier * sliderVelocityBonus;
         }
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             return sigmoid(effectiveBPM, center, range);
         }
 
-        private double calculateObjectDensity(double deltaTime)
+        private double calculateObjectDensity(double deltaTime, double effectiveBPM)
         {
             // The maximum and minimum center value for density.
             const double density_max = 150;
@@ -73,11 +73,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
 
             // Adjusts the penalty for low SV based on object density.
             return density_max - (density_max - density_min) *
-                sigmoid(deltaTime, center, range);
+                sigmoid(effectiveBPM - (deltaTime / 2), center, range);
         }
 
         /// <summary>
         /// Calculates a smooth transition using a sigmoid function.
+        /// <param name="value">The input value</param>
         /// <param name="center">The midpoint of the curve where the output transitions most rapidly.</param>
         /// <param name="range">Determines how steep or gradual the curve is around the center.</param>
         /// </summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -1,5 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
+
 using System;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -39,7 +39,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         {
             TaikoDifficultyHitObject hitObject = (TaikoDifficultyHitObject)current;
 
-            // Calculate High SV and Low SV Object Density,
             double sliderVelocityBonus = calculateHighVelocityBonus(hitObject.EffectiveBPM);
             ObjectDensity = calculateObjectDensity(current.DeltaTime);
 
@@ -53,6 +52,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         /// </summary>
         private double calculateHighVelocityBonus(double effectiveBPM)
         {
+            // The maximum and minimum center value for the impact of EffectiveBPM.
             const double velocity_max = 640;
             const double velocity_min = 480;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -12,10 +12,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         protected override double SkillMultiplier => 1.0;
         protected override double StrainDecayBase => 0.4;
 
+        public static double LowSvBonus;
+        public static double HighSvBonus;
+        public static double ObjectDensity;
+
         private double currentStrain;
 
-        private const double high_sv_multiplier = 1;
-        private const double low_sv_multiplier = 0.25;
+        private const double high_sv_multiplier = 1.0;
+        private const double low_sv_multiplier = 1.0;
 
         /// <summary>
         /// Creates a <see cref="Rhythm"/> skill.
@@ -51,19 +55,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             const double low_sv_delta_time_range = 300; // The range for the transition around the delta time.
 
             // Center range for low SV adjustment based on hit object density.
-            const double low_sv_max_center = 200; // Upper bound for low SV adjustment.
-            const double low_sv_min_center = 100; // Lower bound for low SV adjustment.
-            const double low_sv_range = 100; // Reduced range to make the impact more abrupt at very low SVs.
+            const double low_sv_max_center = 150; // Upper bound for low SV adjustment.
+            const double low_sv_min_center = 50; // Lower bound for low SV adjustment.
+            const double low_sv_range = 240; // Reduced range to make the impact more abrupt at very low SVs.
 
             // Calculate the adjusted center for low SV influence based on object density.
-            double objectDensity = low_sv_max_center - (low_sv_max_center - low_sv_min_center)
+            ObjectDensity = low_sv_max_center - (low_sv_max_center - low_sv_min_center)
                 * sigmoid(current.DeltaTime, low_sv_delta_time_center, low_sv_delta_time_range);
 
             // Calculate bonuses based on high and low SV impact.
-            double highSvBonus = sigmoid(hitObject.EffectiveBPM, high_sv_center, high_sv_range);
-            double lowSvBonus = 1 - sigmoid(hitObject.EffectiveBPM, objectDensity, low_sv_range);
+            HighSvBonus = sigmoid(hitObject.EffectiveBPM, high_sv_center, high_sv_range);
+            LowSvBonus = 1 - sigmoid(hitObject.EffectiveBPM, ObjectDensity, low_sv_range);
 
-            return high_sv_multiplier * highSvBonus + low_sv_multiplier * lowSvBonus;
+            return high_sv_multiplier * HighSvBonus; // No bonuses to lowSV within starRating.
         }
 
         private double sigmoid(double value, double center, double range)

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -29,12 +29,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         protected override double StrainValueOf(DifficultyHitObject current)
         {
             currentStrain *= StrainDecayBase;
-            currentStrain += readingBonus(current) * SkillMultiplier;
+            currentStrain += reading(current) * SkillMultiplier;
 
             return currentStrain;
         }
 
-        private double readingBonus(DifficultyHitObject current)
+        private double reading(DifficultyHitObject current)
         {
             TaikoDifficultyHitObject hitObject = (TaikoDifficultyHitObject)current;
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -12,14 +12,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         protected override double SkillMultiplier => 1.0;
         protected override double StrainDecayBase => 0.4;
 
-        public static double LowSvBonus;
         public static double HighSvBonus;
         public static double ObjectDensity;
 
         private double currentStrain;
 
         private const double high_sv_multiplier = 1.0;
-        private const double low_sv_multiplier = 1.0;
 
         /// <summary>
         /// Creates a <see cref="Rhythm"/> skill.
@@ -57,7 +55,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             // Center range for low SV adjustment based on hit object density.
             const double low_sv_max_center = 150; // Upper bound for low SV adjustment.
             const double low_sv_min_center = 50; // Lower bound for low SV adjustment.
-            const double low_sv_range = 240; // Reduced range to make the impact more abrupt at very low SVs.
 
             // Calculate the adjusted center for low SV influence based on object density.
             ObjectDensity = low_sv_max_center - (low_sv_max_center - low_sv_min_center)
@@ -65,7 +62,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
 
             // Calculate bonuses based on high and low SV impact.
             HighSvBonus = sigmoid(hitObject.EffectiveBPM, high_sv_center, high_sv_range);
-            LowSvBonus = 1 - sigmoid(hitObject.EffectiveBPM, ObjectDensity, low_sv_range);
 
             return high_sv_multiplier * HighSvBonus; // No bonuses to lowSV within starRating.
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+using System;
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
+namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
+{
+    public class Reading : StrainDecaySkill
+    {
+        protected override double SkillMultiplier => 1.0;
+        protected override double StrainDecayBase => 0.4;
+
+        private double currentStrain;
+
+        private const double high_sv_multiplier = 1;
+        private const double low_sv_multiplier = 1;
+
+        /// <summary>
+        /// Creates a <see cref="Rhythm"/> skill.
+        /// </summary>
+        /// <param name="mods">Mods for use in skill calculations.</param>
+        public Reading(Mod[] mods)
+            : base(mods)
+        {
+        }
+
+        protected override double StrainValueOf(DifficultyHitObject current)
+        {
+            currentStrain *= StrainDecayBase;
+            currentStrain += readingBonus(current) * SkillMultiplier;
+
+            return currentStrain;
+        }
+
+        private double readingBonus(DifficultyHitObject current)
+        {
+            TaikoDifficultyHitObject hitObject = (TaikoDifficultyHitObject)current;
+
+            // High SV Variables
+            const double high_sv_upper_bound = 640;
+            const double high_sv_lower_bound = 480;
+
+            const double high_sv_center = (high_sv_upper_bound + high_sv_lower_bound) / 2;
+            const double high_sv_width = high_sv_upper_bound - high_sv_lower_bound;
+
+            // Low SV Variables
+            const double low_sv_delta_time_center = 200;
+            const double low_sv_delta_time_width = 300;
+
+            // Maximum center for low sv (for high density)
+            const double low_sv_center_upper_bound = 200;
+
+            // Minimum center for low sv (for low density)
+            const double low_sv_center_lower_bound = 100;
+            const double low_sv_width = 160;
+
+            // Calculate low sv center, considering density
+            double lowSvCenter = low_sv_center_upper_bound - (low_sv_center_upper_bound - low_sv_center_lower_bound) * this.sigmoid(current.DeltaTime, low_sv_delta_time_center, low_sv_delta_time_width);
+            double highSvBonus = sigmoid(hitObject.EffectiveBPM, high_sv_center, high_sv_width);
+            double lowSvBonus = 1 - sigmoid(hitObject.EffectiveBPM, lowSvCenter, low_sv_width);
+
+            return high_sv_multiplier * highSvBonus + low_sv_multiplier * lowSvBonus;
+        }
+
+        private double sigmoid(double value, double center, double width)
+        {
+            width /= 10;
+            return 1 / (1 + Math.Exp(-(value - center) / width));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -22,9 +22,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
         private const double high_sv_multiplier = 1.0;
 
         /// <summary>
-        /// Creates a <see cref="Rhythm"/> skill.
+        /// Creates a <see cref="Reading"/> skill.
         /// </summary>
-        /// <param name="mods">Mods for use in skill calculations.</param>
         public Reading(Mod[] mods)
             : base(mods)
         {
@@ -49,7 +48,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
 
             // Only return a difficulty value when the Object isn't a Spinner or a Slider.
             double sliderVelocityBonus = calculateHighVelocityBonus(noteObject.EffectiveBPM);
-            ObjectDensity = calculateObjectDensity(noteObject.DeltaTime, noteObject.EffectiveBPM, noteObject.CurrentSliderVelocity);
+            ObjectDensity = calculateObjectDensity(noteObject.DeltaTime, noteObject.CurrentSliderVelocity);
 
             return high_sv_multiplier * sliderVelocityBonus;
         }
@@ -71,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
             return sigmoid(effectiveBPM, center, range);
         }
 
-        private double calculateObjectDensity(double deltaTime, double effectiveBPM, double currentSliderVelocity)
+        private double calculateObjectDensity(double deltaTime, double currentSliderVelocity)
         {
             // The maximum and minimum center value for density.
             const double density_max = 300;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -64,6 +64,15 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("ok_hit_window")]
         public double OkHitWindow { get; set; }
 
+        [JsonProperty("hit_object_density")]
+        public double ObjectDensity { get; set; }
+
+        [JsonProperty("high_sv_bonus")]
+        public double HighSVBonus { get; set; }
+
+        [JsonProperty("low_sv_bonus")]
+        public double LowSVBonus { get; set; }
+
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {
             foreach (var v in base.ToDatabaseAttributes())

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -29,6 +29,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public double RhythmDifficulty { get; set; }
 
         /// <summary>
+        /// The difficulty corresponding to the reading skill.
+        /// </summary>
+        [JsonProperty("reading_difficulty")]
+        public double ReadingDifficulty { get; set; }
+
+        /// <summary>
         /// The difficulty corresponding to the colour skill.
         /// </summary>
         [JsonProperty("colour_difficulty")]

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -64,14 +64,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         [JsonProperty("ok_hit_window")]
         public double OkHitWindow { get; set; }
 
+        /// <summary>
+        /// The calculated object density for a beatmap. Scaled based on the time between consecutive objects.
+        /// </summary>
         [JsonProperty("hit_object_density")]
         public double ObjectDensity { get; set; }
-
-        [JsonProperty("high_sv_bonus")]
-        public double HighSVBonus { get; set; }
-
-        [JsonProperty("low_sv_bonus")]
-        public double LowSVBonus { get; set; }
 
         public override IEnumerable<(int attributeId, object value)> ToDatabaseAttributes()
         {

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using osu.Game.Beatmaps;
@@ -79,6 +80,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             yield return (ATTRIB_ID_GREAT_HIT_WINDOW, GreatHitWindow);
             yield return (ATTRIB_ID_OK_HIT_WINDOW, OkHitWindow);
             yield return (ATTRIB_ID_MONO_STAMINA_FACTOR, MonoStaminaFactor);
+            yield return (ATTRIB_ID_OBJECT_DENSITY, ObjectDensity);
         }
 
         public override void FromDatabaseAttributes(IReadOnlyDictionary<int, double> values, IBeatmapOnlineInfo onlineInfo)
@@ -89,6 +91,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             GreatHitWindow = values[ATTRIB_ID_GREAT_HIT_WINDOW];
             OkHitWindow = values[ATTRIB_ID_OK_HIT_WINDOW];
             MonoStaminaFactor = values[ATTRIB_ID_MONO_STAMINA_FACTOR];
+            ObjectDensity = values[ATTRIB_ID_OBJECT_DENSITY];
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,6 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private const double rhythm_skill_multiplier = 0.2 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.375 * difficulty_multiplier;
+        private const double reading_skill_multiplier = 0.0395 * difficulty_multiplier;
 
         public override int Version => 20241007;
 
@@ -88,7 +89,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
-            double readingRating = reading.DifficultyValue();
+            double readingRating = reading.DifficultyValue() * reading_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -86,17 +86,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             Stamina stamina = (Stamina)skills.First(x => x is Stamina);
             Reading reading = (Reading)skills.First(x => x is Reading);
             Stamina singleColourStamina = (Stamina)skills.Last(x => x is Stamina);
-
-            // Reading related
-            double objectDensity = Reading.ObjectDensity;
-            double highSvBonus = Reading.HighSvBonus;
-
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
             double readingRating = reading.DifficultyValue() * reading_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
+            double objectDensity = Reading.ObjectDensity;
 
             double combinedRating = combinedDifficultyValue(rhythm, colour, stamina, reading);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             }
 
             TaikoColourDifficultyPreprocessor.ProcessAndAssign(difficultyHitObjects);
-            bpmLoader.LoadEffectiveBPM(beatmap.ControlPointInfo);
+            bpmLoader.LoadEffectiveBPM(beatmap.ControlPointInfo, clockRate);
 
             return difficultyHitObjects;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private const double rhythm_skill_multiplier = 0.2 * difficulty_multiplier;
         private const double colour_skill_multiplier = 0.375 * difficulty_multiplier;
         private const double stamina_skill_multiplier = 0.375 * difficulty_multiplier;
-        private double readingSkillMultiplier = 0.1185 * difficulty_multiplier;
+        private const double reading_skill_multiplier = 0.1385 * difficulty_multiplier;
 
         public override int Version => 20241007;
 
@@ -87,9 +87,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             Reading reading = (Reading)skills.First(x => x is Reading);
             Stamina singleColourStamina = (Stamina)skills.Last(x => x is Stamina);
 
+            // Reading related
+            double objectDensity = Reading.ObjectDensity;
+            double highSvBonus = Reading.HighSvBonus;
+            double lowSvBonus = Reading.LowSvBonus;
+
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
-            double readingRating = reading.DifficultyValue() * readingSkillMultiplier;
+            double readingRating = reading.DifficultyValue() * reading_skill_multiplier;
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
@@ -119,6 +124,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 ReadingDifficulty = readingRating,
                 ColourDifficulty = colourRating,
                 PeakDifficulty = combinedRating,
+                // Reading Related
+                ObjectDensity = objectDensity,
+                HighSVBonus = highSvBonus,
+                LowSVBonus = lowSvBonus,
+                // Accuracy Related
                 GreatHitWindow = hitWindows.WindowFor(HitResult.Great) / clockRate,
                 OkHitWindow = hitWindows.WindowFor(HitResult.Ok) / clockRate,
                 MaxCombo = beatmap.GetMaxCombo(),
@@ -159,7 +169,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 double colourPeak = colourPeaks[i] * colour_skill_multiplier;
                 double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier;
                 double staminaPeak = staminaPeaks[i] * stamina_skill_multiplier;
-                double readingPeak = readingPeaks[i] * readingSkillMultiplier;
+                double readingPeak = readingPeaks[i] * reading_skill_multiplier;
 
                 double peak = norm(1.5, colourPeak, staminaPeak);
                 peak = norm(2, peak, rhythmPeak, readingPeak);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             {
                 new Rhythm(mods),
                 new Colour(mods),
+                new Reading(mods),
                 new Stamina(mods, false),
                 new Stamina(mods, true)
             };
@@ -57,6 +58,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             List<TaikoDifficultyHitObject> centreObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> rimObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> noteObjects = new List<TaikoDifficultyHitObject>();
+            EffectiveBPMLoader bpmLoader = new EffectiveBPMLoader(beatmap, noteObjects);
 
             for (int i = 2; i < beatmap.HitObjects.Count; i++)
             {
@@ -68,6 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             }
 
             TaikoColourDifficultyPreprocessor.ProcessAndAssign(difficultyHitObjects);
+            bpmLoader.LoadEffectiveBPM();
 
             return difficultyHitObjects;
         }
@@ -80,10 +83,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             Colour colour = (Colour)skills.First(x => x is Colour);
             Rhythm rhythm = (Rhythm)skills.First(x => x is Rhythm);
             Stamina stamina = (Stamina)skills.First(x => x is Stamina);
+            Reading reading = (Reading)skills.First(x => x is Reading);
             Stamina singleColourStamina = (Stamina)skills.Last(x => x is Stamina);
 
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
+            double readingRating = reading.DifficultyValue();
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
@@ -110,6 +115,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 StaminaDifficulty = staminaRating,
                 MonoStaminaFactor = monoStaminaFactor,
                 RhythmDifficulty = rhythmRating,
+                ReadingDifficulty = readingRating,
                 ColourDifficulty = colourRating,
                 PeakDifficulty = combinedRating,
                 GreatHitWindow = hitWindows.WindowFor(HitResult.Great) / clockRate,

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             }
 
             TaikoColourDifficultyPreprocessor.ProcessAndAssign(difficultyHitObjects);
-            bpmLoader.LoadEffectiveBPM();
+            bpmLoader.LoadEffectiveBPM(beatmap.ControlPointInfo);
 
             return difficultyHitObjects;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -90,7 +90,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // Reading related
             double objectDensity = Reading.ObjectDensity;
             double highSvBonus = Reading.HighSvBonus;
-            double lowSvBonus = Reading.LowSvBonus;
 
             double colourRating = colour.DifficultyValue() * colour_skill_multiplier;
             double rhythmRating = rhythm.DifficultyValue() * rhythm_skill_multiplier;
@@ -124,11 +123,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 ReadingDifficulty = readingRating,
                 ColourDifficulty = colourRating,
                 PeakDifficulty = combinedRating,
-                // Reading Related
                 ObjectDensity = objectDensity,
-                HighSVBonus = highSvBonus,
-                LowSVBonus = lowSvBonus,
-                // Accuracy Related
                 GreatHitWindow = hitWindows.WindowFor(HitResult.Great) / clockRate,
                 OkHitWindow = hitWindows.WindowFor(HitResult.Ok) / clockRate,
                 MaxCombo = beatmap.GetMaxCombo(),

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double staminaRating = stamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaRating = singleColourStamina.DifficultyValue() * stamina_skill_multiplier;
             double monoStaminaFactor = staminaRating == 0 ? 1 : Math.Pow(monoStaminaRating / staminaRating, 5);
-            double objectDensity = Reading.ObjectDensity;
+            double objectDensity = reading.ObjectDensity;
 
             double combinedRating = combinedDifficultyValue(rhythm, colour, stamina, reading);
             double starRating = rescale(combinedRating * 1.4);

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -103,7 +103,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 starRating *= 0.925;
                 // For maps with low colour variance and high stamina requirement, multiple inputs are more likely to be abused.
                 if (colourRating < 2 && staminaRating > 8)
-                    starRating *= 0.80;
+                    starRating *= 0.90;
             }
 
             HitWindows hitWindows = new TaikoHitWindows();

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             List<TaikoDifficultyHitObject> centreObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> rimObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> noteObjects = new List<TaikoDifficultyHitObject>();
-            EffectiveBPMLoader bpmLoader = new EffectiveBPMLoader(beatmap, noteObjects);
+            EffectiveBPMPreprocessor bpmLoader = new EffectiveBPMPreprocessor(beatmap, noteObjects);
 
             for (int i = 2; i < beatmap.HitObjects.Count; i++)
             {
@@ -100,10 +100,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             // TODO: This is temporary measure as we don't detect abuse of multiple-input playstyles of converts within the current system.
             if (beatmap.BeatmapInfo.Ruleset.OnlineID == 0)
             {
-                starRating *= 0.925;
+                starRating *= 0.90;
                 // For maps with low colour variance and high stamina requirement, multiple inputs are more likely to be abused.
                 if (colourRating < 2 && staminaRating > 8)
-                    starRating *= 0.90;
+                    starRating *= 0.80;
             }
 
             HitWindows hitWindows = new TaikoHitWindows();

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             List<TaikoDifficultyHitObject> centreObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> rimObjects = new List<TaikoDifficultyHitObject>();
             List<TaikoDifficultyHitObject> noteObjects = new List<TaikoDifficultyHitObject>();
-            EffectiveBPMPreprocessor bpmLoader = new EffectiveBPMPreprocessor(beatmap, noteObjects);
+            EffectiveBPMPreprocessor noteObjectEffectiveBPM = new EffectiveBPMPreprocessor(beatmap, noteObjects);
 
             for (int i = 2; i < beatmap.HitObjects.Count; i++)
             {
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             }
 
             TaikoColourDifficultyPreprocessor.ProcessAndAssign(difficultyHitObjects);
-            bpmLoader.LoadEffectiveBPM(beatmap.ControlPointInfo, clockRate);
+            noteObjectEffectiveBPM.ProcessEffectiveBPM(beatmap.ControlPointInfo, clockRate);
 
             return difficultyHitObjects;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -94,7 +94,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             // Scale accuracy more harshly on nearly-completely mono (single coloured) speed maps.
             double accScalingExponent = 2 + attributes.MonoStaminaFactor;
-            double accScalingShift = 300 - 100 * attributes.MonoStaminaFactor;
+            double accScalingShift = 400 - 100 * attributes.MonoStaminaFactor;
 
             return difficultyValue * Math.Pow(SpecialFunctions.Erf(accScalingShift / (Math.Sqrt(2) * estimatedUnstableRate.Value)), accScalingExponent);
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -86,9 +86,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;
 
-            if (score.Mods.Any(m => m is ModHardRock))
-                difficultyValue *= 1.10;
-
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);
 

--- a/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyAttributes.cs
@@ -30,6 +30,7 @@ namespace osu.Game.Rulesets.Difficulty
         protected const int ATTRIB_ID_AIM_DIFFICULT_STRAIN_COUNT = 25;
         protected const int ATTRIB_ID_OK_HIT_WINDOW = 27;
         protected const int ATTRIB_ID_MONO_STAMINA_FACTOR = 29;
+        protected const int ATTRIB_ID_OBJECT_DENSITY = 31;
 
         /// <summary>
         /// The mods which were applied to the beatmap.


### PR DESCRIPTION
Introduces the Reading Skill and EffectiveBPM for osu!taiko. The main takeaway is high SV (Slider Velocity) gives a bonus based on a per-object effectiveBPM. This does also mean HR now gives an SR Bonus, however its fixed difficulty pp multiplier has been removed to offset these changes. Similarly, the convert pp nerf has been slightly shifted alongside the addition of reading.

Low SV does not contain considerations within this build. This is primarily due to continued discussions about its impact on pp vs its impact on sr when it comes to mods like hidden and flashlight.

- Uses a sigmoid function to calculate the influence of high SV on difficulty. The function’s centre is around a predefined effective BPM range, 
- Incorporates a calculation for object density based on `DeltaTime`. this currently is only utilised as an attribute but provides a data value for future HD and FL considerations.
- `LoadEffectiveBPM`: Retrieves the current slider velocity from `scroll_speed` by object. My access methods may be a little messy, however.

**Changes are viewable at [Huismetbenen](https://pp.huismetbenen.nl/rankings/topscores/taiko_reading)**

Should #30536 get merged `DifficultyCalculationUtils` can be used instead for the sigmoid.