### PR TITLE
Fix iOS app configuration missing certain specifications

### DIFF
--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -34,9 +34,11 @@
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>We don't really use the camera.</string>
+	<string>We don't use the camera.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>We don't really use the microphone.</string>
+	<string>We don't use the microphone.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>We don't use Bluetooth.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeRight</string>

--- a/osu.iOS/Info.plist
+++ b/osu.iOS/Info.plist
@@ -153,5 +153,7 @@
 	</array>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music-games</string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/7443

After having this one simmer for some time while working on other tasks that require UIKit's document-related components, the specification in this PR here *should* be correct for what osu! is as an iOS app.

osu! is *not* a document-based app, contrary to https://github.com/ppy/osu/issues/7443#issuecomment-571576554. None of its files should be accessible to the user, not even logs, that's the last kind of data I would expose to a user that wants to play a game on their phone. The only kind of files that can be exposed to the user is exported beatmaps/skins/scores, and even then that doesn't justify it to be a document-based app at all.

osu! should not support opening documents in place either, there is nothing in the game that requires opening documents in the user's storage and write to it.

In conclusion, to address `ITMS-90737`:
 - `UISupportsDocumentBrowser` should not be set to YES as osu! is not a document-based app
 - `LSSupportsOpeningDocumentsInPlace` should be set to NO as osu! does not open documents in place.

Tested the iOS file selector/presenter implementations to still work with this key set.