### PR TITLE
Add the ability to switch to and use a beta stream

### DIFF
--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Game;
 using osu.Game.Configuration;
 using osu.Game.Overlays;
@@ -20,7 +19,7 @@ namespace osu.Desktop.Updater
 {
     public partial class VelopackUpdateManager : Game.Updater.UpdateManager
     {
-        private UpdateManager updateManager;
+        private UpdateManager updateManager = null!;
         private INotificationOverlay notificationOverlay = null!;
 
         [Resolved]
@@ -31,9 +30,6 @@ namespace osu.Desktop.Updater
 
         [Resolved]
         private OsuConfigManager osuConfigManager { get; set; } = null!;
-
-        [Resolved]
-        private Storage storage { get; set; } = null!;
 
         private bool isInGameplay => localUserInfo?.PlayingState.Value != LocalUserPlayingState.NotPlaying;
 

--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -50,11 +51,13 @@ namespace osu.Desktop.Updater
                 AllowVersionDowngrade = true,
             };
 
+            string arch = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
+
             string platform = Environment.OSVersion.Platform switch
             {
                 PlatformID.Win32NT => "win",
-                PlatformID.Unix => "linux",
-                PlatformID.MacOSX => "osx",
+                PlatformID.Unix => "linux-" + arch,
+                PlatformID.MacOSX => "osx-" + arch,
                 _ => throw new PlatformNotSupportedException(),
             };
 

--- a/osu.Desktop/Updater/VelopackUpdateManager.cs
+++ b/osu.Desktop/Updater/VelopackUpdateManager.cs
@@ -64,6 +64,7 @@ namespace osu.Desktop.Updater
             if (releaseStream.Value == ReleaseStream.Photon)
             {
                 options.ExplicitChannel = $"{platform}-photon";
+                // TODO: The logging here is not correct. It should be reading from `VelopackLocator.GetDefault(null).Channel` instead. Should also probably be moved to a more appropriate location.
                 Logger.Log("Using photon channel");
             }
             else if (releaseStream.Value == ReleaseStream.Lazer)

--- a/osu.Game/Configuration/ReleaseStream.cs
+++ b/osu.Game/Configuration/ReleaseStream.cs
@@ -6,6 +6,7 @@ namespace osu.Game.Configuration
     public enum ReleaseStream
     {
         Lazer,
+        Photon,
         //Stable40,
         //Beta40,
         //Stable


### PR DESCRIPTION
The main PR and relevant information can be found here: https://github.com/ppy/osu-deploy/pull/183
Relevant discussion: https://github.com/ppy/osu/discussions/29140

Since the code here ties into the osu-deploy PR, the testing checklist on the osu-deploy PR will also include testing for this PR as well.

In addition to the Velopack changes, I also decided to clean up the release stream settings. Previously it wouldn't prompt you to restart after changing release streams, this PR adds that in, so that a dialog similar to the renderer restart dialog asks you to confirm your decision and prompts you to restart upon switching release streams.

There's also some TODO's in the code remaining, I plan on addressing these when I get the time. I'll keep this PR as a draft so long as the osu-deploy PR is a draft, and/or the remaining TODO's in the code are still present.