### PR TITLE
Fix beatmap load not continuing when when settings slider is focused

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs
@@ -18,6 +18,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Rulesets.Mods;
@@ -207,7 +208,25 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         [Test]
-        public void TestBlockLoadViaFocus()
+        public void TestLoadNotBlockedViaArbitraryFocus()
+        {
+            AddStep("load dummy beatmap", () => resetPlayer(false));
+            AddUntilStep("wait for current", () => loader.IsCurrentScreen());
+
+            AddUntilStep("click settings slider", () =>
+            {
+                InputManager.MoveMouseTo(loader.ChildrenOfType<OsuSliderBar<float>>().First());
+                InputManager.Click(MouseButton.Left);
+
+                return InputManager.FocusedDrawable is OsuSliderBar<float>;
+            });
+
+            AddUntilStep("wait for load ready", () => player?.LoadState == LoadState.Ready);
+            AddUntilStep("loads", () => !loader.IsCurrentScreen());
+        }
+
+        [Test]
+        public void TestBlockLoadViaOverlayFocus()
         {
             AddStep("load dummy beatmap", () => resetPlayer(false));
             AddUntilStep("wait for current", () => loader.IsCurrentScreen());

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -122,7 +122,9 @@ namespace osu.Game.Screens.Play
             // not ready if the user is dragging a slider or otherwise.
             && (inputManager.DraggedDrawable == null || inputManager.DraggedDrawable is OsuLogo)
             // not ready if a focused overlay is visible, like settings.
-            && inputManager.FocusedDrawable == null;
+            && inputManager.FocusedDrawable is not OsuFocusedOverlayContainer
+            // or if a child of a focused overlay is focused, like settings' search textbox.
+            && inputManager.FocusedDrawable?.FindClosestParent<OsuFocusedOverlayContainer>() == null;
 
         private readonly Func<Player> createPlayer;
 


### PR DESCRIPTION
Regressed with recent sliderbar focus changes.

Closes #30716.