### PR TITLE
Split diffcalc workflow to add concurrency group

### DIFF
--- a/.github/workflows/_diffcalc_processor.yml
+++ b/.github/workflows/_diffcalc_processor.yml
@@ -1,0 +1,250 @@
+name: "🔒Run diffcalc runner"
+
+on:
+  workflow_call:
+    inputs:
+      id:
+        type: string
+      head-sha:
+        type: string
+      pr-url:
+        type: string
+      pr-text:
+        type: string
+      dispatch-inputs:
+        type: string
+    outputs:
+      target:
+        description: The comparison target.
+        value: ${{ jobs.generator.outputs.target }}
+      sheet:
+        description: The comparison spreadsheet.
+        value: ${{ jobs.generator.outputs.sheet }}
+    secrets:
+      DIFFCALC_GOOGLE_CREDENTIALS:
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  GENERATOR_DIR: ${{ github.workspace }}/${{ inputs.id }}
+  GENERATOR_ENV: ${{ github.workspace }}/${{ inputs.id }}/.env
+
+jobs:
+  environment:
+    name: Setup environment
+    runs-on: self-hosted
+    steps:
+      - name: Checkout diffcalc-sheet-generator
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.id }}
+          repository: 'smoogipoo/diffcalc-sheet-generator'
+
+      - name: Add base environment
+        env:
+          GOOGLE_CREDS_FILE: ${{ github.workspace }}/${{ inputs.id }}/google-credentials.json
+          VARS_JSON: ${{ (vars != null && toJSON(vars)) || '' }}
+        run: |
+          # Required by diffcalc-sheet-generator
+          cp '${{ env.GENERATOR_DIR }}/.env.sample' "${{ env.GENERATOR_ENV }}"
+
+          # Add Google credentials
+          echo '${{ secrets.DIFFCALC_GOOGLE_CREDENTIALS }}' | base64 -d > "${{ env.GOOGLE_CREDS_FILE }}"
+
+          # Add repository variables
+          echo "${VARS_JSON}" | jq -c '. | to_entries | .[]' | while read -r line; do
+              opt=$(jq -r '.key' <<< ${line})
+              val=$(jq -r '.value' <<< ${line})
+
+              if [[ "${opt}" =~ ^DIFFCALC_ ]]; then
+                optNoPrefix=$(echo "${opt}" | cut -d '_' -f2-)
+                sed -i "s;^${optNoPrefix}=.*$;${optNoPrefix}=${val};" "${{ env.GENERATOR_ENV }}"
+              fi
+          done
+
+      - name: Add HEAD environment
+        run: |
+          sed -i "s;^OSU_A=.*$;OSU_A=${{ inputs.head-sha }};" "${{ env.GENERATOR_ENV }}"
+
+      - name: Add pull-request environment
+        if: ${{ inputs.pr-url != '' }}
+        run: |
+          sed -i "s;^OSU_B=.*$;OSU_B=${{ inputs.pr-url }};" "${{ env.GENERATOR_ENV }}"
+
+      - name: Add comment environment
+        if: ${{ inputs.pr-text != '' }}
+        env:
+          PR_TEXT: ${{ inputs.pr-text }}
+        run: |
+          # Add comment environment
+          echo "${PR_TEXT}" | sed -r 's/\r$//' | grep -E '^\w+=' | while read -r line; do
+              opt=$(echo "${line}" | cut -d '=' -f1)
+              sed -i "s;^${opt}=.*$;${line};" "${{ env.GENERATOR_ENV }}"
+          done
+
+      - name: Add dispatch environment
+        if: ${{ inputs.dispatch-inputs != '' }}
+        env:
+          DISPATCH_INPUTS_JSON: ${{ inputs.dispatch-inputs }}
+        run: |
+          function get_input() {
+            echo "${DISPATCH_INPUTS_JSON}" | jq -r ".\"$1\""
+          }
+
+          osu_a=$(get_input 'osu-a')
+          osu_b=$(get_input 'osu-b')
+          ruleset=$(get_input 'ruleset')
+          generators=$(get_input 'generators')
+          difficulty_calculator_a=$(get_input 'difficulty-calculator-a')
+          difficulty_calculator_b=$(get_input 'difficulty-calculator-b')
+          score_processor_a=$(get_input 'score-processor-a')
+          score_processor_b=$(get_input 'score-processor-b')
+          converts=$(get_input 'converts')
+          ranked_only=$(get_input 'ranked-only')
+
+          sed -i "s;^OSU_B=.*$;OSU_B=${osu_b};" "${{ env.GENERATOR_ENV }}"
+          sed -i "s/^RULESET=.*$/RULESET=${ruleset}/" "${{ env.GENERATOR_ENV }}"
+          sed -i "s/^GENERATORS=.*$/GENERATORS=${generators}/" "${{ env.GENERATOR_ENV }}"
+
+          if [[ "${osu_a}" != 'latest' ]]; then
+              sed -i "s;^OSU_A=.*$;OSU_A=${osu_a};" "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${difficulty_calculator_a}" != 'latest' ]]; then
+              sed -i "s;^DIFFICULTY_CALCULATOR_A=.*$;DIFFICULTY_CALCULATOR_A=${difficulty_calculator_a};" "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${difficulty_calculator_b}" != 'latest' ]]; then
+              sed -i "s;^DIFFICULTY_CALCULATOR_B=.*$;DIFFICULTY_CALCULATOR_B=${difficulty_calculator_b};" "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${score_processor_a}" != 'latest' ]]; then
+              sed -i "s;^SCORE_PROCESSOR_A=.*$;SCORE_PROCESSOR_A=${score_processor_a};" "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${score_processor_b}" != 'latest' ]]; then
+              sed -i "s;^SCORE_PROCESSOR_B=.*$;SCORE_PROCESSOR_B=${score_processor_b};" "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${converts}" == 'true' ]]; then
+              sed -i 's/^NO_CONVERTS=.*$/NO_CONVERTS=0/' "${{ env.GENERATOR_ENV }}"
+          else
+              sed -i 's/^NO_CONVERTS=.*$/NO_CONVERTS=1/' "${{ env.GENERATOR_ENV }}"
+          fi
+
+          if [[ "${ranked_only}" == 'true' ]]; then
+              sed -i 's/^RANKED_ONLY=.*$/RANKED_ONLY=1/' "${{ env.GENERATOR_ENV }}"
+          else
+              sed -i 's/^RANKED_ONLY=.*$/RANKED_ONLY=0/' "${{ env.GENERATOR_ENV }}"
+          fi
+
+  scores:
+    name: Setup scores
+    needs: environment
+    runs-on: self-hosted
+    steps:
+      - name: Query latest data
+        id: query
+        run: |
+          ruleset=$(cat ${{ env.GENERATOR_ENV }} | grep -E '^RULESET=' | cut -d '=' -f2-)
+          performance_data_name=$(curl -s "https://data.ppy.sh/" | grep "performance_${ruleset}_top_1000\b" | tail -1 | awk -F "'" '{print $2}' | sed 's/\.tar\.bz2//g')
+
+          echo "TARGET_DIR=${{ env.GENERATOR_DIR }}/sql/${ruleset}" >> "${GITHUB_OUTPUT}"
+          echo "DATA_NAME=${performance_data_name}" >> "${GITHUB_OUTPUT}"
+          echo "DATA_PKG=${performance_data_name}.tar.bz2" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore cache
+        id: restore-cache
+        uses: maxnowack/local-cache@720e69c948191660a90aa1cf6a42fc4d2dacdf30 # v2
+        with:
+          path: ${{ steps.query.outputs.DATA_PKG }}
+          key: ${{ steps.query.outputs.DATA_NAME }}
+
+      - name: Download
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          wget -q -O "${{ steps.query.outputs.DATA_PKG }}" "https://data.ppy.sh/${{ steps.query.outputs.DATA_PKG }}"
+
+      - name: Extract
+        run: |
+          tar -I lbzip2 -xf "${{ steps.query.outputs.DATA_PKG }}"
+          rm -r "${{ steps.query.outputs.TARGET_DIR }}"
+          mv "${{ steps.query.outputs.DATA_NAME }}" "${{ steps.query.outputs.TARGET_DIR }}"
+
+  beatmaps:
+    name: Setup beatmaps
+    needs: environment
+    runs-on: self-hosted
+    steps:
+      - name: Query latest data
+        id: query
+        run: |
+          beatmaps_data_name=$(curl -s "https://data.ppy.sh/" | grep "osu_files" | tail -1 | awk -F "'" '{print $2}' | sed 's/\.tar\.bz2//g')
+
+          echo "TARGET_DIR=${{ env.GENERATOR_DIR }}/beatmaps" >> "${GITHUB_OUTPUT}"
+          echo "DATA_NAME=${beatmaps_data_name}" >> "${GITHUB_OUTPUT}"
+          echo "DATA_PKG=${beatmaps_data_name}.tar.bz2" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore cache
+        id: restore-cache
+        uses: maxnowack/local-cache@720e69c948191660a90aa1cf6a42fc4d2dacdf30 # v2
+        with:
+          path: ${{ steps.query.outputs.DATA_PKG }}
+          key: ${{ steps.query.outputs.DATA_NAME }}
+
+      - name: Download
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          wget -q -O "${{ steps.query.outputs.DATA_PKG }}" "https://data.ppy.sh/${{ steps.query.outputs.DATA_PKG }}"
+
+      - name: Extract
+        run: |
+          tar -I lbzip2 -xf "${{ steps.query.outputs.DATA_PKG }}"
+          rm -r "${{ steps.query.outputs.TARGET_DIR }}"
+          mv "${{ steps.query.outputs.DATA_NAME }}" "${{ steps.query.outputs.TARGET_DIR }}"
+
+  generator:
+    name: Run generator
+    needs: [ environment, scores, beatmaps ]
+    runs-on: self-hosted
+    timeout-minutes: 720
+    outputs:
+      target: ${{ steps.run.outputs.target }}
+      sheet: ${{ steps.run.outputs.sheet }}
+    steps:
+      - name: Run
+        id: run
+        run: |
+          # Add the GitHub token. This needs to be done here because it's unique per-job.
+          sed -i 's/^GH_TOKEN=.*$/GH_TOKEN=${{ github.token }}/' "${{ env.GENERATOR_ENV }}"
+
+          cd "${{ env.GENERATOR_DIR }}"
+
+          docker compose up --build --detach
+          docker compose logs --follow &
+          docker compose wait generator
+
+          link=$(docker compose logs --tail 10 generator | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
+          target=$(cat "${{ env.GENERATOR_ENV }}" | grep -E '^OSU_B=' | cut -d '=' -f2-)
+
+          echo "target=${target}" >> "${GITHUB_OUTPUT}"
+          echo "sheet=${link}" >> "${GITHUB_OUTPUT}"
+
+      - name: Shutdown
+        if: ${{ always() }}
+        run: |
+          cd "${{ env.GENERATOR_DIR }}"
+          docker compose down --volumes
+
+  cleanup:
+    name: Cleanup
+    needs: [ environment, scores, beatmaps, generator ]
+    runs-on: self-hosted
+    if: ${{ always() }}
+    steps:
+      - name: Cleanup
+        run: |
+          rm -rf "${{ needs.directory.outputs.GENERATOR_DIR }}"

--- a/.github/workflows/_diffcalc_processor.yml
+++ b/.github/workflows/_diffcalc_processor.yml
@@ -1,4 +1,4 @@
-name: "🔒Run diffcalc runner"
+name: "🔒diffcalc (do not use)"
 
 on:
   workflow_call:

--- a/.github/workflows/diffcalc.yml
+++ b/.github/workflows/diffcalc.yml
@@ -104,26 +104,6 @@ env:
   EXECUTION_ID: execution-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
 jobs:
-  master-environment:
-    name: Save master environment
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.comment.body, '!diffcalc') }}
-    outputs:
-      HEAD: ${{ steps.get-head.outputs.HEAD }}
-    steps:
-      - name: Checkout osu
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          sparse-checkout: |
-            README.md
-
-      - name: Get HEAD ref
-        id: get-head
-        run: |
-          ref=$(git log -1 --format='%H')
-          echo "HEAD=https://github.com/${{ github.repository }}/commit/${ref}" >> "${GITHUB_OUTPUT}"
-
   check-permissions:
     name: Check permissions
     runs-on: ubuntu-latest
