### PR TITLE
Fix hitobjects' samples getting in bad state when changing selection between objects

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -527,8 +527,11 @@ namespace osu.Game.Tests.Visual.Editing
             checkPlacementSampleBank(HitSampleInfo.BANK_NORMAL);
             checkPlacementSampleAdditionBank(HitSampleInfo.BANK_NORMAL);
 
-            void checkPlacementSampleBank(string expected) => AddAssert($"Placement sample is {expected}", () => EditorBeatmap.PlacementObject.Value.Samples.First(s => s.Name == HitSampleInfo.HIT_NORMAL).Bank, () => Is.EqualTo(expected));
-            void checkPlacementSampleAdditionBank(string expected) => AddAssert($"Placement sample addition is {expected}", () => EditorBeatmap.PlacementObject.Value.Samples.First(s => s.Name != HitSampleInfo.HIT_NORMAL).Bank, () => Is.EqualTo(expected));
+            void checkPlacementSampleBank(string expected) => AddAssert($"Placement sample is {expected}",
+                () => EditorBeatmap.PlacementObject.Value.Samples.First(s => s.Name == HitSampleInfo.HIT_NORMAL).Bank, () => Is.EqualTo(expected));
+
+            void checkPlacementSampleAdditionBank(string expected) => AddAssert($"Placement sample addition is {expected}",
+                () => EditorBeatmap.PlacementObject.Value.Samples.First(s => s.Name != HitSampleInfo.HIT_NORMAL).Bank, () => Is.EqualTo(expected));
         }
 
         [Test]
@@ -774,6 +777,7 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        [Solo]
         public void TestSelectingObjectDoesNotMutateSamples()
         {
             clickSamplePiece(0);
@@ -781,15 +785,39 @@ namespace osu.Game.Tests.Visual.Editing
             setAdditionBankViaPopover(HitSampleInfo.BANK_SOFT);
             dismissPopover();
 
-            hitObjectHasSamples(0, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
-            hitObjectHasSampleNormalBank(0, HitSampleInfo.BANK_NORMAL);
-            hitObjectHasSampleAdditionBank(0, HitSampleInfo.BANK_SOFT);
+            assertNoChanges();
 
-            AddStep("select first object", () => EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects[0]));
+            AddStep("select first object", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.Clear();
+                EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects[0]);
+            });
+            assertNoChanges();
 
-            hitObjectHasSamples(0, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
-            hitObjectHasSampleNormalBank(0, HitSampleInfo.BANK_NORMAL);
-            hitObjectHasSampleAdditionBank(0, HitSampleInfo.BANK_SOFT);
+            AddStep("select second object", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.Clear();
+                EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects[1]);
+            });
+            assertNoChanges();
+
+            AddStep("select first object", () =>
+            {
+                EditorBeatmap.SelectedHitObjects.Clear();
+                EditorBeatmap.SelectedHitObjects.Add(EditorBeatmap.HitObjects[0]);
+            });
+            assertNoChanges();
+
+            void assertNoChanges()
+            {
+                hitObjectHasSamples(0, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
+                hitObjectHasSampleNormalBank(0, HitSampleInfo.BANK_NORMAL);
+                hitObjectHasSampleAdditionBank(0, HitSampleInfo.BANK_SOFT);
+
+                hitObjectHasSamples(1, HitSampleInfo.HIT_NORMAL);
+                hitObjectHasSampleNormalBank(1, HitSampleInfo.BANK_SOFT);
+                hitObjectHasSampleAdditionBank(1, HitSampleInfo.BANK_SOFT);
+            }
         }
 
         private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} sample piece", () =>
@@ -883,11 +911,12 @@ namespace osu.Game.Tests.Visual.Editing
             return h.Samples.All(o => o.Volume == volume);
         });
 
-        private void hitObjectNodeHasSampleVolume(int objectIndex, int nodeIndex, int volume) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has volume {volume}", () =>
-        {
-            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
-            return h is not null && h.NodeSamples[nodeIndex].All(o => o.Volume == volume);
-        });
+        private void hitObjectNodeHasSampleVolume(int objectIndex, int nodeIndex, int volume) => AddAssert(
+            $"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has volume {volume}", () =>
+            {
+                var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
+                return h is not null && h.NodeSamples[nodeIndex].All(o => o.Volume == volume);
+            });
 
         private void setBankViaPopover(string bank) => AddStep($"set bank {bank} via popover", () =>
         {
@@ -944,29 +973,33 @@ namespace osu.Game.Tests.Visual.Editing
             return h.Samples.Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
         });
 
