### PR TITLE
Fix top rank display not showing up on beatmaps with many difficulties

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -26,7 +26,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
-    <PackageReference Include="Velopack" Version="0.0.630-g9c52e40" />
+    <PackageReference Include="Velopack" Version="0.0.869" />
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1280,14 +1280,14 @@ namespace osu.Game.Screens.Select
             }
 
             private const float top_padding = 10;
-            private const float bottom_padding = 80;
+            private const float bottom_padding = 70;
 
             protected override float ToScrollbarPosition(float scrollPosition)
             {
                 if (Precision.AlmostEquals(0, ScrollableExtent))
                     return 0;
 
-                return top_padding + (ScrollbarMovementExtent - bottom_padding) * (scrollPosition / ScrollableExtent);
+                return top_padding + (ScrollbarMovementExtent - (top_padding + bottom_padding)) * (scrollPosition / ScrollableExtent);
             }
 
             protected override float FromScrollbarPosition(float scrollbarPosition)
@@ -1295,7 +1295,7 @@ namespace osu.Game.Screens.Select
                 if (Precision.AlmostEquals(0, ScrollbarMovementExtent))
                     return 0;
 
-                return ScrollableExtent * ((scrollbarPosition - top_padding) / (ScrollbarMovementExtent - bottom_padding));
+                return ScrollableExtent * ((scrollbarPosition - top_padding) / (ScrollbarMovementExtent - (top_padding + bottom_padding)));
             }
         }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -222,12 +222,6 @@ namespace osu.Game.Screens.Select
             InternalChild = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding
-                {
-                    // Avoid clash between scrollbar and osu! logo.
-                    Top = 10,
-                    Bottom = 100,
-                },
                 Children = new Drawable[]
                 {
                     setPool,
@@ -1270,6 +1264,38 @@ namespace osu.Game.Screens.Select
                     return false;
 
                 return base.OnDragStart(e);
+            }
+
+            protected override ScrollbarContainer CreateScrollbar(Direction direction)
+            {
+                return new PaddedScrollbar();
+            }
+
+            protected partial class PaddedScrollbar : OsuScrollbar
+            {
+                public PaddedScrollbar()
+                    : base(Direction.Vertical)
+                {
+                }
+            }
+
+            private const float top_padding = 10;
+            private const float bottom_padding = 80;
+
+            protected override float ToScrollbarPosition(float scrollPosition)
+            {
+                if (Precision.AlmostEquals(0, ScrollableExtent))
+                    return 0;
+
+                return top_padding + (ScrollbarMovementExtent - bottom_padding) * (scrollPosition / ScrollableExtent);
+            }
+
+            protected override float FromScrollbarPosition(float scrollbarPosition)
+            {
+                if (Precision.AlmostEquals(0, ScrollbarMovementExtent))
+                    return 0;
+
+                return ScrollableExtent * ((scrollbarPosition - top_padding) / (ScrollbarMovementExtent - bottom_padding));
             }
         }
 

--- a/osu.Game/osu.Game.csproj
+++ b/osu.Game/osu.Game.csproj
@@ -20,7 +20,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="DiffPlex" Version="1.7.2" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.67" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.10" />
@@ -35,9 +35,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Realm" Version="11.5.0" />
-    <PackageReference Include="ppy.osu.Framework" Version="2024.1025.0" />
+    <PackageReference Include="ppy.osu.Framework" Version="2024.1111.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2024.1106.0" />
-    <PackageReference Include="Sentry" Version="4.12.1" />
+    <PackageReference Include="Sentry" Version="4.13.0" />
     <!-- Held back due to 0.34.0 failing AOT compilation on ZstdSharp.dll dependency. -->
     <PackageReference Include="SharpCompress" Version="0.38.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6415
- [x] Depends on framework package & bump

Closes https://github.com/ppy/osu/issues/30553. Also addresses concerns from the original padding addition (see https://github.com/ppy/osu/pull/26701#discussion_r1466047976) by undoing it.

Note that this doesn't fix the delayed drawables not showing underneath the footer. I have another incoming change to fix that (with design adjustments).

I tested this using

```diff
diff --git a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
index da9661f702..f18fe23607 100644
--- a/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
+++ b/osu.Game/Screens/Select/Carousel/TopLocalRank.cs
@@ -75,7 +75,10 @@ void localScoresChanged(IRealmCollection<ScoreInfo> sender, ChangeSet? changes)
                 if (changes?.HasCollectionChanges() == false)
                     return;
 
-                ScoreInfo? topScore = sender.MaxBy(info => (info.TotalScore, -info.Date.UtcDateTime.Ticks));
+                ScoreInfo? topScore = sender.MaxBy(info => (info.TotalScore, -info.Date.UtcDateTime.Ticks)) ?? new ScoreInfo
+                {
+                    Rank = ScoreRank.A,
+                };
                 updateable.Rank = topScore?.Rank;
                 updateable.Alpha = topScore != null ? 1 : 0;
             }

```

with https://osu.ppy.sh/beatmapsets/2167008#osu/4572759