### PR TITLE
Improve realm update performance

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -29,7 +29,6 @@ using osu.Game.Input.Bindings;
 using osu.Game.Screens.Select.Carousel;
 using osuTK;
 using osuTK.Input;
-using Realms;
 
 namespace osu.Game.Screens.Select
 {
@@ -207,8 +206,6 @@ namespace osu.Game.Screens.Select
 
         private CarouselRoot root;
 
-        private IDisposable? subscriptionBeatmaps;
-
         private readonly DrawablePool<DrawableCarouselBeatmapSet> setPool = new DrawablePool<DrawableCarouselBeatmapSet>(100);
 
         private Sample? spinSample;
@@ -256,13 +253,6 @@ namespace osu.Game.Screens.Select
                 detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);
                 loadNewRoot();
             }
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            subscriptionBeatmaps = realm.RegisterForNotifications(r => r.All<BeatmapInfo>().Where(b => !b.Hidden), beatmapsChanged);
         }
 
         private readonly HashSet<BeatmapSetInfo> setsRequiringUpdate = new HashSet<BeatmapSetInfo>();
@@ -364,35 +354,6 @@ namespace osu.Game.Screens.Select
             setsRequiringUpdate.Clear();
 
             BeatmapSetInfo? fetchFromID(Guid id) => realm.Realm.Find<BeatmapSetInfo>(id);
-        }
-
-        private void beatmapsChanged(IRealmCollection<BeatmapInfo> sender, ChangeSet? changes)
-        {
-            // we only care about actual changes in hidden status.
-            if (changes == null)
-                return;
-
-            bool changed = false;
-
-            foreach (int i in changes.InsertedIndices)
-            {
-                var beatmapInfo = sender[i];
-                var beatmapSet = beatmapInfo.BeatmapSet;
-
-                Debug.Assert(beatmapSet != null);
-
-                // Only require to action here if the beatmap is missing.
-                // This avoids processing these events unnecessarily when new beatmaps are imported, for example.
-                if (root.BeatmapSetsByID.TryGetValue(beatmapSet.ID, out var existingSets)
-                    && existingSets.SelectMany(s => s.Beatmaps).All(b => b.BeatmapInfo.ID != beatmapInfo.ID))
-                {
-                    updateBeatmapSet(beatmapSet.Detach());
-                    changed = true;
-                }
-            }
-
-            if (changed)
-                invalidateAfterChange();
         }
 
         public void RemoveBeatmapSet(BeatmapSetInfo beatmapSet) => Schedule(() =>
@@ -1291,13 +1252,6 @@ namespace osu.Game.Screens.Select
 
                 return ScrollableExtent * ((scrollbarPosition - top_padding) / (ScrollbarMovementExtent - (top_padding + bottom_padding)));
             }
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            subscriptionBeatmaps?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Coming from #28497.

Not sure why I left this around during the refactor. This is 100% handled by the `DetachedBeatmapStore`.

Removing this subscription reduces overheads by a huge amount for users with large beatmap databases. My hypothesis is that subscriptions are more expensive based on **the number of results matching**. This one matches almost every beatmap so removing it is a large win.

Using this patch to test:

```diff
diff --git a/osu.Game/OsuGameBase.cs b/osu.Game/OsuGameBase.cs
index dc13924b4f..11151104fc 100644
--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -419,6 +419,12 @@ private void load(ReadableKeyCombinationProvider keyCombinationProvider, Framewo
 
         private void updateLanguage() => CurrentLanguage.Value = LanguageExtensions.GetLanguageFor(frameworkLocale.Value, localisationParameters.Value);
 
+        protected override void Update()
+        {
+            base.Update();
+            realm.Run(r => r.Refresh());
+        }
+
         private void addFilesWarning()
         {
             var realmStore = new RealmFileStore(realm, Storage);

```

with [this database](https://drive.google.com/file/d/10lLK8tYiqSpsAjkt_pzsLQ0g-bVJ7fhr/view?usp=sharing) provided [here](https://github.com/ppy/osu/issues/28497#issuecomment-2489897060) and profiling the overhead of importing a failed score:

| Before | After |
| :---: | :---: |
| ![Rider 2024-11-27 at 06 15 23](https://github.com/user-attachments/assets/a2d2f87a-2fc3-4940-b6cb-6f6b27d1002d) | ![Rider 2024-11-27 at 06 13 50](https://github.com/user-attachments/assets/c522e17a-2edc-4887-9dba-c62585e46968) |