### PR TITLE
osu!taiko `Hit` & `KiaiHitExplosion` pooling

### DIFF
--- a/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Skinning;
 
@@ -27,9 +28,13 @@ namespace osu.Game.Rulesets.Taiko.Edit
             AddRangeInternal([poolHitEditorMode]);
         }
 
+        /// <summary>
+        /// <see cref="Hit"/> to <see cref="DrawableHit"/> pool that
+        /// returns <see cref="DrawableHit"/> in editor mode (it will recreates its drawable hierarchy each <c>OnApply</c>).
+        /// </summary>
         private readonly HitPool poolHitEditorMode = new HitPool(50, editorMode: true);
 
-        protected override IDrawablePool? AdditionalPrepareDrawablePool(HitObject hitObject)
+        protected override IDrawablePool? PropertyBasedDrawableHitObjectPool(HitObject hitObject)
         {
             switch (hitObject)
             {

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs
@@ -3,6 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Skinning;
 
@@ -20,6 +23,20 @@ namespace osu.Game.Rulesets.Taiko.Edit
                 Anchor = Anchor.TopLeft,
                 Origin = Anchor.TopRight,
             });
+
+            AddRangeInternal([poolHitEditorMode]);
+        }
+
+        private readonly HitPool poolHitEditorMode = new HitPool(50, editorMode: true);
+
+        protected override IDrawablePool? AdditionalPrepareDrawablePool(HitObject hitObject)
+        {
+            switch (hitObject)
+            {
+                // We should to return the editor pool, and suppress non-editor pools.
+                case Hit: return poolHitEditorMode;
+                default: return null;
+            }
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -71,14 +71,15 @@ namespace osu.Game.Rulesets.Taiko.Edit
 
         public void SetRimState(bool state)
         {
-            if (SelectedItems.OfType<Hit>().All(h => h.Type == (state ? HitType.Rim : HitType.Centre)))
+            var expectedType = state ? HitType.Rim : HitType.Centre;
+            if (SelectedItems.OfType<Hit>().All(h => h.Type == expectedType))
                 return;
 
             EditorBeatmap.PerformOnSelection(h =>
             {
-                if (h is Hit taikoHit)
+                if (h is Hit taikoHit && taikoHit.Type != expectedType)
                 {
-                    taikoHit.Type = state ? HitType.Rim : HitType.Centre;
+                    taikoHit.Type = expectedType;
                     EditorBeatmap.Update(h);
                 }
             });

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -77,8 +77,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             OnNewResult += onNewResult;
         }
 
-        protected override void RestorePieceState()
+        protected override void OnApply()
         {
+            base.OnApply();
             updateColour();
             Height = HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE;
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRoll.cs
@@ -6,19 +6,19 @@
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Utils;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -77,9 +77,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             OnNewResult += onNewResult;
         }
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
             updateColour();
             Height = HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE;
         }
@@ -119,8 +118,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             return base.CreateNestedHitObject(hitObject);
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollBody),
-            _ => new ElongatedCirclePiece());
+        protected override SkinnableDrawable OnLoadCreateMainPiece()
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollBody), _ => new ElongatedCirclePiece());
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 
@@ -174,7 +173,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private void updateColour(double fadeDuration = 0)
         {
             Color4 newColour = Interpolation.ValueAt((float)rollingHits / rolling_hits_for_engaged_colour, colourIdle, colourEngaged, 0, 1);
-            (MainPiece.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
+            (MainPiece?.Drawable as IHasAccentColour)?.FadeAccent(newColour, fadeDuration);
         }
 
         public partial class StrongNestedHit : DrawableStrongNestedHit

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -43,10 +43,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             base.OnApply();
 
             IsFirstTick.Value = HitObject.FirstTick;
-        }
-
-        protected override void RestorePieceState()
-        {
             Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableDrumRollTick.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             FillMode = FillMode.Fit;
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
+        protected override SkinnableDrawable OnLoadCreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
 
         protected override void OnApply()
         {
@@ -45,9 +45,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             IsFirstTick.Value = HitObject.FirstTick;
         }
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
             Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs
@@ -3,6 +3,8 @@
 
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
+using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -26,6 +28,17 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             base.LoadComplete();
             ApplyMaxResult();
+            Size = new osuTK.Vector2(0.3f);
+        }
+
+        private static float degree = 0f;
+        protected override void PrepareForUse()
+        {
+            const float single_rotation_degree = 7f;
+
+            base.PrepareForUse();
+            degree = (degree + single_rotation_degree) % 360f;
+            Rotation = degree;
         }
 
         protected override void LoadSamples()
