### PR TITLE
Hide `!mp` commands from tournament streaming chat

### DIFF
--- a/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament.Tests/Components/TestSceneTournamentMatchChatDisplay.cs
@@ -152,6 +152,12 @@ namespace osu.Game.Tournament.Tests.Components
             AddStep("change channel to 2", () => chatDisplay.Channel.Value = testChannel2);
 
             AddStep("change channel to 1", () => chatDisplay.Channel.Value = testChannel);
+
+            AddStep("!mp message (shouldn't display)", () => testChannel.AddNewMessages(new Message(nextMessageId())
+            {
+                Sender = redUser.ToAPIUser(),
+                Content = "!mp wangs"
+            }));
         }
 
         private int messageId;

--- a/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
+++ b/osu.Game.Tournament/Components/TournamentMatchChatDisplay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -72,7 +73,13 @@ namespace osu.Game.Tournament.Components
 
         public void Contract() => this.FadeOut(200);
 
-        protected override ChatLine CreateMessage(Message message) => new MatchMessage(message, ladderInfo);
+        protected override ChatLine? CreateMessage(Message message)
+        {
+            if (message.Content.StartsWith("!mp", StringComparison.Ordinal))
+                return null;
+
+            return new MatchMessage(message, ladderInfo);
+        }
 
         protected override StandAloneDrawableChannel CreateDrawableChannel(Channel channel) => new MatchChannel(channel);
 

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -21,18 +20,18 @@ using osuTK.Input;
 namespace osu.Game.Online.Chat
 {
     /// <summary>
-    /// Display a chat channel in an insolated region.
+    /// Display a chat channel in an isolated region.
     /// </summary>
     public partial class StandAloneChatDisplay : CompositeDrawable
     {
         [Cached]
-        public readonly Bindable<Channel> Channel = new Bindable<Channel>();
+        public readonly Bindable<Channel?> Channel = new Bindable<Channel?>();
 
-        protected readonly ChatTextBox TextBox;
+        protected readonly ChatTextBox? TextBox;
 
-        private ChannelManager channelManager;
+        private ChannelManager? channelManager;
 
-        private StandAloneDrawableChannel drawableChannel;
+        private StandAloneDrawableChannel? drawableChannel;
 
         private readonly bool postingTextBox;
 
@@ -93,6 +92,8 @@ namespace osu.Game.Online.Chat
 
         private void postMessage(TextBox sender, bool newText)
         {
+            Debug.Assert(TextBox != null);
+
             string text = TextBox.Text.Trim();
 
             if (string.IsNullOrWhiteSpace(text))
@@ -106,9 +107,9 @@ namespace osu.Game.Online.Chat
             TextBox.Text = string.Empty;
         }
 
-        protected virtual ChatLine CreateMessage(Message message) => new StandAloneMessage(message);
+        protected virtual ChatLine? CreateMessage(Message message) => new StandAloneMessage(message);
 
-        private void channelChanged(ValueChangedEvent<Channel> e)
+        private void channelChanged(ValueChangedEvent<Channel?> e)
         {
             drawableChannel?.Expire();
 
@@ -128,8 +129,8 @@ namespace osu.Game.Online.Chat
 
         public partial class ChatTextBox : HistoryTextBox
         {
-            public Action Focus;
-            public Action FocusLost;
+            public Action? Focus;
+            public Action? FocusLost;
 
             protected override bool OnKeyDown(KeyDownEvent e)
             {
@@ -171,14 +172,14 @@ namespace osu.Game.Online.Chat
 
         public partial class StandAloneDrawableChannel : DrawableChannel
         {
-            public Func<Message, ChatLine> CreateChatLineAction;
+            public Func<Message, ChatLine?>? CreateChatLineAction;
 
             public StandAloneDrawableChannel(Channel channel)
                 : base(channel)
             {
             }
 
-            protected override ChatLine CreateChatLine(Message m) => CreateChatLineAction(m);
+            protected override ChatLine? CreateChatLine(Message m) => CreateChatLineAction?.Invoke(m) ?? null;
 
             protected override DaySeparator CreateDaySeparator(DateTimeOffset time) => new StandAloneDaySeparator(time);
         }

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -155,8 +155,13 @@ namespace osu.Game.Overlays.Chat
             {
                 addDaySeparatorIfRequired(lastMessage, message);
 
-                ChatLineFlow.Add(CreateChatLine(message));
-                lastMessage = message;
+                var chatLine = CreateChatLine(message);
+
+                if (chatLine != null)
+                {
+                    ChatLineFlow.Add(chatLine);
+                    lastMessage = message;
+                }
             }
 
             var staleMessages = chatLines.Where(c => c.LifetimeEnd == double.MaxValue).ToArray();

--- a/osu.Game/Overlays/Chat/DrawableChannel.cs
+++ b/osu.Game/Overlays/Chat/DrawableChannel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -132,6 +133,7 @@ namespace osu.Game.Overlays.Chat
             Channel.PendingMessageResolved -= pendingMessageResolved;
         }
 
+        [CanBeNull]
         protected virtual ChatLine CreateChatLine(Message m) => new ChatLine(m);
 
         protected virtual DaySeparator CreateDaySeparator(DateTimeOffset time) => new DaySeparator(time);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/GameplayChatDisplay.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [Resolved(CanBeNull = true)]
         private ILocalUserPlayInfo? localUserInfo { get; set; }
 
+        protected new ChatTextBox TextBox => base.TextBox!;
+
         private readonly IBindable<LocalUserPlayingState> localUserPlaying = new Bindable<LocalUserPlayingState>();
 
         public override bool PropagatePositionalInputSubTree => localUserPlaying.Value != LocalUserPlayingState.Playing;
@@ -58,7 +60,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             localUserPlaying.BindValueChanged(playing =>
             {
-                // for now let's never hold focus. this avoid misdirected gameplay keys entering chat.
+                // for now let's never hold focus. this avoids misdirected gameplay keys entering chat.
                 // note that this is done within this callback as it triggers an un-focus as well.
                 TextBox.HoldFocus = false;
 


### PR DESCRIPTION
As requested at https://github.com/ppy/osu/discussions/17367.

Just doing it locally for now as I guarantee there's going to be someone / some tool relying on parsing these (so blocking at bancho seems like a bad idea).