### PR TITLE
Increase idle time before gameplay loads when hovering controls

### DIFF
--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -224,7 +224,7 @@ namespace osu.Game.Screens.Play
                         }
                     },
                 },
-                idleTracker = new IdleTracker(750),
+                idleTracker = new IdleTracker(1500),
                 sampleRestart = new SkinnableSound(new SampleInfo(@"Gameplay/restart", @"pause-retry-click"))
             };
 


### PR DESCRIPTION
Adjusting based off https://github.com/ppy/osu/discussions/30440. I tend to agree that it feels too short as it was.