### PR TITLE
Add a toggle for `Perfect` (osu!mania) requiring PERFECT judgements only

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPerfect.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPerfect.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -9,10 +11,16 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModPerfect : ModPerfect
     {
+        [SettingSource("Full perfect", "Placeholder")]
+        public BindableBool allPerfect { get; } = new BindableBool(false);
+
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)
         {
             if (!isRelevantResult(result.Judgement.MinResult) && !isRelevantResult(result.Judgement.MaxResult) && !isRelevantResult(result.Type))
                 return false;
+
+            if (allPerfect.Value && result.Judgement.MaxResult == HitResult.Perfect)
+                return result.Type < HitResult.Perfect;
 
             // Mania allows imperfect "Great" hits without failing.
             if (result.Judgement.MaxResult == HitResult.Perfect)


### PR DESCRIPTION
Description: `Full perfect`, as the name implies, requires a FULL perfect play. A fail is enforced should a `GREAT` judgement be dropped.

![image](https://github.com/user-attachments/assets/5acd6574-0c5d-4f67-93fa-63ae735aed45)

