### PR TITLE
Always block scroll input above editor toolbox areas

### DIFF
--- a/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
+++ b/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs
@@ -55,12 +55,6 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        protected override bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => base.ReceivePositionalInputAtSubTree(screenSpacePos) && anyToolboxHovered(screenSpacePos);
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => base.ReceivePositionalInputAt(screenSpacePos) && anyToolboxHovered(screenSpacePos);
-
-        private bool anyToolboxHovered(Vector2 screenSpacePos) => FillFlow.ScreenSpaceDrawQuad.Contains(screenSpacePos);
-
         protected override bool OnMouseDown(MouseDownEvent e) => true;
 
         protected override bool OnClick(ClickEvent e) => true;


### PR DESCRIPTION
Originally this was an intentional choice (see https://github.com/ppy/osu/pull/18088) when these controls were more transparent and didn't for a solid toolbox area.

But this is no longer the case, so for now let's always block scroll to match user expectations.

Closes #31262.