### PR TITLE
Add suboption to Hidden (HD) for decreasing visibility based on combo

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -25,6 +25,14 @@ namespace osu.Game.Rulesets.Osu.Mods
         [SettingSource("Only fade approach circles", "The main object body will not fade when enabled.")]
         public Bindable<bool> OnlyFadeApproachCircles { get; } = new BindableBool();
 
+        [SettingSource("Enable at combo", "The combo at which the hidden effect will take full effect. 0 for always.")]
+        public BindableNumber<int> EnableAtCombo { get; } = new BindableNumber<int>()
+        {
+            MinValue = 0,
+            MaxValue = 100,
+            Precision = 1,
+        };
+
         public override LocalisableString Description => @"Play with no approach circles and fading circles/sliders.";
         public override double ScoreMultiplier => UsesDefaultConfiguration ? 1.06 : 1;
 
@@ -32,7 +40,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public const double FADE_IN_DURATION_MULTIPLIER = 0.4;
         public const double FADE_OUT_DURATION_MULTIPLIER = 0.3;
-        private Playfield _playfield = null!;
+        private Playfield playfield = null!;
+
+        protected override int EnableAtComboValue => EnableAtCombo.Value;
 
         protected override bool IsFirstAdjustableObject(HitObject hitObject) => !(hitObject is Spinner || hitObject is SpinnerTick);
 
@@ -197,9 +207,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
         {
-            _playfield = drawableRuleset.Playfield;
+            playfield = drawableRuleset.Playfield;
         }
 
-        public override Playfield PlayfieldAccessor => _playfield;
+        public override Playfield PlayfieldAccessor => playfield;
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                         sliderRepeat.CirclePiece.FadeOut(fadeDuration);
 
                     using (drawableObject.BeginAbsoluteSequence(drawableObject.HitStateUpdateTime))
-                        sliderRepeat.FadeOut();
+                        sliderRepeat.FadeOut(fadeDuration);
 
                     break;
 
@@ -252,7 +252,7 @@ namespace osu.Game.Rulesets.Osu.Mods
         {
             scoreProcessor.Combo.ValueChanged += combo =>
             {
-                fadeDurationFactor = combo.NewValue == 0f ? 1f : 1f - (float)combo.NewValue / 20f;
+                fadeDurationFactor = combo.NewValue == 0f ? 1f : 1f - (float)combo.NewValue / 25f;
                 fadeDurationFactor = Math.Clamp(fadeDurationFactor, 0f, 1f);
             };
         }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -2,14 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using NUnit.Framework.Internal;
-using OpenTabletDriver.Plugin;
+using System.Collections.Generic;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Game.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
@@ -26,12 +29,13 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override bool Ranked => UsesDefaultConfiguration;
 
-        private bool lastShown;
         private uint _combo;
-        private bool Show => _combo < EnableAtCombo.Value;
+        private float _alpha;
+        private Playfield _playfield = null!;
+        private Dictionary<HitObject, float> _opacityTable = new(ReferenceEqualityComparer.Instance);
 
