### PR TITLE
Show osu!(lazer) in windows "default apps" menus

### DIFF
--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -176,7 +176,7 @@ namespace osu.Desktop.Windows
 
         private record FileAssociation(string Extension, LocalisableString Description, string IconPath)
         {
-            private string programId => $@"{program_id_prefix}{Extension}";
+            public string ProgramId => $@"{program_id_prefix}{Extension}";
 
             /// <summary>
             /// Installs a file extension association in accordance with https://learn.microsoft.com/en-us/windows/win32/com/-progid--key
@@ -187,7 +187,7 @@ namespace osu.Desktop.Windows
                 if (classes == null) return;
 
                 // register a program id for the given extension
-                using (var programKey = classes.CreateSubKey(programId))
+                using (var programKey = classes.CreateSubKey(ProgramId))
                 {
                     using (var defaultIconKey = programKey.CreateSubKey(default_icon))
                         defaultIconKey.SetValue(null, IconPath);
@@ -199,12 +199,12 @@ namespace osu.Desktop.Windows
                 using (var extensionKey = classes.CreateSubKey(Extension))
                 {
                     // set ourselves as the default program
-                    extensionKey.SetValue(null, programId);
+                    extensionKey.SetValue(null, ProgramId);
 
                     // add to the open with dialog
                     // https://learn.microsoft.com/en-us/windows/win32/shell/how-to-include-an-application-on-the-open-with-dialog-box
                     using (var openWithKey = extensionKey.CreateSubKey(@"OpenWithProgIds"))
-                        openWithKey.SetValue(programId, string.Empty);
+                        openWithKey.SetValue(ProgramId, string.Empty);
                 }
             }
 
@@ -213,7 +213,7 @@ namespace osu.Desktop.Windows
                 using var classes = Registry.CurrentUser.OpenSubKey(software_classes, true);
                 if (classes == null) return;
 
-                using (var programKey = classes.OpenSubKey(programId, true))
+                using (var programKey = classes.OpenSubKey(ProgramId, true))
                     programKey?.SetValue(null, description);
             }
 
@@ -227,16 +227,16 @@ namespace osu.Desktop.Windows
 
                 using (var extensionKey = classes.OpenSubKey(Extension, true))
                 {
-                    // clear our default association so that Explorer doesn't show the raw programId to users
+                    // clear our default association so that Explorer doesn't show the raw ProgramId to users
                     // the null/(Default) entry is used for both ProdID association and as a fallback friendly name, for legacy reasons
-                    if (extensionKey?.GetValue(null) is string s && s == programId)
+                    if (extensionKey?.GetValue(null) is string s && s == ProgramId)
                         extensionKey.SetValue(null, string.Empty);
 
                     using (var openWithKey = extensionKey?.CreateSubKey(@"OpenWithProgIds"))
-                        openWithKey?.DeleteValue(programId, throwOnMissingValue: false);
+                        openWithKey?.DeleteValue(ProgramId, throwOnMissingValue: false);
                 }
 
-                classes.DeleteSubKeyTree(programId, throwOnMissingSubKey: false);
+                classes.DeleteSubKeyTree(ProgramId, throwOnMissingSubKey: false);
             }
         }
 

