### PR TITLE
Do not force miss slider with strict tracking active if tracking is lost before head was judged

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
@@ -49,5 +49,39 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
         });
+
+        [Test]
+        public void TestReleaseOverSliderBeforeHeadHit() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(501, new Vector2(200, 0), OsuAction.LeftButton),
+                new OsuReplayFrame(1000, new Vector2()),
+                new OsuReplayFrame(1020, new Vector2(), OsuAction.LeftButton),
+                new OsuReplayFrame(1750, new Vector2(0, 100), OsuAction.LeftButton),
+                new OsuReplayFrame(1751, new Vector2(0, 100)),
+            },
+            PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
+        });
     }
 }

--- a/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Mods/TestSceneOsuModStrictTracking.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
@@ -9,6 +10,7 @@ using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
 using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Tests.Mods
@@ -82,6 +84,133 @@ namespace osu.Game.Rulesets.Osu.Tests.Mods
                 new OsuReplayFrame(1751, new Vector2(0, 100)),
             },
             PassCondition = () => Player.ScoreProcessor.Combo.Value == 2
+        });
+
+        [Test]
+        public void TestDoNothing() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(0, new Vector2()),
+            },
+            PassCondition = () => Player.ScoreProcessor.JudgedHits == 3 && Player.ScoreProcessor.Statistics.All(s => s.Key.IsMiss())
+        });
+
+        [Test]
+        public void TestMissHeadButTrackRestOfSlider() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(0, new Vector2()),
+                new OsuReplayFrame(1375, new Vector2(0, 50), OsuAction.LeftButton),
+                new OsuReplayFrame(1751, new Vector2(0, 100)),
+            },
+            PassCondition = () => Player.ScoreProcessor.JudgedHits == 3 && Player.ScoreProcessor.Statistics[HitResult.Miss] == 1 && Player.ScoreProcessor.Statistics[HitResult.Great] == 1
+        });
+
+        [Test]
+        public void TestMissHeadThenDropTracking() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(0, new Vector2()),
+                new OsuReplayFrame(1375, new Vector2(0, 50), OsuAction.LeftButton),
+                new OsuReplayFrame(1475, new Vector2(), OsuAction.LeftButton),
+            },
+            PassCondition = () => Player.ScoreProcessor.JudgedHits == 3 && Player.ScoreProcessor.Statistics.All(s => s.Key.IsMiss())
+        });
+
+        [Test]
+        public void TestLosingTrackingMissesTail() => CreateModTest(new ModTestData
+        {
+            Mod = new OsuModStrictTracking(),
+            Autoplay = false,
+            CreateBeatmap = () => new Beatmap
+            {
+                HitObjects = new List<HitObject>
+                {
+                    new Slider
+                    {
+                        StartTime = 1000,
+                        Path = new SliderPath
+                        {
+                            ControlPoints =
+                            {
+                                new PathControlPoint(),
+                                new PathControlPoint(new Vector2(0, 100))
+                            }
+                        }
+                    }
+                }
+            },
+            ReplayFrames = new List<ReplayFrame>
+            {
+                new OsuReplayFrame(0, new Vector2(), OsuAction.LeftButton),
+                new OsuReplayFrame(500, new Vector2(200, 0), OsuAction.LeftButton),
+                new OsuReplayFrame(501, new Vector2(200, 0)),
+                new OsuReplayFrame(1000, new Vector2(), OsuAction.LeftButton),
+            },
+            PassCondition = () => Player.ScoreProcessor.Statistics.GetValueOrDefault(HitResult.Miss) == 1
         });
     }
 }

--- a/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStrictTracking.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 {
                     if (e.NewValue || slider.Judged) return;
 
-                    if (slider.Time.Current < slider.HitObject.StartTime)
+                    if (slider.Time.Current < slider.HitObject.StartTime || !slider.HeadCircle.Judged)
                         return;
 
                     var tail = slider.NestedHitObjects.OfType<StrictTrackingDrawableSliderTail>().First();


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29371.

https://github.com/ppy/osu/pull/26053 is a previous related fix that should probably have included this change but did not go far enough.

An interesting part of this is the part that pertains to what should happen when the slider head is *not* hit (see test cases added in https://github.com/ppy/osu/commit/033fe3fad541113c47060b1c83949dc398893252). I've opted to go with the lenient choice, which is to let the user continue to pick up tracking the slider even after the head was missed (but if tracking is lost at any point after that, the tail will miss as usual).