### PR TITLE
Use time-based resume overlay when playing osu! on touchscreen

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/UI/DrawableOsuRuleset.cs
@@ -69,7 +69,7 @@ namespace osu.Game.Rulesets.Osu.UI
 
         protected override ResumeOverlay CreateResumeOverlay()
         {
-            if (Mods.Any(m => m is OsuModAutopilot))
+            if (Mods.Any(m => m is OsuModAutopilot or OsuModTouchDevice))
                 return new DelayedResumeOverlay { Scale = new Vector2(0.65f) };
 
             return new OsuResumeOverlay();


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31042

The "click to resume" overlay does not work on touchscreen devices as the idea is to point with a pointer and press a key / mouse button to resume.