### PR TITLE
Use premultiplied colours in rendering

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/SmokeSegment.cs
@@ -265,8 +265,8 @@ namespace osu.Game.Rulesets.Osu.Skinning
             }
 
             protected Color4 ColourAtPosition(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
-                ? ((SRGBColour)DrawColourInfo.Colour).Linear
-                : DrawColourInfo.Colour.Interpolate(Vector2.Divide(localPos, drawSize)).Linear;
+                ? ((SRGBColour)DrawColourInfo.Colour).SRGB
+                : DrawColourInfo.Colour.Interpolate(Vector2.Divide(localPos, drawSize)).SRGB;
 
             protected virtual Color4 PointColour(SmokePoint point)
             {
@@ -352,25 +352,25 @@ namespace osu.Game.Rulesets.Osu.Skinning
                 {
                     Position = localTopLeft,
                     TexturePosition = textureRect.TopLeft,
-                    Colour = Color4Extensions.Multiply(ColourAtPosition(localTopLeft), colour),
+                    Colour = Color4Extensions.Multiply(ColourAtPosition(localTopLeft), colour).ToPremultiplied(),
                 });
                 quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localTopRight,
                     TexturePosition = textureRect.TopRight,
-                    Colour = Color4Extensions.Multiply(ColourAtPosition(localTopRight), colour),
+                    Colour = Color4Extensions.Multiply(ColourAtPosition(localTopRight), colour).ToPremultiplied(),
                 });
                 quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localBotRight,
                     TexturePosition = textureRect.BottomRight,
-                    Colour = Color4Extensions.Multiply(ColourAtPosition(localBotRight), colour),
+                    Colour = Color4Extensions.Multiply(ColourAtPosition(localBotRight), colour).ToPremultiplied(),
                 });
                 quadBatch.Add(new TexturedVertex2D(renderer)
                 {
                     Position = localBotLeft,
                     TexturePosition = textureRect.BottomLeft,
-                    Colour = Color4Extensions.Multiply(ColourAtPosition(localBotLeft), colour),
+                    Colour = Color4Extensions.Multiply(ColourAtPosition(localBotLeft), colour).ToPremultiplied(),
                 });
             }
 

--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -7,7 +7,9 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -19,7 +21,6 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Game.Rulesets.Osu.UI.Cursor
@@ -292,7 +293,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                         Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X * part.Scale.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y) * part.Scale.Y),
                         TexturePosition = textureRect.BottomLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
-                        Colour = DrawColourInfo.Colour.BottomLeft.Linear,
+                        Colour = DrawColourInfo.Colour.BottomLeft.SRGB.ToPremultiplied(),
                         Time = part.Time
                     });
 
@@ -301,7 +302,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                         Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X) * part.Scale.X, part.Position.Y + texture.DisplayHeight * (1 - originPosition.Y) * part.Scale.Y),
                         TexturePosition = textureRect.BottomRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
-                        Colour = DrawColourInfo.Colour.BottomRight.Linear,
+                        Colour = DrawColourInfo.Colour.BottomRight.SRGB.ToPremultiplied(),
                         Time = part.Time
                     });
 
@@ -310,7 +311,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                         Position = new Vector2(part.Position.X + texture.DisplayWidth * (1 - originPosition.X) * part.Scale.X, part.Position.Y - texture.DisplayHeight * originPosition.Y * part.Scale.Y),
                         TexturePosition = textureRect.TopRight,
                         TextureRect = new Vector4(0, 0, 1, 1),
-                        Colour = DrawColourInfo.Colour.TopRight.Linear,
+                        Colour = DrawColourInfo.Colour.TopRight.SRGB.ToPremultiplied(),
                         Time = part.Time
                     });
 
@@ -319,7 +320,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
                         Position = new Vector2(part.Position.X - texture.DisplayWidth * originPosition.X * part.Scale.X, part.Position.Y - texture.DisplayHeight * originPosition.Y * part.Scale.Y),
                         TexturePosition = textureRect.TopLeft,
                         TextureRect = new Vector4(0, 0, 1, 1),
