### PR TITLE
Fix mania notes disappearing on seek to their end time

### DIFF
--- a/osu.Game.Rulesets.Mania/Edit/EditorColumn.cs
+++ b/osu.Game.Rulesets.Mania/Edit/EditorColumn.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Game.Rulesets.Mania.Objects.Drawables;
+using osu.Game.Rulesets.Mania.UI;
+using osu.Game.Rulesets.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Mania.Edit
+{
+    public partial class EditorColumn : Column
+    {
+        public EditorColumn(int index, bool isSpecial)
+            : base(index, isSpecial)
+        {
+        }
+
+        protected override void OnNewDrawableHitObject(DrawableHitObject drawableHitObject)
+        {
+            base.OnNewDrawableHitObject(drawableHitObject);
+            drawableHitObject.ApplyCustomUpdateState += (dho, state) =>
+            {
+                switch (dho)
+                {
+                    // hold note heads are exempt from what follows due to the "freezing" mechanic
+                    // which already ensures they'll never fade away on their own.
+                    case DrawableHoldNoteHead:
+                        break;
+
+                    // mania features instantaneous hitobject fade-outs.
+                    // this means that without manual intervention stopping the clock at the precise time of hitting the object
+                    // means the object will fade out.
+                    // this is anti-user in editor contexts, as the user is expecting to continue the see the note on the receptor line.
+                    // therefore, apply a crude workaround to prevent it from going away.
+                    default:
+                    {
+                        if (state == ArmedState.Hit)
+                            dho.FadeTo(1).Delay(1).FadeOut().Expire();
+                        break;
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/EditorStage.cs
+++ b/osu.Game.Rulesets.Mania/Edit/EditorStage.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mania.Beatmaps;
+using osu.Game.Rulesets.Mania.UI;
+
+namespace osu.Game.Rulesets.Mania.Edit
+{
+    public partial class EditorStage : Stage
+    {
+        public EditorStage(int firstColumnIndex, StageDefinition definition, ref ManiaAction columnStartAction)
+            : base(firstColumnIndex, definition, ref columnStartAction)
+        {
+        }
+
+        protected override Column CreateColumn(int index, bool isSpecial) => new EditorColumn(index, isSpecial);
+    }
+}

--- a/osu.Game.Rulesets.Mania/Edit/ManiaEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaEditorPlayfield.cs
@@ -13,5 +13,8 @@ namespace osu.Game.Rulesets.Mania.Edit
             : base(stages)
         {
         }
+
+        protected override Stage CreateStage(int firstColumnIndex, StageDefinition stageDefinition, ref ManiaAction columnAction)
+            => new EditorStage(firstColumnIndex, stageDefinition, ref columnAction);
     }
 }

--- a/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
+++ b/osu.Game.Rulesets.Mania/UI/ManiaPlayfield.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -71,7 +72,7 @@ namespace osu.Game.Rulesets.Mania.UI
 
             for (int i = 0; i < stageDefinitions.Count; i++)
             {
-                var newStage = new Stage(firstColumnIndex, stageDefinitions[i], ref columnAction);
+                var newStage = CreateStage(firstColumnIndex, stageDefinitions[i], ref columnAction);
 
                 playfieldGrid.Content[0][i] = newStage;
 
@@ -81,6 +82,9 @@ namespace osu.Game.Rulesets.Mania.UI
                 firstColumnIndex += newStage.Columns.Length;
             }
         }
+
+        [Pure]
+        protected virtual Stage CreateStage(int firstColumnIndex, StageDefinition stageDefinition, ref ManiaAction columnAction) => new Stage(firstColumnIndex, stageDefinition, ref columnAction);
 
         public override void Add(HitObject hitObject) => getStageByColumn(((ManiaHitObject)hitObject).Column).Add(hitObject);
 

--- a/osu.Game.Rulesets.Mania/UI/Stage.cs
+++ b/osu.Game.Rulesets.Mania/UI/Stage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -134,12 +135,14 @@ namespace osu.Game.Rulesets.Mania.UI
             {
                 bool isSpecial = definition.IsSpecialColumn(i);
 
-                var column = new Column(firstColumnIndex + i, isSpecial)
+                var action = columnStartAction;
+                columnStartAction++;
+                var column = CreateColumn(firstColumnIndex + i, isSpecial).With(c =>
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 1,
-                    Action = { Value = columnStartAction++ }
-                };
+                    c.RelativeSizeAxes = Axes.Both;
+                    c.Width = 1;
+                    c.Action.Value = action;
+                });
 
                 topLevelContainer.Add(column.TopLevelContainer.CreateProxy());
                 columnBackgrounds.Add(column.BackgroundContainer.CreateProxy());
@@ -153,6 +156,9 @@ namespace osu.Game.Rulesets.Mania.UI
 
             RegisterPool<BarLine, DrawableBarLine>(50, 200);
         }
+
+        [Pure]
+        protected virtual Column CreateColumn(int index, bool isSpecial) => new Column(index, isSpecial);
 
         [BackgroundDependencyLoader]
         private void load(ISkinSource skin)


### PR DESCRIPTION
RFC. Would close https://github.com/ppy/osu/issues/30639.

Not too sold on this myself, but it appears to work well enough for a hack.

Options I also considered but didn't end up going through with:
- applying this sort of delay universally to `ManiaHitObject` (smelled of twisting gameplay code to editor needs)
- mutating the replay used internally by `DrawableEditorRulesetWrapper` to press keys 1ms late instead (no easy entry point to do this, would need to create yet another virtual on `Ruleset` rather than leveraging existing structures, even though this change ended up doing two levels of virtuals)