### PR TITLE
Hide debug settings in release builds

### DIFF
--- a/osu.Game/Localisation/DebugSettingsStrings.cs
+++ b/osu.Game/Localisation/DebugSettingsStrings.cs
@@ -10,21 +10,6 @@ namespace osu.Game.Localisation
         private const string prefix = @"osu.Game.Resources.Localisation.DebugSettings";
 
         /// <summary>
-        /// "Debug"
-        /// </summary>
-        public static LocalisableString DebugSectionHeader => new TranslatableString(getKey(@"debug_section_header"), @"Debug");
-
-        /// <summary>
-        /// "Show log overlay"
-        /// </summary>
-        public static LocalisableString ShowLogOverlay => new TranslatableString(getKey(@"show_log_overlay"), @"Show log overlay");
-
-        /// <summary>
-        /// "Bypass front-to-back render pass"
-        /// </summary>
-        public static LocalisableString BypassFrontToBackPass => new TranslatableString(getKey(@"bypass_front_to_back_pass"), @"Bypass front-to-back render pass");
-
-        /// <summary>
         /// "Import files"
         /// </summary>
         public static LocalisableString ImportFiles => new TranslatableString(getKey(@"import_files"), @"Import files");
@@ -33,16 +18,6 @@ namespace osu.Game.Localisation
         /// "Run latency certifier"
         /// </summary>
         public static LocalisableString RunLatencyCertifier => new TranslatableString(getKey(@"run_latency_certifier"), @"Run latency certifier");
-
-        /// <summary>
-        /// "Memory"
-        /// </summary>
-        public static LocalisableString MemoryHeader => new TranslatableString(getKey(@"memory_header"), @"Memory");
-
-        /// <summary>
-        /// "Clear all caches"
-        /// </summary>
-        public static LocalisableString ClearAllCaches => new TranslatableString(getKey(@"clear_all_caches"), @"Clear all caches");
 
         private static string getKey(string key) => $"{prefix}:{key}";
     }

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
@@ -90,11 +91,13 @@ namespace osu.Game.Overlays.FirstRunSetup
                         new GraphicsSection(),
                         new OnlineSection(),
                         new MaintenanceSection(),
-                        new DebugSection(),
                     },
                     SearchTerm = SettingsItem<bool>.CLASSIC_DEFAULT_SEARCH_TERM,
                 }
             };
+
+            if (DebugUtils.IsDebugBuild)
+                searchContainer.Add(new DebugSection());
         }
 
         private void applyClassic()

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -6,14 +6,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
-using osu.Game.Localisation;
 using osu.Game.Overlays.Settings.Sections.DebugSettings;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
     public partial class DebugSection : SettingsSection
     {
-        public override LocalisableString Header => DebugSettingsStrings.DebugSectionHeader;
+        public override LocalisableString Header => "Debug";
 
         public override Drawable CreateIcon() => new SpriteIcon
         {

--- a/osu.Game/Overlays/Settings/Sections/DebugSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSection.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -12,7 +11,7 @@ namespace osu.Game.Overlays.Settings.Sections
 {
     public partial class DebugSection : SettingsSection
     {
-        public override LocalisableString Header => "Debug";
+        public override LocalisableString Header => @"Debug";
 
         public override Drawable CreateIcon() => new SpriteIcon
         {
@@ -21,12 +20,12 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public DebugSection()
         {
-            Add(new GeneralSettings());
-
-            if (DebugUtils.IsDebugBuild)
-                Add(new BatchImportSettings());
-
-            Add(new MemorySettings());
+            Children = new Drawable[]
+            {
+                new GeneralSettings(),
+                new BatchImportSettings(),
+                new MemorySettings(),
+            };
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public partial class GeneralSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => "General";
+        protected override LocalisableString Header => @"General";
 
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig)
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 new SettingsCheckbox
                 {
-                    LabelText = "Show log overlay",
+                    LabelText = @"Show log overlay",
                     Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay)
                 },
                 new SettingsCheckbox

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -5,13 +5,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public partial class GeneralSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => CommonStrings.General;
+        protected override LocalisableString Header => "General";
 
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig)
@@ -20,12 +19,12 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 new SettingsCheckbox
                 {
-                    LabelText = DebugSettingsStrings.ShowLogOverlay,
+                    LabelText = "Show log overlay",
                     Current = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay)
                 },
                 new SettingsCheckbox
                 {
-                    LabelText = DebugSettingsStrings.BypassFrontToBackPass,
+                    LabelText = @"Bypass front-to-back render pass",
                     Current = config.GetBindable<bool>(DebugSetting.BypassFrontToBackPass)
                 },
             };

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/GeneralSettings.cs
@@ -5,11 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
-using osu.Framework.Screens;
 using osu.Game.Localisation;
-using osu.Game.Screens;
-using osu.Game.Screens.Import;
-using osu.Game.Screens.Utility;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
@@ -18,7 +14,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
         protected override LocalisableString Header => CommonStrings.General;
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig, IPerformFromScreenRunner? performer)
+        private void load(FrameworkDebugConfigManager config, FrameworkConfigManager frameworkConfig)
         {
             Children = new Drawable[]
             {
@@ -32,16 +28,6 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                     LabelText = DebugSettingsStrings.BypassFrontToBackPass,
                     Current = config.GetBindable<bool>(DebugSetting.BypassFrontToBackPass)
                 },
-                new SettingsButton
-                {
-                    Text = DebugSettingsStrings.ImportFiles,
-                    Action = () => performer?.PerformFromScreen(menu => menu.Push(new FileImportScreen()))
-                },
-                new SettingsButton
-                {
-                    Text = DebugSettingsStrings.RunLatencyCertifier,
-                    Action = () => performer?.PerformFromScreen(menu => menu.Push(new LatencyCertifierScreen()))
-                }
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -11,13 +11,12 @@ using osu.Framework.Localisation;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Database;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public partial class MemorySettings : SettingsSubsection
     {
-        protected override LocalisableString Header => DebugSettingsStrings.MemoryHeader;
+        protected override LocalisableString Header => "Memory";
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, RealmAccess realm)
@@ -29,7 +28,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 new SettingsButton
                 {
-                    Text = DebugSettingsStrings.ClearAllCaches,
+                    Text = "Clear all caches",
                     Action = host.Collect
                 },
                 new SettingsButton

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
 {
     public partial class MemorySettings : SettingsSubsection
     {
-        protected override LocalisableString Header => "Memory";
+        protected override LocalisableString Header => @"Memory";
 
         [BackgroundDependencyLoader]
         private void load(GameHost host, RealmAccess realm)
@@ -28,27 +28,27 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 new SettingsButton
                 {
-                    Text = "Clear all caches",
+                    Text = @"Clear all caches",
                     Action = host.Collect
                 },
                 new SettingsButton
                 {
-                    Text = "Compact realm",
+                    Text = @"Compact realm",
                     Action = () =>
                     {
                         // Blocking operations implicitly causes a Compact().
-                        using (realm.BlockAllOperations("compact"))
+                        using (realm.BlockAllOperations(@"compact"))
                         {
                         }
                     }
                 },
                 blockAction = new SettingsButton
                 {
-                    Text = "Block realm",
+                    Text = @"Block realm",
                 },
                 unblockAction = new SettingsButton
                 {
-                    Text = "Unblock realm",
+                    Text = @"Unblock realm",
                 },
             };
 
@@ -56,7 +56,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
             {
                 try
                 {
-                    IDisposable? token = realm.BlockAllOperations("maintenance");
+                    IDisposable? token = realm.BlockAllOperations(@"maintenance");
 
                     blockAction.Enabled.Value = false;
 
@@ -88,7 +88,7 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, "Blocking realm failed");
+                    Logger.Error(e, @"Blocking realm failed");
                 }
             };
         }

