### PR TITLE
Fix discord "view beatmap" button being shown when editing and hide identifiable information is set

### DIFF
--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -167,7 +167,9 @@ namespace osu.Desktop
                 presence.State = clampLength(activity.Value.GetStatus(hideIdentifiableInformation));
                 presence.Details = clampLength(activity.Value.GetDetails(hideIdentifiableInformation) ?? string.Empty);
 
-                if (getBeatmapID(activity.Value) is int beatmapId && beatmapId > 0)
+                if (getBeatmapID(activity.Value) is int beatmapId
+                    && beatmapId > 0
+                    && !(activity.Value is UserActivity.EditingBeatmap && hideIdentifiableInformation))
                 {
                     presence.Buttons = new[]
                     {

--- a/osu.Desktop/DiscordRichPresence.cs
+++ b/osu.Desktop/DiscordRichPresence.cs
@@ -167,9 +167,7 @@ namespace osu.Desktop
                 presence.State = clampLength(activity.Value.GetStatus(hideIdentifiableInformation));
                 presence.Details = clampLength(activity.Value.GetDetails(hideIdentifiableInformation) ?? string.Empty);
 
-                if (getBeatmapID(activity.Value) is int beatmapId
-                    && beatmapId > 0
-                    && !(activity.Value is UserActivity.EditingBeatmap && hideIdentifiableInformation))
+                if (activity.Value.GetBeatmapID(hideIdentifiableInformation) is int beatmapId && beatmapId > 0)
                 {
                     presence.Buttons = new[]
                     {
@@ -327,20 +325,6 @@ namespace osu.Desktop
             password = roomSecret.Password;
 
             return true;
-        }
-
-        private static int? getBeatmapID(UserActivity activity)
-        {
-            switch (activity)
-            {
-                case UserActivity.InGame game:
-                    return game.BeatmapID;
-
-                case UserActivity.EditingBeatmap edit:
-                    return edit.BeatmapID;
-            }
-
-            return null;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Users/UserActivity.cs
+++ b/osu.Game/Users/UserActivity.cs
@@ -41,6 +41,12 @@ namespace osu.Game.Users
 
         public virtual Color4 GetAppropriateColour(OsuColour colours) => colours.GreenDarker;
 
+        /// <summary>
+        /// Returns the ID of the beatmap involved in this activity, if applicable and/or available.
+        /// </summary>
+        /// <param name="hideIdentifiableInformation"></param>
+        public virtual int? GetBeatmapID(bool hideIdentifiableInformation = false) => null;
+
         [MessagePackObject]
         public class ChoosingBeatmap : UserActivity
         {
@@ -76,6 +82,7 @@ namespace osu.Game.Users
 
             public override string GetStatus(bool hideIdentifiableInformation = false) => RulesetPlayingVerb;
             public override string GetDetails(bool hideIdentifiableInformation = false) => BeatmapDisplayTitle;
+            public override int? GetBeatmapID(bool hideIdentifiableInformation = false) => BeatmapID;
         }
 
         [MessagePackObject]
@@ -156,6 +163,11 @@ namespace osu.Game.Users
                 // For now let's assume that showing the beatmap a user is editing could reveal unwanted information.
                 ? string.Empty
                 : BeatmapDisplayTitle;
+
+            public override int? GetBeatmapID(bool hideIdentifiableInformation = false) => hideIdentifiableInformation
+                // For now let's assume that showing the beatmap a user is editing could reveal unwanted information.
+                ? null
+                : BeatmapID;
         }
 
         [MessagePackObject]


### PR DESCRIPTION
- Overlooked in https://github.com/ppy/osu/pull/27440

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f1d432fa-f6b1-4200-9676-84abce49bdd0) | ![image](https://github.com/user-attachments/assets/deb62d46-a4e1-4a43-b286-ee50235e8c98) |