### PR TITLE
Fix playlist room status resetting on enter

### DIFF
--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
@@ -12,7 +12,7 @@ using osu.Game.Tests.Visual.OnlinePlay;
 
 namespace osu.Game.Tests.Visual.Playlists
 {
-    public class TestScenePlaylistsRoomSubScreen : OnlinePlayTestScene
+    public partial class TestScenePlaylistsRoomSubScreen : OnlinePlayTestScene
     {
         protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
 

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Screens;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
+using osu.Game.Online.Rooms.RoomStatuses;
+using osu.Game.Screens.OnlinePlay.Playlists;
+using osu.Game.Tests.Visual.OnlinePlay;
+
+namespace osu.Game.Tests.Visual.Playlists
+{
+    public class TestScenePlaylistsRoomSubScreen : OnlinePlayTestScene
+    {
+        protected new TestRoomManager RoomManager => (TestRoomManager)base.RoomManager;
+
+        [Test]
+        public void TestStatusUpdateOnEnter()
+        {
+            Room room = null!;
+            PlaylistsRoomSubScreen roomScreen = null!;
+
+            AddStep("create room", () =>
+            {
+                RoomManager.AddRoom(room = new Room
+                {
+                    Name = @"Test Room",
+                    Host = new APIUser { Username = @"Host" },
+                    Category = RoomCategory.Normal,
+                    EndDate = DateTimeOffset.Now.AddMinutes(-1)
+                });
+            });
+
+            AddStep("push screen", () => LoadScreen(roomScreen = new PlaylistsRoomSubScreen(room)));
+            AddUntilStep("wait for screen load", () => roomScreen.IsCurrentScreen());
+            AddAssert("status is still ended", () => roomScreen.Room.Status, Is.TypeOf<RoomStatusEnded>);
+        }
+    }
+}

--- a/osu.Game/Online/Rooms/GetRoomsRequest.cs
+++ b/osu.Game/Online/Rooms/GetRoomsRequest.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Framework.IO.Network;
 using osu.Game.Extensions;
 using osu.Game.Online.API;
-using osu.Game.Online.Rooms.RoomStatuses;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
 
 namespace osu.Game.Online.Rooms
@@ -33,25 +31,6 @@ namespace osu.Game.Online.Rooms
                 req.AddParameter("category", category);
 
             return req;
-        }
-
-        protected override void PostProcess()
-        {
-            base.PostProcess();
-
-            if (Response != null)
-            {
-                // API doesn't populate status so let's do it here.
-                foreach (var room in Response)
-                {
-                    if (room.EndDate != null && DateTimeOffset.Now >= room.EndDate)
-                        room.Status = new RoomStatusEnded();
-                    else if (room.HasPassword)
-                        room.Status = new RoomStatusOpenPrivate();
-                    else
-                        room.Status = new RoomStatusOpen();
-                }
-            }
         }
 
         protected override string Target => "rooms";

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using osu.Game.IO.Serialization.Converters;
 using osu.Game.Online.API.Requests.Responses;
@@ -262,6 +263,18 @@ namespace osu.Game.Online.Rooms
         {
             get => availability;
             set => SetField(ref availability, value);
+        }
+
+        [OnDeserialized]
+        private void onDeserialised(StreamingContext context)
+        {
+            // API doesn't populate status so let's do it here.
+            if (EndDate != null && DateTimeOffset.Now >= EndDate)
+                Status = new RoomStatusEnded();
+            else if (HasPassword)
+                Status = new RoomStatusOpenPrivate();
+            else
+                Status = new RoomStatusOpen();
         }
 
         [JsonProperty("id")]

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomManager.cs
@@ -29,38 +29,28 @@ namespace osu.Game.Tests.Visual.OnlinePlay
         {
             for (int i = 0; i < count; i++)
             {
-                var room = new Room
+                AddRoom(new Room
                 {
-                    RoomID = -currentRoomId,
                     Name = $@"Room {currentRoomId}",
                     Host = new APIUser { Username = @"Host" },
                     Duration = TimeSpan.FromSeconds(10),
                     Category = withSpotlightRooms && i % 2 == 0 ? RoomCategory.Spotlight : RoomCategory.Normal,
-                };
-
-                if (withPassword)
-                    room.Password = @"password";
-
-                if (ruleset != null)
-                {
-                    room.PlaylistItemStats = new Room.RoomPlaylistItemStats
-                    {
-                        RulesetIDs = new[] { ruleset.OnlineID },
-                    };
-
-                    room.Playlist =
-                    [
-                        new PlaylistItem(new BeatmapInfo { Metadata = new BeatmapMetadata() })
-                        {
-                            RulesetID = ruleset.OnlineID,
-                        }
-                    ];
-                }
-
-                CreateRoom(room);
-
-                currentRoomId++;
+                    Password = withPassword ? @"password" : null,
+                    PlaylistItemStats = ruleset == null
+                        ? null
+                        : new Room.RoomPlaylistItemStats { RulesetIDs = [ruleset.OnlineID] },
+                    Playlist = ruleset == null
+                        ? Array.Empty<PlaylistItem>()
+                        : [new PlaylistItem(new BeatmapInfo { Metadata = new BeatmapMetadata() }) { RulesetID = ruleset.OnlineID }]
+                });
             }
+        }
+
+        public void AddRoom(Room room)
+        {
+            room.RoomID = -currentRoomId;
+            CreateRoom(room);
+            currentRoomId++;
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/30792

The issue is that `Room.Status` is populated after deserialisation only by `GetRoomsRequest` (in the lounge) and not by `GetRoomRequest` (in the room). This PR applies a direct fix by moving the post-processing to a method that's called when any JSON deserialisation takes place, covering both requests.

It's not the best possible fix because there's probably no realistic use for this entire thing to be a class in the first place, as opposed to for example a helper method, enum, or even being applied in the existing property setters. But I don't consider this an important thing to change at the current moment.