-                        Colour = DrawColourInfo.Colour.TopLeft.Linear,
+                        Colour = DrawColourInfo.Colour.TopLeft.SRGB.ToPremultiplied(),
                         Time = part.Time
                     });
                 }
@@ -354,7 +355,7 @@ namespace osu.Game.Rulesets.Osu.UI.Cursor
             public Vector2 Position;
 
             [VertexMember(4, VertexAttribPointerType.Float)]
-            public Color4 Colour;
+            public PremultipliedColour Colour;
 
             [VertexMember(2, VertexAttribPointerType.Float)]
             public Vector2 TexturePosition;

--- a/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
+++ b/osu.Game.Tests/NonVisual/Skinning/LegacySkinTextureFallbackTest.cs
@@ -18,8 +18,6 @@ using osu.Framework.IO.Stores;
 using osu.Game.Database;
 using osu.Game.IO;
 using osu.Game.Skinning;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Game.Tests.NonVisual.Skinning
 {
@@ -184,7 +182,7 @@ namespace osu.Game.Tests.NonVisual.Skinning
             {
                 // use an incrementing width to allow assertion matching on correct textures as they turn from uploads into actual textures.
                 int width = 1;
-                Textures = fileNames.ToDictionary(fileName => fileName, _ => new TextureUpload(new Image<Rgba32>(width, width++)));
+                Textures = fileNames.ToDictionary(fileName => fileName, _ => new TextureUpload(new PremultipliedImage(width, width++)));
             }
 
             public TextureUpload Get(string name) => Textures.GetValueOrDefault(name);

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     textureUpload.Dispose();
 
                     image.Mutate(i => i.Resize(new Size(textureUpload.Width, textureUpload.Height) * scale_factor));
-                    return new TextureUpload(image);
+                    return new TextureUpload(PremultipliedImage.FromStraight(image));
                 }
 
                 public Stream? GetStream(string name) => textureStore?.GetStream(name);

--- a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestScenePlayerMaxDimensions.cs
@@ -121,7 +121,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 private TextureUpload upscale(TextureUpload textureUpload)
                 {
-                    var image = Image.LoadPixelData(textureUpload.Data, textureUpload.Width, textureUpload.Height);
+                    var image = Image.LoadPixelData(textureUpload.PremultipliedData, textureUpload.Width, textureUpload.Height);
 
                     // The original texture upload will no longer be returned or used.
                     textureUpload.Dispose();

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Beatmaps
 
         private TextureUpload limitTextureUploadSize(TextureUpload textureUpload)
         {
-            var image = Image.LoadPixelData(textureUpload.Data, textureUpload.Width, textureUpload.Height);
+            var image = Image.LoadPixelData(textureUpload.PremultipliedData, textureUpload.Width, textureUpload.Height);
 
             // The original texture upload will no longer be returned or used.
             textureUpload.Dispose();

--- a/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
+++ b/osu.Game/Beatmaps/BeatmapPanelBackgroundTextureLoaderStore.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Beatmaps
 
             image.Mutate(i => i.Crop(cropRectangle));
 
-            return new TextureUpload(image);
+            return new TextureUpload(PremultipliedImage.FromStraight(image));
         }
 
         public Stream? GetStream(string name) => textureStore?.GetStream(name);

--- a/osu.Game/Graphics/OpenGL/Vertices/PositionAndColourVertex.cs
+++ b/osu.Game/Graphics/OpenGL/Vertices/PositionAndColourVertex.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Game.Graphics.OpenGL.Vertices
@@ -17,7 +17,7 @@ namespace osu.Game.Graphics.OpenGL.Vertices
         public Vector2 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         public bool Equals(PositionAndColourVertex other)
             => Position.Equals(other.Position)

--- a/osu.Game/Graphics/Rendering/Vertices/PositionAndColourVertex.cs
+++ b/osu.Game/Graphics/Rendering/Vertices/PositionAndColourVertex.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Rendering.Vertices;
 using osuTK;
 using osuTK.Graphics.ES30;
 
-namespace osu.Game.Graphics.OpenGL.Vertices
+namespace osu.Game.Graphics.Rendering.Vertices
 {
     [StructLayout(LayoutKind.Sequential)]
     public struct PositionAndColourVertex : IEquatable<PositionAndColourVertex>, IVertex

--- a/osu.Game/Graphics/Sprites/LogoAnimation.cs
+++ b/osu.Game/Graphics/Sprites/LogoAnimation.cs
@@ -7,13 +7,13 @@ using System;
 using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Game.Graphics.Sprites
@@ -126,7 +126,7 @@ namespace osu.Game.Graphics.Sprites
                 public Vector2 Position;
 
                 [VertexMember(4, VertexAttribPointerType.Float)]
-                public Color4 Colour;
+                public PremultipliedColour Colour;
 
                 [VertexMember(2, VertexAttribPointerType.Float)]
                 public Vector2 TexturePosition;

--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -175,7 +175,6 @@ namespace osu.Game.Overlays.Volume
                                     {
                                         Colour = meterColour,
                                         BlurSigma = new Vector2(blur_amount),
-                                        Strength = 5,
                                         PadExtent = true
                                     }),
                                 },
