### PR TITLE
Fix strong drum rolls being counted for double the combo in legacy scoring attributes

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -144,6 +144,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                     foreach (var nested in hitObject.NestedHitObjects)
                         simulateHit(nested, ref attributes);
                     return;
+
+                case StrongNestedHitObject:
+                    // we never need to deal with these directly.
+                    // the only thing strong hits do in terms of scoring is double their object's score increase,
+                    // which is already handled at the parent object level via the `strongable.IsStrong` check lower down in this method.
+                    // not handling these here can lead to them falsely being counted as combo-increasing when handling strong drum rolls!
+                    return;
             }
 
             if (hitObject is DrumRollTick tick)


### PR DESCRIPTION
This is the root cause of a multi-system failure that ultimately causes https://github.com/ppy/osu-web/issues/11697. It appears that my theory I described in that issue is correct, although this root failure is a little more specific than I initially suspected - only maps with *strong* drum rolls are affected, rather than maps with any drum rolls at all.

Around 6k beatmaps in total are affected by this. List available here: https://gist.github.com/bdach/a719beed292ef0632dc8d002eb9b274c

> [!CAUTION]
> Intended for @peppy first and foremost:
> This change **affects total score** for **all scores imported from stable which were set on the affected beatmaps** in the new database tables. Therefore, this pull should be followed up with:
> - recomputation of scoring attributes for osu!taiko,
> - verification of all imported taiko scores via `osu-queue-score-statistics` (I'd ask to hold with doing that until verification can correct `maximum_statistics`, which also are affected by this failure and cause further failures down the stack, as described in the issue thread - ~~working on that as I write this~~ see https://github.com/ppy/osu-queue-score-statistics/pull/306).

I ran a sheet locally and it looks as I'd expect it to, but will run one through the workflow here for transparency.

run all ranked
run from 90634 non-ranked