### PR TITLE
Fix stage line alignment in mania not matching stable

### DIFF
--- a/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyStageBackground.cs
+++ b/osu.Game.Rulesets.Mania/Skinning/Legacy/LegacyStageBackground.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                 },
                 columnBackgrounds = new ColumnFlow<Drawable>(stageDefinition)
                 {
-                    RelativeSizeAxes = Axes.Y
+                    RelativeSizeAxes = Axes.Y,
+                    Masking = false,
                 },
                 new HitTargetInsetContainer
                 {
@@ -126,8 +127,8 @@ namespace osu.Game.Rulesets.Mania.Skinning.Legacy
                             },
                             new Container
                             {
+                                X = isLastColumn ? -0.16f : 0,
                                 Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
                                 RelativeSizeAxes = Axes.Y,
                                 Width = rightLineWidth,
                                 Scale = new Vector2(0.740f, 1),

--- a/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
+++ b/osu.Game.Rulesets.Mania/UI/ColumnFlow.cs
@@ -28,6 +28,12 @@ namespace osu.Game.Rulesets.Mania.UI
         private readonly FillFlowContainer<Container<TContent>> columns;
         private readonly StageDefinition stageDefinition;
 
+        public new bool Masking
+        {
+            get => base.Masking;
+            set => base.Masking = value;
+        }
+
         public ColumnFlow(StageDefinition stageDefinition)
         {
             this.stageDefinition = stageDefinition;


### PR DESCRIPTION
Before:
![CleanShot 2024-11-12 at 04 08 43](https://github.com/user-attachments/assets/21af19bb-0a83-4032-b174-bcc6b862d095)

After:
![CleanShot 2024-11-12 at 04 07 32](https://github.com/user-attachments/assets/08132139-f24b-49df-a59f-b8d1d0f20f03)

I guess this comes at the caveat that some lines lose a bit of thickness, but it matches stable anyway.