### PR TITLE
Add setting to allow hold-for-pause to still exist

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -214,6 +214,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorContractSidebars, false);
 
             SetDefault(OsuSetting.AlwaysShowHoldForMenuButton, false);
+            SetDefault(OsuSetting.AlwaysRequireHoldingForPause, false);
         }
 
         protected override bool CheckLookupContainsPrivateInformation(OsuSetting lookup)
@@ -444,5 +445,6 @@ namespace osu.Game.Configuration
         EditorRotationOrigin,
         EditorTimelineShowBreaks,
         EditorAdjustExistingObjectsOnTimingChanges,
+        AlwaysRequireHoldingForPause
     }
 }

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -90,6 +90,11 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysShowHoldForMenuButton => new TranslatableString(getKey(@"always_show_hold_for_menu_button"), @"Always show hold for menu button");
 
         /// <summary>
+        /// "Require holding key to pause gameplay"
+        /// </summary>
+        public static LocalisableString AlwaysRequireHoldForMenu => new TranslatableString(getKey(@"require_holding_key_to_pause_gameplay"), @"Require holding key to pause gameplay");
+
+        /// <summary>
         /// "Always play first combo break sound"
         /// </summary>
         public static LocalisableString AlwaysPlayFirstComboBreak => new TranslatableString(getKey(@"always_play_first_combo_break"), @"Always play first combo break sound");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
+                    LabelText = GameplaySettingsStrings.AlwaysRequireHoldForMenu,
+                    Current = config.GetBindable<bool>(OsuSetting.AlwaysRequireHoldingForPause),
+                },
+                new SettingsCheckbox
+                {
                     LabelText = GameplaySettingsStrings.AlwaysShowHoldForMenuButton,
                     Current = config.GetBindable<bool>(OsuSetting.AlwaysShowHoldForMenuButton),
                 },

--- a/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
+++ b/osu.Game/Screens/Play/HUD/HoldForMenuButton.cs
@@ -162,14 +162,18 @@ namespace osu.Game.Screens.Play.HUD
             private bool pendingAnimation;
             private ScheduledDelegate shakeOperation;
 
+            private Bindable<bool> alwaysRequireHold;
+
             public HoldButton(bool isDangerousAction)
                 : base(isDangerousAction)
             {
             }
 
             [BackgroundDependencyLoader]
-            private void load(OsuColour colours)
+            private void load(OsuColour colours, OsuConfigManager config)
             {
+                alwaysRequireHold = config.GetBindable<bool>(OsuSetting.AlwaysRequireHoldingForPause);
+
                 Size = new Vector2(60);
 
                 Child = new CircularContainer
@@ -300,7 +304,7 @@ namespace osu.Game.Screens.Play.HUD
                     case GlobalAction.Back:
                         if (!pendingAnimation)
                         {
-                            if (IsDangerousAction)
+                            if (IsDangerousAction || alwaysRequireHold.Value)
                                 BeginConfirm();
                             else
                                 Confirm();
@@ -314,7 +318,7 @@ namespace osu.Game.Screens.Play.HUD
 
                         if (!pendingAnimation)
                         {
-                            if (IsDangerousAction)
+                            if (IsDangerousAction || alwaysRequireHold.Value)
                                 BeginConfirm();
                             else
                                 Confirm();


### PR DESCRIPTION
Users have asked for this [multiple](https://github.com/ppy/osu/discussions/30851) [times](https://github.com/ppy/osu/discussions/30664) since last release.

Not sure on the best default value, but I'm going with the stable/classic one, at least for the initial release to avoid needing migrations.

In the future we may reconsider this for new users.

