### PR TITLE
Remove use of `Loop` (and transforms) for slider repeat arrow animations

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -104,9 +104,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 main.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, scale_amount, 1f, move_out_duration, move_out_duration + move_in_duration, Easing.Out));
 
             if (loopCurrentTime < move_out_duration)
-                side.X = Interpolation.ValueAt(loopCurrentTime, 1, move_distance, 0, move_out_duration, Easing.Out);
+                side.X = Interpolation.ValueAt(loopCurrentTime, 0, move_distance, 0, move_out_duration, Easing.Out);
             else
-                side.X = Interpolation.ValueAt(loopCurrentTime, move_distance, 1f, move_out_duration, move_out_duration + move_in_duration, Easing.Out);
+                side.X = Interpolation.ValueAt(loopCurrentTime, move_distance, 0, move_out_duration, move_out_duration + move_in_duration, Easing.Out);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonReverseArrow.cs
@@ -5,12 +5,12 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
@@ -75,44 +75,38 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
             accentColour = drawableRepeat.AccentColour.GetBoundCopy();
             accentColour.BindValueChanged(accent => icon.Colour = accent.NewValue.Darken(4), true);
-
-            drawableRepeat.ApplyCustomUpdateState += updateStateTransforms;
         }
 
-        private void updateStateTransforms(DrawableHitObject hitObject, ArmedState state)
+        protected override void Update()
         {
+            base.Update();
+
+            if (Time.Current >= drawableRepeat.HitStateUpdateTime && drawableRepeat.State.Value == ArmedState.Hit)
+            {
+                double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
+                Scale = new Vector2(Interpolation.ValueAt(Time.Current, 1, 1.5f, drawableRepeat.HitStateUpdateTime, drawableRepeat.HitStateUpdateTime + animDuration, Easing.Out));
+            }
+            else
+                Scale = Vector2.One;
+
             const float move_distance = -12;
+            const float scale_amount = 1.3f;
+
             const double move_out_duration = 35;
             const double move_in_duration = 250;
             const double total = 300;
 
-            switch (state)
-            {
-                case ArmedState.Idle:
-                    main.ScaleTo(1.3f, move_out_duration, Easing.Out)
-                        .Then()
-                        .ScaleTo(1f, move_in_duration, Easing.Out)
-                        .Loop(total - (move_in_duration + move_out_duration));
-                    side
-                        .MoveToX(move_distance, move_out_duration, Easing.Out)
-                        .Then()
-                        .MoveToX(0, move_in_duration, Easing.Out)
-                        .Loop(total - (move_in_duration + move_out_duration));
-                    break;
+            double loopCurrentTime = (Time.Current - drawableRepeat.AnimationStartTime.Value) % total;
 
-                case ArmedState.Hit:
-                    double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
-                    this.ScaleTo(1.5f, animDuration, Easing.Out);
-                    break;
-            }
-        }
+            if (loopCurrentTime < move_out_duration)
+                main.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, 1, scale_amount, 0, move_out_duration, Easing.Out));
+            else
+                main.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, scale_amount, 1f, move_out_duration, move_out_duration + move_in_duration, Easing.Out));
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (drawableRepeat.IsNotNull())
-                drawableRepeat.ApplyCustomUpdateState -= updateStateTransforms;
+            if (loopCurrentTime < move_out_duration)
+                side.X = Interpolation.ValueAt(loopCurrentTime, 1, move_distance, 0, move_out_duration, Easing.Out);
+            else
+                side.X = Interpolation.ValueAt(loopCurrentTime, move_distance, 1f, move_out_duration, move_out_duration + move_in_duration, Easing.Out);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
@@ -9,10 +9,12 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Osu.Skinning.Legacy
@@ -51,8 +53,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
             textureIsDefaultSkin = skin is ISkinTransformer transformer && transformer.Skin is DefaultLegacySkin;
 
-            drawableObject.ApplyCustomUpdateState += updateStateTransforms;
-
             shouldRotate = skinSource.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value <= 1;
         }
 
