### PR TITLE
Fix player settings overlay appearing while in skin editor

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -23,6 +23,7 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.Edit.Components;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Screens.Play.HUD.HitErrorMeters;
 using osu.Game.Skinning;
 using osu.Game.Tests.Beatmaps.IO;
@@ -210,6 +211,33 @@ namespace osu.Game.Tests.Visual.Navigation
             switchToGameplayScene();
 
             AddAssert("no mod selected", () => !((Player)Game.ScreenStack.CurrentScreen).Mods.Value.Any());
+        }
+
+        [Test]
+        public void TestGameplaySettingsDoesNotExpandWhenSkinOverlayPresent()
+        {
+            advanceToSongSelect();
+            openSkinEditor();
+            AddStep("select autoplay", () => Game.SelectedMods.Value = new Mod[] { new OsuModAutoplay() });
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).WaitSafely());
+            AddUntilStep("wait for selected", () => !Game.Beatmap.IsDefault);
+            switchToGameplayScene();
+
+            AddUntilStep("wait for settings", () => getPlayerSettingsOverlay() != null);
+            AddAssert("settings not visible", () => getPlayerSettingsOverlay().DrawWidth, () => Is.EqualTo(0));
+
+            AddStep("move cursor to right of screen", () => InputManager.MoveMouseTo(InputManager.ScreenSpaceDrawQuad.TopRight));
+            AddAssert("settings not visible", () => getPlayerSettingsOverlay().DrawWidth, () => Is.EqualTo(0));
+
+            toggleSkinEditor();
+
+            AddStep("move cursor slightly", () => InputManager.MoveMouseTo(InputManager.ScreenSpaceDrawQuad.TopRight + new Vector2(1)));
+            AddUntilStep("settings visible", () => getPlayerSettingsOverlay().DrawWidth, () => Is.GreaterThan(0));
+
+            AddStep("move cursor to right of screen too far", () => InputManager.MoveMouseTo(InputManager.ScreenSpaceDrawQuad.TopRight + new Vector2(10240, 0)));
+            AddUntilStep("settings not visible", () => getPlayerSettingsOverlay().DrawWidth, () => Is.EqualTo(0));
+
+            PlayerSettingsOverlay getPlayerSettingsOverlay() => ((Player)Game.ScreenStack.CurrentScreen).ChildrenOfType<PlayerSettingsOverlay>().SingleOrDefault();
         }
 
         [Test]

--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -86,11 +86,31 @@ namespace osu.Game.Screens.Play.HUD
             inputManager = GetContainingInputManager()!;
         }
 
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) =>
+            screenSpacePos.X > button.ScreenSpaceDrawQuad.TopLeft.X;
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            checkExpanded();
+            return base.OnMouseMove(e);
+        }
+
         protected override void Update()
         {
             base.Update();
 
-            Expanded.Value = inputManager.CurrentState.Mouse.Position.X >= button.ScreenSpaceDrawQuad.TopLeft.X;
+            // Only check expanded if already expanded.
+            // This is because if we are always checking, it would bypass blocking overlays.
+            // Case in point: the skin editor overlay blocks input from reaching the player, but checking raw coordinates would make settings pop out.
+            if (Expanded.Value)
+                checkExpanded();
+        }
+
+        private void checkExpanded()
+        {
+            float screenMouseX = inputManager.CurrentState.Mouse.Position.X;
+
+            Expanded.Value = screenMouseX >= button.ScreenSpaceDrawQuad.TopLeft.X && screenMouseX <= ToScreenSpace(new Vector2(DrawWidth + EXPANDED_WIDTH, 0)).X;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31088.

Also stops the settings appearing if the mouse is too far away from the window.