### PR TITLE
Change some beatmap default settings to match stable

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapDecoderTest.cs
@@ -1000,7 +1000,7 @@ namespace osu.Game.Tests.Beatmaps.Formats
                     Assert.That(decoded.BeatmapInfo.WidescreenStoryboard, Is.False);
                     Assert.That(decoded.BeatmapInfo.EpilepsyWarning, Is.False);
                     Assert.That(decoded.BeatmapInfo.SamplesMatchPlaybackRate, Is.False);
-                    Assert.That(decoded.BeatmapInfo.Countdown, Is.EqualTo(CountdownType.Normal));
+                    Assert.That(decoded.BeatmapInfo.Countdown, Is.EqualTo(CountdownType.None));
                     Assert.That(decoded.BeatmapInfo.CountdownOffset, Is.EqualTo(0));
                     Assert.That(decoded.BeatmapInfo.Metadata.PreviewTime, Is.EqualTo(-1));
                     Assert.That(decoded.BeatmapInfo.Ruleset.OnlineID, Is.EqualTo(0));

--- a/osu.Game/Beatmaps/BeatmapInfo.cs
+++ b/osu.Game/Beatmaps/BeatmapInfo.cs
@@ -150,7 +150,7 @@ namespace osu.Game.Beatmaps
 
         public bool EpilepsyWarning { get; set; }
 
-        public bool SamplesMatchPlaybackRate { get; set; } = true;
+        public bool SamplesMatchPlaybackRate { get; set; }
 
         /// <summary>
         /// The time at which this beatmap was last played by the local user.
@@ -181,7 +181,7 @@ namespace osu.Game.Beatmaps
         public double? EditorTimestamp { get; set; }
 
         [Ignored]
-        public CountdownType Countdown { get; set; } = CountdownType.Normal;
+        public CountdownType Countdown { get; set; } = CountdownType.None;
 
         /// <summary>
         /// The number of beats to move the countdown backwards (compared to its default location).

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -192,7 +192,6 @@ namespace osu.Game.Beatmaps.Formats
         private static void applyLegacyDefaults(BeatmapInfo beatmapInfo)
         {
             beatmapInfo.WidescreenStoryboard = false;
-            beatmapInfo.SamplesMatchPlaybackRate = false;
         }
 
         protected override void ParseLine(Beatmap beatmap, Section section, string line)


### PR DESCRIPTION
- Countdown should [be off by default](https://github.com/peppy/osu-stable-reference/blob/9a0748563812b5085a0ef5f8600b997408330eab/osu!/GameplayElements/Beatmaps/Beatmap.cs#L372)
- Samples match playback rate [also](https://github.com/peppy/osu-stable-reference/blob/9a0748563812b5085a0ef5f8600b997408330eab/osu!/GameplayElements/Beatmaps/Beatmap.cs#L210)

Addresses https://github.com/ppy/osu/discussions/30822.