### PR TITLE
Allow using "quick retry" shortcut in more cases from results screen

### DIFF
--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -34,10 +34,12 @@ namespace osu.Game.Screens.Play
 
         protected override UserActivity InitialActivity => new UserActivity.WatchingReplay(Score.ScoreInfo);
 
+        private bool isAutoplayPlayback => GameplayState.Mods.OfType<ModAutoplay>().Any();
+
         // Disallow replays from failing. (see https://github.com/ppy/osu/issues/6108)
         protected override bool CheckModsAllowFailure()
         {
-            if (!replayIsFailedScore && !GameplayState.Mods.OfType<ModAutoplay>().Any())
+            if (!replayIsFailedScore && !isAutoplayPlayback)
                 return false;
 
             return base.CheckModsAllowFailure();
@@ -102,7 +104,12 @@ namespace osu.Game.Screens.Play
                 Scores = { BindTarget = LeaderboardScores }
             };
 
-        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score);
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
+        {
+            // Only show the relevant button otherwise things look silly.
+            AllowWatchingReplay = !isAutoplayPlayback,
+            AllowRetry = isAutoplayPlayback,
+        };
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -84,6 +84,7 @@ namespace osu.Game.Screens.Ranking
         /// </summary>
         public bool ShowUserStatistics { get; init; }
 
+        // Only show the relevant button otherwise things look silly.
         private Sample? popInSample;
 
         protected ResultsScreen(ScoreInfo? score)
@@ -186,6 +187,8 @@ namespace osu.Game.Screens.Ranking
                 Scheduler.AddDelayed(() => OverlayActivationMode.Value = OverlayActivation.All, shouldFlair ? AccuracyCircle.TOTAL_DURATION + 1000 : 0);
             }
 
+            bool allowHotkeyRetry = false;
+
             if (AllowWatchingReplay)
             {
                 buttons.Add(new ReplayDownloadButton(SelectedScore.Value)
@@ -193,12 +196,19 @@ namespace osu.Game.Screens.Ranking
                     Score = { BindTarget = SelectedScore },
                     Width = 300
                 });
+
+                // for simplicity, only allow when we're guaranteed the replay is already downloaded and present.
+                allowHotkeyRetry = player is ReplayPlayer;
             }
 
             if (player != null && AllowRetry)
             {
                 buttons.Add(new RetryButton { Width = 300 });
+                allowHotkeyRetry = true;
+            }
 
+            if (allowHotkeyRetry)
+            {
                 AddInternal(new HotkeyRetryOverlay
                 {
                     Action = () =>

--- a/osu.Game/Screens/Ranking/ResultsScreen.cs
+++ b/osu.Game/Screens/Ranking/ResultsScreen.cs
@@ -84,7 +84,6 @@ namespace osu.Game.Screens.Ranking
         /// </summary>
         public bool ShowUserStatistics { get; init; }
 
-        // Only show the relevant button otherwise things look silly.
         private Sample? popInSample;
 
         protected ResultsScreen(ScoreInfo? score)
@@ -197,7 +196,10 @@ namespace osu.Game.Screens.Ranking
                     Width = 300
                 });
 
-                // for simplicity, only allow when we're guaranteed the replay is already downloaded and present.
+                // for simplicity, only allow this when coming from a replay player where we know the replay is ready to be played.
+                //
+                // if we show it in all cases, consider the case where a user comes from song select and potentially has to download
+                // the replay before it can be played back. it wouldn't flow well with the quick retry in such a case.
                 allowHotkeyRetry = player is ReplayPlayer;
             }
 

--- a/osu.Game/Screens/Ranking/RetryButton.cs
+++ b/osu.Game/Screens/Ranking/RetryButton.cs
@@ -38,8 +38,6 @@ namespace osu.Game.Screens.Ranking
                     Icon = FontAwesome.Solid.Redo,
                 },
             };
-
-            TooltipText = "retry";
         }
 
         [BackgroundDependencyLoader]
@@ -48,7 +46,14 @@ namespace osu.Game.Screens.Ranking
             background.Colour = colours.Green;
 
             if (player != null)
+            {
+                TooltipText = player is ReplayPlayer ? "replay" : "retry";
                 Action = () => player.Restart();
+            }
+            else
+            {
+                TooltipText = "retry";
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes "quick retry" hotkey not working for autoplay, but also allows using it for other replays when the replay is already guaranteed to be local (ie. on the second playback).