### PR TITLE
Fix star range display looking a bit bad when changing opacity

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneStarRatingRangeDisplay.cs
@@ -3,29 +3,71 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Components;
-using osu.Game.Tests.Visual.OnlinePlay;
+using osu.Game.Tests.Resources;
+using osuTK;
 
 namespace osu.Game.Tests.Visual.Multiplayer
 {
-    public partial class TestSceneStarRatingRangeDisplay : OnlinePlayTestScene
+    public partial class TestSceneStarRatingRangeDisplay : OsuTestScene
     {
-        public override void SetUpSteps()
+        private readonly Room room = new Room();
+
+        protected override void LoadComplete()
         {
-            base.SetUpSteps();
+            base.LoadComplete();
 
-            AddStep("create display", () =>
+            Child = new FillFlowContainer
             {
-                SelectedRoom.Value = new Room();
-
-                Child = new StarRatingRangeDisplay(SelectedRoom.Value)
+                RelativeSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(10),
+                Children = new Drawable[]
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                };
-            });
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Scale = new Vector2(5),
+                    },
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Scale = new Vector2(2),
+                    },
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Scale = new Vector2(1),
+                    },
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0.2f,
+                        Scale = new Vector2(5),
+                    },
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0.2f,
+                        Scale = new Vector2(2),
+                    },
+                    new StarRatingRangeDisplay(room)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Alpha = 0.2f,
+                        Scale = new Vector2(1),
+                    },
+                }
+            };
         }
 
         [Test]
@@ -33,10 +75,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             AddStep("set playlist", () =>
             {
-                SelectedRoom.Value!.Playlist =
+                room.Playlist =
                 [
-                    new PlaylistItem(new BeatmapInfo { StarRating = min }),
-                    new PlaylistItem(new BeatmapInfo { StarRating = max }),
+                    new PlaylistItem(new BeatmapInfo { StarRating = min }) { ID = TestResources.GetNextTestID() },
+                    new PlaylistItem(new BeatmapInfo { StarRating = max }) { ID = TestResources.GetNextTestID() },
                 ];
             });
         }

--- a/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Components/StarRatingRangeDisplay.cs
@@ -14,7 +14,6 @@ using osu.Game.Beatmaps.Drawables;
 using osu.Game.Graphics;
 using osu.Game.Online.Rooms;
 using osuTK;
-using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Game.Screens.OnlinePlay.Components
 {
@@ -30,6 +29,8 @@ namespace osu.Game.Screens.OnlinePlay.Components
         private StarRatingDisplay maxDisplay = null!;
         private Drawable maxBackground = null!;
 
+        private BufferedContainer bufferedContent = null!;
+
         public StarRatingRangeDisplay(Room room)
         {
             this.room = room;
@@ -41,38 +42,43 @@ namespace osu.Game.Screens.OnlinePlay.Components
         {
             InternalChildren = new Drawable[]
             {
-                new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Masking = true,
-                    CornerRadius = 1,
-                    Children = new[]
-                    {
-                        minBackground = new Box
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                        },
-                        maxBackground = new Box
-                        {
-                            Anchor = Anchor.BottomCentre,
-                            Origin = Anchor.BottomCentre,
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                        },
-                    }
-                },
-                new FillFlowContainer
+                new CircularContainer
                 {
                     AutoSizeAxes = Axes.Both,
-                    Children = new Drawable[]
+                    Masking = true,
+                    // Stops artifacting from boxes drawn behind wrong colour boxes (and edge pixels adding up to higher opacity).
+                    Padding = new MarginPadding(-0.1f),
+                    Child = bufferedContent = new BufferedContainer(pixelSnapping: true, cachedFrameBuffer: true)
                     {
-                        minDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Range),
-                        maxDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Range)
+                        AutoSizeAxes = Axes.Both,
+                        Children = new[]
+                        {
+                            minBackground = new Box
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.Both,
+                                Size = new Vector2(1, 0.5f),
+                            },
+                            maxBackground = new Box
+                            {
+                                Anchor = Anchor.BottomCentre,
+                                Origin = Anchor.BottomCentre,
+                                RelativeSizeAxes = Axes.Both,
+                                Size = new Vector2(1, 0.5f),
+                            },
+                            new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    minDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Range),
+                                    maxDisplay = new StarRatingDisplay(default, StarRatingDisplaySize.Range)
+                                }
+                            }
+                        }
                     }
-                }
+                },
             };
         }
 
@@ -121,6 +127,8 @@ namespace osu.Game.Screens.OnlinePlay.Components
 
             minBackground.Colour = colours.ForStarDifficulty(minDifficulty.Stars);
             maxBackground.Colour = colours.ForStarDifficulty(maxDifficulty.Stars);
+
+            bufferedContent.ForceRedraw();
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Chances are this design will get scrapped tomorrow because we burn through designs lately, but oh well. This has been brought up a handful of times so it must stand out enough to fix it temporarily.

Recommend a mostly visual review. Code quality shouldn't really be of concern for this. Nor should performance because see above. I fixed the edge pixels as well as semi-opacity woes.

| Before | After |
| :---: | :---: |
| ![2025-01-07 02 49 33@2x](https://github.com/user-attachments/assets/6cce35ec-5106-4db8-9b1a-d900c0684f67) | ![2025-01-07 02 53 11@2x](https://github.com/user-attachments/assets/1036f9f7-04e3-4f48-b0e0-d56f4fe18421) |