### PR TITLE
osu!taiko pooling [seems like incorrect way]

### DIFF
--- a/osu.Game.Benchmarks/BenchmarkHitObject.cs
+++ b/osu.Game.Benchmarks/BenchmarkHitObject.cs
@@ -74,11 +74,11 @@ namespace osu.Game.Benchmarks
 
             for (int i = 0; i < Count; i++)
             {
-                hits[i] = new Hit();
+                hits[i] = new HitCentre();
 
                 if (WithBindableAccess)
                 {
-                    _ = hits[i].TypeBindable;
+                    _ = hits[i].Type;
                     _ = hits[i].IsStrongBindable;
                     _ = hits[i].SamplesBindable;
                     _ = hits[i].StartTimeBindable;

--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTaikoRulesetTestScene.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             return new Beatmap
             {
-                HitObjects = new List<HitObject> { new Hit { Type = HitType.Centre } },
+                HitObjects = new List<HitObject> { new HitCentre() },
                 BeatmapInfo = new BeatmapInfo
                 {
                     Difficulty = new BeatmapDifficulty(),

--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTestHit.cs
@@ -7,6 +7,7 @@ using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Tests
 {
@@ -39,5 +40,12 @@ namespace osu.Game.Rulesets.Taiko.Tests
         }
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
+
+        public override TaikoAction[] HitActions
+        {
+            get => HitObject.Type == HitType.Centre ? [TaikoAction.LeftCentre, TaikoAction.RightCentre] : [TaikoAction.LeftRim, TaikoAction.RightRim];
+            protected set { }
+        }
+        protected override SkinnableDrawable? OnLoadCreateMainPiece() => null;
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/DrawableTestStrongHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/DrawableTestStrongHit.cs
@@ -14,7 +14,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private readonly bool hitBoth;
 
         public DrawableTestStrongHit(double startTime, HitResult type = HitResult.Great, bool hitBoth = true)
-            : base(new Hit
+            : base(new HitCentre
             {
                 IsStrong = true,
                 StartTime = startTime,

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
@@ -23,8 +23,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
             AddStep("clear objects", () => EditorBeatmap.Clear());
             AddStep("add two objects", () =>
             {
-                EditorBeatmap.Add(new Hit { StartTime = 1818 });
-                EditorBeatmap.Add(new Hit { StartTime = 1584 });
+                EditorBeatmap.Add(new HitCentre { StartTime = 1818 });
+                EditorBeatmap.Add(new HitCentre { StartTime = 1584 });
             });
             AddStep("seek back", () => EditorClock.Seek(1584));
             AddStep("choose hit placement tool", () => InputManager.Key(Key.Number2));

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorTestGameplay.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoEditorTestGameplay.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
             {
                 EditorBeatmap.Clear();
                 EditorBeatmap.Add(new Swell { StartTime = 500, EndTime = 1500 });
-                EditorBeatmap.Add(new Hit { StartTime = 3000 });
+                EditorBeatmap.Add(new HitCentre { StartTime = 3000 });
             });
             AddStep("seek to 250", () => EditorClock.Seek(250));
             AddUntilStep("wait for seek", () => EditorClock.CurrentTime, () => Is.EqualTo(250));

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneTaikoHitObjectComposer.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
                 };
 
                 for (int i = 0; i < 10; i++)
-                    EditorBeatmap.Add(new Hit { StartTime = 125 * i });
+                    EditorBeatmap.Add(new HitCentre { StartTime = 125 * i });
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneHitJudgements.cs
@@ -26,9 +26,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(hit_time, TaikoAction.LeftCentre),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time
             }));
 
@@ -43,13 +42,11 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(1000, TaikoAction.LeftCentre, TaikoAction.RightCentre),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = 1000,
-            }, new Hit
+            }, new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = 1020
             }));
 
@@ -67,9 +64,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(hit_time, TaikoAction.LeftRim),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitRim
             {
-                Type = HitType.Rim,
                 StartTime = hit_time
             }));
 
@@ -85,9 +81,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0)
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time
             }));
 
@@ -104,9 +99,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(hit_time, TaikoAction.LeftCentre),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
                 IsStrong = true
             }));
@@ -125,9 +119,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             {
                 new TaikoReplayFrame(0),
                 new TaikoReplayFrame(hit_time, TaikoAction.LeftCentre, TaikoAction.RightCentre),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
                 IsStrong = true
             }));
@@ -145,9 +138,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
             PerformTest(new List<ReplayFrame>
             {
                 new TaikoReplayFrame(0),
-            }, CreateBeatmap(new Hit
+            }, CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
                 IsStrong = true
             }));
@@ -162,9 +154,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         {
             const double hit_time = 1000;
 
-            var beatmap = CreateBeatmap(new Hit
+            var beatmap = CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
             });
 
@@ -189,9 +180,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         {
             const double hit_time = 1000;
 
-            var beatmap = CreateBeatmap(new Hit
+            var beatmap = CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
                 IsStrong = true
             });
@@ -215,9 +205,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
         {
             const double hit_time = 1000;
 
-            var beatmap = CreateBeatmap(new Hit
+            var beatmap = CreateBeatmap(new HitCentre
             {
-                Type = HitType.Centre,
                 StartTime = hit_time,
                 IsStrong = true
             });

--- a/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneSwellJudgements.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Judgements/TestSceneSwellJudgements.cs
@@ -209,7 +209,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 RequiredHits = 1
             };
 
-            Hit hit = new Hit
+            Hit hit = new HitCentre
             {
                 StartTime = hit_time
             };
@@ -243,7 +243,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Judgements
                 RequiredHits = 1
             };
 
-            Hit hit = new Hit
+            Hit hit = new HitCentre
             {
                 StartTime = hit_time
             };

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModHidden.cs
@@ -42,14 +42,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                     {
                         HitObjects = new List<TaikoHitObject>
                         {
-                            new Hit
+                            new HitRim
                             {
-                                Type = HitType.Rim,
                                 StartTime = hit_time,
                             },
-                            new Hit
+                            new HitCentre
                             {
-                                Type = HitType.Centre,
                                 StartTime = hit_time * 2,
                             },
                         },

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModPerfect.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModPerfect.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
 
         [TestCase(false)]
         [TestCase(true)]
-        public void TestHit(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new Hit { StartTime = 1000, Type = HitType.Centre }), shouldMiss);
+        public void TestHit(bool shouldMiss) => CreateHitObjectTest(new HitObjectTestData(new HitCentre { StartTime = 1000 }), shouldMiss);
 
         [TestCase(false)]
         [TestCase(true)]

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModRelax.cs
@@ -38,8 +38,8 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             {
                 HitObjects =
                 {
-                    new Hit { StartTime = 0, Type = HitType.Centre, },
-                    new Hit { StartTime = 250, Type = HitType.Rim, },
+                    new HitCentre { StartTime = 0, },
+                    new HitRim { StartTime = 250, },
                     new DrumRoll { StartTime = 500, Duration = 500, },
                     new Swell { StartTime = 1250, Duration = 500 },
                 }

--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModSingleTap.cs
@@ -24,25 +24,21 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             {
                 HitObjects = new List<HitObject>
                 {
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 100,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 300,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 500,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 700,
-                        Type = HitType.Rim
                     },
                 },
             },
