### PR TITLE
Save "featured artists" filter to user settings and disable toggling on iOS

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -57,6 +57,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.ChatDisplayHeight, ChatOverlay.DEFAULT_HEIGHT, 0.2f, 1f, 0.01f);
 
             SetDefault(OsuSetting.BeatmapListingCardSize, BeatmapCardSize.Normal);
+            SetDefault(OsuSetting.BeatmapListingFeaturedArtistFilter, true);
 
             SetDefault(OsuSetting.ProfileCoverExpanded, true);
 
@@ -450,5 +451,6 @@ namespace osu.Game.Configuration
         EditorAdjustExistingObjectsOnTimingChanges,
         AlwaysRequireHoldingForPause,
         MultiplayerShowInProgressFilter,
+        BeatmapListingFeaturedArtistFilter,
     }
 }

--- a/osu.Game/Localisation/BeatmapOverlayStrings.cs
+++ b/osu.Game/Localisation/BeatmapOverlayStrings.cs
@@ -29,9 +29,9 @@ This includes content that may not be correctly licensed for osu! usage. Browse 
         public static LocalisableString UserContentConfirmButtonText => new TranslatableString(getKey(@"understood"), @"I understand");
 
         /// <summary>
-        /// "Toggling this filter is disabled in this platform."
+        /// "Featured Artists are music artists who have collaborated with osu! to make a selection of their tracks available for use in beatmaps. For some osu! releases, we showcase only featured artist beatmaps to better support the surrounding ecosystem."
         /// </summary>
-        public static LocalisableString FeaturedArtistsDisabledTooltip => new TranslatableString(getKey(@"featured_artists_disabled_tooltip"), @"Toggling this filter is disabled in this platform.");
+        public static LocalisableString FeaturedArtistsTooltip => new TranslatableString(getKey(@"featured_artists_disabled_tooltip"), @"Featured Artists are music artists who have collaborated with osu! to make a selection of their tracks available for use in beatmaps. For some osu! releases, we showcase only featured artist beatmaps to better support the surrounding ecosystem.");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/BeatmapOverlayStrings.cs
+++ b/osu.Game/Localisation/BeatmapOverlayStrings.cs
@@ -28,6 +28,11 @@ This includes content that may not be correctly licensed for osu! usage. Browse 
         /// </summary>
         public static LocalisableString UserContentConfirmButtonText => new TranslatableString(getKey(@"understood"), @"I understand");
 
+        /// <summary>
+        /// "Toggling this filter is disabled in this platform."
+        /// </summary>
+        public static LocalisableString FeaturedArtistsDisabledTooltip => new TranslatableString(getKey(@"featured_artists_disabled_tooltip"), @"Toggling this filter is disabled in this platform.");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -221,10 +221,9 @@ namespace osu.Game
         private readonly List<OverlayContainer> visibleBlockingOverlays = new List<OverlayContainer>();
 
         /// <summary>
-        /// Whether the game should be limited from providing access to download non-featured-artist beatmaps.
-        /// This only affects the "featured artists" filter in the beatmap listing overlay.
+        /// Whether the game should be limited to only display licensed content.
         /// </summary>
-        public bool LimitedToFeaturedArtists => RuntimeInfo.OS == RuntimeInfo.Platform.iOS;
+        public bool HideUnlicensedContent => RuntimeInfo.OS == RuntimeInfo.Platform.iOS;
 
         public OsuGame(string[] args = null)
         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -224,7 +224,7 @@ namespace osu.Game
         /// Whether the game should be limited from providing access to download non-featured-artist beatmaps.
         /// This only affects the "featured artists" filter in the beatmap listing overlay.
         /// </summary>
