### PR TITLE
Build Android with non-maui workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           dotnet-version: "8.0.x"
 
       - name: Install .NET workloads
-        run: dotnet workload install maui-android
+        run: dotnet workload install android
 
       - name: Compile
         run: dotnet build -c Debug osu.Android.slnf


### PR DESCRIPTION
The .NET SDK was updated to 8.0.400 over the weekend/very close to it, and our workflows started intermittently failing since. I don't know why, but I'm hoping this fixes it...
- (-8h, fail): https://github.com/ppy/osu/actions/runs/11883407684/job/33110128684
- (-6h, pass): https://github.com/ppy/osu/actions/runs/11884177358/job/33111984290
- (-6h, pass): https://github.com/ppy/osu/actions/runs/11884186730/job/33112007786
- (-1h, fail): https://github.com/ppy/osu/actions/runs/11887442003/job/33120212673

Related issues:
- https://github.com/actions/runner/issues/3578
- https://github.com/getsentry/sentry-dotnet/pull/3764

Of note, sentry also uses `maui-android`. Our build appears to pass without it.