### PR TITLE
Improve performance of UR calculations

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
+++ b/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
@@ -4,7 +4,9 @@
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Utils;
-using osu.Game.Rulesets.Objects;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Benchmarks
@@ -18,8 +20,14 @@ namespace osu.Game.Benchmarks
             base.SetUp();
             events = new List<HitEvent>();
 
-            for (int i = 0; i < 1000; i++)
-                events.Add(new HitEvent(RNG.NextDouble(-200.0, 200.0), RNG.NextDouble(1.0, 2.0), HitResult.Great, new HitObject(), null, null));
+            for (int i = 0; i < 2048; i++)
+            {
+                // Ensure the object has hit windows populated.
+                var hitObject = new HitCircle();
+                hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+
+                events.Add(new HitEvent(RNG.NextDouble(-200.0, 200.0), RNG.NextDouble(1.0, 2.0), HitResult.Great, hitObject, null, null));
+            }
         }
 
         [Benchmark]

--- a/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
+++ b/osu.Game.Benchmarks/BenchmarkUnstableRate.cs
@@ -13,27 +13,45 @@ namespace osu.Game.Benchmarks
 {
     public class BenchmarkUnstableRate : BenchmarkTest
     {
-        private List<HitEvent> events = null!;
+        private readonly List<List<HitEvent>> incrementalEventLists = new List<List<HitEvent>>();
 
         public override void SetUp()
         {
             base.SetUp();
-            events = new List<HitEvent>();
+
+            var events = new List<HitEvent>();
 
             for (int i = 0; i < 2048; i++)
             {
                 // Ensure the object has hit windows populated.
                 var hitObject = new HitCircle();
                 hitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-
                 events.Add(new HitEvent(RNG.NextDouble(-200.0, 200.0), RNG.NextDouble(1.0, 2.0), HitResult.Great, hitObject, null, null));
+
+                incrementalEventLists.Add(new List<HitEvent>(events));
             }
         }
 
         [Benchmark]
         public void CalculateUnstableRate()
         {
-            _ = events.CalculateUnstableRate();
+            for (int i = 0; i < 2048; i++)
+            {
+                var events = incrementalEventLists[i];
+                _ = events.CalculateUnstableRate();
+            }
+        }
+
+        [Benchmark]
+        public void CalculateUnstableRateUsingIncrementalCalculation()
+        {
+            HitEventExtensions.UnstableRateCalculationResult? last = null;
+
+            for (int i = 0; i < 2048; i++)
+            {
+                var events = incrementalEventLists[i];
+                last = events.CalculateUnstableRate(last);
+            }
         }
     }
 }

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -26,7 +26,47 @@ namespace osu.Game.Tests.NonVisual.Ranking
             var unstableRate = new UnstableRate(events);
 
             Assert.IsNotNull(unstableRate.Value);
-            Assert.IsTrue(Precision.AlmostEquals(unstableRate.Value.Value, 10 * Math.Sqrt(10)));
+            Assert.AreEqual(unstableRate.Value.Value, 10 * Math.Sqrt(10), Precision.DOUBLE_EPSILON);
+        }
+
+        [Test]
+        public void TestDistributedHitsIncrementalRewind()
+        {
+            var events = Enumerable.Range(-5, 11)
+                                   .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null))
+                                   .ToList();
+
+            HitEventExtensions.UnstableRateCalculationResult result = null;
+
+            for (int i = 0; i < events.Count; i++)
+            {
+                result = events.GetRange(0, i + 1)
+                               .CalculateUnstableRate(result);
+            }
+
+            result = events.GetRange(0, 2).CalculateUnstableRate(result);
+
+            Assert.IsNotNull(result!.Result);
+            Assert.AreEqual(5, result.Result, Precision.DOUBLE_EPSILON);
+        }
+
+        [Test]
+        public void TestDistributedHitsIncremental()
+        {
+            var events = Enumerable.Range(-5, 11)
+                                   .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null))
+                                   .ToList();
+
+            HitEventExtensions.UnstableRateCalculationResult result = null;
+
+            for (int i = 0; i < events.Count; i++)
+            {
+                result = events.GetRange(0, i + 1)
+                               .CalculateUnstableRate(result);
+            }
+
+            Assert.IsNotNull(result!.Result);
+            Assert.AreEqual(10 * Math.Sqrt(10), result.Result, Precision.DOUBLE_EPSILON);
         }
 
         [Test]

