### PR TITLE
Implement pagination for rankings overlay

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -66,6 +66,9 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Move to next page", () => rankingsOverlay.Header.CurrentPage.Value += 1);
             AddStep("Switch to another scope", () => scope.Value = RankingsScope.Score);
             AddAssert("Check page is first one", () => rankingsOverlay.Header.CurrentPage.Value == 0);
+            AddStep("Move to next page", () => rankingsOverlay.Header.CurrentPage.Value += 1);
+            AddStep("Switch to another ruleset", () => rankingsOverlay.Header.Ruleset.Value = new ManiaRuleset().RulesetInfo);
+            AddAssert("Check page is first one", () => rankingsOverlay.Header.CurrentPage.Value == 0);
         }
 
         private void loadRankingsOverlay()

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -62,13 +62,18 @@ namespace osu.Game.Tests.Visual.Online
         [Test]
         public void TestPageSelection()
         {
-            AddStep("Set score to performance", () => scope.Value = RankingsScope.Performance);
+            AddStep("Set scope to performance", () => scope.Value = RankingsScope.Performance);
             AddStep("Move to next page", () => rankingsOverlay.Header.CurrentPage.Value += 1);
             AddStep("Switch to another scope", () => scope.Value = RankingsScope.Score);
             AddAssert("Check page is first one", () => rankingsOverlay.Header.CurrentPage.Value == 0);
             AddStep("Move to next page", () => rankingsOverlay.Header.CurrentPage.Value += 1);
             AddStep("Switch to another ruleset", () => rankingsOverlay.Header.Ruleset.Value = new ManiaRuleset().RulesetInfo);
             AddAssert("Check page is first one", () => rankingsOverlay.Header.CurrentPage.Value == 0);
+
+            AddStep("Set scope to kudosu", () => scope.Value = RankingsScope.Kudosu);
+            AddAssert("Check available pages is 20", () => rankingsOverlay.Header.AvailablesPages.Value == 20);
+            AddStep("Set scope to performance", () => scope.Value = RankingsScope.Performance);
+            AddAssert("Check available pages is 200", () => rankingsOverlay.Header.AvailablesPages.Value == 200);
         }
 
         private void loadRankingsOverlay()

--- a/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneRankingsOverlay.cs
@@ -59,14 +59,24 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Show US", () => rankingsOverlay.ShowCountry(CountryCode.US));
         }
 
+        [Test]
+        public void TestPageSelection()
+        {
+            AddStep("Set score to performance", () => scope.Value = RankingsScope.Performance);
+            AddStep("Move to next page", () => rankingsOverlay.Header.CurrentPage.Value += 1);
+            AddStep("Switch to another scope", () => scope.Value = RankingsScope.Score);
+            AddAssert("Check page is first one", () => rankingsOverlay.Header.CurrentPage.Value == 0);
+        }
+
         private void loadRankingsOverlay()
         {
             Child = rankingsOverlay = new TestRankingsOverlay
             {
-                Country = { BindTarget = countryBindable },
-                Header = { Current = { BindTarget = scope } },
                 State = { Value = Visibility.Visible },
             };
+
+            countryBindable.BindTo(rankingsOverlay.Country);
+            scope.BindTo(rankingsOverlay.Header.Current);
         }
 
         private partial class TestRankingsOverlay : RankingsOverlay

--- a/osu.Game/Overlays/PageableTabbleOnlineOverlay.cs
+++ b/osu.Game/Overlays/PageableTabbleOnlineOverlay.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Overlays
+{
+    public abstract partial class PageableTabbleOnlineOverlay<THeader, TEnum> : TabbableOnlineOverlay<THeader, TEnum>
+        where THeader : PagedTabControlOverlayHeader<TEnum>
+    {
+        protected PageableTabbleOnlineOverlay(OverlayColourScheme colourScheme)
+            : base(colourScheme)
+        {
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            Header.CurrentPage.BindValueChanged(page => OnPageChanged(page.NewValue));
+        }
+
+        protected override void OnTabChanged(TEnum tab)
+        {
+            // Go back to first page if we switch to another tab
+            Header.CurrentPage.SetDefault();
+            base.OnTabChanged(tab);
+        }
+
+        protected virtual void OnPageChanged(int page)
+        {
+            base.OnTabChanged(Header.Current.Value);
+        }
+    }
+}