-        private void hitObjectNodeHasSamples(int objectIndex, int nodeIndex, params string[] samples) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has samples {string.Join(',', samples)}", () =>
-        {
-            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
-            return h is not null && h.NodeSamples[nodeIndex].Select(s => s.Name).SequenceEqual(samples);
-        });
+        private void hitObjectNodeHasSamples(int objectIndex, int nodeIndex, params string[] samples) => AddAssert(
+            $"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has samples {string.Join(',', samples)}", () =>
+            {
+                var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
+                return h is not null && h.NodeSamples[nodeIndex].Select(s => s.Name).SequenceEqual(samples);
+            });
 
-        private void hitObjectNodeHasSampleBank(int objectIndex, int nodeIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has bank {bank}", () =>
-        {
-            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
-            return h is not null && h.NodeSamples[nodeIndex].All(o => o.Bank == bank);
-        });
+        private void hitObjectNodeHasSampleBank(int objectIndex, int nodeIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has bank {bank}",
+            () =>
+            {
+                var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
+                return h is not null && h.NodeSamples[nodeIndex].All(o => o.Bank == bank);
+            });
 
-        private void hitObjectNodeHasSampleNormalBank(int objectIndex, int nodeIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has normal bank {bank}", () =>
-        {
-            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
-            return h is not null && h.NodeSamples[nodeIndex].Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
-        });
+        private void hitObjectNodeHasSampleNormalBank(int objectIndex, int nodeIndex, string bank) => AddAssert(
+            $"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has normal bank {bank}", () =>
+            {
+                var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
+                return h is not null && h.NodeSamples[nodeIndex].Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
+            });
 
-        private void hitObjectNodeHasSampleAdditionBank(int objectIndex, int nodeIndex, string bank) => AddAssert($"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has addition bank {bank}", () =>
-        {
-            var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
-            return h is not null && h.NodeSamples[nodeIndex].Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
-        });
+        private void hitObjectNodeHasSampleAdditionBank(int objectIndex, int nodeIndex, string bank) => AddAssert(
+            $"{objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node has addition bank {bank}", () =>
+            {
+                var h = EditorBeatmap.HitObjects.ElementAt(objectIndex) as IHasRepeats;
+                return h is not null && h.NodeSamples[nodeIndex].Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
+            });
 
         private void editorTimeIs(double time) => AddAssert($"editor time is {time}", () => Precision.AlmostEquals(EditorClock.CurrentTimeAccurate, time, 1));
     }

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -777,7 +777,6 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        [Solo]
         public void TestSelectingObjectDoesNotMutateSamples()
         {
             clickSamplePiece(0);

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -258,6 +258,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void resetTernaryStates()
         {
+            if (SelectedItems.Count > 0)
+                return;
+
             SelectionNewComboState.Value = TernaryState.False;
             AutoSelectionBankEnabled.Value = true;
             SelectionAdditionBanksEnabled.Value = true;


### PR DESCRIPTION
This was causing state pollution in the new selection. I can't see why this needs to happen when a selection changes to another.

This fixes https://github.com/ppy/osu/issues/30839 and also the same issue happening for the new combo toggle.


Of note, this issue only occurs due to this code having `Schedule` calls, causing the **reset from a `Clear()` call to be run after the subsequent `Add(newSelection)`:

https://github.com/ppy/osu/blob/3ecb3b674d5e519b110546802ff14d6a3d248dc1/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs#L300-L303

Removing the schedules is also a viable solution:

```diff
diff --git a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
index 78cee2c1cf..b7652af23d 100644
--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -258,9 +258,6 @@ private void createStateBindables()
 
         private void resetTernaryStates()
         {
-            if (SelectedItems.Count > 0)
-                return;
-
             SelectionNewComboState.Value = TernaryState.False;
             AutoSelectionBankEnabled.Value = true;
             SelectionAdditionBanksEnabled.Value = true;
@@ -301,9 +298,9 @@ private void onSelectedItemsChanged(object? sender, NotifyCollectionChangedEvent
         {
             // Reset the ternary states when the selection is cleared.
             if (e.OldStartingIndex >= 0 && e.NewStartingIndex < 0)
-                Scheduler.AddOnce(resetTernaryStates);
+                resetTernaryStates();
             else
-                Scheduler.AddOnce(UpdateTernaryStates);
+                UpdateTernaryStates();
         }
 
         private IEnumerable<IList<HitSampleInfo>> enumerateAllSamples(HitObject hitObject)

```
