### PR TITLE
Fix retry button on storage unavailable dialog not reopening realm if retry succeeds

### DIFF
--- a/osu.Game/Screens/Menu/StorageErrorDialog.cs
+++ b/osu.Game/Screens/Menu/StorageErrorDialog.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
@@ -15,6 +16,9 @@ namespace osu.Game.Screens.Menu
     {
         [Resolved]
         private IDialogOverlay dialogOverlay { get; set; } = null!;
+
+        [Resolved]
+        private RealmAccess realmAccess { get; set; } = null!;
 
         public StorageErrorDialog(OsuStorage storage, OsuStorageError error)
         {
@@ -35,7 +39,15 @@ namespace osu.Game.Screens.Menu
                             Text = StorageErrorDialogStrings.TryAgain,
                             Action = () =>
                             {
-                                if (!storage.TryChangeToCustomStorage(out var nextError))
+                                bool success;
+                                OsuStorageError nextError;
+
+                                // blocking all operations has a side effect of closing & reopening the realm db,
+                                // which is desirable here since the restoration of the old storage - if it succeeds - means the realm db has moved.
+                                using (realmAccess.BlockAllOperations(@"restoration of previously unavailable storage"))
+                                    success = storage.TryChangeToCustomStorage(out nextError);
+
+                                if (!success)
                                     dialogOverlay.Push(new StorageErrorDialog(storage, nextError));
                             }
                         },


### PR DESCRIPTION
Related: https://github.com/ppy/osu/issues/30539

When starting up the game with a data location that points to an unavailable external device, a new realm file is created in the default location. Eventually a popup is shown that informs the user that the external storage is unavailable, and the user has an option to try the storage again. The button that invokes said option would check said storage correctly, but would not do anything about realm, which means the previously opened empty realm that is placed in the default location would remain open, which means the retry essentially doesn't work because the user's stuff isn't there after the retry.

To fix this, take out a `BlockAllOperations()`, which will flush all open realms, and re-open the realm on the external location if the custom storage restore succeeds.

Tested on linux using an external usb stick.