### PR TITLE
Fix watch replay button sometimes not loading the replay on first click

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -559,7 +559,11 @@ namespace osu.Game.Beatmaps
                 // If we seem to be missing files, now is a good time to re-fetch.
                 bool missingFiles = beatmapInfo.BeatmapSet?.Files.Count == 0;
 
-                if (refetch || beatmapInfo.IsManaged || missingFiles)
+                if (beatmapInfo.IsManaged)
+                {
+                    beatmapInfo = beatmapInfo.Detach();
+                }
+                else if (refetch || missingFiles)
                 {
                     Guid id = beatmapInfo.ID;
                     beatmapInfo = Realm.Run(r => r.Find<BeatmapInfo>(id)?.Detach()) ?? beatmapInfo;

--- a/osu.Game/Scoring/ScoreManager.cs
+++ b/osu.Game/Scoring/ScoreManager.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Scoring
         /// Perform a lookup query on available <see cref="ScoreInfo"/>s.
         /// </summary>
         /// <param name="query">The query.</param>
-        /// <returns>The first result for the provided query, or null if no results were found.</returns>
+        /// <returns>The first result for the provided query in its detached form, or null if no results were found.</returns>
         public ScoreInfo? Query(Expression<Func<ScoreInfo, bool>> query)
         {
             return Realm.Run(r => r.All<ScoreInfo>().FirstOrDefault(query)?.Detach());
@@ -88,8 +88,14 @@ namespace osu.Game.Scoring
         {
             ScoreInfo? databasedScoreInfo = null;
 
-            if (originalScoreInfo is ScoreInfo scoreInfo && !string.IsNullOrEmpty(scoreInfo.Hash))
-                databasedScoreInfo = Query(s => s.Hash == scoreInfo.Hash);
+            if (originalScoreInfo is ScoreInfo scoreInfo)
+            {
+                if (scoreInfo.IsManaged)
+                    return scoreInfo.Detach();
+
+                if (!string.IsNullOrEmpty(scoreInfo.Hash))
+                    databasedScoreInfo = Query(s => s.Hash == scoreInfo.Hash);
+            }
 
             if (originalScoreInfo.OnlineID > 0)
                 databasedScoreInfo ??= Query(s => s.OnlineID == originalScoreInfo.OnlineID);


### PR DESCRIPTION
Closes #28497.

Note that this *will* force a refresh delay in the previous fail case, via

https://github.com/ppy/osu/blob/6e11162ab10734b86b88f13b4967ae0bf68b6abd/osu.Game/Database/RealmLive.cs#L65-L66

This is intentional – refresh is sometimes required and using `RealmLive` ensures it happens if and only if required. The blocking operation time is reduced drastically with #30893 to the point that makes it hard to trigger this bug anymore with the provided database.

