### PR TITLE
Reduce semi-opaque layers at song select

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -1116,11 +1116,6 @@ namespace osu.Game.Screens.Select
             // adjusting the item's overall X position can cause it to become masked away when
             // child items (difficulties) are still visible.
             item.Header.X = offsetX(dist, visibleHalfHeight) - (parent?.X ?? 0);
-
-            // We are applying a multiplicative alpha (which is internally done by nesting an
-            // additional container and setting that container's alpha) such that we can
-            // layer alpha transformations on top.
-            item.SetMultiplicativeAlpha(Math.Clamp(1.75f - 1.5f * dist, 0, 1));
         }
 
         private enum PendingScrollOperation

--- a/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/osu.Game/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -86,8 +86,6 @@ namespace osu.Game.Screens.Select.Carousel
             };
         }
 
-        public void SetMultiplicativeAlpha(float alpha) => Header.BorderContainer.Alpha = alpha;
-
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -28,7 +28,6 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Select.Filter;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Game.Screens.Select

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -97,8 +97,8 @@ namespace osu.Game.Screens.Select
             {
                 new Box
                 {
-                    Colour = Color4.Black,
-                    Alpha = 0.8f,
+                    Colour = OsuColour.Gray(0.05f),
+                    Alpha = 0.96f,
                     Width = 2,
                     RelativeSizeAxes = Axes.Both,
                 },

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -6,8 +6,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using osuTK;
-using osuTK.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Game/Screens/Select/Footer.cs
+++ b/osu.Game/Screens/Select/Footer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Screens.Select
@@ -82,14 +83,15 @@ namespace osu.Game.Screens.Select
                 {
                     RelativeSizeAxes = Axes.Both,
                     Size = Vector2.One,
-                    Colour = Color4.Black.Opacity(0.5f),
+                    Colour = OsuColour.Gray(0.1f),
+                    Alpha = 0.96f,
                 },
                 modeLight = new Box
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = 3,
                     Position = new Vector2(0, -3),
-                    Colour = Color4.Black,
+                    Colour = OsuColour.Gray(0.1f),
                 },
                 new FillFlowContainer
                 {


### PR DESCRIPTION
I made these changes while working on https://github.com/ppy/osu/pull/30579. Basically, it's hard to fix the ranks not loading while underneath the footer, and the transparency both looks bad, and is going away in the redesign.

I've chosen values here that are moving *in the direction* of the new design without overhauling everything. I figure this will if anything lead to less unexpected change when we finally drop the new design.

- I know that there's still some transparency. I did this because it helps keep all current elements / colours contrasting without too much effort.
- I completely removed the transparency adjustments on the beatmap panels. This always looked bad due to being applied per-layer, and I don't think it added much.


| Before | After |
| :---: | :---: |
| ![osu! 2024-11-11 at 08 58 57](https://github.com/user-attachments/assets/fb1c86b3-d98b-4f20-8d99-aaa4e0b179ce) | ![osu! 2024-11-11 at 08 58 04](https://github.com/user-attachments/assets/f9291c9e-dc8d-4ec2-9eb2-2f056e4778d5) |