### PR TITLE
Fix break overlay grades not using localised string

### DIFF
--- a/osu.Game/Screens/Play/Break/BreakInfoLine.cs
+++ b/osu.Game/Screens/Play/Break/BreakInfoLine.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Screens.Play.Break
         protected virtual LocalisableString Format(T count)
         {
             if (count is Enum countEnum)
-                return countEnum.GetDescription();
+                return countEnum.GetLocalisableDescription();
 
             return count.ToString() ?? string.Empty;
         }


### PR DESCRIPTION
IMO, this looks weird to me in this context for some reason (having silver in the grade name) but it matches and is consistent with the beatmap listing filter now.

Discord convo ref: https://discord.com/channels/188630481301012481/1097318920991559880/1304965291784142858
Wiki ref: https://osu.ppy.sh/wiki/en/Gameplay/Grade

The "+" is only ever mentioned in https://osu.ppy.sh/wiki/en/History_of_osu%21/2018#february and [russian localisation](https://github.com/search?q=repo%3Appy%2Fosu-web%20%22SS%2B%22&type=code) (probably some old translation that never got updated).

| Before | After |
| --- | --- |
| <img width="173" alt="Screenshot 2024-11-09 at 4 46 36 PM" src="https://github.com/user-attachments/assets/5fd22046-8e5c-4797-b4ea-64f703a4db06"> | <img width="166" alt="Screenshot 2024-11-09 at 4 45 39 PM" src="https://github.com/user-attachments/assets/43ea0c82-5f14-47a2-bffd-4b80f685b275"> |

Edit: could probably just play with colors instead for plain text like this?