--- a/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
+++ b/osu.Game.Tests/NonVisual/Ranking/UnstableRateTest.cs
@@ -20,7 +20,8 @@ namespace osu.Game.Tests.NonVisual.Ranking
         public void TestDistributedHits()
         {
             var events = Enumerable.Range(-5, 11)
-                                   .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null));
+                                   .Select(t => new HitEvent(t - 5, 1.0, HitResult.Great, new HitObject(), null, null))
+                                   .ToList();
 
             var unstableRate = new UnstableRate(events);
 

--- a/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
+++ b/osu.Game/Rulesets/Mods/ModAdaptiveSpeed.cs
@@ -205,7 +205,7 @@ namespace osu.Game.Rulesets.Mods
         {
             foreach (var hitObject in hitObjects)
             {
-                if (!(hitObject.HitWindows is HitWindows.EmptyHitWindows))
+                if (hitObject.HitWindows != HitWindows.Empty)
                     yield return hitObject;
 
                 foreach (HitObject nested in getAllApplicableHitObjects(hitObject.NestedHitObjects))

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -73,13 +73,36 @@ namespace osu.Game.Rulesets.Scoring
         public static bool AffectsUnstableRate(HitEvent e) => AffectsUnstableRate(e.HitObject, e.Result);
         public static bool AffectsUnstableRate(HitObject hitObject, HitResult result) => hitObject.HitWindows != HitWindows.Empty && result.IsHit();
 
+        /// <summary>
+        /// Data type returned by <see cref="HitEventExtensions.CalculateUnstableRate"/> which allows efficient incremental processing.
+        /// </summary>
+        /// <remarks>
+        /// This should be passed back into future <see cref="HitEventExtensions.CalculateUnstableRate"/> calls as a parameter.
+        ///
+        /// The optimisations used here rely on hit events being a consecutive sequence from a single gameplay session.
+        /// When a new gameplay session is started, any existing results should be disposed.
+        /// </remarks>
         public class UnstableRateCalculationResult
         {
+            /// <summary>
+            /// Total events processed. For internal incremental calculation use.
+            /// </summary>
             public int EventCount;
+
+            /// <summary>
+            /// Last sum-of-squares value. For internal incremental calculation use.
+            /// </summary>
             public double SumOfSquares;
+
+            /// <summary>
+            /// Last mean value. For internal incremental calculation use.
+            /// </summary>
             public double Mean;
 
-            public double Result => 10.0 * Math.Sqrt(SumOfSquares / EventCount);
+            /// <summary>
+            /// The unstable rate.
+            /// </summary>
+            public double Result => EventCount == 0 ? 0 : 10.0 * Math.Sqrt(SumOfSquares / EventCount);
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -28,26 +28,26 @@ namespace osu.Game.Rulesets.Scoring
             result ??= new UnstableRateCalculationResult();
 
             // Handle rewinding in the simplest way possible.
-            if (hitEvents.Count < result.NextProcessableIndex + 1)
+            if (hitEvents.Count < result.EventCount + 1)
                 result = new UnstableRateCalculationResult();
 
-            for (int i = result.NextProcessableIndex; i < hitEvents.Count; i++)
+            for (int i = result.EventCount; i < hitEvents.Count; i++)
             {
                 HitEvent e = hitEvents[i];
 
                 if (!AffectsUnstableRate(e))
                     continue;
 
-                result.NextProcessableIndex++;
+                result.EventCount++;
 
                 // Division by gameplay rate is to account for TimeOffset scaling with gameplay rate.
                 double currentValue = e.TimeOffset / e.GameplayRate!.Value;
-                double nextMean = result.Mean + (currentValue - result.Mean) / result.NextProcessableIndex;
+                double nextMean = result.Mean + (currentValue - result.Mean) / result.EventCount;
                 result.SumOfSquares += (currentValue - result.Mean) * (currentValue - nextMean);
                 result.Mean = nextMean;
             }
 
-            if (result.NextProcessableIndex == 0)
+            if (result.EventCount == 0)
                 return null;
 
             return result;
@@ -75,11 +75,11 @@ namespace osu.Game.Rulesets.Scoring
 
         public class UnstableRateCalculationResult
         {
-            public int NextProcessableIndex;
+            public int EventCount;
             public double SumOfSquares;
             public double Mean;
 
-            public double Result => 10.0 * Math.Sqrt(SumOfSquares / NextProcessableIndex);
+            public double Result => 10.0 * Math.Sqrt(SumOfSquares / EventCount);
         }
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Scoring
 {
@@ -69,7 +70,8 @@ namespace osu.Game.Rulesets.Scoring
             return timeOffsets.Average();
         }
 
-        public static bool AffectsUnstableRate(HitEvent e) => e.HitObject.HitWindows != HitWindows.Empty && e.Result.IsHit();
+        public static bool AffectsUnstableRate(HitEvent e) => AffectsUnstableRate(e.HitObject, e.Result);
+        public static bool AffectsUnstableRate(HitObject hitObject, HitResult result) => hitObject.HitWindows != HitWindows.Empty && result.IsHit();
 
         public class UnstableRateCalculationResult
         {

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -65,6 +65,6 @@ namespace osu.Game.Rulesets.Scoring
             return timeOffsets.Average();
         }
 
-        public static bool AffectsUnstableRate(HitEvent e) => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsHit();
+        public static bool AffectsUnstableRate(HitEvent e) => e.HitObject.HitWindows != HitWindows.Empty && e.Result.IsHit();
     }
 }

--- a/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
+++ b/osu.Game/Rulesets/Scoring/HitEventExtensions.cs
@@ -20,7 +20,7 @@ namespace osu.Game.Rulesets.Scoring
         /// A non-null <see langword="double"/> value if unstable rate could be calculated,
         /// and <see langword="null"/> if unstable rate cannot be calculated due to <paramref name="hitEvents"/> being empty.
         /// </returns>
-        public static double? CalculateUnstableRate(this IEnumerable<HitEvent> hitEvents)
+        public static double? CalculateUnstableRate(this IReadOnlyList<HitEvent> hitEvents)
         {
             Debug.Assert(hitEvents.All(ev => ev.GameplayRate != null));
 

--- a/osu.Game/Rulesets/Scoring/HitWindows.cs
+++ b/osu.Game/Rulesets/Scoring/HitWindows.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Scoring
         /// An empty <see cref="HitWindows"/> with only <see cref="HitResult.Miss"/> and <see cref="HitResult.Perfect"/>.
         /// No time values are provided (meaning instantaneous hit or miss).
         /// </summary>
-        public static HitWindows Empty => new EmptyHitWindows();
+        public static HitWindows Empty { get; } = new EmptyHitWindows();
 
         public HitWindows()
         {
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Scoring
         /// </summary>
         protected virtual DifficultyRange[] GetRanges() => base_ranges;
 
-        public class EmptyHitWindows : HitWindows
+        private class EmptyHitWindows : HitWindows
         {
             private static readonly DifficultyRange[] ranges =
             {

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Play.HUD
 
         private void updateDisplay()
         {
-            double? unstableRate = scoreProcessor.HitEvents.CalculateUnstableRate();
+            double? unstableRate = scoreProcessor.HitEvents.CalculateUnstableRate()?.Result;
 
             valid.Value = unstableRate != null;
             if (unstableRate != null)

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -44,9 +44,6 @@ namespace osu.Game.Screens.Play.HUD
                 DrawableCount.FadeTo(e.NewValue ? 1 : alpha_when_invalid, 1000, Easing.OutQuint));
         }
 
-        private bool changesUnstableRate(JudgementResult judgement)
-            => judgement.HitObject.HitWindows != HitWindows.Empty && judgement.IsHit;
-
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -28,6 +28,8 @@ namespace osu.Game.Screens.Play.HUD
         private const float alpha_when_invalid = 0.3f;
         private readonly Bindable<bool> valid = new Bindable<bool>();
 
+        private HitEventExtensions.UnstableRateCalculationResult? unstableRateResult;
+
         [Resolved]
         private ScoreProcessor scoreProcessor { get; set; } = null!;
 
@@ -53,13 +55,20 @@ namespace osu.Game.Screens.Play.HUD
             updateDisplay();
         }
 
-        private void updateDisplay(JudgementResult _) => Scheduler.AddOnce(updateDisplay);
+        private void updateDisplay(JudgementResult result)
+        {
+            if (HitEventExtensions.AffectsUnstableRate(result.HitObject, result.Type))
+                Scheduler.AddOnce(updateDisplay);
+        }
 
         private void updateDisplay()
         {
-            double? unstableRate = scoreProcessor.HitEvents.CalculateUnstableRate()?.Result;
+            unstableRateResult = scoreProcessor.HitEvents.CalculateUnstableRate(unstableRateResult);
+
+            double? unstableRate = unstableRateResult?.Result;
 
             valid.Value = unstableRate != null;
+
             if (unstableRate != null)
                 Current.Value = (int)Math.Round(unstableRate.Value);
         }

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Screens.Play.HUD
         }
 
         private bool changesUnstableRate(JudgementResult judgement)
-            => !(judgement.HitObject.HitWindows is HitWindows.EmptyHitWindows) && judgement.IsHit;
+            => judgement.HitObject.HitWindows != HitWindows.Empty && judgement.IsHit;
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
+++ b/osu.Game/Screens/Ranking/Statistics/HitEventTimingDistributionGraph.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="hitEvents">The <see cref="HitEvent"/>s to display the timing distribution of.</param>
         public HitEventTimingDistributionGraph(IReadOnlyList<HitEvent> hitEvents)
         {
-            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.Result.IsBasic() && e.Result.IsHit()).ToList();
+            this.hitEvents = hitEvents.Where(e => e.HitObject.HitWindows != HitWindows.Empty && e.Result.IsBasic() && e.Result.IsHit()).ToList();
             bins = Enumerable.Range(0, total_timing_distribution_bins).Select(_ => new Dictionary<HitResult, int>()).ToArray<IDictionary<HitResult, int>>();
         }
 

--- a/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
+++ b/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
@@ -18,7 +18,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         public UnstableRate(IReadOnlyList<HitEvent> hitEvents)
             : base("Unstable Rate")
         {
-            Value = hitEvents.CalculateUnstableRate();
+            Value = hitEvents.CalculateUnstableRate()?.Result;
         }
 
         protected override string DisplayValue(double? value) => value == null ? "(not available)" : value.Value.ToString(@"N2");

--- a/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
+++ b/osu.Game/Screens/Ranking/Statistics/UnstableRate.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// Creates and computes an <see cref="UnstableRate"/> statistic.
         /// </summary>
         /// <param name="hitEvents">Sequence of <see cref="HitEvent"/>s to calculate the unstable rate based on.</param>
-        public UnstableRate(IEnumerable<HitEvent> hitEvents)
+        public UnstableRate(IReadOnlyList<HitEvent> hitEvents)
             : base("Unstable Rate")
         {
             Value = hitEvents.CalculateUnstableRate();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30635.

Baseline:

| Method                | Mean     | Error    | StdDev   | Allocated |
|---------------------- |---------:|---------:|---------:|----------:|
| CalculateUnstableRate | 15.15 us | 0.123 us | 0.115 us |      96 B |

With patch applied (605fe71f46eaf2944b659389cca3cfa03011e5de):

| Method                | Mean     | Error    | StdDev   | Allocated |
|---------------------- |---------:|---------:|---------:|----------:|
| CalculateUnstableRate | 11.30 us | 0.064 us | 0.060 us |      96 B |

Didn't show as much of an improvement as I expected to see based on the profiler results (seems like profiler is getting the point of usage slightly wrong...)

With list `for` iteration (33d725e889481843601fe1f647a88ba866a8c6ce with `foreach` switched to `for`):

| Method                | Mean     | Error     | StdDev    | Allocated |
|---------------------- |---------:|----------:|----------:|----------:|
| CalculateUnstableRate | 9.917 us | 0.1824 us | 0.1706 us |      48 B |

Full PR:

| Method                                           | Mean         | Error      | StdDev     | Allocated |
|------------------------------------------------- |-------------:|-----------:|-----------:|----------:|
| CalculateUnstableRate                            | 25,305.35 us | 417.166 us | 348.352 us |   81943 B |
| CalculateUnstableRateUsingIncrementalCalculation |     24.46 us |   0.483 us |   0.537 us |      40 B |

I'm not immediately sure why it's benchmarking slower. Spent my allocated time on this so I'm going just going to smile and nod, but interested if anyone has an idea.

Importantly though, real world performance is much better (over a single autoplay run of [this beatmap](https://osu.ppy.sh/beatmapsets/367631#osu/958098)):

Baseline:

![JetBrains Rider 2024-11-25 at 12 00 17](https://github.com/user-attachments/assets/8b9b3841-c2b2-428f-a424-6c07cd84b341)

On ea68d4b33abbd920e267001fb4785ae000031f54:

![JetBrains Rider 2024-11-25 at 11 58 27](https://github.com/user-attachments/assets/5c9b4ef3-5fd6-4d6c-ab29-4526e4317602)

On bbe8f2ec44cf7f2fa76c23dddbfcc33bea7045ee (kinda OP because slider ticks and what not will not recalc at all):

![JetBrains Rider 2024-11-25 at 12 03 36](https://github.com/user-attachments/assets/22db11de-49b5-48a0-a20c-d908a8c8e799)