@@ -261,7 +260,7 @@ namespace osu.Game.Overlays.Volume
                 if (displayVolume >= 0.995f)
                 {
                     text.Text = "MAX";
-                    maxGlow.EffectColour = meterColour.Opacity(2f);
+                    maxGlow.EffectColour = meterColour.Opacity(1.25f);
                 }
                 else
                 {

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -18,7 +18,7 @@ using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Graphics.OpenGL.Vertices;
+using osu.Game.Graphics.Rendering.Vertices;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.UI;

--- a/osu.Game/Screens/Edit/Timing/TapButton.cs
+++ b/osu.Game/Screens/Edit/Timing/TapButton.cs
@@ -394,7 +394,7 @@ namespace osu.Game.Screens.Edit.Timing
                             {
                                 Colour = colourProvider.Colour1.Opacity(0.4f),
                                 BlurSigma = new Vector2(9f),
-                                Strength = 10,
+                                Strength = 2,
                                 PadExtent = true
                             }),
                         }

--- a/osu.Game/Screens/Play/HUD/ArgonHealthDisplayParts/ArgonHealthDisplayBar.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonHealthDisplayParts/ArgonHealthDisplayBar.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
@@ -116,8 +117,8 @@ namespace osu.Game.Screens.Play.HUD.ArgonHealthDisplayParts
             private Vector2 progressRange;
             private float pathRadius;
             private float glowPortion;
