### PR TITLE
Add a toggle for star fountains during gameplay

### DIFF
--- a/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
@@ -77,14 +77,14 @@ namespace osu.Game.Tests.Visual.Menus
         }
 
         [Test]
-        public void TestGameplayKiaiStarToggle()
+        public void TestGameplayStarFountainsSetting()
         {
-            Bindable<bool> kiaiStarEffectsEnabled = null!;
+            Bindable<bool> starFountainsEnabled = null!;
 
             AddStep("load configuration", () =>
             {
                 var config = new OsuConfigManager(LocalStorage);
-                kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
+                starFountainsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
             });
 
             AddStep("make fountains", () =>
@@ -106,21 +106,21 @@ namespace osu.Game.Tests.Visual.Menus
                 };
             });
 
-            AddStep("enable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = true);
+            AddStep("enable KiaiStarEffects", () => starFountainsEnabled.Value = true);
             AddRepeatStep("activate fountains (enabled)", () =>
             {
                 ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);
                 ((KiaiGameplayFountains.GameplayStarFountain)Children[1]).Shoot(-1);
             }, 100);
 
-            AddStep("disable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = false);
+            AddStep("disable KiaiStarEffects", () => starFountainsEnabled.Value = false);
             AddRepeatStep("attempt to activate fountains (disabled)", () =>
             {
                 ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);
                 ((KiaiGameplayFountains.GameplayStarFountain)Children[1]).Shoot(-1);
             }, 100);
 
-            AddStep("re-enable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = true);
+            AddStep("re-enable KiaiStarEffects", () => starFountainsEnabled.Value = true);
             AddRepeatStep("activate fountains (re-enabled)", () =>
             {
                 ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);

--- a/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.Menus
             AddStep("load configuration", () =>
             {
                 var config = new OsuConfigManager(LocalStorage);
-                kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.KiaiStarFountain);
+                kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
             });
 
             AddStep("make fountains", () =>

--- a/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneStarFountain.cs
@@ -3,8 +3,10 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play;
 
@@ -72,6 +74,58 @@ namespace osu.Game.Tests.Visual.Menus
                 ((StarFountain)Children[0]).Shoot(1);
                 ((StarFountain)Children[1]).Shoot(-1);
             });
+        }
+
+        [Test]
+        public void TestGameplayKiaiStarToggle()
+        {
+            Bindable<bool> kiaiStarEffectsEnabled = null!;
+
+            AddStep("load configuration", () =>
+            {
+                var config = new OsuConfigManager(LocalStorage);
+                kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.KiaiStarFountain);
+            });
+
+            AddStep("make fountains", () =>
+            {
+                Children = new Drawable[]
+                {
+                    new KiaiGameplayFountains.GameplayStarFountain
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        X = 75,
+                    },
+                    new KiaiGameplayFountains.GameplayStarFountain
+                    {
+                        Anchor = Anchor.BottomRight,
+                        Origin = Anchor.BottomRight,
+                        X = -75,
+                    },
+                };
+            });
+
+            AddStep("enable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = true);
+            AddRepeatStep("activate fountains (enabled)", () =>
+            {
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[1]).Shoot(-1);
+            }, 100);
+
+            AddStep("disable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = false);
+            AddRepeatStep("attempt to activate fountains (disabled)", () =>
+            {
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[1]).Shoot(-1);
+            }, 100);
+
+            AddStep("re-enable KiaiStarEffects", () => kiaiStarEffectsEnabled.Value = true);
+            AddRepeatStep("activate fountains (re-enabled)", () =>
+            {
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[0]).Shoot(1);
+                ((KiaiGameplayFountains.GameplayStarFountain)Children[1]).Shoot(-1);
+            }, 100);
         }
     }
 }

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -138,6 +138,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LightenDuringBreaks, true);
 
             SetDefault(OsuSetting.HitLighting, true);
+            SetDefault(OsuSetting.KiaiStarFountain, true);
 
             SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
             SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
@@ -414,6 +415,7 @@ namespace osu.Game.Configuration
         NotifyOnPrivateMessage,
         UIHoldActivationDelay,
         HitLighting,
+        KiaiStarFountain,
         MenuBackgroundSource,
         GameplayDisableWinKey,
         SeasonalBackgroundMode,

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.LightenDuringBreaks, true);
 
             SetDefault(OsuSetting.HitLighting, true);
-            SetDefault(OsuSetting.KiaiStarFountain, true);
+            SetDefault(OsuSetting.StarFountains, true);
 
             SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
             SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
@@ -415,7 +415,7 @@ namespace osu.Game.Configuration
         NotifyOnPrivateMessage,
         UIHoldActivationDelay,
         HitLighting,
-        KiaiStarFountain,
+        StarFountains,
         MenuBackgroundSource,
         GameplayDisableWinKey,
         SeasonalBackgroundMode,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -75,6 +75,11 @@ namespace osu.Game.Localisation
         public static LocalisableString FadePlayfieldWhenHealthLow => new TranslatableString(getKey(@"fade_playfield_when_health_low"), @"Fade playfield to red when health is low");
 
         /// <summary>
