### PR TITLE
Hide "Import files" button in settings on iOS

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Maintenance/GeneralSettings.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Localisation;
 using osu.Framework.Screens;
@@ -18,19 +19,22 @@ namespace osu.Game.Overlays.Settings.Sections.Maintenance
         [BackgroundDependencyLoader]
         private void load(IPerformFromScreenRunner? performer)
         {
-            Children = new[]
+            // the screen does not look appropriate on iOS with system file selection implemented,
+            // and functionality is already provided by opening said files externally.
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.iOS)
             {
-                new SettingsButton
+                Add(new SettingsButton
                 {
                     Text = DebugSettingsStrings.ImportFiles,
                     Action = () => performer?.PerformFromScreen(menu => menu.Push(new FileImportScreen()))
-                },
-                new SettingsButton
-                {
-                    Text = DebugSettingsStrings.RunLatencyCertifier,
-                    Action = () => performer?.PerformFromScreen(menu => menu.Push(new LatencyCertifierScreen()))
-                }
-            };
+                });
+            }
+
+            Add(new SettingsButton
+            {
+                Text = DebugSettingsStrings.RunLatencyCertifier,
+                Action = () => performer?.PerformFromScreen(menu => menu.Push(new LatencyCertifierScreen()))
+            });
         }
     }
 }


### PR DESCRIPTION
Following https://github.com/ppy/osu-framework/pull/6445, and restating the comment in the commit, the screen does not look appropriate on iOS with system file selection implemented (initial testing shows it to be severely broken), and functionality is already provided by opening such files externally, so I don't think it's worth the effort to try and fix this rather than just omit it from iOS.