### PR TITLE
Hide Player Settings when in Skin Editor

### DIFF
--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -347,6 +347,7 @@ namespace osu.Game.Overlays.SkinEditor
                 {
                     ShowResults = false,
                     AutomaticallySkipIntro = true,
+                    HidePlayerConfiguration = true,
                 })
             {
             }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -78,6 +78,8 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public Bindable<bool> ShowHud { get; } = new BindableBool();
 
+        public Bindable<bool> HideConfigSettings { get; } = new Bindable<bool>();
+
         private Bindable<HUDVisibilityMode> configVisibilityMode;
         private Bindable<bool> configLeaderboardVisibility;
         private Bindable<bool> configSettingsOverlay;
@@ -348,7 +350,7 @@ namespace osu.Game.Screens.Play
                 return;
             }
 
-            if (configSettingsOverlay.Value && replayLoaded.Value)
+            if (configSettingsOverlay.Value && replayLoaded.Value && !HideConfigSettings.Value)
                 PlayerSettingsOverlay.Show();
             else
                 PlayerSettingsOverlay.Hide();

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Screens.Play
         /// </summary>
         public Bindable<bool> ShowHud { get; } = new BindableBool();
 
-        public Bindable<bool> HideConfigSettings { get; } = new Bindable<bool>();
+        public Bindable<bool> HidePlayerConfiguration { get; } = new Bindable<bool>();
 
         private Bindable<HUDVisibilityMode> configVisibilityMode;
         private Bindable<bool> configLeaderboardVisibility;
@@ -350,7 +350,7 @@ namespace osu.Game.Screens.Play
                 return;
             }
 
-            if (configSettingsOverlay.Value && replayLoaded.Value && !HideConfigSettings.Value)
+            if (configSettingsOverlay.Value && replayLoaded.Value && !HidePlayerConfiguration.Value)
                 PlayerSettingsOverlay.Show();
             else
                 PlayerSettingsOverlay.Hide();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -330,11 +330,7 @@ namespace osu.Game.Screens.Play
             failAnimationContainer.Add(createOverlayComponents(Beatmap.Value));
 
             if (Configuration.HidePlayerConfiguration)
-            {
-                HUDOverlay.HideConfigSettings.Value = true;
-                HUDOverlay.HideConfigSettings.Disabled = true;
-                HUDOverlay.PlayerSettingsOverlay.Hide();
-            }
+                HUDOverlay.HidePlayerConfiguration.Value = true;
 
             if (!DrawableRuleset.AllowGameplayOverlays)
             {

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -329,6 +329,13 @@ namespace osu.Game.Screens.Play
             // we may want to limit this in the future to disallow rulesets from outright replacing elements the user expects to be there.
             failAnimationContainer.Add(createOverlayComponents(Beatmap.Value));
 
+            if (Configuration.HidePlayerConfiguration)
+            {
+                HUDOverlay.HideConfigSettings.Value = true;
+                HUDOverlay.HideConfigSettings.Disabled = true;
+                HUDOverlay.PlayerSettingsOverlay.Hide();
+            }
+
             if (!DrawableRuleset.AllowGameplayOverlays)
             {
                 HUDOverlay.ShowHud.Value = false;

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -45,5 +45,10 @@ namespace osu.Game.Screens.Play
         /// Whether the gameplay leaderboard should always be shown (usually in a contracted state).
         /// </summary>
         public bool AlwaysShowLeaderboard { get; set; }
+
+        /// <summary>
+        /// Whether the player configuration settings should be hidden.
+        /// </summary>
+        public bool HidePlayerConfiguration { get; set; }
     }
 }


### PR DESCRIPTION
Now that the player settings overlays over the player, instead of moving around items (see before).

This now hides the player settings when in the skin editor, to prevent overlaying what the user is trying to edit.


Before #30749 

https://github.com/user-attachments/assets/d594e574-4b66-4861-bf52-2af6dfbe4b7e

(I didn't know this until recording, but the player settings were unusable in the skin editor anyways)


After #30749 

https://github.com/user-attachments/assets/dfd2fcab-bf42-4e07-b1f7-98828b08fe01


After This PR

https://github.com/user-attachments/assets/0e053683-4f13-49ad-9344-476f3577fa0e

_I'll admit, I have a feeling it's not best practice in this repo to add a new `PlayerConfiguration` property for this. I'll watch and learn if there's changes._


