### PR TITLE
Implement `Reading` Skill into osu!taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Difficulty.Utils;
+using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
+
+namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
+{
+    public static class ReadingEvaluator
+    {
+        private readonly struct VelocityRange
+        {
+            public double Min { get; }
+            public double Max { get; }
+            public double Center => (Max + Min) / 2;
+            public double Range => Max - Min;
+
+            public VelocityRange(double min, double max)
+            {
+                Min = min;
+                Max = max;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the influence of higher slider velocities on hitobject difficulty.
+        /// The bonus is determined based on the EffectiveBPM, shifting within a defined range
+        /// between the upper and lower boundaries to reflect how increased slider velocity impacts difficulty.
+        /// </summary>
+        /// <param name="noteObject">The hit object to evaluate.</param>
+        /// <returns>The reading difficulty value for the given hit object.</returns>
+        public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
+        {
+            double effectiveBPM = noteObject.EffectiveBPM;
+
+            var highVelocity = new VelocityRange(480, 640);
+            var midVelocity = new VelocityRange(360, 480);
+
+            return 1.0 * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10))
+                   + 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Reading/EffectiveBPM.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Reading/EffectiveBPM.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+
+namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Reading
+{
+    public class EffectiveBPMPreprocessor
+    {
+        private readonly IList<TaikoDifficultyHitObject> noteObjects;
+        private readonly double globalSliderVelocity;
+
+        public EffectiveBPMPreprocessor(IBeatmap beatmap, List<TaikoDifficultyHitObject> noteObjects)
+        {
+            this.noteObjects = noteObjects;
+            globalSliderVelocity = beatmap.Difficulty.SliderMultiplier;
+        }
+
+        /// <summary>
+        /// Calculates and sets the effective BPM and slider velocity for each note object, considering clock rate and scroll speed.
+        /// </summary>
+        public void ProcessEffectiveBPM(ControlPointInfo controlPointInfo, double clockRate)
+        {
+            foreach (var currentNoteObject in noteObjects)
+            {
+                double startTime = currentNoteObject.StartTime * clockRate;
+
+                // Retrieve the timing point at the note's start time
+                TimingControlPoint currentControlPoint = controlPointInfo.TimingPointAt(startTime);
+
+                // Calculate the slider velocity at the note's start time.
+                double currentSliderVelocity = calculateSliderVelocity(controlPointInfo, startTime, clockRate);
+                currentNoteObject.CurrentSliderVelocity = currentSliderVelocity;
+
+                currentNoteObject.EffectiveBPM = currentControlPoint.BPM * currentSliderVelocity;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the slider velocity based on control point info and clock rate.
+        /// </summary>
+        private double calculateSliderVelocity(ControlPointInfo controlPointInfo, double startTime, double clockRate)
+        {
+            var activeEffectControlPoint = controlPointInfo.EffectPointAt(startTime);
+            return globalSliderVelocity * (activeEffectControlPoint.ScrollSpeed) * clockRate;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/TaikoDifficultyHitObject.cs
@@ -49,6 +49,16 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing
         public readonly TaikoDifficultyHitObjectColour Colour;
 
         /// <summary>
+        /// The adjusted BPM of this hit object, based on its slider velocity and scroll speed.
+        /// </summary>
+        public double EffectiveBPM;
+
+        /// <summary>
+        /// The current slider velocity of this hit object.
+        /// </summary>
+        public double CurrentSliderVelocity;
+
+        /// <summary>
         /// Creates a new difficulty hit object.
         /// </summary>
         /// <param name="hitObject">The gameplay <see cref="HitObject"/> associated with this difficulty object.</param>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Skills/Reading.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Taiko.Difficulty.Evaluators;
+using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.Difficulty.Skills
+{
+    /// <summary>
+    /// Calculates the reading coefficient of taiko difficulty.
+    /// </summary>
+    public class Reading : StrainDecaySkill
+    {
+        protected override double SkillMultiplier => 1.0;
+        protected override double StrainDecayBase => 0.4;
+
+        private double currentStrain;
+
+        public Reading(Mod[] mods)
+            : base(mods)
+        {
+        }
+
+        protected override double StrainValueOf(DifficultyHitObject current)
+        {
+            // Drum Rolls and Swells are exempt.
+            if (current.BaseObject is not Hit)
+            {
+                return 0.0;
+            }
+
+            var taikoObject = (TaikoDifficultyHitObject)current;
+
+            currentStrain *= StrainDecayBase;
+            currentStrain += ReadingEvaluator.EvaluateDifficultyOf(taikoObject) * SkillMultiplier;
+
+            return currentStrain;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyAttributes.cs
@@ -29,6 +29,12 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         public double RhythmDifficulty { get; set; }
 
         /// <summary>
+        /// The difficulty corresponding to the reading skill.
+        /// </summary>
+        [JsonProperty("reading_difficulty")]
+        public double ReadingDifficulty { get; set; }
+
+        /// <summary>
         /// The difficulty corresponding to the colour skill.
         /// </summary>
         [JsonProperty("colour_difficulty")]

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -87,9 +87,6 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             if (score.Mods.Any(m => m is ModHidden))
                 difficultyValue *= 1.025;
 
-            if (score.Mods.Any(m => m is ModHardRock))
-                difficultyValue *= 1.10;
-
             if (score.Mods.Any(m => m is ModFlashlight<TaikoHitObject>))
                 difficultyValue *= Math.Max(1, 1.050 - Math.Min(attributes.MonoStaminaFactor / 50, 1) * lengthBonus);
 


### PR DESCRIPTION
# Introduction of the Reading Skill within osu!taiko

## Reading Evaluator
Calculates the influence of higher slider velocities on hitobject difficulty. The bonus is determined based on the EffectiveBPM, shifting within a defined range of a sigmoid function between the upper and lower boundaries to reflect how increased slider velocity impacts difficulty.

Two ranges are used, one for high velocity, and one for mid-range velocity, with mid-range giving less of a bonus.

- Drumrolls and Swells are exempt from reading difficulty calculation, as they are not required to be hit.
- Convert Penalty once again increased due to converts having generally higher SV than osu!taiko maps.

## EffectiveBPM Preprocessor
Calculates and sets the effective BPM and slider velocity for each note object, considering clock rate and scroll speed. This is map based, as both its base slider velocity and its scroll speed are defined differently, is determined by accessing ControlPoints for timing.

## Performance Points Changes
- Removed fixed HR Difficulty Performance Point multipliers , this is now handled only within Star Rating Calculation and the Accuracy side of Performance Points.