### PR TITLE
Fix top score statistics section total score display being terminally broken

### DIFF
--- a/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
+++ b/osu.Game/Overlays/BeatmapSet/Scores/TopScoreStatisticsSection.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics;
@@ -35,7 +34,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
         private readonly FontUsage smallFont = OsuFont.GetFont(size: 16);
         private readonly FontUsage largeFont = OsuFont.GetFont(size: 22, weight: FontWeight.Light);
 
-        private readonly TextColumn totalScoreColumn;
+        private readonly TotalScoreColumn totalScoreColumn;
         private readonly TextColumn accuracyColumn;
         private readonly TextColumn maxComboColumn;
         private readonly TextColumn ppColumn;
@@ -67,7 +66,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                         Spacing = new Vector2(margin, 0),
                         Children = new Drawable[]
                         {
-                            totalScoreColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersScoreTotal, largeFont, top_columns_min_width),
+                            totalScoreColumn = new TotalScoreColumn(BeatmapsetsStrings.ShowScoreboardHeadersScoreTotal, largeFont, top_columns_min_width),
                             accuracyColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersAccuracy, largeFont, top_columns_min_width),
                             maxComboColumn = new TextColumn(BeatmapsetsStrings.ShowScoreboardHeadersCombo, largeFont, top_columns_min_width)
                         }
@@ -226,7 +225,7 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
             }
         }
 
-        private partial class TextColumn : InfoColumn, IHasCurrentValue<string>
+        private partial class TextColumn : InfoColumn
         {
             private readonly OsuTextFlowContainer text;
 
@@ -249,18 +248,6 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 }
             }
 
-            private Bindable<string> current;
-
-            public Bindable<string> Current
-            {
-                get => current;
-                set
-                {
-                    text.Clear();
-                    text.AddText(value.Value, t => t.Current = current = value);
-                }
-            }
-
             public TextColumn(LocalisableString title, FontUsage font, float? minWidth = null)
                 : this(title, new OsuTextFlowContainer(t => t.Font = font)
                 {
@@ -273,6 +260,28 @@ namespace osu.Game.Overlays.BeatmapSet.Scores
                 : base(title, text, minWidth)
             {
                 this.text = text;
+            }
+        }
+
+        private partial class TotalScoreColumn : TextColumn
+        {
+            private readonly BindableWithCurrent<string> current = new BindableWithCurrent<string>();
+
+            public TotalScoreColumn(LocalisableString title, FontUsage font, float? minWidth = null)
+                : base(title, font, minWidth)
+            {
+            }
+
+            public Bindable<string> Current
+            {
+                get => current;
+                set => current.Current = value;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                Current.BindValueChanged(_ => Text = current.Value, true);
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31038.

If you don't realise why this does anything, realise this: the drawable creation callback runs for every created sprite text in the text flow. And the created sprite texts are split by whitespace. And Russian / Ukrainian / Polish etc. use spaces as thousands separators. So on those languages the first encountered part of the score would duplicate itself to the remaining parts.

I'm actively convinced it was _more difficult_ to produce what was in place in `master` than to do it properly. Why did `TextColumn` even have `LocalisableString Text` and `Bindable<string> Current` next to each other?????