### PR TITLE
Fix joining playlists room sometimes not selecting the first item

### DIFF
--- a/osu.Game/Online/Rooms/JoinRoomRequest.cs
+++ b/osu.Game/Online/Rooms/JoinRoomRequest.cs
@@ -7,7 +7,7 @@ using osu.Game.Online.API;
 
 namespace osu.Game.Online.Rooms
 {
-    public class JoinRoomRequest : APIRequest
+    public class JoinRoomRequest : APIRequest<Room>
     {
         public readonly Room Room;
         public readonly string? Password;

--- a/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/RoomManager.cs
@@ -72,9 +72,13 @@ namespace osu.Game.Screens.OnlinePlay.Components
             currentJoinRoomRequest?.Cancel();
             currentJoinRoomRequest = new JoinRoomRequest(room, password);
 
-            currentJoinRoomRequest.Success += () =>
+            currentJoinRoomRequest.Success += result =>
             {
                 joinedRoom.Value = room;
+
+                AddOrUpdateRoom(result);
+                room.CopyFrom(result); // Also copy back to the source model, since this is likely to have been stored elsewhere.
+
                 onSuccess?.Invoke(room);
             };
 

--- a/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
+++ b/osu.Game/Tests/Visual/OnlinePlay/TestRoomRequestsHandler.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Tests.Visual.OnlinePlay
                         return true;
                     }
 
-                    joinRoomRequest.TriggerSuccess();
+                    joinRoomRequest.TriggerSuccess(createResponseRoom(room, true));
                     return true;
                 }
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-web/pull/11675

When the room is joined and has a non-null ID, the playlists subscreen expects the playlist to be populated to select the first item:

https://github.com/ppy/osu/blob/23ef8fd909f1cdbfc1662a35d281cd001fb71aad/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs#L89-L97

This will now be possible after the above osu!web change.