@@ -139,9 +119,23 @@ jobs:
           done
           exit 1
 
+  run-diffcalc:
+    name: Run spreadsheet generator
+    needs: check-permissions
+    uses: ./.github/workflows/_diffcalc_processor.yml
+    with:
+      # Can't reference env... Why GitHub, WHY?
+      id: execution-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      head-sha: https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha || github.sha }}
+      pr-url: ${{ github.event.issue.pull_request.html_url || '' }}
+      pr-text: ${{ github.event.comment.body || '' }}
+      dispatch-inputs: ${{ toJSON(inputs) }}
+    secrets:
+      DIFFCALC_GOOGLE_CREDENTIALS: ${{ secrets.DIFFCALC_GOOGLE_CREDENTIALS }}
+
   create-comment:
     name: Create PR comment
-    needs: [ master-environment, check-permissions ]
+    needs: check-permissions
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
     steps:
@@ -154,249 +148,34 @@ jobs:
 
             *This comment will update on completion*
 
-  directory:
-    name: Prepare directory
-    needs: check-permissions
-    runs-on: self-hosted
-    outputs:
-      GENERATOR_DIR: ${{ steps.set-outputs.outputs.GENERATOR_DIR }}
-      GENERATOR_ENV: ${{ steps.set-outputs.outputs.GENERATOR_ENV }}
-      GOOGLE_CREDS_FILE: ${{ steps.set-outputs.outputs.GOOGLE_CREDS_FILE }}
-    steps:
-      - name: Checkout diffcalc-sheet-generator
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.EXECUTION_ID }}
-          repository: 'smoogipoo/diffcalc-sheet-generator'
-
-      - name: Set outputs
-        id: set-outputs
-        run: |
-          echo "GENERATOR_DIR=${{ github.workspace }}/${{ env.EXECUTION_ID }}" >> "${GITHUB_OUTPUT}"
-          echo "GENERATOR_ENV=${{ github.workspace }}/${{ env.EXECUTION_ID }}/.env" >> "${GITHUB_OUTPUT}"
-          echo "GOOGLE_CREDS_FILE=${{ github.workspace }}/${{ env.EXECUTION_ID }}/google-credentials.json" >> "${GITHUB_OUTPUT}"
-
-  environment:
-    name: Setup environment
-    needs: [ master-environment, directory ]
-    runs-on: self-hosted
-    env:
-      VARS_JSON: ${{ toJSON(vars) }}
-    steps:
-      - name: Add base environment
-        run: |
-          # Required by diffcalc-sheet-generator
-          cp '${{ needs.directory.outputs.GENERATOR_DIR }}/.env.sample' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-
-          # Add Google credentials
-          echo '${{ secrets.DIFFCALC_GOOGLE_CREDENTIALS }}' | base64 -d > "${{ needs.directory.outputs.GOOGLE_CREDS_FILE }}"
-
-          # Add repository variables
-          echo "${VARS_JSON}" | jq -c '. | to_entries | .[]' | while read -r line; do
-              opt=$(jq -r '.key' <<< ${line})
-              val=$(jq -r '.value' <<< ${line})
-
-              if [[ "${opt}" =~ ^DIFFCALC_ ]]; then
-                optNoPrefix=$(echo "${opt}" | cut -d '_' -f2-)
-                sed -i "s;^${optNoPrefix}=.*$;${optNoPrefix}=${val};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
-              fi
-          done
-
-      - name: Add master environment
-        run: |
-          sed -i "s;^OSU_A=.*$;OSU_A=${{ needs.master-environment.outputs.HEAD }};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
-
-      - name: Add pull-request environment
-        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
-        run: |
-          sed -i "s;^OSU_B=.*$;OSU_B=${{ github.event.issue.pull_request.html_url }};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
-
-      - name: Add comment environment
-        if: ${{ github.event_name == 'issue_comment' }}
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          # Add comment environment
-          echo "$COMMENT_BODY" | sed -r 's/\r$//' | grep -E '^\w+=' | while read -r line; do
-              opt=$(echo "${line}" | cut -d '=' -f1)
-              sed -i "s;^${opt}=.*$;${line};" "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          done
-
-      - name: Add dispatch environment
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          sed -i 's;^OSU_B=.*$;OSU_B=${{ inputs.osu-b }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          sed -i 's/^RULESET=.*$/RULESET=${{ inputs.ruleset }}/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          sed -i 's/^GENERATORS=.*$/GENERATORS=${{ inputs.generators }}/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-
-          if [[ '${{ inputs.osu-a }}' != 'latest' ]]; then
-              sed -i 's;^OSU_A=.*$;OSU_A=${{ inputs.osu-a }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.difficulty-calculator-a }}' != 'latest' ]]; then
-              sed -i 's;^DIFFICULTY_CALCULATOR_A=.*$;DIFFICULTY_CALCULATOR_A=${{ inputs.difficulty-calculator-a }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.difficulty-calculator-b }}' != 'latest' ]]; then
-              sed -i 's;^DIFFICULTY_CALCULATOR_B=.*$;DIFFICULTY_CALCULATOR_B=${{ inputs.difficulty-calculator-b }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.score-processor-a }}' != 'latest' ]]; then
-              sed -i 's;^SCORE_PROCESSOR_A=.*$;SCORE_PROCESSOR_A=${{ inputs.score-processor-a }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.score-processor-b }}' != 'latest' ]]; then
-              sed -i 's;^SCORE_PROCESSOR_B=.*$;SCORE_PROCESSOR_B=${{ inputs.score-processor-b }};' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.converts }}' == 'true' ]]; then
-              sed -i 's/^NO_CONVERTS=.*$/NO_CONVERTS=0/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          else
-              sed -i 's/^NO_CONVERTS=.*$/NO_CONVERTS=1/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-          if [[ '${{ inputs.ranked-only }}' == 'true' ]]; then
-              sed -i 's/^RANKED_ONLY=.*$/RANKED_ONLY=1/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          else
-              sed -i 's/^RANKED_ONLY=.*$/RANKED_ONLY=0/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-          fi
-
-  scores:
-    name: Setup scores
-    needs: [ directory, environment ]
-    runs-on: self-hosted
-    steps:
-      - name: Query latest data
-        id: query
-        run: |
-          ruleset=$(cat ${{ needs.directory.outputs.GENERATOR_ENV }} | grep -E '^RULESET=' | cut -d '=' -f2-)
-          performance_data_name=$(curl -s "https://data.ppy.sh/" | grep "performance_${ruleset}_top_1000\b" | tail -1 | awk -F "'" '{print $2}' | sed 's/\.tar\.bz2//g')
-
-          echo "TARGET_DIR=${{ needs.directory.outputs.GENERATOR_DIR }}/sql/${ruleset}" >> "${GITHUB_OUTPUT}"
-          echo "DATA_NAME=${performance_data_name}" >> "${GITHUB_OUTPUT}"
-          echo "DATA_PKG=${performance_data_name}.tar.bz2" >> "${GITHUB_OUTPUT}"
-
-      - name: Restore cache
-        id: restore-cache
-        uses: maxnowack/local-cache@720e69c948191660a90aa1cf6a42fc4d2dacdf30 # v2
-        with:
-          path: ${{ steps.query.outputs.DATA_PKG }}
-          key: ${{ steps.query.outputs.DATA_NAME }}
-
-      - name: Download
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: |
-          wget -q -O "${{ steps.query.outputs.DATA_PKG }}" "https://data.ppy.sh/${{ steps.query.outputs.DATA_PKG }}"
-
-      - name: Extract
-        run: |
-          tar -I lbzip2 -xf "${{ steps.query.outputs.DATA_PKG }}"
-          rm -r "${{ steps.query.outputs.TARGET_DIR }}"
-          mv "${{ steps.query.outputs.DATA_NAME }}" "${{ steps.query.outputs.TARGET_DIR }}"
-
-  beatmaps:
-    name: Setup beatmaps
-    needs: directory
-    runs-on: self-hosted
-    steps:
-      - name: Query latest data
-        id: query
-        run: |
-          beatmaps_data_name=$(curl -s "https://data.ppy.sh/" | grep "osu_files" | tail -1 | awk -F "'" '{print $2}' | sed 's/\.tar\.bz2//g')
-
-          echo "TARGET_DIR=${{ needs.directory.outputs.GENERATOR_DIR }}/beatmaps" >> "${GITHUB_OUTPUT}"
-          echo "DATA_NAME=${beatmaps_data_name}" >> "${GITHUB_OUTPUT}"
-          echo "DATA_PKG=${beatmaps_data_name}.tar.bz2" >> "${GITHUB_OUTPUT}"
-
-      - name: Restore cache
-        id: restore-cache
-        uses: maxnowack/local-cache@720e69c948191660a90aa1cf6a42fc4d2dacdf30 # v2
-        with:
-          path: ${{ steps.query.outputs.DATA_PKG }}
-          key: ${{ steps.query.outputs.DATA_NAME }}
-
-      - name: Download
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: |
-          wget -q -O "${{ steps.query.outputs.DATA_PKG }}" "https://data.ppy.sh/${{ steps.query.outputs.DATA_PKG }}"
-
-      - name: Extract
-        run: |
-          tar -I lbzip2 -xf "${{ steps.query.outputs.DATA_PKG }}"
-          rm -r "${{ steps.query.outputs.TARGET_DIR }}"
-          mv "${{ steps.query.outputs.DATA_NAME }}" "${{ steps.query.outputs.TARGET_DIR }}"
-
-  generator:
-    name: Run generator
-    needs: [ directory, environment, scores, beatmaps ]
-    runs-on: self-hosted
-    timeout-minutes: 720
-    outputs:
-      TARGET: ${{ steps.run.outputs.TARGET }}
-      SPREADSHEET_LINK: ${{ steps.run.outputs.SPREADSHEET_LINK }}
-    steps:
-      - name: Run
-        id: run
-        run: |
-          # Add the GitHub token. This needs to be done here because it's unique per-job.
-          sed -i 's/^GH_TOKEN=.*$/GH_TOKEN=${{ github.token }}/' "${{ needs.directory.outputs.GENERATOR_ENV }}"
-
-          cd "${{ needs.directory.outputs.GENERATOR_DIR }}"
-
-          docker compose up --build --detach
-          docker compose logs --follow &
-          docker compose wait generator
-
-          link=$(docker compose logs --tail 10 generator | grep 'http' | sed -E 's/^.*(http.*)$/\1/')
-          target=$(cat "${{ needs.directory.outputs.GENERATOR_ENV }}" | grep -E '^OSU_B=' | cut -d '=' -f2-)
-
-          echo "TARGET=${target}" >> "${GITHUB_OUTPUT}"
-          echo "SPREADSHEET_LINK=${link}" >> "${GITHUB_OUTPUT}"
-
-      - name: Shutdown
-        if: ${{ always() }}
-        run: |
-          cd "${{ needs.directory.outputs.GENERATOR_DIR }}"
-          docker compose down --volumes
-
   output-cli:
