### PR TITLE
Use temporary storage for file exports on iOS

### DIFF
--- a/osu.Game.Tests/Database/LegacyModelExporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyModelExporterTest.cs
@@ -12,6 +12,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Database;
+using osu.Game.IO;
 using osu.Game.Overlays.Notifications;
 using Realms;
 
@@ -21,7 +22,9 @@ namespace osu.Game.Tests.Database
     public class LegacyModelExporterTest
     {
         private TestLegacyModelExporter legacyExporter = null!;
-        private TemporaryNativeStorage storage = null!;
+
+        private OsuStorage storage = null!;
+        private TemporaryNativeStorage underlyingStorage = null!;
 
         private const string short_filename = "normal file name";
 
@@ -31,7 +34,7 @@ namespace osu.Game.Tests.Database
         [SetUp]
         public void SetUp()
         {
-            storage = new TemporaryNativeStorage("export-storage");
+            storage = new OsuStorage(new HeadlessGameHost(), underlyingStorage = new TemporaryNativeStorage("export-storage"));
             legacyExporter = new TestLegacyModelExporter(storage);
         }
 
@@ -102,8 +105,8 @@ namespace osu.Game.Tests.Database
         [TearDown]
         public void TearDown()
         {
-            if (storage.IsNotNull())
-                storage.Dispose();
+            if (underlyingStorage.IsNotNull())
+                underlyingStorage.Dispose();
         }
 
         private class TestLegacyModelExporter : LegacyExporter<TestModel>

--- a/osu.Game.Tests/Database/LegacyModelExporterTest.cs
+++ b/osu.Game.Tests/Database/LegacyModelExporterTest.cs
@@ -12,7 +12,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Game.Database;
-using osu.Game.IO;
 using osu.Game.Overlays.Notifications;
 using Realms;
 
@@ -22,9 +21,7 @@ namespace osu.Game.Tests.Database
     public class LegacyModelExporterTest
     {
         private TestLegacyModelExporter legacyExporter = null!;
-
-        private OsuStorage storage = null!;
-        private TemporaryNativeStorage underlyingStorage = null!;
+        private TemporaryNativeStorage storage = null!;
 
         private const string short_filename = "normal file name";
 
@@ -34,7 +31,7 @@ namespace osu.Game.Tests.Database
         [SetUp]
         public void SetUp()
         {
-            storage = new OsuStorage(new HeadlessGameHost(), underlyingStorage = new TemporaryNativeStorage("export-storage"));
+            storage = new TemporaryNativeStorage("export-storage");
             legacyExporter = new TestLegacyModelExporter(storage);
         }
 
@@ -105,8 +102,8 @@ namespace osu.Game.Tests.Database
         [TearDown]
         public void TearDown()
         {
-            if (underlyingStorage.IsNotNull())
-                underlyingStorage.Dispose();
+            if (storage.IsNotNull())
+                storage.Dispose();
         }
 
         private class TestLegacyModelExporter : LegacyExporter<TestModel>

--- a/osu.Game/Database/LegacyExporter.cs
+++ b/osu.Game/Database/LegacyExporter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -42,15 +41,13 @@ namespace osu.Game.Database
         protected abstract string FileExtension { get; }
 
         protected readonly Storage UserFileStorage;
-        private readonly Storage? exportStorage;
+        private readonly Storage exportStorage;
 
         public Action<Notification>? PostNotification { get; set; }
 
         protected LegacyExporter(Storage storage)
         {
-            if (storage is OsuStorage osuStorage)
-                exportStorage = osuStorage.GetExportStorage();
-
+            exportStorage = (storage as OsuStorage)?.GetExportStorage() ?? storage.GetStorageForDirectory(@"exports");
             UserFileStorage = storage.GetStorageForDirectory(@"files");
         }
 
@@ -72,8 +69,6 @@ namespace osu.Game.Database
         /// <param name="cancellationToken">A cancellation token.</param>
         public async Task ExportAsync(Live<TModel> model, CancellationToken cancellationToken = default)
         {
-            Debug.Assert(exportStorage != null);
-
             string itemFilename = model.PerformRead(s => GetFilename(s).GetValidFilename());
 
             if (itemFilename.Length > MAX_FILENAME_LENGTH - FileExtension.Length)

--- a/osu.Game/IO/OsuStorage.cs
+++ b/osu.Game/IO/OsuStorage.cs
@@ -62,6 +62,11 @@ namespace osu.Game.IO
         }
 
         /// <summary>
+        /// Returns the <see cref="Storage"/> used for storing exported files.
+        /// </summary>
+        public virtual Storage GetExportStorage() => GetStorageForDirectory(@"exports");
+
+        /// <summary>
         /// Resets the custom storage path, changing the target storage to the default location.
         /// </summary>
         public void ResetCustomStoragePath()

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -5,6 +5,8 @@ using System;
 using Foundation;
 using Microsoft.Maui.Devices;
 using osu.Framework.Graphics;
+using osu.Framework.iOS;
+using osu.Framework.Platform;
 using osu.Game;
 using osu.Game.Updater;
 using osu.Game.Utils;
@@ -18,6 +20,8 @@ namespace osu.iOS
         protected override UpdateManager CreateUpdateManager() => new MobileUpdateNotifier();
 
         protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();
+
+        protected override Storage CreateStorage(GameHost host, Storage defaultStorage) => new OsuStorageIOS((IOSGameHost)host, defaultStorage);
 
         protected override Edges SafeAreaOverrideEdges =>
             // iOS shows a home indicator at the bottom, and adds a safe area to account for this.

--- a/osu.iOS/OsuStorageIOS.cs
+++ b/osu.iOS/OsuStorageIOS.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using osu.Framework.iOS;
+using osu.Framework.Platform;
+using osu.Game.IO;
+
+namespace osu.iOS
+{
+    public class OsuStorageIOS : OsuStorage
+    {
+        private readonly IOSGameHost host;
+
+        public OsuStorageIOS(IOSGameHost host, Storage defaultStorage)
+            : base(host, defaultStorage)
+        {
+            this.host = host;
+        }
+
+        public override Storage GetExportStorage() => new IOSStorage(Path.GetTempPath(), host);
+    }
+}


### PR DESCRIPTION
Usually on iOS the user is explicitly asked where to store every exported file, storing exports permanently will clog up the user's phone storage. I've tried to approach this with as less changes as possible.