### PR TITLE
Attempt to fix flaky editor beatmap creation test

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -203,12 +203,19 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestCreateNewDifficultyWithScrollSpeed_SameRuleset()
         {
-            string firstDifficultyName = Guid.NewGuid().ToString();
+            string previousDifficultyName = null!;
 
+            AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = previousDifficultyName = Guid.NewGuid().ToString());
             AddStep("save beatmap", () => Editor.Save());
             AddStep("create new difficulty", () => Editor.CreateNewDifficulty(new ManiaRuleset().RulesetInfo));
 
-            AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = firstDifficultyName);
+            AddUntilStep("wait for created", () =>
+            {
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                return difficultyName != null && difficultyName != previousDifficultyName;
+            });
+
+            AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = previousDifficultyName = Guid.NewGuid().ToString());
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
             AddStep("add effect points", () =>
             {
@@ -229,7 +236,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddUntilStep("wait for created", () =>
             {
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
-                return difficultyName != null && difficultyName != firstDifficultyName;
+                return difficultyName != null && difficultyName != previousDifficultyName;
             });
 
             AddAssert("created difficulty has timing point", () =>


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/actions/runs/12289146465/job/34294167417#step:5:1588 or https://github.com/ppy/osu/actions/runs/12310133160/job/34358241666#step:5:53.

Exception messages hint pretty strongly at this being a threading issue and there does seem to be a rather frivolous lack of waiting for `CreateNewDifficulty()` to do its thing, so I'm thinking maybe this will help.

I can't reproduce this locally so I'm PRing to see what happens on CI. If CI fails I'll just close.

cc @frenzibyte