### PR TITLE
Revert velopack

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -26,7 +26,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
-    <PackageReference Include="Velopack" Version="0.0.869" />
+    <PackageReference Include="Velopack" Version="0.0.630-g9c52e40" />
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />


### PR DESCRIPTION
Because even if you somehow bypass the breakage [that bricks your install by installing the missing libssl-1.0 or whatever](https://github.com/ppy/osu/issues/30648#issuecomment-2478856055), there's [another](https://github.com/ppy/osu/issues/30648#issuecomment-2478926177) [brick upstream](https://github.com/velopack/velopack/issues/355).

Can we even downgrade like this? No idea. How does one test this? No idea. At this point I am like a headless chicken, screaming into the void trying to restore any semblance of order into my crumbling universe.

If this is tried and linux is still broken with the libssl garbage, then the `osulazer-2024.1115.1-linux-x64-*.nupkg` assets should be pulled from the release, which should be enough to stop the game from auto-updating. Maybe the appimage itself can stay up and people can upgrade manually if they so desire. Or maybe not. Who knows.