--- a/osu.Game/Overlays/PagedTabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/PagedTabControlOverlayHeader.cs
@@ -32,8 +32,12 @@ namespace osu.Game.Overlays
                 });
         }
 
-        public void ShowPageSelector() => pageSelector.Show();
-
-        public void HidePageSelector() => pageSelector.Hide();
+        public void ShowPageSelector(bool visible)
+        {
+            if (visible)
+                pageSelector.Show();
+            else
+                pageSelector.Hide();
+        }
     }
 }

--- a/osu.Game/Overlays/PagedTabControlOverlayHeader.cs
+++ b/osu.Game/Overlays/PagedTabControlOverlayHeader.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Graphics.UserInterface.PageSelector;
+
+namespace osu.Game.Overlays
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// An extended overlay header that add a pagination support for a <see cref="TabControlOverlayHeader{T}" />
+    /// </summary>
+    /// <typeparam name="TEnum"></typeparam>
+    public abstract partial class PagedTabControlOverlayHeader<TEnum> : TabControlOverlayHeader<TEnum>
+    {
+        private readonly PageSelector pageSelector;
+
+        public BindableInt CurrentPage => pageSelector.CurrentPage;
+        public BindableInt AvailablesPages => pageSelector.AvailablePages;
+
+        protected PagedTabControlOverlayHeader()
+        {
+            HeaderInfo.Add(
+                pageSelector = new PageSelector
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Margin = new MarginPadding { Vertical = 15 },
+                });
+        }
+
+        public void ShowPageSelector() => pageSelector.Show();
+
+        public void HidePageSelector() => pageSelector.Hide();
+    }
+}

--- a/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
+++ b/osu.Game/Overlays/Rankings/RankingsOverlayHeader.cs
@@ -11,7 +11,7 @@ using osu.Game.Users;
 
 namespace osu.Game.Overlays.Rankings
 {
-    public partial class RankingsOverlayHeader : TabControlOverlayHeader<RankingsScope>
+    public partial class RankingsOverlayHeader : PagedTabControlOverlayHeader<RankingsScope>
     {
         public Bindable<RulesetInfo> Ruleset => rulesetSelector.Current;
 

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -85,6 +85,13 @@ namespace osu.Game.Overlays
             if (Header.Current.Value != RankingsScope.Performance)
                 Country.SetDefault();
 
+            // Hide page selection for spotlights scope
+            if (tab == RankingsScope.Spotlights)
+            {
+                Header.HidePageSelector();
+            }
+            else Header.ShowPageSelector();
+
             Scheduler.AddOnce(triggerTabChanged);
         }
 

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -50,9 +50,10 @@ namespace osu.Game.Overlays
                 if (!Country.IsDefault)
                 {
                     Header.Current.Value = RankingsScope.Performance;
-                    Header.HidePageSelector();
                 }
-                else Header.ShowPageSelector();
+
+                // Hide page selection with country filter
+                Header.ShowPageSelector(Country.IsDefault);
 
                 Scheduler.AddOnce(triggerTabChanged);
             });
@@ -86,11 +87,7 @@ namespace osu.Game.Overlays
                 Country.SetDefault();
 
             // Hide page selection for spotlights scope
-            if (tab == RankingsScope.Spotlights)
-            {
-                Header.HidePageSelector();
-            }
-            else Header.ShowPageSelector();
+            Header.ShowPageSelector(tab != RankingsScope.Spotlights);
 
             Scheduler.AddOnce(triggerTabChanged);
         }

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -86,6 +86,9 @@ namespace osu.Game.Overlays
             if (Header.Current.Value != RankingsScope.Performance)
                 Country.SetDefault();
 
+            // Kudosu scope have only 20 fetchable pages.
+            Header.AvailablesPages.Value = tab == RankingsScope.Kudosu ? 20 : 200;
+
             // Hide page selection for spotlights scope
             Header.ShowPageSelector(tab != RankingsScope.Spotlights);
 

