### PR TITLE
Ignore whitespace while 2FA authentication

### DIFF
--- a/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
+++ b/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
@@ -121,9 +121,9 @@ namespace osu.Game.Overlays.Login
 
             codeTextBox.Current.BindValueChanged(code =>
             {
-                if (code.NewValue.Length == 8)
+                if (code.NewValue.Trim().Length == 8)
                 {
-                    api.AuthenticateSecondFactor(code.NewValue);
+                    api.AuthenticateSecondFactor(code.NewValue.Trim());
                     codeTextBox.Current.Disabled = true;
                 }
             });

--- a/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
+++ b/osu.Game/Overlays/Login/SecondFactorAuthForm.cs
@@ -121,9 +121,11 @@ namespace osu.Game.Overlays.Login
 
             codeTextBox.Current.BindValueChanged(code =>
             {
-                if (code.NewValue.Trim().Length == 8)
+                string trimmedCode = code.NewValue.Trim();
+
+                if (trimmedCode.Length == 8)
                 {
-                    api.AuthenticateSecondFactor(code.NewValue.Trim());
+                    api.AuthenticateSecondFactor(trimmedCode);
                     codeTextBox.Current.Disabled = true;
                 }
             });


### PR DESCRIPTION
Add `.Trim()` to handle spaces in 2FA code input

The account verification emails state "You can enter the code with or without spaces", but osu!lazer currently does not ignore spaces when inputting 2FA codes. This PR adds `.Trim()` to handle spaces in the input.

Changes:
- Added `.Trim()` (Change `code.NewValue` to `code.NewValue.Trim()` in 2FA Textbox) to ignore spaces in 2FA code input

Testing:
- Verified working when login on dev.ppy.sh

Note: If the current behaviour is intentional, please let me know and I'll close this PR.