-        [SettingSource("Enable at combo", "The combo at which the hidden effect will start to take effect.")]
-        public BindableNumber<int> EnableAtCombo { get; } = new BindableNumber<int>(10)
+        [SettingSource("Enable at combo", "The combo at which the hidden effect will take full effect. 0 for always.")]
+        public BindableNumber<int> EnableAtCombo { get; } = new BindableNumber<int>(10) // TODO: set default to 0
         {
             MinValue = 0,
             MaxValue = 100,
@@ -56,22 +60,87 @@ namespace osu.Game.Rulesets.Mods
         public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
         {
             _combo = (uint)EnableAtCombo.Value;
-            lastShown = false;
+            Logger.Log("Hidden mod applied", level: LogLevel.Verbose);
+            _opacityTable.Clear();
+
+            if (EnableAtCombo.Value == 0) return;
 
             scoreProcessor.NewJudgement += result => ScoreProcessorOnNewJudgement(result);
             scoreProcessor.JudgementReverted += result => ScoreProcessorOnNewJudgement(result, true);
 
-            void ScoreProcessorOnNewJudgement(JudgementResult obj, bool revert = false)
+            void ScoreProcessorOnNewJudgement(JudgementResult judgement, bool revert = false)
             {
-                if (revert) return;
-                uint abs = GetHiddenComboInfluence(obj);
-                _combo = !obj.IsHit && abs > 0 ? 0 : _combo + abs;
-                Logger.Log($"Combo: {_combo}", level: LogLevel.Verbose);
+                if (revert) return; // TODO: handle revert for replays
+                uint oldCombo = _combo;
+                _combo = ComputeNewComboValue(_combo, judgement);
+                if (oldCombo == _combo)
+                    return;
+                else
+                {
+
+                }
+                uint comboValue = GetHiddenComboInfluence(judgement);
+                if (comboValue == 0) return;
+                _combo = !judgement.IsHit ? 0 : _combo + comboValue;
+                float oldAlpha = _alpha;
+                _alpha = Math.Clamp(Interpolation.ValueAt(_combo, 1f, 0f, 0, EnableAtCombo.Value, Easing.InQuad), 0, 1);
+
+                if (oldAlpha != _alpha)
+                {
+                    foreach (DrawableHitObject? drawableHitObject in PlayfieldAccessor.HitObjectContainer.AliveObjects)
+                    {
+                        drawableHitObject.RefreshStateTransforms();
+                    }
+                }
+
+                Logger.Log($"Combo: {_combo}     {_alpha}", level: LogLevel.Verbose);
             }
         }
 
-        protected virtual bool OverrideShowHitObjects() => Show;
+        protected float GetAndUpdateDrawableHitObjectComboAlpha(DrawableHitObject dho, bool? hasStarted = null)
+        {
+            if (EnableAtCombo.Value == 0) return 0;
+            HitObject? ho = dho.HitObject;
 
+            hasStarted ??= ho.StartTime - ((ho as IHasTimePreempt)?.TimePreempt ?? 0) < dho.Time.Current;
+
+            if (_opacityTable.TryGetValue(dho.HitObject, out float alpha))
+            {
+                if (_alpha > alpha || !hasStarted.Value)
+                {
+                    alpha = _alpha;
+                    _opacityTable[ho] = alpha;
+                }
+            }
+            else _opacityTable.Add(ho, alpha = _alpha);
+
+            return alpha;
+        }
+
+        /// <summary>
+        /// Speciefies how much a hit will add to the internal combo of the mod. Return zero to not break the combo on miss.
+        /// </summary>
         protected virtual uint GetHiddenComboInfluence(JudgementResult judgementResult) => 0;
+
+        /// <summary>
+        /// Computes the new combo value based on the current combo and the judgement.
+        /// The default Implementation is based on the <see cref="GetHiddenComboInfluence(JudgementResult)"/> method.
+        /// Override this method to provide a custom combo calculation.
+        /// </summary>
+        protected virtual uint ComputeNewComboValue(uint currentCombo, JudgementResult judgement)
+        {
+            uint comboValue = GetHiddenComboInfluence(judgement);
+            if (comboValue == 0) return currentCombo;
+            return !judgement.IsHit ? 0 : currentCombo + comboValue;
+        }
+
+        /// <summary>
+        /// Playfield accessor for the hidden mod.
+        /// </summary>
+        /// <remarks>
+        /// This is required because implementing IApplicableToDrawableRuleset&lt;HitObject&gt; here does not work,
+        /// probabbly because the type parameter is not specific enough
+        /// </remarks>
+        public virtual Playfield PlayfieldAccessor => null!;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -1,10 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using NUnit.Framework.Internal;
+using OpenTabletDriver.Plugin;
+using osu.Framework.Bindables;
 using osu.Game.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using Logger = osu.Framework.Logging.Logger;
+using LogLevel = osu.Framework.Logging.LogLevel;
 
 namespace osu.Game.Rulesets.Mods
 {
@@ -16,9 +26,17 @@ namespace osu.Game.Rulesets.Mods
         public override ModType Type => ModType.DifficultyIncrease;
         public override bool Ranked => UsesDefaultConfiguration;
 
-        public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        private bool lastShown;
+        private uint _combo;
+        private bool Show => _combo < EnableAtCombo.Value;
+
+        [SettingSource("Enable at combo", "The combo at which the hidden effect will start to take effect.")]
+        public BindableNumber<int> EnableAtCombo { get; } = new BindableNumber<int>(10)
         {
-        }
+            MinValue = 0,
+            MaxValue = 100,
+            Precision = 1,
+        };
 
         public virtual ScoreRank AdjustRank(ScoreRank rank, double accuracy)
         {
@@ -34,5 +52,26 @@ namespace osu.Game.Rulesets.Mods
                     return rank;
             }
         }