@@ -69,25 +65,21 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             {
                 HitObjects = new List<HitObject>
                 {
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 100,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 300,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 500,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 700,
-                        Type = HitType.Rim
                     },
                 },
             },
@@ -114,10 +106,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             {
                 HitObjects = new List<HitObject>
                 {
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 100,
-                        Type = HitType.Rim
                     },
                 },
             },
@@ -140,21 +131,18 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
             {
                 HitObjects = new List<HitObject>
                 {
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 100,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 300,
-                        Type = HitType.Rim,
                         IsStrong = true
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 500,
-                        Type = HitType.Rim,
                     },
                 },
             },
@@ -183,15 +171,13 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
                 },
                 HitObjects = new List<HitObject>
                 {
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 100,
-                        Type = HitType.Rim
                     },
-                    new Hit
+                    new HitRim
                     {
                         StartTime = 2000,
-                        Type = HitType.Rim,
                     },
                 },
             },

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableHit.cs
@@ -48,39 +48,25 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 
         private void addHitSteps()
         {
-            AddStep("Centre hit", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime())
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            }));
+            AddStep("Centre hit", () => SetContents(_ => createDrawableHitAtCurrentTime()));
+            AddStep("Centre hit (strong)", () => SetContents(_ => createDrawableHitAtCurrentTime(true)));
+            AddStep("Rim hit", () => SetContents(_ => createDrawableHitAtCurrentTime(rim: true)));
+            AddStep("Rim hit (strong)", () => SetContents(_ => createDrawableHitAtCurrentTime(true, true)));
+        }
 
-            AddStep("Centre hit (strong)", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(true))
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            }));
-
-            AddStep("Rim hit", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(rim: true))
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            }));
-
-            AddStep("Rim hit (strong)", () => SetContents(_ => new DrawableHit(createHitAtCurrentTime(true, true))
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            }));
+        private DrawableHit createDrawableHitAtCurrentTime(bool strong = false, bool rim = false)
+        {
+            var drawable = DrawableHit.CreateConcrete(createHitAtCurrentTime(strong, rim));
+            drawable.Anchor = Anchor.Centre;
+            drawable.Origin = Anchor.Centre;
+            return drawable;
         }
 
         private Hit createHitAtCurrentTime(bool strong = false, bool rim = false)
         {
-            var hit = new Hit
-            {
-                Type = rim ? HitType.Rim : HitType.Centre,
-                IsStrong = strong,
-                StartTime = Time.Current + 3000,
-            };
+            Hit hit = rim ? new HitRim() : new HitCentre();
+            hit.IsStrong = strong;
+            hit.StartTime = Time.Current + 3000;
 
             hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneDrawableTaikoMascot.cs
@@ -78,7 +78,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             AddStep("create mascot", () => SetContents(_ => new DrawableTaikoMascot { RelativeSizeAxes = Axes.Both }));
 
             AddStep("set clear state", () => mascots.ForEach(mascot => mascot.State.Value = TaikoMascotAnimationState.Clear));
-            AddStep("miss", () => mascots.ForEach(mascot => mascot.LastResult.Value = new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss }));
+            AddStep("miss", () => mascots.ForEach(mascot => mascot.LastResult.Value = new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Miss }));
             AddAssert("skins with animations remain in clear state", () => animatedMascotsIn(TaikoMascotAnimationState.Clear));
             AddUntilStep("state reverts to fail", () => allMascotsIn(TaikoMascotAnimationState.Fail));
 
@@ -91,7 +91,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             prepareDrawableRulesetAndBeatmap(false);
 
-            var hit = new Hit();
+            var hit = new HitCentre();
             assertStateAfterResult(new JudgementResult(hit, new TaikoJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
             assertStateAfterResult(new JudgementResult(new Hit.StrongNestedHit(hit), new TaikoStrongJudgement()) { Type = HitResult.IgnoreMiss }, TaikoMascotAnimationState.Idle);
         }
@@ -101,9 +101,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             prepareDrawableRulesetAndBeatmap(true);
 
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Kiai);
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoStrongJudgement()) { Type = HitResult.IgnoreMiss }, TaikoMascotAnimationState.Kiai);
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Kiai);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoStrongJudgement()) { Type = HitResult.IgnoreMiss }, TaikoMascotAnimationState.Kiai);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
         }
 
         [Test]
@@ -111,9 +111,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             prepareDrawableRulesetAndBeatmap(false);
 
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Idle);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Great }, TaikoMascotAnimationState.Idle);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Miss }, TaikoMascotAnimationState.Fail);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Idle);
         }
 
         [TestCase(true)]
@@ -122,9 +122,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
         {
             prepareDrawableRulesetAndBeatmap(kiai);
 
-            AddRepeatStep("reach 49 combo", () => applyNewResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Great }), 49);
+            AddRepeatStep("reach 49 combo", () => applyNewResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Great }), 49);
 
-            assertStateAfterResult(new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Clear);
+            assertStateAfterResult(new JudgementResult(new HitCentre(), new TaikoJudgement()) { Type = HitResult.Ok }, TaikoMascotAnimationState.Clear);
         }
 
         [TestCase(true, TaikoMascotAnimationState.Kiai)]
@@ -147,7 +147,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 
             Beatmap.Value = CreateWorkingBeatmap(new Beatmap
             {
-                HitObjects = new List<HitObject> { new Hit { Type = HitType.Centre } },
+                HitObjects = new List<HitObject> { new HitCentre() },
                 BeatmapInfo = new BeatmapInfo
                 {
                     Difficulty = new BeatmapDifficulty(),
@@ -205,7 +205,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
 
             foreach (var playfield in playfields)
             {
-                var hit = new DrawableTestHit(new Hit(), judgementResult.Type);
+                var hit = new DrawableTestHit(new HitCentre(), judgementResult.Type);
                 playfield.Add(hit);
 
                 playfield.OnNewResult(hit, judgementResult);

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneHitExplosion.cs
@@ -65,7 +65,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             };
         }
 
-        private DrawableTestHit createHit(HitResult type) => new DrawableTestHit(new Hit { StartTime = Time.Current }, type);
+        private DrawableTestHit createHit(HitResult type) => new DrawableTestHit(new HitCentre { StartTime = Time.Current }, type);
 
         private DrawableTestHit createStrongHit(HitResult type) => new DrawableTestStrongHit(Time.Current, type);
     }

--- a/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Skinning/TestSceneKiaiHitExplosion.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Tests.Skinning
             };
         }
 
