### PR TITLE
Reposition the real time digital clock when shown solely

### DIFF
--- a/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
+++ b/osu.Game/Overlays/Toolbar/DigitalClockDisplay.cs
@@ -78,6 +78,9 @@ namespace osu.Game.Overlays.Toolbar
         {
             Width = showRuntime || !use24HourDisplay ? 66 : 45; // Allows for space for game time up to 99 days (in the padding area since this is quite rare).
 
+            realTime.Anchor = showRuntime ? Anchor.TopLeft : Anchor.Centre;
+            realTime.Origin = showRuntime ? Anchor.TopLeft : Anchor.Centre;
+
             gameTime.FadeTo(showRuntime ? 1 : 0);
         }
     }


### PR DESCRIPTION
This is a quite simple PR around the toolbar clock UI.

Recently I've noticed that when switching the clock to show the real time only, the text part would be too close to the right border of the outer container. A possible solution is to change the anchor and the origin of the real time clock text sprite, making it stay at the centre.

This will cause the text to slightly move a bit sometimes, but it should be visually better than the original behaviour.

| Before | After |
| :-: | :-: |
| ![Original layout](https://github.com/user-attachments/assets/36ecc421-9620-4f3a-8550-cb1ac28b6b69) | ![Changed layout](https://github.com/user-attachments/assets/c1c150fe-9f43-41e7-9bda-12008f0f4f30) |
