### PR TITLE
Ensure intro files exist in storage during startup

### DIFF
--- a/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
+++ b/osu.Game.Tests/Visual/Menus/IntroTestScene.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Menus
 
         protected OsuScreenStack IntroStack;
 
-        private IntroScreen intro;
+        protected IntroScreen Intro { get; private set; }
 
         [Cached(typeof(INotificationOverlay))]
         private NotificationOverlay notifications;
@@ -62,22 +62,9 @@ namespace osu.Game.Tests.Visual.Menus
         [Test]
         public virtual void TestPlayIntro()
         {
-            AddStep("restart sequence", () =>
-            {
-                logo.FinishTransforms();
-                logo.IsTracking = false;
+            RestartIntro();
 
-                IntroStack?.Expire();
-
-                Add(IntroStack = new OsuScreenStack
-                {
-                    RelativeSizeAxes = Axes.Both,
-                });
-
-                IntroStack.Push(intro = CreateScreen());
-            });
-
-            AddUntilStep("wait for menu", () => intro.DidLoadMenu);
+            WaitForMenu();
         }
 
         [Test]
@@ -103,23 +90,46 @@ namespace osu.Game.Tests.Visual.Menus
                     RelativeSizeAxes = Axes.Both,
                 });
 
-                IntroStack.Push(intro = CreateScreen());
+                IntroStack.Push(Intro = CreateScreen());
             });
 
             AddStep("trigger failure", () =>
             {
                 trackResetDelegate = Scheduler.AddDelayed(() =>
                 {
-                    intro.Beatmap.Value.Track.Seek(0);
+                    Intro.Beatmap.Value.Track.Seek(0);
                 }, 0, true);
             });
 
-            AddUntilStep("wait for menu", () => intro.DidLoadMenu);
+            WaitForMenu();
 
             if (IntroReliesOnTrack)
                 AddUntilStep("wait for notification", () => notifications.UnreadCount.Value == 1);
 
             AddStep("uninstall delegate", () => trackResetDelegate?.Cancel());
+        }
+
+        protected void RestartIntro()
+        {
+            AddStep("restart sequence", () =>
+            {
+                logo.FinishTransforms();
+                logo.IsTracking = false;
+
+                IntroStack?.Expire();
+
+                Add(IntroStack = new OsuScreenStack
+                {
+                    RelativeSizeAxes = Axes.Both,
+                });
+
+                IntroStack.Push(Intro = CreateScreen());
+            });
+        }
+
+        protected void WaitForMenu()
+        {
+            AddUntilStep("wait for menu", () => Intro.DidLoadMenu);
         }
 
         protected abstract IntroScreen CreateScreen();

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroIntegrity.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroIntegrity.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Screens.Menu;
+
+namespace osu.Game.Tests.Visual.Menus
+{
+    [HeadlessTest]
+    [TestFixture]
+    public partial class TestSceneIntroIntegrity : IntroTestScene
+    {
+        [Test]
+        public virtual void TestDeletedFilesRestored()
+        {
+            RestartIntro();
+            WaitForMenu();
+
+            AddStep("delete game files unexpectedly", () => LocalStorage.DeleteDirectory("files"));
+            AddStep("reset game beatmap", () => Dependencies.Get<Bindable<WorkingBeatmap>>().Value = new DummyWorkingBeatmap(Audio, null));
+            AddStep("invalidate beatmap from cache", () => Dependencies.Get<IWorkingBeatmapCache>().Invalidate(Intro.Beatmap.Value.BeatmapSetInfo));
+
+            RestartIntro();
+            WaitForMenu();
+
+            AddUntilStep("wait for track playing", () => Intro.Beatmap.Value.Track is TrackBass trackBass && trackBass.IsRunning);
+        }
+
+        protected override bool IntroReliesOnTrack => true;
+        protected override IntroScreen CreateScreen() => new IntroTriangles();
+    }
+}

--- a/osu.Game.Tests/Visual/Menus/TestSceneIntroIntegrity.cs
+++ b/osu.Game.Tests/Visual/Menus/TestSceneIntroIntegrity.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Visual.Menus
             RestartIntro();
             WaitForMenu();
 
-            AddUntilStep("wait for track playing", () => Intro.Beatmap.Value.Track is TrackBass trackBass && trackBass.IsRunning);
+            AddUntilStep("ensure track is not virtual", () => Intro.Beatmap.Value.Track is TrackBass);
         }
 
         protected override bool IntroReliesOnTrack => true;

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -315,6 +315,7 @@ namespace osu.Game
             dependencies.Cache(ScoreManager = new ScoreManager(RulesetStore, () => BeatmapManager, Storage, realm, API, LocalConfig));
 
             dependencies.Cache(BeatmapManager = new BeatmapManager(Storage, realm, API, Audio, Resources, Host, defaultBeatmap, difficultyCache, performOnlineLookups: true));
+            dependencies.CacheAs<IWorkingBeatmapCache>(BeatmapManager);
 
             dependencies.Cache(BeatmapDownloader = new BeatmapModelDownloader(BeatmapManager, API));
             dependencies.Cache(ScoreDownloader = new ScoreModelDownloader(ScoreManager, API));

--- a/osu.Game/Screens/Menu/IntroScreen.cs
+++ b/osu.Game/Screens/Menu/IntroScreen.cs
@@ -20,6 +20,7 @@ using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Overlays;
@@ -170,7 +171,14 @@ namespace osu.Game.Screens.Menu
                     if (s.Beatmaps.Count == 0)
                         return;
 
-                    initialBeatmap = beatmaps.GetWorkingBeatmap(s.Beatmaps.First());
+                    var working = beatmaps.GetWorkingBeatmap(s.Beatmaps.First());
+
+                    // Ensure files area actually present on disk.
+                    // This is to handle edge cases like users deleting files outside the game and breaking the world.
+                    if (!hasAllFiles(working))
+                        return;
+
+                    initialBeatmap = working;
                 });
 
                 return UsingThemedIntro = initialBeatmap != null;
@@ -187,6 +195,20 @@ namespace osu.Game.Screens.Menu
 
         [Resolved]
         private INotificationOverlay notifications { get; set; }
+
+        private bool hasAllFiles(WorkingBeatmap working)
+        {
+            foreach (var f in working.BeatmapSetInfo.Files)
+            {
+                using (var str = working.GetStream(f.File.GetStoragePath()))
+                {
+                    if (str == null)
+                        return false;
+                }
+            }
+
+            return true;
+        }
 
         private void ensureEventuallyArrivingAtMenu()
         {


### PR DESCRIPTION
Guards against user interdiction. See [https://discord.com/channels/188630481301012481/1097318920991559880/1324765503012601927](recent) but not only case of this occurring.

There's no end to users breaking game in edge case ways like this and I'm not sure this was worth the time spent on it.