-        private DrawableTestHit createHit(HitType type) => new DrawableTestHit(new Hit { StartTime = Time.Current, Type = type });
+        private DrawableTestHit createHit(HitType type) => new DrawableTestHit(
+            type == HitType.Centre ? new HitCentre { StartTime = Time.Current } : new HitRim { StartTime = Time.Current });
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoHealthProcessorTest.cs
@@ -21,11 +21,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit(),
-                    new Hit { StartTime = 1000 },
-                    new Hit { StartTime = 2000 },
-                    new Hit { StartTime = 3000 },
-                    new Hit { StartTime = 4000 },
+                    new HitCentre(),
+                    new HitCentre { StartTime = 1000 },
+                    new HitCentre { StartTime = 2000 },
+                    new HitCentre { StartTime = 3000 },
+                    new HitCentre { StartTime = 4000 },
                 }
             };
 
@@ -52,11 +52,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit(),
-                    new Hit { StartTime = 1000 },
-                    new Hit { StartTime = 2000 },
-                    new Hit { StartTime = 3000 },
-                    new Hit { StartTime = 4000 },
+                    new HitCentre(),
+                    new HitCentre { StartTime = 1000 },
+                    new HitCentre { StartTime = 2000 },
+                    new HitCentre { StartTime = 3000 },
+                    new HitCentre { StartTime = 4000 },
                 }
             };
 
@@ -83,11 +83,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit(),
-                    new Hit { StartTime = 1000 },
-                    new Hit { StartTime = 2000 },
-                    new Hit { StartTime = 3000 },
-                    new Hit { StartTime = 4000 },
+                    new HitCentre(),
+                    new HitCentre { StartTime = 1000 },
+                    new HitCentre { StartTime = 2000 },
+                    new HitCentre { StartTime = 3000 },
+                    new HitCentre { StartTime = 4000 },
                 }
             };
 
@@ -180,7 +180,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit(),
+                    new HitCentre(),
                     new Swell { Duration = 2000 }
                 }
             };
@@ -212,8 +212,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private static readonly object[][] test_cases =
         [
             // hitobject, fail expected after miss
-            [new Hit(), true],
-            [new Hit.StrongNestedHit(new Hit()), false],
+            [new HitCentre(), true],
+            [new Hit.StrongNestedHit(new HitCentre()), false],
             [new DrumRollTick(new DrumRoll()), false],
             [new DrumRollTick.StrongNestedHit(new DrumRollTick(new DrumRoll())), false],
             [new DrumRoll(), false],

--- a/osu.Game.Rulesets.Taiko.Tests/TaikoScoreProcessorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoScoreProcessorTest.cs
@@ -22,8 +22,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit(),
-                    new Hit { StartTime = 1000 }
+                    new HitCentre(),
+                    new HitCentre { StartTime = 1000 }
                 }
             };
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneBarLineGeneration.cs
@@ -23,9 +23,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit
+                    new HitCentre
                     {
-                        Type = HitType.Centre,
                         StartTime = start_time
                     }
                 },
@@ -57,9 +56,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit
+                    new HitCentre
                     {
-                        Type = HitType.Centre,
                         StartTime = start_time
                     }
                 },
@@ -94,9 +92,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
                 HitObjects =
                 {
-                    new Hit
+                    new HitCentre
                     {
-                        Type = HitType.Centre,
                         StartTime = 1000
                     }
                 },

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneDrumSampleTriggerSource.cs
@@ -58,16 +58,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             AddStep("add hit with normal samples", () =>
             {
-                var hit = new Hit
-                {
-                    StartTime = 100,
-                    Samples = new List<HitSampleInfo>
-                    {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
-                    }
-                };
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+                var hit = Hit.CreateConcreteBySample(samples);
+                hit.StartTime = 100;
                 hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-                var drawableHit = new DrawableHit(hit);
+                var drawableHit = DrawableHit.CreateConcrete(hit);
                 hitObjectContainer.Add(drawableHit);
             });
 
@@ -86,16 +81,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             AddStep("add hit with soft samples", () =>
             {
-                var hit = new Hit
-                {
-                    StartTime = 100,
-                    Samples = new List<HitSampleInfo>
-                    {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT)
-                    }
-                };
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT) };
+                var hit = Hit.CreateConcreteBySample(samples);
+                hit.StartTime = 100;
                 hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-                var drawableHit = new DrawableHit(hit);
+                var drawableHit = DrawableHit.CreateConcrete(hit);
                 hitObjectContainer.Add(drawableHit);
             });
 
@@ -116,31 +106,24 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
             AddStep("add hit with normal samples", () =>
             {
-                first = new Hit
-                {
-                    StartTime = 100,
-                    Samples = new List<HitSampleInfo>
-                    {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL)
-                    }
-                };
+                var samples = new List<HitSampleInfo> { new HitSampleInfo(HitSampleInfo.HIT_NORMAL) };
+                first = Hit.CreateConcreteBySample(samples);
+                first.StartTime = 100;
                 first.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-                var drawableHit = new DrawableHit(first);
+                var drawableHit = DrawableHit.CreateConcrete(first);
                 hitObjectContainer.Add(drawableHit);
             });
             AddStep("add hit with soft samples", () =>
             {
-                second = new Hit
+                var samples = new List<HitSampleInfo>
                 {
-                    StartTime = 500,
-                    Samples = new List<HitSampleInfo>
-                    {
                         new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_SOFT),
                         new HitSampleInfo(HitSampleInfo.HIT_CLAP, HitSampleInfo.BANK_SOFT)
-                    }
                 };
+                second = Hit.CreateConcreteBySample(samples);
+                second.StartTime = 500;
                 second.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-                var drawableHit = new DrawableHit(second);
+                var drawableHit = DrawableHit.CreateConcrete(second);
                 hitObjectContainer.Add(drawableHit);
             });
 
