### PR TITLE
Use `LocalisationManager.GetLocalisedString()` instead of bindable hack

### DIFF
--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -148,15 +148,7 @@ namespace osu.Desktop.Windows
             foreach (var association in uri_associations)
                 association.UpdateDescription(getLocalisedString(association.Description));
 
-            string getLocalisedString(LocalisableString s)
-            {
-                if (localisation == null)
-                    return s.ToString();
-
-                var b = localisation.GetLocalisedBindableString(s);
-                b.UnbindAll();
-                return b.Value;
-            }
+            string getLocalisedString(LocalisableString s) => localisation?.GetLocalisedString(s) ?? s.ToString();
         }
 
         #region Native interop

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -114,10 +114,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                             if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows || RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
                             {
                                 t.NewLine();
-                                var formattedSource = MessageFormatter.FormatText(localisation.GetLocalisedBindableString(TabletSettingsStrings.NoTabletDetectedDescription(
+                                var formattedSource = MessageFormatter.FormatText(localisation.GetLocalisedString(TabletSettingsStrings.NoTabletDetectedDescription(
                                     RuntimeInfo.OS == RuntimeInfo.Platform.Windows
                                         ? @"https://opentabletdriver.net/Wiki/FAQ/Windows"
-                                        : @"https://opentabletdriver.net/Wiki/FAQ/Linux")).Value);
+                                        : @"https://opentabletdriver.net/Wiki/FAQ/Linux")));
                                 t.AddLinks(formattedSource.Text, formattedSource.Links);
                             }
                         }),


### PR DESCRIPTION
- Made possible by https://github.com/ppy/osu-framework/pull/6377

One of these usages is wrong, but that's out of scope for this PR.

![image](https://github.com/user-attachments/assets/b51e2c13-e6e9-4e70-8d9a-52707720a742)
