### PR TITLE
Deactivate new combo toggle on deselecting objects

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -258,8 +258,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void resetTernaryStates()
         {
-            if (SelectionNewComboState.Value == TernaryState.Indeterminate)
-                SelectionNewComboState.Value = TernaryState.False;
+            SelectionNewComboState.Value = TernaryState.False;
             AutoSelectionBankEnabled.Value = true;
             SelectionAdditionBanksEnabled.Value = true;
             SelectionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30713.

[Was a point of discussion doing review.](https://github.com/ppy/osu/pull/30214#discussion_r1798833139) Given it got pointed out immediately for something so minor, I'm inclined to believe it's a rather undesirable change.