### PR TITLE
Close object context menu on tool change

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
@@ -17,7 +17,6 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         private ContextMenuContainer contextMenuContainer
             => Editor.ChildrenOfType<ContextMenuContainer>().First();
 
-
         [Test]
         public void TestToolChangeClosesMenu()
         {

--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneContextMenuClose.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.UI;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public partial class TestSceneContextMenuClose : TestSceneOsuEditor
+    {
+        private ContextMenuContainer contextMenuContainer
+            => Editor.ChildrenOfType<ContextMenuContainer>().First();
+
+
+        [Test]
+        public void TestToolChangeClosesMenu()
+        {
+            Playfield playfield = null!;
+
+            AddStep("select circle placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move mouse to top left of playfield", () =>
+            {
+                playfield = this.ChildrenOfType<Playfield>().Single();
+                var location = (3 * playfield.ScreenSpaceDrawQuad.TopLeft + playfield.ScreenSpaceDrawQuad.BottomRight) / 4;
+                InputManager.MoveMouseTo(location);
+            });
+            AddStep("place circle", () => InputManager.Click(MouseButton.Left));
+            AddStep("right click circle", () => InputManager.Click(MouseButton.Right));
+            AddUntilStep("context menu is visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Open);
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddUntilStep("context menu is not visible", () => contextMenuContainer.ChildrenOfType<OsuContextMenu>().Single().State == MenuState.Closed);
+        }
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -531,6 +531,9 @@ namespace osu.Game.Rulesets.Edit
 
             if (!(tool is SelectTool))
                 EditorBeatmap.SelectedHitObjects.Clear();
+
+            // Prevent object context menu from staying open.
+            GetContainingFocusManager()?.ChangeFocus(null);
         }
 
         #endregion


### PR DESCRIPTION
fixes #31053

Normally, clicking on a different Toolbox button will ensure focus is changed via https://github.com/ppy/osu-framework/blob/f5900ab07acf7fc11b58b461e037f3222ae0190d/osu.Framework/Input/MouseButtonEventManager.cs#L167 which causes the context menu to close.

However, using number buttons (1-4) to select tools seems not to cause any focus change.

To address the issue, a focus change is forced on any tool change (by setting focused drawable -> null), which ensures that the context menu closes. I am unaware of other means of selection loss that should also close the menu.