--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -254,8 +254,10 @@ namespace osu.Desktop.Windows
 
                 using (var extensionKey = classes.CreateSubKey(Extension))
                 {
-                    // set ourselves as the default program
-                    extensionKey.SetValue(null, ProgramId);
+                    // Clear out our existing default ProgramID. Default programs in Windows are handled internally by Explorer,
+                    // so having it here is just confusing and may override user preferences.
+                    if (extensionKey.GetValue(null) is string s && s == ProgramId)
+                        extensionKey.SetValue(null, string.Empty);
 
                     // add to the open with dialog
                     // https://learn.microsoft.com/en-us/windows/win32/shell/how-to-include-an-application-on-the-open-with-dialog-box
@@ -283,11 +285,6 @@ namespace osu.Desktop.Windows
 
                 using (var extensionKey = classes.OpenSubKey(Extension, true))
                 {
-                    // clear our default association so that Explorer doesn't show the raw ProgramId to users
-                    // the null/(Default) entry is used for both ProdID association and as a fallback friendly name, for legacy reasons
-                    if (extensionKey?.GetValue(null) is string s && s == ProgramId)
-                        extensionKey.SetValue(null, string.Empty);
-
                     using (var openWithKey = extensionKey?.CreateSubKey(@"OpenWithProgIds"))
                         openWithKey?.DeleteValue(ProgramId, throwOnMissingValue: false);
                 }

--- a/osu.Desktop/Windows/WindowsAssociationManager.cs
+++ b/osu.Desktop/Windows/WindowsAssociationManager.cs
@@ -329,11 +329,9 @@ namespace osu.Desktop.Windows
                 {
                     protocolKey.SetValue(URL_PROTOCOL, string.Empty);
 
-                    using (var defaultIconKey = protocolKey.CreateSubKey(default_icon))
-                        defaultIconKey.SetValue(null, IconPath);
-
-                    using (var openCommandKey = protocolKey.CreateSubKey(SHELL_OPEN_COMMAND))
-                        openCommandKey.SetValue(null, $@"""{exe_path}"" ""%1""");
+                    // clear out old data
+                    protocolKey.DeleteSubKeyTree(default_icon, throwOnMissingSubKey: false);
+                    protocolKey.DeleteSubKeyTree(@"Shell", throwOnMissingSubKey: false);
                 }
 
                 // register a program id for the given protocol
@@ -360,7 +358,6 @@ namespace osu.Desktop.Windows
             {
                 using var classes = Registry.CurrentUser.OpenSubKey(software_classes, true);
                 classes?.DeleteSubKeyTree(ProgramId, throwOnMissingSubKey: false);
-                classes?.DeleteSubKeyTree(Protocol, throwOnMissingSubKey: false);
             }
         }
     }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu/pull/31450
- [x] Needs to be refactored to read more like #31450.
- Alternative to / closes https://github.com/ppy/osu/issues/30473
  - file and URI associations are always installed, but ([with some osu! stable code changes](https://github.com/ppy/osu-stable-issues/issues/1277)) the user can choose between stable and lazer in all the usual places

# Implementation

Very simple, just sets the registry keys as defined in https://learn.microsoft.com/en-us/windows/win32/shell/default-programs. You can read the commits for more details. The specific keys/concepts used are: `RegisteredApplications`, `Capabilities`, `ApplicationDescription`, `FileAssociations` and `UrlAssociations`.
Previously, the default URI handler and file type handlers were set to osu!(lazer) when it was installed. This has now been removed. We trust that the windows explorer / shell will provide a sane default (works as expected from my testing).

# End goal for the UX

Important: this doesn't work yet with this PR, changes to osu!(stable) are needed to get this working. Lazer will continue to steal association from stable at the moment.

## osu! and osu!(lazer) appear in the "Open with" context menu

![context menu](https://github.com/user-attachments/assets/bea2572a-50b8-4cb6-b27c-a6be6dd13251)

## The user can choose default apps for each file type / URI in the Settings app

![default apps](https://github.com/user-attachments/assets/b4830aeb-846d-4b5c-9130-8d0e88e3fa04)

## The user is presented with the "Select an app..." after installing osu!(lazer)

In this example, osu!(stable) was first installed, an `.osk` file was opened in stable, and then osu!(lazer) was installed and the `.osk` file double-clicked.

![select an app where stable is the default](https://github.com/user-attachments/assets/3c665140-6828-4b66-925c-682b5e206193)

Same applies when opening an `osu://` URI.

![select an app for protocol](https://github.com/user-attachments/assets/11b95491-4846-4f7c-a832-9e5e1b4901cb)

If the user never opened a file type in osu!(stable), both options are presented equally when lazer is installed.

![slika](https://github.com/user-attachments/assets/865d8487-12a4-4659-a220-57fdabb07fdc)


