### PR TITLE
Fix key counter not updating activation state on initial load

### DIFF
--- a/osu.Game/Screens/Play/HUD/InputTrigger.cs
+++ b/osu.Game/Screens/Play/HUD/InputTrigger.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Screens.Play.HUD
         public IBindable<int> ActivationCount => activationCount;
 
         /// <summary>
+        /// Whether this <see cref="InputTrigger"/> is currently active.
+        /// </summary>
+        public bool IsActive { get; private set; }
+
+        /// <summary>
         /// Whether any activation or deactivation of this <see cref="InputTrigger"/> impacts its <see cref="ActivationCount"/>
         /// </summary>
         public IBindable<bool> IsCounting => isCounting;
@@ -49,6 +54,7 @@ namespace osu.Game.Screens.Play.HUD
             if (forwardPlayback && isCounting.Value)
                 activationCount.Value++;
 
+            IsActive = true;
             OnActivate?.Invoke(forwardPlayback);
         }
 
@@ -57,6 +63,7 @@ namespace osu.Game.Screens.Play.HUD
             if (!forwardPlayback && isCounting.Value)
                 activationCount.Value--;
 
+            IsActive = false;
             OnDeactivate?.Invoke(forwardPlayback);
         }
     }

--- a/osu.Game/Screens/Play/HUD/KeyCounter.cs
+++ b/osu.Game/Screens/Play/HUD/KeyCounter.cs
@@ -36,6 +36,14 @@ namespace osu.Game.Screens.Play.HUD
             Trigger.OnDeactivate += Deactivate;
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (Trigger.IsActive)
+                Activate();
+        }
+
         protected virtual void Activate(bool forwardPlayback = true)
         {
             isActive.Value = true;


### PR DESCRIPTION
Minor improvement to key counter display when changing skins (previously key counter activation state is not updated when changing skins until the next key press).