--- a/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Localisation;
+using osu.Framework.Screens;
+using osu.Game.Localisation;
+using osu.Game.Screens;
+using osu.Game.Screens.Import;
+using osu.Game.Screens.Utility;
+
+namespace osu.Game.Overlays.Settings.Sections.Maintenance
+{
+    public partial class GeneralSettings : SettingsSubsection
+    {
+        protected override LocalisableString Header => CommonStrings.General;
+
+        [BackgroundDependencyLoader]
+        private void load(IPerformFromScreenRunner? performer)
+        {
+            Children = new[]
+            {
+                new SettingsButton
+                {
+                    Text = DebugSettingsStrings.ImportFiles,
+                    Action = () => performer?.PerformFromScreen(menu => menu.Push(new FileImportScreen()))
+                },
+                new SettingsButton
+                {
+                    Text = DebugSettingsStrings.RunLatencyCertifier,
+                    Action = () => performer?.PerformFromScreen(menu => menu.Push(new LatencyCertifierScreen()))
+                }
+            };
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/MaintenanceSection.cs
@@ -23,6 +23,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             Children = new Drawable[]
             {
+                new GeneralSettings(),
                 new BeatmapSettings(),
                 new SkinSettings(),
                 new CollectionsSettings(),

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -27,21 +28,28 @@ namespace osu.Game.Overlays
         public LocalisableString Title => SettingsStrings.HeaderTitle;
         public LocalisableString Description => SettingsStrings.HeaderDescription;
 
-        protected override IEnumerable<SettingsSection> CreateSections() => new SettingsSection[]
+        protected override IEnumerable<SettingsSection> CreateSections()
         {
-            // This list should be kept in sync with ScreenBehaviour.
-            new GeneralSection(),
-            new SkinSection(),
-            new InputSection(createSubPanel(new KeyBindingPanel())),
-            new UserInterfaceSection(),
-            new GameplaySection(),
-            new RulesetSection(),
-            new AudioSection(),
-            new GraphicsSection(),
-            new OnlineSection(),
-            new MaintenanceSection(),
-            new DebugSection(),
-        };
+            var sections = new List<SettingsSection>
+            {
+                // This list should be kept in sync with ScreenBehaviour.
+                new GeneralSection(),
+                new SkinSection(),
+                new InputSection(createSubPanel(new KeyBindingPanel())),
+                new UserInterfaceSection(),
+                new GameplaySection(),
+                new RulesetSection(),
+                new AudioSection(),
+                new GraphicsSection(),
+                new OnlineSection(),
+                new MaintenanceSection(),
+            };
+
+            if (DebugUtils.IsDebugBuild)
+                sections.Add(new DebugSection());
+
+            return sections;
+        }
 
         private readonly List<SettingsSubPanel> subPanels = new List<SettingsSubPanel>();
 


### PR DESCRIPTION
Intended to be done long ago but was seemingly forgotten (see [relevant discussion](https://discord.com/channels/188630481301012481/188630652340404224/1300697115898413076)). Some decisions made in this PR may be questionable (such as removing the "show log overlay" and "bypass front-to-back" settings), but I'm opening this PR just to shine back on doing this.