### PR TITLE
Add recommended difficulty numerical value near filter in beatmap listing

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -13,9 +13,12 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Extensions;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
@@ -23,6 +26,8 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Tests.Resources;
 using osu.Game.Users;
+using osu.Game.Utils;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.SongSelect
 {
@@ -168,6 +173,45 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             // Present mania set, expect the difficulty that matches recommended mania star rating
             presentAndConfirm(() => maniaSet, 5);
+        }
+
+        [Test]
+        public void TestBeatmapListingFilter()
+        {
+            AddStep("set playmode to taiko", () => ((DummyAPIAccess)API).LocalUser.Value.PlayMode = "taiko");
+
+            AddStep("open beatmap listing", () =>
+            {
+                InputManager.PressKey(Key.ControlLeft);
+                InputManager.PressKey(Key.B);
+                InputManager.ReleaseKey(Key.B);
+                InputManager.ReleaseKey(Key.ControlLeft);
+            });
+
+            AddUntilStep("wait for load", () => Game.ChildrenOfType<BeatmapListingOverlay>().SingleOrDefault()?.IsLoaded, () => Is.True);
+
+            checkRecommendedDifficulty(3);
+
+            AddStep("change mode filter to osu!", () => Game.ChildrenOfType<BeatmapSearchRulesetFilterRow>().Single().ChildrenOfType<FilterTabItem<RulesetInfo>>().ElementAt(1).TriggerClick());
+
+            checkRecommendedDifficulty(2);
+
+            AddStep("change mode filter to osu!taiko", () => Game.ChildrenOfType<BeatmapSearchRulesetFilterRow>().Single().ChildrenOfType<FilterTabItem<RulesetInfo>>().ElementAt(2).TriggerClick());
+
+            checkRecommendedDifficulty(3);
+
+            AddStep("change mode filter to osu!catch", () => Game.ChildrenOfType<BeatmapSearchRulesetFilterRow>().Single().ChildrenOfType<FilterTabItem<RulesetInfo>>().ElementAt(3).TriggerClick());
+
+            checkRecommendedDifficulty(4);
+
+            AddStep("change mode filter to osu!mania", () => Game.ChildrenOfType<BeatmapSearchRulesetFilterRow>().Single().ChildrenOfType<FilterTabItem<RulesetInfo>>().ElementAt(4).TriggerClick());
+
+            checkRecommendedDifficulty(5);
+
+            void checkRecommendedDifficulty(double starRating)
+                => AddAssert($"recommended difficulty is {starRating}",
+                    () => Game.ChildrenOfType<BeatmapSearchGeneralFilterRow>().Single().ChildrenOfType<OsuSpriteText>().ElementAt(1).Text.ToString(),
+                    () => Is.EqualTo($"Recommended difficulty ({starRating.FormatStarRating()})"));
         }
 
         private BeatmapSetInfo importBeatmapSet(IEnumerable<RulesetInfo> difficultyRulesets)

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneBeatmapRecommendations.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Tests.Visual.SongSelect
                         return 336; // recommended star rating of 2
 
                     case 1:
-                        return 928; // SR 3
+                        return 973; // SR 3
 
                     case 2:
                         return 1905; // SR 4

--- a/osu.Game.Tournament/Components/SongBar.cs
+++ b/osu.Game.Tournament/Components/SongBar.cs
@@ -15,6 +15,7 @@ using osu.Game.Graphics;
 using osu.Game.Models;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Menu;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -207,7 +208,7 @@ namespace osu.Game.Tournament.Components
                                         Children = new Drawable[]
                                         {
                                             new DiffPiece(stats),
-                                            new DiffPiece(("Star Rating", $"{beatmap.StarRating:0.00}{srExtra}"))
+                                            new DiffPiece(("Star Rating", $"{beatmap.StarRating.FormatStarRating()}{srExtra}"))
                                         }
                                     },
                                     new FillFlowContainer

