### PR TITLE
Add game mod `Unranked`

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -133,6 +133,7 @@ namespace osu.Game.Rulesets.Catch
                         new CatchModDifficultyAdjust(),
                         new CatchModClassic(),
                         new CatchModMirror(),
+                        new CatchModUnranked(),
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Catch/Mods/CatchModUnranked.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModUnranked.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Catch.Mods
+{
+    public class CatchModUnranked : ModUnranked
+    {
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(CatchModRelax) }).ToArray();
+    }
+}

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -277,6 +277,7 @@ namespace osu.Game.Rulesets.Mania
                             new ManiaModKey9(),
                             new ManiaModKey10()
                         ),
+                        new ManiaModUnranked()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModUnranked.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModUnranked.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mania.Mods
+{
+    public class ManiaModUnranked : ModUnranked
+    {
+    }
+}

--- a/osu.Game.Rulesets.Osu/Mods/OsuModUnranked.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModUnranked.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModUnranked : ModUnranked
+    {
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(OsuModAutopilot), typeof(OsuModRelax) }).ToArray();
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -184,7 +184,8 @@ namespace osu.Game.Rulesets.Osu
                         new OsuModClassic(),
                         new OsuModRandom(),
                         new OsuModMirror(),
-                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap())
+                        new MultiMod(new OsuModAlternate(), new OsuModSingleTap()),
+                        new OsuModUnranked()
                     };
 
                 case ModType.Automation:

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModUnranked.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModUnranked.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Taiko.Mods
+{
+    public class TaikoModUnranked : ModUnranked
+    {
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(TaikoModRelax) }).ToArray();
+    }
+}

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Rulesets.Taiko
                         new TaikoModSwap(),
                         new TaikoModSingleTap(),
                         new TaikoModConstantSpeed(),
+                        new TaikoModUnranked()
                     };
 
                 case ModType.Automation:

--- a/osu.Game/Rulesets/Mods/ModUnranked.cs
+++ b/osu.Game/Rulesets/Mods/ModUnranked.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Rulesets.Scoring;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public class ModUnranked : Mod, IApplicableToScoreProcessor
+    {
+        public override string Name => @"Unranked";
+        public override string Acronym => @"UR";
+        public override ModType Type => ModType.Conversion;
+        public override LocalisableString Description => @"As the name suggests, makes this play unranked.";
+        public override Type[] IncompatibleMods => base.IncompatibleMods.Concat(new[] { typeof(ModAutoplay), typeof(ModCinema) }).ToArray();
+        public override double ScoreMultiplier => 1.0;
+        public override bool UserPlayable => true;
+        public override bool ValidForMultiplayer => true;
+        public override bool ValidForMultiplayerAsFreeMod => true;
+
+        public void ApplyToScoreProcessor(ScoreProcessor scoreProcessor)
+        {
+            return;
+        }
+
+        public ScoreRank AdjustRank(ScoreRank rank, double accuracy) => rank;
+    }
+}


### PR DESCRIPTION
### Overview
Makes any plays with it unranked. Simple as that.

### Why?
There are some ranked maps out there that allow the player to gain a lot of performance points with barely any effort (colloquially known as "farm maps"), and I thought it would have been a neat idea if there was a mod that would just allow anyone to not get PP while also not modifying the gameplay process.

### Current state
Simple implementation for Standard, Taiko, Catch, and Mania; verified to work on Standard and Mania on the  **client-side**.

### Notes
Code inspection was not finished as it was running for way too long and had no result :(