### PR TITLE
Fix pause shortcut on multiplayer no longer requiring hold

### DIFF
--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -299,7 +299,13 @@ namespace osu.Game.Screens.Play.HUD
                 {
                     case GlobalAction.Back:
                         if (!pendingAnimation)
-                            Confirm();
+                        {
+                            if (IsDangerousAction)
+                                BeginConfirm();
+                            else
+                                Confirm();
+                        }
+
                         return true;
 
                     case GlobalAction.PauseGameplay:
@@ -307,7 +313,13 @@ namespace osu.Game.Screens.Play.HUD
                         if (ReplayLoaded.Value) return false;
 
                         if (!pendingAnimation)
-                            Confirm();
+                        {
+                            if (IsDangerousAction)
+                                BeginConfirm();
+                            else
+                                Confirm();
+                        }
+
                         return true;
                 }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/30697

Since it's a time-based behaviour, I don't think I can write tests for it.