@@ -33,5 +46,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             // block base call - flying hits are not supposed to play samples
             // the base call could overwrite the type of this hit
         }
+
+        // TODO: which skin use?
+        protected override SkinnableDrawable? OnLoadCreateMainPiece()
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell), _ => new SwellCirclePiece(), confineMode: ConfineMode.ScaleToFit);
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -55,15 +55,14 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             type.BindTo(HitObject.TypeBindable);
             // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            type.BindValueChanged(_ => Scheduler.AddOnce(RecreatePieces));
+            type.BindValueChanged(_ => Scheduler.AddOnce(RestorePieceState));
 
             base.OnApply();
         }
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
             updateActionsFromType();
-            base.RecreatePieces();
             Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }
 
@@ -90,7 +89,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     : new[] { TaikoAction.LeftRim, TaikoAction.RightRim };
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => HitObject.Type == HitType.Centre
+        protected override SkinnableDrawable OnLoadCreateMainPiece() => HitObject.Type == HitType.Centre
             ? new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.CentreHit), _ => new CentreHitCirclePiece(), confineMode: ConfineMode.ScaleToFit)
             : new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.RimHit), _ => new RimHitCirclePiece(), confineMode: ConfineMode.ScaleToFit);
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -56,15 +56,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override void OnApply()
         {
+            base.OnApply(); // it's empty actually
             type.BindTo(HitObject.TypeBindable);
-            // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            type.BindValueChanged(_ => Scheduler.AddOnce(RestorePieceState));
 
-            base.OnApply();
-        }
-
-        protected override void RestorePieceState()
-        {
             if (editorMode)
             {
                 // We in Editor Mode so the performance is not critical and we can recreate piece.

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -40,15 +40,18 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         private readonly Bindable<HitType> type = new Bindable<HitType>();
 
+        private readonly bool editorMode = false;
+
         public DrawableHit()
             : this(null)
         {
         }
 
-        public DrawableHit([CanBeNull] Hit hit)
+        public DrawableHit([CanBeNull] Hit hit, bool editorMode = false)
             : base(hit)
         {
             FillMode = FillMode.Fit;
+            this.editorMode = editorMode;
         }
 
         protected override void OnApply()
@@ -62,6 +65,12 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override void RestorePieceState()
         {
+            if (editorMode)
+            {
+                // We in Editor Mode so the performance is not critical and we can recreate piece.
+                if (MainPiece != null) Content.Remove(MainPiece, true);
+                Content.Add(MainPiece = OnLoadCreateMainPiece());
+            }
             updateActionsFromType();
             Size = new Vector2(HitObject.IsStrong ? TaikoStrongableHitObject.DEFAULT_STRONG_SIZE : TaikoHitObject.DEFAULT_SIZE);
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -10,16 +10,16 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
-using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Screens.Play;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 {
@@ -136,7 +136,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             targetRing.BorderColour = colours.YellowDark.Opacity(0.25f);
         }
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell),
+        protected override SkinnableDrawable OnLoadCreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.Swell),
             _ => new SwellCirclePiece
             {
                 // to allow for rotation transform
@@ -144,9 +144,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Origin = Anchor.Centre,
             });
 
-        protected override void RecreatePieces()
+        protected override void RestorePieceState()
         {
-            base.RecreatePieces();
             Size = baseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwell.cs
@@ -144,8 +144,9 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Origin = Anchor.Centre,
             });
 
-        protected override void RestorePieceState()
+        protected override void OnApply()
         {
+            base.OnApply();
             Size = baseSize = new Vector2(TaikoHitObject.DEFAULT_SIZE);
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -43,7 +43,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 
-        protected override void RestorePieceState() { }
         protected override SkinnableDrawable OnLoadCreateMainPiece()
             => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
     }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableSwellTick.cs
@@ -43,7 +43,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => false;
 
