### PR TITLE
Fix mobile release dialog obstructed by the software keyboard

### DIFF
--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -317,13 +317,12 @@ namespace osu.Game.Screens.Menu
 
         private void displayLoginIfApplicable()
         {
+            if (loginDisplayed.Value) return;
+
             if (!api.IsLoggedIn || api.State.Value == APIState.RequiresSecondFactorAuth)
             {
-                if (!loginDisplayed.Value)
-                {
-                    Scheduler.AddDelayed(() => login?.Show(), 500);
-                    loginDisplayed.Value = true;
-                }
+                Scheduler.AddDelayed(() => login?.Show(), 500);
+                loginDisplayed.Value = true;
             }
         }
 

--- a/osu.Game/Screens/Menu/MainMenu.cs
+++ b/osu.Game/Screens/Menu/MainMenu.cs
@@ -297,15 +297,6 @@ namespace osu.Game.Screens.Menu
 
         private bool onLogoClick(Func<bool> originalAction)
         {
-            if (!api.IsLoggedIn || api.State.Value == APIState.RequiresSecondFactorAuth)
-            {
-                if (!loginDisplayed.Value)
-                {
-                    Scheduler.AddDelayed(() => login?.Show(), 500);
-                    loginDisplayed.Value = true;
-                }
-            }
-
             if (showMobileDisclaimer.Value)
             {
                 mobileDisclaimerSchedule?.Cancel();
@@ -314,11 +305,26 @@ namespace osu.Game.Screens.Menu
                     dialogOverlay.Push(new MobileDisclaimerDialog(() =>
                     {
                         showMobileDisclaimer.Value = false;
+                        displayLoginIfApplicable();
                     }));
                 }, 500);
             }
+            else
+                displayLoginIfApplicable();
 
             return originalAction.Invoke();
+        }
+
+        private void displayLoginIfApplicable()
+        {
+            if (!api.IsLoggedIn || api.State.Value == APIState.RequiresSecondFactorAuth)
+            {
+                if (!loginDisplayed.Value)
+                {
+                    Scheduler.AddDelayed(() => login?.Show(), 500);
+                    loginDisplayed.Value = true;
+                }
+            }
         }
 
         protected override void LogoSuspending(OsuLogo logo)


### PR DESCRIPTION
Caused by the login overlay making the text boxes focused. Fix is delaying login overlay until the dialog is dismissed.

https://github.com/user-attachments/assets/e5da2385-bed9-4ef0-b048-561057da2010

