### PR TITLE
osu!taiko further considerations for rhythm

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TaikoDifficultyCalculatorTest.cs
@@ -14,13 +14,13 @@ namespace osu.Game.Rulesets.Taiko.Tests
     {
         protected override string ResourceAssembly => "osu.Game.Rulesets.Taiko";
 
-        [TestCase(3.3172381854905493d, 200, "diffcalc-test")]
-        [TestCase(3.3172381854905493d, 200, "diffcalc-test-strong")]
+        [TestCase(3.3167800835687551d, 200, "diffcalc-test")]
+        [TestCase(3.3167800835687551d, 200, "diffcalc-test-strong")]
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 
-        [TestCase(4.4640702427013101d, 200, "diffcalc-test")]
-        [TestCase(4.4640702427013101d, 200, "diffcalc-test-strong")]
+        [TestCase(4.4631326105105122d, 200, "diffcalc-test")]
+        [TestCase(4.4631326105105122d, 200, "diffcalc-test-strong")]
         public void TestClockRateAdjusted(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new TaikoModDoubleTime());
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -22,11 +22,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         }
 
         /// <summary>
-        /// To prevent against infinite ratio values where maps breach regular mapping conditions, we validate the ratio.
+        /// Validates the ratio by ensuring it is a normal number in cases where maps breach regular mapping conditions.
         /// </summary>
         private static double validateRatio(double ratio)
         {
-            return double.IsInfinity(ratio) || double.IsNaN(ratio) ? 0 : ratio;
+            return double.IsNormal(ratio) ? ratio : 0;
         }
 
         /// <summary>

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -45,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         }
 
         /// <summary>
-        /// Determines if the changes in hit object intervals is consistent based on a given threshold.
+        /// Determines if the changes in hit object intervals are consistent based on a given threshold.
         /// </summary>
         private static double repeatedIntervalPenalty(SameRhythmHitObjects sameRhythmHitObjects, double hitWindow, double threshold = 0.1)
         {
@@ -62,31 +62,46 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 
             double sameInterval(SameRhythmHitObjects startObject, int intervalCount)
             {
+                List<double?> intervalRatios = new List<double?>();
                 List<double?> intervals = new List<double?>();
                 var currentObject = startObject;
 
                 for (int i = 0; i < intervalCount && currentObject != null; i++)
                 {
+                    intervalRatios.Add(currentObject.HitObjectIntervalRatio);
                     intervals.Add(currentObject.HitObjectInterval);
                     currentObject = currentObject.Previous;
                 }
 
+                intervalRatios.RemoveAll(interval => interval == null);
                 intervals.RemoveAll(interval => interval == null);
 
-                if (intervals.Count < intervalCount)
+                if (intervalRatios.Count < intervalCount || intervals.Count < intervalCount)
                     return 1.0; // No penalty if there aren't enough valid intervals.
 
+                // Check for penalties based on HitObjectIntervalRatio
+                for (int i = 0; i < intervalRatios.Count; i++)
+                {
+                    for (int j = i + 1; j < intervalRatios.Count; j++)
+                    {
+                        double ratio = intervalRatios[i]!.Value / intervalRatios[j]!.Value;
+                        if (Math.Abs(1 - ratio) <= threshold) // If any two ratios are similar
+                            return 0.0;
+                    }
+                }
+
+                // Check for penalties based on HitObjectInterval
                 for (int i = 0; i < intervals.Count; i++)
                 {
                     for (int j = i + 1; j < intervals.Count; j++)
                     {
-                        double ratio = intervals[i]!.Value / intervals[j]!.Value;
-                        if (Math.Abs(1 - ratio) <= threshold) // If any two intervals are similar, apply a penalty.
-                            return 0.3;
+                        double difference = Math.Abs(intervals[i]!.Value - intervals[j]!.Value);
+                        if (difference <= hitWindow) // If any two intervals are close
+                            return 0.5;
                     }
                 }
 
-                return 1.0; // No penalty if all intervals are different.
+                return 1.0; // No penalty if all intervals are sufficiently different.
             }
         }
 


### PR DESCRIPTION
After some feedback from players, it was noted how rhythm changes should be harshly penalised based on their repeated patterns.

This change aims to:
- Add consideration for both interval and ratio
- Provide different penalties based on either value
- Is no longer a strict check, to be able to penalise similar offsnaps inflating difficulty.

Also includes a ratio validity check, as breaching regular mapping conditions can cause ratio's to be infinite (negative start times etc)