### PR TITLE
Add style options to dynamic skin elements

### DIFF
--- a/osu.Game/Graphics/OsuFont.cs
+++ b/osu.Game/Graphics/OsuFont.cs
@@ -87,6 +87,10 @@ namespace osu.Game.Graphics
                 // torus doesn't have a medium; fallback to regular.
                 weight = FontWeight.Regular;
 
+            // venera only has bold; switch to bold if it isn't
+            if (family == GetFamilyString(Typeface.Venera) && weight != FontWeight.Bold)
+                weight = FontWeight.Bold;
+
             return weight.ToString();
         }
     }

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -120,10 +120,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 Font.BindValueChanged(typeface =>
                 {
-                    // We only have bold weight for venera, so let's force that.
-                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
-
-                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: FontWeight.Regular);
 
                     // Fixed width looks better on venera only in my opinion.
                     text.Font = f.With(size: 16, fixedWidth: typeface.NewValue == Typeface.Venera);

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -5,7 +5,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
@@ -17,7 +16,6 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation.SkinComponents;
 using osu.Game.Skinning;
 using osuTK;
-using Vortice.DXGI;
 
 namespace osu.Game.Screens.Play.HUD
 {

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Play.HUD
             return $@"{count:0}";
         }
 
-        protected override IHasText CreateText() => new TextComponent()
+        protected override IHasText CreateText() => new TextComponent
         {
             ShowLabel = { BindTarget = ShowLabel },
             Font = { BindTarget = Font },
@@ -74,6 +74,7 @@ namespace osu.Game.Screens.Play.HUD
                 get => text.Text;
                 set => text.Text = value;
             }
+
             public Bindable<bool> ShowLabel { get; } = new BindableBool();
             public Bindable<Typeface> Font { get; } = new Bindable<Typeface>();
 

--- a/osu.Game/Screens/Play/HUD/BPMCounter.cs
+++ b/osu.Game/Screens/Play/HUD/BPMCounter.cs
@@ -3,22 +3,36 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Skinning;
 using osuTK;
+using Vortice.DXGI;
 
 namespace osu.Game.Screens.Play.HUD
 {
     public partial class BPMCounter : RollingCounter<double>, ISerialisableDrawable
     {
         protected override double RollingDuration => 375;
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
+        public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Venera);
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public BindableColour4 TextColour { get; } = new BindableColour4(Color4Extensions.FromHex(@"ddffff"));
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
 
         [Resolved]
         private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
@@ -27,10 +41,10 @@ namespace osu.Game.Screens.Play.HUD
         private IGameplayClock gameplayClock { get; set; } = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OsuColour colour)
+        private void load()
         {
-            Colour = colour.BlueLighter;
             Current.Value = DisplayedCount = 0;
+            TextColour.BindValueChanged(c => Colour = TextColour.Value, true);
         }
 
         protected override void Update()
@@ -49,7 +63,11 @@ namespace osu.Game.Screens.Play.HUD
             return $@"{count:0}";
         }
 
-        protected override IHasText CreateText() => new TextComponent();
+        protected override IHasText CreateText() => new TextComponent()
+        {
+            ShowLabel = { BindTarget = ShowLabel },
+            Font = { BindTarget = Font },
+        };
 
         private partial class TextComponent : CompositeDrawable, IHasText
         {
@@ -58,8 +76,11 @@ namespace osu.Game.Screens.Play.HUD
                 get => text.Text;
                 set => text.Text = value;
             }
+            public Bindable<bool> ShowLabel { get; } = new BindableBool();
+            public Bindable<Typeface> Font { get; } = new Bindable<Typeface>();
 
             private readonly OsuSpriteText text;
+            private readonly OsuSpriteText label;
 
             public TextComponent()
             {
@@ -77,7 +98,7 @@ namespace osu.Game.Screens.Play.HUD
                             Origin = Anchor.BottomLeft,
                             Font = OsuFont.Numeric.With(size: 16, fixedWidth: true)
                         },