--- a/osu.Game/Beatmaps/DifficultyRecommender.cs
+++ b/osu.Game/Beatmaps/DifficultyRecommender.cs
@@ -83,7 +83,8 @@ namespace osu.Game.Beatmaps
             StarRatingUpdated?.Invoke();
         }
 
-        public double GetRecommendedStarRatingFor(RulesetInfo ruleset) => recommendedDifficultyMapping[ruleset.ShortName];
+        public double? GetRecommendedStarRatingFor(RulesetInfo ruleset)
+            => recommendedDifficultyMapping.TryGetValue(ruleset.ShortName, out double starRating) ? starRating : null;
 
         /// <summary>
         /// Find the recommended difficulty from a selection of available difficulties for the current local user.

--- a/osu.Game/Beatmaps/DifficultyRecommender.cs
+++ b/osu.Game/Beatmaps/DifficultyRecommender.cs
@@ -20,6 +20,8 @@ namespace osu.Game.Beatmaps
     /// </summary>
     public partial class DifficultyRecommender : Component
     {
+        public event Action? StarRatingUpdated;
+
         private readonly LocalUserStatisticsProvider statisticsProvider;
 
         [Resolved]
@@ -77,7 +79,11 @@ namespace osu.Game.Beatmaps
         {
             // algorithm taken from https://github.com/ppy/osu-web/blob/e6e2825516449e3d0f3f5e1852c6bdd3428c3437/app/Models/User.php#L1505
             recommendedDifficultyMapping[ruleset.ShortName] = Math.Pow((double)(statistics.PP ?? 0), 0.4) * 0.195;
+
+            StarRatingUpdated?.Invoke();
         }
+
+        public double GetRecommendedStarRatingFor(RulesetInfo ruleset) => recommendedDifficultyMapping[ruleset.ShortName];
 
         /// <summary>
         /// Find the recommended difficulty from a selection of available difficulties for the current local user.

--- a/osu.Game/Beatmaps/DifficultyRecommender.cs
+++ b/osu.Game/Beatmaps/DifficultyRecommender.cs
@@ -1,12 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -26,7 +23,7 @@ namespace osu.Game.Beatmaps
         private readonly LocalUserStatisticsProvider statisticsProvider;
 
         [Resolved]
-        private Bindable<RulesetInfo> gameRuleset { get; set; }
+        private Bindable<RulesetInfo> gameRuleset { get; set; } = null!;
 
         [Resolved]
         private RulesetStore rulesets { get; set; } = null!;
@@ -90,15 +87,14 @@ namespace osu.Game.Beatmaps
         /// </remarks>
         /// <param name="beatmaps">A collection of beatmaps to select a difficulty from.</param>
         /// <returns>The recommended difficulty, or null if a recommendation could not be provided.</returns>
-        [CanBeNull]
-        public BeatmapInfo GetRecommendedBeatmap(IEnumerable<BeatmapInfo> beatmaps)
+        public BeatmapInfo? GetRecommendedBeatmap(IEnumerable<BeatmapInfo> beatmaps)
         {
             foreach (string r in orderedRulesets)
             {
                 if (!recommendedDifficultyMapping.TryGetValue(r, out double recommendation))
                     continue;
 
-                BeatmapInfo beatmapInfo = beatmaps.Where(b => b.Ruleset.ShortName.Equals(r, StringComparison.Ordinal)).MinBy(b =>
+                BeatmapInfo? beatmapInfo = beatmaps.Where(b => b.Ruleset.ShortName.Equals(r, StringComparison.Ordinal)).MinBy(b =>
                 {
                     double difference = b.StarRating - recommendation;
                     return difference >= 0 ? difference * 2 : difference * -1; // prefer easier over harder

--- a/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
+++ b/osu.Game/Beatmaps/Drawables/StarRatingDisplay.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -14,6 +13,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -156,7 +156,7 @@ namespace osu.Game.Beatmaps.Drawables
 
             displayedStars.BindValueChanged(s =>
             {
-                starsText.Text = s.NewValue < 0 ? "-" : s.NewValue.ToLocalisableString("0.00");
+                starsText.Text = s.NewValue < 0 ? "-" : s.NewValue.FormatStarRating();
 
                 background.Colour = colours.ForStarDifficulty(s.NewValue);
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -29,7 +27,7 @@ namespace osu.Game.Overlays.BeatmapListing
         /// <summary>
         /// Any time the text box receives key events (even while masked).
         /// </summary>
-        public Action TypingStarted;
+        public Action? TypingStarted;
 
         public Bindable<string> Query => textBox.Current;
 
@@ -51,7 +49,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public Bindable<SearchExplicit> ExplicitContent => explicitContentFilter.Current;
 
-        public APIBeatmapSet BeatmapSet
+        public APIBeatmapSet? BeatmapSet
         {
             set
             {
@@ -151,7 +149,7 @@ namespace osu.Game.Overlays.BeatmapListing
             categoryFilter.Current.Value = SearchCategory.Leaderboard;
         }
 
-        private IBindable<bool> allowExplicitContent;
+        private IBindable<bool> allowExplicitContent = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider, OsuConfigManager config)
@@ -172,7 +170,7 @@ namespace osu.Game.Overlays.BeatmapListing
             /// <summary>
             /// Any time the text box receives key events (even while masked).
             /// </summary>
-            public Action TextChanged;
+            public Action? TextChanged;
 
             protected override Color4 SelectionColour => Color4.Gray;
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         private readonly BeatmapSearchTextBox textBox;
-        private readonly BeatmapSearchMultipleSelectionFilterRow<SearchGeneral> generalFilter;
+        private readonly BeatmapSearchGeneralFilterRow generalFilter;
         private readonly BeatmapSearchRulesetFilterRow modeFilter;
         private readonly BeatmapSearchFilterRow<SearchCategory> categoryFilter;
         private readonly BeatmapSearchFilterRow<SearchGenre> genreFilter;
@@ -161,6 +161,13 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 ExplicitContent.Value = allow.NewValue ? SearchExplicit.Show : SearchExplicit.Hide;
             }, true);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            generalFilter.Ruleset.BindTo(Ruleset);
         }
 
         public void TakeFocus() => textBox.TakeFocus();

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -82,7 +82,8 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 base.LoadComplete();
 
-                if (recommender != null) recommender.StarRatingUpdated += updateText;
+                if (recommender != null)
+                    recommender.StarRatingUpdated += updateText;
 
                 Ruleset.BindValueChanged(_ => updateText(), true);
             }
@@ -101,6 +102,14 @@ namespace osu.Game.Overlays.BeatmapListing
                     Text.Text = LocalisableString.Interpolate($"{Value.GetLocalisableDescription()} ({starRating.Value.FormatStarRating()})");
                 else
                     Text.Text = Value.GetLocalisableDescription();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                if (recommender != null)
+                    recommender.StarRatingUpdated -= updateText;
             }
         }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -91,8 +91,16 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 // fallback to profile default game mode if beatmap listing mode filter is set to Any
                 // TODO: find a way to update `PlayMode` when the profile default game mode has changed
-                var ruleset = Ruleset.Value.IsLegacyRuleset() ? Ruleset.Value : rulesets.GetRuleset(api.LocalUser.Value.PlayMode)!;
-                Text.Text = LocalisableString.Interpolate($"{Value.GetLocalisableDescription()} ({recommender?.GetRecommendedStarRatingFor(ruleset).FormatStarRating()})");
+                RulesetInfo? ruleset = Ruleset.Value.IsLegacyRuleset() ? Ruleset.Value : rulesets.GetRuleset(api.LocalUser.Value.PlayMode);
+
+                if (ruleset == null) return;
+
+                double? starRating = recommender?.GetRecommendedStarRatingFor(ruleset);
+
+                if (starRating != null)
+                    Text.Text = LocalisableString.Interpolate($"{Value.GetLocalisableDescription()} ({starRating.Value.FormatStarRating()})");
+                else
+                    Text.Text = Value.GetLocalisableDescription();
             }
         }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -40,7 +38,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private partial class FeaturedArtistsTabItem : MultipleSelectionFilterTabItem
         {
-            private Bindable<bool> disclaimerShown;
+            private Bindable<bool> disclaimerShown = null!;
 
             public FeaturedArtistsTabItem()
                 : base(SearchGeneral.FeaturedArtists)
@@ -48,13 +46,13 @@ namespace osu.Game.Overlays.BeatmapListing
             }
 
             [Resolved]
