### PR TITLE
Fix score no longer being saved when quick-restarting after pass

### DIFF
--- a/osu.Game.Tests/Visual/Mods/TestSceneModFailCondition.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModFailCondition.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Tests.Visual.Mods
         protected override TestPlayer CreateModPlayer(Ruleset ruleset)
         {
             var player = base.CreateModPlayer(ruleset);
-            player.RestartRequested = _ => restartRequested = true;
+            player.PrepareLoaderForRestart = _ => restartRequested = true;
             return player;
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -646,7 +646,6 @@ namespace osu.Game.Screens.Play
             // import current score if possible.
             prepareAndImportScoreAsync();
 
-            // Screen may not be current if a restart has been performed.
             if (this.IsCurrentScreen())
             {
                 skipExitTransition = skipTransition;
@@ -656,6 +655,12 @@ namespace osu.Game.Screens.Play
                 // - the pause / fail dialog was requested but is already displayed (user showing intention to exit).
                 // - the pause / fail dialog was requested but couldn't be displayed due to the type or state of this Player instance.
                 this.Exit();
+            }
+            else
+            {
+                // May be restarting from results screen.
+                if (this.GetChildScreen() != null)
+                    this.MakeCurrent();
             }
 
             return true;
@@ -721,16 +726,6 @@ namespace osu.Game.Screens.Play
 
             skipExitTransition = quickRestart;
             PrepareLoaderForRestart?.Invoke(quickRestart);
-
-            if (!this.IsCurrentScreen())
-            {
-                // if we're called externally (i.e. from results screen),
-                // use MakeCurrent to exit results screen as well as this player screen
-                // since ValidForResume = false in here
-                Debug.Assert(!ValidForResume);
-                this.MakeCurrent();
-                return true;
-            }
 
             return PerformExit(quickRestart);
         }

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -722,6 +722,16 @@ namespace osu.Game.Screens.Play
             skipExitTransition = quickRestart;
             PrepareLoaderForRestart?.Invoke(quickRestart);
 
+            if (!this.IsCurrentScreen())
+            {
+                // if we're called externally (i.e. from results screen),
+                // use MakeCurrent to exit results screen as well as this player screen
+                // since ValidForResume = false in here
+                Debug.Assert(!ValidForResume);
+                this.MakeCurrent();
+                return true;
+            }
+
             return PerformExit(quickRestart);
         }
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -83,7 +83,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         protected virtual bool PauseOnFocusLost => true;
 
-        public Action<bool> RestartRequested;
+        public Action<bool> PrepareLoaderForRestart;
 
         private bool isRestarting;
         private bool skipExitTransition;
@@ -719,12 +719,8 @@ namespace osu.Game.Screens.Play
             // stopping here is to ensure music doesn't become audible after exiting back to PlayerLoader.
             musicController.Stop();
 
-            if (RestartRequested != null)
-            {
-                skipExitTransition = quickRestart;
-                RestartRequested?.Invoke(quickRestart);
-                return true;
-            }
+            skipExitTransition = quickRestart;
+            PrepareLoaderForRestart?.Invoke(quickRestart);
 
             return PerformExit(quickRestart);
         }

--- a/osu.Game/Screens/Play/PlayerLoader.cs
+++ b/osu.Game/Screens/Play/PlayerLoader.cs
@@ -457,7 +457,7 @@ namespace osu.Game.Screens.Play
             CurrentPlayer = createPlayer();
             CurrentPlayer.Configuration.AutomaticallySkipIntro |= quickRestart;
             CurrentPlayer.RestartCount = restartCount++;
-            CurrentPlayer.RestartRequested = restartRequested;
+            CurrentPlayer.PrepareLoaderForRestart = prepareForRestart;
 
             LoadTask = LoadComponentAsync(CurrentPlayer, _ =>
             {
@@ -470,13 +470,11 @@ namespace osu.Game.Screens.Play
         {
         }
 
-        private void restartRequested(bool quickRestartRequested)
+        private void prepareForRestart(bool quickRestartRequested)
         {
             quickRestart = quickRestartRequested;
             hideOverlays = true;
             ValidForResume = true;
-
-            this.MakeCurrent();
         }
 
         private void contentIn(double delayBeforeSideDisplays = 0)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/30642

The `PerformExit` path ensures the score is imported even if the user restarts after passing the beatmap during the one second completion delay `RESULTS_DISPLAY_DELAY`. 

In https://github.com/ppy/osu/pull/30623, `Restart` no longer calls `PerformExit`, therefore discarding the score for the scenario in question.

I've resolved the issue by still calling `PerformExit` rather than letting the `PlayerLoader` do the exiting process.

I wanted to write a test case for this but timing is critical, I'll have to change the constant to be overridable and make my test case set the delay to infinity, but it feels weird to break parts of the component itself in order to test it. I can still write a test case if wanted.