-                        new OsuSpriteText
+                        label = new OsuSpriteText
                         {
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
@@ -87,6 +108,28 @@ namespace osu.Game.Screens.Play.HUD
                         }
                     }
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                ShowLabel.BindValueChanged(s =>
+                {
+                    label.Alpha = s.NewValue ? 1 : 0;
+                }, true);
+
+                Font.BindValueChanged(typeface =>
+                {
+                    // We only have bold weight for venera, so let's force that.
+                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
+
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+
+                    // Fixed width looks better on venera only in my opinion.
+                    text.Font = f.With(size: 16, fixedWidth: typeface.NewValue == Typeface.Venera);
+                    label.Font = f.With(size: 8);
+                }, true);
             }
         }
 

--- a/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
@@ -128,10 +128,7 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
 
                 Font.BindValueChanged(typeface =>
                 {
-                    // We only have bold weight for venera, so let's force that.
-                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
-
-                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: FontWeight.Regular);
 
                     // align baseline with fonts that aren't venera
                     secLabel.Padding = new MarginPadding { Bottom = typeface.NewValue == Typeface.Venera ? 3f : 2f };

--- a/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
@@ -2,13 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Skinning;
 using osuTK;
 
@@ -19,6 +23,15 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
         [Resolved]
         private ClicksPerSecondController controller { get; set; } = null!;
 
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
+        public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Venera);
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public BindableColour4 TextColour { get; } = new BindableColour4(Color4Extensions.FromHex(@"ddffff"));
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
+
         protected override double RollingDuration => 175;
 
         public bool UsesFixedAnchor { get; set; }
@@ -26,12 +39,7 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
         public ClicksPerSecondCounter()
         {
             Current.Value = 0;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
-        {
-            Colour = colours.BlueLighter;
+            TextColour.BindValueChanged(c => Colour = TextColour.Value, true);
         }
 
         protected override void Update()
@@ -41,7 +49,11 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
             Current.Value = controller.Value;
         }
 
-        protected override IHasText CreateText() => new TextComponent();
+        protected override IHasText CreateText() => new TextComponent()
+        {
+            ShowLabel = { BindTarget = ShowLabel },
+            Font = { BindTarget = Font },
+        };
 
         private partial class TextComponent : CompositeDrawable, IHasText
         {
@@ -51,7 +63,14 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
                 set => text.Text = value;
             }
 
+            public Bindable<bool> ShowLabel { get; } = new BindableBool();
+            public Bindable<Typeface> Font { get; } = new Bindable<Typeface>();
+
+            private readonly FillFlowContainer labelContainer;
+
             private readonly OsuSpriteText text;
+            private readonly OsuSpriteText clickLabel;
+            private readonly OsuSpriteText secLabel;
 
             public TextComponent()
             {
@@ -69,7 +88,7 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
                             Origin = Anchor.BottomLeft,
                             Font = OsuFont.Numeric.With(size: 16, fixedWidth: true)
                         },
-                        new FillFlowContainer
+                        labelContainer = new FillFlowContainer
                         {
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
@@ -77,14 +96,14 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                new OsuSpriteText
+                                clickLabel = new OsuSpriteText
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
                                     Font = OsuFont.Numeric.With(size: 6, fixedWidth: false),
                                     Text = @"clicks",
                                 },
-                                new OsuSpriteText
+                                secLabel = new OsuSpriteText
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
@@ -96,6 +115,32 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
                         }
                     }
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                ShowLabel.BindValueChanged(s =>
+                {
+                    labelContainer.Alpha = s.NewValue ? 1 : 0;
+                }, true);
+
+                Font.BindValueChanged(typeface =>
+                {
+                    // We only have bold weight for venera, so let's force that.
+                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
+
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+
+                    // align baseline with fonts that aren't venera
+                    secLabel.Padding = new MarginPadding { Bottom = typeface.NewValue == Typeface.Venera ? 3f : 2f };
+
+                    // Fixed width looks better on venera only in my opinion.
+                    text.Font = f.With(size: 16, fixedWidth: typeface.NewValue == Typeface.Venera);
+                    clickLabel.Font = f.With(size: 6, fixedWidth: false);
+                    secLabel.Font = f.With(size: 6, fixedWidth: false);
+                }, true);
             }
         }
     }