@@ -169,17 +152,15 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             AddStep("add strong hit with drum samples", () =>
             {
-                var hit = new Hit
+                var samples = new List<HitSampleInfo>
                 {
-                    StartTime = 100,
-                    Samples = new List<HitSampleInfo>
-                    {
-                        new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM),
-                        new HitSampleInfo(HitSampleInfo.HIT_FINISH, HitSampleInfo.BANK_DRUM) // implies strong
-                    }
+                    new HitSampleInfo(HitSampleInfo.HIT_NORMAL, HitSampleInfo.BANK_DRUM),
+                    new HitSampleInfo(HitSampleInfo.HIT_FINISH, HitSampleInfo.BANK_DRUM) // implies strong
                 };
+                var hit = Hit.CreateConcreteBySample(samples);
+                hit.StartTime = 100;
                 hit.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
-                var drawableHit = new DrawableHit(hit);
+                var drawableHit = DrawableHit.CreateConcrete(hit);
                 hitObjectContainer.Add(drawableHit);
             });
 

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHitApplication.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHitApplication.cs
@@ -12,26 +12,43 @@ namespace osu.Game.Rulesets.Taiko.Tests
         [Test]
         public void TestApplyNewHit()
         {
-            var hit = new DrawableHit();
+            // Now we have pools for different types:
+            // ```
+            // RegisterPool<HitRim, DrawableHitRim>(50);
+            // RegisterPool<HitCentre, DrawableHitCentre>(50);
+            // ```
+            // And therefore we cant Apply between differ HitTypes
 
-            AddStep("apply new hit", () => hit.Apply(PrepareObject(new Hit
+            var first_rim = new HitRim
             {
-                Type = HitType.Rim,
+                IsStrong = false,
+                StartTime = 100
+            };
+            var hit_rim = DrawableHit.CreateConcrete(first_rim);
+
+            AddStep("apply new rim hit", () => hit_rim.Apply(PrepareObject(new HitRim
+            {
                 IsStrong = false,
                 StartTime = 300
             })));
 
-            AddHitObject(hit);
-            RemoveHitObject(hit);
+            AddHitObject(hit_rim);
+            RemoveHitObject(hit_rim);
 
-            AddStep("apply new hit", () => hit.Apply(PrepareObject(new Hit
+            var first_centre = new HitCentre
             {
-                Type = HitType.Centre,
+                IsStrong = false,
+                StartTime = 400
+            };
+            var hit_centre = DrawableHit.CreateConcrete(first_centre);
+
+            AddStep("apply new centre hit", () => hit_centre.Apply(PrepareObject(new HitCentre
+            {
                 IsStrong = true,
                 StartTime = 500
             })));
 
-            AddHitObject(hit);
+            AddHitObject(hit_centre);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHits.cs
@@ -107,7 +107,8 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             HitResult hitResult = RNG.Next(2) == 0 ? HitResult.Ok : HitResult.Great;
 
-            Hit hit = new Hit { StartTime = DrawableRuleset.Playfield.Time.Current };
+            Hit hit = RNG.NextBool() ? new HitCentre() : new HitRim();
+            hit.StartTime = DrawableRuleset.Playfield.Time.Current;
             var h = new DrawableTestHit(hit, kiai: kiai) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
 
             DrawableRuleset.Playfield.Add(h);
@@ -119,12 +120,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             HitResult hitResult = RNG.Next(2) == 0 ? HitResult.Ok : HitResult.Great;
 
-            Hit hit = new Hit
-            {
-                StartTime = DrawableRuleset.Playfield.Time.Current,
-                IsStrong = true,
-                Samples = createSamples(strong: true)
-            };
+            Hit hit = RNG.NextBool() ? new HitCentre() : new HitRim();
+            hit.StartTime = DrawableRuleset.Playfield.Time.Current;
+            hit.IsStrong = true;
+            hit.Samples = createSamples(strong: true);
+
             var h = new DrawableTestHit(hit, kiai: kiai) { X = RNG.NextSingle(hitResult == HitResult.Ok ? -0.1f : -0.05f, hitResult == HitResult.Ok ? 0.1f : 0.05f) };
 
             DrawableRuleset.Playfield.Add(h);
@@ -136,7 +136,9 @@ namespace osu.Game.Rulesets.Taiko.Tests
         private void addMissJudgement()
         {
             DrawableTestHit h;
-            DrawableRuleset.Playfield.Add(h = new DrawableTestHit(new Hit { StartTime = DrawableRuleset.Playfield.Time.Current }, HitResult.Miss)
+            Hit hit = RNG.NextBool() ? new HitCentre() : new HitRim();
+            hit.StartTime = DrawableRuleset.Playfield.Time.Current;
+            DrawableRuleset.Playfield.Add(h = new DrawableTestHit(hit, HitResult.Miss)
             {
                 Alpha = 0
             });
@@ -191,30 +193,24 @@ namespace osu.Game.Rulesets.Taiko.Tests
 
         private void addCentreHit(bool strong)
         {
-            Hit h = new Hit
-            {
-                StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time,
-                IsStrong = strong,
-                Samples = createSamples(HitType.Centre, strong)
-            };
+            Hit h = Hit.CreateConcreteBySample(createSamples(HitType.Centre, strong));
+            h.StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time;
+            h.IsStrong = strong;
 
             h.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
-            DrawableRuleset.Playfield.Add(new DrawableHit(h));
+            DrawableRuleset.Playfield.Add(DrawableHit.CreateConcrete(h));
         }
 
         private void addRimHit(bool strong)
         {
-            Hit h = new Hit
-            {
-                StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time,
-                IsStrong = strong,
-                Samples = createSamples(HitType.Rim, strong)
-            };
+            Hit h = Hit.CreateConcreteBySample(createSamples(HitType.Rim, strong));
+            h.StartTime = DrawableRuleset.Playfield.Time.Current + scroll_time;
+            h.IsStrong = strong;
 
             h.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
 
-            DrawableRuleset.Playfield.Add(new DrawableHit(h));
+            DrawableRuleset.Playfield.Add(DrawableHit.CreateConcrete(h));
         }
 
         // TODO: can be removed if a better way of handling colour/strong type and samples is developed

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneScoring.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneScoring.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
+using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
@@ -32,7 +33,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             var beatmap = new TaikoBeatmap();
             for (int i = 0; i < maxCombo; ++i)
-                beatmap.HitObjects.Add(new Hit());
+                beatmap.HitObjects.Add(RNG.NextBool() ? new HitCentre() : new HitRim());
             return beatmap;
         }
 
@@ -207,10 +208,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
             {
             }
 
+            private static Hit randomHit() => RNG.NextBool() ? new HitCentre() : new HitRim();
             protected override ScoreProcessor CreateScoreProcessor() => new TaikoScoreProcessor();
-            protected override JudgementResult CreatePerfectJudgementResult() => new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Great };
-            protected override JudgementResult CreateNonPerfectJudgementResult() => new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Ok };
-            protected override JudgementResult CreateMissJudgementResult() => new JudgementResult(new Hit(), new TaikoJudgement()) { Type = HitResult.Miss };
+            protected override JudgementResult CreatePerfectJudgementResult() => new JudgementResult(randomHit(), new TaikoJudgement()) { Type = HitResult.Great };
+            protected override JudgementResult CreateNonPerfectJudgementResult() => new JudgementResult(randomHit(), new TaikoJudgement()) { Type = HitResult.Ok };
+            protected override JudgementResult CreateMissJudgementResult() => new JudgementResult(randomHit(), new TaikoJudgement()) { Type = HitResult.Miss };
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneTaikoSuddenDeath.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
                 HitObjects =
                 {
                     new Swell { StartTime = 1500 },
-                    new Hit { StartTime = 100000 },
+                    new HitCentre { StartTime = 100000 },
                 },
                 BeatmapInfo =
                 {

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmap.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Beatmaps;
@@ -37,6 +38,20 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                     Content = swells.ToString(),
                 }
             };
+        }
+
+        public void InvertTypes(Predicate<(int, TaikoHitObject)> need_invert)
+        {
+            for (int index = 0; index < HitObjects.Count; index++)
+            {
+                var obj = HitObjects[index];
+                if (need_invert((index, obj)))
+                {
+                    var newValue = Hit.InvertType(obj);
+                    if (newValue is not null)
+                        HitObjects[index] = newValue;
+                }
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Game.Beatmaps;
-using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
-using osu.Game.Rulesets.Taiko.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Utils;
 using System.Threading;
+using osu.Framework.Utils;
 using osu.Game.Audio;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Legacy;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Beatmaps
 {

--- a/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
+++ b/osu.Game.Rulesets.Taiko/Beatmaps/TaikoBeatmapConverter.cs
@@ -119,11 +119,9 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
                         {
                             IList<HitSampleInfo> currentSamples = allSamples[i];
 
-                            yield return new Hit
-                            {
-                                StartTime = j,
-                                Samples = currentSamples,
-                            };
+                            Hit hit = Hit.CreateConcreteBySample(currentSamples);
+                            hit.StartTime = j;
+                            yield return hit;
 
                             i = (i + 1) % allSamples.Count;
 
@@ -161,12 +159,9 @@ namespace osu.Game.Rulesets.Taiko.Beatmaps
 
                 default:
                 {
-                    yield return new Hit
-                    {
-                        StartTime = obj.StartTime,
-                        Samples = samples,
-                    };
-
+                    Hit hit = Hit.CreateConcreteBySample(samples);
+                    hit.StartTime = obj.StartTime;
+                    yield return hit;
                     break;
                 }
             }

--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
         public new Hit HitObject => (Hit)base.HitObject;
 
         public HitPlacementBlueprint()
-            : base(new Hit(HitType.Centre))
+            : base(new HitCentre())
         {
             InternalChild = piece = new HitPiece
             {

--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
         public new Hit HitObject => (Hit)base.HitObject;
 
         public HitPlacementBlueprint()
-            : base(new Hit())
+            : base(new Hit(HitType.Centre))
         {
             InternalChild = piece = new HitPiece
             {

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -71,18 +71,14 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetRimState(bool state)
         {
-            if (SelectedItems.OfType<Hit>().All(h => h.Type == (state ? HitType.Rim : HitType.Centre)))
+            var expectedType = state ? HitType.Rim : HitType.Centre;
+            if (SelectedItems.OfType<Hit>().All(h => h.Type == expectedType))
                 return;
 
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                if (h is Hit taikoHit)
-                {
-                    // TODO: seems like we should to change type (and pass all fileds between them ://)
-                    taikoHit.ChangeType(state ? HitType.Rim : HitType.Centre);
-                    EditorBeatmap.Update(h);
-                }
-            });
+            EditorBeatmap.ChangeOnSelection(hit => (hit is Hit taikoHit && taikoHit.Type != expectedType) ? (true, Hit.InvertType(taikoHit)) : (false, null));
+
+            //// TODO: invert state function & bind it to some key (seems handy):
+            //EditorBeatmap.ChangeOnSelection(hit => (hit is TaikoHitObject taikoHit) ? (true, Hit.InvertType(taikoHit)) : (false, null));
         }
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -78,7 +78,8 @@ namespace osu.Game.Rulesets.Taiko.Edit
             {
                 if (h is Hit taikoHit)
                 {
-                    taikoHit.Type = state ? HitType.Rim : HitType.Centre;
+                    // TODO: seems like we should to change type (and pass all fileds between them ://)
+                    taikoHit.ChangeType(state ? HitType.Rim : HitType.Centre);
                     EditorBeatmap.Update(h);
                 }
             });

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
             foreach (var obj in taikoBeatmap.HitObjects)
             {
                 if (obj is Hit hit)
-                    hit.Type = rng.Next(2) == 0 ? HitType.Centre : HitType.Rim;
+                    hit.ChangeType(rng.Next(2) == 0 ? HitType.Centre : HitType.Rim); // TODO: seems like we should to change type (and pass all fileds between them ://)
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
@@ -19,16 +19,11 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
-            var taikoBeatmap = (TaikoBeatmap)beatmap;
-
             Seed.Value ??= RNG.Next();
             var rng = new Random((int)Seed.Value);
 
-            foreach (var obj in taikoBeatmap.HitObjects)
-            {
-                if (obj is Hit hit)
-                    hit.ChangeType(rng.Next(2) == 0 ? HitType.Centre : HitType.Rim); // TODO: seems like we should to change type (and pass all fileds between them ://)
-            }
+            var taikoBeatmap = (TaikoBeatmap)beatmap;
+            taikoBeatmap.InvertTypes(_ => rng.Next(2) == 0);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRandom.cs
@@ -8,7 +8,6 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Beatmaps;
-using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModRelax.cs
@@ -18,14 +18,12 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         public void ApplyToDrawableHitObject(DrawableHitObject drawable)
         {
-            var allActions = Enum.GetValues<TaikoAction>();
-
             drawable.HitObjectApplied += dho =>
             {
                 switch (dho)
                 {
                     case DrawableHit hit:
-                        hit.HitActions = allActions;
+                        hit.RelaxMod = true;
                         break;
 
                     case DrawableSwell swell:

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -7,7 +7,6 @@ using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Beatmaps;
-using osu.Game.Rulesets.Taiko.Objects;
 
 namespace osu.Game.Rulesets.Taiko.Mods
 {

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -23,13 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Mods
         public void ApplyToBeatmap(IBeatmap beatmap)
         {
             var taikoBeatmap = (TaikoBeatmap)beatmap;
-
-            foreach (var obj in taikoBeatmap.HitObjects)
-            {
-                // TODO: seems like we should to change type (and pass all fileds between them ://)
-                if (obj is Hit hit)
-                    hit.ChangeType(hit.Type == HitType.Centre ? HitType.Rim : HitType.Centre);
-            }
+            taikoBeatmap.InvertTypes(_ => true);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModSwap.cs
@@ -26,8 +26,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
             foreach (var obj in taikoBeatmap.HitObjects)
             {
+                // TODO: seems like we should to change type (and pass all fileds between them ://)
                 if (obj is Hit hit)
-                    hit.Type = hit.Type == HitType.Centre ? HitType.Rim : HitType.Centre;
+                    hit.ChangeType(hit.Type == HitType.Centre ? HitType.Rim : HitType.Centre);
             }
         }
     }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -6,19 +6,19 @@
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Utils;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -77,9 +77,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             OnNewResult += onNewResult;
         }
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
+            //base.RestorePieceState(); // TODO:STOP HERE
             updateColour();
             Height = HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE;
         }
@@ -119,8 +119,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollBody),
-            _ => new ElongatedCirclePiece());
+        protected override SkinnableDrawable OnLoadCreateMainPiece()
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollBody), _ => new ElongatedCirclePiece());
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -79,7 +79,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override void RestorePieceState()
         {
-            //base.RestorePieceState(); // TODO:STOP HERE
             updateColour();
             Height = HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE;
         }
@@ -174,7 +173,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private void updateColour(double fadeDuration = 0)
         {
             Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
-            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
+            (MainPiece?.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
         }
 
         public partial class StrongNestedHit : DrawableStrongNestedHit

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             FillMode = FillMode.Fit;
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
+        protected override SkinnableDrawable OnLoadCreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
 
         protected override void OnApply()
         {
@@ -45,9 +45,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             IsFirstTick.Value = HitObject.FirstTick;
         }
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
             Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
@@ -3,6 +3,8 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -12,20 +14,31 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
     public partial class DrawableFlyingHit : DrawableHit
     {
         public DrawableFlyingHit(DrawableDrumRollTick drumRollTick)
-            : base(new IgnoreHit
+            : base(new IgnoreHit(drumRollTick.JudgementType)
             {
                 StartTime = drumRollTick.HitObject.StartTime + drumRollTick.Result.TimeOffset,
                 IsStrong = drumRollTick.HitObject.IsStrong,
-                Type = drumRollTick.JudgementType
             })
         {
             HitObject.ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
         }
 
+        private static float degree = 0f;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
             ApplyMaxResult();
+            Size = new osuTK.Vector2(0.3f);
+        }
+
+        protected override void PrepareForUse()
+        {
+            const float single_rotation_degree = 7f;
+
+            base.PrepareForUse();
+            degree = (degree + single_rotation_degree) % 360f;
+            Rotation = degree;
         }
 
         protected override void LoadSamples()
@@ -33,5 +46,22 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             // block base call - flying hits are not supposed to play samples
             // the base call could overwrite the type of this hit
         }
+
+
+        //public override TaikoAction[] HitActions { get; protected set; } = Array.Empty<TaikoAction>();
+        public override TaikoAction[] HitActions
+        {
+            //get => HitObject.Type == HitType.Centre ? [TaikoAction.LeftCentre, TaikoAction.RightCentre] : [TaikoAction.LeftRim, TaikoAction.RightRim];
+            get => [TaikoAction.LeftCentre, TaikoAction.RightCentre, TaikoAction.LeftRim, TaikoAction.RightRim];
+            protected set { }
+        }
+
+        protected override SkinnableDrawable? OnLoadCreateMainPiece()
+            //=> null;
+            //=> new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece(), confineMode: ConfineMode.ScaleToFit);
+            //
+            // TODO: idk, seems like there need to be added new skin component & in it's Animation should be changed it's collor in depends of `hit / this_drum_roll_hits`
+            //     | just like in stable version
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell), _ => new SwellCirclePiece(), confineMode: ConfineMode.ScaleToFit);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -53,6 +53,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             FillMode = FillMode.Fit;
         }
 
+        public static DrawableHit CreateConcrete(Hit hit)
+            => hit.Type == HitType.Centre ? new DrawableHitCentre(hit) : new DrawableHitRim(hit);
+
         protected override void OnApply()
         {
             base.OnApply();
@@ -228,14 +231,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         }
     }
 
-    public partial class DrawableHitCenter : DrawableHit
+    public partial class DrawableHitCentre : DrawableHit
     {
         public override TaikoAction[] HitActions { get; protected set; } = { TaikoAction.LeftCentre, TaikoAction.RightCentre };
 
         /// <summary> This constructor exsits only to satisfy Pool where constraints </summary>
-        public DrawableHitCenter() : base(null) { }
+        public DrawableHitCentre() : base(null) { }
 
-        public DrawableHitCenter([CanBeNull] Hit hit)
+        public DrawableHitCentre([CanBeNull] Hit hit)
             : base(hit)
         {
             if (hit != null && hit.Type != HitType.Centre)

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -10,16 +10,16 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -287,7 +287,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             else
                 UnproxyContent();
 
-            if ((Clock as IGameplayClock)?.IsRewinding == true)
+            if (Clock is IGameplayClock { IsRewinding: true })
                 lastPressHandleTime = null;
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell),
+        protected override SkinnableDrawable OnLoadCreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell),
             _ => new SwellCirclePiece
             {
                 // to allow for rotation transform
@@ -144,9 +144,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Origin = Anchor.Centre,
             });
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
             Size = baseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -43,7 +43,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick),
-            _ => new TickPiece());
+        protected override SkinnableDrawable OnLoadCreateMainPiece()
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
+
+        protected override void RestorePieceState() { }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -141,22 +142,26 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             RelativeSizeAxes = Axes.Both;
         }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            //InternalChild =
