### PR TITLE
Fix the length bonus by determining how much of the map is hard

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -137,8 +137,15 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             double aimValue = OsuStrainSkill.DifficultyToPerformance(attributes.AimDifficulty);
 
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            double difficultyFactor = Aim.AvgDifficulty / totalHits / Aim.MaxDifficulty;
+
+            double hardHits = totalHits * difficultyFactor;
+
+            double avgHit = (hardHits + totalHits) / 2;
+
+            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, avgHit / 1500.0) +
+                                 (avgHit > 1500 ? Math.Log10(avgHit / 1500.0) * 0.5 : 0.0);
+
             aimValue *= lengthBonus;
 
             if (effectiveMissCount > 0)
@@ -201,8 +208,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double speedValue = OsuStrainSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
 
-            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, totalHits / 2000.0) +
-                                 (totalHits > 2000 ? Math.Log10(totalHits / 2000.0) * 0.5 : 0.0);
+            double difficultyFactor = Speed.AvgDifficulty / totalHits / Speed.MaxDifficulty;
+
+            double hardHits = totalHits * difficultyFactor;
+
+            double avgHit = (hardHits + totalHits) / 2;
+
+            double lengthBonus = 0.95 + 0.4 * Math.Min(1.0, avgHit / 1500.0) +
+                                 (avgHit > 1500 ? Math.Log10(avgHit / 1500.0) * 0.5 : 0.0);
             speedValue *= lengthBonus;
 
             if (effectiveMissCount > 0)

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -137,7 +137,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             double aimValue = OsuStrainSkill.DifficultyToPerformance(attributes.AimDifficulty);
 
-            double difficultyFactor = Aim.AvgDifficulty / totalHits / Aim.MaxDifficulty;
+            double difficultyFactor = Aim.SummedDifficulty / totalHits / Aim.MaxDifficulty;
 
             double hardHits = totalHits * difficultyFactor;
 
@@ -208,7 +208,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double speedValue = OsuStrainSkill.DifficultyToPerformance(attributes.SpeedDifficulty);
 
-            double difficultyFactor = Speed.AvgDifficulty / totalHits / Speed.MaxDifficulty;
+            double difficultyFactor = Speed.SummedDifficulty / totalHits / Speed.MaxDifficulty;
 
             double hardHits = totalHits * difficultyFactor;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             currentStrain += currentHitObjectStrain;
 
-            avgDifficulty += currentHitObjectStrain;
+            summedDifficulty += currentHitObjectStrain;
 
             if (maxDifficulty < currentHitObjectStrain)
                 maxDifficulty = currentHitObjectStrain;
@@ -54,7 +54,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (current.Next(1) is null)
             {
                 MaxDifficulty = maxDifficulty;
-                AvgDifficulty = avgDifficulty;
+                SummedDifficulty = summedDifficulty;
             }
 
             return currentStrain;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -21,7 +21,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public static double MaxDifficulty;
 
-        public static double AvgDifficulty;
+        public static double SummedDifficulty;
 
         private readonly bool withSliders;
 
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double maxDifficulty;
 
-        private double avgDifficulty;
+        private double summedDifficulty;
 
         private double skillMultiplier => 25.18;
         private double strainDecayBase => 0.15;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -19,9 +19,17 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             this.withSliders = withSliders;
         }
 
+        public static double MaxDifficulty;
+
+        public static double AvgDifficulty;
+
         private readonly bool withSliders;
 
         private double currentStrain;
+
+        private double maxDifficulty;
+
+        private double avgDifficulty;
 
         private double skillMultiplier => 25.18;
         private double strainDecayBase => 0.15;
@@ -33,7 +41,21 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         protected override double StrainValueAt(DifficultyHitObject current)
         {
             currentStrain *= strainDecay(current.DeltaTime);
-            currentStrain += AimEvaluator.EvaluateDifficultyOf(current, withSliders) * skillMultiplier;
+
+            double currentHitObjectStrain = AimEvaluator.EvaluateDifficultyOf(current, withSliders) * skillMultiplier;
+
+            currentStrain += currentHitObjectStrain;
+
+            avgDifficulty += currentHitObjectStrain;
+
+            if (maxDifficulty < currentHitObjectStrain)
+                maxDifficulty = currentHitObjectStrain;
+
+            if (current.Next(1) is null)
+            {
+                MaxDifficulty = maxDifficulty;
+                AvgDifficulty = avgDifficulty;
+            }
 
             return currentStrain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -15,18 +15,24 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     /// </summary>
     public class Speed : OsuStrainSkill
     {
+        public Speed(Mod[] mods)
+            : base(mods)
+        {
+        }
+
+        public static double MaxDifficulty;
+
+        public static double AvgDifficulty;
+        protected override int ReducedSectionCount => 5;
         private double skillMultiplier => 1.430;
         private double strainDecayBase => 0.3;
 
         private double currentStrain;
         private double currentRhythm;
 
-        protected override int ReducedSectionCount => 5;
+        private double maxDifficulty;
 
-        public Speed(Mod[] mods)
-            : base(mods)
-        {
-        }
+        private double avgDifficulty;
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
 
@@ -35,11 +41,25 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         protected override double StrainValueAt(DifficultyHitObject current)
         {
             currentStrain *= strainDecay(((OsuDifficultyHitObject)current).StrainTime);
-            currentStrain += SpeedEvaluator.EvaluateDifficultyOf(current) * skillMultiplier;
+
+            double currentHitObjectStrain = SpeedEvaluator.EvaluateDifficultyOf(current) * skillMultiplier;
+
+            currentStrain += currentHitObjectStrain;
 
             currentRhythm = RhythmEvaluator.EvaluateDifficultyOf(current);
 
             double totalStrain = currentStrain * currentRhythm;
+
+            avgDifficulty += currentHitObjectStrain * currentRhythm;
+
+            if (maxDifficulty < currentHitObjectStrain)
+                maxDifficulty = currentHitObjectStrain;
+
+            if (current.Next(1) is null)
+            {
+                MaxDifficulty = maxDifficulty;
+                AvgDifficulty = avgDifficulty;
+            }
 
             return totalStrain;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public static double MaxDifficulty;
 
-        public static double AvgDifficulty;
+        public static double SummedDifficulty;
         protected override int ReducedSectionCount => 5;
         private double skillMultiplier => 1.430;
         private double strainDecayBase => 0.3;
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double maxDifficulty;
 
-        private double avgDifficulty;
+        private double summedDifficulty;
 
         private double strainDecay(double ms) => Math.Pow(strainDecayBase, ms / 1000);
 
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double totalStrain = currentStrain * currentRhythm;
 
-            avgDifficulty += currentHitObjectStrain * currentRhythm;
+            summedDifficulty += currentHitObjectStrain * currentRhythm;
 
             if (maxDifficulty < currentHitObjectStrain)
                 maxDifficulty = currentHitObjectStrain;
@@ -58,7 +58,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             if (current.Next(1) is null)
             {
                 MaxDifficulty = maxDifficulty;
-                AvgDifficulty = avgDifficulty;
+                SummedDifficulty = summedDifficulty;
             }
 
             return totalStrain;


### PR DESCRIPTION
The change modifies:

- The length bonus is no longer determined only by max hits
Dividing summedDifficulty by totalHits and then by maxDifficulty results in a multiplier that shows how much of the map is hard. Multiplying this multiplier by totalHits shows how many of the hits are hard.