### PR TITLE
Do not show timing distribution graph in offset control if there's not enough timed hits

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBeatmapOffsetControl.cs
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Tests.Resources;
@@ -45,6 +49,39 @@ namespace osu.Game.Tests.Visual.Gameplay
                 offsetControl.ReferenceScore.Value = new ScoreInfo
                 {
                     HitEvents = TestSceneHitEventTimingDistributionGraph.CreateDistributedHitEvents(0, 2),
+                    BeatmapInfo = Beatmap.Value.BeatmapInfo,
+                };
+            });
+
+            AddAssert("No calibration button", () => !offsetControl.ChildrenOfType<SettingsButton>().Any());
+        }
+
+        [Test]
+        public void TestNotEnoughTimedHitEvents()
+        {
+            AddStep("Set short reference score", () =>
+            {
+                List<HitEvent> hitEvents =
+                [
+                    // 10 events total. one of them (head circle) being timed / having hitwindows, rest having no hitwindows
+                    new HitEvent(30, 1, HitResult.LargeTickHit, new SliderHeadCircle { ClassicSliderBehaviour = true }, null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                    new HitEvent(0, 1, HitResult.LargeTickHit, new SliderTick(), null, null),
+                ];
+
+                foreach (var ev in hitEvents)
+                    ev.HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+                offsetControl.ReferenceScore.Value = new ScoreInfo
+                {
+                    HitEvents = hitEvents,
                     BeatmapInfo = Beatmap.Value.BeatmapInfo,
                 };
             });

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Scoring
 
             foreach (var e in hitEvents)
             {
-                if (!affectsUnstableRate(e))
+                if (!AffectsUnstableRate(e))
                     continue;
 
                 count++;
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </returns>
         public static double? CalculateAverageHitError(this IEnumerable<HitEvent> hitEvents)
         {
-            double[] timeOffsets = hitEvents.Where(affectsUnstableRate).Select(ev => ev.TimeOffset).ToArray();
+            double[] timeOffsets = hitEvents.Where(AffectsUnstableRate).Select(ev => ev.TimeOffset).ToArray();
 
             if (timeOffsets.Length == 0)
                 return null;
@@ -65,6 +65,6 @@ namespace osu.Game.Rulesets.Scoring
             return timeOffsets.Average();
         }
 
-        private static bool affectsUnstableRate(HitEvent e) => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit();
+        public static bool AffectsUnstableRate(HitEvent e) => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit();
     }
 }

--- a/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
+++ b/osu.Game/Screens/Play/PlayerSettings/BeatmapOffsetControl.cs
@@ -195,7 +195,10 @@ namespace osu.Game.Screens.Play.PlayerSettings
                 },
             };
 
-            if (hitEvents.Count < 10)
+            // affecting unstable rate here is used as a substitute of determining if a hit event represents a *timed* hit event,
+            // i.e. an user input that the user had to *time to the track*,
+            // i.e. one that it *makes sense to use* when doing anything with timing and offsets.
+            if (hitEvents.Count(HitEventExtensions.AffectsUnstableRate) < 10)
             {
                 referenceScoreContainer.AddRange(new Drawable[]
                 {


### PR DESCRIPTION
Intended to address concerns raised in https://github.com/ppy/osu/pull/30620#issuecomment-2475744164.

I'm intentionally not using the version of the check from

https://github.com/ppy/osu/blob/d08c8ae48211765f6ee6def305618320fd2aa2b4/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs#L61

since that version of the conditional is special and fixes a purely visual issue visible on the results screen (https://github.com/ppy/osu/issues/24274).