### PR TITLE
Add `Hidden` cursor state flag on non-desktop platforms as well

### DIFF
--- a/osu.Desktop/OsuGameDesktop.cs
+++ b/osu.Desktop/OsuGameDesktop.cs
@@ -134,7 +134,6 @@ namespace osu.Desktop
             if (iconStream != null)
                 host.Window.SetIconFromStream(iconStream);
 
-            host.Window.CursorState |= CursorState.Hidden;
             host.Window.Title = Name;
         }
 

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -319,6 +319,7 @@ namespace osu.Game
 
             if (host.Window != null)
             {
+                host.Window.CursorState |= CursorState.Hidden;
                 host.Window.DragDrop += path =>
                 {
                     // on macOS/iOS, URL associations are handled via SDL_DROPFILE events.


### PR DESCRIPTION
- Closes #31233
- Related to https://github.com/ppy/osu/issues/22864

This makes the "high precision mouse" setting effective on iPadOS, however, raw mouse input is completely broke on iPadOS similar to macOS. The default value of the setting should be changed to false on such platforms anyway (https://github.com/ppy/osu-framework/pull/6469).

This hides the little iPad system cursor that is shown along the menu cursor.