### PR TITLE
Don't play fail animation if restarting on fail

### DIFF
--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -976,7 +976,9 @@ namespace osu.Game.Screens.Play
                 if (PauseOverlay.State.Value == Visibility.Visible)
                     PauseOverlay.Hide();
 
-                failAnimationContainer.Start();
+                bool restartOnFail = GameplayState.Mods.OfType<IApplicableFailOverride>().Any(m => m.RestartOnFail);
+                if (!restartOnFail)
+                    failAnimationContainer.Start();
 
                 // Failures can be triggered either by a judgement, or by a mod.
                 //
@@ -990,7 +992,7 @@ namespace osu.Game.Screens.Play
                     ScoreProcessor.FailScore(Score.ScoreInfo);
                     OnFail();
 
-                    if (GameplayState.Mods.OfType<IApplicableFailOverride>().Any(m => m.RestartOnFail))
+                    if (restartOnFail)
                         Restart(true);
                 });
             }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/30657

Since restarting is instantaneous, we don't want the fail animation to be played if we are restarting. I was going to write an inline comment explaining why we shouldn't play the fail animation, but after seeing a comment block both above and below the code, I felt maybe there's too much commentary happening in this method.