### PR TITLE
Fix slider repeats not properly respecting "show hit markers" setting

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs
@@ -377,6 +377,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             UpdateState(ArmedState.Idle);
             HeadCircle.SuppressHitAnimations();
+
+            foreach (var repeat in repeatContainer)
+                repeat.SuppressHitAnimations();
+
             TailCircle.SuppressHitAnimations();
         }
 
@@ -384,6 +388,10 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
             UpdateState(ArmedState.Hit);
             HeadCircle.RestoreHitAnimations();
+
+            foreach (var repeat in repeatContainer)
+                repeat.RestoreHitAnimations();
+
             TailCircle.RestoreHitAnimations();
         }
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderRepeat.cs
@@ -14,6 +14,7 @@ using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Objects.Drawables
 {
@@ -163,5 +164,37 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                 Arrow.Rotation = Interpolation.ValueAt(Math.Clamp(Clock.ElapsedFrameTime, 0, 100), Arrow.Rotation, aimRotation, 0, 50, Easing.OutQuint);
             }
         }
+
+        #region FOR EDITOR USE ONLY, DO NOT USE FOR ANY OTHER PURPOSE
+
+        internal void SuppressHitAnimations()
+        {
+            UpdateState(ArmedState.Idle);
+            UpdateComboColour();
+
+            // This method is called every frame in editor contexts, thus the lack of need for transforms.
+
+            bool hit = Time.Current >= HitStateUpdateTime;
+
+            if (hit)
+            {
+                // More or less matches stable (see https://github.com/peppy/osu-stable-reference/blob/bb57924c1552adbed11ee3d96cdcde47cf96f2b6/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L336-L338)
+                AccentColour.Value = Color4.White;
+                Alpha = Interpolation.ValueAt(Time.Current, 1f, 0f, HitStateUpdateTime, HitStateUpdateTime + 700);
+            }
+
+            Arrow.Alpha = hit ? 0 : 1;
+
+            LifetimeEnd = HitStateUpdateTime + 700;
+        }
+
+        internal void RestoreHitAnimations()
+        {
+            UpdateState(ArmedState.Hit);
+            UpdateComboColour();
+            Arrow.Alpha = 1;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31286.

Before:

https://github.com/user-attachments/assets/d89e84d1-1e37-4501-8bfa-51ea8336a7dd

After:

https://github.com/user-attachments/assets/3bc745ce-8574-4de3-aa99-7bf978cb0fee

Gonna be honest, didn't do cross-checking against stable on this one, just went off copy-paste and the gifs provided by the issue thread author.

Curious on thoughts about how the instant arrow fade looks on non-classic skins. On argon it's probably fine, but it does look a little off on triangles...