### PR TITLE
Fix NaN PP counter values while SR is 0

### DIFF
--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -70,9 +70,12 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public virtual double CountTopWeightedStrains()
         {
+            if (ObjectStrains.Count == 0)
+                return 0.0;
+
             double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
 
-            if (ObjectStrains.Count == 0 || consistentTopStrain == 0)
+            if (consistentTopStrain == 0)
                 return 0.0;
 
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -76,7 +76,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
 
             if (consistentTopStrain == 0)
-                return 0.0;
+                return ObjectStrains.Count;
 
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
             return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));

--- a/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -70,10 +70,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public virtual double CountTopWeightedStrains()
         {
-            if (ObjectStrains.Count == 0)
+            double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
+
+            if (ObjectStrains.Count == 0 || consistentTopStrain == 0)
                 return 0.0;
 
-            double consistentTopStrain = DifficultyValue() / 10; // What would the top strain be if all strain values were identical
             // Use a weighted sum of all strains. Constants are arbitrary and give nice values
             return ObjectStrains.Sum(s => 1.1 / (1 + Math.Exp(-10 * (s / consistentTopStrain - 0.88))));
         }


### PR DESCRIPTION
The first few notes of a map can have 0 difficulty, but the check for this was accidentally removed in the miss penalty note count formula.