### PR TITLE
Fix reference issues in iOS tests

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj
+++ b/osu.Game.Rulesets.Osu.Tests.iOS/osu.Game.Rulesets.Osu.Tests.iOS.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Osu\osu.Game.Rulesets.Osu.csproj" />
   </ItemGroup>
+  <ItemGroup Label="Package References">
+    <PackageReference Include="DeepEqual" Version="2.0.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+  </ItemGroup>
 </Project>

--- a/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj
+++ b/osu.Game.Rulesets.Taiko.Tests.iOS/osu.Game.Rulesets.Taiko.Tests.iOS.csproj
@@ -13,7 +13,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Label="Project References">
-    <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
     <ProjectReference Include="..\osu.Game.Rulesets.Taiko\osu.Game.Rulesets.Taiko.csproj" />
+    <ProjectReference Include="..\osu.Game.Tests\osu.Game.Tests.csproj" />
+    <ProjectReference Include="..\osu.Game\osu.Game.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
1. `osu.Game.Rulesets.Osu.Tests.iOS` was missing references for `Moq` and `DeepEqual`
2. `osu.Game.Rulesets.Taiko.Tests.iOS` was missing a reference to `osu.Game.Tests`, causing issues with trying to use `osu.Game.Tests.Beatmaps.IO.BeatmapImportHelper`

Both caused the tests to not compile.