### PR TITLE
Fix context menu not closing when placing freehand slider

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("move mouse to top left of playfield", () =>
             {
                 playfield = this.ChildrenOfType<Playfield>().Single();
-                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight / 4);
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));
@@ -34,14 +34,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
             AddStep("move mouse to bottom right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight / 4);
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
                 InputManager.MoveMouseTo(location);
             });
             AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
             AddStep("begin placement", () => InputManager.PressButton(MouseButton.Left));
             AddStep("move mouse to top right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopRight + playfield.ScreenSpaceDrawQuad.BottomLeft / 4);
+                var location = (playfield.ScreenSpaceDrawQuad.TopRight + playfield.ScreenSpaceDrawQuad.BottomLeft) / 4;
                 InputManager.MoveMouseTo(location);
             });
             AddStep("end placement", () => InputManager.ReleaseButton(MouseButton.Left));
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("move mouse to top left of playfield", () =>
             {
                 playfield = this.ChildrenOfType<Playfield>().Single();
-                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight / 4);
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
             AddStep("move mouse to bottom right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight / 4);
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.UI;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public partial class TestSceneContextMenuClose : TestSceneOsuEditor
+    {
+        private ContextMenuContainer contextMenuContainer
+            => Editor.ChildrenOfType<ContextMenuContainer>().First();
+
+
+        [Test]
+        public void TestDrawnSliderClosesMenu()
+        {
+            Playfield playfield = null!;
+
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to top left of playfield", () =>
+            {
+                playfield = this.ChildrenOfType<Playfield>().Single();
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddStep("right click circle", () => InputManager.Click(MouseButton.Right));
+            AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
+            AddStep("move mouse to bottom right of playfield", () =>
+            {
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddStep("begin placement", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move mouse to top right of playfield", () =>
+            {
+                var location = (playfield.ScreenSpaceDrawQuad.TopRight + playfield.ScreenSpaceDrawQuad.BottomLeft) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("end placement", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddUntilStep("context menu is not visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Closed);
+        }
+
+        [Test]
+        public void TestCircleClosesMenu()
+        {
+            Playfield playfield = null!;
+
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to top left of playfield", () =>
+            {
+                playfield = this.ChildrenOfType<Playfield>().Single();
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddStep("right click circle", () => InputManager.Click(MouseButton.Right));
+            AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
+            AddStep("move mouse to bottom right of playfield", () =>
+            {
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddUntilStep("context menu is not visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Closed);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         private ContextMenuContainer contextMenuContainer
             => Editor.ChildrenOfType<ContextMenuContainer>().First();
 
-
         [Test]
         public void TestDrawnSliderClosesMenu()
         {
@@ -27,7 +26,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("move mouse to top left of playfield", () =>
             {
                 playfield = this.ChildrenOfType<Playfield>().Single();
-                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight / 4);
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));
@@ -35,14 +34,14 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
             AddStep("move mouse to bottom right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight / 4);
                 InputManager.MoveMouseTo(location);
             });
             AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
             AddStep("begin placement", () => InputManager.PressButton(MouseButton.Left));
             AddStep("move mouse to top right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopRight + playfield.ScreenSpaceDrawQuad.BottomLeft) / 4;
+                var location = (playfield.ScreenSpaceDrawQuad.TopRight + playfield.ScreenSpaceDrawQuad.BottomLeft / 4);
                 InputManager.MoveMouseTo(location);
             });
             AddStep("end placement", () => InputManager.ReleaseButton(MouseButton.Left));
@@ -58,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("move mouse to top left of playfield", () =>
             {
                 playfield = this.ChildrenOfType<Playfield>().Single();
-                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight / 4);
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));
@@ -66,7 +65,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
             AddStep("move mouse to bottom right of playfield", () =>
             {
-                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                var location = (playfield.ScreenSpaceDrawQuad.TopLeft + 3 * playfield.ScreenSpaceDrawQuad.BottomRight / 4);
                 InputManager.MoveMouseTo(location);
             });
             AddStep("place circle", () => InputManager.Click(MouseButton.Left));

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -40,6 +40,8 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         private int currentSegmentLength;
         private bool usingCustomSegmentType;
 
+        public override bool DragBlocksClick => false;
+
         [Resolved]
         private IPositionSnapProvider? positionSnapProvider { get; set; }
 


### PR DESCRIPTION
Fixes #31053 by overriding `SliderPlacementBlueprint`'s `DragBlocksClick` to always return false.

The issue arose because `osu.Framework.Input.MouseButtonEventManager` did not trigger a change focus event, because the `HandleButtonUp` method requires that `DraggedDrawable` does not block clicks (due to 9482125)