--- a/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
+++ b/osu.Game/Screens/Play/HUD/ClicksPerSecond/ClicksPerSecondCounter.cs
@@ -49,7 +49,7 @@ namespace osu.Game.Screens.Play.HUD.ClicksPerSecond
             Current.Value = controller.Value;
         }
 
-        protected override IHasText CreateText() => new TextComponent()
+        protected override IHasText CreateText() => new TextComponent
         {
             ShowLabel = { BindTarget = ShowLabel },
             Font = { BindTarget = Font },

--- a/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
@@ -2,12 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
+using osu.Game.Localisation.SkinComponents;
 using osu.Game.Rulesets.Scoring;
 using osuTK;
 
@@ -15,14 +19,27 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class LongestComboCounter : ComboCounter
     {
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Font), nameof(SkinnableComponentStrings.FontDescription))]
+        public Bindable<Typeface> Font { get; } = new Bindable<Typeface>(Typeface.Venera);
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.Colour), nameof(SkinnableComponentStrings.ColourDescription))]
+        public BindableColour4 TextColour { get; } = new BindableColour4(Color4Extensions.FromHex(@"ffffdd"));
+
+        [SettingSource(typeof(SkinnableComponentStrings), nameof(SkinnableComponentStrings.ShowLabel), nameof(SkinnableComponentStrings.ShowLabelDescription))]
+        public Bindable<bool> ShowLabel { get; } = new BindableBool(true);
+
         [BackgroundDependencyLoader]
-        private void load(OsuColour colours, ScoreProcessor scoreProcessor)
+        private void load(ScoreProcessor scoreProcessor)
         {
-            Colour = colours.YellowLighter;
+            TextColour.BindValueChanged(c => Colour = TextColour.Value, true);
             Current.BindTo(scoreProcessor.HighestCombo);
         }
 
-        protected override IHasText CreateText() => new TextComponent();
+        protected override IHasText CreateText() => new TextComponent()
+        {
+            ShowLabel = { BindTarget = ShowLabel },
+            Font = { BindTarget = Font },
+        };
 
         private partial class TextComponent : CompositeDrawable, IHasText
         {
@@ -32,7 +49,14 @@ namespace osu.Game.Screens.Play.HUD
                 set => text.Text = $"{value}x";
             }
 
+            public Bindable<bool> ShowLabel { get; } = new BindableBool();
+            public Bindable<Typeface> Font { get; } = new Bindable<Typeface>();
+
+            private readonly FillFlowContainer labelContainer;
+
             private readonly OsuSpriteText text;
+            private readonly OsuSpriteText longestLabel;
+            private readonly OsuSpriteText comboLabel;
 
             public TextComponent()
             {
@@ -50,7 +74,7 @@ namespace osu.Game.Screens.Play.HUD
                             Origin = Anchor.BottomLeft,
                             Font = OsuFont.Numeric.With(size: 20)
                         },
-                        new FillFlowContainer
+                        labelContainer = new FillFlowContainer
                         {
                             Anchor = Anchor.BottomLeft,
                             Origin = Anchor.BottomLeft,
@@ -58,14 +82,14 @@ namespace osu.Game.Screens.Play.HUD
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
-                                new OsuSpriteText
+                                longestLabel = new OsuSpriteText
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
                                     Font = OsuFont.Numeric.With(size: 8),
                                     Text = @"longest",
                                 },
