### PR TITLE
Clear previous `LastLocalUserScore` when returning to song select

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -355,6 +355,23 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestLastScoreNullAfterExitingPlayer()
+        {
+            AddUntilStep("wait for last play null", getLastPlay, () => Is.Null);
+
+            var getOriginalPlayer = playToCompletion();
+
+            AddStep("attempt to retry", () => getOriginalPlayer().ChildrenOfType<HotkeyRetryOverlay>().First().Action());
+            AddUntilStep("wait for last play matches player", getLastPlay, () => Is.EqualTo(getOriginalPlayer().Score.ScoreInfo));
+
+            AddUntilStep("wait for player", () => Game.ScreenStack.CurrentScreen != getOriginalPlayer() && Game.ScreenStack.CurrentScreen is Player);
+            AddStep("exit player", () => (Game.ScreenStack.CurrentScreen as Player)?.Exit());
+            AddUntilStep("wait for last play null", getLastPlay, () => Is.Null);
+
+            ScoreInfo getLastPlay() => Game.Dependencies.Get<SessionStatics>().Get<ScoreInfo>(Static.LastLocalUserScore);
+        }
+
+        [Test]
         public void TestRetryImmediatelyAfterCompletion()
         {
             var getOriginalPlayer = playToCompletion();

--- a/osu.Game/Configuration/SessionStatics.cs
+++ b/osu.Game/Configuration/SessionStatics.cs
@@ -10,6 +10,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Mods;
 using osu.Game.Scoring;
+using osu.Game.Screens.Play;
 
 namespace osu.Game.Configuration
 {
@@ -77,7 +78,8 @@ namespace osu.Game.Configuration
         TouchInputActive,
 
         /// <summary>
-        /// Stores the local user's last score (can be completed or aborted).
+        /// Contains the local user's last score (can be completed or aborted) after exiting <see cref="Player"/>.
+        /// Will be cleared to <c>null</c> when leaving <see cref="PlayerLoader"/>.
         /// </summary>
         LastLocalUserScore,
 

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -28,6 +28,7 @@ using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Performance;
+using osu.Game.Scoring;
 using osu.Game.Screens.Menu;
 using osu.Game.Screens.Play.PlayerSettings;
 using osu.Game.Skinning;
@@ -77,6 +78,8 @@ namespace osu.Game.Screens.Play
 
         private FillFlowContainer disclaimers = null!;
         private OsuScrollContainer settingsScroll = null!;
+
+        private Bindable<ScoreInfo?> lastScore = null!;
 
         private Bindable<bool> showStoryboards = null!;
 
@@ -179,6 +182,8 @@ namespace osu.Game.Screens.Play
         {
             muteWarningShownOnce = sessionStatics.GetBindable<bool>(Static.MutedAudioNotificationShownOnce);
             batteryWarningShownOnce = sessionStatics.GetBindable<bool>(Static.LowBatteryNotificationShownOnce);
+            lastScore = sessionStatics.GetBindable<ScoreInfo?>(Static.LastLocalUserScore);
+
             showStoryboards = config.GetBindable<bool>(OsuSetting.ShowStoryboard);
 
             const float padding = 25;
@@ -346,6 +351,8 @@ namespace osu.Game.Screens.Play
 
             highPerformanceSession?.Dispose();
             highPerformanceSession = null;
+
+            lastScore.Value = null;
 
             return base.OnExiting(e);
         }


### PR DESCRIPTION
This seems like the lowest friction way to fix https://github.com/ppy/osu/issues/30885.

We could also only null this on application, but this feels worse because

- It would require local handling (potentially complex) in `BeatmapOffsetControl` if we want to continue displaying the graph and button after clicking it.
- It would make the session static very specific in usage and potentially make future usage not possible due to being nulled in only a very specific scenario.

One might argue that it would be nice to have this non-null until the next play, but if such a usage comes up I'd propose we rename this session static and add a new one with that purpose.