-        protected override SkinnableDrawable CreateMainPiece() => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick),
-            _ => new TickPiece());
+        protected override void RestorePieceState() { }
+        protected override SkinnableDrawable OnLoadCreateMainPiece()
+            => new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.DrumRollTick), _ => new TickPiece());
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         /// <summary>
         /// Moves <see cref="Content"/> to the normal hitobject layer.
-        /// Does nothing is content is not currently proxied.
+        /// Does nothing if content is not currently proxied.
         /// </summary>
         protected void UnproxyContent()
         {

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -141,22 +142,31 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
             RelativeSizeAxes = Axes.Both;
         }
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var drawable = OnLoadCreateMainPiece();
+            if (drawable is not null)
+                Content.Add(MainPiece = drawable);
+        }
+
         protected override void OnApply()
         {
             base.OnApply();
 
+            // TODO: now it fixed, yes?
             // TODO: THIS CANNOT BE HERE, it makes pooling pointless (see https://github.com/ppy/osu/issues/21072).
-            RecreatePieces();
+            RestorePieceState();
         }
 
-        protected virtual void RecreatePieces()
+        protected abstract void RestorePieceState();
+        protected abstract SkinnableDrawable OnLoadCreateMainPiece();
+
+        // TODO: call it from Editor OR even delete it and use somehow TaikoPlayfield from Editor
+        public unsafe void ReLoadMainPiece()
         {
-            if (MainPiece != null)
-                Content.Remove(MainPiece, true);
-
-            Content.Add(MainPiece = CreateMainPiece());
+            Content.Remove(MainPiece, true);
+            load();
         }
-
-        protected abstract SkinnableDrawable CreateMainPiece();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -150,17 +150,6 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 Content.Add(MainPiece = drawable);
         }
 
-        protected override void OnApply()
-        {
-            base.OnApply();
-
-            // TODO: now it fixed, yes?
-            // TODO: THIS CANNOT BE HERE, it makes pooling pointless (see https://github.com/ppy/osu/issues/21072).
-            RestorePieceState();
-        }
-
-        protected abstract void RestorePieceState();
-
         /// <summary>Creates <c>MainPiece</c>. Calls only on <c>load</c> or in EditorMode.</summary>
         protected abstract SkinnableDrawable OnLoadCreateMainPiece();
     }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -161,12 +161,5 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected abstract void RestorePieceState();
         protected abstract SkinnableDrawable OnLoadCreateMainPiece();
-
-        // TODO: call it from Editor OR even delete it and use somehow TaikoPlayfield from Editor
-        public unsafe void ReLoadMainPiece()
-        {
-            Content.Remove(MainPiece, true);
-            load();
-        }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoHitObject.cs
@@ -160,6 +160,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         }
 
         protected abstract void RestorePieceState();
+
+        /// <summary>Creates <c>MainPiece</c>. Calls only on <c>load</c> or in EditorMode.</summary>
         protected abstract SkinnableDrawable OnLoadCreateMainPiece();
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -27,11 +27,8 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
 
         protected override void OnApply()
         {
-            isStrong.BindTo(HitObject.IsStrongBindable);
-            // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RestorePieceState));
-
             base.OnApply();
+            isStrong.BindTo(HitObject.IsStrongBindable);
         }
 
         protected override void OnFree()

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableTaikoStrongableHitObject.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         {
             isStrong.BindTo(HitObject.IsStrongBindable);
             // this doesn't need to be run inline as RecreatePieces is called by the base call below.
-            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RecreatePieces));
+            isStrong.BindValueChanged(_ => Scheduler.AddOnce(RestorePieceState));
 
             base.OnApply();
         }

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -42,8 +42,9 @@ namespace osu.Game.Rulesets.Taiko.Objects
             SamplesBindable.BindCollectionChanged((_, _) => updateTypeFromSamples());
         }
 
-        public Hit(HitType type) : this()
+        public Hit(HitType type, bool isStroing) : this()
         {
+            IsStrong = isStroing;
             Type = type;
         }
 

--- a/osu.Game.Rulesets.Taiko/Objects/Hit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Hit.cs
@@ -42,6 +42,11 @@ namespace osu.Game.Rulesets.Taiko.Objects
             SamplesBindable.BindCollectionChanged((_, _) => updateTypeFromSamples());
         }
 
