### PR TITLE
Access beatmap store via abstract base class

### DIFF
--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Tests.Visual.Background
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             manager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();

--- a/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
+++ b/osu.Game.Tests/Visual/Background/TestSceneUserDimBackgrounds.cs
@@ -49,17 +49,17 @@ namespace osu.Game.Tests.Visual.Background
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
             Dependencies.Cache(new OsuConfigManager(LocalStorage));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             manager.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely();
 
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
 
             Beatmap.SetDefault();
         }

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -44,14 +44,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/QueueModeTestScene.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             Add(beatmapStore);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -66,14 +66,14 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayer.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(beatmaps = new BeatmapManager(LocalStorage, Realm, API, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             Add(beatmapStore);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -46,16 +46,16 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             importedBeatmapSet = manager.Import(TestResources.CreateTestBeatmapSetInfo(8, rulesets.AvailableRulesets.ToArray()))!;
 
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
         }
 
         private void setUp()

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSongSelect.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             importedBeatmapSet = manager.Import(TestResources.CreateTestBeatmapSetInfo(8, rulesets.AvailableRulesets.ToArray()))!;

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -31,18 +31,18 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             var beatmapSet = TestResources.CreateTestBeatmapSetInfo();
 
             manager.Import(beatmapSet);
 
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
         }
 
         public override void SetUpSteps()

--- a/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestScenePlaylistsSongSelect.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             Dependencies.Cache(new RealmRulesetStore(Realm));
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, Beatmap.Default));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
             Dependencies.Cache(Realm);
 
             var beatmapSet = TestResources.CreateTestBeatmapSetInfo();

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapCarousel.cs
@@ -16,6 +16,7 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Osu;
@@ -23,6 +24,7 @@ using osu.Game.Rulesets.Taiko;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
 
@@ -41,6 +43,9 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private const int set_count = 5;
         private const int diff_count = 3;
+
+        [Cached(typeof(BeatmapStore))]
+        private TestBeatmapStore beatmaps = new TestBeatmapStore();
 
         [BackgroundDependencyLoader]
         private void load(RulesetStore rulesets)
@@ -1329,7 +1334,8 @@ namespace osu.Game.Tests.Visual.SongSelect
 
                 carouselAdjust?.Invoke(carousel);
 
-                carousel.BeatmapSets = beatmapSets;
+                beatmaps.BeatmapSets.Clear();
+                beatmaps.BeatmapSets.AddRange(beatmapSets);
 
                 (target ?? this).Child = carousel;
             });

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -56,20 +56,20 @@ namespace osu.Game.Tests.Visual.SongSelect
         [BackgroundDependencyLoader]
         private void load(GameHost host, AudioManager audio)
         {
-            DetachedBeatmapStore detachedBeatmapStore;
+            BeatmapStore beatmapStore;
 
             // These DI caches are required to ensure for interactive runs this test scene doesn't nuke all user beatmaps in the local install.
             // At a point we have isolated interactive test runs enough, this can likely be removed.
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(Realm);
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
-            Dependencies.Cache(detachedBeatmapStore = new DetachedBeatmapStore());
+            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
 
             Dependencies.Cache(music = new MusicController());
 
             // required to get bindables attached
             Add(music);
-            Add(detachedBeatmapStore);
+            Add(beatmapStore);
 
             Dependencies.Cache(config = new OsuConfigManager(LocalStorage));
         }

--- a/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestScenePlaySongSelect.cs
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             Dependencies.Cache(rulesets = new RealmRulesetStore(Realm));
             Dependencies.Cache(Realm);
             Dependencies.Cache(manager = new BeatmapManager(LocalStorage, Realm, null, audio, Resources, host, defaultBeatmap = Beatmap.Default));
-            Dependencies.Cache(beatmapStore = new RealmDetachedBeatmapStore());
+            Dependencies.CacheAs(beatmapStore = new RealmDetachedBeatmapStore());
 
             Dependencies.Cache(music = new MusicController());
 

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneUpdateBeatmapSetButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -10,12 +9,14 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Database;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Carousel;
 using osu.Game.Screens.Select.Filter;
+using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Online;
 using osu.Game.Tests.Resources;
 using osuTK.Input;
@@ -30,6 +31,9 @@ namespace osu.Game.Tests.Visual.SongSelect
         private TestSceneOnlinePlayBeatmapAvailabilityTracker.TestBeatmapModelDownloader beatmapDownloader = null!;
 
         private BeatmapSetInfo testBeatmapSetInfo = null!;
+
+        [Cached(typeof(BeatmapStore))]
+        private TestBeatmapStore beatmaps = new TestBeatmapStore();
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {
@@ -246,13 +250,12 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         private BeatmapCarousel createCarousel()
         {
+            beatmaps.BeatmapSets.Clear();
+            beatmaps.BeatmapSets.Add(testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo(5));
+
             return carousel = new BeatmapCarousel(new FilterCriteria())
             {
                 RelativeSizeAxes = Axes.Both,
-                BeatmapSets = new List<BeatmapSetInfo>
-                {
-                    (testBeatmapSetInfo = TestResources.CreateTestBeatmapSetInfo(5)),
-                }
             };
         }
     }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunScreenUIScale.cs