-    name: Output info
-    needs: generator
+    name: Info
+    needs: run-diffcalc
     runs-on: ubuntu-latest
     steps:
       - name: Output info
         run: |
-          echo "Target: ${{ needs.generator.outputs.TARGET }}"
-          echo "Spreadsheet: ${{ needs.generator.outputs.SPREADSHEET_LINK }}"
-
-  cleanup:
-    name: Cleanup
-    needs: [ directory, generator ]
-    if: ${{ always() && needs.directory.result == 'success' }}
-    runs-on: self-hosted
-    steps:
-      - name: Cleanup
-        run: |
-          rm -rf "${{ needs.directory.outputs.GENERATOR_DIR }}"
+          echo "Target: ${{ needs.run-diffcalc.outputs.target }}"
+          echo "Spreadsheet: ${{ needs.run-diffcalc.outputs.sheet }}"
 
   update-comment:
     name: Update PR comment
-    needs: [ create-comment, generator ]
+    needs: [ create-comment, run-diffcalc ]
     runs-on: ubuntu-latest
     if: ${{ always() && needs.create-comment.result == 'success' }}
     steps:
       - name: Update comment on success
-        if: ${{ needs.generator.result == 'success' }}
+        if: ${{ needs.run-diffcalc.result == 'success' }}
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: ${{ env.EXECUTION_ID }}
           mode: recreate
           message: |
