### PR TITLE
Reset playback speed to 100% on entering test play

### DIFF
--- a/osu.Game/Screens/Edit/Components/BottomBarContainer.cs
+++ b/osu.Game/Screens/Edit/Components/BottomBarContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -17,8 +16,6 @@ namespace osu.Game.Screens.Edit.Components
         private const float contents_padding = 15;
 
         protected readonly IBindable<WorkingBeatmap> Beatmap = new Bindable<WorkingBeatmap>();
-
-        protected readonly IBindable<Track> Track = new Bindable<Track>();
 
         public readonly Drawable Background;
         private readonly Container content;
@@ -45,10 +42,9 @@ namespace osu.Game.Screens.Edit.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, EditorClock clock)
+        private void load(IBindable<WorkingBeatmap> beatmap)
         {
             Beatmap.BindTo(beatmap);
-            Track.BindTo(clock.Track);
         }
     }
 }

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -75,7 +76,7 @@ namespace osu.Game.Screens.Edit.Components
                 }
             };
 
-            Track.BindValueChanged(tr => tr.NewValue?.AddAdjustment(AdjustableProperty.Tempo, tempoAdjustment), true);
+            editorClock.AudioAdjustments.AddAdjustment(AdjustableProperty.Tempo, tempoAdjustment);
 
             if (editor != null)
                 currentScreenMode.BindTo(editor.Mode);
@@ -105,7 +106,8 @@ namespace osu.Game.Screens.Edit.Components
 
         protected override void Dispose(bool isDisposing)
         {
-            Track.Value?.RemoveAdjustment(AdjustableProperty.Tempo, tempoAdjustment);
+            if (editorClock.IsNotNull())
+                editorClock.AudioAdjustments.RemoveAdjustment(AdjustableProperty.Tempo, tempoAdjustment);
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/Edit/Components/PlaybackControl.cs
+++ b/osu.Game/Screens/Edit/Components/PlaybackControl.cs
@@ -148,7 +148,7 @@ namespace osu.Game.Screens.Edit.Components
             public LocalisableString TooltipText { get; set; }
         }
 
-        private partial class PlaybackTabControl : OsuTabControl<double>
+        public partial class PlaybackTabControl : OsuTabControl<double>
         {
             private static readonly double[] tempo_values = { 0.25, 0.5, 0.75, 1 };
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/Timeline.cs
@@ -3,9 +3,9 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
@@ -49,6 +49,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
 
+        [Resolved]
+        private IBindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
         /// <summary>
         /// The timeline's scroll position in the last frame.
         /// </summary>
@@ -86,8 +89,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
         private double trackLengthForZoom;
 
-        private readonly IBindable<Track> track = new Bindable<Track>();
-
         public Timeline(Drawable userContent)
         {
             this.userContent = userContent;
@@ -101,7 +102,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         }
 
         [BackgroundDependencyLoader]
-        private void load(IBindable<WorkingBeatmap> beatmap, OsuColour colours, OverlayColourProvider colourProvider, OsuConfigManager config)
+        private void load(OsuColour colours, OverlayColourProvider colourProvider, OsuConfigManager config)
         {
             CentreMarker centreMarker;
 
@@ -150,14 +151,16 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             controlPointsVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTimingChanges);
             ticksVisible = config.GetBindable<bool>(OsuSetting.EditorTimelineShowTicks);
 
-            track.BindTo(editorClock.Track);
-            track.BindValueChanged(_ =>
-            {
-                waveform.Waveform = beatmap.Value.Waveform;
-                Scheduler.AddOnce(applyVisualOffset, beatmap);
-            }, true);
+            editorClock.TrackChanged += updateWaveform;
+            updateWaveform();
 
             Zoom = (float)(defaultTimelineZoom * editorBeatmap.TimelineZoom);
+        }
+
+        private void updateWaveform()
+        {
+            waveform.Waveform = beatmap.Value.Waveform;
+            Scheduler.AddOnce(applyVisualOffset, beatmap);
         }
 
         private void applyVisualOffset(IBindable<WorkingBeatmap> beatmap)
@@ -333,6 +336,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             double time = TimeAtPosition(Content.ToLocalSpace(screenSpacePosition).X);
             return new SnapResult(screenSpacePosition, beatSnapProvider.SnapTime(time));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (editorClock.IsNotNull())
+                editorClock.TrackChanged -= updateWaveform;
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -861,6 +861,7 @@ namespace osu.Game.Screens.Edit
         {
             base.OnResuming(e);
             dimBackground();
+            clock.BindAdjustments();
         }
 
         private void dimBackground()
@@ -925,6 +926,10 @@ namespace osu.Game.Screens.Edit
             base.OnSuspending(e);
             clock.Stop();
             refetchBeatmap();
+            // unfortunately ordering matters here.
+            // this unbind MUST happen after `refetchBeatmap()`, because along other things, `refetchBeatmap()` causes a global working beatmap change,
+            // which causes `EditorClock` to reload the track and automatically reapply adjustments to it.
+            clock.UnbindAdjustments();
         }
 
         private void refetchBeatmap()

--- a/osu.Game/Screens/Edit/EditorClock.cs
+++ b/osu.Game/Screens/Edit/EditorClock.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
@@ -24,7 +25,8 @@ namespace osu.Game.Screens.Edit
     /// </summary>
     public partial class EditorClock : CompositeComponent, IFrameBasedClock, IAdjustableClock, ISourceChangeableClock
     {
-        public IBindable<Track> Track => track;
+        [CanBeNull]
+        public event Action TrackChanged;
 
         private readonly Bindable<Track> track = new Bindable<Track>();
 
@@ -59,6 +61,8 @@ namespace osu.Game.Screens.Edit
 
             underlyingClock = new FramedBeatmapClock(applyOffsets: true, requireDecoupling: true);
             AddInternal(underlyingClock);
+
+            track.BindValueChanged(_ => TrackChanged?.Invoke());
         }
 
         /// <summary>


### PR DESCRIPTION
RFC. There's no issue thread for this, [it was reported internally](https://discord.com/channels/90072389919997952/1259818301517725707/1320412291929346048).

This ended up being way more annoying to write than I initially had hoped because the playback control could just beeline for the audio track to apply adjustments to it and that just completely breaks any hope of layering it with the screen system. It's one of these weird things wherein the audio subsystem is just completely parallel to everything and you can have stuff that isn't drawn or even updating affect the ambient state of the game.

To that end I ended up rerouting the audio adjustment via `EditorClock` (https://github.com/ppy/osu/commit/a5036cd092b0bb020982c6606d2ed110de25f387) and doing some extra encapsulation to ensure nobody gets to touch the track directly via `EditorClock` in https://github.com/ppy/osu/commit/98bb723438c0ce37311451e52529e86f2386777a.