### PR TITLE
Stop loudly logging backwards seek bug to sentry

### DIFF
--- a/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
+++ b/osu.Game/Rulesets/UI/FrameStabilityContainer.cs
@@ -3,19 +3,15 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
-using osu.Game.Beatmaps;
 using osu.Game.Input.Handlers;
 using osu.Game.Screens.Play;
-using osu.Game.Utils;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -168,13 +164,7 @@ namespace osu.Game.Rulesets.UI
                 if (lastBackwardsSeekLogTime == null || Math.Abs(Clock.CurrentTime - lastBackwardsSeekLogTime.Value) > 1000)
                 {
                     lastBackwardsSeekLogTime = Clock.CurrentTime;
-
-                    string loggableContent = $"Denying backwards seek during gameplay (reference: {referenceClock.CurrentTime:N2} stable: {proposedTime:N2})";
-
-                    if (parentGameplayClock is GameplayClockContainer gcc)
-                        loggableContent += $"\n{gcc.ChildrenOfType<FramedBeatmapClock>().Single().GetSnapshot()}";
-
-                    Logger.Error(new SentryOnlyDiagnosticsException("backwards seek"), loggableContent);
+                    Logger.Log($"Denying backwards seek during gameplay (reference: {referenceClock.CurrentTime:N2} stable: {proposedTime:N2})");
                 }
 
                 state = PlaybackState.NotValid;


### PR DESCRIPTION
Several users have reported stutters when this happens. It's potentially from the error report overhead. We now know that this is a BASS level issue anyway, so having this logging is not helpful.
