### PR TITLE
Move hit error to centre in Triangles and Argon

### DIFF
--- a/osu.Game/Skinning/ArgonSkin.cs
+++ b/osu.Game/Skinning/ArgonSkin.cs
@@ -131,6 +131,7 @@ namespace osu.Game.Skinning
                                 var score = container.OfType<ArgonScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<ArgonAccuracyCounter>().FirstOrDefault();
                                 var performancePoints = container.OfType<ArgonPerformancePointsCounter>().FirstOrDefault();
+                                var hitError = container.OfType<HitErrorMeter>().FirstOrDefault();
                                 var songProgress = container.OfType<ArgonSongProgress>().FirstOrDefault();
                                 var keyCounter = container.OfType<ArgonKeyCounterDisplay>().FirstOrDefault();
 
@@ -178,22 +179,12 @@ namespace osu.Game.Skinning
                                         performancePoints.Origin = Anchor.TopRight;
                                     }
 
-                                    var hitError = container.OfType<HitErrorMeter>().FirstOrDefault();
-
                                     if (hitError != null)
                                     {
-                                        hitError.Anchor = Anchor.CentreLeft;
+                                        hitError.Position = new Vector2(0, -20);
+                                        hitError.Anchor = Anchor.BottomCentre;
                                         hitError.Origin = Anchor.CentreLeft;
-                                    }
-
-                                    var hitError2 = container.OfType<HitErrorMeter>().LastOrDefault();
-
-                                    if (hitError2 != null)
-                                    {
-                                        hitError2.Anchor = Anchor.CentreRight;
-                                        hitError2.Scale = new Vector2(-1, 1);
-                                        // origin flipped to match scale above.
-                                        hitError2.Origin = Anchor.CentreLeft;
+                                        hitError.Rotation = -90;
                                     }
 
                                     if (songProgress != null)
@@ -240,7 +231,6 @@ namespace osu.Game.Skinning
                                     {
                                         Scale = new Vector2(0.8f),
                                     },
-                                    new BarHitErrorMeter(),
                                     new BarHitErrorMeter(),
                                     new ArgonSongProgress(),
                                     new ArgonKeyCounterDisplay(),

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Skinning
 
                                     if (hitError != null)
                                     {
-                                        hitError.Position = new Vector2(0, -30);
+                                        hitError.Position = new Vector2(0, -50);
                                         hitError.Anchor = Anchor.BottomCentre;
                                         hitError.Origin = Anchor.CentreLeft;
                                         hitError.Rotation = -90;

--- a/osu.Game/Skinning/TrianglesSkin.cs
+++ b/osu.Game/Skinning/TrianglesSkin.cs
@@ -87,6 +87,7 @@ namespace osu.Game.Skinning
                                 var score = container.OfType<DefaultScoreCounter>().FirstOrDefault();
                                 var accuracy = container.OfType<DefaultAccuracyCounter>().FirstOrDefault();
                                 var combo = container.OfType<DefaultComboCounter>().FirstOrDefault();
+                                var hitError = container.OfType<HitErrorMeter>().FirstOrDefault();
                                 var ppCounter = container.OfType<PerformancePointsCounter>().FirstOrDefault();
                                 var songProgress = container.OfType<DefaultSongProgress>().FirstOrDefault();
                                 var keyCounter = container.OfType<DefaultKeyCounterDisplay>().FirstOrDefault();
@@ -123,22 +124,12 @@ namespace osu.Game.Skinning
                                         }
                                     }
 
-                                    var hitError = container.OfType<HitErrorMeter>().FirstOrDefault();
-
                                     if (hitError != null)
                                     {
-                                        hitError.Anchor = Anchor.CentreLeft;
+                                        hitError.Position = new Vector2(0, -30);
+                                        hitError.Anchor = Anchor.BottomCentre;
                                         hitError.Origin = Anchor.CentreLeft;
-                                    }
-
-                                    var hitError2 = container.OfType<HitErrorMeter>().LastOrDefault();
-
-                                    if (hitError2 != null)
-                                    {
-                                        hitError2.Anchor = Anchor.CentreRight;
-                                        hitError2.Scale = new Vector2(-1, 1);
-                                        // origin flipped to match scale above.
-                                        hitError2.Origin = Anchor.CentreLeft;
+                                        hitError.Rotation = -90;
                                     }
                                 }
 
@@ -163,7 +154,6 @@ namespace osu.Game.Skinning
                                     new DefaultHealthDisplay(),
                                     new DefaultSongProgress(),
                                     new DefaultKeyCounterDisplay(),
-                                    new BarHitErrorMeter(),
                                     new BarHitErrorMeter(),
                                     new TrianglesPerformancePointsCounter()
                                 }


### PR DESCRIPTION
Most player skins and classic also use this

In game (mania):
<img width="709" alt="螢幕截圖 2024-12-27 03 33 28" src="https://github.com/user-attachments/assets/7e776e7f-4d92-42a0-b67b-f13a277496f7" />

Autoplay (mania) is broken but I'm not sure why:
<img width="714" alt="image" src="https://github.com/user-attachments/assets/eef9d638-0355-4014-a899-0ee04643a9a2" />