@@ -3,8 +3,10 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Screens;
+using osu.Game.Database;
 using osu.Game.Overlays;
 using osu.Game.Overlays.FirstRunSetup;
+using osu.Game.Tests.Beatmaps;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
@@ -12,6 +14,9 @@ namespace osu.Game.Tests.Visual.UserInterface
     {
         [Cached]
         private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        [Cached(typeof(BeatmapStore))]
+        private BeatmapStore beatmapStore = new TestBeatmapStore();
 
         public TestSceneFirstRunScreenUIScale()
         {

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFirstRunSetupOverlay.cs
@@ -17,12 +17,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Overlays.FirstRunSetup;
 using osu.Game.Overlays.Notifications;
 using osu.Game.Screens;
 using osu.Game.Screens.Footer;
+using osu.Game.Tests.Beatmaps;
 using osuTK;
 using osuTK.Input;
 
@@ -47,6 +49,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             Dependencies.Cache(LocalConfig = new OsuConfigManager(LocalStorage));
             Dependencies.CacheAs<IPerformFromScreenRunner>(performer.Object);
             Dependencies.CacheAs<INotificationOverlay>(notificationOverlay.Object);
+            Dependencies.CacheAs<BeatmapStore>(new TestBeatmapStore());
         }
 
         [SetUpSteps]

--- a/osu.Game/Database/BeatmapStore.cs
+++ b/osu.Game/Database/BeatmapStore.cs
@@ -30,6 +30,6 @@ namespace osu.Game.Database
         /// It is generally expected that once a beatmap store is in a good state, the overhead of this call
         /// should be negligible.
         /// </remarks>
-        public abstract IBindableList<BeatmapSetInfo> GetBeatmaps(CancellationToken? cancellationToken);
+        public abstract IBindableList<BeatmapSetInfo> GetBeatmapSets(CancellationToken? cancellationToken);
     }
 }

--- a/osu.Game/Database/BeatmapStore.cs
+++ b/osu.Game/Database/BeatmapStore.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+
+namespace osu.Game.Database
+{
+    /// <summary>
+    /// A store which contains a thread-safe representation of beatmaps available game-wide.
+    /// This exposes changes to available beatmaps, such as post-import or deletion.
+    /// </summary>
+    /// <remarks>
+    /// The main goal of classes which implement this interface should be to provide change
+    /// tracking and thread safety in a performant way, rather than having to worry about such
+    /// concerns at the point of usage.
+    /// </remarks>
+    public abstract partial class BeatmapStore : Component
+    {
+        /// <summary>
+        /// Get all available beatmaps.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token which allows early abort from the operation.</param>
+        /// <returns>A bindable list of all available beatmap sets.</returns>
+        /// <remarks>
+        /// This operation may block during the initial load process.
+        ///
+        /// It is generally expected that once a beatmap store is in a good state, the overhead of this call
+        /// should be negligible.
+        /// </remarks>
+        public abstract IBindableList<BeatmapSetInfo> GetBeatmaps(CancellationToken? cancellationToken);
+    }
+}

