### PR TITLE
Fix osu!catch "buzz slider" SR abuse

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -26,7 +26,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
 
         private float? lastPlayerPosition;
         private float lastDistanceMoved;
+        private float lastExactDistanceMoved;
         private double lastStrainTime;
+        private bool isBuzzSliderTriggered = false;
 
         /// <summary>
         /// The speed multiplier applied to the player's catcher.
@@ -58,6 +60,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
             );
 
             float distanceMoved = playerPosition - lastPlayerPosition.Value;
+
+            // For the exact position we consider that the catcher is in the correct position for both objects
+            float exactDistanceMoved = catchCurrent.NormalizedPosition - lastPlayerPosition.Value;
 
             double weightedStrainTime = catchCurrent.StrainTime + 13 + (3 / catcherSpeedMultiplier);
 
@@ -95,9 +100,26 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
                 distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20) * Math.Pow((Math.Min(catchCurrent.StrainTime * catcherSpeedMultiplier, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
             }
 
+            // There is an edge case where horizontal back and forth sliders create "buzz" patterns which are repeated "movements" with a distance lower than
+            // the platter's width but high enough to be considered a movement due to the absolute_player_positioning_error and normalized_hitobject_radius offsets
+            // We are detecting this exact scenario. The first back and forth is counted but all subsequent ones are nullified.
+            // To achieve that, we need to store the exact distances (distance ignoring absolute_player_positioning_error and normalized_hitobject_radius)
+            if (Math.Abs(exactDistanceMoved) <= HalfCatcherWidth * 2 && exactDistanceMoved == -lastExactDistanceMoved && catchCurrent.StrainTime == lastStrainTime)
+            {
+                if (isBuzzSliderTriggered)
+                    distanceAddition = 0;
+                else isBuzzSliderTriggered = true;
+            }
+            else
+            {
+                if (isBuzzSliderTriggered)
+                    isBuzzSliderTriggered = false;
+            }
+
             lastPlayerPosition = playerPosition;
             lastDistanceMoved = distanceMoved;
             lastStrainTime = catchCurrent.StrainTime;
+            lastExactDistanceMoved = exactDistanceMoved;
 
             return distanceAddition / weightedStrainTime;
         }

--- a/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Skills/Movement.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
         private float lastDistanceMoved;
         private float lastExactDistanceMoved;
         private double lastStrainTime;
-        private bool isBuzzSliderTriggered = false;
+        private bool isBuzzSliderTriggered;
 
         /// <summary>
         /// The speed multiplier applied to the player's catcher.
@@ -97,7 +97,8 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
                     playerPosition = catchCurrent.NormalizedPosition;
                 }
 
-                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20) * Math.Pow((Math.Min(catchCurrent.StrainTime * catcherSpeedMultiplier, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
+                distanceAddition *= 1.0 + edgeDashBonus * ((20 - catchCurrent.LastObject.DistanceToHyperDash) / 20)
+                                                        * Math.Pow((Math.Min(catchCurrent.StrainTime * catcherSpeedMultiplier, 265) / 265), 1.5); // Edge Dashes are easier at lower ms values
             }
 
             // There is an edge case where horizontal back and forth sliders create "buzz" patterns which are repeated "movements" with a distance lower than
@@ -108,12 +109,12 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Skills
             {
                 if (isBuzzSliderTriggered)
                     distanceAddition = 0;
-                else isBuzzSliderTriggered = true;
+                else
+                    isBuzzSliderTriggered = true;
             }
             else
             {
-                if (isBuzzSliderTriggered)
-                    isBuzzSliderTriggered = false;
+                isBuzzSliderTriggered = false;
             }
 
             lastPlayerPosition = playerPosition;


### PR DESCRIPTION
This addresses the same issue as https://github.com/ppy/osu/pull/28451 but in a simpler, more straight-forward way.

The issue being solved is fixing the SR calculation for a certain pattern we are calling "buzz slider", which is an horizontal back & forth slider that has a length smaller than the catcher's width but is large enough to be detected as movements, resulting in it being considered as very fast jumps instead of a stand still pattern. No specific map has this issue because it's not allowed by the ranking criteria, but some converts do contain it (like https://osu.ppy.sh/beatmapsets/2066239#fruits/4343468).

This bug is caused by some offsets that are added to the player's position to account for potential mispositioning between objects. It's useful in some scenarios and has effect on pretty much everything so we don't want to remove that logic until a proper rework is being done. So in the mean time, this is a temporary fix that targets this exact pattern.

This is currently a draft since I need to run the calc sheet first to dectect potential side effects.