@@ -68,7 +68,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             accentColour = drawableRepeat.AccentColour.GetBoundCopy();
             accentColour.BindValueChanged(c =>
             {
-                arrow.Colour = textureIsDefaultSkin && c.NewValue.R + c.NewValue.G + c.NewValue.B > (600 / 255f) ? Color4.Black : Color4.White;
+                arrow.Colour = textureIsDefaultSkin && c.NewValue.R + c.NewValue.G + c.NewValue.B > 600 / 255f ? Color4.Black : Color4.White;
             }, true);
         }
 
@@ -80,36 +80,25 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             drawableRepeat.DrawableSlider.OverlayElementContainer.Add(proxy);
         }
 
-        private void updateStateTransforms(DrawableHitObject hitObject, ArmedState state)
+        protected override void Update()
         {
-            const double duration = 300;
-            const float rotation = 5.625f;
+            base.Update();
 
-            switch (state)
+            if (Time.Current >= drawableRepeat.HitStateUpdateTime && drawableRepeat.State.Value == ArmedState.Hit)
             {
-                case ArmedState.Idle:
-                    if (shouldRotate)
-                    {
-                        InternalChild.ScaleTo(1.3f)
-                                     .RotateTo(rotation)
-                                     .Then()
-                                     .ScaleTo(1f, duration)
-                                     .RotateTo(-rotation, duration)
-                                     .Loop();
-                    }
-                    else
-                    {
-                        InternalChild.ScaleTo(1.3f).Then()
-                                     .ScaleTo(1f, duration, Easing.Out)
-                                     .Loop();
-                    }
+                double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
+                arrow.Scale = new Vector2(Interpolation.ValueAt(Time.Current, 1, 1.4f, drawableRepeat.HitStateUpdateTime, drawableRepeat.HitStateUpdateTime + animDuration, Easing.Out));
+            }
+            else
+            {
+                const double duration = 300;
+                const float rotation = 5.625f;
 
-                    break;
+                double loopCurrentTime = (Time.Current - drawableRepeat.AnimationStartTime.Value) % duration;
 
-                case ArmedState.Hit:
-                    double animDuration = Math.Min(300, drawableRepeat.HitObject.SpanDuration);
-                    InternalChild.ScaleTo(1.4f, animDuration, Easing.Out);
-                    break;
+                if (shouldRotate)
+                    arrow.Rotation = Interpolation.ValueAt(loopCurrentTime, rotation, -rotation, 0, duration);
+                arrow.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, 1.3f, 1, 0, duration));
             }
         }
 
@@ -120,7 +109,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             if (drawableRepeat.IsNotNull())
             {
                 drawableRepeat.HitObjectApplied -= onHitObjectApplied;
-                drawableRepeat.ApplyCustomUpdateState -= updateStateTransforms;
             }
         }
     }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyReverseArrow.cs
@@ -96,9 +96,16 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
                 double loopCurrentTime = (Time.Current - drawableRepeat.AnimationStartTime.Value) % duration;
 
+                // Reference: https://github.com/peppy/osu-stable-reference/blob/2280c4c436f80d04f9c79d3c905db00ac2902273/osu!/GameplayElements/HitObjects/Osu/HitCircleSliderEnd.cs#L79-L96
                 if (shouldRotate)
+                {
                     arrow.Rotation = Interpolation.ValueAt(loopCurrentTime, rotation, -rotation, 0, duration);
-                arrow.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, 1.3f, 1, 0, duration));
+                    arrow.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, 1.3f, 1, 0, duration));
+                }
+                else
+                {
+                    arrow.Scale = new Vector2(Interpolation.ValueAt(loopCurrentTime, 1.3f, 1, 0, duration, Easing.Out));
+                }
             }
         }
 


### PR DESCRIPTION
Less transforms in gameplay is always better. But this also avoids bug https://github.com/ppy/osu-framework/issues/6482.

This fixes repeat arrows animating completely incorrectly in the editor (and probably gameplay when rewinding).

Noticed while reviewing https://github.com/ppy/osu/pull/31354 and had to fix.

Closes https://github.com/ppy/osu/issues/31316

master:

https://github.com/user-attachments/assets/06194aef-4f51-44ba-b6b2-1101393318c1

this pr:

https://github.com/user-attachments/assets/232778d6-7b7a-4353-bfd8-88ec698c2510

i haven't frame comparisoned yet, just rough visual. not sure the previous animations were correct enough to warrant it (might be better to wait for someone to notice an issue).