### PR TITLE
Show an ongoing operation when checking for updates

### DIFF
--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -45,6 +45,11 @@ namespace osu.Game.Localisation
         public static LocalisableString CheckUpdate => new TranslatableString(getKey(@"check_update"), @"Check for updates");
 
         /// <summary>
+        /// "Checking for updates"
+        /// </summary>
+        public static LocalisableString CheckingForUpdates => new TranslatableString(getKey(@"checking_for_updates"), @"Checking for updates");
+
+        /// <summary>
         /// "Open osu! folder"
         /// </summary>
         public static LocalisableString OpenOsuFolder => new TranslatableString(getKey(@"open_osu_folder"), @"Open osu! folder");

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -4,7 +4,6 @@
 using System.Threading.Tasks;
 using osu.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Framework.Logging;
@@ -13,6 +12,7 @@ using osu.Framework.Screens;
 using osu.Framework.Statistics;
 using osu.Game.Configuration;
 using osu.Game.Localisation;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Overlays.Settings.Sections.Maintenance;
 using osu.Game.Updater;
@@ -36,8 +36,11 @@ namespace osu.Game.Overlays.Settings.Sections.General
         [Resolved]
         private Storage storage { get; set; } = null!;
 
+        [Resolved]
+        private OsuGame? game { get; set; }
+
         [BackgroundDependencyLoader]
-        private void load(OsuConfigManager config, OsuGame? game)
+        private void load(OsuConfigManager config)
         {
             Add(new SettingsEnumDropdown<ReleaseStream>
             {
@@ -50,31 +53,7 @@ namespace osu.Game.Overlays.Settings.Sections.General
                 Add(checkForUpdatesButton = new SettingsButton
                 {
                     Text = GeneralSettingsStrings.CheckUpdate,
-                    Action = () =>
-                    {
-                        checkForUpdatesButton.Enabled.Value = false;
-
-                        var checkingNotification = new ProgressNotification { Text = GeneralSettingsStrings.CheckingForUpdates, };
-                        notifications?.Post(checkingNotification);
-
-                        Task.Run(updateManager.CheckForUpdateAsync).ContinueWith(task => Schedule(() =>
-                        {
-                            // This sequence allows the notification to be immediately dismissed.
-                            checkingNotification.State = ProgressNotificationState.Cancelled;
-                            checkingNotification.Close(false);
-
-                            if (!task.GetResultSafely())
-                            {
-                                notifications?.Post(new SimpleNotification
-                                {
-                                    Text = GeneralSettingsStrings.RunningLatestRelease(game!.Version),
-                                    Icon = FontAwesome.Solid.CheckCircle,
-                                });
-                            }
-
-                            checkForUpdatesButton.Enabled.Value = true;
-                        }));
-                    }
+                    Action = () => checkForUpdates().FireAndForget()
                 });
             }
 
@@ -99,6 +78,44 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     Text = GeneralSettingsStrings.ChangeFolderLocation,
                     Action = () => game?.PerformFromScreen(menu => menu.Push(new MigrationSelectScreen()))
                 });
+            }
+        }
+
+        private async Task checkForUpdates()
+        {
+            if (updateManager == null || game == null)
+                return;
+
+            checkForUpdatesButton.Enabled.Value = false;
+
+            var checkingNotification = new ProgressNotification
+            {
+                Text = GeneralSettingsStrings.CheckingForUpdates,
+            };
+            notifications?.Post(checkingNotification);
+
+            try
+            {
+                bool foundUpdate = await updateManager.CheckForUpdateAsync().ConfigureAwait(true);
+
+                if (!foundUpdate)
+                {
+                    notifications?.Post(new SimpleNotification
+                    {
+                        Text = GeneralSettingsStrings.RunningLatestRelease(game.Version),
+                        Icon = FontAwesome.Solid.CheckCircle,
+                    });
+                }
+            }
+            catch
+            {
+            }
+            finally
+            {
+                // This sequence allows the notification to be immediately dismissed.
+                checkingNotification.State = ProgressNotificationState.Cancelled;
+                checkingNotification.Close(false);
+                checkForUpdatesButton.Enabled.Value = true;
             }
         }
 

--- a/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs
@@ -53,8 +53,16 @@ namespace osu.Game.Overlays.Settings.Sections.General
                     Action = () =>
                     {
                         checkForUpdatesButton.Enabled.Value = false;
+
+                        var checkingNotification = new ProgressNotification { Text = GeneralSettingsStrings.CheckingForUpdates, };
+                        notifications?.Post(checkingNotification);
+
                         Task.Run(updateManager.CheckForUpdateAsync).ContinueWith(task => Schedule(() =>
                         {
+                            // This sequence allows the notification to be immediately dismissed.
+                            checkingNotification.State = ProgressNotificationState.Cancelled;
+                            checkingNotification.Close(false);
+
                             if (!task.GetResultSafely())
                             {
                                 notifications?.Post(new SimpleNotification


### PR DESCRIPTION
Addresses https://github.com/ppy/osu/discussions/30950.

Thought this would be a quick one, but during testing I noticed an unobserved exception could lead to a failure (even on `master`). Also, if the settings overlay was closed during the update check, the `Schedule` in the `ContinueWith` would not run (as the settings panel is not present).

I've fixed both issues by using the (relatively unused) `SynchronizationContext` presence, which means the continuation will be automatically scheduled back to the update thread (since it was triggered from that thread).

Can be tested using some iteration of:

```diff
diff --git a/osu.Game/Updater/UpdateManager.cs b/osu.Game/Updater/UpdateManager.cs
index c114e3a8d0..d9aa12fa46 100644
--- a/osu.Game/Updater/UpdateManager.cs
+++ b/osu.Game/Updater/UpdateManager.cs
@@ -26,9 +26,7 @@ public partial class UpdateManager : CompositeDrawable
         /// <summary>
         /// Whether this UpdateManager should be or is capable of checking for updates.
         /// </summary>
-        public bool CanCheckForUpdate => game.IsDeployedBuild &&
-                                         // only implementations will actually check for updates.
-                                         GetType() != typeof(UpdateManager);
+        public bool CanCheckForUpdate => true;
 
         [Resolved]
         private OsuConfigManager config { get; set; } = null!;
@@ -70,13 +68,15 @@ protected override void LoadComplete()
 
         public async Task<bool> CheckForUpdateAsync()
         {
+            await Task.Delay(3000).ConfigureAwait(false);
+
             if (!CanCheckForUpdate)
                 return false;
 
             Task<bool> waitTask;
 
             lock (updateTaskLock)
-                waitTask = (updateCheckTask ??= PerformUpdateCheck());
+                waitTask = updateCheckTask ??= PerformUpdateCheck();
 
             bool hasUpdates = await waitTask.ConfigureAwait(false);
 

```
