### PR TITLE
Adjust beat synced animation to be smoother in skip and break overlay

### DIFF
--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Screens.Play
                 return;
 
             float timeBoxTargetWidth = (float)Math.Max(0, (remainingTimeForCurrentPeriod - timingPoint.BeatLength / currentPeriod.Value.Value.Duration));
-            remainingTimeBox.ResizeWidthTo(timeBoxTargetWidth, timingPoint.BeatLength * 2, Easing.OutQuint);
+            remainingTimeBox.ResizeWidthTo(timeBoxTargetWidth, timingPoint.BeatLength * 3.5, Easing.OutQuint);
         }
 
         private void updateDisplay(ValueChangedEvent<Period?> period)

--- a/osu.Game/Screens/Play/SkipOverlay.cs
+++ b/osu.Game/Screens/Play/SkipOverlay.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Screens.Play
 
             float progress = (float)(gameplayClock.CurrentTime - displayTime) / (float)(fadeOutBeginTime - displayTime);
             float newWidth = 1 - Math.Clamp(progress, 0, 1);
-            remainingTimeBox.ResizeWidthTo(newWidth, timingPoint.BeatLength * 2, Easing.OutQuint);
+            remainingTimeBox.ResizeWidthTo(newWidth, timingPoint.BeatLength * 3.5, Easing.OutQuint);
         }
 
         public partial class FadeContainer : Container, IStateful<Visibility>


### PR DESCRIPTION
The multipliers for how slow each beat-synced animation is, were changed from 2 to 3.5.

Context PR & Comment:
https://github.com/ppy/osu/pull/29616
https://github.com/ppy/osu/pull/29616#discussion_r1846440740

Here's a video from the above PR but with its beat-synced animation adjusted:

https://github.com/user-attachments/assets/9aa7c27f-4faf-49d2-ac4b-4712c6e5456d