### PR TITLE
Speed up metronome in timing screen when pressing control key

### DIFF
--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -238,9 +238,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private bool spedUp;
 
-        private bool divisorChanged;
-
-        private void updateDivisor()
+        private bool updateDivisor()
         {
             int divisor = 1;
 
@@ -248,12 +246,12 @@ namespace osu.Game.Screens.Edit.Timing
                 divisor = beatDivisor.Value % 3 == 0 ? 3 : 2;
 
             if (divisor == Divisor)
-                return;
-
-            divisorChanged = true;
+                return false;
 
             Divisor = divisor;
             metronomeTick.Divisor = divisor;
+
+            return true;
         }
 
         protected override void LoadComplete()
@@ -274,9 +272,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             timingPoint = BeatSyncSource.ControlPoints.TimingPointAt(BeatSyncSource.Clock.CurrentTime);
 
-            updateDivisor();
-
-            if (beatLength != timingPoint.BeatLength || divisorChanged)
+            if (updateDivisor() || beatLength != timingPoint.BeatLength)
             {
                 beatLength = timingPoint.BeatLength;
 
@@ -312,8 +308,6 @@ namespace osu.Game.Screens.Edit.Timing
                         latchDelegate = Schedule(() => sampleLatch?.Play());
                 }
             }
-
-            divisorChanged = false;
         }
 
         protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)

--- a/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
+++ b/osu.Game/Screens/Edit/Timing/MetronomeDisplay.cs
@@ -42,6 +42,9 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private OverlayColourProvider overlayColourProvider { get; set; } = null!;
 
+        [Resolved]
+        private BindableBeatDivisor beatDivisor { get; set; } = null!;
+
         public bool EnableClicking
         {
             get => metronomeTick.EnableClicking;
@@ -233,10 +236,17 @@ namespace osu.Game.Screens.Edit.Timing
 
         private ScheduledDelegate? latchDelegate;
 
+        private bool spedUp;
+
         private bool divisorChanged;
 
-        private void setDivisor(int divisor)
+        private void updateDivisor()
         {
+            int divisor = 1;
+
+            if (spedUp)
+                divisor = beatDivisor.Value % 3 == 0 ? 3 : 2;
+
             if (divisor == Divisor)
                 return;
 
@@ -263,6 +273,8 @@ namespace osu.Game.Screens.Edit.Timing
             metronomeClock.Rate = IsBeatSyncedWithTrack ? BeatSyncSource.Clock.Rate : 1;
 
             timingPoint = BeatSyncSource.ControlPoints.TimingPointAt(BeatSyncSource.Clock.CurrentTime);
+
+            updateDivisor();
 
             if (beatLength != timingPoint.BeatLength || divisorChanged)
             {
@@ -346,7 +358,7 @@ namespace osu.Game.Screens.Edit.Timing
             updateDivisorFromKey(e);
         }
 
-        private void updateDivisorFromKey(UIEvent e) => setDivisor(e.ControlPressed ? 2 : 1);
+        private void updateDivisorFromKey(UIEvent e) => spedUp = e.ControlPressed;
 
         private partial class MetronomeTick : BeatSyncedContainer
         {


### PR DESCRIPTION
Changes the speed at which the metronome swings & the tick sample plays to 2x (or 3x when beat divisor is in triples mode) the speed when control is pressed, matching stable behavior.

Addresses one of the points made in #31263 (4. point in `timing` section)

### Example on regular beat divisor

https://github.com/user-attachments/assets/632b3f96-ef63-4b9f-9ab9-6b5e808f3c9e

### Example on 1/3 beat divisor

https://github.com/user-attachments/assets/da3b50e2-7bcc-4dae-ba69-b829f559a620

