### PR TITLE
Implement RemoveAdjustmentsFromAllProperties helper for samples

### DIFF
--- a/osu.Game.Tests/Rulesets/TestSceneDrawableRulesetDependencies.cs
+++ b/osu.Game.Tests/Rulesets/TestSceneDrawableRulesetDependencies.cs
@@ -144,6 +144,8 @@ namespace osu.Game.Tests.Rulesets
 
             public void RemoveAllAdjustments(AdjustableProperty type) => throw new NotImplementedException();
 
+            public void RemoveAdjustmentsFromAllProperties() => throw new NotImplementedException();
+
             public IBindable<double> AggregateVolume => throw new NotImplementedException();
             public IBindable<double> AggregateBalance => throw new NotImplementedException();
             public IBindable<double> AggregateFrequency => throw new NotImplementedException();

--- a/osu.Game/Overlays/MusicController.cs
+++ b/osu.Game/Overlays/MusicController.cs
@@ -585,11 +585,7 @@ namespace osu.Game.Overlays
         /// </remarks>
         public void ResetTrackAdjustments()
         {
-            // todo: we probably want a helper method rather than this.
-            CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Balance);
-            CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Frequency);
-            CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Tempo);
-            CurrentTrack.RemoveAllAdjustments(AdjustableProperty.Volume);
+            CurrentTrack.RemoveAdjustmentsFromAllProperties();
 
             if (applyModTrackAdjustments)
             {

--- a/osu.Game/Rulesets/Mods/MetronomeBeat.cs
+++ b/osu.Game/Rulesets/Mods/MetronomeBeat.cs
@@ -86,6 +86,11 @@ namespace osu.Game.Rulesets.Mods
             sample.RemoveAllAdjustments(type);
         }
 
+        public void RemoveAdjustmentsFromAllProperties()
+        {
+            sample.RemoveAdjustmentsFromAllProperties();
+        }
+
         #endregion
     }
 }

--- a/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
+++ b/osu.Game/Rulesets/UI/DrawableRulesetDependencies.cs
@@ -137,6 +137,8 @@ namespace osu.Game.Rulesets.UI
 
             public void RemoveAllAdjustments(AdjustableProperty type) => throw new NotSupportedException();
 
+            public void RemoveAdjustmentsFromAllProperties() => throw new NotSupportedException();
+
             public void BindAdjustments(IAggregateAudioAdjustment component) => throw new NotImplementedException();
 
             public void UnbindAdjustments(IAggregateAudioAdjustment component) => throw new NotImplementedException();

--- a/osu.Game/Skinning/PoolableSkinnableSample.cs
+++ b/osu.Game/Skinning/PoolableSkinnableSample.cs
@@ -181,6 +181,8 @@ namespace osu.Game.Skinning
 
         public void RemoveAllAdjustments(AdjustableProperty type) => sampleContainer.RemoveAllAdjustments(type);
 
+        public void RemoveAdjustmentsFromAllProperties() => sampleContainer.RemoveAdjustmentsFromAllProperties();
+
         public IBindable<double> AggregateVolume => sampleContainer.AggregateVolume;
 
         public IBindable<double> AggregateBalance => sampleContainer.AggregateBalance;

--- a/osu.Game/Skinning/SkinnableSound.cs
+++ b/osu.Game/Skinning/SkinnableSound.cs
@@ -194,6 +194,8 @@ namespace osu.Game.Skinning
 
         public void RemoveAllAdjustments(AdjustableProperty type) => samplesContainer.RemoveAllAdjustments(type);
 
+        public void RemoveAdjustmentsFromAllProperties() => samplesContainer.RemoveAdjustmentsFromAllProperties();
+
         /// <summary>
         /// Whether any samples are currently playing.
         /// </summary>


### PR DESCRIPTION
Requires https://github.com/ppy/osu-framework/pull/6423 to get merged.

Implements `RemoveAdjustmentsFromAllProperties` within the required classes with the aim of reducing repeated code.