+        /// "Star fountain during kiai time"
+        /// </summary>
+        public static LocalisableString KiaiStarFountain => new TranslatableString(getKey(@"star_fountain_during_kiai_time"), @"Star fountain during kiai time");
+
+        /// <summary>
         /// "Always show key overlay"
         /// </summary>
         public static LocalisableString AlwaysShowKeyOverlay => new TranslatableString(getKey(@"key_overlay"), @"Always show key overlay");

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -75,9 +75,9 @@ namespace osu.Game.Localisation
         public static LocalisableString FadePlayfieldWhenHealthLow => new TranslatableString(getKey(@"fade_playfield_when_health_low"), @"Fade playfield to red when health is low");
 
         /// <summary>
-        /// "Star fountain during kiai time"
+        /// "Star fountains"
         /// </summary>
-        public static LocalisableString KiaiStarFountain => new TranslatableString(getKey(@"star_fountain_during_kiai_time"), @"Star fountain during kiai time");
+        public static LocalisableString StarFountains => new TranslatableString(getKey(@"star_fountains"), @"Star fountains");
 
         /// <summary>
         /// "Always show key overlay"

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -33,8 +33,8 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = GameplaySettingsStrings.KiaiStarFountain,
-                    Current = config.GetBindable<bool>(OsuSetting.KiaiStarFountain)
+                    LabelText = GameplaySettingsStrings.StarFountains,
+                    Current = config.GetBindable<bool>(OsuSetting.StarFountains)
                 },
             };
         }

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -31,6 +31,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     LabelText = GraphicsSettingsStrings.HitLighting,
                     Current = config.GetBindable<bool>(OsuSetting.HitLighting)
                 },
+                new SettingsCheckbox
+                {
+                    LabelText = GameplaySettingsStrings.KiaiStarFountain,
+                    Current = config.GetBindable<bool>(OsuSetting.KiaiStarFountain)
+                },
             };
         }
     }

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -20,12 +20,12 @@ namespace osu.Game.Screens.Play
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
 
-        private Bindable<bool> kiaiStarFountainsEnabled = null!;
+        private Bindable<bool> kiaiStarFountains = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            kiaiStarFountainsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
+            kiaiStarFountains = config.GetBindable<bool>(OsuSetting.StarFountains);
 
             RelativeSizeAxes = Axes.Both;
 
@@ -54,10 +54,7 @@ namespace osu.Game.Screens.Play
         {
             base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
 
-            if (!kiaiStarFountainsEnabled.Value)
-                return;
-
-            if (!kiaiStarFountainsEnabled.Value)
+            if (!kiaiStarFountains.Value)
                 return;
 
             if (effectPoint.KiaiMode && !isTriggered)

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -20,12 +20,12 @@ namespace osu.Game.Screens.Play
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
 
-        private Bindable<bool> kiaiStarEffectsEnabled = null!;
+        private Bindable<bool> kiaiStarFountainsEnabled = null!;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
+            kiaiStarFountainsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
 
             RelativeSizeAxes = Axes.Both;
 
@@ -54,10 +54,10 @@ namespace osu.Game.Screens.Play
         {
             base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
 
-            if (!kiaiStarEffectsEnabled.Value)
+            if (!kiaiStarFountainsEnabled.Value)
                 return;
 
-            if (!kiaiStarEffectsEnabled.Value)
+            if (!kiaiStarFountainsEnabled.Value)
                 return;
 
             if (effectPoint.KiaiMode && !isTriggered)
@@ -87,8 +87,6 @@ namespace osu.Game.Screens.Play
             private partial class GameplayStarFountainSpewer : StarFountainSpewer
             {
                 protected override double ShootDuration => 400;
-
-                private readonly Bindable<bool> kiaiStarEffectsEnabled = new Bindable<bool>();
 
                 public GameplayStarFountainSpewer()
                     : base(perSecond: 180)

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Screens.Play
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.KiaiStarFountain);
+            kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.StarFountains);
 
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Game/Screens/Play/KiaiGameplayFountains.cs
+++ b/osu.Game/Screens/Play/KiaiGameplayFountains.cs
@@ -5,8 +5,10 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Configuration;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Graphics.Containers;
 using osu.Game.Screens.Menu;
@@ -18,9 +20,13 @@ namespace osu.Game.Screens.Play
         private StarFountain leftFountain = null!;
         private StarFountain rightFountain = null!;
 
+        private Bindable<bool> kiaiStarEffectsEnabled = null!;
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
+            kiaiStarEffectsEnabled = config.GetBindable<bool>(OsuSetting.KiaiStarFountain);
+
             RelativeSizeAxes = Axes.Both;
 
             Children = new[]
@@ -47,6 +53,12 @@ namespace osu.Game.Screens.Play
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             base.OnNewBeat(beatIndex, timingPoint, effectPoint, amplitudes);
+
+            if (!kiaiStarEffectsEnabled.Value)
+                return;
+
+            if (!kiaiStarEffectsEnabled.Value)
+                return;
 
             if (effectPoint.KiaiMode && !isTriggered)
             {
@@ -75,6 +87,8 @@ namespace osu.Game.Screens.Play
             private partial class GameplayStarFountainSpewer : StarFountainSpewer
             {
                 protected override double ShootDuration => 400;
+
+                private readonly Bindable<bool> kiaiStarEffectsEnabled = new Bindable<bool>();
 
                 public GameplayStarFountainSpewer()
                     : base(perSecond: 180)


### PR DESCRIPTION
- Addresses #29830

Adds an option under Gameplay > General Settings that allows users to enable/disable star fountains during gameplay.

![image](https://github.com/user-attachments/assets/b77ac652-bec1-49da-93e8-2216deafb5e0)
