### PR TITLE
Reduce allocations in the editor caused by `TimelineBlueprintContainer`

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModTargetPractice.cs
@@ -230,7 +230,7 @@ namespace osu.Game.Rulesets.Osu.Mods
 
                 // If samples aren't available at the exact start time of the object,
                 // use samples (without additions) in the closest original hit object instead
-                obj.Samples = samples ?? getClosestHitObject(originalHitObjects, obj.StartTime).Samples.Where(s => !HitSampleInfo.AllAdditions.Contains(s.Name)).ToList();
+                obj.Samples = samples ?? getClosestHitObject(originalHitObjects, obj.StartTime).Samples.Where(s => !HitSampleInfo.ALL_ADDITIONS.Contains(s.Name)).ToList();
             }
         }
 

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -33,12 +33,12 @@ namespace osu.Game.Audio
         /// <summary>
         /// All valid sample addition constants.
         /// </summary>
-        public static readonly string[] ALL_ADDITIONS = new[] { HIT_WHISTLE, HIT_FINISH, HIT_CLAP };
+        public static readonly string[] ALL_ADDITIONS = [HIT_WHISTLE, HIT_FINISH, HIT_CLAP];
 
         /// <summary>
         /// All valid bank constants.
         /// </summary>
-        public static readonly string[] ALL_BANKS = new[] { BANK_NORMAL, BANK_SOFT, BANK_DRUM };
+        public static readonly string[] ALL_BANKS = [BANK_NORMAL, BANK_SOFT, BANK_DRUM];
 
         /// <summary>
         /// The name of the sample to load.

--- a/osu.Game/Audio/HitSampleInfo.cs
+++ b/osu.Game/Audio/HitSampleInfo.cs
@@ -33,12 +33,12 @@ namespace osu.Game.Audio
         /// <summary>
         /// All valid sample addition constants.
         /// </summary>
-        public static IEnumerable<string> AllAdditions => new[] { HIT_WHISTLE, HIT_FINISH, HIT_CLAP };
+        public static readonly string[] ALL_ADDITIONS = new[] { HIT_WHISTLE, HIT_FINISH, HIT_CLAP };
 
         /// <summary>
         /// All valid bank constants.
         /// </summary>
-        public static IEnumerable<string> AllBanks => new[] { BANK_NORMAL, BANK_SOFT, BANK_DRUM };
+        public static readonly string[] ALL_BANKS = new[] { BANK_NORMAL, BANK_SOFT, BANK_DRUM };
 
         /// <summary>
         /// The name of the sample to load.

--- a/osu.Game/Rulesets/Edit/Checks/CheckDelayedHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckDelayedHitsounds.cs
@@ -119,8 +119,8 @@ namespace osu.Game.Rulesets.Edit.Checks
             string bank = parts[0];
             string sampleSet = parts[1];
 
-            return HitSampleInfo.AllBanks.Contains(bank)
-                   && HitSampleInfo.AllAdditions.Append(HitSampleInfo.HIT_NORMAL).Any(sampleSet.StartsWith);
+            return HitSampleInfo.ALL_BANKS.Contains(bank)
+                   && HitSampleInfo.ALL_ADDITIONS.Append(HitSampleInfo.HIT_NORMAL).Any(sampleSet.StartsWith);
         }
 
         public class IssueTemplateConsequentDelay : IssueTemplate

--- a/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
+++ b/osu.Game/Rulesets/Edit/Checks/CheckFewHitsounds.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Rulesets.Edit.Checks
                 ++objectsWithoutHitsounds;
         }
 
