### PR TITLE
Remove Conditional `SkillRating` nerf to Converts

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -113,9 +113,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 // For maps with relax, multiple inputs are more likely to be abused.
                 if (isRelax)
                     starRating *= 0.60;
-                // For maps with either relax or low colour variance and high stamina requirement, multiple inputs are more likely to be abused.
-                else if (colourRating < 2 && staminaRating > 8)
-                    starRating *= 0.80;
             }
 
             HitWindows hitWindows = new TaikoHitWindows();


### PR DESCRIPTION
With the addition of `monostaminafactor`, the blanket convert nerf for values above 8* doesn't make sense, this uncaps the blanket nerf to `starRating` where `colourRating < 2` and `staminaRating > 8`.

This provides no value changes to most maps, as there is only one significant converts that meets this requirement. The only noticeable change will be (among the lower dt scores) will be:

Ney: 28065 - StrangeProgram by DJ Sharpnel (HDDTFL) `96.34, 2x | Old = 659.21pp | New = 1009.77pp`

New including #31195 - `1137.18pp`

Old:
SR NM - 7.95* : SR DT - 8.32*

New:
SR NM - 7.95* : SR DT - 10.40*
