### PR TITLE
Recreate beatmap every test run in `ModTestScene`

### DIFF
--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModNoScope.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -99,7 +99,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
             Mod = new CatchModRelax(),
             Autoplay = false,
             PassCondition = passCondition,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
+++ b/osu.Game.Rulesets.Catch.Tests/Mods/TestSceneCatchModRelax.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Tests.Mods
             Mod = new CatchModRelax(),
             Autoplay = false,
             PassCondition = passCondition,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             CreateModTest(new ModTestData
             {
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
+++ b/osu.Game.Rulesets.Catch.Tests/TestSceneCatchModHidden.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Rulesets.Catch.Tests
         {
             CreateModTest(new ModTestData
             {
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModAutoplay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
-                Beatmap = new ManiaBeatmap(new StageDefinition(1))
+                Beatmap = () => new ManiaBeatmap(new StageDefinition(1))
                 {
                     HitObjects = new List<ManiaHitObject>
                     {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModAutoplay.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModAutoplay.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
-                Beatmap = () => new ManiaBeatmap(new StageDefinition(1))
+                CreateBeatmap = () => new ManiaBeatmap(new StageDefinition(1))
                 {
                     HitObjects = new List<ManiaHitObject>
                     {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                                   && Precision.AlmostEquals(Player.ScoreProcessor.Accuracy.Value, 0.9836, 0.01)
                                   && Player.ScoreProcessor.TotalScore.Value == 946_049,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                 Difficulty = { OverallDifficulty = 10 },
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                                       && Player.ScoreProcessor.Accuracy.Value == 1
                                       && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * doubleTime.ScoreMultiplier),
                 Autoplay = false,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                     Difficulty = { OverallDifficulty = 10 },

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModDoubleTime.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                                   && Precision.AlmostEquals(Player.ScoreProcessor.Accuracy.Value, 0.9836, 0.01)
                                   && Player.ScoreProcessor.TotalScore.Value == 946_049,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                 Difficulty = { OverallDifficulty = 10 },
@@ -56,7 +56,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
                                       && Player.ScoreProcessor.Accuracy.Value == 1
                                       && Player.ScoreProcessor.TotalScore.Value == (long)(1_000_000 * doubleTime.ScoreMultiplier),
                 Autoplay = false,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     BeatmapInfo = { Ruleset = new ManiaRuleset().RulesetInfo },
                     Difficulty = { OverallDifficulty = 10 },

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Mod = new ManiaModHidden(),
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
                     Breaks = { new BreakPeriod(2000, 28000) }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModFadeIn.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Mod = new ManiaModHidden(),
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
                     Breaks = { new BreakPeriod(2000, 28000) }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Mod = new ManiaModHidden(),
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
                     Breaks = { new BreakPeriod(2000, 28000) }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModHidden.cs
@@ -74,7 +74,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Mod = new ManiaModHidden(),
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(1, 100).Select(i => (HitObject)new Note { StartTime = 1000 + 200 * i }).ToList(),
                     Breaks = { new BreakPeriod(2000, 28000) }

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModPerfect.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModPerfect.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true) && Player.Results.Count == 2,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModPerfect.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModPerfect.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -59,7 +59,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true) && Player.Results.Count == 2,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModSuddenDeath.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true) && Player.Results.Count == 2,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Mods/TestSceneManiaModSuddenDeath.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -51,7 +51,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Mods
             Mod = new ManiaModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true) && Player.Results.Count == 2,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 4,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 1,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 2,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAlternate.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 4,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 1,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -131,7 +131,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModAlternate(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 2,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Autoplay = true,
                 Mod = mod,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects =
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModAutoplay.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Autoplay = true,
                 Mod = mod,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects =
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestNoAdjustment() => CreateModTest(new ModTestData
         {
             Mod = new OsuModDifficultyAdjust(),
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 BeatmapInfo = new BeatmapInfo
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModDifficultyAdjust.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestNoAdjustment() => CreateModTest(new ModTestData
         {
             Mod = new OsuModDifficultyAdjust(),
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 BeatmapInfo = new BeatmapInfo
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime < 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && !sliderDimmedBeforeStartTime;
                 },
-                Beatmap = () => new OsuBeatmap
+                CreateBeatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && sliderDimmed;
                 },
-                Beatmap = () => new OsuBeatmap
+                CreateBeatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && sliderDimmed;
                 },
-                Beatmap = () => new OsuBeatmap
+                CreateBeatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModFlashlight.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime < 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && !sliderDimmedBeforeStartTime;
                 },
-                Beatmap = new OsuBeatmap
+                Beatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && sliderDimmed;
                 },
-                Beatmap = new OsuBeatmap
+                Beatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                         Player.GameplayClockContainer.CurrentTime >= 1000 && Player.ChildrenOfType<ModFlashlight<OsuHitObject>.Flashlight>().Single().FlashlightDim > 0;
                     return Player.GameplayState.HasPassed && sliderDimmed;
                 },
-                Beatmap = new OsuBeatmap
+                Beatmap = () => new OsuBeatmap
                 {
                     HitObjects = new List<OsuHitObject>
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new OsuModHidden { OnlyFadeApproachCircles = { Value = true } },
             Autoplay = true,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModHidden.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -63,7 +63,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -98,7 +98,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new TestOsuModHidden(),
             Autoplay = true,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -122,7 +122,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new OsuModHidden { OnlyFadeApproachCircles = { Value = true } },
             Autoplay = true,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModMirror.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestCorrectReflections([Values] OsuModMirror.MirrorType type, [Values] bool withStrictTracking) => CreateModTest(new ModTestData
         {
             Autoplay = true,
-            Beatmap = new OsuBeatmap
+            Beatmap = () => new OsuBeatmap
             {
                 HitObjects =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModMirror.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModMirror.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         public void TestCorrectReflections([Values] OsuModMirror.MirrorType type, [Values] bool withStrictTracking) => CreateModTest(new ModTestData
         {
             Autoplay = true,
-            Beatmap = () => new OsuBeatmap
+            CreateBeatmap = () => new OsuBeatmap
             {
                 HitObjects =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModNoScope.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {
@@ -113,7 +113,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 },
                 Autoplay = true,
                 PassCondition = () => true,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = new List<HitObject>
                     {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPerfect.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPerfect.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPerfect.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModPerfect.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModPerfect(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRandom.cs
@@ -55,10 +55,10 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             PassCondition = () => true
         });
 
-        private OsuBeatmap jumpBeatmap =>
+        private OsuBeatmap jumpBeatmap() =>
             createHitCircleBeatmap(new[] { 100, 200, 300, 400 }, 8, 300, 2 * 300);
 
-        private OsuBeatmap streamBeatmap =>
+        private OsuBeatmap streamBeatmap() =>
             createHitCircleBeatmap(new[] { 10, 20, 30, 40, 50, 60, 70, 80 }, 16, 150, 4 * 150);
 
         private OsuBeatmap createHitCircleBeatmap(IEnumerable<int> spacings, int objectsPerSpacing, int interval, int beatLength)

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRandom.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModRandom.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 AngleSharpness = { Value = angleSharpness }
             },
-            Beatmap = jumpBeatmap,
+            CreateBeatmap = jumpBeatmap,
             Autoplay = true,
             PassCondition = () => true
         });
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 AngleSharpness = { Value = angleSharpness }
             },
-            Beatmap = streamBeatmap,
+            CreateBeatmap = streamBeatmap,
             Autoplay = true,
             PassCondition = () => true
         });

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 1,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 2,
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSingleTap.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -62,7 +62,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 1,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -100,7 +100,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 1,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSingleTap(),
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 0 && Player.ScoreProcessor.HighestCombo.Value == 2,
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSpunOut.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             });
         }
 
-        private Beatmap singleSpinnerBeatmap => new Beatmap
+        private Beatmap singleSpinnerBeatmap() => new Beatmap
         {
             HitObjects = new List<HitObject>
             {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSpunOut.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSpunOut.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Mod = new OsuModSpunOut(),
                 Autoplay = false,
-                Beatmap = singleSpinnerBeatmap,
+                CreateBeatmap = singleSpinnerBeatmap,
                 PassCondition = () =>
                 {
                     // Bind to the first spinner's results for further tracking.
@@ -71,7 +71,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Mods = mods,
                 Autoplay = false,
-                Beatmap = singleSpinnerBeatmap,
+                CreateBeatmap = singleSpinnerBeatmap,
                 PassCondition = () =>
                 {
                     var counter = Player.ChildrenOfType<SpinnerSpmCalculator>().SingleOrDefault();
@@ -101,7 +101,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             {
                 Mod = new OsuModSpunOut(),
                 Autoplay = false,
-                Beatmap = singleSpinnerBeatmap,
+                CreateBeatmap = singleSpinnerBeatmap,
                 PassCondition = () =>
                 {
                     // Bind to the first spinner's results for further tracking.

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new OsuModStrictTracking(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
         {
             Mod = new OsuModStrictTracking(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSuddenDeath.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModSuddenDeath.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(false),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             Mod = new OsuModSuddenDeath(),
             PassCondition = () => ((ModFailConditionTestPlayer)Player).CheckFailed(true),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 Autoplay = false,
                 Mod = new TestAutoMod(),
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = { new HitCircle { Position = new Vector2(256, 192) } }
                 },
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             CreateModTest(new ModTestData
             {
                 Autoplay = false,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = { new HitCircle { Position = new Vector2(256, 192) } }
                 },

--- a/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneMissHitWindowJudgements.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Tests
             {
                 Autoplay = false,
                 Mod = new TestAutoMod(),
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = { new HitCircle { Position = new Vector2(256, 192) } }
                 },
@@ -47,18 +47,16 @@ namespace osu.Game.Rulesets.Osu.Tests
         [Test]
         public void TestMissViaNotHitting()
         {
-            var beatmap = new Beatmap
-            {
-                HitObjects = { new HitCircle { Position = new Vector2(256, 192) } }
-            };
-
             var hitWindows = new OsuHitWindows();
-            hitWindows.SetDifficulty(beatmap.Difficulty.OverallDifficulty);
+            hitWindows.SetDifficulty(IBeatmapDifficultyInfo.DEFAULT_DIFFICULTY);
 
             CreateModTest(new ModTestData
             {
                 Autoplay = false,
-                Beatmap = beatmap,
+                Beatmap = () => new Beatmap
+                {
+                    HitObjects = { new HitCircle { Position = new Vector2(256, 192) } }
+                },
                 PassCondition = () => Player.Results.Count > 0 && Player.Results[0].TimeOffset >= hitWindows.WindowFor(HitResult.Meh) && !Player.Results[0].IsHit
             });
         }

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                 Mod = new TaikoModHidden(),
                 Autoplay = true,
                 PassCondition = checkAllMaxResultJudgements(2),
-                Beatmap = () =>
+                CreateBeatmap = () =>
                 {
                     var beatmap = new Beatmap<TaikoHitObject>
                     {

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
@@ -31,40 +31,42 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             const double hit_time = 1;
 
-            var beatmap = new Beatmap<TaikoHitObject>
-            {
-                HitObjects = new List<TaikoHitObject>
-                {
-                    new Hit
-                    {
-                        Type = HitType.Rim,
-                        StartTime = hit_time,
-                    },
-                    new Hit
-                    {
-                        Type = HitType.Centre,
-                        StartTime = hit_time * 2,
-                    },
-                },
-                BeatmapInfo =
-                {
-                    Difficulty = new BeatmapDifficulty
-                    {
-                        SliderTickRate = 4,
-                        OverallDifficulty = 0,
-                    },
-                    Ruleset = new TaikoRuleset().RulesetInfo
-                },
-            };
-
-            beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
-
             CreateModTest(new ModTestData
             {
                 Mod = new TaikoModHidden(),
                 Autoplay = true,
                 PassCondition = checkAllMaxResultJudgements(2),
-                Beatmap = beatmap,
+                Beatmap = () =>
+                {
+                    var beatmap = new Beatmap<TaikoHitObject>
+                    {
+                        HitObjects = new List<TaikoHitObject>
+                        {
+                            new Hit
+                            {
+                                Type = HitType.Rim,
+                                StartTime = hit_time,
+                            },
+                            new Hit
+                            {
+                                Type = HitType.Centre,
+                                StartTime = hit_time * 2,
+                            },
+                        },
+                        BeatmapInfo =
+                        {
+                            Difficulty = new BeatmapDifficulty
+                            {
+                                SliderTickRate = 4,
+                                OverallDifficulty = 0,
+                            },
+                            Ruleset = new TaikoRuleset().RulesetInfo
+                        },
+                    };
+
+                    beatmap.ControlPointInfo.Add(0, new EffectControlPoint { ScrollSpeed = 0.1f });
+                    return beatmap;
+                },
             });
         }
     }

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             CreateModTest(new ModTestData
             {
                 Mod = new TaikoModRelax(),
-                Beatmap = createBeatmap,
+                CreateBeatmap = createBeatmap,
                 ReplayFrames = replay.Frames,
                 Autoplay = false,
                 PassCondition = () => Player.ScoreProcessor.HasCompleted.Value && Player.ScoreProcessor.Accuracy.Value == 1,

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
@@ -15,7 +15,26 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         [Test]
         public void TestRelax()
         {
-            var beatmap = new TaikoBeatmap
+            var beatmapForReplay = createBeatmap();
+
+            foreach (var ho in beatmapForReplay.HitObjects)
+                ho.ApplyDefaults(beatmapForReplay.ControlPointInfo, beatmapForReplay.Difficulty);
+
+            var replay = new TaikoAutoGenerator(beatmapForReplay).Generate();
+
+            foreach (var frame in replay.Frames.OfType<TaikoReplayFrame>().Where(r => r.Actions.Any()))
+                frame.Actions = [TaikoAction.LeftCentre];
+
+            CreateModTest(new ModTestData
+            {
+                Mod = new TaikoModRelax(),
+                Beatmap = createBeatmap,
+                ReplayFrames = replay.Frames,
+                Autoplay = false,
+                PassCondition = () => Player.ScoreProcessor.HasCompleted.Value && Player.ScoreProcessor.Accuracy.Value == 1,
+            });
+
+            TaikoBeatmap createBeatmap() => new TaikoBeatmap
             {
                 HitObjects =
                 {
@@ -25,22 +44,6 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                     new Swell { StartTime = 1250, Duration = 500 },
                 }
             };
-            foreach (var ho in beatmap.HitObjects)
-                ho.ApplyDefaults(beatmap.ControlPointInfo, beatmap.Difficulty);
-
-            var replay = new TaikoAutoGenerator(beatmap).Generate();
-
-            foreach (var frame in replay.Frames.OfType<TaikoReplayFrame>().Where(r => r.Actions.Any()))
-                frame.Actions = [TaikoAction.LeftCentre];
-
-            CreateModTest(new ModTestData
-            {
-                Mod = new TaikoModRelax(),
-                Beatmap = beatmap,
-                ReplayFrames = replay.Frames,
-                Autoplay = false,
-                PassCondition = () => Player.ScoreProcessor.HasCompleted.Value && Player.ScoreProcessor.Accuracy.Value == 1,
-            });
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 HitObjects = new List<HitObject>
                 {
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
         {
             Mod = new TaikoModSingleTap(),
             Autoplay = false,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 Breaks =
                 {

--- a/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Mods
                     MinimumAccuracy = { Value = 0.6 }
                 },
                 Autoplay = false,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(0, 5).Select(i => new HitCircle
                     {
@@ -56,7 +56,7 @@ namespace osu.Game.Tests.Visual.Mods
                     AccuracyJudgeMode = { Value = ModAccuracyChallenge.AccuracyMode.Standard }
                 },
                 Autoplay = false,
-                Beatmap = new Beatmap
+                Beatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(0, 5).Select(i => new HitCircle
                     {

--- a/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModAccuracyChallenge.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Mods
                     MinimumAccuracy = { Value = 0.6 }
                 },
                 Autoplay = false,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(0, 5).Select(i => new HitCircle
                     {
@@ -56,7 +56,7 @@ namespace osu.Game.Tests.Visual.Mods
                     AccuracyJudgeMode = { Value = ModAccuracyChallenge.AccuracyMode.Standard }
                 },
                 Autoplay = false,
-                Beatmap = () => new Beatmap
+                CreateBeatmap = () => new Beatmap
                 {
                     HitObjects = Enumerable.Range(0, 5).Select(i => new HitCircle
                     {

--- a/osu.Game/Tests/Visual/ModFailConditionTestScene.cs
+++ b/osu.Game/Tests/Visual/ModFailConditionTestScene.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual
         protected void CreateHitObjectTest(HitObjectTestData testData, bool shouldMiss) => CreateModTest(new ModTestData
         {
             Mod = mod,
-            Beatmap = () => new Beatmap
+            CreateBeatmap = () => new Beatmap
             {
                 BeatmapInfo = { Ruleset = CreatePlayerRuleset().RulesetInfo },
                 HitObjects = { testData.HitObject }

--- a/osu.Game/Tests/Visual/ModFailConditionTestScene.cs
+++ b/osu.Game/Tests/Visual/ModFailConditionTestScene.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Tests.Visual
         protected void CreateHitObjectTest(HitObjectTestData testData, bool shouldMiss) => CreateModTest(new ModTestData
         {
             Mod = mod,
-            Beatmap = new Beatmap
+            Beatmap = () => new Beatmap
             {
                 BeatmapInfo = { Ruleset = CreatePlayerRuleset().RulesetInfo },
                 HitObjects = { testData.HitObject }

--- a/osu.Game/Tests/Visual/ModTestScene.cs
+++ b/osu.Game/Tests/Visual/ModTestScene.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Tests.Visual
             base.TearDownSteps();
         }
 
-        protected sealed override IBeatmap CreateBeatmap(RulesetInfo ruleset) => CurrentTestData?.Beatmap ?? base.CreateBeatmap(ruleset);
+        protected sealed override IBeatmap CreateBeatmap(RulesetInfo ruleset) => CurrentTestData?.Beatmap?.Invoke() ?? base.CreateBeatmap(ruleset);
 
         protected sealed override TestPlayer CreatePlayer(Ruleset ruleset)
         {
@@ -107,7 +107,7 @@ namespace osu.Game.Tests.Visual
             /// The beatmap for this test case.
             /// </summary>
             [CanBeNull]
-            public IBeatmap Beatmap;
+            public Func<IBeatmap> Beatmap;
 
             /// <summary>
             /// The conditions that cause this test case to pass.

--- a/osu.Game/Tests/Visual/ModTestScene.cs
+++ b/osu.Game/Tests/Visual/ModTestScene.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Tests.Visual
             base.TearDownSteps();
         }
 
-        protected sealed override IBeatmap CreateBeatmap(RulesetInfo ruleset) => CurrentTestData?.Beatmap?.Invoke() ?? base.CreateBeatmap(ruleset);
+        protected sealed override IBeatmap CreateBeatmap(RulesetInfo ruleset) => CurrentTestData?.CreateBeatmap?.Invoke() ?? base.CreateBeatmap(ruleset);
 
         protected sealed override TestPlayer CreatePlayer(Ruleset ruleset)
         {
@@ -93,7 +93,7 @@ namespace osu.Game.Tests.Visual
         protected class ModTestData
         {
             /// <summary>
-            /// Whether to use a replay to simulate an auto-play. True by default.
+            /// Whether to use a replay to simulate an autoplay. True by default.
             /// </summary>
             public bool Autoplay = true;
 
@@ -104,10 +104,11 @@ namespace osu.Game.Tests.Visual
             public List<ReplayFrame> ReplayFrames;
 
             /// <summary>
-            /// The beatmap for this test case.
+            /// A function which should create a new instance of a beatmap containing relevant
+            /// content to the test.
             /// </summary>
             [CanBeNull]
-            public Func<IBeatmap> Beatmap;
+            public Func<IBeatmap> CreateBeatmap;
 
             /// <summary>
             /// The conditions that cause this test case to pass.


### PR DESCRIPTION
- Works around #30818 
- See https://github.com/ppy/osu/pull/30731#issuecomment-2487082189

This works around the issue by recreating the beatmap every time the mod test scene player is loaded, and it's probably a good change for a component which shouldn't care about preserving the state of anything anyway.