--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Database
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public override IBindableList<BeatmapSetInfo> GetBeatmaps(CancellationToken? cancellationToken)
+        public override IBindableList<BeatmapSetInfo> GetBeatmapSets(CancellationToken? cancellationToken)
         {
             loaded.Wait(cancellationToken ?? CancellationToken.None);
             return detachedBeatmapSets.GetBoundCopy();

--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -8,14 +8,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Multiplayer;
 using Realms;
 
 namespace osu.Game.Database
 {
-    public partial class DetachedBeatmapStore : Component
+    public partial class RealmDetachedBeatmapStore : BeatmapStore
     {
         private readonly ManualResetEventSlim loaded = new ManualResetEventSlim();
 
@@ -28,7 +27,7 @@ namespace osu.Game.Database
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
 
-        public IBindableList<BeatmapSetInfo> GetDetachedBeatmaps(CancellationToken? cancellationToken)
+        public override IBindableList<BeatmapSetInfo> GetBeatmaps(CancellationToken? cancellationToken)
         {
             loaded.Wait(cancellationToken ?? CancellationToken.None);
             return detachedBeatmapSets.GetBoundCopy();

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1143,7 +1143,7 @@ namespace osu.Game
             loadComponentSingleFile(new MedalOverlay(), topMostOverlayContent.Add);
 
             loadComponentSingleFile(new BackgroundDataStoreProcessor(), Add);
-            loadComponentSingleFile(new DetachedBeatmapStore(), Add, true);
+            loadComponentSingleFile<BeatmapStore>(new RealmDetachedBeatmapStore(), Add, true);
 
             Add(externalLinkOpener = new ExternalLinkOpener());
             Add(new MusicKeyBindingHandler());

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -113,7 +113,7 @@ namespace osu.Game.Screens.Select
         private RealmAccess realm { get; set; } = null!;
 
         [Resolved]
-        private DetachedBeatmapStore? detachedBeatmapStore { get; set; }
+        private BeatmapStore? beatmapStore { get; set; }
 
         private IBindableList<BeatmapSetInfo>? detachedBeatmapSets;
 
@@ -244,9 +244,9 @@ namespace osu.Game.Screens.Select
 
             RightClickScrollingEnabled.BindValueChanged(enabled => Scroll.RightMouseScrollbar = enabled.NewValue, true);
 
-            if (detachedBeatmapStore != null && detachedBeatmapSets == null)
+            if (beatmapStore != null && detachedBeatmapSets == null)
             {
-                detachedBeatmapSets = detachedBeatmapStore.GetDetachedBeatmaps(cancellationToken);
+                detachedBeatmapSets = beatmapStore.GetBeatmaps(cancellationToken);
                 detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);
                 loadNewRoot();
             }

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -246,9 +246,6 @@ namespace osu.Game.Screens.Select
 
             if (detachedBeatmapStore != null && detachedBeatmapSets == null)
             {
-                // This is performing an unnecessary second lookup on realm (in addition to the subscription), but for performance reasons
-                // we require it to be separate: the subscription's initial callback (with `ChangeSet` of `null`) will run on the update
-                // thread. If we attempt to detach beatmaps in this callback the game will fall over (it takes time).
                 detachedBeatmapSets = detachedBeatmapStore.GetDetachedBeatmaps(cancellationToken);
                 detachedBeatmapSets.BindCollectionChanged(beatmapSetsChanged);
                 loadNewRoot();

--- a/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroup.cs
@@ -10,8 +10,31 @@ namespace osu.Game.Screens.Select.Carousel
     /// <summary>
     /// A group which ensures only one item is selected.
     /// </summary>
-    public class CarouselGroup : CarouselItem
+    public abstract class CarouselGroup : CarouselItem
     {
+        protected CarouselGroup(List<CarouselItem>? items = null)
+        {
+            if (items != null) this.items = items;
+
+            State.ValueChanged += state =>
+            {
+                switch (state.NewValue)
+                {
+                    case CarouselItemState.Collapsed:
+                    case CarouselItemState.NotSelected:
+                        this.items.ForEach(c => c.State.Value = CarouselItemState.Collapsed);
+                        break;
+
+                    case CarouselItemState.Selected:
+                        this.items.ForEach(c =>
+                        {
+                            if (c.State.Value == CarouselItemState.Collapsed) c.State.Value = CarouselItemState.NotSelected;
+                        });
+                        break;
+                }
+            };
+        }
+
         public override DrawableCarouselItem? CreateDrawableRepresentation() => null;
 
         public SlimReadOnlyListWrapper<CarouselItem> Items => items.AsSlimReadOnly();
@@ -65,29 +88,6 @@ namespace osu.Game.Screens.Select.Carousel
 
             if (!i.Filtered.Value)
                 TotalItemsNotFiltered++;
-        }
-
-        public CarouselGroup(List<CarouselItem>? items = null)
-        {
-            if (items != null) this.items = items;
-
-            State.ValueChanged += state =>
-            {
-                switch (state.NewValue)
-                {
-                    case CarouselItemState.Collapsed:
-                    case CarouselItemState.NotSelected:
-                        this.items.ForEach(c => c.State.Value = CarouselItemState.Collapsed);
-                        break;
-
-                    case CarouselItemState.Selected:
-                        this.items.ForEach(c =>
-                        {
-                            if (c.State.Value == CarouselItemState.Collapsed) c.State.Value = CarouselItemState.NotSelected;
-                        });
-                        break;
-                }
-            };
         }
 
         public override void Filter(FilterCriteria criteria)

--- a/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
+++ b/osu.Game/Screens/Select/Carousel/CarouselGroupEagerSelect.cs
@@ -10,9 +10,9 @@ namespace osu.Game.Screens.Select.Carousel
     /// <summary>
     /// A group which ensures at least one item is selected (if the group itself is selected).
     /// </summary>
-    public class CarouselGroupEagerSelect : CarouselGroup
+    public abstract class CarouselGroupEagerSelect : CarouselGroup
     {
-        public CarouselGroupEagerSelect()
+        protected CarouselGroupEagerSelect()
         {
             State.ValueChanged += state =>
             {

--- a/osu.Game/Tests/Beatmaps/TestBeatmapStore.cs
+++ b/osu.Game/Tests/Beatmaps/TestBeatmapStore.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Framework.Bindables;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+
+namespace osu.Game.Tests.Beatmaps
+{
+    internal partial class TestBeatmapStore : BeatmapStore
+    {
+        public readonly BindableList<BeatmapSetInfo> BeatmapSets = new BindableList<BeatmapSetInfo>();
+        public override IBindableList<BeatmapSetInfo> GetBeatmapSets(CancellationToken? cancellationToken) => BeatmapSets;
+    }
+}


### PR DESCRIPTION
The intention here is to make things more testable going forward. Specifically, to remove the "back-door" entrance into `BeatmapCarousel` where `BeatmapSets` can be set by tests and bypas/block realm retrieval.

A few code quality improvements thrown in. Was on the fence as to whether I should actually remove the `BeatmapSets` test flow in `BeatmapCarousel` since I am currently looking at replacing/rewriting that class completely, but it was low effort.