+            var drawable = OnLoadCreateMainPiece();
+            if (drawable is not null)
+                Content.Add(MainPiece = drawable);
+        }
+
         protected override void OnApply()
         {
             base.OnApply();
 
             // TODO: THIS CANNOT BE HERE, it makes pooling pointless (see https://github.com/ppy/osu/issues/21072).
-            RecreatePieces();
+            RestorePieceState();
         }
 
-        protected virtual void RecreatePieces()
-        {
-            if (MainPiece != null)
-                Content.Remove(MainPiece, true);
 
-            Content.Add(MainPiece = CreateMainPiece());
-        }
 
-        protected abstract SkinnableDrawable CreateMainPiece();
+        protected abstract void RestorePieceState();
+        protected abstract SkinnableDrawable OnLoadCreateMainPiece();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             isStrong.BindTo(HitObject.IsStrongBindable);
             // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RecreatePieces));
+            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RestorePieceState));
 
             base.OnApply();
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -26,8 +26,12 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
         public Hit(HitType type)
         {
-            ChangeType(type);
-            SamplesBindable.BindCollectionChanged((_, _) => updateTypeFromSamples());
+            changeType(type);
+            SamplesBindable.BindCollectionChanged((_, _) =>
+            {
+                updateSamplesFromType();
+                updateTypeFromSamples();
+            });
         }
 
         public static Hit? InvertType(TaikoHitObject obj)
