### PR TITLE
Hide player settings overlay in skin editor

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -37,6 +37,8 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         protected override bool Autoplay => true;
 
+        protected override bool ShowSettingsOverlay => false;
+
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 

--- a/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinEditorOverlay.cs
@@ -347,6 +347,7 @@ namespace osu.Game.Overlays.SkinEditor
                 {
                     ShowResults = false,
                     AutomaticallySkipIntro = true,
+                    ShowSettingsOverlay = false,
                 })
             {
             }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -84,6 +84,8 @@ namespace osu.Game.Screens.Play
 
         private readonly BindableBool replayLoaded = new BindableBool();
 
+        private readonly bool showSettingsOverlay;
+
         private static bool hasShownNotificationOnce;
 
         private readonly FillFlowContainer bottomRightElements;
@@ -113,12 +115,13 @@ namespace osu.Game.Screens.Play
         /// </summary>
         internal readonly Drawable PlayfieldSkinLayer;
 
-        public HUDOverlay([CanBeNull] DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods, bool alwaysShowLeaderboard = true)
+        public HUDOverlay([CanBeNull] DrawableRuleset drawableRuleset, IReadOnlyList<Mod> mods, bool alwaysShowLeaderboard = true, bool showSettingsOverlay = true)
         {
             Container rightSettings;
 
             this.drawableRuleset = drawableRuleset;
             this.mods = mods;
+            this.showSettingsOverlay = showSettingsOverlay;
 
             RelativeSizeAxes = Axes.Both;
 
@@ -189,6 +192,9 @@ namespace osu.Game.Screens.Play
 
             if (!alwaysShowLeaderboard)
                 hideTargets.Add(LeaderboardFlow);
+
+            if (!showSettingsOverlay)
+                hideTargets.Add(rightSettings);
         }
 
         [BackgroundDependencyLoader(true)]
@@ -348,7 +354,7 @@ namespace osu.Game.Screens.Play
                 return;
             }
 
-            if (configSettingsOverlay.Value && replayLoaded.Value)
+            if (configSettingsOverlay.Value && replayLoaded.Value && showSettingsOverlay)
                 PlayerSettingsOverlay.Show();
             else
                 PlayerSettingsOverlay.Hide();

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -439,7 +439,7 @@ namespace osu.Game.Screens.Play
                 Children = new[]
                 {
                     DimmableStoryboard.OverlayLayerContainer.CreateProxy(),
-                    HUDOverlay = new HUDOverlay(DrawableRuleset, GameplayState.Mods, Configuration.AlwaysShowLeaderboard)
+                    HUDOverlay = new HUDOverlay(DrawableRuleset, GameplayState.Mods, Configuration.AlwaysShowLeaderboard, Configuration.ShowSettingsOverlay)
                     {
                         HoldToQuit =
                         {

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -49,6 +49,6 @@ namespace osu.Game.Screens.Play
         /// <summary>
         /// Whether the right overlay containing settings should be shown or not.
         /// </summary>
-        public bool ShowSettingsOverlay { get; set; }
+        public bool ShowSettingsOverlay { get; set; } = true;
     }
 }

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -45,5 +45,10 @@ namespace osu.Game.Screens.Play
         /// Whether the gameplay leaderboard should always be shown (usually in a contracted state).
         /// </summary>
         public bool AlwaysShowLeaderboard { get; set; }
+
+        /// <summary>
+        /// Whether the right overlay containing settings should be shown or not.
+        /// </summary>
+        public bool ShowSettingsOverlay { get; set; }
     }
 }

--- a/osu.Game/Tests/Visual/PlayerTestScene.cs
+++ b/osu.Game/Tests/Visual/PlayerTestScene.cs
@@ -86,6 +86,8 @@ namespace osu.Game.Tests.Visual
 
         protected virtual bool Autoplay => false;
 
+        protected virtual bool ShowSettingsOverlay => true;
+
         protected void LoadPlayer() => LoadPlayer(Array.Empty<Mod>());
 
         protected void LoadPlayer(Mod[] mods)
@@ -136,6 +138,6 @@ namespace osu.Game.Tests.Visual
 
         protected sealed override Ruleset CreateRuleset() => CreatePlayerRuleset();
 
-        protected virtual TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(false, false, AllowBackwardsSeeks);
+        protected virtual TestPlayer CreatePlayer(Ruleset ruleset) => new TestPlayer(false, false, AllowBackwardsSeeks, ShowSettingsOverlay);
     }
 }

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -51,11 +51,12 @@ namespace osu.Game.Tests.Visual
         [Resolved]
         private SpectatorClient spectatorClient { get; set; }
 
-        public TestPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false)
+        public TestPlayer(bool allowPause = true, bool showResults = true, bool pauseOnFocusLost = false, bool showSettingsOverlay = true)
             : base(new PlayerConfiguration
             {
                 AllowPause = allowPause,
-                ShowResults = showResults
+                ShowResults = showResults,
+                ShowSettingsOverlay = showSettingsOverlay
             })
         {
             PauseOnFocusLost = pauseOnFocusLost;


### PR DESCRIPTION
Fixes #31088.

This change introduces a new flag in the PlayerConfiguration to allow disabling the settings overlay in certain contexts (e.g., within the Skin Editor). This new flag ensures that the default behavior, as it was previously used, remains intact unless explicitly specified to disable the overlay.

In the Skin Editor, the settings overlay can interfere with the user experience when modifying components on the right side of the screen. Additionally, there should be no need to adjust the settings since the primary focus is simply on gameplay, which showcases the skin.

This change have also been made to the Skin Editor Test Scene.