-            private Color4 barColour;
-            private Color4 glowColour;
+            private SRGBColour barColour;
+            private SRGBColour glowColour;
 
             public override void ApplyState()
             {
@@ -146,8 +147,8 @@ namespace osu.Game.Screens.Play.HUD.ArgonHealthDisplayParts
                 parametersBuffer ??= renderer.CreateUniformBuffer<ArgonBarPathParameters>();
                 parametersBuffer.Data = new ArgonBarPathParameters
                 {
-                    BarColour = new Vector4(barColour.R, barColour.G, barColour.B, barColour.A),
-                    GlowColour = new Vector4(glowColour.R, glowColour.G, glowColour.B, glowColour.A),
+                    BarColour = barColour.SRGB.ToPremultiplied(),
+                    GlowColour = glowColour.SRGB.ToPremultiplied(),
                     GlowPortion = glowPortion,
                     Size = size,
                     ProgressRange = progressRange,
@@ -168,8 +169,8 @@ namespace osu.Game.Screens.Play.HUD.ArgonHealthDisplayParts
             [StructLayout(LayoutKind.Sequential, Pack = 1)]
             private record struct ArgonBarPathParameters
             {
-                public UniformVector4 BarColour;
-                public UniformVector4 GlowColour;
+                public UniformColour BarColour;
+                public UniformColour GlowColour;
                 public UniformVector2 Size;
                 public UniformVector2 ProgressRange;
                 public UniformFloat PathRadius;

--- a/osu.Game/Skinning/LegacyTextureLoaderStore.cs
+++ b/osu.Game/Skinning/LegacyTextureLoaderStore.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Skinning
             // which matches mode BT.601 (https://en.wikipedia.org/wiki/Grayscale#Luma_coding_in_video_systems)
             image.Mutate(i => i.Grayscale(GrayscaleMode.Bt601));
 
-            return new TextureUpload(image);
+            return new TextureUpload(PremultipliedImage.FromStraight(image));
         }
 
         public Stream? GetStream(string name) => wrappedStore?.GetStream(name);

--- a/osu.Game/Skinning/LegacyTextureLoaderStore.cs
+++ b/osu.Game/Skinning/LegacyTextureLoaderStore.cs
@@ -73,7 +73,7 @@ namespace osu.Game.Skinning
 
         private TextureUpload convertToGrayscale(TextureUpload textureUpload)
         {
-            var image = Image.LoadPixelData(textureUpload.Data, textureUpload.Width, textureUpload.Height);
+            var image = Image.LoadPixelData(textureUpload.PremultipliedData, textureUpload.Width, textureUpload.Height);
 
             // stable uses `0.299 * r + 0.587 * g + 0.114 * b`
             // (https://github.com/peppy/osu-stable-reference/blob/013c3010a9d495e3471a9c59518de17006f9ad89/osu!/Graphics/Textures/pTexture.cs#L138-L153)

--- a/osu.Game/Skinning/MaxDimensionLimitedTextureLoaderStore.cs
+++ b/osu.Game/Skinning/MaxDimensionLimitedTextureLoaderStore.cs
@@ -71,7 +71,7 @@ namespace osu.Game.Skinning
                     Math.Min(textureUpload.Height, max_supported_texture_size)
                 )));
 
-                return new TextureUpload(image);
+                return new TextureUpload(PremultipliedImage.FromStraight(image));
             }
 
             return textureUpload;

--- a/osu.Game/Skinning/MaxDimensionLimitedTextureLoaderStore.cs
+++ b/osu.Game/Skinning/MaxDimensionLimitedTextureLoaderStore.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Skinning
 
             if (textureUpload.Height > max_supported_texture_size || textureUpload.Width > max_supported_texture_size)
             {
-                var image = Image.LoadPixelData(textureUpload.Data, textureUpload.Width, textureUpload.Height);
+                var image = Image.LoadPixelData(textureUpload.PremultipliedData, textureUpload.Width, textureUpload.Height);
 
                 // The original texture upload will no longer be returned or used.
                 textureUpload.Dispose();


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu-framework/pull/6456
- [ ] Depends on https://github.com/ppy/osu-resources/pull/348

| master | PR without adjustments | PR with adjustments |
|--------|---------|--------------|
| ![CleanShot 2024-12-22 at 09 56 34](https://github.com/user-attachments/assets/cdfd769d-eba8-401a-9adf-e7c70c57279d) | ![CleanShot 2024-12-22 at 09 56 06](https://github.com/user-attachments/assets/2e71f90f-fb8e-4bae-9fbe-5bb70c961c6d) | ![CleanShot 2024-12-22 at 09 56 46](https://github.com/user-attachments/assets/657adce4-3152-4641-80fb-b3b832b452f5) |
| ![CleanShot 2024-12-22 at 10 00 43](https://github.com/user-attachments/assets/37233f3f-8202-4376-9637-f35ec3a8d0b1) | ![CleanShot 2024-12-22 at 10 01 53](https://github.com/user-attachments/assets/3b3f79ad-83b7-4fde-9cb5-aae2f7d3d243) | ![CleanShot 2024-12-22 at 10 00 32](https://github.com/user-attachments/assets/fcfa4146-ec1e-4a3b-a5d0-bea5a3295c0a) |