### PR TITLE
Pause playback when entering gameplay test from editor

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorTestGameplay.cs
@@ -177,6 +177,7 @@ namespace osu.Game.Tests.Visual.Editing
             // bit of a hack to ensure this test can be ran multiple times without running into UNIQUE constraint failures
             AddStep("set unique difficulty name", () => EditorBeatmap.BeatmapInfo.DifficultyName = Guid.NewGuid().ToString());
 
+            AddStep("start playing track", () => InputManager.Key(Key.Space));
             AddStep("click test gameplay button", () =>
             {
                 var button = Editor.ChildrenOfType<TestGameplayButton>().Single();
@@ -185,11 +186,13 @@ namespace osu.Game.Tests.Visual.Editing
                 InputManager.Click(MouseButton.Left);
             });
             AddUntilStep("save prompt shown", () => DialogOverlay.CurrentDialog is SaveRequiredPopupDialog);
+            AddAssert("track stopped", () => !Beatmap.Value.Track.IsRunning);
 
             AddStep("save changes", () => DialogOverlay.CurrentDialog!.PerformOkAction());
 
             EditorPlayer editorPlayer = null;
             AddUntilStep("player pushed", () => (editorPlayer = Stack.CurrentScreen as EditorPlayer) != null);
+            AddUntilStep("track playing", () => Beatmap.Value.Track.IsRunning);
             AddAssert("beatmap has 1 object", () => editorPlayer.Beatmap.Value.Beatmap.HitObjects.Count == 1);
 
             AddUntilStep("wait for return to editor", () => Stack.CurrentScreen is Editor);

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -523,6 +523,8 @@ namespace osu.Game.Screens.Edit
 
         public void TestGameplay()
         {
+            clock.Stop();
+
             if (HasUnsavedChanges)
             {
                 dialogOverlay.Push(new SaveRequiredPopupDialog(() => attemptMutationOperation(() =>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31290.

Tend to agree that this is a good idea for gameplay test at least. Not sure about other similar interactions like exiting - I don't think it matters what's done in those cases, because for exiting timing is in no way key, so I just applied this locally to gameplay test.