-        public bool LimitedToFeaturedArtists => RuntimeInfo.OS == RuntimeInfo.Platform.iOS && true;
+        public bool LimitedToFeaturedArtists => RuntimeInfo.OS == RuntimeInfo.Platform.iOS;
 
         public OsuGame(string[] args = null)
         {

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -220,6 +220,12 @@ namespace osu.Game
 
         private readonly List<OverlayContainer> visibleBlockingOverlays = new List<OverlayContainer>();
 
+        /// <summary>
+        /// Whether the game should be limited from providing access to download non-featured-artist beatmaps.
+        /// This only affects the "featured artists" filter in the beatmap listing overlay.
+        /// </summary>
+        public bool LimitedToFeaturedArtists => RuntimeInfo.OS == RuntimeInfo.Platform.iOS && true;
+
         public OsuGame(string[] args = null)
         {
             this.args = args;

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -221,9 +221,9 @@ namespace osu.Game
         private readonly List<OverlayContainer> visibleBlockingOverlays = new List<OverlayContainer>();
 
         /// <summary>
-        /// Whether the game should be limited to only display licensed content.
+        /// Whether the game should be limited to only display officially licensed content.
         /// </summary>
-        public bool HideUnlicensedContent => RuntimeInfo.OS == RuntimeInfo.Platform.iOS;
+        public virtual bool HideUnlicensedContent => false;
 
         public OsuGame(string[] args = null)
         {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 if (!Active.Value)
                     disclaimerShown.Value = true;
 
-                if (game.LimitedToFeaturedArtists)
+                if (game.HideUnlicensedContent)
                 {
                     Enabled.Value = false;
                     Active.Disabled = true;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -126,9 +126,6 @@ namespace osu.Game.Overlays.BeatmapListing
             private OsuColour colours { get; set; } = null!;
 
             [Resolved]
-            private OsuGame game { get; set; } = null!;
-
-            [Resolved]
             private OsuConfigManager config { get; set; } = null!;
 
             [Resolved]
@@ -136,6 +133,9 @@ namespace osu.Game.Overlays.BeatmapListing
 
             [Resolved]
             private IDialogOverlay? dialogOverlay { get; set; }
+
+            [Resolved]
+            private OsuGame? game { get; set; }
 
             protected override void LoadComplete()
             {
@@ -148,7 +148,7 @@ namespace osu.Game.Overlays.BeatmapListing
                 if (!Active.Value)
                     disclaimerShown.Value = true;
 
-                if (game.HideUnlicensedContent)
+                if (game?.HideUnlicensedContent == true)
                 {
                     Enabled.Value = false;
                     Active.Disabled = true;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
@@ -113,7 +114,7 @@ namespace osu.Game.Overlays.BeatmapListing
             }
         }
 
-        private partial class FeaturedArtistsTabItem : MultipleSelectionFilterTabItem
+        private partial class FeaturedArtistsTabItem : MultipleSelectionFilterTabItem, IHasTooltip
         {
             private Bindable<bool> disclaimerShown = null!;
 
@@ -136,6 +137,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
             [Resolved]
             private OsuGame? game { get; set; }
+
+            public LocalisableString TooltipText => !Enabled.Value ? BeatmapOverlayStrings.FeaturedArtistsDisabledTooltip : string.Empty;
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Overlays.BeatmapListing
             [Resolved]
             private OsuGame? game { get; set; }
 
-            public LocalisableString TooltipText => !Enabled.Value ? BeatmapOverlayStrings.FeaturedArtistsDisabledTooltip : string.Empty;
+            public LocalisableString TooltipText => BeatmapOverlayStrings.FeaturedArtistsTooltip;
 
             protected override void LoadComplete()
             {

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -126,6 +126,9 @@ namespace osu.Game.Overlays.BeatmapListing
             private OsuColour colours { get; set; } = null!;
 
             [Resolved]
+            private OsuGame game { get; set; } = null!;
+
+            [Resolved]
             private OsuConfigManager config { get; set; } = null!;
 
             [Resolved]
@@ -144,6 +147,12 @@ namespace osu.Game.Overlays.BeatmapListing
                 // no need to show the disclaimer if the user already had it toggled off in config.
                 if (!Active.Value)
                     disclaimerShown.Value = true;
+
+                if (game.LimitedToFeaturedArtists)
+                {
+                    Enabled.Value = false;
+                    Active.Disabled = true;
+                }
             }
 
             protected override Color4 ColourNormal => colours.Orange1;
@@ -151,6 +160,9 @@ namespace osu.Game.Overlays.BeatmapListing
 
             protected override bool OnClick(ClickEvent e)
             {
+                if (!Enabled.Value)
+                    return true;
+
                 if (!disclaimerShown.Value && dialogOverlay != null)
                 {
                     dialogOverlay.Push(new FeaturedArtistConfirmDialog(() =>

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchGeneralFilterRow.cs
@@ -126,6 +126,9 @@ namespace osu.Game.Overlays.BeatmapListing
             private OsuColour colours { get; set; } = null!;
 
             [Resolved]
+            private OsuConfigManager config { get; set; } = null!;
+
+            [Resolved]
             private SessionStatics sessionStatics { get; set; } = null!;
 
             [Resolved]
@@ -135,7 +138,12 @@ namespace osu.Game.Overlays.BeatmapListing
             {
                 base.LoadComplete();
 
+                config.BindWith(OsuSetting.BeatmapListingFeaturedArtistFilter, Active);
                 disclaimerShown = sessionStatics.GetBindable<bool>(Static.FeaturedArtistDisclaimerShownOnce);
+
+                // no need to show the disclaimer if the user already had it toggled off in config.
+                if (!Active.Value)
+                    disclaimerShown.Value = true;
             }
 
             protected override Color4 ColourNormal => colours.Orange1;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -107,7 +107,6 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             private Container activeContent = null!;
             private Circle background = null!;
-            private SpriteIcon icon = null!;
 
             public MultipleSelectionFilterTabItem(T value)
                 : base(value)
@@ -129,6 +128,7 @@ namespace osu.Game.Overlays.BeatmapListing
                     Alpha = 0,
                     Padding = new MarginPadding
                     {
+                        Left = -16,
                         Right = -4,
                         Vertical = -2
                     },
@@ -139,9 +139,8 @@ namespace osu.Game.Overlays.BeatmapListing
                             Colour = Color4.White,
                             RelativeSizeAxes = Axes.Both,
                         },
-                        icon = new SpriteIcon
+                        new SpriteIcon
                         {
-                            Alpha = 0f,
                             Icon = FontAwesome.Solid.TimesCircle,
                             Size = new Vector2(10),
                             Colour = ColourProvider.Background4,
@@ -173,19 +172,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
                 if (Active.Value)
                 {
-                    if (Enabled.Value)
-                    {
-                        // This just allows enough spacing for adjacent tab items to show the "x".
-                        Padding = new MarginPadding { Left = 12 };
-                        activeContent.Padding = activeContent.Padding with { Left = -16 };
-                        icon.Show();
-                    }
-                    else
-                    {
-                        Padding = new MarginPadding();
-                        activeContent.Padding = activeContent.Padding with { Left = -4 };
-                        icon.Hide();
-                    }
+                    // This just allows enough spacing for adjacent tab items to show the "x".
+                    Padding = new MarginPadding { Left = 12 };
 
                     activeContent.FadeIn(200, Easing.OutQuint);
                     background.FadeColour(colour, 200, Easing.OutQuint);

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -76,8 +76,6 @@ namespace osu.Game.Overlays.BeatmapListing
                 {
                     if (!c.Active.Disabled)
                         c.Active.Value = Current.Contains(c.Value);
-                    else if (c.Active.Value != Current.Contains(c.Value))
-                        throw new InvalidOperationException($"Expected filter {c.Value} to be set to {Current.Contains(c.Value)}, but was {c.Active.Value}");
                 }
             }
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapSearchMultipleSelectionFilterRow.cs
@@ -183,7 +183,7 @@ namespace osu.Game.Overlays.BeatmapListing
                     else
                     {
                         Padding = new MarginPadding();
-                        activeContent.Padding = activeContent.Padding with { Left = -6 };
+                        activeContent.Padding = activeContent.Padding with { Left = -4 };
                         icon.Hide();
                     }
 

--- a/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
+++ b/osu.Game/Overlays/BeatmapListing/FilterTabItem.cs
@@ -57,7 +57,9 @@ namespace osu.Game.Overlays.BeatmapListing
         {
             base.LoadComplete();
 
+            Enabled.BindValueChanged(_ => UpdateState());
             UpdateState();
+
             FinishTransforms(true);
         }
 

--- a/osu.iOS/OsuGameIOS.cs
+++ b/osu.iOS/OsuGameIOS.cs
@@ -17,6 +17,8 @@ namespace osu.iOS
     {
         public override Version AssemblyVersion => new Version(NSBundle.MainBundle.InfoDictionary["CFBundleVersion"].ToString());
 
+        public override bool HideUnlicensedContent => true;
+
         protected override UpdateManager CreateUpdateManager() => new MobileUpdateNotifier();
 
         protected override BatteryInfo CreateBatteryInfo() => new IOSBatteryInfo();


### PR DESCRIPTION
The toggle will remain visible on iOS but in a grayed and non-interactive state. Hiding it would be misleading since it's always turned on.