### PR TITLE
Fix some hitcircle sprites missing in certain skins since last release

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -61,13 +61,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             var drawableOsuObject = (DrawableOsuHitObject?)drawableObject;
 
-            // As a precondition, ensure that any prefix lookups are run against the skin which is providing "hitcircle".
+            // As a precondition, prefer that any *prefix* lookups are run against the skin which is providing "hitcircle".
             // This is to correctly handle a case such as:
             //
             // - Beatmap provides `hitcircle`
             // - User skin provides `sliderstartcircle`
             //
             // In such a case, the `hitcircle` should be used for slider start circles rather than the user's skin override.
+            //
+            // Of note, this consideration should only be used to decide whether to continue looking up the prefixed name or not.
+            // The final lookups must still run on the full skin hierarchy as per usual in order to correctly handle fallback cases.
             var provider = skin.FindProvider(s => s.GetTexture(base_lookup) != null) ?? skin;
 
             // if a base texture for the specified prefix exists, continue using it for subsequent lookups.
@@ -81,7 +84,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             // expected behaviour in this scenario is not showing the overlay, rather than using hitcircleoverlay.png.
             InternalChildren = new[]
             {
-                CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = provider.GetTexture(circleName)?.WithMaximumSize(maxSize) })
+                CircleSprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(circleName)?.WithMaximumSize(maxSize) })
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -90,7 +93,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = provider.GetTexture(@$"{circleName}overlay")?.WithMaximumSize(maxSize) })
+                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(@$"{circleName}overlay")?.WithMaximumSize(maxSize) })
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,


### PR DESCRIPTION
I was a bit too eager to replace all calls with the new `provider` in https://github.com/ppy/osu/commit/dae380b7fa927c351e2e413c5b23834f717908d9, while it doesn't actually make sense.

To handle the case that was trying to be fixed, using the `provider` to check whether the *prefix* version of the circle sprite is available is enough alone.

Closes https://github.com/ppy/osu/issues/31200

Have tested against the skins linked in #31200, along with the original test case used in https://github.com/ppy/osu/pull/31052 (https://github.com/ppy/osu/discussions/30927#discussioncomment-11444118)


