### PR TITLE
Display popup disclaimer about game state and performance on mobile platforms

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Configuration.Tracking;
@@ -163,6 +164,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.Version, string.Empty);
 
             SetDefault(OsuSetting.ShowFirstRunSetup, true);
+            SetDefault(OsuSetting.ShowMobileDisclaimer, RuntimeInfo.IsMobile);
 
             SetDefault(OsuSetting.ScreenshotFormat, ScreenshotFormat.Jpg);
             SetDefault(OsuSetting.ScreenshotCaptureMenuCursor, false);
@@ -452,5 +454,6 @@ namespace osu.Game.Configuration
         AlwaysRequireHoldingForPause,
         MultiplayerShowInProgressFilter,
         BeatmapListingFeaturedArtistFilter,
+        ShowMobileDisclaimer,
     }
 }

--- a/osu.Game/Localisation/ButtonSystemStrings.cs
+++ b/osu.Game/Localisation/ButtonSystemStrings.cs
@@ -59,6 +59,25 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString DailyChallenge => new TranslatableString(getKey(@"daily_challenge"), @"daily challenge");
 
+        /// <summary>
+        /// "A few important words from your dev team!"
+        /// </summary>
+        public static LocalisableString MobileDisclaimerHeader => new TranslatableString(getKey(@"mobile_disclaimer_header"), @"A few important words from your dev team!");
+
+        /// <summary>
+        /// "While we have released osu! on mobile platforms to maximise the number of people that can enjoy the game, our focus is still on the PC version.
+        ///
+        /// Your experience will not be perfect, and may even feel subpar compared to games which are made mobile-first.
+        ///
+        /// Please bear with us as we continue to improve the game for you!"
+        /// </summary>
+        public static LocalisableString MobileDisclaimerBody => new TranslatableString(getKey(@"mobile_disclaimer_body"),
+            @"While we have released osu! on mobile platforms to maximise the number of people that can enjoy the game, our focus is still on the PC version.
+
+Your experience will not be perfect, and may even feel subpar compared to games which are made mobile-first.
+
+Please bear with us as we continue to improve the game for you!");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -302,6 +302,7 @@ namespace osu.Game.Overlays.Dialog
             {
                 content.ScaleTo(0.7f);
                 ring.ResizeTo(ringMinifiedSize);
+                icon.ScaleTo(0f);
             }
 
             content
@@ -309,6 +310,7 @@ namespace osu.Game.Overlays.Dialog
                 .FadeIn(ENTER_DURATION, Easing.OutQuint);
 
             ring.ResizeTo(ringSize, ENTER_DURATION * 1.5f, Easing.OutQuint);
+            icon.Delay(100).ScaleTo(1, ENTER_DURATION * 1.5f, Easing.OutQuint);
         }
 
         protected override void PopOut()

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -75,7 +75,9 @@ namespace osu.Game.Overlays.Dialog
                     return;
 
                 bodyText = value;
+
                 body.Text = value;
+                body.TextAnchor = bodyText.ToString().Contains('\n') ? Anchor.TopLeft : Anchor.TopCentre;
             }
         }
 
@@ -210,13 +212,12 @@ namespace osu.Game.Overlays.Dialog
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     TextAnchor = Anchor.TopCentre,
-                                    Padding = new MarginPadding { Horizontal = 15 },
+                                    Padding = new MarginPadding { Horizontal = 15, Bottom = 10 },
                                 },
                                 body = new OsuTextFlowContainer(t => t.Font = t.Font.With(size: 18))
                                 {
                                     Origin = Anchor.TopCentre,
                                     Anchor = Anchor.TopCentre,
-                                    TextAnchor = Anchor.TopCentre,
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Padding = new MarginPadding { Horizontal = 15 },

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -303,8 +303,11 @@ namespace osu.Game.Screens.Menu
 
             if (showMobileDisclaimer.Value)
             {
-                this.Delay(500).Schedule(() => dialogOverlay.Push(new MobileDisclaimerDialog()));
-                showMobileDisclaimer.Value = false;
+                this.Delay(500).Schedule(() =>
+                {
+                    dialogOverlay.Push(new MobileDisclaimerDialog());
+                    showMobileDisclaimer.Value = false;
+                });
             }
 
             return originalAction.Invoke();

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -41,6 +41,7 @@ using osu.Game.Screens.Select;
 using osu.Game.Seasonal;
 using osuTK;
 using osuTK.Graphics;
+using osu.Game.Localisation;
 
 namespace osu.Game.Screens.Menu
 {
@@ -470,11 +471,10 @@ namespace osu.Game.Screens.Menu
         {
             public MobileDisclaimerDialog(Action confirmed)
             {
-                HeaderText = "A few important words from your dev team!";
-                BodyText =
-                    "While we have released osu! on mobile platforms to maximise the number of people that can enjoy the game, our focus is still on the PC version.\n\nYour experience will not be perfect, and may even feel subpar compared to games which are made mobile-first.\n\nPlease bear with us as we continue to improve the game for you!";
+                HeaderText = ButtonSystemStrings.MobileDisclaimerHeader;
+                BodyText = ButtonSystemStrings.MobileDisclaimerBody;
 
-                Icon = FontAwesome.Solid.Mobile;
+                Icon = FontAwesome.Solid.SmileBeam;
 
                 Buttons = new PopupDialogButton[]
                 {

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -310,25 +310,6 @@ namespace osu.Game.Screens.Menu
             return originalAction.Invoke();
         }
 
-        internal partial class MobileDisclaimerDialog : PopupDialog
-        {
-            public MobileDisclaimerDialog()
-            {
-                HeaderText = "Mobile disclaimer";
-                BodyText = "We're releasing this for your enjoyment, but PC is still our focus and mobile is hard to support.\n\nPlease bear with us as we continue to improve the experience!";
-
-                Icon = FontAwesome.Solid.Mobile;
-
-                Buttons = new PopupDialogButton[]
-                {
-                    new PopupDialogOkButton
-                    {
-                        Text = "Alright!",
-                    },
-                };
-            }
-        }
-
         protected override void LogoSuspending(OsuLogo logo)
         {
             var seq = logo.FadeOut(300, Easing.InSine)
@@ -473,6 +454,25 @@ namespace osu.Game.Screens.Menu
 
         public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
         {
+        }
+
+        private partial class MobileDisclaimerDialog : PopupDialog
+        {
+            public MobileDisclaimerDialog()
+            {
+                HeaderText = "Mobile disclaimer";
+                BodyText = "We're releasing this for your enjoyment, but PC is still our focus and mobile is hard to support.\n\nPlease bear with us as we continue to improve the experience!";
+
+                Icon = FontAwesome.Solid.Mobile;
+
+                Buttons = new PopupDialogButton[]
+                {
+                    new PopupDialogOkButton
+                    {
+                        Text = "Alright!",
+                    },
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] Localisation strings, once text is finalised

Preview (text not final):

https://github.com/user-attachments/assets/aeea4158-f436-4ac5-8574-6ed2baebe63a

For simplicity purposes, the code for displaying the mobile disclaimer is placed directly in `MainMenu`, backed by a config setting that is only enabled on mobile platforms.