+
+        public virtual void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        {
+            _combo = (uint)EnableAtCombo.Value;
+            lastShown = false;
+
+            scoreProcessor.NewJudgement += result => ScoreProcessorOnNewJudgement(result);
+            scoreProcessor.JudgementReverted += result => ScoreProcessorOnNewJudgement(result, true);
+
+            void ScoreProcessorOnNewJudgement(JudgementResult obj, bool revert = false)
+            {
+                if (revert) return;
+                uint abs = GetHiddenComboInfluence(obj);
+                _combo = !obj.IsHit && abs > 0 ? 0 : _combo + abs;
+                Logger.Log($"Combo: {_combo}", level: LogLevel.Verbose);
+            }
+        }
+
+        protected virtual bool OverrideShowHitObjects() => Show;
+
+        protected virtual uint GetHiddenComboInfluence(JudgementResult judgementResult) => 0;
     }
 }

--- a/osu.Game/Rulesets/Mods/ModHidden.cs
+++ b/osu.Game/Rulesets/Mods/ModHidden.cs
@@ -75,10 +75,6 @@ namespace osu.Game.Rulesets.Mods
                 _combo = ComputeNewComboValue(_combo, judgement);
                 if (oldCombo == _combo)
                     return;
-                else
-                {
-
-                }
                 uint comboValue = GetHiddenComboInfluence(judgement);
                 if (comboValue == 0) return;
                 _combo = !judgement.IsHit ? 0 : _combo + comboValue;
@@ -97,14 +93,23 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
-        protected float GetAndUpdateDrawableHitObjectComboAlpha(DrawableHitObject dho, bool? hasStarted = null)
+        /// <summary>
+        /// Gets the alpha value for a hit object based on the current combo. And stores it internally.
+        /// Hitobjects that have already started will never have this value decreased.
+        /// </summary>
+        /// <param name="hasStarted">
+        /// An optional to use instead of computing it from drawableHitObject.
+        /// The default can handle objects implementing IHasTimePreempt.
+        /// </param>
+        /// <returns></returns>
+        protected float GetAndUpdateDrawableHitObjectComboAlpha(DrawableHitObject drawableHitObject, bool? hasStarted = null)
         {
             if (EnableAtCombo.Value == 0) return 0;
-            HitObject? ho = dho.HitObject;
+            HitObject? ho = drawableHitObject.HitObject;
 
-            hasStarted ??= ho.StartTime - ((ho as IHasTimePreempt)?.TimePreempt ?? 0) < dho.Time.Current;
+            hasStarted ??= ho.StartTime - ((ho as IHasTimePreempt)?.TimePreempt ?? 0) < drawableHitObject.Time.Current;
 
-            if (_opacityTable.TryGetValue(dho.HitObject, out float alpha))
+            if (_opacityTable.TryGetValue(drawableHitObject.HitObject, out float alpha))
             {
                 if (_alpha > alpha || !hasStarted.Value)
                 {

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
@@ -78,12 +79,14 @@ namespace osu.Game.Rulesets.Mods
             dho.ApplyCustomUpdateState += (o, state) =>
             {
                 // Increased visibility is applied to the entire first object, including all of its nested hitobjects.
-                if (IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject))
+                // TODO Not sure if this OverrideShowHitObject() is necessary, seems not beacause of pooling
+                if ((IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject)))
                     ApplyIncreasedVisibilityState(o, state);
                 else
                     ApplyNormalVisibilityState(o, state);
             };
         }
+
 
         /// <summary>
         /// Checks whether a given object is nested within a target.

--- a/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
+++ b/osu.Game/Rulesets/Mods/ModWithVisibilityAdjustment.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 
@@ -79,14 +78,12 @@ namespace osu.Game.Rulesets.Mods
             dho.ApplyCustomUpdateState += (o, state) =>
             {
                 // Increased visibility is applied to the entire first object, including all of its nested hitobjects.
-                // TODO Not sure if this OverrideShowHitObject() is necessary, seems not beacause of pooling
-                if ((IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject)))
+                if (IncreaseFirstObjectVisibility.Value && isObjectEqualToOrNestedIn(o.HitObject, FirstObject))
                     ApplyIncreasedVisibilityState(o, state);
                 else
                     ApplyNormalVisibilityState(o, state);
             };
         }
-
 
         /// <summary>
         /// Checks whether a given object is nested within a target.


### PR DESCRIPTION
Video:

https://www.youtube.com/watch?v=Hc0kffA_Ewk

This implementation addresses #30871 for osu!std.

When a player's combo breaks, all approach circles on the screen become visible. As the player's combo increases again, the visibility of new approach circles gradually decreases until they disappear completely once the combo reaches the value specified by the player. The mod tracks and uses an internal combo value that is influenced solely by the results of HitCircles and SliderHeads.

This behavior can also be easily adapted for hidden mods in other rulesets. ModHidden handles most of the necessary logic and provides extensions for implementers to adjust key aspects, after which they only need to apply the opacity provided by ModHidden.