### PR TITLE
Adjust osu!taiko constant scroll algorithm to match expectations

### DIFF
--- a/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs
@@ -84,8 +84,11 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         protected virtual double ComputeTimeRange()
         {
-            // Adjust when we're using constant algorithm to not be sluggish.
-            double multiplier = VisualisationMethod == ScrollVisualisationMethod.Constant ? 4 * Beatmap.Difficulty.SliderMultiplier : 1;
+            // Using the constant algorithm results in a sluggish scroll speed that's equal to 60 BPM.
+            // We need to adjust it to the expected default scroll speed (BPM * base SV multiplier).
+            double multiplier = VisualisationMethod == ScrollVisualisationMethod.Constant
+                ? (Beatmap.BeatmapInfo.BPM * Beatmap.Difficulty.SliderMultiplier) / 60
+                : 1;
             return PlayfieldAdjustmentContainer.ComputeTimeRange() / multiplier;
         }
 


### PR DESCRIPTION
resolves #28566

my explanation is in the replies but I'll repost here for visibility:

--- 

it seems like the `Constant` `ScrollVisualisationMethod` results in a 60BPM scroll speed by default (hence a 4x multiplier existing, which bumped scroll speed to 240 BPM), so adjusting [this line](https://github.com/ppy/osu/blob/3d6a9ccb6d8e2ed270ca45a97ed5a0fa18e9781f/osu.Game.Rulesets.Taiko/UI/DrawableTaikoRuleset.cs#L88) to the following would fix this:

```diff
-             double multiplier = VisualisationMethod == ScrollVisualisationMethod.Constant ? 4 * Beatmap.Difficulty.SliderMultiplier : 1;
+             double multiplier = VisualisationMethod == ScrollVisualisationMethod.Constant ? (Beatmap.BeatmapInfo.BPM * Beatmap.Difficulty.SliderMultiplier) / 60 : 1;
```

I've tested the above and on a [beatmap](https://osu.ppy.sh/beatmapsets/1516860#taiko/3105299) with 1.4 base SV and no scroll speed changes, and toggling between `Constant` and `Overlapping` `ScrollVisualisationMethod` results in identical visuals, which should be the expected behavior.

https://github.com/user-attachments/assets/f4ddd7ad-0f05-4b7d-a30a-48077f77957a