### PR TITLE
Show results screen when reaching the end of a failed replay

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -83,6 +83,11 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool PauseOnFocusLost => true;
 
+        /// <summary>
+        /// Whether to show the fail overlay (with buttons to retry / exit) on failing.
+        /// </summary>
+        protected virtual bool ShowFailOverlay => true;
+
         public Action<bool> RestartRequested;
 
         private bool isRestarting;
@@ -990,6 +995,9 @@ namespace osu.Game.Screens.Play
         /// </summary>
         private void onFailComplete()
         {
+            if (!ShowFailOverlay)
+                return;
+
             GameplayClockContainer.Stop();
 
             FailOverlay.Retries = RestartCount;

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -11,6 +11,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Input.Bindings;
@@ -33,6 +34,8 @@ namespace osu.Game.Screens.Play
         private readonly bool replayIsFailedScore;
 
         protected override UserActivity InitialActivity => new UserActivity.WatchingReplay(Score.ScoreInfo);
+
+        protected override bool ShowFailOverlay => false;
 
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure()
@@ -155,6 +158,20 @@ namespace osu.Game.Screens.Play
             double target = Math.Clamp(GameplayClockContainer.CurrentTime + amount * BASE_SEEK_AMOUNT, 0, GameplayState.Beatmap.GetLastObjectTime());
 
             Seek(target);
+        }
+
+        protected override void OnFail()
+        {
+            // Replays will always show the results screen on failing.
+            Scheduler.AddDelayed(() =>
+            {
+                if (!this.IsCurrentScreen())
+                    // This player instance may already be in the process of exiting.
+                    return;
+
+                ValidForResume = false;
+                this.Push(CreateResults(Score.ScoreInfo));
+            }, RESULTS_DISPLAY_DELAY);
         }
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/30577.

Consider this a RFC. There's multiple ways this could be implemented, but I went for the most stand-alone approach, bypassing all the score preparation and progress logic (because it's probably simplest this way?).


https://github.com/user-attachments/assets/88d148ab-a37b-4434-bc42-668f41b62dd3