-                                new OsuSpriteText
+                                comboLabel = new OsuSpriteText
                                 {
                                     Anchor = Anchor.TopLeft,
                                     Origin = Anchor.TopLeft,
@@ -77,6 +101,32 @@ namespace osu.Game.Screens.Play.HUD
                         }
                     }
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                ShowLabel.BindValueChanged(s =>
+                {
+                    labelContainer.Alpha = s.NewValue ? 1 : 0;
+                }, true);
+
+                Font.BindValueChanged(typeface =>
+                {
+                    // We only have bold weight for venera, so let's force that.
+                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
+
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+
+                    // align baseline with fonts that aren't venera
+                    comboLabel.Padding = new MarginPadding { Bottom = typeface.NewValue == Typeface.Venera ? 3f : 1f };
+
+                    // Fixed width looks better on venera only in my opinion.
+                    text.Font = f.With(size: 16, fixedWidth: typeface.NewValue == Typeface.Venera);
+                    longestLabel.Font = f.With(size: 6, fixedWidth: false);
+                    comboLabel.Font = f.With(size: 6, fixedWidth: false);
+                }, true);
             }
         }
     }

--- a/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Screens.Play.HUD
             Current.BindTo(scoreProcessor.HighestCombo);
         }
 
-        protected override IHasText CreateText() => new TextComponent()
+        protected override IHasText CreateText() => new TextComponent
         {
             ShowLabel = { BindTarget = ShowLabel },
             Font = { BindTarget = Font },

--- a/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
+++ b/osu.Game/Screens/Play/HUD/LongestComboCounter.cs
@@ -114,10 +114,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 Font.BindValueChanged(typeface =>
                 {
-                    // We only have bold weight for venera, so let's force that.
-                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
-
-                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: FontWeight.Regular);
 
                     // align baseline with fonts that aren't venera
                     comboLabel.Padding = new MarginPadding { Bottom = typeface.NewValue == Typeface.Venera ? 3f : 1f };

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -156,10 +156,7 @@ namespace osu.Game.Screens.Play.HUD
 
                 Font.BindValueChanged(typeface =>
                 {
-                    // We only have bold weight for venera, so let's force that.
-                    FontWeight fontWeight = typeface.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
-
-                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: fontWeight);
+                    FontUsage f = OsuFont.GetFont(typeface.NewValue, weight: FontWeight.Regular);
 
                     // Fixed width looks better on venera only in my opinion.
                     text.Font = f.With(size: 16, fixedWidth: typeface.NewValue == Typeface.Venera);

--- a/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
+++ b/osu.Game/Screens/Play/HUD/UnstableRateCounter.cs
@@ -110,6 +110,7 @@ namespace osu.Game.Screens.Play.HUD
                 get => text.Text;
                 set => text.Text = value;
             }
+
             public Bindable<bool> ShowLabel { get; } = new BindableBool();
             public Bindable<Typeface> Font { get; } = new Bindable<Typeface>();
 

--- a/osu.Game/Skinning/FontAdjustableSkinComponent.cs
+++ b/osu.Game/Skinning/FontAdjustableSkinComponent.cs
@@ -37,10 +37,7 @@ namespace osu.Game.Skinning
 
             Font.BindValueChanged(e =>
             {
-                // We only have bold weight for venera, so let's force that.
-                FontWeight fontWeight = e.NewValue == Typeface.Venera ? FontWeight.Bold : FontWeight.Regular;
-
-                FontUsage f = OsuFont.GetFont(e.NewValue, weight: fontWeight);
+                FontUsage f = OsuFont.GetFont(e.NewValue, weight: FontWeight.Regular);
                 SetFont(f);
             }, true);
 


### PR DESCRIPTION
This pr adds style options: `Font`, `TextColour`, and `ShowLabel`, to a few dynamic skin elements.

The skin elements being: `BPMCounter`. `ClicksPerSecondCounter`, `LongestComboCounter` and `UnstableRateCounter`.

Made this to make these elements less restrictive and add more customization to the skin editor.

Preview:
![image](https://github.com/user-attachments/assets/51e87b92-cd3f-4813-be0c-0806f6b380ef)
