### PR TITLE
Fix osu! cursor not expanding when holding key before load finish

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/OsuCursorContainer.cs
@@ -33,6 +33,11 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
 
         private readonly CursorRippleVisualiser rippleVisualiser;
 
+        // we still want to receive input even while hidden,
+        // otherwise the cursor may not expand sometimes.
+        // (e.g. holding left/right button before player is loaded)
+        public override bool PropagateNonPositionalInputSubTree => true;
+
         public OsuCursorContainer()
         {
             InternalChild = fadeContainer = new Container


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu-framework/pull/6398 to actually have an effect

Minor requirement with https://github.com/ppy/osu-framework/pull/6398 (after commit https://github.com/ppy/osu-framework/pull/6398/commits/00fc4fffe22a863ae0520038fc8bba1633fb3854). Since input is now being synced slightly earlier, the osu! cursor will receive synced key presses while it is hidden and therefore ignore it from expanding the cursor. It is hidden because `GlobalCursorDisplay` has not updated it to become visible yet (it just so happens that I'm syncing input exactly one frame behind `GlobalCursorDisplay` updating the cursor state).

This might be an indicator that commit https://github.com/ppy/osu-framework/pull/6398/commits/00fc4fffe22a863ae0520038fc8bba1633fb3854 may actually be causing input to be synced at very irregular point in time? I don't know, it works, and it's a single schedule now.