-            Target: ${{ needs.generator.outputs.TARGET }}
-            Spreadsheet: ${{ needs.generator.outputs.SPREADSHEET_LINK }}
+            Target: ${{ needs.run-diffcalc.outputs.target }}
+            Spreadsheet: ${{ needs.run-diffcalc.outputs.sheet }}
 
       - name: Update comment on failure
-        if: ${{ needs.generator.result == 'failure' }}
+        if: ${{ needs.run-diffcalc.result == 'failure' }}
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: ${{ env.EXECUTION_ID }}
@@ -405,7 +184,7 @@ jobs:
             Difficulty calculation failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Update comment on cancellation
-        if: ${{ needs.generator.result == 'cancelled' }}
+        if: ${{ needs.run-diffcalc.result == 'cancelled' }}
         uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           comment_tag: ${{ env.EXECUTION_ID }}


### PR DESCRIPTION
The diffcalc runner currently dies when many runs are queued up because they're running in lock-step and each one eventually manages to extract scores/beatmaps prior to other runs having completed.

The plan of attack here is to split the workflow into two pieces: the main `diffcalc.yml` and a new reusable `_diffcalc_processor.yml` workflow with concurrency applied that effectively locks for the duration of the workflow on the self-hosted runner.

I've tried to make as minimal changes as possible for now. Most of the changes are around the "environment" job because there's a level of indirection for data like the PR URL, comment text, and dispatch inputs.

Here's a dispatched run: https://github.com/ppy/osu/actions/runs/11756297523

Keep in mind I haven't tested the PR/comment part of this though I've made a good effort to ensure it _should_ work. I'm hoping this can be first merged with minimal friction and I can commit directly to master any follow-up fixes that need to be done (it's hard to test that part out in full...).