### PR TITLE
Fix up + improve CI test reporting workflow

### DIFF
--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -5,33 +5,40 @@
 name: Annotate CI run with test results
 on:
   workflow_run:
-    workflows: ["Continuous Integration"]
+    workflows: [ "Continuous Integration" ]
     types:
       - completed
-permissions: {}
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
 jobs:
   annotate:
-    permissions:
-      checks: write # to create checks (dorny/test-reporter)
-
     name: Annotate CI run with test results
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
-    strategy:
-       fail-fast: false
-       matrix:
-          os:
-            - { prettyname: Windows }
-            - { prettyname: macOS }
-            - { prettyname: Linux }
-          threadingMode: ['SingleThread', 'MultiThreaded']
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: osu-test-results-*
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
       - name: Annotate CI run with test results
         uses: dorny/test-reporter@v1.8.0
         with:
-          artifact: osu-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
-          name: Test Results (${{matrix.os.prettyname}}, ${{matrix.threadingMode}})
+          name: Results
           path: "*.trx"
           reporter: dotnet-trx
           list-suites: 'failed'


### PR DESCRIPTION
GitHub issued a deprecation warning for `actions/upload-artifact@v3`, so we upgraded to v4. This now uses Azure Blob Storage with SAS, which the [`dorny/test-reporter`](https://github.com/dorny/test-reporter) action seems to not be compatible with likely because it passes the `Authorization` header that is no longer required.

To fix this I've rewritten the workflow so that it uses `actions/download-artifact` to download the results, with the test reporter now running on local files.

In the process I've refactored it to run once per execution which comes with the benefit of deduping annotations.

See example: https://github.com/smoogipoo/osu/actions/runs/11735233749/job/32693913350