### PR TITLE
Fix player settings overlay cog overlapping skin elements

### DIFF
--- a/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
+++ b/osu.Game/Screens/Play/HUD/PlayerSettingsOverlay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -42,6 +43,9 @@ namespace osu.Game.Screens.Play.HUD
         private readonly IconButton button;
 
         private InputManager inputManager = null!;
+
+        [Resolved]
+        private HUDOverlay? hudOverlay { get; set; }
 
         public PlayerSettingsOverlay()
             : base(0, EXPANDED_WIDTH)
@@ -98,6 +102,9 @@ namespace osu.Game.Screens.Play.HUD
         protected override void Update()
         {
             base.Update();
+
+            if (hudOverlay != null)
+                button.Y = ToLocalSpace(hudOverlay.TopRightElements.ScreenSpaceDrawQuad.BottomRight).Y;
 
             // Only check expanded if already expanded.
             // This is because if we are always checking, it would bypass blocking overlays.

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -87,7 +87,8 @@ namespace osu.Game.Screens.Play
         private static bool hasShownNotificationOnce;
 
         private readonly FillFlowContainer bottomRightElements;
-        private readonly FillFlowContainer topRightElements;
+
+        internal readonly FillFlowContainer TopRightElements;
 
         internal readonly IBindable<bool> IsPlaying = new Bindable<bool>();
 
@@ -136,7 +137,7 @@ namespace osu.Game.Screens.Play
                 PlayfieldSkinLayer = drawableRuleset != null
                     ? new SkinnableContainer(new GlobalSkinnableContainerLookup(GlobalSkinnableContainers.Playfield, drawableRuleset.Ruleset.RulesetInfo)) { AlwaysPresent = true, }
                     : Empty(),
-                topRightElements = new FillFlowContainer
+                TopRightElements = new FillFlowContainer
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
@@ -182,7 +183,7 @@ namespace osu.Game.Screens.Play
                 },
             };
 
-            hideTargets = new List<Drawable> { mainComponents, topRightElements, rightSettings };
+            hideTargets = new List<Drawable> { mainComponents, TopRightElements, rightSettings };
 
             if (rulesetComponents != null)
                 hideTargets.Add(rulesetComponents);
@@ -275,9 +276,9 @@ namespace osu.Game.Screens.Play
                 processDrawables(rulesetComponents);
 
             if (lowestTopScreenSpaceRight.HasValue)
-                topRightElements.Y = MathHelper.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceRight.Value)).Y, 0, DrawHeight - topRightElements.DrawHeight);
+                TopRightElements.Y = MathHelper.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceRight.Value)).Y, 0, DrawHeight - TopRightElements.DrawHeight);
             else
-                topRightElements.Y = 0;
+                TopRightElements.Y = 0;
 
             if (lowestTopScreenSpaceLeft.HasValue)
                 LeaderboardFlow.Y = MathHelper.Clamp(ToLocalSpace(new Vector2(0, lowestTopScreenSpaceLeft.Value)).Y, 0, DrawHeight - LeaderboardFlow.DrawHeight);


### PR DESCRIPTION
This brings it down to be in line with the flowing elements that usually do their best to not get in the way.

Decided against putting it in the `HUDOverlay` flow for simplicity. It will work fine until it doesn't.

https://github.com/user-attachments/assets/883c880a-51cd-4d10-8aaa-462f4b090f4f

- [x] Depends on https://github.com/ppy/osu/pull/31105 for ease of merging
