### PR TITLE
Trim username on Sign-In button click

### DIFF
--- a/osu.Game/Overlays/Login/LoginForm.cs
+++ b/osu.Game/Overlays/Login/LoginForm.cs
@@ -140,6 +140,9 @@ namespace osu.Game.Overlays.Login
 
         private void performLogin()
         {
+            // Ensure username is trimmed and fix it visually for the user if not.
+            username.Text = username.Text.Trim();
+
             if (!string.IsNullOrEmpty(username.Text) && !string.IsNullOrEmpty(password.Text))
                 api.Login(username.Text, password.Text);
             else


### PR DESCRIPTION
Little QoL change and fix #31159.

This PR ensure that when we click on the Sign-In button of the `LoginForm` overlay, we don't leave any leading/trailing white-space on the username that would cause Login API request to fail, and we also directly fix it visually for the user.

The issue also talk about the password field, but I'm really unsure about trimming password is a good idea because I do think password can have trailing and leading white-space ? That would cause some passwords to never be able to be submitted as they are expected.


https://github.com/user-attachments/assets/0e49028f-8510-46e7-b479-b55b986a3d0c