-        private bool isHitsound(HitSampleInfo sample) => HitSampleInfo.AllAdditions.Any(sample.Name.Contains);
+        private bool isHitsound(HitSampleInfo sample) => HitSampleInfo.ALL_ADDITIONS.Any(sample.Name.Contains);
         private bool isHitnormal(HitSampleInfo sample) => sample.Name.Contains(HitSampleInfo.HIT_NORMAL);
 
         public abstract class IssueTemplateLongPeriod : IssueTemplate

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         private void createStateBindables()
         {
-            foreach (string bankName in HitSampleInfo.AllBanks.Prepend(HIT_BANK_AUTO))
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
             {
                 var bindable = new Bindable<TernaryState>
                 {
@@ -143,7 +143,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 SelectionBankStates[bankName] = bindable;
             }
 
-            foreach (string bankName in HitSampleInfo.AllBanks.Prepend(HIT_BANK_AUTO))
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
             {
                 var bindable = new Bindable<TernaryState>
                 {
@@ -216,7 +216,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             resetTernaryStates();
 
-            foreach (string sampleName in HitSampleInfo.AllAdditions)
+            foreach (string sampleName in HitSampleInfo.ALL_ADDITIONS)
             {
                 var bindable = new Bindable<TernaryState>
                 {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -409,7 +409,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             private void createStateBindables()
             {
-                foreach (string sampleName in HitSampleInfo.AllAdditions)
+                foreach (string sampleName in HitSampleInfo.ALL_ADDITIONS)
                 {
                     var bindable = new Bindable<TernaryState>
                     {
@@ -433,7 +433,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     selectionSampleStates[sampleName] = bindable;
                 }
 
-                banks.AddRange(HitSampleInfo.AllBanks.Prepend(EditorSelectionHandler.HIT_BANK_AUTO));
+                banks.AddRange(HitSampleInfo.ALL_BANKS.Prepend(EditorSelectionHandler.HIT_BANK_AUTO));
             }
 
             private void updateTernaryStates()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -155,8 +155,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 if (hitObject.GetEndTime() < editorClock.CurrentTime - timeline.VisibleRange / 2)
                     break;
 
-                foreach (var sample in hitObject.Samples)
+                for (int i = 0; i < hitObject.Samples.Count; i++)
                 {
+                    var sample = hitObject.Samples[i];
+
                     if (!HitSampleInfo.ALL_BANKS.Contains(sample.Bank))
                         minimumGap = Math.Max(minimumGap, absolute_minimum_gap + sample.Bank.Length * 3);
                 }
@@ -165,10 +167,17 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     smallestTimeGap = Math.Min(smallestTimeGap, hasRepeats.Duration / hasRepeats.SpanCount() / 2);
 
-                    foreach (var sample in hasRepeats.NodeSamples.SelectMany(s => s))
+                    for (int i = 0; i < hasRepeats.NodeSamples.Count; i++)
                     {
-                        if (!HitSampleInfo.ALL_BANKS.Contains(sample.Bank))
-                            minimumGap = Math.Max(minimumGap, absolute_minimum_gap + sample.Bank.Length * 3);
+                        var node = hasRepeats.NodeSamples[i];
+
+                        for (int j = 0; j < node.Count; j++)
+                        {
+                            var sample = node[j];
+
+                            if (!HitSampleInfo.ALL_BANKS.Contains(sample.Bank))
+                                minimumGap = Math.Max(minimumGap, absolute_minimum_gap + sample.Bank.Length * 3);
+                        }
                     }
                 }
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -157,7 +157,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 foreach (var sample in hitObject.Samples)
                 {
-                    if (!HitSampleInfo.AllBanks.Contains(sample.Bank))
+                    if (!HitSampleInfo.ALL_BANKS.Contains(sample.Bank))
                         minimumGap = Math.Max(minimumGap, absolute_minimum_gap + sample.Bank.Length * 3);
                 }
 
@@ -167,7 +167,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     foreach (var sample in hasRepeats.NodeSamples.SelectMany(s => s))
                     {
-                        if (!HitSampleInfo.AllBanks.Contains(sample.Bank))
+                        if (!HitSampleInfo.ALL_BANKS.Contains(sample.Bank))
                             minimumGap = Math.Max(minimumGap, absolute_minimum_gap + sample.Bank.Length * 3);
                     }
                 }


### PR DESCRIPTION
Noticed while investigating https://github.com/ppy/osu/issues/31428.
Unfortunately I couldn't figure out a sane way to not call `updateSamplePointContractedState` in the `Update()`, but allocations were quite big, so at least this should help in some capacity (since I believe the issue caused by allocations, but there are other places to fix, in a separate pr's).

Values were taken in the editor while idling for ~30sec.
|master|pr|
|---|---|
|![master](https://github.com/user-attachments/assets/a558dced-7091-450d-ac85-51adfa51fe1d)|![pr](https://github.com/user-attachments/assets/76939d9a-a68d-4b9f-86a4-c8c1215fc772)|

