### PR TITLE
Do not deselect objects when control-clicking without hitting anything

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuComposerSelection.cs
@@ -231,6 +231,36 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddAssert("slider still has 2 anchors", () => secondSlider.Path.ControlPoints.Count, () => Is.EqualTo(2));
         }
 
+        [Test]
+        public void TestControlClickDoesNotDiscardExistingSelectionEvenIfNothingHit()
+        {
+            var firstSlider = new Slider
+            {
+                StartTime = 0,
+                Position = new Vector2(0, 0),
+                Path = new SliderPath
+                {
+                    ControlPoints =
+                    {
+                        new PathControlPoint(),
+                        new PathControlPoint(new Vector2(100))
+                    }
+                }
+            };
+
+            AddStep("add object", () => EditorBeatmap.AddRange([firstSlider]));
+            AddStep("select first slider", () => EditorBeatmap.SelectedHitObjects.AddRange([firstSlider]));
+
+            AddStep("move mouse to middle of playfield", () => InputManager.MoveMouseTo(blueprintContainer.ScreenSpaceDrawQuad.Centre));
+            AddStep("control-click left mouse", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.Click(MouseButton.Left);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+            AddAssert("selection preserved", () => EditorBeatmap.SelectedHitObjects.Count, () => Is.EqualTo(1));
+        }
+
         private ComposeBlueprintContainer blueprintContainer
             => Editor.ChildrenOfType<ComposeBlueprintContainer>().First();
 

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -433,7 +433,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// Finishes the current blueprint selection.
         /// </summary>
         /// <param name="e">The mouse event which triggered end of selection.</param>
-        /// <returns>Whether a click selection was active.</returns>
+        /// <returns>
+        /// Whether the mouse event is considered to be fully handled.
+        /// If the return value is <see langword="false"/>, the standard click / mouse up action will follow.
+        /// </returns>
         private bool endClickSelection(MouseButtonEvent e)
         {
             // If already handled a selection, double-click, or drag, we don't want to perform a mouse up / click action.
@@ -443,14 +446,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             if (e.ControlPressed)
             {
-                // if a selection didn't occur, we may want to trigger a deselection.
-
                 // Iterate from the top of the input stack (blueprints closest to the front of the screen first).
                 // Priority is given to already-selected blueprints.
                 foreach (SelectionBlueprint<T> blueprint in SelectionBlueprints.AliveChildren.Where(b => b.IsHovered).OrderByDescending(b => b.IsSelected))
                     return clickSelectionHandled = SelectionHandler.MouseUpSelectionRequested(blueprint, e);
 
-                return false;
+                // can only be reached if there are no hovered blueprints.
+                // in that case, we still want to suppress mouse up / click handling, because when control is pressed,
+                // it is presumed we want to add to existing selection, not remove from it
+                // (unless explicitly control-clicking a selected object, which is handled above).
+                return true;
             }
 
             if (selectedBlueprintAlreadySelectedOnMouseDown && SelectedItems.Count == 1)


### PR DESCRIPTION
As per feedback in https://discord.com/channels/90072389919997952/1259818301517725707/1310270647187935284.

I checked a few apps to see what they do in this type of scenario and it's a very mixed bag but I think this behaviour makes sense.