-            private OsuColour colours { get; set; }
+            private OsuColour colours { get; set; } = null!;
 
             [Resolved]
-            private SessionStatics sessionStatics { get; set; }
+            private SessionStatics sessionStatics { get; set; } = null!;
 
-            [Resolved(canBeNull: true)]
-            private IDialogOverlay dialogOverlay { get; set; }
+            [Resolved]
+            private IDialogOverlay? dialogOverlay { get; set; }
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
+++ b/osu.Game/Overlays/BeatmapSet/BeatmapPicker.cs
@@ -21,6 +21,7 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Rulesets;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Overlays.BeatmapSet
@@ -185,7 +186,7 @@ namespace osu.Game.Overlays.BeatmapSet
                                                                 OnHovered = beatmap =>
                                                                 {
                                                                     showBeatmap(beatmap);
-                                                                    starRating.Text = beatmap.StarRating.ToLocalisableString(@"0.00");
+                                                                    starRating.Text = beatmap.StarRating.FormatStarRating();
                                                                     starRatingContainer.FadeIn(100);
                                                                 },
                                                                 OnClicked = beatmap => { Beatmap.Value = beatmap; },

--- a/osu.Game/Skinning/Components/BeatmapAttributeText.cs
+++ b/osu.Game/Skinning/Components/BeatmapAttributeText.cs
@@ -226,7 +226,7 @@ namespace osu.Game.Skinning.Components
                     return computeDifficulty().ApproachRate.ToLocalisableString(@"0.##");
 
                 case BeatmapAttribute.StarRating:
