### PR TITLE
No longer remove expired playlist items from `Room` model

### DIFF
--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -388,19 +388,8 @@ namespace osu.Game.Online.Rooms
             CurrentPlaylistItem = other.CurrentPlaylistItem;
             AutoSkip = other.AutoSkip;
 
-            other.RemoveExpiredPlaylistItems();
-
             Playlist = other.Playlist;
             RecentParticipants = other.RecentParticipants;
-        }
-
-        public void RemoveExpiredPlaylistItems()
-        {
-            // Todo: This is not the best way/place to do this, but the intention is to display all playlist items when the room has ended,
-            // and display only the non-expired playlist items while the room is still active. In order to achieve this, all expired items are removed from the source Room.
-            // More refactoring is required before this can be done locally instead - DrawableRoomPlaylist is currently directly bound to the playlist to display items in the room.
-            if (Status is not RoomStatusEnded)
-                Playlist = Playlist.Where(i => !i.Expired).ToArray();
         }
 
         [JsonObject(MemberSerialization.OptIn)]

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -366,12 +366,8 @@ namespace osu.Game.Online.Rooms
         {
             RoomID = other.RoomID;
             Name = other.Name;
-
             Category = other.Category;
-
-            if (other.Host != null && Host?.Id != other.Host.Id)
-                Host = other.Host;
-
+            Host = other.Host;
             ChannelId = other.ChannelId;
             Status = other.Status;
             Availability = other.Availability;
@@ -387,7 +383,6 @@ namespace osu.Game.Online.Rooms
             PlaylistItemStats = other.PlaylistItemStats;
             CurrentPlaylistItem = other.CurrentPlaylistItem;
             AutoSkip = other.AutoSkip;
-
             Playlist = other.Playlist;
             RecentParticipants = other.RecentParticipants;
         }

--- a/osu.Game/Screens/OnlinePlay/Components/ListingPollingComponent.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/ListingPollingComponent.cs
@@ -60,10 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Components
                 }
 
                 foreach (var incoming in result)
-                {
-                    incoming.RemoveExpiredPlaylistItems();
                     RoomManager.AddOrUpdateRoom(incoming);
-                }
 
                 initialRoomsReceived.Value = true;
                 tcs.SetResult(true);

--- a/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/SelectionPollingComponent.cs
@@ -36,7 +36,6 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             req.Success += result =>
             {
-                result.RemoveExpiredPlaylistItems();
                 RoomManager.AddOrUpdateRoom(result);
                 tcs.SetResult(true);
             };


### PR DESCRIPTION
I don't remember why this exists. It blames back 3 years ago before multiplayer had ability to queue items, or had just been given the initial ability to queue items but doesn't structurally match the current implementation.

I can't see any breakage without this.