### PR TITLE
Fix occasional flash when quick exiting / retrying from player

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneStoryboardWithOutro.cs
@@ -223,7 +223,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected partial class OutroPlayer : TestPlayer
         {
-            public void ExitViaPause() => PerformExit(true);
+            public void ExitViaPause() => PerformExitWithConfirmation();
 
             public new FailOverlay FailOverlay => base.FailOverlay;
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -158,7 +158,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             if (!string.IsNullOrEmpty(message))
                 Logger.Log(message, LoggingTarget.Runtime, LogLevel.Important);
 
-            Schedule(() => PerformExit(false));
+            Schedule(() => PerformExit());
         }
 
         private void onGameplayStarted() => Scheduler.Add(() =>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -298,7 +298,7 @@ namespace osu.Game.Screens.Play
                     {
                         if (!this.IsCurrentScreen()) return;
 
-                        PerformExit(true);
+                        PerformExit(skipTransition: true);
                     },
                 },
             });
@@ -721,7 +721,7 @@ namespace osu.Game.Screens.Play
 
             RestartRequested?.Invoke(quickRestart);
 
-            return PerformExit(quickRestart);
+            return PerformExit(skipTransition: quickRestart);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -719,9 +719,14 @@ namespace osu.Game.Screens.Play
             // stopping here is to ensure music doesn't become audible after exiting back to PlayerLoader.
             musicController.Stop();
 
-            RestartRequested?.Invoke(quickRestart);
+            if (RestartRequested != null)
+            {
+                skipExitTransition = quickRestart;
+                RestartRequested?.Invoke(quickRestart);
+                return true;
+            }
 
-            return PerformExit(skipTransition: quickRestart);
+            return PerformExit(quickRestart);
         }
 
         /// <summary>

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -594,7 +594,7 @@ namespace osu.Game.Screens.Play
         /// This method will show the pause or fail dialog before performing an exit.
         /// If a dialog is not yet displayed, the exit will be blocked and the relevant dialog will display instead.
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>Whether this call resulted in a final exit.</returns>
         protected bool PerformExitWithConfirmation()
         {
             bool pauseOrFailDialogVisible =


### PR DESCRIPTION
The gist of the issue is that `fadeOut` was being called *twice* in the quick exit/retry scenarios, causing weirdness with transforms.

I've restructured things to ensure it's only called once.