-                    return (starDifficulty?.Stars ?? 0).ToLocalisableString(@"F2");
+                    return (starDifficulty?.Stars ?? 0).FormatStarRating();
 
                 case BeatmapAttribute.MaxPP:
                     return Math.Round(starDifficulty?.PerformanceAttributes?.Total ?? 0, MidpointRounding.AwayFromZero).ToLocalisableString();

--- a/osu.Game/Utils/FormatUtils.cs
+++ b/osu.Game/Utils/FormatUtils.cs
@@ -33,6 +33,12 @@ namespace osu.Game.Utils
         public static string FormatRank(this int rank) => rank.ToMetric(decimals: rank < 100_000 ? 1 : 0);
 
         /// <summary>
+        /// Formats the supplied star rating in a consistent, simplified way.
+        /// </summary>
+        /// <param name="starRating">The star rating to be formatted.</param>
+        public static LocalisableString FormatStarRating(this double starRating) => starRating.ToLocalisableString("0.00");
+
+        /// <summary>
         /// Finds the number of digits after the decimal.
         /// </summary>
         /// <param name="d">The value to find the number of decimal digits for.</param>


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/30394

Relevant web code: https://github.com/ppy/osu-web/blob/027026fccc91525e39cee5d2f369f1b343eb1bf1/app/Libraries/Search/BeatmapsetSearchParams.php#L98-L101

The tests in `TestSceneBeatmapRecommendations` occasionally fail to populate ruleset statistics and I don't know how to fix it.

![Kapture 2024-12-12 at 15 37 57](https://github.com/user-attachments/assets/711c5c81-db65-4eef-9421-cce7f6e2c57d)