### PR TITLE
Fix editor grid settings not displaying decimal portion in slider tooltips

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 0f,
             MaxValue = OsuPlayfield.BASE_SIZE.X,
+            Precision = 0.01f,
         };
 
         /// <summary>
@@ -47,6 +48,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 0f,
             MaxValue = OsuPlayfield.BASE_SIZE.Y,
+            Precision = 0.01f,
         };
 
         /// <summary>
@@ -56,6 +58,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = 4f,
             MaxValue = 128f,
+            Precision = 0.01f,
         };
 
         /// <summary>
@@ -65,6 +68,7 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             MinValue = -180f,
             MaxValue = 180f,
+            Precision = 0.01f,
         };
 
         /// <summary>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/30176

Since the bindable is not specifying any precision, the slider is falling back to not display any decimal value. Specifying a precision fixes.

Precisions borrowed from here:

https://github.com/ppy/osu/blob/cab26c70c1f2fca14b3feaa2abff5385963a401b/osu.Game.Rulesets.Osu/Edit/OsuGridToolboxGroup.cs#L182-L214