### PR TITLE
Delay back button appearance when performing a quick restart

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -175,6 +175,11 @@ namespace osu.Game
         /// </summary>
         public readonly IBindable<OverlayActivation> OverlayActivationMode = new Bindable<OverlayActivation>();
 
+        /// <summary>
+        /// Whether the back button is currently displayed.
+        /// </summary>
+        public readonly IBindable<bool> BackButtonVisibility = new Bindable<bool>();
+
         IBindable<LocalUserPlayingState> ILocalUserPlayInfo.PlayingState => playingState;
 
         private readonly Bindable<LocalUserPlayingState> playingState = new Bindable<LocalUserPlayingState>();
@@ -1019,7 +1024,7 @@ namespace osu.Game
                                             if (!(ScreenStack.CurrentScreen is IOsuScreen currentScreen))
                                                 return;
 
-                                            if (!((Drawable)currentScreen).IsLoaded || (currentScreen.AllowBackButton && !currentScreen.OnBackButton()))
+                                            if (!((Drawable)currentScreen).IsLoaded || (currentScreen.AllowUserExit && !currentScreen.OnBackButton()))
                                                 ScreenStack.Exit();
                                         }
                                     },
@@ -1187,6 +1192,14 @@ namespace osu.Game
             OverlayActivationMode.ValueChanged += mode =>
             {
                 if (mode.NewValue != OverlayActivation.All) CloseAllOverlays();
+            };
+
+            BackButtonVisibility.ValueChanged += visible =>
+            {
+                if (visible.NewValue)
+                    BackButton.Show();
+                else
+                    BackButton.Hide();
             };
 
             // Importantly, this should be run after binding PostNotification to the import handlers so they can present the import after game startup.