+        public Hit(HitType type) : this()
+        {
+            Type = type;
+        }
+
         private void updateTypeFromSamples()
         {
             Type = getRimSamples().Any() ? HitType.Rim : HitType.Centre;

--- a/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/Skinning/Default/DefaultKiaiHitExplosion.cs
@@ -7,12 +7,14 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
 using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Skinning.Default
 {
-    public partial class DefaultKiaiHitExplosion : CircularContainer
+    public partial class DefaultKiaiHitExplosion : CircularContainer, IAnimatableHitExplosion
     {
         public override bool RemoveWhenNotAlive => true;
 
@@ -51,14 +53,16 @@ namespace osu.Game.Rulesets.Taiko.Skinning.Default
             };
         }
 
-        protected override void LoadComplete()
+        public void Animate(DrawableHitObject _drawableHitObject)
         {
-            base.LoadComplete();
-
             this.ScaleTo(new Vector2(1, 3f), 500, Easing.OutQuint);
             this.FadeOut(250);
+        }
 
-            Expire(true);
+        public void AnimateSecondHit()
+        {
+            this.ScaleTo(new Vector2(TaikoStrongableHitObject.STRONG_SCALE, 3f), 500, Easing.OutQuint);
+            this.FadeOut(250);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosion.cs
@@ -2,34 +2,22 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Pooling;
-using osu.Game.Rulesets.Judgements;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
     /// <summary>
     /// A circle explodes from the hit target to indicate a hitobject has been hit.
     /// </summary>
-    internal partial class HitExplosion : PoolableDrawable
+    internal partial class HitExplosion : HitExplosionBase
     {
-        public override bool RemoveWhenNotAlive => true;
-        public override bool RemoveCompletedTransforms => false;
-
         private readonly HitResult result;
-
-        private double? secondHitTime;
-
-        public DrawableHitObject? JudgedObject;
-
-        private SkinnableDrawable skinnable = null!;
 
         /// <summary>
         /// This constructor only exists to meet the <c>new()</c> type constraint of <see cref="DrawablePool{T}"/>.
@@ -42,60 +30,12 @@ namespace osu.Game.Rulesets.Taiko.UI
         public HitExplosion(HitResult result)
         {
             this.result = result;
-
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-
             Size = new Vector2(TaikoHitObject.DEFAULT_SIZE);
-            RelativeSizeAxes = Axes.Both;
-
             RelativePositionAxes = Axes.Both;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            InternalChild = skinnable = new SkinnableDrawable(new TaikoSkinComponentLookup(getComponentName(result)), _ => new DefaultHitExplosion(result));
-            skinnable.OnSkinChanged += runAnimation;
-        }
-
-        public void Apply(DrawableHitObject? drawableHitObject)
-        {
-            JudgedObject = drawableHitObject;
-            secondHitTime = null;
-        }
-
-        protected override void PrepareForUse()
-        {
-            base.PrepareForUse();
-            runAnimation();
-        }
-
-        private void runAnimation()
-        {
-            if (JudgedObject?.Result == null)
-                return;
-
-            double resultTime = JudgedObject.Result.TimeAbsolute;
-
-            LifetimeStart = resultTime;
-
-            ApplyTransformsAt(double.MinValue, true);
-            ClearTransforms(true);
-
-            using (BeginAbsoluteSequence(resultTime))
-                (skinnable.Drawable as IAnimatableHitExplosion)?.Animate(JudgedObject);
-
-            if (secondHitTime != null)
-            {
-                using (BeginAbsoluteSequence(secondHitTime.Value))
-                {
-                    (skinnable.Drawable as IAnimatableHitExplosion)?.AnimateSecondHit();
-                }
-            }
-
-            LifetimeEnd = skinnable.Drawable.LatestTransformEndTime;
-        }
+        protected override SkinnableDrawable OnLoadSkinnableCreate() =>
+            new SkinnableDrawable(new TaikoSkinComponentLookup(getComponentName(result)), _ => new DefaultHitExplosion(result));
 
         private static TaikoSkinComponents getComponentName(HitResult result)
         {
@@ -112,12 +52,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             }
 
             throw new ArgumentOutOfRangeException(nameof(result), $"Invalid result type: {result}");
-        }
-
-        public void VisualiseSecondHit(JudgementResult judgementResult)
-        {
-            secondHitTime = judgementResult.TimeAbsolute;
-            runAnimation();
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
@@ -15,6 +15,7 @@ namespace osu.Game.Rulesets.Taiko.UI
     /// </summary>
     internal abstract partial class HitExplosionBase : PoolableDrawable
     {
+        /// <summary>Creates <c>Skinnable</c>. Calls only on <c>load</c>.</summary>
         protected abstract SkinnableDrawable OnLoadSkinnableCreate();
 
         public override bool RemoveWhenNotAlive => true;

--- a/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitExplosionBase.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    /// <summary>
+    /// A base class for taiko explosions from target hitting to indicate a hitobject has been hit.
+    /// </summary>
+    internal abstract partial class HitExplosionBase : PoolableDrawable
+    {
+        protected abstract SkinnableDrawable OnLoadSkinnableCreate();
+
+        public override bool RemoveWhenNotAlive => true;
+        public override bool RemoveCompletedTransforms => false;
+
+
+        protected double? SecondHitTime;
+
+        public DrawableHitObject? JudgedObject;
+
+        protected SkinnableDrawable Skinnable = null!;
+
+        public HitExplosionBase()
+        {
+            Anchor = Anchor.Centre;
+            Origin = Anchor.Centre;
+
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = Skinnable = OnLoadSkinnableCreate();
+            Skinnable.OnSkinChanged += RunAnimation;
+        }
+
+        public void Apply(DrawableHitObject? drawableHitObject)
+        {
+            JudgedObject = drawableHitObject;
+            SecondHitTime = null;
+        }
+
+        protected override void PrepareForUse()
+        {
+            base.PrepareForUse();
+            RunAnimation();
+        }
+
+        protected void RunAnimation()
+        {
+            if (JudgedObject?.Result is null) return;
+
+            double resultTime = JudgedObject.Result.TimeAbsolute;
+            LifetimeStart = resultTime;
+
+            // Clear transforms
+            ApplyTransformsAt(double.MinValue, true);
+            ClearTransforms(true);
+
+            if (Skinnable.Drawable is IAnimatableHitExplosion animatable)
+            {
+                using (BeginAbsoluteSequence(resultTime))
+                    animatable.Animate(JudgedObject);
+
+                if (SecondHitTime != null)
+                    using (BeginAbsoluteSequence(SecondHitTime.Value))
+                        animatable.AnimateSecondHit();
+            }
+
+            LifetimeEnd = Skinnable.Drawable.LatestTransformEndTime;
+        }
+
+        public void VisualiseSecondHit(JudgementResult judgementResult)
+        {
+            SecondHitTime = judgementResult.TimeAbsolute;
+            RunAnimation();
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/HitPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitPool.cs
@@ -12,6 +12,12 @@ namespace osu.Game.Rulesets.Taiko.UI
     {
         private readonly HitType hitType;
         private readonly bool isStrong;
+        private readonly bool editorMode = false;
+
+        public HitPool(int initialSize, bool editorMode) : base(initialSize)
+        {
+            this.editorMode = editorMode;
+        }
 
         public HitPool(int initialSize, HitType hitType, bool isStrong)
             : base(initialSize)
@@ -20,6 +26,6 @@ namespace osu.Game.Rulesets.Taiko.UI
             this.isStrong = isStrong;
         }
 
-        protected override DrawableHit CreateNewDrawable() => new DrawableHit(new Hit(hitType, isStrong));
+        protected override DrawableHit CreateNewDrawable() => new DrawableHit(new Hit(hitType, isStrong), editorMode);
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitPool.cs
@@ -11,13 +11,15 @@ namespace osu.Game.Rulesets.Taiko.UI
     internal partial class HitPool : DrawablePool<DrawableHit>
     {
         private readonly HitType hitType;
+        private readonly bool isStrong;
 
-        public HitPool(HitType hitType, int initialSize)
+        public HitPool(int initialSize, HitType hitType, bool isStrong)
             : base(initialSize)
         {
             this.hitType = hitType;
+            this.isStrong = isStrong;
         }
 
-        protected override DrawableHit CreateNewDrawable() => new DrawableHit(new Hit(hitType));
+        protected override DrawableHit CreateNewDrawable() => new DrawableHit(new Hit(hitType, isStrong));
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/HitPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/HitPool.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    /// <summary>Pool for hit of a specific HitType.</summary>
+    internal partial class HitPool : DrawablePool<DrawableHit>
+    {
+        private readonly HitType hitType;
+
+        public HitPool(HitType hitType, int initialSize)
+            : base(initialSize)
+        {
+            this.hitType = hitType;
+        }
+
+        protected override DrawableHit CreateNewDrawable() => new DrawableHit(new Hit(hitType));
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosion.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Skinning.Default;
@@ -12,37 +10,30 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.UI
 {
-    public partial class KiaiHitExplosion : Container
+    /// <summary>
+    /// An explosion from the hit target in Kiai mode to indicate a hitobject has been hit.
+    /// </summary>
+    internal partial class KiaiHitExplosion : HitExplosionBase
     {
-        public override bool RemoveWhenNotAlive => true;
-
-        [Cached(typeof(DrawableHitObject))]
-        public readonly DrawableHitObject JudgedObject;
-
         private readonly HitType hitType;
 
-        private SkinnableDrawable skinnable = null!;
+        /// <summary>
+        /// This constructor only exists to meet the <c>new()</c> type constraint of <see cref="DrawablePool{T}"/>.
+        /// </summary>
+        public KiaiHitExplosion() : this(HitType.Centre) { }
 
-        public override double LifetimeStart => skinnable.Drawable.LifetimeStart;
-
-        public override double LifetimeEnd => skinnable.Drawable.LifetimeEnd;
-
-        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType hitType)
+        public KiaiHitExplosion(HitType hitType)
         {
-            JudgedObject = judgedObject;
             this.hitType = hitType;
-
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-
-            RelativeSizeAxes = Axes.Both;
             Size = new Vector2(TaikoHitObject.DEFAULT_SIZE, 1);
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        public KiaiHitExplosion(DrawableHitObject judgedObject, HitType hitType) : this(hitType)
         {
-            Child = skinnable = new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
+            Apply(judgedObject);
         }
+
+        protected override SkinnableDrawable OnLoadSkinnableCreate() =>
+            new SkinnableDrawable(new TaikoSkinComponentLookup(TaikoSkinComponents.TaikoExplosionKiai), _ => new DefaultKiaiHitExplosion(hitType));
     }
 }

--- a/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosionPool.cs
+++ b/osu.Game.Rulesets.Taiko/UI/KiaiHitExplosionPool.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Pooling;
+using osu.Game.Rulesets.Taiko.Objects;
+
+namespace osu.Game.Rulesets.Taiko.UI
+{
+    /// <summary>
+    /// Pool for hit explosions of a specific type.
+    /// </summary>
+    internal partial class KiaiHitExplosionPool : DrawablePool<KiaiHitExplosion>
+    {
+        private readonly HitType hitType;
+
+        public KiaiHitExplosionPool(HitType hitType) : base(15)
+        {
+            this.hitType = hitType;
+        }
+
+        protected override KiaiHitExplosion CreateNewDrawable() => new KiaiHitExplosion(hitType);
+    }
+}

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private JudgementPooler<DrawableTaikoJudgement> judgementPooler = null!;
         private readonly IDictionary<HitResult, HitExplosionPool> explosionPools = new Dictionary<HitResult, HitExplosionPool>();
+        private readonly IDictionary<HitType, KiaiHitExplosionPool> kiaiExplosionPools = new Dictionary<HitType, KiaiHitExplosionPool>();
 
         private ProxyContainer topLevelHitContainer = null!;
         private InputDrum inputDrum = null!;
@@ -202,6 +203,10 @@ namespace osu.Game.Rulesets.Taiko.UI
                 explosionPools.Add(result, new HitExplosionPool(result));
             AddRangeInternal(explosionPools.Values);
 
+            foreach (var type in Enum.GetValues<HitType>())
+                kiaiExplosionPools.Add(type, new KiaiHitExplosionPool(type));
+            AddRangeInternal(kiaiExplosionPools.Values);
+
             AddRangeInternal(poolsHit.Values);
         }
 
@@ -320,7 +325,11 @@ namespace osu.Game.Rulesets.Taiko.UI
             {
                 case TaikoStrongJudgement:
                     if (result.IsHit)
+                    {
                         hitExplosionContainer.Children.FirstOrDefault(e => e.JudgedObject == ((DrawableStrongNestedHit)judgedObject).ParentHitObject)?.VisualiseSecondHit(result);
+                        if (result.HitObject.Kiai)
+                            kiaiExplosionContainer.Children.FirstOrDefault(e => e.JudgedObject == ((DrawableStrongNestedHit)judgedObject).ParentHitObject)?.VisualiseSecondHit(result);
+                    }
                     break;
 
                 case TaikoDrumRollTickJudgement:
@@ -356,8 +365,12 @@ namespace osu.Game.Rulesets.Taiko.UI
         {
             hitExplosionContainer.Add(explosionPools[result]
                 .Get(explosion => explosion.Apply(drawableObject)));
-            if (drawableObject.HitObject.Kiai)
-                kiaiExplosionContainer.Add(new KiaiHitExplosion(drawableObject, type));
+
+            //TODO: should we check `result.IsHit` ?
+            if (drawableObject.HitObject.Kiai && result.IsHit())
+                kiaiExplosionContainer.Add(
+                    kiaiExplosionPools[type].Get(
+                        explosion => explosion.Apply(drawableObject)));
         }
 
         private partial class ProxyContainer : LifetimeManagementContainer

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -210,6 +210,7 @@ namespace osu.Game.Rulesets.Taiko.UI
             AddRangeInternal(poolsHit.Values);
         }
 
+        /// <summary><see cref="Hit"/> to <see cref="DrawableHit"/> pools based on its <c>(HitType, IsStrong)</c> properties.</summary>
         private readonly IDictionary<(HitType, bool), HitPool> poolsHit = new Dictionary<(HitType, bool), HitPool>()
         {
             // Non strong (pool size is 50 for each type):
@@ -219,10 +220,11 @@ namespace osu.Game.Rulesets.Taiko.UI
             {(HitType.Centre, true), new HitPool(20, HitType.Centre, true)},
             {(HitType.Rim, true), new HitPool(20, HitType.Rim, true)},
         };
-        protected override IDrawablePool? AdditionalPrepareDrawablePool(HitObject hitObject)
+        protected override IDrawablePool? PropertyBasedDrawableHitObjectPool(HitObject hitObject)
         {
             switch (hitObject)
             {
+                // IDrawablePool for `Hit` object determined by its `HitType` & `IsStrong` properties.
                 case Hit hit: return poolsHit[(hit.Type, hit.IsStrong)];
                 default: return null;
             }

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -205,18 +205,20 @@ namespace osu.Game.Rulesets.Taiko.UI
             AddRangeInternal(poolsHit.Values);
         }
 
-        private readonly IDictionary<HitType, HitPool> poolsHit = new Dictionary<HitType, HitPool>()
+        private readonly IDictionary<(HitType, bool), HitPool> poolsHit = new Dictionary<(HitType, bool), HitPool>()
         {
-            {HitType.Centre, new HitPool(HitType.Centre, 50)},
-            {HitType.Rim, new HitPool(HitType.Rim, 50)},
+            // Non strong (pool size is 50 for each type):
+            {(HitType.Centre, false), new HitPool(50, HitType.Centre, false)},
+            {(HitType.Rim, false), new HitPool(50, HitType.Rim, false)},
+            // Strong (pool size is 20 for each type):
+            {(HitType.Centre, true), new HitPool(20, HitType.Centre, true)},
+            {(HitType.Rim, true), new HitPool(20, HitType.Rim, true)},
         };
         protected override IDrawablePool? AdditionalPrepareDrawablePool(HitObject hitObject)
         {
             switch (hitObject)
             {
-                case Hit hit: return poolsHit[hit.Type];
-                // TODO: ???
-                //case Hit.StrongNestedHit hitStrong: return  ;
+                case Hit hit: return poolsHit[(hit.Type, hit.IsStrong)];
                 default: return null;
             }
         }

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -350,8 +350,6 @@ namespace osu.Game.Rulesets.UI
             OnHitObjectRemoved(entry.HitObject);
         }
 
-        protected virtual IDrawablePool AdditionalPrepareDrawablePool(HitObject hitObject) => null;
-
         /// <summary>
         /// Creates the <see cref="HitObjectLifetimeEntry"/> for a given <see cref="HitObject"/>.
         /// </summary>
@@ -430,10 +428,21 @@ namespace osu.Game.Rulesets.UI
             });
         }
 
+        /// <summary>
+        /// Returns a pool for given <see cref="HitObject"/> in case when it can not be determined only by <see cref="HitObject"/> type alone.<br/>
+        /// It only have sense if the same <see cref="HitObject"/> can have different <see cref="PoolableDrawable"/> for its representation.
+        /// </summary>
+        /// <param name="hitObject">The <see cref="HitObject"/> for which <see cref="IDrawablePool"/> will be returned.</param>
+        /// <returns>
+        /// * <c>null</c> if no property based pool is required for given <see cref="HitObject"/>;<br/>
+        /// * <see cref="IDrawablePool"/> if given <see cref="HitObject"/> requires property based pool.
+        /// </returns>
+        protected virtual IDrawablePool PropertyBasedDrawableHitObjectPool(HitObject hitObject) => null;
+
         private IDrawablePool prepareDrawableHitObjectPool(HitObject hitObject)
         {
-            var additional = AdditionalPrepareDrawablePool(hitObject);
-            if (additional is not null) return additional;
+            var property_based_pool = PropertyBasedDrawableHitObjectPool(hitObject);
+            if (property_based_pool is not null) return property_based_pool;
 
             var lookupType = hitObject.GetType();
 

--- a/osu.Game/Rulesets/UI/Playfield.cs
+++ b/osu.Game/Rulesets/UI/Playfield.cs
@@ -11,19 +11,19 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Objects.Pooling;
 using osu.Game.Skinning;
 using osuTK;
-using osu.Game.Rulesets.Objects.Pooling;
-using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Graphics.Primitives;
 
 namespace osu.Game.Rulesets.UI
 {
@@ -350,6 +350,8 @@ namespace osu.Game.Rulesets.UI
             OnHitObjectRemoved(entry.HitObject);
         }
 
+        protected virtual IDrawablePool AdditionalPrepareDrawablePool(HitObject hitObject) => null;
+
         /// <summary>
         /// Creates the <see cref="HitObjectLifetimeEntry"/> for a given <see cref="HitObject"/>.
         /// </summary>
@@ -430,12 +432,13 @@ namespace osu.Game.Rulesets.UI
 
         private IDrawablePool prepareDrawableHitObjectPool(HitObject hitObject)
         {
+            var additional = AdditionalPrepareDrawablePool(hitObject);
+            if (additional is not null) return additional;
+
             var lookupType = hitObject.GetType();
 
-            IDrawablePool pool;
-
             // Tests may add derived hitobject instances for which pools don't exist. Try to find any applicable pool and dynamically assign the type if the pool exists.
-            if (!pools.TryGetValue(lookupType, out pool))
+            if (!pools.TryGetValue(lookupType, out var pool))
             {
                 foreach (var (t, p) in pools)
                 {


### PR DESCRIPTION
Fixes #21072 

**Need To Disucss**:
* Which skin should be used [here](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableFlyingHit.cs#L50-L52)? Previously was drawn dynamic `Hit`. In osu!stable there drawn a circle with color that changed from yellow to red. Maybe there should be additional `TaikoSkinComponents`?
* seems like Kiai explosion should be displayed only [when hit happens](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs#L370). Am I wrong?
* Is there a benches that check performance related to pooling? How to run it?

**Solution Notes**:
The `Hit` part of solution use different behavior for editor and non-editor mode. When it's EditorMode we still [recreate](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/Edit/TaikoEditorPlayfield.cs#L30-L37) `Hit` pieces each `Apply` (also [see](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs#L68-L73)) but in game we [don't recreate it](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs#L213-L226). It's done in that way because [SetRimState](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs#L82) should to change `SkinnableDrawable` for the same `HitObject` and seems like `DrawableHitObject` is buffered for it and simple `Remove` + `Insert` does not work. 
Instead of doing [this](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game/Rulesets/UI/Playfield.cs#L353) + [this](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game/Rulesets/UI/Playfield.cs#L435-L436) + [this](https://github.com/Nikita-str/osu/blob/d57ed5841a1eb80a54ad18be5827cfa85ccbf61b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs#L222-L229) you can split taiko `Hit` into few types and pooling by them but such solution is more complicated.