### PR TITLE
Add `Alt`+`MouseWheel` as a global volume adjust binding

### DIFF
--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -209,7 +209,9 @@ namespace osu.Game.Input.Bindings
         private static IEnumerable<KeyBinding> audioControlKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.Alt, InputKey.Up }, GlobalAction.IncreaseVolume),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.MouseWheelUp }, GlobalAction.IncreaseVolume),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Down }, GlobalAction.DecreaseVolume),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.MouseWheelDown }, GlobalAction.DecreaseVolume),
 
             new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, GlobalAction.PreviousVolumeMeter),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, GlobalAction.NextVolumeMeter),


### PR DESCRIPTION
This offers the defaults users have come to expect while also allowing rebinding (if they don't want it) and better compatibility with other global actions (since this is no longer implemented using `OnScroll` event flow).

Addresses part of https://github.com/ppy/osu/issues/31267.