@@ -1581,20 +1594,14 @@ namespace osu.Game
 
             if (current is IOsuScreen currentOsuScreen)
             {
-                if (currentOsuScreen.AllowBackButton)
-                    BackButton.State.UnbindFrom(currentOsuScreen.BackButtonState);
-
+                BackButtonVisibility.UnbindFrom(currentOsuScreen.BackButtonVisibility);
                 OverlayActivationMode.UnbindFrom(currentOsuScreen.OverlayActivationMode);
                 API.Activity.UnbindFrom(currentOsuScreen.Activity);
             }
 
             if (newScreen is IOsuScreen newOsuScreen)
             {
-                if (newOsuScreen.AllowBackButton)
-                    ((IBindable<Visibility>)BackButton.State).BindTo(newOsuScreen.BackButtonState);
-                else
-                    BackButton.Hide();
-
+                BackButtonVisibility.BindTo(newOsuScreen.BackButtonVisibility);
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
                 API.Activity.BindTo(newOsuScreen.Activity);
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1581,12 +1581,20 @@ namespace osu.Game
 
             if (current is IOsuScreen currentOsuScreen)
             {
+                if (currentOsuScreen.AllowBackButton)
+                    BackButton.State.UnbindFrom(currentOsuScreen.BackButtonState);
+
                 OverlayActivationMode.UnbindFrom(currentOsuScreen.OverlayActivationMode);
                 API.Activity.UnbindFrom(currentOsuScreen.Activity);
             }
 
             if (newScreen is IOsuScreen newOsuScreen)
             {
+                if (newOsuScreen.AllowBackButton)
+                    ((IBindable<Visibility>)BackButton.State).BindTo(newOsuScreen.BackButtonState);
+                else
+                    BackButton.Hide();
+
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
                 API.Activity.BindTo(newOsuScreen.Activity);
 
@@ -1596,11 +1604,6 @@ namespace osu.Game
                     CloseAllOverlays();
                 else
                     Toolbar.Show();
-
-                if (newOsuScreen.AllowBackButton)
-                    BackButton.Show();
-                else
-                    BackButton.Hide();
 
                 if (newOsuScreen.ShowFooter)
                 {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -178,7 +178,7 @@ namespace osu.Game
         /// <summary>
         /// Whether the back button is currently displayed.
         /// </summary>
-        public readonly IBindable<bool> BackButtonVisibility = new Bindable<bool>();
+        private readonly IBindable<bool> backButtonVisibility = new Bindable<bool>();
 
         IBindable<LocalUserPlayingState> ILocalUserPlayInfo.PlayingState => playingState;
 
@@ -1194,7 +1194,7 @@ namespace osu.Game
                 if (mode.NewValue != OverlayActivation.All) CloseAllOverlays();
             };
 
-            BackButtonVisibility.ValueChanged += visible =>
+            backButtonVisibility.ValueChanged += visible =>
             {
                 if (visible.NewValue)
                     BackButton.Show();
@@ -1594,14 +1594,14 @@ namespace osu.Game
 
             if (current is IOsuScreen currentOsuScreen)
             {
-                BackButtonVisibility.UnbindFrom(currentOsuScreen.BackButtonVisibility);
+                backButtonVisibility.UnbindFrom(currentOsuScreen.BackButtonVisibility);
                 OverlayActivationMode.UnbindFrom(currentOsuScreen.OverlayActivationMode);
                 API.Activity.UnbindFrom(currentOsuScreen.Activity);
             }
 
             if (newScreen is IOsuScreen newOsuScreen)
             {
-                BackButtonVisibility.BindTo(newOsuScreen.BackButtonVisibility);
+                backButtonVisibility.BindTo(newOsuScreen.BackButtonVisibility);
                 OverlayActivationMode.BindTo(newOsuScreen.OverlayActivationMode);
                 API.Activity.BindTo(newOsuScreen.Activity);
 

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/MigrationRunScreen.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         [Resolved(canBeNull: true)]
         private OsuGame game { get; set; }
 
-        public override bool AllowBackButton => false;
+        public override bool AllowUserExit => false;
 
         public override bool AllowExternalScreenChange => false;
 

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -80,8 +80,6 @@ namespace osu.Game.Screens.Edit
 
         public override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool AllowUserExit => false;
-
         public override bool HideOverlaysOnEnter => true;
 
         public override bool DisallowExternalBeatmapRulesetChanges => true;
@@ -193,6 +191,8 @@ namespace osu.Game.Screens.Edit
                 return new UserActivity.ModdingBeatmap(Beatmap.Value.BeatmapInfo);
             }
         }
+
+        protected override bool InitialBackButtonVisibility => false;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
             => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
@@ -760,11 +760,6 @@ namespace osu.Game.Screens.Edit
 
             switch (e.Action)
             {
-                case GlobalAction.Back:
-                    // as we don't want to display the back button, manual handling of exit action is required.
-                    this.Exit();
-                    return true;
-
                 case GlobalAction.EditorCloneSelection:
                     Clone();
                     return true;

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.Edit
 
         public override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool AllowBackButton => false;
+        public override bool AllowUserExit => false;
 
         public override bool HideOverlaysOnEnter => true;
 

--- a/osu.Game/Screens/Edit/EditorLoader.cs
+++ b/osu.Game/Screens/Edit/EditorLoader.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Edit
 
         public override float BackgroundParallaxAmount => 0.1f;
 
-        public override bool AllowBackButton => false;
+        public override bool AllowUserExit => false;
 
         public override bool HideOverlaysOnEnter => true;
 

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -3,10 +3,8 @@
 
 using System.Collections.Generic;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
@@ -24,15 +22,20 @@ namespace osu.Game.Screens
         bool DisallowExternalBeatmapRulesetChanges { get; }
 
         /// <summary>
-        /// Whether the user can exit this <see cref="IOsuScreen"/> by pressing the back button.
+        /// Whether the user can exit this <see cref="IOsuScreen"/>.
         /// </summary>
-        bool AllowBackButton { get; }
+        /// <remarks>
+        /// When overriden to <c>false</c>,
+        /// the user is blocked from exiting the screen via the <see cref="GlobalAction.Back"/> action,
+        /// and the back button is hidden from this screen by the initial state of <see cref="BackButtonVisibility"/> being set to hidden.
+        /// </remarks>
+        bool AllowUserExit { get; }
 
         /// <summary>
         /// Whether a footer (and a back button) should be displayed underneath the screen.
         /// </summary>
         /// <remarks>
-        /// Temporarily, the back button is shown regardless of whether <see cref="AllowBackButton"/> is true.
+        /// Temporarily, the back button is shown regardless of whether <see cref="AllowUserExit"/> is true.
         /// </remarks>
         bool ShowFooter { get; }
 
@@ -63,13 +66,9 @@ namespace osu.Game.Screens
         IBindable<OverlayActivation> OverlayActivationMode { get; }
 
         /// <summary>
-        /// Controls the visibility state of <see cref="BackButton"/> to better work with screen-specific transitions (i.e. quick restart in player).
-        /// The back button can still be triggered by the <see cref="GlobalAction.Back"/> action even while hidden.
+        /// Whether the back button should be displayed in this screen.
         /// </summary>
-        /// <remarks>
-        /// This is ignored when <see cref="AllowBackButton"/> is set to false.
-        /// </remarks>
-        IBindable<Visibility> BackButtonState { get; }
+        IBindable<bool> BackButtonVisibility { get; }
 
         /// <summary>
         /// The current <see cref="UserActivity"/> for this screen.

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -35,7 +35,8 @@ namespace osu.Game.Screens
         /// Whether a footer (and a back button) should be displayed underneath the screen.
         /// </summary>
         /// <remarks>
-        /// Temporarily, the back button is shown regardless of whether <see cref="AllowUserExit"/> is true.
+        /// Temporarily, the footer's own back button is shown regardless of whether <see cref="BackButtonVisibility"/> is set to hidden.
+        /// This will be corrected as the footer becomes used more commonly.
         /// </remarks>
         bool ShowFooter { get; }
 

--- a/osu.Game/Screens/IOsuScreen.cs
+++ b/osu.Game/Screens/IOsuScreen.cs
@@ -3,8 +3,11 @@
 
 using System.Collections.Generic;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Footer;
@@ -58,6 +61,15 @@ namespace osu.Game.Screens
         /// Whether overlays should be able to be opened when this screen is current.
         /// </summary>
         IBindable<OverlayActivation> OverlayActivationMode { get; }
+
+        /// <summary>
+        /// Controls the visibility state of <see cref="BackButton"/> to better work with screen-specific transitions (i.e. quick restart in player).
+        /// The back button can still be triggered by the <see cref="GlobalAction.Back"/> action even while hidden.
+        /// </summary>
+        /// <remarks>
+        /// This is ignored when <see cref="AllowBackButton"/> is set to false.
+        /// </remarks>
+        IBindable<Visibility> BackButtonState { get; }
 
         /// <summary>
         /// The current <see cref="UserActivity"/> for this screen.

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Screens.Menu
 
         public override bool HideOverlaysOnEnter => Buttons == null || Buttons.State == ButtonSystemState.Initial;
 
-        public override bool AllowBackButton => false;
+        public override bool AllowUserExit => false;
 
         public override bool AllowExternalScreenChange => true;
 

--- a/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayScreen.cs
@@ -180,7 +180,7 @@ namespace osu.Game.Screens.OnlinePlay
             if (!(screenStack.CurrentScreen is IOnlinePlaySubScreen onlineSubScreen))
                 return false;
 
-            if (((Drawable)onlineSubScreen).IsLoaded && onlineSubScreen.AllowBackButton && onlineSubScreen.OnBackButton())
+            if (((Drawable)onlineSubScreen).IsLoaded && onlineSubScreen.AllowUserExit && onlineSubScreen.OnBackButton())
                 return true;
 
             if (screenStack.CurrentScreen != null && !(screenStack.CurrentScreen is LoungeSubScreen))

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -11,7 +11,6 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -38,7 +37,7 @@ namespace osu.Game.Screens
 
         public string Description => Title;
 
-        public virtual bool AllowBackButton => true;
+        public virtual bool AllowUserExit => true;
 
         public virtual bool ShowFooter => false;
 
@@ -57,9 +56,14 @@ namespace osu.Game.Screens
 
         IBindable<OverlayActivation> IOsuScreen.OverlayActivationMode => OverlayActivationMode;
 
-        public readonly Bindable<Visibility> BackButtonState = new Bindable<Visibility>(Visibility.Visible);
+        /// <summary>
+        /// The initial visibility state of the back button when this screen is entered for the first time.
+        /// </summary>
+        protected virtual bool InitialBackButtonVisibility => AllowUserExit;
 
-        IBindable<Visibility> IOsuScreen.BackButtonState => BackButtonState;
+        public readonly Bindable<bool> BackButtonVisibility;
+
+        IBindable<bool> IOsuScreen.BackButtonVisibility => BackButtonVisibility;
 
         public virtual bool CursorVisible => true;
 
@@ -159,6 +163,7 @@ namespace osu.Game.Screens
             Origin = Anchor.Centre;
 
             OverlayActivationMode = new Bindable<OverlayActivation>(InitialOverlayActivationMode);
+            BackButtonVisibility = new Bindable<bool>(InitialBackButtonVisibility);
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Game/Screens/OsuScreen.cs
+++ b/osu.Game/Screens/OsuScreen.cs
@@ -11,6 +11,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Beatmaps;
 using osu.Game.Overlays;
@@ -55,6 +56,10 @@ namespace osu.Game.Screens
         public readonly Bindable<OverlayActivation> OverlayActivationMode;
 
         IBindable<OverlayActivation> IOsuScreen.OverlayActivationMode => OverlayActivationMode;
+
+        public readonly Bindable<Visibility> BackButtonState = new Bindable<Visibility>(Visibility.Visible);
+
+        IBindable<Visibility> IOsuScreen.BackButtonState => BackButtonState;
 
         public virtual bool CursorVisible => true;
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public event Action OnGameplayStarted;
 
-        public override bool AllowBackButton => false; // handled by HoldForMenuButton
+        public override bool AllowUserExit => false; // handled by HoldForMenuButton
 
         protected override bool PlayExitSound => !isRestarting;
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -478,7 +478,7 @@ namespace osu.Game.Screens.Play
 
             if (quickRestart)
             {
-                BackButtonState.Value = Visibility.Hidden;
+                BackButtonVisibility.Value = false;
 
                 // A quick restart starts by triggering a fade to black
                 AddInternal(quickRestartBlackLayer = new Box
@@ -499,7 +499,7 @@ namespace osu.Game.Screens.Play
                     .ScaleTo(1)
                     .FadeInFromZero(500, Easing.OutQuint);
 
-                this.Delay(quick_restart_initial_delay).Schedule(() => BackButtonState.Value = Visibility.Visible);
+                this.Delay(quick_restart_initial_delay).Schedule(() => BackButtonVisibility.Value = true);
             }
             else
             {

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -478,6 +478,8 @@ namespace osu.Game.Screens.Play
 
             if (quickRestart)
             {
+                BackButtonState.Value = Visibility.Hidden;
+
                 // A quick restart starts by triggering a fade to black
                 AddInternal(quickRestartBlackLayer = new Box
                 {
@@ -496,6 +498,8 @@ namespace osu.Game.Screens.Play
                     .Delay(quick_restart_initial_delay)
                     .ScaleTo(1)
                     .FadeInFromZero(500, Easing.OutQuint);
+
+                this.Delay(quick_restart_initial_delay).Schedule(() => BackButtonState.Value = Visibility.Visible);
             }
             else
             {

--- a/osu.Game/Screens/StartupScreen.cs
+++ b/osu.Game/Screens/StartupScreen.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens
     /// </summary>
     public abstract partial class StartupScreen : OsuScreen
     {
-        public override bool AllowBackButton => false;
+        public override bool AllowUserExit => false;
 
         public override bool HideOverlaysOnEnter => true;
 


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/30679

Adding tests for the `BackButtonState` property seems to be too much work for not much benefit, but I can add one if insisted.

Note that I've created another bindable for this rather than turning `AllowBackButton` itself into a bindable, this is because we still want to allow the user to exit right after performing a quick restart (since exiting is controlled by `AllowBackButton`, meanwhile the new bindable only affects the visual state of the button itself).

Preview:

https://github.com/user-attachments/assets/84bf531b-a861-4419-b8e6-c49a6d289ee4

