### PR TITLE
Add description to osu! file associations in iOS

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -68,6 +68,8 @@
 			<array>
 				<string>sh.ppy.osu.items</string>
 			</array>
+			<key>UTTypeDescription</key>
+			<string>osu! replay</string>
 			<key>UTTypeIdentifier</key>
 			<string>sh.ppy.osu.osr</string>
 			<key>UTTypeTagSpecification</key>
@@ -81,6 +83,8 @@
 			<array>
 				<string>sh.ppy.osu.items</string>
 			</array>
+			<key>UTTypeDescription</key>
+			<string>osu! skin</string>
 			<key>UTTypeIdentifier</key>
 			<string>sh.ppy.osu.osk</string>
 			<key>UTTypeTagSpecification</key>
@@ -94,6 +98,8 @@
 			<array>
 				<string>sh.ppy.osu.items</string>
 			</array>
+			<key>UTTypeDescription</key>
+			<string>osu! beatmap</string>
 			<key>UTTypeIdentifier</key>
 			<string>sh.ppy.osu.osz</string>
 			<key>UTTypeTagSpecification</key>
@@ -107,6 +113,8 @@
 			<array>
 				<string>sh.ppy.osu.items</string>
 			</array>
+			<key>UTTypeDescription</key>
+			<string>osu! beatmap</string>
 			<key>UTTypeIdentifier</key>
 			<string>sh.ppy.osu.olz</string>
 			<key>UTTypeTagSpecification</key>


### PR DESCRIPTION
Fixes osu! files appearing under the name "data" when viewing them in Files app or when presented to the user for save after being exported (new feature coming in just a moment ;)). Now shows the appropriate description taken from https://github.com/ppy/osu/blob/1b8d9370aa8035e3dddf0c0eb4616bf0480f140e/osu.Game/Localisation/WindowsAssociationManagerStrings.cs (lowercased):

![IMG_1779](https://github.com/user-attachments/assets/07c15e20-dad9-42b1-8939-0dbe675ac01c)
