### PR TITLE
Constrain range of usable characters in romanised metadata to ASCII only

### DIFF
--- a/osu.Game/Beatmaps/MetadataUtils.cs
+++ b/osu.Game/Beatmaps/MetadataUtils.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Beatmaps
         /// Returns <see langword="true"/> if the character <paramref name="c"/> can be used in <see cref="BeatmapMetadata.Artist"/> and <see cref="BeatmapMetadata.Title"/> fields.
         /// Characters not matched by this method can be placed in <see cref="BeatmapMetadata.ArtistUnicode"/> and <see cref="BeatmapMetadata.TitleUnicode"/>.
         /// </summary>
-        public static bool IsRomanised(char c) => c <= 0xFF;
+        public static bool IsRomanised(char c) => char.IsAscii(c) && !char.IsControl(c);
 
         /// <summary>
         /// Returns <see langword="true"/> if the string <paramref name="str"/> can be used in <see cref="BeatmapMetadata.Artist"/> and <see cref="BeatmapMetadata.Title"/> fields.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/31398.

Rationale given in issue.

Compare stable logic:

- https://github.com/peppy/osu-stable-reference/blob/2280c4c436f80d04f9c79d3c905db00ac2902273/osu!/GameModes/Edit/Forms/SongSetup.cs#L118-L122
- https://github.com/peppy/osu-stable-reference/blob/2280c4c436f80d04f9c79d3c905db00ac2902273/osu!common/Helpers/GeneralHelper.cs#L410-L423

The control character check is a bit gratuitous (text boxes will already not allow insertion of those, see
[framework logic](https://github.com/ppy/osu-framework/blob/e05cb86ff64abd343de49a143ada9734fd160a0a/osu.Framework/Graphics/UserInterface/TextBox.cs#L92)), but as it's a general helper I figured might as well.