### PR TITLE
Update Velopack to 0.0.915

### DIFF
--- a/osu.Desktop/osu.Desktop.csproj
+++ b/osu.Desktop/osu.Desktop.csproj
@@ -26,7 +26,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
-    <PackageReference Include="Velopack" Version="0.0.630-g9c52e40" />
+    <PackageReference Include="Velopack" Version="0.0.915" />
   </ItemGroup>
   <ItemGroup Label="Resources">
     <EmbeddedResource Include="lazer.ico" />


### PR DESCRIPTION
I haven't tested the full update flow, but this version doesn't link `UpdateNix` to libssl.

See also: https://github.com/ppy/osu-deploy/pull/182