### PR TITLE
Use consistent decimal places in BeatmapAttributeText

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapAttributeText.cs
@@ -73,10 +73,10 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
         });
 
-        [TestCase(BeatmapAttribute.CircleSize, "Circle Size: 1.00")]
-        [TestCase(BeatmapAttribute.HPDrain, "HP Drain: 2.00")]
-        [TestCase(BeatmapAttribute.Accuracy, "Accuracy: 3.00")]
-        [TestCase(BeatmapAttribute.ApproachRate, "Approach Rate: 4.00")]
+        [TestCase(BeatmapAttribute.CircleSize, "Circle Size: 1")]
+        [TestCase(BeatmapAttribute.HPDrain, "HP Drain: 2")]
+        [TestCase(BeatmapAttribute.Accuracy, "Accuracy: 3")]
+        [TestCase(BeatmapAttribute.ApproachRate, "Approach Rate: 4")]
         [TestCase(BeatmapAttribute.Title, "Title: _Title")]
         [TestCase(BeatmapAttribute.Artist, "Artist: _Artist")]
         [TestCase(BeatmapAttribute.Creator, "Creator: _Creator")]
@@ -121,15 +121,15 @@ namespace osu.Game.Tests.Visual.UserInterface
                     Difficulty =
                     {
                         ApproachRate = 10,
-                        CircleSize = 9
+                        CircleSize = 9.5f
                     }
                 }
             }));
 
-            test(BeatmapAttribute.BPM, new OsuModDoubleTime(), "BPM: 100.00", "BPM: 150.00");
+            test(BeatmapAttribute.BPM, new OsuModDoubleTime(), "BPM: 100", "BPM: 150");
             test(BeatmapAttribute.Length, new OsuModDoubleTime(), "Length: 00:30", "Length: 00:20");
-            test(BeatmapAttribute.ApproachRate, new OsuModDoubleTime(), "Approach Rate: 10.00", "Approach Rate: 11.00");
-            test(BeatmapAttribute.CircleSize, new OsuModHardRock(), "Circle Size: 9.00", "Circle Size: 10.00");
+            test(BeatmapAttribute.ApproachRate, new OsuModDoubleTime(), "Approach Rate: 10", "Approach Rate: 11");
+            test(BeatmapAttribute.CircleSize, new OsuModHardRock(), "Circle Size: 9.5", "Circle Size: 10");
 
             void test(BeatmapAttribute attribute, Mod mod, string before, string after)
             {

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -211,19 +211,19 @@ namespace osu.Game.Skinning.Components
                     return beatmap.Value.BeatmapInfo.Status.GetLocalisableDescription();
 
                 case BeatmapAttribute.BPM:
-                    return FormatUtils.RoundBPM(beatmap.Value.BeatmapInfo.BPM, ModUtils.CalculateRateWithMods(mods.Value)).ToLocalisableString(@"F2");
+                    return FormatUtils.RoundBPM(beatmap.Value.BeatmapInfo.BPM, ModUtils.CalculateRateWithMods(mods.Value)).ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.CircleSize:
-                    return computeDifficulty().CircleSize.ToLocalisableString(@"F2");
+                    return computeDifficulty().CircleSize.ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.HPDrain:
-                    return computeDifficulty().DrainRate.ToLocalisableString(@"F2");
+                    return computeDifficulty().DrainRate.ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.Accuracy:
-                    return computeDifficulty().OverallDifficulty.ToLocalisableString(@"F2");
+                    return computeDifficulty().OverallDifficulty.ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.ApproachRate:
-                    return computeDifficulty().ApproachRate.ToLocalisableString(@"F2");
+                    return computeDifficulty().ApproachRate.ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.StarRating:
                     return (starDifficulty?.Stars ?? 0).ToLocalisableString(@"F2");


### PR DESCRIPTION
Currently, BeatmapAttributeText will always display 2 decimal places, possibly with trailing zeroes, for attributes that normally don't have trailing zeroes.

In most of the game, and on web, difficulty attributes are displayed with one decimal place, but can be displayed as whole numbers if there are no decimals e.g. (CS 3.8, HP 5.5, Accuracy 9, AR 9.2) for https://osu.ppy.sh/beatmapsets/1314891#osu/2725039. If mods are applied, difficulty attributes will be displayed with up to 2 decimal places. This can be seen by turning on DT then looking at the top left section of lazer song select. So I have changed the difficulty attribute format to `0.##`.

The same logic applies for BPM. Usually it's displayed as a whole number, but it can have up to 2 decimal places if necessary: https://osu.ppy.sh/beatmapsets/2268670#fruits/4831566. So I changed this format to `0.##` as well.

I have not changed the display of star rating because it's always 2 decimal places with trailing zeroes: https://osu.ppy.sh/beatmapsets/2253429#osu/4794131

I tested this manually and it seems to work. I'm not sure if there's any automated tests that need to be updated.