### PR TITLE
Fix multiplayer auto-start setting applied to the wrong component

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerMatchSettingsOverlay.cs
@@ -438,7 +438,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                 => MaxParticipantsField.Text = room.MaxParticipants?.ToString();
 
             private void updateRoomAutoStartDuration()
-                => typeLabel.Text = room.AutoStartDuration.GetLocalisableDescription();
+                => startModeDropdown.Current.Value = (StartMode)room.AutoStartDuration.TotalSeconds;
 
             private void updateRoomPlaylist()
                 => drawablePlaylist.Items.ReplaceRange(0, drawablePlaylist.Items.Count, room.Playlist);


### PR DESCRIPTION
Noticed while looking at https://github.com/ppy/osu/pull/30830, was wondering why all of a sudden I'm seeing `00:00:00` in the game type label :p