### PR TITLE
Populate metadata from ID3 tags when changing beatmap audio track in editor

### DIFF
--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -28,33 +28,29 @@ namespace osu.Game.Screens.Edit.Setup
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(SetupScreen setupScreen)
         {
-            var metadata = Beatmap.Metadata;
-
             Children = new[]
             {
-                ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist,
-                    !string.IsNullOrEmpty(metadata.ArtistUnicode) ? metadata.ArtistUnicode : metadata.Artist),
-                RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist,
-                    !string.IsNullOrEmpty(metadata.Artist) ? metadata.Artist : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
-                TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title,
-                    !string.IsNullOrEmpty(metadata.TitleUnicode) ? metadata.TitleUnicode : metadata.Title),
-                RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle,
-                    !string.IsNullOrEmpty(metadata.Title) ? metadata.Title : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode)),
-                creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator, metadata.Author.Username),
-                difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName, Beatmap.BeatmapInfo.DifficultyName),
-                sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource, metadata.Source),
-                tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoTags, metadata.Tags)
+                ArtistTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Artist),
+                RomanisedArtistTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedArtist),
+                TitleTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Title),
+                RomanisedTitleTextBox = createTextBox<FormRomanisedTextBox>(EditorSetupStrings.RomanisedTitle),
+                creatorTextBox = createTextBox<FormTextBox>(EditorSetupStrings.Creator),
+                difficultyTextBox = createTextBox<FormTextBox>(EditorSetupStrings.DifficultyName),
+                sourceTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoSource),
+                tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoTags)
             };
+
+            setupScreen.MetadataChanged += reloadMetadata;
+            reloadMetadata();
         }
 
-        private TTextBox createTextBox<TTextBox>(LocalisableString label, string initialValue)
+        private TTextBox createTextBox<TTextBox>(LocalisableString label)
             where TTextBox : FormTextBox, new()
             => new TTextBox
             {
                 Caption = label,
-                Current = { Value = initialValue },
                 TabbableContentContainer = this
             };
 
@@ -94,10 +90,29 @@ namespace osu.Game.Screens.Edit.Setup
 
             // for now, update on commit rather than making BeatmapMetadata bindables.
             // after switching database engines we can reconsider if switching to bindables is a good direction.
-            updateMetadata();
+            setMetadata();
         }
 
-        private void updateMetadata()
+        private void reloadMetadata()
+        {
+            var metadata = Beatmap.Metadata;
+
+            RomanisedArtistTextBox.ReadOnly = false;
+            RomanisedTitleTextBox.ReadOnly = false;
+
+            ArtistTextBox.Current.Value = !string.IsNullOrEmpty(metadata.ArtistUnicode) ? metadata.ArtistUnicode : metadata.Artist;
+            RomanisedArtistTextBox.Current.Value = !string.IsNullOrEmpty(metadata.Artist) ? metadata.Artist : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode);
+            TitleTextBox.Current.Value = !string.IsNullOrEmpty(metadata.TitleUnicode) ? metadata.TitleUnicode : metadata.Title;
+            RomanisedTitleTextBox.Current.Value = !string.IsNullOrEmpty(metadata.Title) ? metadata.Title : MetadataUtils.StripNonRomanisedCharacters(metadata.ArtistUnicode);
+            creatorTextBox.Current.Value = metadata.Author.Username;
+            difficultyTextBox.Current.Value = Beatmap.BeatmapInfo.DifficultyName;
+            sourceTextBox.Current.Value = metadata.Source;
+            tagsTextBox.Current.Value = metadata.Tags;
+
+            updateReadOnlyState();
+        }
+
+        private void setMetadata()
         {
             Beatmap.Metadata.ArtistUnicode = ArtistTextBox.Current.Value;
             Beatmap.Metadata.Artist = RomanisedArtistTextBox.Current.Value;

--- a/osu.Game/Screens/Edit/Setup/MetadataSection.cs
+++ b/osu.Game/Screens/Edit/Setup/MetadataSection.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.Edit.Setup
         public override LocalisableString Title => EditorSetupStrings.MetadataHeader;
 
         [BackgroundDependencyLoader]
-        private void load(SetupScreen setupScreen)
+        private void load(SetupScreen? setupScreen)
         {
             Children = new[]
             {
@@ -42,7 +42,9 @@ namespace osu.Game.Screens.Edit.Setup
                 tagsTextBox = createTextBox<FormTextBox>(BeatmapsetsStrings.ShowInfoTags)
             };
 
-            setupScreen.MetadataChanged += reloadMetadata;
+            if (setupScreen != null)
+                setupScreen.MetadataChanged += reloadMetadata;
+
             reloadMetadata();
         }
 

--- a/osu.Game/Screens/Edit/Setup/SetupScreen.cs
+++ b/osu.Game/Screens/Edit/Setup/SetupScreen.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -13,11 +14,14 @@ using osuTK;
 
 namespace osu.Game.Screens.Edit.Setup
 {
+    [Cached]
     public partial class SetupScreen : EditorScreen
     {
         public const float COLUMN_WIDTH = 450;
         public const float SPACING = 28;
         public const float MAX_WIDTH = 2 * COLUMN_WIDTH + SPACING;
+
+        public Action? MetadataChanged { get; set; }
 
         public SetupScreen()
             : base(EditorScreenMode.SongSetup)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/21189
- Supersedes / closes https://github.com/ppy/osu-framework/pull/5627
- Supersedes / closes https://github.com/ppy/osu/pull/22235

The reason why I opted for a complete rewrite rather than a revival of that aforementioned pull series is that it always felt quite gross to me to be pulling framework's audio subsystem into the task of reading ID3 tags, and I also partially don't believe that BASS is *good* at reading ID3 tags. Meanwhile, we already have another library pulled in that is *explicitly* intended for reading multimedia metadata, and using it does not require framework changes. (And it was pulled in explicitly for use in the editor verify tab as well.)

The hard and dumb part of this diff is hacking the gibson such that the metadata section on setup screen actually *updates itself* after the resources section is done doing its thing. After significant gnashing of teeth I just did the bare minimum to make work by caching a common parent and exposing an `Action?` on it. If anyone has better ideas, I'm all ears.