### PR TITLE
Add `consistentRatioPenalty` to the `Colour` skill.

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(2.9028399902546886d, 200, "diffcalc-test")]
-        [TestCase(2.9028399902546886d, 200, "diffcalc-test-strong")]
+        [TestCase(2.8492342476337797d, 200, "diffcalc-test")]
+        [TestCase(2.8492342476337797d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(3.8741038430570431d, 200, "diffcalc-test")]
-        [TestCase(3.8741038430570431d, 200, "diffcalc-test-strong")]
+        [TestCase(3.8179679353183031d, 200, "diffcalc-test")]
+        [TestCase(3.8179679353183031d, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -21,7 +21,6 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         [TestCase(3.8741038430570431d, 200, "diffcalc-test")]
         [TestCase(3.8741038430570431d, 200, "diffcalc-test-strong")]
-
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(2.8492342476337797d, 200, "diffcalc-test")]
-        [TestCase(2.8492342476337797d, 200, "diffcalc-test-strong")]
+        [TestCase(2.837609165845338d, 200, "diffcalc-test")]
+        [TestCase(2.837609165845338d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(3.8179679353183031d, 200, "diffcalc-test")]
-        [TestCase(3.8179679353183031d, 200, "diffcalc-test-strong")]
+        [TestCase(3.8005218640444949, 200, "diffcalc-test")]
+        [TestCase(3.8005218640444949, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(3.0920212594351191d, 200, "diffcalc-test")]
-        [TestCase(3.0920212594351191d, 200, "diffcalc-test-strong")]
+        [TestCase(2.9028399902546886d, 200, "diffcalc-test")]
+        [TestCase(2.9028399902546886d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(4.0789820318081444d, 200, "diffcalc-test")]
-        [TestCase(4.0789820318081444d, 200, "diffcalc-test-strong")]
+        [TestCase(3.8741038430570431d, 200, "diffcalc-test")]
+        [TestCase(3.8741038430570431d, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 
             double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.15;
 
-            return 1.0 - (1 - ratioPenalty);
+            return ratioPenalty;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -36,17 +36,63 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             return 2 * (1 - DifficultyCalculationUtils.Logistic(exponent: Math.E * repeatingHitPattern.RepetitionInterval - 2 * Math.E));
         }
 
+        /// <summary>
+        /// Calculates a consistency penalty based on the number of consecutive consistent intervals,
+        /// considering the delta time between each colour sequence.
+        /// </summary>
+        /// <param name="hitObject">The current hitObject to consider.</param>
+        /// <param name="threshold"> The allowable margin of error for determining whether ratios are consistent.</param>
+        private static double consistentRatioPenalty(TaikoDifficultyHitObject hitObject, double threshold = 0.01)
+        {
+            int consistentRatioCount = 0;
+            double totalRatioCount = 0.0;
+
+            TaikoDifficultyHitObject current = hitObject;
+
+            while (current.Previous(1) is TaikoDifficultyHitObject previousHitObject)
+            {
+                double currentRatio = current.Rhythm.Ratio;
+                double previousRatio = previousHitObject.Rhythm.Ratio;
+
+                // If there's no valid hit object before the previous one, break the loop.
+                if (previousHitObject.Previous(1) is not TaikoDifficultyHitObject)
+                    break;
+
+                // A consistent interval is defined as the percentage difference between the two rhythmic ratios with the margin of error.
+                if (Math.Abs(1 - currentRatio / previousRatio) <= threshold)
+                {
+                    consistentRatioCount++;
+                    totalRatioCount += currentRatio;
+                }
+
+                current = previousHitObject;
+            }
+
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.15;
+
+            return 1.0 - (1 - ratioPenalty);
+        }
+
+        /// <summary>
+        /// Evaluate the difficulty of the first hitobject within a colour streak.
+        /// </summary>
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)
         {
             TaikoDifficultyHitObjectColour colour = ((TaikoDifficultyHitObject)hitObject).Colour;
+            var taikoObject = (TaikoDifficultyHitObject)hitObject;
             double difficulty = 0.0d;
 
             if (colour.MonoStreak?.FirstHitObject == hitObject) // Difficulty for MonoStreak
                 difficulty += EvaluateDifficultyOf(colour.MonoStreak);
+
             if (colour.AlternatingMonoPattern?.FirstHitObject == hitObject) // Difficulty for AlternatingMonoPattern
                 difficulty += EvaluateDifficultyOf(colour.AlternatingMonoPattern);
+
             if (colour.RepeatingHitPattern?.FirstHitObject == hitObject) // Difficulty for RepeatingHitPattern
                 difficulty += EvaluateDifficultyOf(colour.RepeatingHitPattern);
+
+            double consistencyPenalty = consistentRatioPenalty(taikoObject);
+            difficulty *= consistencyPenalty;
 
             return difficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -1,3 +1,4 @@
+
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
@@ -68,7 +69,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 current = previousHitObject;
             }
 
-            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.15;
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.30;
 
             return ratioPenalty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -43,18 +43,20 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <param name="hitObject">The current hitObject to consider.</param>
         /// <param name="threshold"> The allowable margin of error for determining whether ratios are consistent.</param>
         /// <param name="maxObjectsToCheck">The maximum objects to check per count of consistent ratio.</param>
-        private static double consistentRatioPenalty(TaikoDifficultyHitObject? hitObject, double threshold = 0.01, int maxObjectsToCheck = 64)
+        private static double consistentRatioPenalty(TaikoDifficultyHitObject hitObject, double threshold = 0.01, int maxObjectsToCheck = 64)
         {
             int consistentRatioCount = 0;
             double totalRatioCount = 0.0;
 
-            TaikoDifficultyHitObject? current = hitObject;
+            TaikoDifficultyHitObject current = hitObject;
 
             for (int i = 0; i < maxObjectsToCheck; i++)
             {
-                // If there is no previous or current object to check, break the loop.
-                if (current?.Previous(1) is not TaikoDifficultyHitObject previousHitObject || previousHitObject.Index <= 1)
+                // Break if there is no valid previous object
+                if (current.Index <= 1)
                     break;
+
+                var previousHitObject = (TaikoDifficultyHitObject)current.Previous(1);
 
                 double currentRatio = current.Rhythm.Ratio;
                 double previousRatio = previousHitObject.Rhythm.Ratio;
@@ -67,6 +69,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                     break;
                 }
 
+                // Move to the previous object
                 current = previousHitObject;
             }
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 current = previousHitObject;
             }
 
-            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.30;
+            double ratioPenalty = 1 - totalRatioCount / (consistentRatioCount + 1) * 0.40;
 
             return ratioPenalty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ColourEvaluator.cs
@@ -78,8 +78,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// </summary>
         public static double EvaluateDifficultyOf(DifficultyHitObject hitObject)
         {
-            TaikoDifficultyHitObjectColour colour = ((TaikoDifficultyHitObject)hitObject).Colour;
             var taikoObject = (TaikoDifficultyHitObject)hitObject;
+            TaikoDifficultyHitObjectColour colour = taikoObject.Colour;
             double difficulty = 0.0d;
 
             if (colour.MonoStreak?.FirstHitObject == hitObject) // Difficulty for MonoStreak


### PR DESCRIPTION
## osu!taiko Colour Skill Fix

Relies on #31284 for values to look good. Both of these are available for testing on huismetbenen together.

Introduces a new method, consistentRatioPenalty, to evaluate a consistency penalty based on the number of consecutive consistent intervals in rhythmic ratios. The function is designed to penalise patterns with excessive consistency in rhythmic sequences.

- Consistency Check: Compares the ratio of current and previous rhythmic intervals, applying a penalty if the percentage difference between the ratios is within a defined margin of error (threshold).
- 
- Penalty Calculation: The penalty scales based on the number of consecutive consistent intervals (consistentRatioCount) and the cumulative sum of their ratios (totalRatioCount).

The loop terminates when no valid previous TaikoDifficultyHitObject is available, as well as terminating on rhythm change, to ensure that this doesn't affect performance of the calculator, this has been tested with minimal increase to map load and calculation times.