--- a/osu.Game/Overlays/RankingsOverlay.cs
+++ b/osu.Game/Overlays/RankingsOverlay.cs
@@ -15,9 +15,12 @@ using osu.Game.Overlays.Rankings.Tables;
 
 namespace osu.Game.Overlays
 {
-    public partial class RankingsOverlay : TabbableOnlineOverlay<RankingsOverlayHeader, RankingsScope>
+    public partial class RankingsOverlay : PageableTabbleOnlineOverlay<RankingsOverlayHeader, RankingsScope>
     {
         protected Bindable<CountryCode> Country => Header.Country;
+
+        // First page is 0, need to apply +1 to get the right data actually.
+        private int currentPage => Header.CurrentPage.Value + 1;
 
         private APIRequest lastRequest;
 
@@ -45,7 +48,11 @@ namespace osu.Game.Overlays
             {
                 // if a country is requested, force performance scope.
                 if (!Country.IsDefault)
+                {
                     Header.Current.Value = RankingsScope.Performance;
+                    Header.HidePageSelector();
+                }
+                else Header.ShowPageSelector();
 
                 Scheduler.AddOnce(triggerTabChanged);
             });
@@ -83,7 +90,10 @@ namespace osu.Game.Overlays
 
         private void triggerTabChanged() => base.OnTabChanged(Header.Current.Value);
 
-        protected override RankingsOverlayHeader CreateHeader() => new RankingsOverlayHeader();
+        protected override RankingsOverlayHeader CreateHeader() => new RankingsOverlayHeader
+        {
+            AvailablesPages = { Value = 200 }
+        };
 
         public void ShowCountry(CountryCode requested)
         {
@@ -128,16 +138,16 @@ namespace osu.Game.Overlays
             switch (Header.Current.Value)
             {
                 case RankingsScope.Performance:
-                    return new GetUserRankingsRequest(ruleset.Value, countryCode: Country.Value);
+                    return new GetUserRankingsRequest(ruleset.Value, page: currentPage, countryCode: Country.Value);
 
                 case RankingsScope.Country:
-                    return new GetCountryRankingsRequest(ruleset.Value);
+                    return new GetCountryRankingsRequest(ruleset.Value, page: currentPage);
 
                 case RankingsScope.Score:
-                    return new GetUserRankingsRequest(ruleset.Value, UserRankingsType.Score);
+                    return new GetUserRankingsRequest(ruleset.Value, UserRankingsType.Score, page: currentPage);
 
                 case RankingsScope.Kudosu:
-                    return new GetKudosuRankingsRequest();
+                    return new GetKudosuRankingsRequest(page: currentPage);
             }
 
             return null;
@@ -154,10 +164,10 @@ namespace osu.Game.Overlays
                     switch (userRequest.Type)
                     {
                         case UserRankingsType.Performance:
-                            return new PerformanceTable(1, userRequest.Response.Users);
+                            return new PerformanceTable(currentPage, userRequest.Response.Users);
 
                         case UserRankingsType.Score:
-                            return new ScoresTable(1, userRequest.Response.Users);
+                            return new ScoresTable(currentPage, userRequest.Response.Users);
                     }
 
                     return null;
@@ -167,14 +177,14 @@ namespace osu.Game.Overlays
                     if (countryRequest.Response == null)
                         return null;
 
-                    return new CountriesTable(1, countryRequest.Response.Countries);
+                    return new CountriesTable(currentPage, countryRequest.Response.Countries);
                 }
 
                 case GetKudosuRankingsRequest kudosuRequest:
                     if (kudosuRequest.Response == null)
                         return null;
 
-                    return new KudosuTable(1, kudosuRequest.Response.Users);
+                    return new KudosuTable(currentPage, kudosuRequest.Response.Users);
             }
 
             return null;


### PR DESCRIPTION
Closes #31036.

Fully functional but may need to polish the way we implement this because I'm not sure adding the pagination in the Header is the way we want this, waiting for some reviews.
I've tried to visually replicate the website implementation, apart that we only show one page selector (on top) instead of two (bottom and top) as I think having both is kinda useless and we should just choose if we put it on top or bottom of the table.

About the available pages, as we can't fetch the potential total that the API would fetch, we put it to 200 available pages (like in the web version).

This PR also change the way the `TestRankingsOverlay` is loaded for tests Set-up to better start from a clean instance on each test.


https://github.com/user-attachments/assets/54aa7c55-143b-416c-bd20-e95798aaebb1