@@ -39,15 +43,13 @@ namespace osu.Game.Rulesets.Taiko.Objects
                 case HitCentre centre:
                     return new HitRim(centre);
                 case Hit hit:
-                    hit.ChangeType(hit.Type == HitType.Centre ? HitType.Rim : HitType.Centre);
+                    hit.changeType(hit.Type == HitType.Centre ? HitType.Rim : HitType.Centre);
                     break;
             }
             return null;
         }
 
-        // TODO:EDITOR ONLY
-        // TODO: seems like we should to change type (and pass all fileds between them ://)
-        public void ChangeType(HitType type)
+        private void changeType(HitType type)
         {
             Type = type;
             DisplayColour.Value = Type == HitType.Centre ? COLOUR_CENTRE : COLOUR_RIM;
@@ -55,9 +57,9 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
         private void updateTypeFromSamples()
         {
-            var newType = getRimSamples().Any() ? HitType.Rim : HitType.Centre;
-            //if (newType != Type)
-            //    throw new ArgumentException("new type differs from previous");
+            HitType newType = getRimSamples().Any() ? HitType.Rim : HitType.Centre;
+            if ((newType != Type) && (this is HitCentre || this is HitRim))
+                throw new ArgumentException("HitCentre/HitRim was dynamically changed between each other!");
         }
 
         public static HitType SampleType(IList<HitSampleInfo> samples)

--- a/osu.Game.Rulesets.Taiko/Objects/IgnoreHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/IgnoreHit.cs
@@ -8,5 +8,6 @@ namespace osu.Game.Rulesets.Taiko.Objects
     public class IgnoreHit : Hit
     {
         public override Judgement CreateJudgement() => new IgnoreJudgement();
+        public IgnoreHit(HitType type) : base(type) { }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/TaikoStrongableHitObject.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Taiko.Objects
 
         protected TaikoStrongableHitObject()
         {
-            IsStrongBindable.BindValueChanged(_ => updateSamplesFromType());
+            IsStrongBindable.BindValueChanged(_ => UpdateStrongSamplesFromType());
             SamplesBindable.BindCollectionChanged((_, _) => updateTypeFromSamples());
         }
 
@@ -47,14 +47,15 @@ namespace osu.Game.Rulesets.Taiko.Objects
             IsStrong = getStrongSamples().Any();
         }
 
-        private void updateSamplesFromType()
+        protected void UpdateStrongSamplesFromType()
         {
             var strongSamples = getStrongSamples();
+            int volume = Samples.Any() ? Samples.First().Volume : 100;
 
             if (IsStrongBindable.Value != strongSamples.Any())
             {
                 if (IsStrongBindable.Value)
-                    Samples.Add(CreateHitSampleInfo(HitSampleInfo.HIT_FINISH));
+                    Samples.Add(CreateHitSampleInfo(HitSampleInfo.HIT_FINISH).With(newVolume: volume));
                 else
                 {
                     foreach (var sample in strongSamples)

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
@@ -7,12 +7,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Skinning.Default
 {
-    public partial class DefaultKiaiHitExplosion : CircularContainer
+    public partial class DefaultKiaiHitExplosion : CircularContainer, IAnimatableHitExplosion
     {
         public override bool RemoveWhenNotAlive => true;
 
@@ -51,14 +53,17 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             };
         }
 
-        protected override void LoadComplete()
+        public void Animate(DrawableHitObject _drawableHitObject)
         {
-            base.LoadComplete();
-
             this.ScaleTo(new Vector2(1, 3f), 500, Easing.OutQuint);
             this.FadeOut(250);
+        }
 
-            Expire(true);
+        public void AnimateSecondHit()
+        {
+            // TODO: STRONG_SCALE * 5
+            this.ScaleTo(new Vector2(TaikoStrongableHitObject.STRONG_SCALE, 3f), 500, Easing.OutQuint);
+            this.FadeOut(250);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -2,34 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
-using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
     /// <summary>
     /// A circle explodes from the hit target to indicate a hitobject has been hit.
     /// </summary>
-    internal partial class HitExplosion : PoolableDrawable
+    internal partial class HitExplosion : HitExplosionBase
     {
-        public override bool RemoveWhenNotAlive => true;
-        public override bool RemoveCompletedTransforms => false;
-
         private readonly HitResult result;
-
-        private double? secondHitTime;
-
-        public DrawableHitObject? JudgedObject;
-
-        private SkinnableDrawable skinnable = null!;
 
         /// <summary>
         /// This constructor only exists to meet the <c>new()</c> type constraint of <see cref="DrawablePool{T}"/>.
@@ -42,60 +30,12 @@ namespace osu.Game.Rulesets.Taiko.UI
         public HitExplosion(HitResult result)
         {
             this.result = result;
-
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-
             Size = new Vector2(TaikoHitObject.DEFAULT_SIZE);
-            RelativeSizeAxes = Axes.Both;
-
             RelativePositionAxes = Axes.Both;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            InternalChild = skinnable = new SkinnableDrawable(new TaikoSkinComponentLookup(getComponentName(result)), _ => new DefaultHitExplosion(result));
-            skinnable.OnSkinChanged += runAnimation;
-        }
-
-        public void Apply(DrawableHitObject? drawableHitObject)
-        {
-            JudgedObject = drawableHitObject;
-            secondHitTime = null;
-        }
-
-        protected override void PrepareForUse()
-        {
-            base.PrepareForUse();
-            runAnimation();
-        }
-
-        private void runAnimation()
-        {
-            if (JudgedObject?.Result == null)
-                return;
-
-            double resultTime = JudgedObject.Result.TimeAbsolute;
-
-            LifetimeStart = resultTime;
-
-            ApplyTransformsAt(double.MinValue, true);
-            ClearTransforms(true);
-
-            using (BeginAbsoluteSequence(resultTime))
-                (skinnable.Drawable as IAnimatableHitExplosion)?.Animate(JudgedObject);
-
-            if (secondHitTime != null)
-            {
-                using (BeginAbsoluteSequence(secondHitTime.Value))
-                {
-                    (skinnable.Drawable as IAnimatableHitExplosion)?.AnimateSecondHit();
-                }
-            }
-
-            LifetimeEnd = skinnable.Drawable.LatestTransformEndTime;
-        }
+        protected override SkinnableDrawable OnLoadSkinnableCreate() =>
+            new SkinnableDrawable(new TaikoSkinComponentLookup(getComponentName(result)), _ => new DefaultHitExplosion(result));
 
         private static TaikoSkinComponents getComponentName(HitResult result)
         {
@@ -112,12 +52,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             }
 
             throw new ArgumentOutOfRangeException(nameof(result), $"Invalid result type: {result}");
-        }
-
-        public void VisualiseSecondHit(JudgementResult judgementResult)
-        {
-            secondHitTime = judgementResult.TimeAbsolute;
-            runAnimation();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    /// <summary>
+    /// A base class for taiko explosions from target hitting to indicate a hitobject has been hit.
+    /// </summary>
+    internal abstract partial class HitExplosionBase : PoolableDrawable
+    {
+        protected abstract SkinnableDrawable OnLoadSkinnableCreate();
+
+        public override bool RemoveWhenNotAlive => true;
+        public override bool RemoveCompletedTransforms => false;
+
+
+        protected double? SecondHitTime;
+
+        public DrawableHitObject? JudgedObject;
+
+        protected SkinnableDrawable Skinnable = null!;
+
+        public HitExplosionBase()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = Skinnable = OnLoadSkinnableCreate();
+            Skinnable.OnSkinChanged += RunAnimation;
+        }
+
+        public void Apply(DrawableHitObject? drawableHitObject)
+        {
+            JudgedObject = drawableHitObject;
+            SecondHitTime = null;
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+            RunAnimation();
+        }
+
+        protected void RunAnimation()
+        {
+            if (JudgedObject?.Result is null) return;
+
+            double resultTime = JudgedObject.Result.TimeAbsolute;
+            LifetimeStart = resultTime;
+
+            // Clear transforms
+            ApplyTransformsAt(double.MinValue, true);
+            ClearTransforms(true);
+
+            if (Skinnable.Drawable is IAnimatableHitExplosion animatable)
+            {
+                using (BeginAbsoluteSequence(resultTime))
+                    animatable.Animate(JudgedObject);
+
+                if (SecondHitTime != null)
+                    using (BeginAbsoluteSequence(SecondHitTime.Value))
+                        animatable.AnimateSecondHit();
+            }
+
+            LifetimeEnd = Skinnable.Drawable.LatestTransformEndTime;
+        }
+
+        public void VisualiseSecondHit(JudgementResult judgementResult)
+        {
+            SecondHitTime = judgementResult.TimeAbsolute;
+            RunAnimation();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -12,37 +10,30 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
-    public partial class KiaiHitExplosion : Container
+    /// <summary>
+    /// An explosion from the hit target in Kiai mode to indicate a hitobject has been hit.
+    /// </summary>
+    internal partial class KiaiHitExplosion : HitExplosionBase
     {
-        public override bool RemoveWhenNotAlive => true;
-
-        [Cached(typeof(DrawableHitObject))]
-        public readonly DrawableHitObject JudgedObject;
-
         private readonly HitType hitType;
 
-        private SkinnableDrawable skinnable = null!;
+        /// <summary>
+        /// This constructor only exists to meet the <c>new()</c> type constraint of <see cref="DrawablePool{T}"/>.
+        /// </summary>
+        public KiaiHitExplosion() : this(HitType.Centre) { }
 
-        public override double LifetimeStart => skinnable.Drawable.LifetimeStart;
-
-        public override double LifetimeEnd => skinnable.Drawable.LifetimeEnd;
-
-        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType hitType)
+        public KiaiHitExplosion(HitType hitType)
         {
-            JudgedObject = judgedObject;
             this.hitType = hitType;
-
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-
-            RelativeSizeAxes = Axes.Both;
             Size = new Vector2(TaikoHitObject.DEFAULT_SIZE, 1);
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType hitType) : this(hitType)
         {
-            Child = skinnable = new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
+            Apply(judgedObject);
         }
+
+        protected override SkinnableDrawable OnLoadSkinnableCreate() =>
+            new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosionPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosionPool.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    /// <summary>
+    /// Pool for hit explosions of a specific type.
+    /// </summary>
+    internal partial class KiaiHitExplosionPool : DrawablePool<KiaiHitExplosion>
+    {
+        private readonly HitType hitType;
+
+        public KiaiHitExplosionPool(HitType hitType)
+            : base(15)
+        {
+            this.hitType = hitType;
+        }
+
+        protected override KiaiHitExplosion CreateNewDrawable() => new KiaiHitExplosion(hitType);
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/TaikoHitTarget.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoHitTarget.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK;
-using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Rulesets.Taiko.Objects;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             };
 
             RegisterPool<HitRim, DrawableHitRim>(50);
-            RegisterPool<HitCentre, DrawableHitCenter>(50);
+            RegisterPool<HitCentre, DrawableHitCentre>(50);
             RegisterPool<Hit.StrongNestedHit, DrawableHit.StrongNestedHit>(50);
 
             RegisterPool<DrumRoll, DrawableDrumRoll>(5);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -8,16 +8,16 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI;
-using osu.Game.Rulesets.UI.Scrolling;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Scoring;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.UI

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -181,7 +181,8 @@ namespace osu.Game.Rulesets.Taiko.UI
                 inputDrum,
             };
 
-            RegisterPool<Hit, DrawableHit>(50);
+            RegisterPool<HitRim, DrawableHitRim>(50);
+            RegisterPool<HitCenter, DrawableHitCenter>(50);
             RegisterPool<Hit.StrongNestedHit, DrawableHit.StrongNestedHit>(50);
 
             RegisterPool<DrumRoll, DrawableDrumRoll>(5);

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -182,7 +182,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             };
 
             RegisterPool<HitRim, DrawableHitRim>(50);
-            RegisterPool<HitCenter, DrawableHitCenter>(50);
+            RegisterPool<HitCentre, DrawableHitCenter>(50);
             RegisterPool<Hit.StrongNestedHit, DrawableHit.StrongNestedHit>(50);
 
             RegisterPool<DrumRoll, DrawableDrumRoll>(5);

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorBeatmapCreation.cs
@@ -593,11 +593,11 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("add timing point", () => EditorBeatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 1000 }));
             AddStep("add hitobjects", () => EditorBeatmap.AddRange(new[]
             {
-                new Hit
+                new HitCentre
                 {
                     StartTime = 0
                 },
-                new Hit
+                new HitCentre
                 {
                     StartTime = 1000
                 }


### PR DESCRIPTION
# Don't read text below there is more simpler approach

**Help Wanted:**
* One thing that I don't understand how to fix after the changes is: why can `<editor right-click-menu click action>` and `<editor key down action>` for the same action (W/R key: set rim types for the selection) perform different behavior? Action is correct for right-click-menu but only do redo/undo record for W/R key down. There is changes in `TaikoSelectionHandler:SetRimState` but as I can understand it's called for both click & key down. Seems like it's not expected from  `EditorSelectionHandler` to remove/create objects? And therefore some events don't called? Sorry for uncertainty.
* Another thing is why on undo/redo action in Editor can change `Samples.Volume` (only for `HitRim` class that is differ from `HitCentre`)? Seems like the problem is about `Samples` changing/setting, but I couldn't find where it, and maybe something like this already happened before and so it's simpler to ask.

Please also see **See.1** in the end of PR comment

---

Try to fix #21072

---

**About The Issue Solution:**
Added `HitCentre: Hit` & `HitRim: Hit` classes that corresponding to don & katsu circles. They cannot change `Hit.Type` and now we can do: 
```c#
RegisterPool<HitRim, DrawableHitRim>(50);
RegisterPool<HitCentre, DrawableHitCenter>(50);
```
in `TaikoPlayfield`.
And with them there are problems mentioned in `Help Wanted` section.

Also added pool for `KiaiHitExplosion` (first commit), with it there no problem.

Just for case, do I understand correctly that changing the `Content` in `DrawableHitObject` is long performing operation that should be optimized? (because if not, and the long operation is creating new `SkinnableDrawable` and we can change them dynamically in `Content` then this changes can be done more-more simpler)

---

**Should be solved before non-Draft**:
Except for problems mentioned in `Help Wanted` section, there is some todo's that is just question about how to do better & simple bugs that do not require help, but should to be mentioned and closed before make PR non-Draft:
*  `DefaultKiaiHitExplosion.cs`: strong hit looks better with greater X scaling. but I don't sure about perf & it's not about this PR actually (question).
*  `TaikoPlayfield.cs`: seems like Kiai explosion should be displayed only whin hit(when `result.IsHit`). Am I wrong? (question)
* Is there benchmarks for taiko playfield drawing during game? how to run it? Or how I can test performance of the canhges in pooling? (question)
* `DrawableFlyingHit.cs`: what should we draw on hit? I use swell circle but don't sure that it's correct. Before we draw `DrawableHit` with dynamic `SkinnableDrawable`. In osu!stable draws yellow-to-red Hit Cirlce, so maybe there should be some additional `TaikoSkinComponents`? (question)
* strong taiko circle drawn with filled star (bug).

---

One more time, sorry for big uncertainty, real help needed only for `Help Wanted` section because it takes more time than I expected.

**See.1**:
Maybe the solution approach is bad, maybe there is more good way to do all this changes without splitting `Hit` into `HitCentre` & `HitRim`? but how else can we pool it? Maybe give a way to get your pool in `Playfield.cs`:`IPooledHitObjectProvider.GetPooledDrawableRepresentation` if there no `RegisterPool`? and then we can give correct pool for `Hit` without splitting it into `HitCentre` & `HitRim`? Such approach seems more simpler.
