### PR TITLE
Add a toggle for time-stretching different playback rates in editor

### DIFF
--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -100,6 +100,11 @@ namespace osu.Game.Localisation
         public static LocalisableString PlaybackSpeed => new TranslatableString(getKey(@"playback_speed"), @"Playback speed");
 
         /// <summary>
+        /// "Adjust pitch"
+        /// </summary>
+        public static LocalisableString AdjustPitch => new TranslatableString(getKey(@"adjust_pitch"), @"Adjust pitch");
+
+        /// <summary>
         /// "Test!"
         /// </summary>
         public static LocalisableString TestBeatmap => new TranslatableString(getKey(@"test_beatmap"), @"Test!");

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Screens.Edit.Components
     public partial class PlaybackControl : BottomBarContainer
     {
         private IconButton playButton = null!;
-        private Bindable<bool> adjustPitch = new Bindable<bool>(false);
+        private readonly Bindable<bool> adjustPitch = new Bindable<bool>(false);
 
         [Resolved]
         private EditorClock editorClock { get; set; } = null!;


### PR DESCRIPTION
I really like being able to change the rate of playback in the editor's timing mode.

I understand that a change was made back in mid June (1b4a3b0e2eb) to have playback control use time-stretching in order to preserve pitch, and that this produces a lot of artifacts, making the resulting audio unreliable for timing purposes.

As a compromise, I've added a switch button that toggles between time-stretching and mere resampling. The switch is also automatic when navigating to and from timing mode.